### PR TITLE
fix(ci): use metadata-action version for docker inspect

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -157,5 +157,5 @@ jobs:
 
             - name: Inspect image
               run: |
-                  docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.version }}
+                  docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 


### PR DESCRIPTION
## Summary
- Fix docker inspect step failing on pre-releases
- Changed from `needs.build.outputs.version` to `steps.meta.outputs.version`
- Aligns with ops workflow pattern

**Root cause:** Build job outputs `v0.4.0-beta.0`, but metadata-action creates tag `0.4.0-beta.0`

Fixes #113