### PR TITLE
feat: add toast notifications (sonner) and migrate inline messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "next-auth": "^5.0.0-beta.30",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "sonner": "^2.0.7",
         "urql": "^5.0.1",
         "webapp": ".",
         "zod": "^4.3.6"
@@ -8519,6 +8520,16 @@
       "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.2.tgz",
       "integrity": "sha512-2NCmWxY7A9pYKGXNBfteo4hy14gWu47rg5692peVMst6lQLPKrVjhY+UTEsPI5ceFRJSl3gVgMYaUi/hKuaiKw==",
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next-auth": "^5.0.0-beta.30",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "sonner": "^2.0.7",
     "urql": "^5.0.1",
     "webapp": ".",
     "zod": "^4.3.6"

--- a/src/app/admin/identities/[id]/edit/EditIdentityFormWrapper.tsx
+++ b/src/app/admin/identities/[id]/edit/EditIdentityFormWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { IdentityForm } from "@/components/admin/identities/IdentityForm";
 import { Identity } from "@/components/admin/identities/IdentityTable";
 import { Team } from "@/components/admin/teams/TeamTable";
@@ -14,9 +15,8 @@ type EditIdentityFormWrapperProps = {
 };
 
 export function EditIdentityFormWrapper({ identity, teams }: EditIdentityFormWrapperProps) {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+   const router = useRouter();
+   const [isLoading, setIsLoading] = useState(false);
 
   const initialData: Identity = {
     canonical_id: identity.canonical_id,
@@ -26,42 +26,34 @@ export function EditIdentityFormWrapper({ identity, teams }: EditIdentityFormWra
     provider_identities: identity.provider_identities,
   };
 
-  const handleSubmit = async (data: Identity) => {
-    setIsLoading(true);
-    setError(null);
+   const handleSubmit = async (data: Identity) => {
+     setIsLoading(true);
 
-    const result = await updateIdentity(identity.id, {
-      display_name: data.display_name || undefined,
-      email: data.email || undefined,
-      provider_identities: data.provider_identities,
-      team_ids: data.team_ids,
-    });
+     const result = await updateIdentity(identity.id, {
+       display_name: data.display_name || undefined,
+       email: data.email || undefined,
+       provider_identities: data.provider_identities,
+       team_ids: data.team_ids,
+     });
 
-    setIsLoading(false);
+     setIsLoading(false);
 
-    if (result.error) {
-      setError(result.error);
-      return;
-    }
+     if (result.error) {
+       toast.error(result.error);
+       return;
+     }
 
-    router.push("/admin/identities");
-    router.refresh();
-  };
+     router.push("/admin/identities");
+     router.refresh();
+   };
 
-  return (
-    <>
-      {error && (
-        <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500">
-          {error}
-        </div>
-      )}
-      <IdentityForm
-        initialData={initialData}
-        teams={teams}
-        onSubmit={handleSubmit}
-        isEditing
-        isLoading={isLoading}
-      />
-    </>
-  );
-}
+   return (
+     <IdentityForm
+       initialData={initialData}
+       teams={teams}
+       onSubmit={handleSubmit}
+       isEditing
+       isLoading={isLoading}
+     />
+   );
+ }

--- a/src/app/admin/identities/new/page.tsx
+++ b/src/app/admin/identities/new/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { IdentityForm } from "@/components/admin/identities/IdentityForm";
 import { Identity } from "@/components/admin/identities/IdentityTable";
