### PR TITLE
fix: handle stale session cookies in auth() without crashing

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,7 +6,8 @@ const authSecret = process.env.AUTH_SECRET
   || process.env.NEXTAUTH_SECRET 
   || "dev-secret-change-in-production"
 
-export const { handlers, auth, signIn, signOut } = NextAuth({
+const nextAuth = NextAuth({
+  trustHost: true,
   providers: [
     CredentialsProvider({
       name: "Credentials",
@@ -88,3 +89,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   },
   secret: authSecret,
 })
+
+export const { handlers, signIn, signOut } = nextAuth
+
+import type { Session } from "next-auth"
+
+export async function auth(): Promise<Session | null> {
+  try {
+    return await nextAuth.auth()
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

- Wraps the exported `auth()` function so it returns `null` instead of throwing `JWTSessionError` when encountering a stale or corrupt session cookie
- Enables `trustHost: true` to fix `UntrustedHost` error in local dev

## Why

Auth.js v5 throws `JWTSessionError` when it can't decode a session JWT (stale cookie, secret rotation, etc.). This crashed every page calling `auth()` — 11 call sites across the app. Rather than wrapping each in try/catch, the fix lives in the single exported `auth()` function: failed session decode → return `null` → user is treated as unauthenticated.

## Changes

`src/lib/auth.ts`:
- `NextAuth()` result stored in `nextAuth` (private)
- `handlers`, `signIn`, `signOut` re-exported directly
- `auth()` exported as a wrapper that catches errors and returns `null`
- Added `trustHost: true` to config