### PR TITLE
feat: reroute billing calls from license-svc to ops

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,6 @@
 # Backend API URL (required for full-stack mode)
 BACKEND_URL=http://127.0.0.1:8000
 
-# License service URL (for billing/checkout features)
-LICENSE_SVC_URL=http://localhost:3100
-
 # =============================================================================
 # Feature Flags
 # =============================================================================

--- a/src/lib/billing/__tests__/actions.test.ts
+++ b/src/lib/billing/__tests__/actions.test.ts
@@ -25,8 +25,7 @@ function mockSession(overrides: Partial<Session> & { user?: Partial<Session["use
 describe("getSubscriptionDetails", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.stubEnv("LICENSE_SVC_URL", "http://test-license-svc:3100");
-    vi.stubEnv("ADMIN_API_KEY", "test-admin-key");
+    vi.stubEnv("BACKEND_URL", "http://test-ops:8000");
   });
 
   it("returns subscription details when API succeeds", async () => {
@@ -35,13 +34,11 @@ describe("getSubscriptionDetails", () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
-          org_id: "org-123",
           tier: "team",
           features: { basic_analytics: true, team_dashboard: true },
           limits: { users: 25, repos: 20, api_rate: 300 },
-          expires_at: "2027-01-01T00:00:00Z",
-          is_active: true,
-          is_grace_period: false,
+          is_licensed: true,
+          in_grace_period: false,
         }),
         { status: 200 },
       ),
@@ -52,7 +49,7 @@ describe("getSubscriptionDetails", () => {
     expect(result.data!.tier).toBe("team");
     expect(result.data!.status).toBe("active");
     expect(result.data!.features).toEqual({ basic_analytics: true, team_dashboard: true });
-    expect(result.data!.current_period_end).toBe("2027-01-01T00:00:00Z");
+    expect(result.data!.current_period_end).toBeNull();
 
     fetchSpy.mockRestore();
   });
@@ -89,11 +86,10 @@ describe("getSubscriptionDetails", () => {
       new Response(
         JSON.stringify({
           tier: "team",
-          is_active: true,
-          is_grace_period: true,
+          is_licensed: true,
+          in_grace_period: true,
           features: {},
           limits: {},
-          expires_at: "2026-01-01T00:00:00Z",
         }),
         { status: 200 },
       ),

--- a/src/lib/billing/actions.ts
+++ b/src/lib/billing/actions.ts
@@ -6,8 +6,8 @@ import { auth } from "@/lib/auth";
 type CheckoutResponse = { session_id: string; checkout_url: string };
 type ActionResult<T> = { data: T; error?: never } | { data?: never; error: string };
 
-function getLicenseSvcUrl(): string {
-  return process.env.LICENSE_SVC_URL ?? "http://localhost:3100";
+function getBackendUrl(): string {
+  return process.env.BACKEND_URL ?? "http://127.0.0.1:8000";
 }
 
 // Server action: Create Stripe checkout session
@@ -25,14 +25,13 @@ export async function createCheckoutSession(
     }
 
     const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
-    const res = await fetch(`${getLicenseSvcUrl()}/api/checkout/session`, {
+    const res = await fetch(`${getBackendUrl()}/api/v1/billing/checkout`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${session.access_token}`,
       },
       body: JSON.stringify({
-        org_id: orgId,
         tier,
         success_url: `${baseUrl}/admin/settings?billing=success`,
         cancel_url: `${baseUrl}/admin/settings?billing=cancelled`,
@@ -45,14 +44,13 @@ export async function createCheckoutSession(
     }
 
     const data = await res.json();
-    return { data };
+    return { data: { session_id: data.session_id, checkout_url: data.url } };
   } catch (err) {
     return { error: err instanceof Error ? err.message : "Unknown error" };
   }
 }
 
 // Server action: Create billing portal session (for subscription management)
-// NOTE: license-svc #32 (portal API) is not yet built — this is a forward-compatible stub
 export async function createPortalSession(): Promise<ActionResult<{ portal_url: string }>> {
   try {
     const session = await auth();
@@ -64,26 +62,28 @@ export async function createPortalSession(): Promise<ActionResult<{ portal_url: 
       return { error: "No organization ID" };
     }
 
-    const res = await fetch(`${getLicenseSvcUrl()}/api/portal/billing`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${session.access_token}`,
+    const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+    const returnUrl = encodeURIComponent(`${baseUrl}/admin/settings`);
+    const res = await fetch(
+      `${getBackendUrl()}/api/v1/billing/portal?return_url=${returnUrl}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+        },
       },
-      body: JSON.stringify({ org_id: orgId }),
-    });
+    );
 
     if (!res.ok) {
-      // Portal API may not exist yet (license-svc #32)
       if (res.status === 404) {
-        return { error: "Billing portal is not yet available. Contact support for billing changes." };
+        return { error: "No billing account found for this organization." };
       }
       const error = await res.json().catch(() => ({ detail: res.statusText }));
       return { error: error.detail || `Portal session failed (${res.status})` };
     }
 
     const data = await res.json();
-    return { data };
+    return { data: { portal_url: data.url } };
   } catch (err) {
     return { error: err instanceof Error ? err.message : "Unknown error" };
   }
@@ -109,13 +109,9 @@ export async function getSubscriptionDetails(): Promise<ActionResult<Subscriptio
       return { error: "No organization ID" };
     }
 
-    const res = await fetch(`${getLicenseSvcUrl()}/api/entitlements/${orgId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${process.env.ADMIN_API_KEY ?? ""}`,
-        },
-        next: { revalidate: 60 },
-      }
+    const res = await fetch(
+      `${getBackendUrl()}/api/v1/billing/entitlements/${orgId}`,
+      { next: { revalidate: 60 } },
     );
 
     if (!res.ok) {
@@ -135,12 +131,12 @@ export async function getSubscriptionDetails(): Promise<ActionResult<Subscriptio
     return {
       data: {
         tier: entitlements.tier ?? "community",
-        status: entitlements.is_active
-          ? entitlements.is_grace_period
+        status: entitlements.is_licensed
+          ? entitlements.in_grace_period
             ? "past_due"
             : "active"
           : "canceled",
-        current_period_end: entitlements.expires_at ?? null,
+        current_period_end: null,
         cancel_at_period_end: false,
         features: entitlements.features ?? {},
         limits: entitlements.limits ?? {},


### PR DESCRIPTION
## Summary

Step 5 of the license-svc migration (see dev-health-ops PR #366). All billing API calls now hit dev-health-ops instead of the standalone license-svc.

## Changes

- `getLicenseSvcUrl()` → `getBackendUrl()` using `BACKEND_URL` env var
- Endpoint paths updated to ops billing router:
  - `/api/checkout/session` → `/api/v1/billing/checkout`
  - `/api/portal/billing` → `/api/v1/billing/portal`
  - `/api/entitlements/{orgId}` → `/api/v1/billing/entitlements/{orgId}`
- Response field mapping adapted (ops returns `url`, `is_licensed`, `in_grace_period`)
- Removed `LICENSE_SVC_URL` from `.env.example`
- Removed stale license-svc comments
- Tests updated and passing (119/119)

## Depends On

- full-chaos/dev-health-ops#366 (billing module must be deployed first)