@@ -9,11 +10,10 @@ import { Team } from "@/components/admin/teams/TeamTable";
 import { createIdentity, listTeams } from "@/lib/admin/server";
 
 export default function NewIdentityPage() {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [teams, setTeams] = useState<Team[]>([]);
-  const [teamsLoading, setTeamsLoading] = useState(true);
+   const router = useRouter();
+   const [isLoading, setIsLoading] = useState(false);
+   const [teams, setTeams] = useState<Team[]>([]);
+   const [teamsLoading, setTeamsLoading] = useState(true);
 
   useEffect(() => {
     listTeams().then((result) => {
@@ -32,27 +32,26 @@ export default function NewIdentityPage() {
     });
   }, []);
 
-  const handleSubmit = async (data: Identity) => {
-    setIsLoading(true);
-    setError(null);
+   const handleSubmit = async (data: Identity) => {
+     setIsLoading(true);
 
-    const result = await createIdentity({
-      canonical_id: data.canonical_id,
-      display_name: data.display_name || undefined,
-      email: data.email || undefined,
-      provider_identities: data.provider_identities,
-      team_ids: data.team_ids,
-    });
+     const result = await createIdentity({
+       canonical_id: data.canonical_id,
+       display_name: data.display_name || undefined,
+       email: data.email || undefined,
+       provider_identities: data.provider_identities,
+       team_ids: data.team_ids,
+     });
 
-    setIsLoading(false);
+     setIsLoading(false);
 
-    if (result.error) {
-      setError(result.error);
-      return;
-    }
+     if (result.error) {
+       toast.error(result.error);
+       return;
+     }
 
-    router.push("/admin/identities");
-  };
+     router.push("/admin/identities");
+   };
 
   if (teamsLoading) {
     return (
@@ -66,18 +65,13 @@ export default function NewIdentityPage() {
     );
   }
 
-  return (
-    <div>
-      <AdminHeader
-        title="Add Identity"
-        description="Create a new identity and map provider accounts."
-      />
-      {error && (
-        <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500">
-          {error}
-        </div>
-      )}
-      <IdentityForm teams={teams} onSubmit={handleSubmit} isLoading={isLoading} />
-    </div>
-  );
-}
+   return (
+     <div>
+       <AdminHeader
+         title="Add Identity"
+         description="Create a new identity and map provider accounts."
+       />
+       <IdentityForm teams={teams} onSubmit={handleSubmit} isLoading={isLoading} />
+     </div>
+   );
+ }

--- a/src/app/admin/teams/[id]/edit/EditTeamFormWrapper.tsx
+++ b/src/app/admin/teams/[id]/edit/EditTeamFormWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { TeamForm } from "@/components/admin/teams/TeamForm";
 import { Team } from "@/components/admin/teams/TeamTable";
 import { updateTeam } from "@/lib/admin/server";
@@ -12,9 +13,8 @@ type EditTeamFormWrapperProps = {
 };
 
 export function EditTeamFormWrapper({ team }: EditTeamFormWrapperProps) {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+   const router = useRouter();
+   const [isLoading, setIsLoading] = useState(false);
 
   const initialData: Team = {
     team_id: team.team_id,
@@ -24,36 +24,28 @@ export function EditTeamFormWrapper({ team }: EditTeamFormWrapperProps) {
     project_keys: team.project_keys,
   };
 
-  const handleSubmit = async (data: Team) => {
-    setIsLoading(true);
-    setError(null);
+   const handleSubmit = async (data: Team) => {
+     setIsLoading(true);
 
-    const result = await updateTeam(team.id, {
-      name: data.name,
-      description: data.description || undefined,
-      repo_patterns: data.repo_patterns,
-      project_keys: data.project_keys,
-    });
+     const result = await updateTeam(team.id, {
+       name: data.name,
+       description: data.description || undefined,
+       repo_patterns: data.repo_patterns,
+       project_keys: data.project_keys,
+     });
 
-    setIsLoading(false);
+     setIsLoading(false);
 
-    if (result.error) {
-      setError(result.error);
-      return;
-    }
+     if (result.error) {
+       toast.error(result.error);
+       return;
+     }
 
-    router.push("/admin/teams");
-    router.refresh();
-  };
+     router.push("/admin/teams");
+     router.refresh();
+   };
 
-  return (
-    <>
-      {error && (
-        <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500">
-          {error}
-        </div>
-      )}
-      <TeamForm initialData={initialData} onSubmit={handleSubmit} isEditing isLoading={isLoading} />
-    </>
-  );
-}
+   return (
+     <TeamForm initialData={initialData} onSubmit={handleSubmit} isEditing isLoading={isLoading} />
+   );
+ }

--- a/src/app/admin/teams/new/page.tsx
+++ b/src/app/admin/teams/new/page.tsx
@@ -2,50 +2,44 @@
 
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { TeamForm } from "@/components/admin/teams/TeamForm";
 import { Team } from "@/components/admin/teams/TeamTable";
 import { createTeam } from "@/lib/admin/server";
 
 export default function NewTeamPage() {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+   const router = useRouter();
+   const [isLoading, setIsLoading] = useState(false);
 
-  const handleSubmit = async (data: Team) => {
-    setIsLoading(true);
-    setError(null);
+   const handleSubmit = async (data: Team) => {
+     setIsLoading(true);
 
-    const result = await createTeam({
-      team_id: data.team_id,
-      name: data.name,
-      description: data.description || undefined,
-      repo_patterns: data.repo_patterns,
-      project_keys: data.project_keys,
-    });
+     const result = await createTeam({
+       team_id: data.team_id,
+       name: data.name,
+       description: data.description || undefined,
+       repo_patterns: data.repo_patterns,
+       project_keys: data.project_keys,
+     });
 
-    setIsLoading(false);
+     setIsLoading(false);
 
-    if (result.error) {
-      setError(result.error);
-      return;
-    }
+     if (result.error) {
+       toast.error(result.error);
+       return;
+     }
 
-    router.push("/admin/teams");
-  };
+     router.push("/admin/teams");
+   };
 
-  return (
-    <div>
-      <AdminHeader
-        title="Add Team"
-        description="Create a new team and define its resource ownership."
-      />
-      {error && (
-        <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500">
-          {error}
-        </div>
-      )}
-      <TeamForm onSubmit={handleSubmit} isLoading={isLoading} />
-    </div>
-  );
-}
+   return (
+     <div>
+       <AdminHeader
+         title="Add Team"
+         description="Create a new team and define its resource ownership."
+       />
+       <TeamForm onSubmit={handleSubmit} isLoading={isLoading} />
+     </div>
+   );
+ }

