### PR TITLE
fix: resolve hydration mismatch in formatTimestamp

### DIFF
--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -9,7 +9,10 @@ export const compactFormatter = new Intl.NumberFormat("en-US", {
   notation: "compact",
   maximumFractionDigits: 1,
 });
-const timestampFormatter = new Intl.DateTimeFormat("en-US", {
+// Build timestamp strings manually via formatToParts to avoid hydration
+// mismatches — Node and browsers disagree on literal separators
+// (e.g. "Feb 8, 12:19 PM" vs "Feb 8 at 12:19 PM").
+const _tsParts = new Intl.DateTimeFormat("en-US", {
   month: "short",
   day: "numeric",
   hour: "numeric",
@@ -84,5 +87,7 @@ export const formatTimestamp = (value?: string | null) => {
   if (Number.isNaN(date.getTime())) {
     return "Unavailable";
   }
-  return timestampFormatter.format(date);
+  const parts = _tsParts.formatToParts(date);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+  return `${get("month")} ${get("day")}, ${get("hour")}:${get("minute")} ${get("dayPeriod")}`;
 };


### PR DESCRIPTION
## Summary

Fixes a React hydration mismatch error on the home page (CockpitClient timeline events).

## Root Cause

`Intl.DateTimeFormat.format()` produces different literal separators between Node.js and browsers:
- **Server (Node)**: `Feb 8, 12:19 PM` 
- **Client (browser)**: `Feb 8 at 12:19 PM`

This is a known ICU data divergence — Node.js and browsers ship different versions of the ICU locale data, causing the literal text between date parts to differ.

## Fix

Switch from `timestampFormatter.format(date)` to `_tsParts.formatToParts(date)` and manually assemble the string with consistent separators. This ensures identical output regardless of runtime.

## Affected areas

`formatTimestamp()` is used in 10 files across the app (CockpitClient, BackendBanner, DataStatusBanner, deployment/issue/PR detail pages, investment transforms, people page). All are now hydration-safe.

## Tests

119 vitest tests passing.