### PR TITLE
fix: use port 8001 for Playwright mock server to avoid Docker conflict

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,7 @@ const nextConfig = {
     : {
         pageExtensions: ["tsx", "ts", "jsx", "js"],
       }),
-  // API proxying is handled by middleware.ts at runtime (not baked at build time)
+  // API proxying is handled by proxy.ts at runtime (not baked at build time)
 };
 
 module.exports = nextConfig;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,9 +10,12 @@ export default defineConfig({
   webServer: [
     {
       command: "npx tsx ./tests/mocks/http-server.ts",
-      url: "http://127.0.0.1:8000/health",
+      url: "http://127.0.0.1:8001/health",
       reuseExistingServer: !process.env.CI,
       timeout: 30_000,
+      env: {
+        MOCK_SERVER_PORT: "8001",
+      },
     },
     {
       command: "npm run dev -- --hostname 127.0.0.1 --port 3001",
@@ -21,6 +24,7 @@ export default defineConfig({
       timeout: 120_000,
       env: {
         PLAYWRIGHT_TEST: "true",
+        BACKEND_URL: "http://127.0.0.1:8001",
       },
     },
   ],


### PR DESCRIPTION
Mock server port 8000 was shadowed by Docker API container. Moved to 8001.