### PR TITLE
feat(admin): sync configuration CRUD and status monitoring

### DIFF
--- a/src/app/admin/sync/[configId]/edit/page.tsx
+++ b/src/app/admin/sync/[configId]/edit/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { SyncConfigForm } from "@/components/admin/sync/SyncConfigForm";
+import { getSyncConfig, listCredentials } from "@/lib/admin/server";
+
+interface EditSyncConfigPageProps {
+  params: {
+    configId: string;
+  };
+}
+
+export default async function EditSyncConfigPage({ params }: EditSyncConfigPageProps) {
+  const [configResult, credentialsResult] = await Promise.all([
+    getSyncConfig(params.configId),
+    listCredentials(),
+  ]);
+
+  if (configResult.error || !configResult.data) {
+    notFound();
+  }
+
+  const config = configResult.data;
+  const credentials = credentialsResult.data || [];
+
+  return (
+    <div className="space-y-6">
+      <AdminHeader
+        title={`Edit ${config.name}`}
+        description="Update sync configuration settings."
+      />
+
+      <SyncConfigForm initialData={config} credentials={credentials} />
+    </div>
+  );
+}

--- a/src/app/admin/sync/[configId]/page.tsx
+++ b/src/app/admin/sync/[configId]/page.tsx
@@ -1,9 +1,10 @@
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { SyncStatusBadge } from "@/components/admin/sync/SyncStatusBadge";
-import { getSyncConfig } from "@/lib/admin/server";
-import { toSyncConfig } from "@/lib/sync-types";
-import Link from "next/link";
+import { SyncJobHistory } from "@/components/admin/sync/SyncJobHistory";
+import { SyncProgressBar } from "@/components/admin/sync/SyncProgressBar";
+import { getSyncConfig, getSyncJobs, triggerSync, getCurrentOrg } from "@/lib/admin/server";
 
 interface PageProps {
   params: Promise<{ configId: string }>;
@@ -11,14 +12,30 @@ interface PageProps {
 
 export default async function SyncConfigDetailPage({ params }: PageProps) {
   const { configId } = await params;
-  const result = await getSyncConfig(configId);
+  const [configResult, jobsResult, orgResult] = await Promise.all([
+    getSyncConfig(configId),
+    getSyncJobs(configId),
+    getCurrentOrg(),
+  ]);
 
-  if (result.error || !result.data) {
+  if (configResult.error || !configResult.data) {
     notFound();
   }
 
-  const config = toSyncConfig(result.data);
-  const apiConfig = result.data;
+  const config = configResult.data;
+  const jobs = jobsResult.data || [];
+  const orgId = orgResult.data?.id || "";
+
+  // Helper to trigger sync from server component (via form action)
+  async function triggerSyncAction() {
+    "use server";
+    await triggerSync(configId);
+  }
+
+  const getStatus = () => {
+    if (!config.last_sync_at) return "never";
+    return config.last_sync_success ? "success" : "failed";
+  };
 
   return (
     <div className="space-y-8">
@@ -26,14 +43,27 @@ export default async function SyncConfigDetailPage({ params }: PageProps) {
         <AdminHeader
           title={config.name}
           description={`Provider: ${config.provider}`}
-        />
-        <Link
-          href="/admin/sync"
-          className="text-sm font-medium text-(--ink-muted) hover:text-foreground"
         >
-          ← Back to List
-        </Link>
+          <div className="flex items-center gap-3">
+            <Link
+              href={`/admin/sync/${config.id}/edit`}
+              className="rounded-md bg-(--card-70) px-4 py-2 text-sm font-medium text-(--ink-muted) hover:bg-(--card-60) hover:text-foreground"
+            >
+              Edit Config
+            </Link>
+            <form action={triggerSyncAction}>
+              <button
+                type="submit"
+                className="rounded-md bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent-hover)"
+              >
+                Sync Now
+              </button>
+            </form>
+          </div>
+        </AdminHeader>
       </div>
+
+      <SyncProgressBar configId={config.id} provider={config.provider} orgId={orgId} />
 
       <div className="grid gap-6 md:grid-cols-3">
         <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
@@ -41,7 +71,7 @@ export default async function SyncConfigDetailPage({ params }: PageProps) {
             Current Status
           </h3>
           <div className="mt-2">
-            <SyncStatusBadge status={config.status} className="text-sm px-3 py-1" />
+            <SyncStatusBadge status={getStatus()} className="text-sm px-3 py-1" />
           </div>
         </div>
 
@@ -61,18 +91,18 @@ export default async function SyncConfigDetailPage({ params }: PageProps) {
             Active
           </h3>
           <p className="mt-2 text-lg font-medium text-foreground">
-            {apiConfig.is_active ? "Yes" : "No"}
+            {config.is_active ? "Yes" : "No"}
           </p>
         </div>
       </div>
 
-      {apiConfig.sync_targets.length > 0 && (
+      {config.sync_targets.length > 0 && (
         <div className="space-y-2">
           <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
             Sync Targets
           </h3>
           <div className="flex flex-wrap gap-2">
-            {apiConfig.sync_targets.map((target) => (
+            {config.sync_targets.map((target) => (
               <span
                 key={target}
                 className="rounded-full bg-(--card-70) px-3 py-1 text-xs font-medium text-foreground"
@@ -84,19 +114,15 @@ export default async function SyncConfigDetailPage({ params }: PageProps) {
         </div>
       )}
 
-      {apiConfig.last_sync_error && (
+      {config.last_sync_error && (
         <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500">
-          <span className="font-medium">Last sync error:</span> {apiConfig.last_sync_error}
+          <span className="font-medium">Last sync error:</span> {config.last_sync_error}
         </div>
       )}
 
       <div className="space-y-4">
         <h2 className="text-lg font-medium text-foreground">Job History</h2>
-        <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-8 text-center">
-          <p className="text-sm text-(--ink-muted)">
-            Job history is not yet available. Sync job tracking is coming soon.
-          </p>
-        </div>
+        <SyncJobHistory jobs={jobs} />
       </div>
     </div>
   );

--- a/src/app/admin/sync/new/page.tsx
+++ b/src/app/admin/sync/new/page.tsx
@@ -1,0 +1,19 @@
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { SyncConfigForm } from "@/components/admin/sync/SyncConfigForm";
+import { listCredentials } from "@/lib/admin/server";
+
+export default async function NewSyncConfigPage() {
+  const credentialsResult = await listCredentials();
+  const credentials = credentialsResult.data || [];
+
+  return (
+    <div className="space-y-6">
+      <AdminHeader
+        title="New Sync Configuration"
+        description="Configure a new data synchronization source."
+      />
+
+      <SyncConfigForm credentials={credentials} />
+    </div>
+  );
+}

--- a/src/app/admin/sync/page.tsx
+++ b/src/app/admin/sync/page.tsx
@@ -1,18 +1,25 @@
+import Link from "next/link";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { SyncConfigCard } from "@/components/admin/sync/SyncConfigCard";
 import { listSyncConfigs } from "@/lib/admin/server";
-import { toSyncConfig } from "@/lib/sync-types";
 
 export default async function SyncStatusPage() {
   const result = await listSyncConfigs();
-  const configs = (result.data ?? []).map(toSyncConfig);
+  const configs = result.data ?? [];
 
   return (
     <div className="space-y-8">
       <AdminHeader
         title="Sync Status"
         description="Monitor and manage data synchronization jobs."
-      />
+      >
+        <Link
+          href="/admin/sync/new"
+          className="rounded-md bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent-hover)"
+        >
+          New Config
+        </Link>
+      </AdminHeader>
 
       {result.error && (
         <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-red-500">
@@ -22,7 +29,7 @@ export default async function SyncStatusPage() {
 
       {configs.length === 0 && !result.error && (
         <div className="rounded-lg border border-(--card-stroke) bg-(--card-80) p-8 text-center text-(--ink-muted)">
-          No sync configurations found. Configure integrations first.
+          No sync configurations found. Create a new configuration to get started.
         </div>
       )}
 

--- a/src/components/admin/sync/SyncConfigCard.tsx
+++ b/src/components/admin/sync/SyncConfigCard.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
 import { toast } from "sonner";
-import { SyncConfig } from "@/lib/sync-types";
+import { SyncConfig } from "@/lib/admin/types";
+import { triggerSync, toggleSyncActive, deleteSyncConfig } from "@/lib/admin/server";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 
 interface SyncConfigCardProps {
@@ -10,10 +13,49 @@ interface SyncConfigCardProps {
 }
 
 export function SyncConfigCard({ config }: SyncConfigCardProps) {
-   const handleSync = (e: React.MouseEvent) => {
-     e.preventDefault();
-     toast.success(`Sync triggered for ${config.name}`);
-   };
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const handleTrigger = async () => {
+    startTransition(async () => {
+      const result = await triggerSync(config.id);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("Sync triggered successfully");
+        router.refresh();
+      }
+    });
+  };
+
+  const handleToggleActive = async () => {
+    startTransition(async () => {
+      const result = await toggleSyncActive(config.id, !config.is_active);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        router.refresh();
+      }
+    });
+  };
+
+  const handleDelete = async () => {
+    startTransition(async () => {
+      const result = await deleteSyncConfig(config.id);
+      if (result.error) {
+        toast.error(result.error);
+        setShowDeleteConfirm(false);
+      } else {
+        router.refresh();
+      }
+    });
+  };
+
+  const getStatus = () => {
+    if (!config.last_sync_at) return "never";
+    return config.last_sync_success ? "success" : "failed";
+  };
 
   return (
     <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6 transition-all hover:border-(--card-stroke-hover)">
@@ -24,24 +66,75 @@ export function SyncConfigCard({ config }: SyncConfigCardProps) {
               {config.name}
             </Link>
           </h3>
-          <p className="mt-1 text-sm text-(--ink-muted) capitalize">
-            Provider: {config.provider}
-          </p>
+          <div className="mt-1 flex items-center gap-2 text-sm text-(--ink-muted)">
+            <span className="capitalize">{config.provider}</span>
+            <span>•</span>
+            <span className={config.is_active ? "text-green-500" : "text-(--ink-muted)"}>
+              {config.is_active ? "Active" : "Paused"}
+            </span>
+          </div>
         </div>
-        <SyncStatusBadge status={config.status} />
+        <SyncStatusBadge status={getStatus()} />
       </div>
 
       <div className="mt-6 flex items-center justify-between border-t border-(--card-stroke) pt-4">
         <div className="text-xs text-(--ink-muted)">
-          Last sync: {config.last_sync_at ? new Date(config.last_sync_at).toLocaleString() : "Never"}
+          Last sync:{" "}
+          {config.last_sync_at ? new Date(config.last_sync_at).toLocaleString() : "Never"}
         </div>
-         <button
-           type="button"
-           onClick={handleSync}
-           className="rounded-md bg-(--accent) px-3 py-1.5 text-xs font-medium text-white hover:bg-(--accent-hover) focus:outline-none focus:ring-2 focus:ring-(--accent) focus:ring-offset-2"
-         >
-           Sync Now
-         </button>
+        
+        <div className="flex items-center gap-2">
+          {showDeleteConfirm ? (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-red-500">Are you sure?</span>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={isPending}
+                className="rounded-md bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                Yes, Delete
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(false)}
+                disabled={isPending}
+                className="rounded-md bg-(--card-70) px-2 py-1 text-xs font-medium text-(--ink-muted) hover:bg-(--card-60)"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={handleToggleActive}
+                disabled={isPending}
+                className="rounded-md bg-(--card-70) px-3 py-1.5 text-xs font-medium text-(--ink-muted) hover:bg-(--card-60) disabled:opacity-50"
+              >
+                {config.is_active ? "Pause" : "Resume"}
+              </button>
+              
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={isPending}
+                className="rounded-md bg-(--card-70) px-3 py-1.5 text-xs font-medium text-red-500 hover:bg-red-500/10 disabled:opacity-50"
+              >
+                Delete
+              </button>
+
+              <button
+                type="button"
+                onClick={handleTrigger}
+                disabled={isPending}
+                className="rounded-md bg-(--accent) px-3 py-1.5 text-xs font-medium text-white hover:bg-(--accent-hover) focus:outline-none focus:ring-2 focus:ring-(--accent) focus:ring-offset-2 disabled:opacity-50"
+              >
+                {isPending ? "Syncing..." : "Sync Now"}
+              </button>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import React, { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { SyncConfig, IntegrationCredential, PROVIDERS, PROVIDER_LABELS } from "@/lib/admin/types";
+import { createSyncConfig, updateSyncConfig } from "@/lib/admin/server";
+
+type SyncConfigFormProps = {
+  initialData?: SyncConfig;
+  credentials: IntegrationCredential[];
+  onSuccess?: () => void;
+};
+
+const SYNC_TARGETS = [
+  { id: "git", label: "Git Data (Commits, Branches)" },
+  { id: "prs", label: "Pull Requests" },
+  { id: "cicd", label: "CI/CD Pipelines" },
+  { id: "deployments", label: "Deployments" },
+  { id: "incidents", label: "Incidents" },
+  { id: "work-items", label: "Work Items (Issues, Tickets)" },
+];
+
+export function SyncConfigForm({ initialData, credentials, onSuccess }: SyncConfigFormProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  const [formData, setFormData] = useState({
+    name: initialData?.name || "",
+    provider: initialData?.provider || "github",
+    credential_id: initialData?.credential_id || "",
+    sync_targets: initialData?.sync_targets || [],
+    is_active: initialData?.is_active ?? true,
+  });
+
+  const filteredCredentials = credentials.filter((c) => c.provider === formData.provider);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value, type } = e.target;
+    
+    if (type === "checkbox" && name === "is_active") {
+      setFormData((prev) => ({ ...prev, is_active: (e.target as HTMLInputElement).checked }));
+    } else {
+      setFormData((prev) => ({ ...prev, [name]: value }));
+    }
+  };
+
+  const handleTargetChange = (targetId: string, checked: boolean) => {
+    setFormData((prev) => {
+      const newTargets = checked
+        ? [...prev.sync_targets, targetId]
+        : prev.sync_targets.filter((t) => t !== targetId);
+      return { ...prev, sync_targets: newTargets };
+    });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage(null);
+
+    startTransition(async () => {
+      let result: { error?: string } | undefined;
+      if (initialData) {
+        result = await updateSyncConfig(initialData.id, {
+          sync_targets: formData.sync_targets,
+          is_active: formData.is_active,
+          // Note: provider and name are usually not editable after creation in some systems, 
+          // but API allows updating sync_options. For now we focus on targets and active state for updates
+          // as per the update type definition which only includes sync_targets, sync_options, is_active.
+        });
+      } else {
+        result = await createSyncConfig({
+          name: formData.name,
+          provider: formData.provider,
+          credential_id: formData.credential_id || null,
+          sync_targets: formData.sync_targets,
+        });
+      }
+
+      if (result?.error) {
+        setMessage({ type: "error", text: result.error });
+      } else {
+        setMessage({ type: "success", text: initialData ? "Config updated" : "Config created" });
+        if (onSuccess) {
+          onSuccess();
+        } else {
+          router.push("/admin/sync");
+          router.refresh();
+        }
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-2xl space-y-6">
+      <div className="space-y-6 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+        
+        {/* Name */}
+        <div>
+          <label htmlFor="name" className="mb-1.5 block text-sm font-medium">
+            Configuration Name
+          </label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+            disabled={!!initialData} // Name often immutable or just disabled for simplicity in edit
+            required
+            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
+            placeholder="e.g., GitHub Main Org Sync"
+          />
+        </div>
+
+        {/* Provider */}
+        <div>
+          <label htmlFor="provider" className="mb-1.5 block text-sm font-medium">
+            Provider
+          </label>
+          <select
+            id="provider"
+            name="provider"
+            value={formData.provider}
+            onChange={handleChange}
+            disabled={!!initialData}
+            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
+          >
+            {PROVIDERS.map((p) => (
+              <option key={p} value={p}>
+                {PROVIDER_LABELS[p]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Credential */}
+        <div>
+          <label htmlFor="credential_id" className="mb-1.5 block text-sm font-medium">
+            Credential
+          </label>
+          <select
+            id="credential_id"
+            name="credential_id"
+            value={formData.credential_id}
+            onChange={handleChange}
+            disabled={!!initialData} // Changing credential might require re-auth flow, keep simple for now
+            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
+          >
+            <option value="">Select a credential...</option>
+            {filteredCredentials.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          {filteredCredentials.length === 0 && !initialData && (
+            <p className="mt-1 text-xs text-amber-500">
+              No credentials found for this provider. <Link href="/admin/integrations" className="underline">Add one first</Link>.
+            </p>
+          )}
+        </div>
+
+        {/* Sync Targets */}
+        <div>
+          <span className="mb-2 block text-sm font-medium">Sync Targets</span>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {SYNC_TARGETS.map((target) => (
+              <label
+                key={target.id}
+                className="flex items-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 hover:bg-(--card-60)"
+              >
+                <input
+                  type="checkbox"
+                  checked={formData.sync_targets.includes(target.id)}
+                  onChange={(e) => handleTargetChange(target.id, e.target.checked)}
+                  className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
+                />
+                <span className="text-sm">{target.label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Active Toggle */}
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="is_active"
+            name="is_active"
+            checked={formData.is_active}
+            onChange={handleChange}
+            className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
+          />
+          <label htmlFor="is_active" className="text-sm font-medium">
+            Enable automatic sync schedule
+          </label>
+        </div>
+
+        {/* Feedback Message */}
+        {message && (
+          <div
+            className={`rounded-md p-3 text-sm ${
+              message.type === "success"
+                ? "bg-green-500/10 text-green-500 border border-green-500/20"
+                : "bg-red-500/10 text-red-500 border border-red-500/20"
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-4">
+        <Link
+          href="/admin/sync"
+          className="rounded-lg px-4 py-2 text-sm font-medium text-(--ink-muted) hover:text-foreground"
+        >
+          Cancel
+        </Link>
+        <button
+          type="button"
+          disabled={isPending}
+          className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90 disabled:opacity-50"
+        >
+          {isPending ? "Saving..." : initialData ? "Update Configuration" : "Create Configuration"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -1,4 +1,4 @@
-import { SyncJob } from "@/lib/sync-types";
+import { SyncJob } from "@/lib/admin/types";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 
 interface SyncJobHistoryProps {
@@ -13,6 +13,21 @@ export function SyncJobHistory({ jobs }: SyncJobHistoryProps) {
       </div>
     );
   }
+
+  const getBadgeStatus = (status: SyncJob["status"]) => {
+    switch (status) {
+      case "SUCCESS":
+        return "success";
+      case "FAILED":
+        return "failed";
+      case "RUNNING":
+        return "running";
+      case "PENDING":
+        return "idle";
+      default:
+        return "never";
+    }
+  };
 
   return (
     <div className="overflow-hidden rounded-xl border border-(--card-stroke) bg-(--card-80)">
@@ -32,20 +47,22 @@ export function SyncJobHistory({ jobs }: SyncJobHistoryProps) {
               Items Synced
             </th>
             <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider">
-              Errors
+              Error
             </th>
           </tr>
         </thead>
         <tbody className="divide-y divide-(--card-stroke) bg-(--card-80)">
           {jobs.map((job) => {
-            const duration = job.completed_at
+            const duration = job.duration_seconds
+              ? `${Math.round(job.duration_seconds)}s`
+              : job.completed_at
               ? Math.round((new Date(job.completed_at).getTime() - new Date(job.started_at).getTime()) / 1000) + "s"
               : "-";
 
             return (
               <tr key={job.id}>
                 <td className="px-6 py-4 whitespace-nowrap">
-                  <SyncStatusBadge status={job.status} />
+                  <SyncStatusBadge status={getBadgeStatus(job.status)} />
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
                   {new Date(job.started_at).toLocaleString()}
@@ -57,12 +74,10 @@ export function SyncJobHistory({ jobs }: SyncJobHistoryProps) {
                   {job.items_synced}
                 </td>
                 <td className="px-6 py-4 text-sm text-red-500">
-                  {job.errors.length > 0 ? (
-                    <ul className="list-disc pl-4">
-                      {job.errors.map((error, i) => (
-                        <li key={i}>{error}</li>
-                      ))}
-                    </ul>
+                  {job.error ? (
+                    <span title={job.error} className="line-clamp-2">
+                      {job.error}
+                    </span>
                   ) : (
                     <span className="text-(--ink-muted)">-</span>
                   )}

--- a/src/components/admin/sync/SyncProgressBar.tsx
+++ b/src/components/admin/sync/SyncProgressBar.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useSyncProgress } from "@/lib/graphql/hooks/useSubscription";
+import { useEffect, useState } from "react";
+
+interface SyncProgressBarProps {
+  configId: string;
+  provider: string;
+  orgId: string;
+}
+
+export function SyncProgressBar({ provider, orgId }: SyncProgressBarProps) {
+  const [progress, setProgress] = useState<{
+    itemsProcessed: number;
+    itemsTotal: number;
+    message?: string;
+    status: string;
+  } | null>(null);
+
+  useSyncProgress({
+    orgId,
+    onUpdate: (data) => {
+      // Filter updates for this provider
+      // Note: The subscription currently returns updates by provider, not configId.
+      // This assumes one active sync per provider per org, which is a reasonable simplification for now.
+      if (data.provider === provider) {
+        setProgress({
+          itemsProcessed: data.itemsProcessed,
+          itemsTotal: data.itemsTotal,
+          message: data.message,
+          status: data.status,
+        });
+      }
+    },
+  });
+
+  // Reset progress when status changes to something terminal, but keep showing it for a moment
+  useEffect(() => {
+    if (progress?.status === "SUCCESS" || progress?.status === "FAILED") {
+      const timer = setTimeout(() => {
+        setProgress(null);
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [progress?.status]);
+
+  if (!progress || progress.status === "IDLE" || progress.status === "PENDING") {
+    return null;
+  }
+
+  const percentage =
+    progress.itemsTotal > 0
+      ? Math.min(100, Math.round((progress.itemsProcessed / progress.itemsTotal) * 100))
+      : 0;
+
+  return (
+    <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+      <div className="mb-2 flex items-center justify-between text-sm">
+        <span className="font-medium text-foreground">
+          {progress.status === "RUNNING" ? "Syncing..." : progress.status}
+        </span>
+        <span className="text-(--ink-muted)">
+          {progress.itemsProcessed} / {progress.itemsTotal} ({percentage}%)
+        </span>
+      </div>
+      
+      <div className="h-2 w-full overflow-hidden rounded-full bg-(--card-70)">
+        <div
+          className="h-full bg-(--accent) transition-all duration-500 ease-out"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+      
+      {progress.message && (
+        <p className="mt-2 text-xs text-(--ink-muted)">{progress.message}</p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/admin/api.ts
+++ b/src/lib/admin/api.ts
@@ -11,6 +11,7 @@ import type {
   SyncConfig,
   SyncConfigCreate,
   SyncConfigUpdate,
+  SyncJob,
   IdentityMapping,
   IdentityMappingCreate,
   IdentityMappingUpdate,
@@ -152,6 +153,9 @@ export const adminApi = {
     list: (token?: string) =>
       request<SyncConfig[]>("/sync-configs", {}, token),
 
+    get: (id: string, token?: string) =>
+      request<SyncConfig>(`/sync-configs/${id}`, {}, token),
+
     create: (data: SyncConfigCreate, token?: string) =>
       request<SyncConfig>(
         "/sync-configs",
@@ -168,6 +172,12 @@ export const adminApi = {
 
     delete: (id: string, token?: string) =>
       request<void>(`/sync-configs/${id}`, { method: "DELETE" }, token),
+
+    trigger: (id: string, token?: string) =>
+      request<void>(`/sync-configs/${id}/trigger`, { method: "POST" }, token),
+
+    jobs: (id: string, token?: string) =>
+      request<SyncJob[]>(`/sync-configs/${id}/jobs`, {}, token),
   },
 
   identities: {

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -12,6 +12,8 @@ import type {
   TestConnectionResponse,
   SyncConfig,
   SyncConfigCreate,
+  SyncConfigUpdate,
+  SyncJob,
   IdentityMapping,
   IdentityMappingCreate,
   IdentityMappingUpdate,
@@ -152,6 +154,52 @@ export async function getSyncConfig(id: string): Promise<ActionResult<SyncConfig
     }
     return config;
   });
+}
+
+export async function updateSyncConfig(
+  id: string,
+  data: SyncConfigUpdate
+): Promise<ActionResult<SyncConfig>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    const result = await adminApi.syncConfigs.update(id, data, token);
+    revalidatePath("/admin/sync");
+    revalidatePath(`/admin/sync/${id}`);
+    return result;
+  });
+}
+
+export async function deleteSyncConfig(id: string): Promise<ActionResult<void>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    const result = await adminApi.syncConfigs.delete(id, token);
+    revalidatePath("/admin/sync");
+    return result;
+  });
+}
+
+export async function triggerSync(id: string): Promise<ActionResult<void>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    const result = await adminApi.syncConfigs.trigger(id, token);
+    revalidatePath("/admin/sync");
+    revalidatePath(`/admin/sync/${id}`);
+    return result;
+  });
+}
+
+export async function getSyncJobs(id: string): Promise<ActionResult<SyncJob[]>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    return adminApi.syncConfigs.jobs(id, token);
+  });
+}
+
+export async function toggleSyncActive(
+  id: string,
+  isActive: boolean
+): Promise<ActionResult<SyncConfig>> {
+  return updateSyncConfig(id, { is_active: isActive });
 }
 
 export async function listIdentities(): Promise<ActionResult<IdentityMapping[]>> {

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -90,6 +90,17 @@ export interface SyncConfig {
   updated_at: string;
 }
 
+export interface SyncJob {
+  id: string;
+  config_id: string;
+  status: "PENDING" | "RUNNING" | "SUCCESS" | "FAILED";
+  started_at: string;
+  completed_at: string | null;
+  duration_seconds: number | null;
+  items_synced: number;
+  error?: string;
+}
+
 export interface SyncConfigCreate {
   name: string;
   provider: string;


### PR DESCRIPTION
## Summary

Implements full sync configuration management and status monitoring UX for the enterprise admin panel.

**Closes #143, closes #144**

## Changes

### New Pages
- **`/admin/sync/new`** — Create new sync configuration (provider select, credential linking, sync target checkboxes)
- **`/admin/sync/[configId]/edit`** — Edit existing sync configuration
- **`/admin/sync/[configId]`** — Detail view with job history table and real-time progress bar

### Enhanced Components
- **`SyncConfigCard`** — Replaced `alert()` stubs with real server actions: trigger sync, pause/resume toggle, delete with confirmation, loading states
- **`SyncJobHistory`** — Typed `SyncJob` model with proper status→badge color mapping
- **`SyncConfigForm`** (new) — Reusable create/edit form component with provider selection, credential linking, and target configuration
- **`SyncProgressBar`** (new) — Real-time progress bar using `useSyncProgress` GraphQL subscription hook

### API Layer
- `adminApi.syncConfigs` — Added `get()`, `trigger()`, `jobs()` methods
- Server actions — Added `triggerSync()`, `getSyncJobs()`, `toggleSyncActive()`, `deleteSyncConfig()`, `updateSyncConfig()`
- `SyncJob` type — New interface in `admin/types.ts`

## Backend Contract Assumptions

Existing endpoints (confirmed):
- `GET/POST /api/v1/admin/sync-configs` — list/create
- `PATCH/DELETE /api/v1/admin/sync-configs/{id}` — update/delete

Assumed endpoints (may need backend work):
- `POST /api/v1/admin/sync-configs/{id}/trigger` — manual sync trigger
- `GET /api/v1/admin/sync-configs/{id}/jobs` — job history

## Verification
- [x] `tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [ ] Vitest — pre-existing rollup native module issue (not from this PR)
- [ ] Playwright e2e — not yet run