### PR TITLE
fix: use team_id for update call, remove router.refresh in edit team

### DIFF
--- a/src/app/admin/teams/[id]/edit/EditTeamFormWrapper.tsx
+++ b/src/app/admin/teams/[id]/edit/EditTeamFormWrapper.tsx
@@ -27,7 +27,7 @@ export function EditTeamFormWrapper({ team }: EditTeamFormWrapperProps) {
    const handleSubmit = async (data: Team) => {
      setIsLoading(true);
 
-     const result = await updateTeam(team.id, {
+      const result = await updateTeam(team.team_id, {
        name: data.name,
        description: data.description || undefined,
        repo_patterns: data.repo_patterns,
@@ -41,8 +41,7 @@ export function EditTeamFormWrapper({ team }: EditTeamFormWrapperProps) {
        return;
      }
 
-     router.push("/admin/teams");
-     router.refresh();
+      router.push("/admin/teams");
    };
 
    return (


### PR DESCRIPTION
## Summary
- Fix `EditTeamFormWrapper` to pass `team.team_id` (slug like "API") instead of `team.id` (UUID) to `updateTeam()`, which was causing the PATCH call to 404
- Remove `router.refresh()` after `router.push()` to prevent the "Saving..." button getting stuck (same fix applied to SyncConfigForm in #158)

## Context
Companion backend PR: full-chaos/dev-health-ops#405 (adds the GET and PATCH endpoints)

## Testing
- Playwright E2E: full edit flow (navigate → load form → edit description → submit → redirect) verified working