### PR TITLE
fix: pass form credentials to test-connection endpoint

### DIFF
--- a/src/app/admin/integrations/[provider]/IntegrationFormWrapper.tsx
+++ b/src/app/admin/integrations/[provider]/IntegrationFormWrapper.tsx
@@ -47,8 +47,15 @@ export function IntegrationFormWrapper({
     }
   };
 
-  const handleTestConnection = async (): Promise<boolean> => {
-    const result = await testConnection(provider, "default");
+  const handleTestConnection = async (formData: Record<string, FormDataEntryValue>): Promise<boolean> => {
+    const credentials: Record<string, unknown> = {};
+    Object.entries(formData).forEach(([key, value]) => {
+      if (!key.startsWith("config_")) {
+        credentials[key] = value;
+      }
+    });
+
+    const result = await testConnection(provider, "default", credentials);
 
     if (result.error) {
       throw new Error(result.error);

--- a/src/lib/admin/api.ts
+++ b/src/lib/admin/api.ts
@@ -140,10 +140,10 @@ export const adminApi = {
     delete: (provider: string, name: string, token?: string) =>
       request<void>(`/credentials/${provider}/${name}`, { method: "DELETE" }, token),
 
-    test: (provider: string, name: string = "default", token?: string) =>
+    test: (provider: string, name: string = "default", credentials?: Record<string, unknown>, token?: string) =>
       request<TestConnectionResponse>(
         "/credentials/test",
-        { method: "POST", body: JSON.stringify({ provider, name }) },
+        { method: "POST", body: JSON.stringify({ provider, name, credentials }) },
         token
       ),
   },

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -99,11 +99,12 @@ export async function createCredential(
 
 export async function testConnection(
   provider: string,
-  name = "default"
+  name = "default",
+  credentials?: Record<string, unknown>
 ): Promise<ActionResult<TestConnectionResponse>> {
   return withErrorHandling(async () => {
     const token = await getToken();
-    return adminApi.credentials.test(provider, name, token);
+    return adminApi.credentials.test(provider, name, credentials, token);
   });
 }
 

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -64,6 +64,7 @@ export interface IntegrationCredentialUpdate {
 export interface TestConnectionRequest {
   provider: string;
   name?: string;
+  credentials?: Record<string, unknown>;
 }
 
 export interface TestConnectionResponse {


### PR DESCRIPTION
## Summary
Fix credential status display and add page revalidation for integration management.

### Changes

**Commit 1: Pass form credentials to test-connection endpoint**
- IntegrationFormWrapper now sends form field values as inline credentials to test endpoint
- API client updated to accept and pass through credentials object

**Commit 2: Credential status display and page revalidation**
- getStatus() now returns connected for saved credentials with null test result instead of incorrectly showing not_configured
- Added revalidatePath calls after credential create, test, and delete so server components re-render with fresh data from the API

### Files Changed
- `src/lib/admin/types.ts` - Added credentials field to TestConnectionRequest
- `src/lib/admin/api.ts` - Updated test method signature to accept credentials
- `src/lib/admin/server.ts` - Pass-through credentials, added revalidatePath on mutations
- `src/app/admin/integrations/[provider]/IntegrationFormWrapper.tsx` - Extract and pass form credentials
- `src/app/admin/integrations/page.tsx` - Fixed getStatus fallback
- `src/app/admin/integrations/[provider]/page.tsx` - Fixed getStatus fallback