### PR TITLE
feat: superadmin user management pages (Phase 3)

### DIFF
--- a/public/runtime-config.js
+++ b/public/runtime-config.js
@@ -1,0 +1,2 @@
+// Auto-generated at start-up.
+window.__DEV_HEALTH_RUNTIME__ = {"publicEnv":{"NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS":"true","NEXT_PUBLIC_DEV_HEALTH_TEST_MODE":"false","NEXT_PUBLIC_DOCS_URL":"/docs"}};

--- a/src/app/superadmin/users/[id]/page.tsx
+++ b/src/app/superadmin/users/[id]/page.tsx
@@ -1,0 +1,45 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { SettingsSection } from "@/components/admin/settings/SettingsSection";
+import { UserEditForm } from "@/components/superadmin/UserEditForm";
+import { UserSetPasswordForm } from "@/components/superadmin/UserSetPasswordForm";
+import { UserDeleteSection } from "@/components/superadmin/UserDeleteSection";
+import { getUser } from "@/lib/admin/server";
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function UserDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const { data: user, error } = await getUser(id);
+
+  if (error || !user) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <AdminHeader
+        title={user.full_name || user.email}
+        description={`Manage user ${user.email}`}
+      />
+
+      <SettingsSection
+        title="User Profile"
+        description="Update user details and configuration."
+      >
+        <UserEditForm user={user} />
+      </SettingsSection>
+
+      <SettingsSection
+        title="Security"
+        description="Manage user password and security settings."
+      >
+        <UserSetPasswordForm userId={user.id} />
+      </SettingsSection>
+
+      <UserDeleteSection userId={user.id} userEmail={user.email} />
+    </div>
+  );
+}

