### PR TITLE
fix(cicd): Docker build on pull requests were causing failures from missing credentials

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -58,10 +58,20 @@ jobs:
                   echo "tags=${IMAGE_TAG}" >> $GITHUB_OUTPUT
                   echo "image_base=${IMAGE_BASE}" >> $GITHUB_OUTPUT
 
+                  # Calculate if we should push (true by default for non-PRs, unless explicitly disabled)
+                  SHOULD_PUSH="true"
+                  if [ "${{ github.event_name }}" == "pull_request" ]; then
+                    SHOULD_PUSH="false"
+                  elif [ "${{ github.event.inputs.push }}" == "false" ]; then
+                    SHOULD_PUSH="false"
+                  fi
+                  echo "should_push=${SHOULD_PUSH}" >> $GITHUB_OUTPUT
+
                   echo "### Build Info 🐳" >> $GITHUB_STEP_SUMMARY
                   echo "- **Version**: ${VERSION}" >> $GITHUB_STEP_SUMMARY
                   echo "- **Image**: ${IMAGE_TAG}" >> $GITHUB_STEP_SUMMARY
                   echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Push**: ${SHOULD_PUSH}" >> $GITHUB_STEP_SUMMARY
               env:
                   GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
@@ -69,7 +79,7 @@ jobs:
               uses: docker/setup-buildx-action@v3
 
             - name: Log in to GitHub Container Registry
-              if: github.event.inputs.push != false && github.event_name != 'pull_request'
+              if: steps.meta.outputs.should_push == 'true'
               uses: docker/login-action@v3
               with:
                   registry: ${{ env.REGISTRY }}
@@ -82,7 +92,7 @@ jobs:
               with:
                   context: .
                   platforms: linux/amd64,linux/arm64
-                  push: ${{ github.event.inputs.push != false && github.event_name != 'pull_request' }}
+                  push: ${{ steps.meta.outputs.should_push == 'true' }}
                   tags: ${{ steps.meta.outputs.tags }}
                   # Note: http://127.0.0.1:8000 is a dev-only fallback. Override with BACKEND_URL at runtime for production.
                   build-args: |
@@ -100,7 +110,7 @@ jobs:
                   retention-days: 3
 
             - name: Add latest tag for version releases
-              if: startsWith(github.ref, 'refs/tags/v') && github.event.inputs.push != false
+              if: startsWith(github.ref, 'refs/tags/v') && steps.meta.outputs.should_push == 'true'
               run: |
                   docker buildx imagetools create \
                     -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \


### PR DESCRIPTION
Resolves issue where login step was skipped on push events because github.event.inputs.push is null.
