### PR TITLE
fix: resolve 'tag is needed' error in parallel docker builds

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -85,6 +85,7 @@ jobs:
                   platforms: ${{ matrix.platform }}
                   build-args: |
                       BACKEND_URL=${{ secrets.BACKEND_URL || 'http://127.0.0.1:8000' }}
+                  tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
                   outputs: ${{ steps.meta.outputs.should_push == 'true' && 'type=image,push-by-digest=true,name-canonical=true,push=true' || format('type=oci,dest=/tmp/docker-image-{0}.tar', strategy.job-index) }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR adds the missing repository name to the Docker build jobs to resolve the 'tag is needed when pushing to registry' error.