### PR TITLE
fix: match job status casing to API response

### DIFF
--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -16,13 +16,13 @@ export function SyncJobHistory({ jobs }: SyncJobHistoryProps) {
 
   const getBadgeStatus = (status: SyncJob["status"]) => {
     switch (status) {
-      case "SUCCESS":
+      case "success":
         return "success";
-      case "FAILED":
+      case "failed":
         return "failed";
-      case "RUNNING":
+      case "running":
         return "running";
-      case "PENDING":
+      case "pending":
         return "idle";
       default:
         return "never";
@@ -71,7 +71,7 @@ export function SyncJobHistory({ jobs }: SyncJobHistoryProps) {
                   {duration}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-(--ink-muted)">
-                  {job.items_synced}
+                  {job.items_synced ?? "-"}
                 </td>
                 <td className="px-6 py-4 text-sm text-red-500">
                   {job.error ? (

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -93,7 +93,7 @@ export interface SyncConfig {
 export interface SyncJob {
   id: string;
   config_id: string;
-  status: "PENDING" | "RUNNING" | "SUCCESS" | "FAILED";
+  status: "pending" | "running" | "success" | "failed";
   started_at: string;
   completed_at: string | null;
   duration_seconds: number | null;


### PR DESCRIPTION
## Summary

- Fix job history displaying all statuses as "Never Synced" due to case mismatch
- API returns lowercase labels (`success`, `failed`, `running`, `pending`) but frontend expected uppercase (`SUCCESS`, `FAILED`, etc.)
- Add null safety for `items_synced` field

## Related

- Backend PR: full-chaos/dev-health-ops#376 (stores status as integer codes, API maps int→string)

## Changes

| File | Change |
|------|--------|
| `src/lib/admin/types.ts` | `SyncJob.status` union type: uppercase → lowercase |
| `src/components/admin/sync/SyncJobHistory.tsx` | `getBadgeStatus` switch cases: uppercase → lowercase; `items_synced` null safety |