--- a/src/app/admin/users/[id]/DeleteUserButton.tsx
+++ b/src/app/admin/users/[id]/DeleteUserButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { deleteUser } from "@/lib/admin/server";
 
 type DeleteUserButtonProps = {
@@ -10,58 +11,58 @@ type DeleteUserButtonProps = {
 };
 
 export function DeleteUserButton({ userId, userEmail }: DeleteUserButtonProps) {
-  const router = useRouter();
-  const [isConfirming, setIsConfirming] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+   const router = useRouter();
+   const [isConfirming, setIsConfirming] = useState(false);
+   const [isDeleting, setIsDeleting] = useState(false);
 
-  const handleDelete = async () => {
-    setIsDeleting(true);
-    setError(null);
+   const handleDelete = async () => {
+     setIsDeleting(true);
 
-    const result = await deleteUser(userId);
+     const result = await deleteUser(userId);
 
-    if (result.error) {
-      setError(result.error);
-      setIsDeleting(false);
-      return;
-    }
+     if (result.error) {
+       toast.error(result.error);
+       setIsDeleting(false);
+       return;
+     }
 
-    router.push("/admin/users");
-    router.refresh();
-  };
+     router.push("/admin/users");
+     router.refresh();
+   };
 
-  if (isConfirming) {
-    return (
-      <div className="space-y-2">
-        <p className="text-sm text-red-500">Delete {userEmail}?</p>
-        {error && <p className="text-xs text-red-500">{error}</p>}
-        <div className="flex gap-2">
-          <button
-            onClick={handleDelete}
-            disabled={isDeleting}
-            className="flex-1 rounded-lg bg-red-500 px-3 py-2 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
-          >
-            {isDeleting ? "Deleting..." : "Confirm"}
-          </button>
-          <button
-            onClick={() => setIsConfirming(false)}
-            disabled={isDeleting}
-            className="flex-1 rounded-lg border border-(--card-stroke) px-3 py-2 text-sm font-medium text-(--ink-muted) hover:bg-(--card-70)"
-          >
-            Cancel
-          </button>
-        </div>
-      </div>
-    );
-  }
+   if (isConfirming) {
+     return (
+       <div className="space-y-2">
+         <p className="text-sm text-red-500">Delete {userEmail}?</p>
+         <div className="flex gap-2">
+           <button
+             type="button"
+             onClick={handleDelete}
+             disabled={isDeleting}
+             className="flex-1 rounded-lg bg-red-500 px-3 py-2 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+           >
+             {isDeleting ? "Deleting..." : "Confirm"}
+           </button>
+           <button
+             type="button"
+             onClick={() => setIsConfirming(false)}
+             disabled={isDeleting}
+             className="flex-1 rounded-lg border border-(--card-stroke) px-3 py-2 text-sm font-medium text-(--ink-muted) hover:bg-(--card-70)"
+           >
+             Cancel
+           </button>
+         </div>
+       </div>
+     );
+   }
 
-  return (
-    <button
-      onClick={() => setIsConfirming(true)}
-      className="w-full rounded-lg border border-red-500/20 px-4 py-2 text-sm font-medium text-red-500 hover:bg-red-500/10 text-left"
-    >
-      Delete User
-    </button>
-  );
+   return (
+     <button
+       type="button"
+       onClick={() => setIsConfirming(true)}
+       className="w-full rounded-lg border border-red-500/20 px-4 py-2 text-sm font-medium text-red-500 hover:bg-red-500/10 text-left"
+     >
+       Delete User
+     </button>
+   );
 }

--- a/src/app/admin/users/[id]/edit/EditUserFormWrapper.tsx
+++ b/src/app/admin/users/[id]/edit/EditUserFormWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { UserForm, UserFormData } from "@/components/admin/users/UserForm";
 import { updateUser } from "@/lib/admin/server";
 import type { User } from "@/lib/admin/types";
@@ -11,43 +12,40 @@ type EditUserFormWrapperProps = {
 };
 
 export function EditUserFormWrapper({ user }: EditUserFormWrapperProps) {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+   const router = useRouter();
+   const [isLoading, setIsLoading] = useState(false);
 
-  const handleSubmit = async (data: UserFormData) => {
-    setIsLoading(true);
-    setError(null);
+   const handleSubmit = async (data: UserFormData) => {
+     setIsLoading(true);
 
-    const result = await updateUser(user.id, {
-      full_name: data.full_name || undefined,
-      username: data.username || undefined,
-      is_active: data.is_active,
-    });
+     const result = await updateUser(user.id, {
+       full_name: data.full_name || undefined,
+       username: data.username || undefined,
+       is_active: data.is_active,
+     });
 
-    setIsLoading(false);
+     setIsLoading(false);
 
-    if (result.error) {
-      setError(result.error);
-      return;
-    }
+     if (result.error) {
+       toast.error(result.error);
+       return;
+     }
 
-    router.push(`/admin/users/${user.id}`);
-    router.refresh();
-  };
+     router.push(`/admin/users/${user.id}`);
+     router.refresh();
+   };
 
   const handleCancel = () => {
     router.push(`/admin/users/${user.id}`);
   };
 
-  return (
-    <UserForm
-      initialData={user}
-      onSubmit={handleSubmit}
-      onCancel={handleCancel}
-      isEdit
-      isLoading={isLoading}
-      error={error}
-    />
-  );
-}
+   return (
+     <UserForm
+       initialData={user}
+       onSubmit={handleSubmit}
+       onCancel={handleCancel}
+       isEdit
+       isLoading={isLoading}
+     />
+   );
+ }

--- a/src/app/admin/users/new/page.tsx
+++ b/src/app/admin/users/new/page.tsx
@@ -2,52 +2,50 @@
 
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { UserForm, UserFormData } from "@/components/admin/users/UserForm";
 import { createUser } from "@/lib/admin/server";
 
 export default function NewUserPage() {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+   const router = useRouter();
+   const [isLoading, setIsLoading] = useState(false);
 
-  const handleSubmit = async (data: UserFormData) => {
-    setIsLoading(true);
-    setError(null);
+   const handleSubmit = async (data: UserFormData) => {
+     setIsLoading(true);
 
-    const result = await createUser({
-      email: data.email,
-      password: data.password || undefined,
-      full_name: data.full_name || undefined,
-      username: data.username || undefined,
-    });
+     const result = await createUser({
+       email: data.email,
+       password: data.password || undefined,
+       full_name: data.full_name || undefined,
+       username: data.username || undefined,
+     });
 
-    setIsLoading(false);
+     setIsLoading(false);
 
-    if (result.error) {
-      setError(result.error);
-      return;
-    }
+     if (result.error) {
+       toast.error(result.error);
+       return;
+     }
 
-    router.push("/admin/users");
-  };
+     router.push("/admin/users");
+   };
 
   const handleCancel = () => {
     router.push("/admin/users");
   };
 
-  return (
-    <div className="max-w-2xl">
-      <AdminHeader
-        title="Create User"
-        description="Add a new team member to the organization."
-      />
-      <UserForm
-        onSubmit={handleSubmit}
-        onCancel={handleCancel}
-        isLoading={isLoading}
-        error={error}
-      />
-    </div>
-  );
-}
+   return (
+     <div className="max-w-2xl">
+       <AdminHeader
+         title="Create User"
+         description="Add a new team member to the organization."
+       />
+       <UserForm
+         onSubmit={handleSubmit}
+         onCancel={handleCancel}
+         isLoading={isLoading}
+       />
+     </div>
+   );
+ }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { SessionProvider } from "@/components/auth/SessionProvider";
 import { UserMenu } from "@/components/auth/UserMenu";
 import { GraphQLProvider } from "@/lib/graphql/provider";
