### PR TITLE
fix: add concurrency groups and deduplicate CI triggers

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,6 +4,10 @@ permissions:
     contents: read
     packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
     push:
         branches:

--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Cloudflare project name - defaults to 'dev-health-web' if secret is not set
   # Public Cloudflare project name; if the secret is unset or empty, use a non-secret default.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,12 @@ name: Build
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,12 @@ name: Tests
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Add concurrency groups to all CI workflows to prevent duplicate runs
- Restrict push triggers to main branch only (except build-docker which has release event)
- Keep pull_request triggers on all branches (correct behavior)
- Add cancel-in-progress: true to cancel stale runs when new commits arrive

## Changes

**tests.yml & build.yml:**
- Changed bare `push:` to `push: branches: [main]` to prevent runs on every branch
- Added concurrency group with cancel-in-progress

**build-static.yml & build-docker.yml:**
- Added concurrency group with cancel-in-progress (triggers already properly scoped)

**deploy-demo.yml & package.yml:**
- No changes (already correct)

## Result

- PR runs will be grouped by PR number
- Main branch runs will be grouped by ref
- Stale runs are automatically cancelled when new commits arrive
- No more duplicate runs from push + PR on the same commit