### PR TITLE
fix(server): Allow better dynamic api and path handling

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,27 +20,7 @@ const nextConfig: NextConfig = {
     : {
       pageExtensions: ["tsx", "ts", "jsx", "js"],
     }),
-  ...(isDemoExport
-    ? {}
-    : {
-      async rewrites() {
-        return {
-          // Use afterFiles so Next.js API routes are matched FIRST
-          // This allows /api/v1/llm-proxy/* to be handled by our API route
-          // while other /api/* paths get proxied to the backend
-          afterFiles: [
-            {
-              source: "/api/:path*",
-              destination: `${process.env.BACKEND_URL || "http://127.0.0.1:8000"}/api/:path*`,
-            },
-            {
-              source: "/graphql",
-              destination: `${process.env.BACKEND_URL || "http://127.0.0.1:8000"}/graphql`,
-            },
-          ],
-        };
-      },
-    }),
+  // API proxying is handled by middleware.ts at runtime (not baked at build time)
 };
 
 export default nextConfig;

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -9,19 +9,16 @@ export type ApiFetchInit = RequestInit & {
   };
 };
 
-const API_BASE =
-  typeof window === "undefined"
-    ? process.env.BACKEND_URL ?? "http://127.0.0.1:8000"
-    : "";
-
+// Server-side: fetch directly from backend (BACKEND_URL read at runtime, not build time)
+// Client-side: use relative paths, proxied through Next.js rewrites
 const resolveOrigin = () => {
-  if (API_BASE) {
-    return API_BASE;
-  }
   if (typeof window !== "undefined") {
+    // Browser: use relative paths, Next.js rewrites proxy to backend
     return window.location.origin;
   }
-  return "http://127.0.0.1:8000";
+  // Server-side SSR: must use absolute URL to reach backend directly
+  // process.env is read at runtime, not baked in at build time
+  return process.env.BACKEND_URL ?? "http://127.0.0.1:8000";
 };
 
 const buildUrl = (path: string, params?: ApiQueryParams) => {
@@ -96,7 +93,6 @@ const sendBeacon = (
 };
 
 export const apiClient = {
-  baseUrl: API_BASE,
   buildUrl,
   request,
   fetchJson,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,8 @@
 export const config = {
   api: {
-    baseUrl: process.env.BACKEND_URL || "http://127.0.0.1:8000",
-    docsUrl: process.env.BACKEND_URL || "http://127.0.0.1:8000/docs",
+    // Use relative paths - Next.js rewrites proxy /api/* and /graphql to backend
+    baseUrl: "",
+    // Docs URL can be set via NEXT_PUBLIC_ env var for external links
+    docsUrl: process.env.NEXT_PUBLIC_DOCS_URL || "/docs",
   },
 };

--- a/src/lib/graphql/client.ts
+++ b/src/lib/graphql/client.ts
@@ -9,19 +9,16 @@ import type { GraphQLResponse } from "./types";
 
 const GRAPHQL_PATH = "/graphql";
 
+// Server-side: fetch directly from backend (BACKEND_URL read at runtime, not build time)
+// Client-side: use relative paths, proxied through Next.js rewrites
 const resolveOrigin = (): string => {
-    const backendUrl =
-        typeof window === "undefined"
-            ? process.env.BACKEND_URL ?? "http://127.0.0.1:8000"
-            : "";
-
-    if (backendUrl) {
-        return backendUrl;
-    }
     if (typeof window !== "undefined") {
+        // Browser: use relative paths, Next.js rewrites proxy to backend
         return window.location.origin;
     }
-    return "http://127.0.0.1:8000";
+    // Server-side SSR: must use absolute URL to reach backend directly
+    // process.env is read at runtime, not baked in at build time
+    return process.env.BACKEND_URL ?? "http://127.0.0.1:8000";
 };
 
 export interface GraphQLClientOptions {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Proxy to forward /api/* and /graphql requests to the backend.
+ * 
+ * This runs at REQUEST TIME, so BACKEND_URL is read from the runtime environment,
+ * not baked in at build time. This is critical for Docker deployments where
+ * the backend URL varies per environment.
+ */
+export function proxy(request: NextRequest) {
+    const { pathname } = request.nextUrl;
+
+    // Only proxy /api/* (except Next.js API routes) and /graphql
+    const shouldProxy =
+        pathname === "/graphql" ||
+        (pathname.startsWith("/api/") && !pathname.startsWith("/api/v1/llm-proxy"));
+
+    if (!shouldProxy) {
+        return NextResponse.next();
+    }
+
+    // Read BACKEND_URL at runtime
+    const backendUrl = process.env.BACKEND_URL || "http://127.0.0.1:8000";
+    const targetUrl = new URL(pathname + request.nextUrl.search, backendUrl);
+
+    // Rewrite the request to the backend
+    return NextResponse.rewrite(targetUrl);
+}
+
+export const config = {
+    matcher: ["/api/:path*", "/graphql"],
+};


### PR DESCRIPTION
- Server-side SSR reads BACKEND_URL at runtime (not baked at build)
- Client-side uses relative paths proxied through Next.js rewrites
- Removed hardcoded BACKEND_URL from config.ts
