### PR TITLE
fix: redirect superusers without org to /superadmin

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -15,6 +15,12 @@ export default async function AdminLayout({
 
   const role = session.user.role;
   const isSuperuser = session.user.is_superuser === true;
+
+  // Superusers without an org context must use Platform Admin instead
+  if (isSuperuser && !session.user.org_id) {
+    redirect("/superadmin");
+  }
+
   if (!isSuperuser && role !== "admin" && role !== "owner") {
     redirect("/");
   }


### PR DESCRIPTION
## Summary

- Superusers with no `org_id` in their session were passing through the admin layout gate and hitting errors on org-scoped pages
- Added guard in `admin/layout.tsx`: if `isSuperuser && !session.user.org_id`, redirect to `/superadmin`
- Superusers can then manage the platform or impersonate into a specific org

## Changes

- `src/app/admin/layout.tsx`: Added org_id check before the role-based access gate