+import { Toaster } from "sonner";
 
 const bodyFont = Noto_Sans({
   variable: "--font-body",
@@ -65,16 +66,17 @@ export default function RootLayout({
         className={`${bodyFont.variable} ${displayFont.variable} ${monoFont.variable} antialiased`}
       >
         <SessionProvider>
-          <GraphQLProvider>
-            <Script src={runtimeConfigSrc} strategy="beforeInteractive" />
-            <script dangerouslySetInnerHTML={{ __html: themeScript }} />
-            <div className="fixed right-6 top-6 z-50">
-              <UserMenu />
-            </div>
-            {children}
-          </GraphQLProvider>
-        </SessionProvider>
-      </body>
+           <GraphQLProvider>
+             <Script src={runtimeConfigSrc} strategy="beforeInteractive" />
+             <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+             <div className="fixed right-6 top-6 z-50">
+               <UserMenu />
+             </div>
+             {children}
+             <Toaster richColors position="top-right" theme="dark" />
+           </GraphQLProvider>
+         </SessionProvider>
+       </body>
     </html>
   );
 }

--- a/src/components/admin/integrations/IntegrationForm.tsx
+++ b/src/components/admin/integrations/IntegrationForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import { toast } from "sonner";
 import { ConnectionStatus, ConnectionStatusType } from "./ConnectionStatus";
 
 type FormDataRecord = Record<string, FormDataEntryValue>;
@@ -19,77 +20,62 @@ export function IntegrationForm({
   onTestConnection,
   children,
 }: IntegrationFormProps) {
-  const [status, setStatus] = useState<ConnectionStatusType>(initialStatus);
-  const [isSaving, setIsSaving] = useState(false);
-  const [isTesting, setIsTesting] = useState(false);
-  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+   const [status, setStatus] = useState<ConnectionStatusType>(initialStatus);
+   const [isSaving, setIsSaving] = useState(false);
+   const [isTesting, setIsTesting] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsSaving(true);
-    setMessage(null);
+   const handleSubmit = async (e: React.FormEvent) => {
+     e.preventDefault();
+     setIsSaving(true);
 
-    const formData = new FormData(e.target as HTMLFormElement);
-    const data = Object.fromEntries(formData.entries());
+     const formData = new FormData(e.target as HTMLFormElement);
+     const data = Object.fromEntries(formData.entries());
 
-    try {
-      await onSave(data);
-      setMessage({ type: "success", text: "Settings saved successfully." });
-    } catch {
-      setMessage({ type: "error", text: "Failed to save settings." });
-    } finally {
-      setIsSaving(false);
-    }
-  };
+     try {
+       await onSave(data);
+       toast.success("Settings saved successfully.");
+     } catch {
+       toast.error("Failed to save settings.");
+     } finally {
+       setIsSaving(false);
+     }
+   };
 
-  const handleTestConnection = async (e: React.MouseEvent) => {
-    e.preventDefault();
-    setIsTesting(true);
-    setStatus("connecting");
-    setMessage(null);
+   const handleTestConnection = async (e: React.MouseEvent) => {
+     e.preventDefault();
+     setIsTesting(true);
+     setStatus("connecting");
 
-    // In a real app, we would grab the form data here too
-    // For now, we assume the parent handles data gathering or we pass current form state
-    const form = (e.target as HTMLElement).closest("form");
-    const formData = new FormData(form!);
-    const data = Object.fromEntries(formData.entries());
+     // In a real app, we would grab the form data here too
+     // For now, we assume the parent handles data gathering or we pass current form state
+     const form = (e.target as HTMLElement).closest("form");
+     const formData = new FormData(form!);
+     const data = Object.fromEntries(formData.entries());
 
-    try {
-      const success = await onTestConnection(data);
-      setStatus(success ? "connected" : "error");
-      if (success) {
-        setMessage({ type: "success", text: "Connection successful!" });
-      } else {
-        setMessage({ type: "error", text: "Connection failed. Please check your credentials." });
-      }
-    } catch {
-      setStatus("error");
-      setMessage({ type: "error", text: "An error occurred while testing the connection." });
-    } finally {
-      setIsTesting(false);
-    }
-  };
+     try {
+       const success = await onTestConnection(data);
+       setStatus(success ? "connected" : "error");
+       if (success) {
+         toast.success("Connection successful!");
+       } else {
+         toast.error("Connection failed. Please check your credentials.");
+       }
+     } catch {
+       setStatus("error");
+       toast.error("An error occurred while testing the connection.");
+     } finally {
+       setIsTesting(false);
+     }
+   };
 
   return (
     <div className="max-w-2xl rounded-lg border border-(--border-subtle) bg-(--surface-base) p-6 shadow-sm">
-      <div className="mb-6 flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-(--ink-base)">Configuration</h2>
-        <ConnectionStatus status={status} />
-      </div>
+       <div className="mb-6 flex items-center justify-between">
+         <h2 className="text-xl font-semibold text-(--ink-base)">Configuration</h2>
+         <ConnectionStatus status={status} />
+       </div>
 
-      {message && (
-        <div
-          className={`mb-6 rounded-md p-4 text-sm ${
-            message.type === "success"
-              ? "bg-green-50 text-green-700"
-              : "bg-red-50 text-red-700"
-          }`}
-        >
-          {message.text}
-        </div>
-      )}
-
-      <form onSubmit={handleSubmit} className="space-y-6">
+       <form onSubmit={handleSubmit} className="space-y-6">
         {children}
 
         <div className="flex items-center justify-end gap-4 pt-4 border-t border-(--border-subtle)">

--- a/src/components/admin/settings/BillingSettings.tsx
+++ b/src/components/admin/settings/BillingSettings.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { useSearchParams } from "next/navigation";
+import { toast } from "sonner";
 import { SettingsSection } from "./SettingsSection";
 import {
-  createCheckoutSession,
-  createPortalSession,
-  getSubscriptionDetails,
-  type SubscriptionDetails,
-} from "@/lib/billing/actions";
+   createCheckoutSession,
+   createPortalSession,
+   getSubscriptionDetails,
+   type SubscriptionDetails,
+ } from "@/lib/billing/actions";
 
 const TIER_LABELS: Record<string, string> = {
   community: "Community",
@@ -22,24 +23,21 @@ type BillingSettingsProps = {
 };
 
 export function BillingSettings({ tier = "community" }: BillingSettingsProps) {
-  const searchParams = useSearchParams();
-  const [isPending, startTransition] = useTransition();
-  const [error, setError] = useState<string | null>(null);
-  const [subscriptionResult, setSubscriptionResult] = useState<{
-    data?: SubscriptionDetails;
-    error?: string;
-  } | null>(null);
-  const [selectedTier, setSelectedTier] = useState<"team" | "enterprise" | null>(null);
-  const [dismissed, setDismissed] = useState<"success" | "cancelled" | null>(null);
+   const searchParams = useSearchParams();
+   const [isPending, startTransition] = useTransition();
+   const [subscriptionResult, setSubscriptionResult] = useState<{
+     data?: SubscriptionDetails;
+     error?: string;
+   } | null>(null);
+   const [selectedTier, setSelectedTier] = useState<"team" | "enterprise" | null>(null);
+   const [dismissed, setDismissed] = useState<"success" | "cancelled" | null>(null);
 
   const billingParam = searchParams.get("billing");
   const showSuccess = useMemo(() => billingParam === "success" && dismissed !== "success", [billingParam, dismissed]);
   const showCancelled = useMemo(() => billingParam === "cancelled" && dismissed !== "cancelled", [billingParam, dismissed]);
 
-  const subscription = subscriptionResult?.data;
-  const subscriptionError = subscriptionResult?.error ?? null;
-  const errorMessage = error ?? subscriptionError;
-  const currentTier = subscription?.tier ?? tier;
+   const subscription = subscriptionResult?.data;
+   const currentTier = subscription?.tier ?? tier;
   const tierLabel = TIER_LABELS[currentTier] ?? currentTier;
   const canUpgrade = currentTier !== "enterprise";
   const isPaidTier = currentTier === "team" || currentTier === "enterprise";
@@ -112,50 +110,50 @@ export function BillingSettings({ tier = "community" }: BillingSettingsProps) {
 
 
 
-  useEffect(() => {
-    let isActive = true;
+   useEffect(() => {
+     let isActive = true;
 
-    const loadSubscription = async () => {
-      const result = await getSubscriptionDetails();
-      if (!isActive) return;
-      startTransition(() => {
-        setSubscriptionResult(result);
-      });
-    };
+     const loadSubscription = async () => {
+       const result = await getSubscriptionDetails();
+       if (!isActive) return;
+       startTransition(() => {
+         setSubscriptionResult(result);
+         if (result.error) {
+           toast.error(result.error);
+         }
+       });
+     };
 
-    loadSubscription();
+     loadSubscription();
 
-    return () => {
-      isActive = false;
-    };
-  }, []);
+     return () => {
+       isActive = false;
+     };
+   }, []);
 
-  const handleUpgrade = () => {
-    if (!selectedTier) return;
-    setError(null);
+   const handleUpgrade = () => {
+     if (!selectedTier) return;
 
-    startTransition(async () => {
-      const result = await createCheckoutSession(selectedTier);
-      if (result.error) {
-        setError(result.error);
-      } else if (result.data?.checkout_url) {
-        window.location.href = result.data.checkout_url;
-      }
-    });
-  };
+     startTransition(async () => {
+       const result = await createCheckoutSession(selectedTier);
+       if (result.error) {
+         toast.error(result.error);
+       } else if (result.data?.checkout_url) {
+         window.location.href = result.data.checkout_url;
+       }
+     });
+   };
 
-  const handleManageBilling = () => {
-    setError(null);
-
-    startTransition(async () => {
-      const result = await createPortalSession();
-      if (result.error) {
-        setError(result.error);
-      } else if (result.data?.portal_url) {
-        window.location.href = result.data.portal_url;
-      }
-    });
-  };
+   const handleManageBilling = () => {
+     startTransition(async () => {
+       const result = await createPortalSession();
+       if (result.error) {
+         toast.error(result.error);
+       } else if (result.data?.portal_url) {
+         window.location.href = result.data.portal_url;
+       }
+     });
+   };
 
   return (
     <SettingsSection
@@ -175,26 +173,20 @@ export function BillingSettings({ tier = "community" }: BillingSettingsProps) {
         </div>
       )}
 
-      {showCancelled && (
-        <div className="mb-4 flex items-center justify-between rounded-md border border-amber-500/20 bg-amber-500/10 p-4 text-amber-700">
-          <p className="text-sm font-medium">Checkout was cancelled. No changes were made.</p>
-          <button
-            type="button"
-            onClick={() => setDismissed("cancelled")}
-            className="ml-4 text-sm font-medium hover:underline"
-          >
-            Dismiss
-          </button>
-        </div>
-      )}
+       {showCancelled && (
+         <div className="mb-4 flex items-center justify-between rounded-md border border-amber-500/20 bg-amber-500/10 p-4 text-amber-700">
+           <p className="text-sm font-medium">Checkout was cancelled. No changes were made.</p>
+           <button
+             type="button"
+             onClick={() => setDismissed("cancelled")}
+             className="ml-4 text-sm font-medium hover:underline"
+           >
+             Dismiss
+           </button>
+         </div>
+       )}
 
-      {errorMessage && (
-        <div className="mb-4 rounded-md border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-700">
-          {errorMessage}
-        </div>
-      )}
-
-      <div className="flex items-center justify-between rounded-md border border-(--card-stroke) bg-(--background) p-4">
+       <div className="flex items-center justify-between rounded-md border border-(--card-stroke) bg-(--background) p-4">
         <div>
           <p className="text-sm font-medium text-(--foreground)">Current Plan</p>
           <div className="mt-1 flex flex-wrap items-center gap-3">

--- a/src/components/admin/settings/DangerZone.tsx
+++ b/src/components/admin/settings/DangerZone.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { SettingsSection } from "./SettingsSection";
 import { deleteCurrentOrg } from "@/lib/admin/server";
 
@@ -10,39 +11,32 @@ type DangerZoneProps = {
 };
 
 export function DangerZone({ orgName }: DangerZoneProps) {
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
-  const [showConfirm, setShowConfirm] = useState(false);
-  const [confirmText, setConfirmText] = useState("");
-  const [error, setError] = useState<string | null>(null);
+   const router = useRouter();
+   const [isPending, startTransition] = useTransition();
+   const [showConfirm, setShowConfirm] = useState(false);
+   const [confirmText, setConfirmText] = useState("");
 
-  const handleDelete = () => {
-    if (confirmText !== orgName) return;
-    setError(null);
+   const handleDelete = () => {
+     if (confirmText !== orgName) return;
 
-    startTransition(async () => {
-      const result = await deleteCurrentOrg();
-      if (result.error) {
-        setError(result.error);
-      } else {
-        // Org is gone — redirect to sign-out / landing
-        router.push("/api/auth/signout?callbackUrl=/");
-      }
-    });
-  };
+     startTransition(async () => {
+       const result = await deleteCurrentOrg();
+       if (result.error) {
+         toast.error(result.error);
+       } else {
+         // Org is gone — redirect to sign-out / landing
+         router.push("/api/auth/signout?callbackUrl=/");
+       }
+     });
+   };
 
   return (
-    <SettingsSection
-      title="Danger Zone"
-      description="Irreversible actions for your organization."
-      danger
-    >
-      {error && (
-        <div className="mb-4 rounded-md border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-700">
-          {error}
-        </div>
-      )}
-      {!showConfirm ? (
+     <SettingsSection
+       title="Danger Zone"
+       description="Irreversible actions for your organization."
+       danger
+     >
+       {!showConfirm ? (
         <div className="flex items-center justify-between">
           <div>
             <p className="text-sm font-medium text-(--foreground)">Delete Organization</p>
@@ -74,11 +68,10 @@ export function DangerZone({ orgName }: DangerZoneProps) {
           <div className="flex gap-3">
             <button
               type="button"
-              onClick={() => {
-                setShowConfirm(false);
-                setConfirmText("");
-                setError(null);
-              }}
+               onClick={() => {
+                 setShowConfirm(false);
+                 setConfirmText("");
+               }}
               disabled={isPending}
               className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm font-medium text-(--foreground) hover:bg-(--card-70) disabled:opacity-50"
             >

--- a/src/components/admin/settings/GeneralSettings.tsx
+++ b/src/components/admin/settings/GeneralSettings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { SettingsSection } from "./SettingsSection";
 import { updateCurrentOrg } from "@/lib/admin/server";
 import type { Organization } from "@/lib/admin/types";
@@ -10,46 +11,33 @@ type GeneralSettingsProps = {
 };
 
 export function GeneralSettings({ org }: GeneralSettingsProps) {
-  const [isLoading, setIsLoading] = useState(false);
-  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+   const [isLoading, setIsLoading] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setIsLoading(true);
-    setMessage(null);
+   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+     e.preventDefault();
+     setIsLoading(true);
 
-    const formData = new FormData(e.currentTarget);
-    const result = await updateCurrentOrg({
-      name: formData.get("name") as string,
-      description: formData.get("description") as string || undefined,
-    });
+     const formData = new FormData(e.currentTarget);
+     const result = await updateCurrentOrg({
+       name: formData.get("name") as string,
+       description: formData.get("description") as string || undefined,
+     });
 
-    setIsLoading(false);
+     setIsLoading(false);
 
-    if (result.error) {
-      setMessage({ type: "error", text: result.error });
-    } else {
-      setMessage({ type: "success", text: "Settings saved successfully" });
-    }
-  };
+     if (result.error) {
+       toast.error(result.error);
+     } else {
+       toast.success("Settings saved successfully");
+     }
+   };
 
-  return (
-    <SettingsSection
-      title="General Settings"
-      description="Manage your organization's basic information."
-    >
-      {message && (
-        <div
-          className={`mb-4 rounded-md p-3 text-sm ${
-            message.type === "success"
-              ? "bg-green-500/10 text-green-600"
-              : "bg-red-500/10 text-red-500"
-          }`}
-        >
-          {message.text}
-        </div>
-      )}
-      <form onSubmit={handleSubmit} className="space-y-4">
+   return (
+     <SettingsSection
+       title="General Settings"
+       description="Manage your organization's basic information."
+     >
+       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label htmlFor="name" className="block text-sm font-medium text-(--foreground)">
             Organization Name

--- a/src/components/admin/settings/SecuritySettings.tsx
+++ b/src/components/admin/settings/SecuritySettings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useTransition } from "react";
+import { toast } from "sonner";
 import { SettingsSection } from "./SettingsSection";
 import { getSecuritySettings, updateSecuritySetting } from "@/lib/admin/server";
 import type { Setting } from "@/lib/admin/types";
@@ -20,9 +21,8 @@ function findSetting(settings: Setting[], key: string): string | null {
 }
 
 export function SecuritySettings() {
-  const [isPending, startTransition] = useTransition();
-  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
-  const [loaded, setLoaded] = useState(false);
+   const [isPending, startTransition] = useTransition();
+   const [loaded, setLoaded] = useState(false);
 
   const [sessionTimeout, setSessionTimeout] = useState(DEFAULT_SESSION_TIMEOUT);
   const [enforce2fa, setEnforce2fa] = useState(false);
@@ -47,46 +47,34 @@ export function SecuritySettings() {
     return () => { active = false; };
   }, []);
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setMessage(null);
+   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+     e.preventDefault();
 
-    startTransition(async () => {
-      const results = await Promise.allSettled([
-        updateSecuritySetting("session_timeout", sessionTimeout),
-        updateSecuritySetting("enforce_2fa", String(enforce2fa)),
-      ]);
+     startTransition(async () => {
+       const results = await Promise.allSettled([
+         updateSecuritySetting("session_timeout", sessionTimeout),
+         updateSecuritySetting("enforce_2fa", String(enforce2fa)),
+       ]);
 
-      const errors = results
-        .map((r) => (r.status === "fulfilled" ? r.value : { error: "Request failed" }))
-        .filter((r) => r.error)
-        .map((r) => r.error);
+       const errors = results
+         .map((r) => (r.status === "fulfilled" ? r.value : { error: "Request failed" }))
+         .filter((r) => r.error)
+         .map((r) => r.error);
 
-      if (errors.length > 0) {
-        setMessage({ type: "error", text: errors.join("; ") });
-      } else {
-        setMessage({ type: "success", text: "Security settings saved successfully" });
-      }
-    });
-  };
+       if (errors.length > 0) {
+         toast.error(errors.join("; "));
+       } else {
+         toast.success("Security settings saved successfully");
+       }
+     });
+   };
 
-  return (
-    <SettingsSection
-      title="Security"
-      description="Configure security settings for your organization."
-    >
-      {message && (
-        <div
-          className={`mb-4 rounded-md p-3 text-sm ${
-            message.type === "success"
-              ? "bg-green-500/10 text-green-600"
-              : "bg-red-500/10 text-red-500"
-          }`}
-        >
-          {message.text}
-        </div>
-      )}
-      <form onSubmit={handleSubmit} className="space-y-4">
+   return (
+     <SettingsSection
+       title="Security"
+       description="Configure security settings for your organization."
+     >
+       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label htmlFor="sessionTimeout" className="block text-sm font-medium text-(--foreground)">
             Session Timeout

--- a/src/components/admin/sync/SyncConfigCard.tsx
+++ b/src/components/admin/sync/SyncConfigCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { toast } from "sonner";
 import { SyncConfig } from "@/lib/sync-types";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 
@@ -9,12 +10,10 @@ interface SyncConfigCardProps {
 }
 
 export function SyncConfigCard({ config }: SyncConfigCardProps) {
-  const handleSync = (e: React.MouseEvent) => {
-    e.preventDefault();
-    // Mock sync trigger
-    console.log(`Triggering sync for ${config.id}`);
-    alert(`Sync triggered for ${config.name}`);
-  };
+   const handleSync = (e: React.MouseEvent) => {
+     e.preventDefault();
+     toast.success(`Sync triggered for ${config.name}`);
+   };
 
   return (
     <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6 transition-all hover:border-(--card-stroke-hover)">
@@ -36,12 +35,13 @@ export function SyncConfigCard({ config }: SyncConfigCardProps) {
         <div className="text-xs text-(--ink-muted)">
           Last sync: {config.last_sync_at ? new Date(config.last_sync_at).toLocaleString() : "Never"}
         </div>
-        <button
-          onClick={handleSync}
-          className="rounded-md bg-(--accent) px-3 py-1.5 text-xs font-medium text-white hover:bg-(--accent-hover) focus:outline-none focus:ring-2 focus:ring-(--accent) focus:ring-offset-2"
-        >
-          Sync Now
-        </button>
+         <button
+           type="button"
+           onClick={handleSync}
+           className="rounded-md bg-(--accent) px-3 py-1.5 text-xs font-medium text-white hover:bg-(--accent-hover) focus:outline-none focus:ring-2 focus:ring-(--accent) focus:ring-offset-2"
+         >
+           Sync Now
+         </button>
       </div>
     </div>
   );

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -6,22 +6,20 @@ import type { UserCreate, User } from "@/lib/admin/types";
 export type UserFormData = UserCreate & { is_active?: boolean };
 
 type UserFormProps = {
-  initialData?: User;
-  onSubmit: (data: UserFormData) => Promise<void>;
-  onCancel: () => void;
-  isEdit?: boolean;
-  isLoading?: boolean;
-  error?: string | null;
-};
+   initialData?: User;
+   onSubmit: (data: UserFormData) => Promise<void>;
+   onCancel: () => void;
+   isEdit?: boolean;
+   isLoading?: boolean;
+ };
 
 export function UserForm({
-  initialData,
-  onSubmit,
-  onCancel,
-  isEdit = false,
-  isLoading = false,
-  error = null,
-}: UserFormProps) {
+   initialData,
+   onSubmit,
+   onCancel,
+   isEdit = false,
+   isLoading = false,
+ }: UserFormProps) {
   const [formData, setFormData] = useState<UserFormData>({
     email: initialData?.email || "",
     full_name: initialData?.full_name || "",
@@ -44,15 +42,9 @@ export function UserForm({
   const inputClass =
     "w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)";
 
-  return (
-    <form onSubmit={handleSubmit} className="space-y-6 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
-      {error && (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-500">
-          {error}
-        </div>
-      )}
-
-      <div className="grid gap-6 md:grid-cols-2">
+   return (
+     <form onSubmit={handleSubmit} className="space-y-6 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+       <div className="grid gap-6 md:grid-cols-2">
         <div className="space-y-2">
           <label htmlFor="email" className="text-sm font-medium text-(--ink-muted)">
             Email *

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -3,48 +3,41 @@
 import { useState } from "react"
 import { signIn } from "next-auth/react"
 import { useRouter } from "next/navigation"
+import { toast } from "sonner"
 
 export function LoginForm() {
-  const router = useRouter()
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
-  const [error, setError] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
+   const router = useRouter()
+   const [email, setEmail] = useState("")
+   const [password, setPassword] = useState("")
+   const [loading, setLoading] = useState(false)
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setError(null)
-    setLoading(true)
+   const handleSubmit = async (e: React.FormEvent) => {
+     e.preventDefault()
+     setLoading(true)
 
-    try {
-      const result = await signIn("credentials", {
-        email,
-        password,
-        redirect: false,
-      })
+     try {
+       const result = await signIn("credentials", {
+         email,
+         password,
+         redirect: false,
+       })
 
-      if (result?.error) {
-        setError("Invalid email or password")
-      } else {
-        router.push("/")
-        router.refresh()
-      }
-    } catch {
-      setError("An error occurred. Please try again.")
-    } finally {
-      setLoading(false)
-    }
-  }
+       if (result?.error) {
+         toast.error("Invalid email or password")
+       } else {
+         router.push("/")
+         router.refresh()
+       }
+     } catch {
+       toast.error("An error occurred. Please try again.")
+     } finally {
+       setLoading(false)
+     }
+   }
 
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
-      {error && (
-        <div className="p-3 text-sm text-red-500 bg-red-50 rounded-md border border-red-200">
-          {error}
-        </div>
-      )}
-      
-      <div className="space-y-2">
+   return (
+     <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
+       <div className="space-y-2">
         <label htmlFor="email" className="block text-sm font-medium text-[var(--foreground)]">
           Email
         </label>

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -3,69 +3,62 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
+import { toast } from "sonner"
 import { getBackendUrl } from "@/lib/origin"
 
 export function SignupForm() {
-  const router = useRouter()
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
-  const [fullName, setFullName] = useState("")
-  const [error, setError] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
+   const router = useRouter()
+   const [email, setEmail] = useState("")
+   const [password, setPassword] = useState("")
+   const [confirmPassword, setConfirmPassword] = useState("")
+   const [fullName, setFullName] = useState("")
+   const [loading, setLoading] = useState(false)
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setError(null)
+   const handleSubmit = async (e: React.FormEvent) => {
+     e.preventDefault()
 
-    if (password !== confirmPassword) {
-      setError("Passwords do not match")
-      return
-    }
+     if (password !== confirmPassword) {
+       toast.error("Passwords do not match")
+       return
+     }
 
-    if (password.length < 8) {
-      setError("Password must be at least 8 characters")
-      return
-    }
+     if (password.length < 8) {
+       toast.error("Password must be at least 8 characters")
+       return
+     }
 
-    setLoading(true)
+     setLoading(true)
 
-    try {
-      const backendUrl = getBackendUrl()
-      const res = await fetch(`${backendUrl}/api/v1/auth/register`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          email,
-          password,
-          full_name: fullName || undefined,
-        }),
-      })
+     try {
+       const backendUrl = getBackendUrl()
+       const res = await fetch(`${backendUrl}/api/v1/auth/register`, {
+         method: "POST",
+         headers: { "Content-Type": "application/json" },
+         body: JSON.stringify({
+           email,
+           password,
+           full_name: fullName || undefined,
+         }),
+       })
 
-      const data = await res.json()
+       const data = await res.json()
 
-      if (!res.ok) {
-        setError(data.detail || "Registration failed")
-        return
-      }
+       if (!res.ok) {
+         toast.error(data.detail || "Registration failed")
+         return
+       }
 
-      router.push("/auth/signin?registered=true")
-    } catch {
-      setError("An error occurred. Please try again.")
-    } finally {
-      setLoading(false)
-    }
-  }
+       router.push("/auth/signin?registered=true")
+     } catch {
+       toast.error("An error occurred. Please try again.")
+     } finally {
+       setLoading(false)
+     }
+   }
 
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
-      {error && (
-        <div className="p-3 text-sm text-red-400 bg-red-950/50 rounded-md border border-red-800">
-          {error}
-        </div>
-      )}
-
-      <div className="space-y-2">
+   return (
+     <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
+       <div className="space-y-2">
         <label htmlFor="fullName" className="block text-sm font-medium text-[var(--foreground)]">
           Full Name
         </label>


### PR DESCRIPTION
## Summary

Adds the `sonner` toast notification library and migrates all inline `useState`-based success/error message blocks to `toast()` calls across 15 components. Net -92 lines.

## Changes

### Infrastructure
- Added `sonner` dependency (~3KB)
- Added `<Toaster richColors position="top-right" theme="dark" />` to root layout

### Migrated Components (15 files)

**Auth forms:**
- `LoginForm` — error state → `toast.error()`
- `SignupForm` — validation + API errors → `toast.error()`

**Admin Settings:**
- `GeneralSettings` — success/error message state → toast
- `SecuritySettings` — success/error message state → toast
- `DangerZone` — error state → `toast.error()`
- `BillingSettings` — error state + subscription error → toast (URL-param banners preserved)

**Integrations:**
- `IntegrationForm` — success/error for save + test connection → toast

**Sync:**
- `SyncConfigCard` — replaced `alert()` stub with `toast.success()`

**Admin CRUD:**
- `UserForm` — removed `error` prop and inline error block
- `NewUserPage`, `EditUserFormWrapper`, `DeleteUserButton` — error → toast
- `NewTeamPage`, `EditTeamFormWrapper` — error → toast
- `NewIdentityPage`, `EditIdentityFormWrapper` — error → toast

### What was NOT migrated (intentionally)
- `PeopleSearch.tsx` / `EvidencePanel.tsx` — use `setError` for loading states, not user notifications
- `BillingSettings` URL-param banners (success/cancelled after Stripe redirect) — kept as inline

## Verification
- [x] `tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Net negative LOC (−92 lines)