### PR TITLE
feat: superadmin licensing, audit log, and settings pages (Phases 4+5)

### DIFF
--- a/src/app/superadmin/audit/page.tsx
+++ b/src/app/superadmin/audit/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { AuditLogTable } from "@/components/superadmin/AuditLogTable";
+import { AuditLogFilters } from "@/components/superadmin/AuditLogFilters";
+import { listPlatformAuditLogs } from "@/lib/admin/server";
+import type { AuditLog, AuditLogFilter } from "@/lib/admin/types";
+
+export default function AuditLogPage() {
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<AuditLogFilter>({});
+  const [offset, setOffset] = useState(0);
+  const limit = 50;
+
+  const fetchLogs = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data, error: apiError } = await listPlatformAuditLogs(filters, limit, offset);
+      if (apiError) {
+        setError(apiError);
+      } else if (data) {
+        setLogs(data.items);
+      }
+    } catch (err) {
+      setError("An unexpected error occurred");
+    } finally {
+      setLoading(false);
+    }
+  }, [filters, offset]);
+
+  useEffect(() => {
+    fetchLogs();
+  }, [fetchLogs]);
+
+  const handleFilter = (newFilters: AuditLogFilter) => {
+    setFilters(newFilters);
+    setOffset(0);
+  };
+
+  const handleNextPage = () => {
+    setOffset((prev) => prev + limit);
+  };
+
+  const handlePrevPage = () => {
+    setOffset((prev) => Math.max(0, prev - limit));
+  };
+
+  return (
+    <div>
+      <AdminHeader
+        title="Platform Audit Log"
+        description="View and filter system-wide audit events."
+      />
+
+      <AuditLogFilters onFilter={handleFilter} />
+
+      {error && (
+        <div className="mb-6 rounded-2xl border border-red-500/20 bg-red-500/10 p-4 text-red-500">
+          Error loading audit logs: {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="py-12 text-center text-(--ink-muted)">Loading audit logs...</div>
+      ) : (
+        <>
+          <AuditLogTable logs={logs} />
+          <div className="mt-4 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={handlePrevPage}
+              disabled={offset === 0}
+              className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
+            >
+              Previous
+            </button>
+            <span className="text-sm text-(--ink-muted)">
+              Showing {offset + 1}-{offset + logs.length}
+            </span>
+            <button
+              type="button"
+              onClick={handleNextPage}
+              disabled={logs.length < limit}
+              className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/superadmin/licensing/[orgId]/page.tsx
+++ b/src/app/superadmin/licensing/[orgId]/page.tsx
@@ -1,0 +1,49 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { EntitlementsDetail } from "@/components/superadmin/EntitlementsDetail";
+import {
+  getOrganization,
+  getOrgEntitlements,
+  listFeatureOverrides,
+  listFeatureFlags,
+} from "@/lib/admin/server";
+
+type PageProps = {
+  params: Promise<{ orgId: string }>;
+};
+
+export default async function LicensingDetailPage({ params }: PageProps) {
+  const { orgId } = await params;
+  
+  const [orgResult, entitlementsResult, overridesResult, flagsResult] = await Promise.all([
+    getOrganization(orgId),
+    getOrgEntitlements(orgId),
+    listFeatureOverrides(orgId),
+    listFeatureFlags(),
+  ]);
+
+  const org = orgResult.data;
+  const entitlements = entitlementsResult.data;
+  const overrides = overridesResult.data;
+  const featureFlags = flagsResult.data;
+
+  if (!org || !entitlements) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <AdminHeader
+        title={`${org.name} Entitlements`}
+        description={`Manage licensing and feature flags for ${org.slug}`}
+      />
+      
+      <EntitlementsDetail
+        orgId={org.id}
+        entitlements={entitlements}
+        overrides={overrides || []}
+        featureFlags={featureFlags || []}
+      />
+    </div>
+  );
+}

--- a/src/app/superadmin/licensing/page.tsx
+++ b/src/app/superadmin/licensing/page.tsx
@@ -1,0 +1,31 @@
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { LicenseTable } from "@/components/superadmin/LicenseTable";
+import { listOrganizations } from "@/lib/admin/server";
+
+export default async function LicensingPage() {
+  const { data: orgs, error } = await listOrganizations();
+
+  if (error) {
+    return (
+      <div>
+        <AdminHeader
+          title="Licensing"
+          description="Organization tiers and entitlements."
+        />
+        <div className="rounded-2xl border border-red-500/20 bg-red-500/10 p-4 text-red-500">
+          Error loading organizations: {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <AdminHeader
+        title="Licensing"
+        description="Organization tiers and entitlements."
+      />
+      <LicenseTable orgs={orgs || []} />
+    </div>
+  );
+}

--- a/src/app/superadmin/settings/page.tsx
+++ b/src/app/superadmin/settings/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { SettingsSection } from "@/components/admin/settings/SettingsSection";
+import { listSettingCategories, listSettings } from "@/lib/admin/server";
+
+export default async function SettingsPage() {
+  const { data: categories, error: categoriesError } = await listSettingCategories();
+
+  if (categoriesError) {
+    return (
+      <div>
+        <AdminHeader
+          title="Platform Settings"
+          description="Global platform configuration."
+        />
+        <div className="rounded-2xl border border-red-500/20 bg-red-500/10 p-4 text-red-500">
+          Error loading settings: {categoriesError}
+        </div>
+      </div>
+    );
+  }
+
+  const settingsPromises = (categories || []).map(async (category) => {
+    const { data } = await listSettings(category);
+    return { category, settings: data || [] };
+  });
+
+  const allSettings = await Promise.all(settingsPromises);
+
+  return (
+    <div>
+      <AdminHeader
+        title="Platform Settings"
+        description="Global platform configuration."
+      />
+
+      <div className="space-y-8">
+        {allSettings.map(({ category, settings }) => (
+          <SettingsSection
+            key={category}
+            title={category.charAt(0).toUpperCase() + category.slice(1)}
+            description={`Configuration for ${category} settings.`}
+          >
+            {settings.length === 0 ? (
+              <div className="text-sm text-(--ink-muted)">No settings found.</div>
+            ) : (
+              <div className="overflow-x-auto rounded-lg border border-(--card-stroke)">
+                <table className="w-full text-left text-sm">
+                  <thead className="bg-(--card-70) text-(--ink-muted)">
+                    <tr>
+                      <th className="px-4 py-3 font-medium">Key</th>
+                      <th className="px-4 py-3 font-medium">Value</th>
+                      <th className="px-4 py-3 font-medium">Description</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-(--card-stroke)">
+                    {settings.map((setting) => (
+                      <tr key={setting.key}>
+                        <td className="px-4 py-3 font-mono text-xs">{setting.key}</td>
+                        <td className="px-4 py-3 font-mono text-xs text-(--ink-muted)">
+                          {setting.is_encrypted ? "********" : setting.value}
+                        </td>
+                        <td className="px-4 py-3 text-(--ink-muted)">
+                          {setting.description || "-"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </SettingsSection>
+        ))}
+
+        <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-center">
+          <p className="text-sm text-(--ink-muted)">
+            To edit these settings, please use the{" "}
+            <Link href="/admin/settings" className="text-(--accent) hover:underline">
+              Org Admin Settings
+            </Link>{" "}
+            page or the CLI.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/superadmin/AuditLogFilters.tsx
+++ b/src/components/superadmin/AuditLogFilters.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { useState } from "react";
+import type { AuditLogFilter } from "@/lib/admin/types";
+
+type AuditLogFiltersProps = {
+  onFilter: (filters: AuditLogFilter) => void;
+};
+
+export function AuditLogFilters({ onFilter }: AuditLogFiltersProps) {
+  const [action, setAction] = useState("");
+  const [resourceType, setResourceType] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onFilter({
+      action: action || undefined,
+      resource_type: resourceType || undefined,
+      start_date: startDate || undefined,
+      end_date: endDate || undefined,
+    });
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mb-6 grid gap-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4 sm:grid-cols-2 lg:grid-cols-5"
+    >
+      <div>
+        <label htmlFor="action-filter" className="mb-1 block text-xs font-medium text-(--ink-muted)">
+          Action
+        </label>
+        <input
+          id="action-filter"
+          type="text"
+          value={action}
+          onChange={(e) => setAction(e.target.value)}
+          placeholder="e.g. org.create"
+          className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+        />
+      </div>
+      <div>
+        <label htmlFor="resource-filter" className="mb-1 block text-xs font-medium text-(--ink-muted)">
+          Resource Type
+        </label>
+        <input
+          id="resource-filter"
+          type="text"
+          value={resourceType}
+          onChange={(e) => setResourceType(e.target.value)}
+          placeholder="e.g. organization"
+          className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+        />
+      </div>
+      <div>
+        <label htmlFor="start-date" className="mb-1 block text-xs font-medium text-(--ink-muted)">
+          Start Date
+        </label>
+        <input
+          id="start-date"
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+        />
+      </div>
+      <div>
+        <label htmlFor="end-date" className="mb-1 block text-xs font-medium text-(--ink-muted)">
+          End Date
+        </label>
+        <input
+          id="end-date"
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+        />
+      </div>
+      <div className="flex items-end">
+        <button
+          type="submit"
+          className="w-full rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90"
+        >
+          Search
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/superadmin/AuditLogTable.tsx
+++ b/src/components/superadmin/AuditLogTable.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import type { AuditLog } from "@/lib/admin/types";
+
+type AuditLogTableProps = {
+  logs: AuditLog[];
+};
+
+export function AuditLogTable({ logs }: AuditLogTableProps) {
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+      <table className="w-full text-left text-sm">
+        <thead className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+          <tr>
+            <th className="px-6 py-4 font-medium">Timestamp</th>
+            <th className="px-6 py-4 font-medium">Action</th>
+            <th className="px-6 py-4 font-medium">Resource</th>
+            <th className="px-6 py-4 font-medium">User</th>
+            <th className="px-6 py-4 font-medium">Status</th>
+            <th className="px-6 py-4 font-medium">Description</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-(--card-stroke)">
+          {logs.map((log) => (
+            <tr key={log.id} className="hover:bg-(--card-70)/50">
+              <td className="px-6 py-4 text-(--ink-muted)">
+                {new Date(log.created_at).toLocaleString()}
+              </td>
+              <td className="px-6 py-4 font-mono text-xs">{log.action}</td>
+              <td className="px-6 py-4">
+                <div className="flex flex-col">
+                  <span className="text-xs font-medium">{log.resource_type}</span>
+                  <span className="font-mono text-[10px] text-(--ink-muted)">
+                    {log.resource_id}
+                  </span>
+                </div>
+              </td>
+              <td className="px-6 py-4 font-mono text-xs text-(--ink-muted)">
+                {log.user_id || "System"}
+              </td>
+              <td className="px-6 py-4">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                    log.status === "success"
+                      ? "bg-green-500/10 text-green-500"
+                      : "bg-red-500/10 text-red-500"
+                  }`}
+                >
+                  {log.status}
+                </span>
+              </td>
+              <td className="px-6 py-4 text-(--ink-muted)">{log.description || "-"}</td>
+            </tr>
+          ))}
+          {logs.length === 0 && (
+            <tr>
+              <td colSpan={6} className="px-6 py-8 text-center text-(--ink-muted)">
+                No audit logs found.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/superadmin/EntitlementsDetail.tsx
+++ b/src/components/superadmin/EntitlementsDetail.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import React, { useState } from "react";
+import { toast } from "sonner";
+import type { FeatureFlag, FeatureOverride, OrgEntitlements } from "@/lib/admin/types";
+import { createFeatureOverride, deleteFeatureOverride } from "@/lib/admin/server";
+
+type EntitlementsDetailProps = {
+  orgId: string;
+  entitlements: OrgEntitlements;
+  overrides: FeatureOverride[];
+  featureFlags: FeatureFlag[];
+};
+
+export function EntitlementsDetail({
+  orgId,
+  entitlements,
+  overrides,
+  featureFlags,
+}: EntitlementsDetailProps) {
+  const [isCreating, setIsCreating] = useState(false);
+  const [selectedFeatureId, setSelectedFeatureId] = useState("");
+  const [overrideReason, setOverrideReason] = useState("");
+  const [overrideEnabled, setOverrideEnabled] = useState(true);
+
+  const handleCreateOverride = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedFeatureId) return;
+
+    try {
+      const { error } = await createFeatureOverride(orgId, {
+        feature_id: selectedFeatureId,
+        is_enabled: overrideEnabled,
+        reason: overrideReason || null,
+      });
+
+      if (error) {
+        toast.error(`Failed to create override: ${error}`);
+      } else {
+        toast.success("Override created successfully");
+        setIsCreating(false);
+        setSelectedFeatureId("");
+        setOverrideReason("");
+        setOverrideEnabled(true);
+      }
+    } catch (err) {
+      toast.error("An unexpected error occurred");
+    }
+  };
+
+  const handleDeleteOverride = async (overrideId: string) => {
+    if (!confirm("Are you sure you want to delete this override?")) return;
+
+    try {
+      const { error } = await deleteFeatureOverride(orgId, overrideId);
+      if (error) {
+        toast.error(`Failed to delete override: ${error}`);
+      } else {
+        toast.success("Override deleted successfully");
+      }
+    } catch (err) {
+      toast.error("An unexpected error occurred");
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* Limits Section */}
+      <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+        <h3 className="mb-4 text-lg font-medium">Limits</h3>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="rounded-xl border border-(--card-stroke) bg-(--card-70) p-4">
+            <div className="text-sm text-(--ink-muted)">Licensed Users</div>
+            <div className="mt-1 text-2xl font-semibold">
+              {entitlements.licensed_users === null ? "Unlimited" : entitlements.licensed_users}
+            </div>
+          </div>
+          <div className="rounded-xl border border-(--card-stroke) bg-(--card-70) p-4">
+            <div className="text-sm text-(--ink-muted)">Licensed Repos</div>
+            <div className="mt-1 text-2xl font-semibold">
+              {entitlements.licensed_repos === null ? "Unlimited" : entitlements.licensed_repos}
+            </div>
+          </div>
+          {Object.entries(entitlements.limits).map(([key, value]) => (
+            <div key={key} className="rounded-xl border border-(--card-stroke) bg-(--card-70) p-4">
+              <div className="text-sm text-(--ink-muted)">{key}</div>
+              <div className="mt-1 text-2xl font-semibold">
+                {value === null ? "Unlimited" : value}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Features Section */}
+      <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+        <h3 className="mb-4 text-lg font-medium">Features</h3>
+        <div className="overflow-x-auto rounded-xl border border-(--card-stroke)">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-(--card-70) text-(--ink-muted)">
+              <tr>
+                <th className="px-4 py-3 font-medium">Feature</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Source</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-(--card-stroke)">
+              {Object.entries(entitlements.features).map(([key, enabled]) => {
+                const isOverridden = entitlements.features_override && key in entitlements.features_override;
+                return (
+                  <tr key={key}>
+                    <td className="px-4 py-3 font-mono text-xs">{key}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                          enabled
+                            ? "bg-green-500/10 text-green-500"
+                            : "bg-red-500/10 text-red-500"
+                        }`}
+                      >
+                        {enabled ? "Enabled" : "Disabled"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-(--ink-muted)">
+                      {isOverridden ? (
+                        <span className="text-purple-400">Override</span>
+                      ) : (
+                        "Tier Default"
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Overrides Section */}
+      <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-lg font-medium">Feature Overrides</h3>
+          <button
+            type="button"
+            onClick={() => setIsCreating(!isCreating)}
+            className="rounded-lg bg-(--accent) px-3 py-1.5 text-sm font-medium text-white hover:bg-(--accent)/90"
+          >
+            {isCreating ? "Cancel" : "Add Override"}
+          </button>
+        </div>
+
+        {isCreating && (
+          <form onSubmit={handleCreateOverride} className="mb-6 rounded-xl border border-(--card-stroke) bg-(--card-70) p-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label htmlFor="feature-select" className="mb-1 block text-xs font-medium text-(--ink-muted)">Feature</label>
+                <select
+                  id="feature-select"
+                  value={selectedFeatureId}
+                  onChange={(e) => setSelectedFeatureId(e.target.value)}
+                  className="w-full rounded-lg border border-(--card-stroke) bg-(--card-80) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                  required
+                >
+                  <option value="">Select a feature...</option>
+                  {featureFlags.map((flag) => (
+                    <option key={flag.id} value={flag.id}>
+                      {flag.key} ({flag.name})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="state-select" className="mb-1 block text-xs font-medium text-(--ink-muted)">State</label>
+                <select
+                  id="state-select"
+                  value={overrideEnabled ? "true" : "false"}
+                  onChange={(e) => setOverrideEnabled(e.target.value === "true")}
+                  className="w-full rounded-lg border border-(--card-stroke) bg-(--card-80) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                >
+                  <option value="true">Enabled</option>
+                  <option value="false">Disabled</option>
+                </select>
+              </div>
+              <div className="sm:col-span-2">
+                <label htmlFor="reason-input" className="mb-1 block text-xs font-medium text-(--ink-muted)">Reason</label>
+                <input
+                  id="reason-input"
+                  type="text"
+                  value={overrideReason}
+                  onChange={(e) => setOverrideReason(e.target.value)}
+                  placeholder="Why is this override being applied?"
+                  className="w-full rounded-lg border border-(--card-stroke) bg-(--card-80) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                />
+              </div>
+            </div>
+            <div className="mt-4 flex justify-end">
+              <button
+                type="submit"
+                className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90"
+              >
+                Save Override
+              </button>
+            </div>
+          </form>
+        )}
+
+        {overrides.length === 0 ? (
+          <div className="text-sm text-(--ink-muted)">No overrides active.</div>
+        ) : (
+          <div className="overflow-x-auto rounded-xl border border-(--card-stroke)">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-(--card-70) text-(--ink-muted)">
+                <tr>
+                  <th className="px-4 py-3 font-medium">Feature</th>
+                  <th className="px-4 py-3 font-medium">State</th>
+                  <th className="px-4 py-3 font-medium">Reason</th>
+                  <th className="px-4 py-3 font-medium">Created</th>
+                  <th className="px-4 py-3 font-medium text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-(--card-stroke)">
+                {overrides.map((override) => (
+                  <tr key={override.id}>
+                    <td className="px-4 py-3 font-mono text-xs">{override.feature_key}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                          override.is_enabled
+                            ? "bg-green-500/10 text-green-500"
+                            : "bg-red-500/10 text-red-500"
+                        }`}
+                      >
+                        {override.is_enabled ? "Enabled" : "Disabled"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-(--ink-muted)">{override.reason || "-"}</td>
+                    <td className="px-4 py-3 text-(--ink-muted)">
+                      {new Date(override.created_at).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteOverride(override.id)}
+                        className="text-red-500 hover:underline"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/superadmin/LicenseTable.tsx
+++ b/src/components/superadmin/LicenseTable.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import Link from "next/link";
+import type { Organization } from "@/lib/admin/types";
+
+type LicenseTableProps = {
+  orgs: Organization[];
+};
+
+function getTierBadge(tier: string) {
+  switch (tier) {
+    case "enterprise":
+      return "bg-purple-500/10 text-purple-500";
+    case "team":
+      return "bg-blue-500/10 text-blue-500";
+    default:
+      return "bg-green-500/10 text-green-500";
+  }
+}
+
+export function LicenseTable({ orgs }: LicenseTableProps) {
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+      <table className="w-full text-left text-sm">
+        <thead className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+          <tr>
+            <th className="px-6 py-4 font-medium">Organization</th>
+            <th className="px-6 py-4 font-medium">Slug</th>
+            <th className="px-6 py-4 font-medium">Tier</th>
+            <th className="px-6 py-4 font-medium">Status</th>
+            <th className="px-6 py-4 font-medium text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-(--card-stroke)">
+          {orgs.map((org) => (
+            <tr key={org.id} className="hover:bg-(--card-70)/50">
+              <td className="px-6 py-4 font-medium text-foreground">
+                <Link href={`/superadmin/licensing/${org.id}`} className="hover:underline">
+                  {org.name}
+                </Link>
+              </td>
+              <td className="px-6 py-4 text-(--ink-muted)">{org.slug}</td>
+              <td className="px-6 py-4">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${getTierBadge(
+                    org.tier
+                  )}`}
+                >
+                  {org.tier}
+                </span>
+              </td>
+              <td className="px-6 py-4">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                    org.is_active
+                      ? "bg-green-500/10 text-green-500"
+                      : "bg-red-500/10 text-red-500"
+                  }`}
+                >
+                  {org.is_active ? "active" : "inactive"}
+                </span>
+              </td>
+              <td className="px-6 py-4 text-right">
+                <Link
+                  href={`/superadmin/licensing/${org.id}`}
+                  className="text-(--accent) hover:underline"
+                >
+                  Manage Entitlements
+                </Link>
+              </td>
+            </tr>
+          ))}
+          {orgs.length === 0 && (
+            <tr>
+              <td colSpan={5} className="px-6 py-8 text-center text-(--ink-muted)">
+                No organizations found.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/superadmin/SuperadminSidebar.tsx
+++ b/src/components/superadmin/SuperadminSidebar.tsx
@@ -7,6 +7,9 @@ const navItems = [
   { id: "dashboard", label: "Dashboard", href: "/superadmin", description: "Overview" },
   { id: "orgs", label: "Organizations", href: "/superadmin/orgs", description: "Tenants" },
   { id: "users", label: "Users", href: "/superadmin/users", description: "Global" },
+  { id: "licensing", label: "Licensing", href: "/superadmin/licensing", description: "Tiers" },
+  { id: "audit", label: "Audit Log", href: "/superadmin/audit", description: "Events" },
+  { id: "settings", label: "Settings", href: "/superadmin/settings", description: "Platform" },
 ];
 
 export function SuperadminSidebar() {

--- a/src/lib/admin/api.ts
+++ b/src/lib/admin/api.ts
@@ -44,6 +44,10 @@ import type {
   RetentionPolicyListResponse,
   RetentionExecuteResponse,
   PlatformStats,
+  FeatureFlag,
+  FeatureOverride,
+  FeatureOverrideCreate,
+  OrgEntitlements,
 } from "./types";
 
 export class AdminApiError extends Error {
@@ -64,6 +68,46 @@ async function request<T>(
 ): Promise<T> {
   const baseUrl = getBackendUrl();
   const url = `${baseUrl}/api/v1/admin${path}`;
+
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+    ...options.headers,
+  };
+
+  if (accessToken) {
+    (headers as Record<string, string>)["Authorization"] = `Bearer ${accessToken}`;
+  }
+
+  const response = await fetch(url, {
+    ...options,
+    headers,
+  });
+
+  if (!response.ok) {
+    let detail: string | undefined;
+    try {
+      const errorData = await response.json();
+      detail = errorData.detail || errorData.message;
+    } catch {
+      detail = undefined;
+    }
+    throw new AdminApiError(response.status, response.statusText, detail);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json();
+}
+
+async function licensingRequest<T>(
+  path: string,
+  options: RequestInit = {},
+  accessToken?: string
+): Promise<T> {
+  const baseUrl = getBackendUrl();
+  const url = `${baseUrl}/api/v1/licensing${path}`;
 
   const headers: HeadersInit = {
     "Content-Type": "application/json",
@@ -492,6 +536,43 @@ export const adminApi = {
   platform: {
     stats: (token?: string) =>
       request<PlatformStats>("/platform/stats", {}, token),
+  },
+
+  licensing: {
+    entitlements: (orgId: string, token?: string) =>
+      licensingRequest<OrgEntitlements>(`/entitlements/${orgId}`, {}, token),
+
+    featureFlags: (token?: string) =>
+      request<FeatureFlag[]>("/feature-flags", {}, token),
+
+    overrides: {
+      list: (orgId: string, token?: string) =>
+        request<FeatureOverride[]>(`/orgs/${orgId}/feature-overrides`, {}, token),
+
+      create: (orgId: string, data: FeatureOverrideCreate, token?: string) =>
+        request<FeatureOverride>(
+          `/orgs/${orgId}/feature-overrides`,
+          { method: "POST", body: JSON.stringify(data) },
+          token
+        ),
+
+      delete: (orgId: string, overrideId: string, token?: string) =>
+        request<void>(`/orgs/${orgId}/feature-overrides/${overrideId}`, { method: "DELETE" }, token),
+    },
+  },
+
+  platformAudit: {
+    list: (filters?: AuditLogFilter, limit?: number, offset?: number, token?: string) => {
+      const params = new URLSearchParams();
+      if (limit) params.set("limit", String(limit));
+      if (offset) params.set("offset", String(offset));
+      if (filters) {
+        Object.entries(filters).forEach(([k, v]) => {
+          if (v != null) params.set(k, String(v));
+        });
+      }
+      return request<AuditLogListResponse>(`/platform/audit-logs?${params.toString()}`, {}, token);
+    },
   },
 };
 

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -32,6 +32,12 @@ import type {
   OrganizationUpdate,
   Membership,
   PlatformStats,
+  OrgEntitlements,
+  FeatureFlag,
+  FeatureOverride,
+  FeatureOverrideCreate,
+  AuditLogListResponse,
+  AuditLogFilter,
 } from "./types";
 
 async function getToken(): Promise<string> {
@@ -535,5 +541,61 @@ export async function getPlatformStats(): Promise<ActionResult<PlatformStats>> {
   return withErrorHandling(async () => {
     const token = await getToken();
     return adminApi.platform.stats(token);
+  });
+}
+
+export async function getOrgEntitlements(orgId: string): Promise<ActionResult<OrgEntitlements>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    return adminApi.licensing.entitlements(orgId, token);
+  });
+}
+
+export async function listFeatureFlags(): Promise<ActionResult<FeatureFlag[]>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    return adminApi.licensing.featureFlags(token);
+  });
+}
+
+export async function listFeatureOverrides(orgId: string): Promise<ActionResult<FeatureOverride[]>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    return adminApi.licensing.overrides.list(orgId, token);
+  });
+}
+
+export async function createFeatureOverride(
+  orgId: string,
+  data: FeatureOverrideCreate
+): Promise<ActionResult<FeatureOverride>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    const result = await adminApi.licensing.overrides.create(orgId, data, token);
+    revalidatePath(`/superadmin/licensing/${orgId}`);
+    return result;
+  });
+}
+
+export async function deleteFeatureOverride(
+  orgId: string,
+  overrideId: string
+): Promise<ActionResult<void>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    const result = await adminApi.licensing.overrides.delete(orgId, overrideId, token);
+    revalidatePath(`/superadmin/licensing/${orgId}`);
+    return result;
+  });
+}
+
+export async function listPlatformAuditLogs(
+  filters?: AuditLogFilter,
+  limit?: number,
+  offset?: number
+): Promise<ActionResult<AuditLogListResponse>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    return adminApi.platformAudit.list(filters, limit, offset, token);
   });
 }

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -477,3 +477,52 @@ export interface PlatformStats {
   recent_syncs_success: number;
   recent_syncs_failed: number;
 }
+
+// ---- Licensing & Feature Flags ----
+
+export interface FeatureFlag {
+  id: string;
+  key: string;
+  name: string;
+  description: string | null;
+  category: string;
+  min_tier: string;
+  is_enabled: boolean;
+  is_beta: boolean;
+  is_deprecated: boolean;
+  created_at: string;
+}
+
+export interface FeatureOverride {
+  id: string;
+  org_id: string;
+  feature_id: string;
+  feature_key: string;
+  is_enabled: boolean;
+  expires_at: string | null;
+  config: Record<string, unknown> | null;
+  reason: string | null;
+  created_by: string | null;
+  created_at: string;
+}
+
+export interface FeatureOverrideCreate {
+  feature_id: string;
+  is_enabled?: boolean;
+  expires_at?: string | null;
+  config?: Record<string, unknown> | null;
+  reason?: string | null;
+}
+
+export interface OrgEntitlements {
+  org_id: string;
+  tier: string;
+  licensed_users: number | null;
+  licensed_repos: number | null;
+  features: Record<string, boolean>;
+  features_override: Record<string, boolean> | null;
+  limits_override: Record<string, number | null> | null;
+  expires_at: string | null;
+  is_valid: boolean;
+  limits: Record<string, number | null>;
+}


### PR DESCRIPTION
## Summary

Completes Global Admin UI Phases 4 and 5 (#447):

**Phase 4 — Licensing:**
- `/superadmin/licensing` — org tier overview table
- `/superadmin/licensing/[orgId]` — per-org entitlements detail: features, limits, override management (create/delete)
- `LicenseTable`, `EntitlementsDetail` components

**Phase 5 — Audit & Settings:**
- `/superadmin/audit` — cross-org audit log viewer with action/resource/date filters + pagination
- `/superadmin/settings` — read-only platform configuration overview by category
- `AuditLogTable`, `AuditLogFilters` components

**Shared:**
- Updated `SuperadminSidebar` with Licensing, Audit Log, Settings nav items
- Added licensing + platformAudit API client methods, TypeScript types, server actions

## Depends On

- `full-chaos/dev-health-ops` PR for backend endpoints (feat/admin-platform-endpoints)

## Pages Added

| Route | Description |
|-------|-------------|
| `/superadmin/licensing` | Org tier overview |
| `/superadmin/licensing/[orgId]` | Entitlements + overrides |
| `/superadmin/audit` | Cross-org audit viewer |
| `/superadmin/settings` | Platform config |