--- a/src/app/superadmin/users/page.tsx
+++ b/src/app/superadmin/users/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { UserTable } from "@/components/superadmin/UserTable";
+import { listUsers } from "@/lib/admin/server";
+
+export default async function UsersPage() {
+  const { data: users, error } = await listUsers();
+
+  if (error) {
+    return (
+      <div>
+        <AdminHeader
+          title="Users"
+          description="Manage all users across the platform."
+        />
+        <div className="rounded-2xl border border-red-500/20 bg-red-500/10 p-4 text-red-500">
+          Error loading users: {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <AdminHeader
+        title="Users"
+        description="Manage all users across the platform."
+      >
+        <Link
+          href="/superadmin/users/new"
+          className="inline-flex items-center rounded-xl bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90"
+        >
+          Create User
+        </Link>
+      </AdminHeader>
+      <UserTable users={users || []} />
+    </div>
+  );
+}

--- a/src/components/superadmin/UserDeleteSection.tsx
+++ b/src/components/superadmin/UserDeleteSection.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { deleteUser } from "@/lib/admin/server";
+import { SettingsSection } from "@/components/admin/settings/SettingsSection";
+
+type UserDeleteSectionProps = {
+  userId: string;
+  userEmail: string;
+};
+
+export function UserDeleteSection({ userId, userEmail }: UserDeleteSectionProps) {
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [confirmEmail, setConfirmEmail] = useState("");
+
+  async function handleDelete() {
+    if (confirmEmail !== userEmail) return;
+
+    setIsDeleting(true);
+    const result = await deleteUser(userId);
+
+    if (result.error) {
+      toast.error(result.error);
+      setIsDeleting(false);
+    } else {
+      toast.success("User deleted successfully");
+      router.push("/superadmin/users");
+    }
+  }
+
+  return (
+    <SettingsSection
+      title="Delete User"
+      description="Permanently delete this user and all their data. This action cannot be undone."
+      danger
+    >
+      <div className="space-y-4">
+        <div className="rounded-md bg-red-50 p-4 dark:bg-red-900/20">
+          <div className="flex">
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-red-800 dark:text-red-200">
+                Warning
+              </h3>
+              <div className="mt-2 text-sm text-red-700 dark:text-red-300">
+                <p>
+                  This will permanently delete the user <strong>{userEmail}</strong> and remove all associated data.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="confirm-email" className="block text-sm font-medium text-(--foreground)">
+            Type <span className="font-mono font-bold">{userEmail}</span> to confirm
+          </label>
+          <div className="mt-1 flex gap-4">
+            <input
+              type="text"
+              id="confirm-email"
+              value={confirmEmail}
+              onChange={(e) => setConfirmEmail(e.target.value)}
+              className="block w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              placeholder={userEmail}
+            />
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={isDeleting || confirmEmail !== userEmail}
+              className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50"
+            >
+              {isDeleting ? "Deleting..." : "Delete User"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/src/components/superadmin/UserEditForm.tsx
+++ b/src/components/superadmin/UserEditForm.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { updateUser } from "@/lib/admin/server";
+import type { User } from "@/lib/admin/types";
+
+type UserEditFormProps = {
+  user: User;
+};
+
+export function UserEditForm({ user }: UserEditFormProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleSubmit(formData: FormData) {
+    setIsLoading(true);
+    const result = await updateUser(user.id, {
+      email: formData.get("email") as string,
+      username: (formData.get("username") as string) || null,
+      full_name: (formData.get("full_name") as string) || null,
+      is_active: formData.get("is_active") === "on",
+      is_verified: formData.get("is_verified") === "on",
+      is_superuser: formData.get("is_superuser") === "on",
+    });
+    setIsLoading(false);
+
+    if (result.error) {
+      toast.error(result.error);
+    } else {
+      toast.success("User updated successfully");
+    }
+  }
+
+  return (
+    <form action={handleSubmit} className="space-y-6">
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="email" className="text-sm font-medium">
+            Email
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            defaultValue={user.email}
+            required
+            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="username" className="text-sm font-medium">
+            Username
+          </label>
+          <input
+            id="username"
+            name="username"
+            defaultValue={user.username || ""}
+            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="full_name" className="text-sm font-medium">
+          Full Name
+        </label>
+        <input
+          id="full_name"
+          name="full_name"
+          defaultValue={user.full_name || ""}
+          className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+        />
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-3">
+        <div className="flex items-center space-x-3 pt-4">
+          <input
+            type="checkbox"
+            id="is_active"
+            name="is_active"
+            defaultChecked={user.is_active}
+            className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
+          />
+          <label htmlFor="is_active" className="text-sm font-medium">
+            Active
+          </label>
+        </div>
+        <div className="flex items-center space-x-3 pt-4">
+          <input
+            type="checkbox"
+            id="is_verified"
+            name="is_verified"
+            defaultChecked={user.is_verified}
+            className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
+          />
+          <label htmlFor="is_verified" className="text-sm font-medium">
+            Verified
+          </label>
+        </div>
+        <div className="flex items-center space-x-3 pt-4">
+          <input
+            type="checkbox"
+            id="is_superuser"
+            name="is_superuser"
+            defaultChecked={user.is_superuser}
+            className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
+          />
+          <label htmlFor="is_superuser" className="text-sm font-medium">
+            Superuser
+          </label>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="rounded-xl bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90 disabled:opacity-50"
+        >
+          {isLoading ? "Saving..." : "Save Changes"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/superadmin/UserSetPasswordForm.tsx
+++ b/src/components/superadmin/UserSetPasswordForm.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { setUserPassword } from "@/lib/admin/server";
+
+type UserSetPasswordFormProps = {
+  userId: string;
+};
+
+export function UserSetPasswordForm({ userId }: UserSetPasswordFormProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleSubmit(formData: FormData) {
+    const password = formData.get("password") as string;
+    const confirmPassword = formData.get("confirm_password") as string;
+
+    if (password !== confirmPassword) {
+      toast.error("Passwords do not match");
+      return;
+    }
+
+    if (password.length < 8) {
+      toast.error("Password must be at least 8 characters long");
+      return;
+    }
+
+    setIsLoading(true);
+    const result = await setUserPassword(userId, password);
+    setIsLoading(false);
+
+    if (result.error) {
+      toast.error(result.error);
+    } else {
+      toast.success("Password updated successfully");
+      (document.getElementById("password-form") as HTMLFormElement)?.reset();
+    }
+  }
+
+  return (
+    <form id="password-form" action={handleSubmit} className="space-y-6">
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="password" className="text-sm font-medium">
+            New Password
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            required
+            minLength={8}
+            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="confirm_password" className="text-sm font-medium">
+            Confirm Password
+          </label>
+          <input
+            id="confirm_password"
+            name="confirm_password"
+            type="password"
+            required
+            minLength={8}
+            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="rounded-xl bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90 disabled:opacity-50"
+        >
+          {isLoading ? "Setting Password..." : "Set Password"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/superadmin/UserTable.tsx
+++ b/src/components/superadmin/UserTable.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import Link from "next/link";
+import type { User } from "@/lib/admin/types";
+
+type UserTableProps = {
+  users: User[];
+};
+
+export function UserTable({ users }: UserTableProps) {
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+      <table className="w-full text-left text-sm">
+        <thead className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+          <tr>
+            <th className="px-6 py-4 font-medium">Name / Email</th>
+            <th className="px-6 py-4 font-medium">Username</th>
+            <th className="px-6 py-4 font-medium">Auth Provider</th>
+            <th className="px-6 py-4 font-medium">Status</th>
+            <th className="px-6 py-4 font-medium">Role</th>
+            <th className="px-6 py-4 font-medium">Last Login</th>
+            <th className="px-6 py-4 font-medium text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-(--card-stroke)">
+          {users.map((user) => (
+            <tr key={user.id} className="hover:bg-(--card-70)/50">
+              <td className="px-6 py-4 font-medium text-foreground">
+                <Link href={`/superadmin/users/${user.id}`} className="hover:underline">
+                  <div className="font-medium">{user.full_name || "No Name"}</div>
+                  <div className="text-xs text-(--ink-muted)">{user.email}</div>
+                </Link>
+              </td>
+              <td className="px-6 py-4 text-(--ink-muted)">{user.username || "-"}</td>
+              <td className="px-6 py-4 text-(--ink-muted)">{user.auth_provider}</td>
+              <td className="px-6 py-4">
+                <div className="flex gap-2">
+                  <span
+                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                      user.is_active
+                        ? "bg-green-500/10 text-green-500"
+                        : "bg-red-500/10 text-red-500"
+                    }`}
+                  >
+                    {user.is_active ? "active" : "inactive"}
+                  </span>
+                  {user.is_verified && (
+                    <span className="inline-flex items-center rounded-full bg-blue-500/10 px-2.5 py-0.5 text-xs font-medium text-blue-500">
+                      verified
+                    </span>
+                  )}
+                </div>
+              </td>
+              <td className="px-6 py-4">
+                {user.is_superuser && (
+                  <span className="inline-flex items-center rounded-full bg-purple-500/10 px-2.5 py-0.5 text-xs font-medium text-purple-500">
+                    superuser
+                  </span>
+                )}
+              </td>
+              <td className="px-6 py-4 text-(--ink-muted)">
+                {user.last_login_at
+                  ? new Date(user.last_login_at).toLocaleDateString()
+                  : "-"}
+              </td>
+              <td className="px-6 py-4 text-right">
+                <Link
+                  href={`/superadmin/users/${user.id}`}
+                  className="text-(--accent) hover:underline"
+                >
+                  Edit
+                </Link>
+              </td>
+            </tr>
+          ))}
+          {users.length === 0 && (
+            <tr>
+              <td colSpan={7} className="px-6 py-8 text-center text-(--ink-muted)">
+                No users found.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -91,6 +91,13 @@ export async function deleteUser(userId: string): Promise<ActionResult<void>> {
   });
 }
 
+export async function setUserPassword(userId: string, password: string): Promise<ActionResult<void>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    return adminApi.users.setPassword(userId, password, token);
+  });
+}
+
 export async function listCredentials(): Promise<ActionResult<IntegrationCredential[]>> {
   return withErrorHandling(async () => {
     const token = await getToken();

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -263,6 +263,7 @@ export interface UserUpdate {
   avatar_url?: string | null;
   is_active?: boolean | null;
   is_verified?: boolean | null;
+  is_superuser?: boolean | null;
 }
 
 export interface UserSetPassword {


### PR DESCRIPTION
## Summary

Implements Phase 3 of the Global Admin UI (#447) — cross-org user management for superadmins.

- **User list page** (`/superadmin/users`) — table with name/email, username, auth provider, active/verified badges, superuser badge, last login
- **User detail page** (`/superadmin/users/[id]`) — profile edit form, password reset, delete with email confirmation
- **UserEditForm** — email, username, full_name, is_active/is_verified/is_superuser toggles
- **UserSetPasswordForm** — password reset with min 8 char validation + confirmation match
- **UserDeleteSection** — danger zone with email confirmation before hard delete
- Added `setUserPassword` server action and `is_superuser` to `UserUpdate` type

## Depends On

- `full-chaos/dev-health-ops` PR for `is_superuser` in `UserUpdate` schema (feat/user-update-superuser)

## Design

Follows existing superadmin patterns from org management pages (OrgTable, OrgEditForm, OrgDeleteSection). Pure Tailwind with CSS variables, no component libraries.