### PR TITLE
refactor: rename LICENSE_SVC_ADMIN_KEY to ADMIN_API_KEY

### DIFF
--- a/src/lib/billing/__tests__/actions.test.ts
+++ b/src/lib/billing/__tests__/actions.test.ts
@@ -26,7 +26,7 @@ describe("getSubscriptionDetails", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.stubEnv("LICENSE_SVC_URL", "http://test-license-svc:3100");
-    vi.stubEnv("LICENSE_SVC_ADMIN_KEY", "test-admin-key");
+    vi.stubEnv("ADMIN_API_KEY", "test-admin-key");
   });
 
   it("returns subscription details when API succeeds", async () => {

--- a/src/lib/billing/actions.ts
+++ b/src/lib/billing/actions.ts
@@ -112,7 +112,7 @@ export async function getSubscriptionDetails(): Promise<ActionResult<Subscriptio
     const res = await fetch(`${getLicenseSvcUrl()}/api/entitlements/${orgId}`,
       {
         headers: {
-          Authorization: `Bearer ${process.env.LICENSE_SVC_ADMIN_KEY ?? ""}`,
+          Authorization: `Bearer ${process.env.ADMIN_API_KEY ?? ""}`,
         },
         next: { revalidate: 60 },
       }


### PR DESCRIPTION
## Summary
- Rename `LICENSE_SVC_ADMIN_KEY` → `ADMIN_API_KEY` in billing server actions and tests
- Part of cross-repo auth secret consolidation — all services now use the same env var name for the admin API key

## Companion PRs
- full-chaos/license-svc — `PORTAL_JWT_SECRET` → `JWT_SECRET_KEY`, `DEV_HEALTH_OPS_WEBHOOK_SECRET` → `LICENSE_WEBHOOK_SECRET`

## Secret naming (after merge)
| Secret | Canonical Name | Services |
|--------|---------------|----------|
| Admin API key | `ADMIN_API_KEY` | license-svc, dev-health-web |
| JWT signing | `JWT_SECRET_KEY` | license-svc, dev-health-ops |
| Webhook secret | `LICENSE_WEBHOOK_SECRET` | license-svc, dev-health-ops |