### PR TITLE
fix: pass X-Org-Id header on all org-scoped admin API calls

### DIFF
--- a/src/lib/admin/api.ts
+++ b/src/lib/admin/api.ts
@@ -64,7 +64,8 @@ export class AdminApiError extends Error {
 async function request<T>(
   path: string,
   options: RequestInit = {},
-  accessToken?: string
+  accessToken?: string,
+  orgId?: string
 ): Promise<T> {
   const baseUrl = getBackendUrl();
   const url = `${baseUrl}/api/v1/admin${path}`;
@@ -76,6 +77,10 @@ async function request<T>(
 
   if (accessToken) {
     (headers as Record<string, string>)["Authorization"] = `Bearer ${accessToken}`;
+  }
+
+  if (orgId) {
+    (headers as Record<string, string>)["X-Org-Id"] = orgId;
   }
 
   const response = await fetch(url, {
@@ -104,7 +109,8 @@ async function request<T>(
 async function licensingRequest<T>(
   path: string,
   options: RequestInit = {},
-  accessToken?: string
+  accessToken?: string,
+  orgId?: string
 ): Promise<T> {
   const baseUrl = getBackendUrl();
   const url = `${baseUrl}/api/v1/licensing${path}`;
@@ -116,6 +122,10 @@ async function licensingRequest<T>(
 
   if (accessToken) {
     (headers as Record<string, string>)["Authorization"] = `Bearer ${accessToken}`;
+  }
+
+  if (orgId) {
+    (headers as Record<string, string>)["X-Org-Id"] = orgId;
   }
 
   const response = await fetch(url, {
@@ -143,155 +153,166 @@ async function licensingRequest<T>(
 
 export const adminApi = {
   settings: {
-    listCategories: (token?: string) =>
-      request<string[]>("/settings/categories", {}, token),
+    listCategories: (token?: string, orgId?: string) =>
+      request<string[]>("/settings/categories", {}, token, orgId),
 
-    listByCategory: (category: string, token?: string) =>
-      request<SettingsListResponse>(`/settings/${category}`, {}, token),
+    listByCategory: (category: string, token?: string, orgId?: string) =>
+      request<SettingsListResponse>(`/settings/${category}`, {}, token, orgId),
 
-    get: (category: string, key: string, token?: string) =>
-      request<Setting>(`/settings/${category}/${key}`, {}, token),
+    get: (category: string, key: string, token?: string, orgId?: string) =>
+      request<Setting>(`/settings/${category}/${key}`, {}, token, orgId),
 
-    create: (data: SettingCreate, token?: string) =>
-      request<Setting>("/settings", { method: "POST", body: JSON.stringify(data) }, token),
+    create: (data: SettingCreate, token?: string, orgId?: string) =>
+      request<Setting>("/settings", { method: "POST", body: JSON.stringify(data) }, token, orgId),
 
-    update: (category: string, key: string, data: SettingUpdate, token?: string) =>
+    update: (category: string, key: string, data: SettingUpdate, token?: string, orgId?: string) =>
       request<Setting>(
         `/settings/${category}/${key}`,
         { method: "PUT", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    delete: (category: string, key: string, token?: string) =>
-      request<void>(`/settings/${category}/${key}`, { method: "DELETE" }, token),
+    delete: (category: string, key: string, token?: string, orgId?: string) =>
+      request<void>(`/settings/${category}/${key}`, { method: "DELETE" }, token, orgId),
   },
 
   credentials: {
-    list: (token?: string) =>
-      request<IntegrationCredential[]>("/credentials", {}, token),
+    list: (token?: string, orgId?: string) =>
+      request<IntegrationCredential[]>("/credentials", {}, token, orgId),
 
-    get: (provider: string, name: string, token?: string) =>
-      request<IntegrationCredential>(`/credentials/${provider}/${name}`, {}, token),
+    get: (provider: string, name: string, token?: string, orgId?: string) =>
+      request<IntegrationCredential>(`/credentials/${provider}/${name}`, {}, token, orgId),
 
-    create: (data: IntegrationCredentialCreate, token?: string) =>
+    create: (data: IntegrationCredentialCreate, token?: string, orgId?: string) =>
       request<IntegrationCredential>(
         "/credentials",
         { method: "POST", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    update: (provider: string, name: string, data: IntegrationCredentialUpdate, token?: string) =>
+    update: (provider: string, name: string, data: IntegrationCredentialUpdate, token?: string, orgId?: string) =>
       request<IntegrationCredential>(
         `/credentials/${provider}/${name}`,
         { method: "PATCH", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    delete: (provider: string, name: string, token?: string) =>
-      request<void>(`/credentials/${provider}/${name}`, { method: "DELETE" }, token),
+    delete: (provider: string, name: string, token?: string, orgId?: string) =>
+      request<void>(`/credentials/${provider}/${name}`, { method: "DELETE" }, token, orgId),
 
-    test: (provider: string, name: string = "default", credentials?: Record<string, unknown>, token?: string) =>
+    test: (provider: string, name: string = "default", credentials?: Record<string, unknown>, token?: string, orgId?: string) =>
       request<TestConnectionResponse>(
         "/credentials/test",
         { method: "POST", body: JSON.stringify({ provider, name, credentials }) },
-        token
+        token,
+        orgId
       ),
   },
 
   syncConfigs: {
-    list: (token?: string) =>
-      request<SyncConfig[]>("/sync-configs", {}, token),
+    list: (token?: string, orgId?: string) =>
+      request<SyncConfig[]>("/sync-configs", {}, token, orgId),
 
-    get: (id: string, token?: string) =>
-      request<SyncConfig>(`/sync-configs/${id}`, {}, token),
+    get: (id: string, token?: string, orgId?: string) =>
+      request<SyncConfig>(`/sync-configs/${id}`, {}, token, orgId),
 
-    create: (data: SyncConfigCreate, token?: string) =>
+    create: (data: SyncConfigCreate, token?: string, orgId?: string) =>
       request<SyncConfig>(
         "/sync-configs",
         { method: "POST", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    update: (id: string, data: SyncConfigUpdate, token?: string) =>
+    update: (id: string, data: SyncConfigUpdate, token?: string, orgId?: string) =>
       request<SyncConfig>(
         `/sync-configs/${id}`,
         { method: "PATCH", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    delete: (id: string, token?: string) =>
-      request<void>(`/sync-configs/${id}`, { method: "DELETE" }, token),
+    delete: (id: string, token?: string, orgId?: string) =>
+      request<void>(`/sync-configs/${id}`, { method: "DELETE" }, token, orgId),
 
-    trigger: (id: string, token?: string) =>
-      request<void>(`/sync-configs/${id}/trigger`, { method: "POST" }, token),
+    trigger: (id: string, token?: string, orgId?: string) =>
+      request<void>(`/sync-configs/${id}/trigger`, { method: "POST" }, token, orgId),
 
-    jobs: (id: string, token?: string) =>
-      request<SyncJob[]>(`/sync-configs/${id}/jobs`, {}, token),
+    jobs: (id: string, token?: string, orgId?: string) =>
+      request<SyncJob[]>(`/sync-configs/${id}/jobs`, {}, token, orgId),
   },
 
   identities: {
-    list: (token?: string) =>
-      request<IdentityMapping[]>("/identities", {}, token),
+    list: (token?: string, orgId?: string) =>
+      request<IdentityMapping[]>("/identities", {}, token, orgId),
 
-    get: (id: string, token?: string) =>
-      request<IdentityMapping>(`/identities/${id}`, {}, token),
+    get: (id: string, token?: string, orgId?: string) =>
+      request<IdentityMapping>(`/identities/${id}`, {}, token, orgId),
 
-    create: (data: IdentityMappingCreate, token?: string) =>
+    create: (data: IdentityMappingCreate, token?: string, orgId?: string) =>
       request<IdentityMapping>(
         "/identities",
         { method: "POST", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    update: (id: string, data: IdentityMappingUpdate, token?: string) =>
+    update: (id: string, data: IdentityMappingUpdate, token?: string, orgId?: string) =>
       request<IdentityMapping>(
         `/identities/${id}`,
         { method: "PATCH", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    delete: (id: string, token?: string) =>
-      request<void>(`/identities/${id}`, { method: "DELETE" }, token),
+    delete: (id: string, token?: string, orgId?: string) =>
+      request<void>(`/identities/${id}`, { method: "DELETE" }, token, orgId),
   },
 
   teams: {
-    list: (token?: string) =>
-      request<TeamMapping[]>("/teams", {}, token),
+    list: (token?: string, orgId?: string) =>
+      request<TeamMapping[]>("/teams", {}, token, orgId),
 
-    get: (teamId: string, token?: string) =>
-      request<TeamMapping>(`/teams/${teamId}`, {}, token),
+    get: (teamId: string, token?: string, orgId?: string) =>
+      request<TeamMapping>(`/teams/${teamId}`, {}, token, orgId),
 
-    create: (data: TeamMappingCreate, token?: string) =>
+    create: (data: TeamMappingCreate, token?: string, orgId?: string) =>
       request<TeamMapping>(
         "/teams",
         { method: "POST", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    update: (teamId: string, data: TeamMappingUpdate, token?: string) =>
+    update: (teamId: string, data: TeamMappingUpdate, token?: string, orgId?: string) =>
       request<TeamMapping>(
         `/teams/${teamId}`,
         { method: "PATCH", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    delete: (teamId: string, token?: string) =>
-      request<void>(`/teams/${teamId}`, { method: "DELETE" }, token),
+    delete: (teamId: string, token?: string, orgId?: string) =>
+      request<void>(`/teams/${teamId}`, { method: "DELETE" }, token, orgId),
 
-    discover: (provider: string, token?: string) =>
-      request<TeamDiscoverResponse>(`/teams/discover?provider=${provider}`, {}, token),
+    discover: (provider: string, token?: string, orgId?: string) =>
+      request<TeamDiscoverResponse>(`/teams/discover?provider=${provider}`, {}, token, orgId),
 
-    import: (data: TeamImportRequest, token?: string) =>
+    import: (data: TeamImportRequest, token?: string, orgId?: string) =>
       request<TeamImportResponse>(
         "/teams/import",
         { method: "POST", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    pendingChanges: (token?: string) =>
-      request<PendingChangesResponse>('/teams/pending-changes', {}, token),
+    pendingChanges: (token?: string, orgId?: string) =>
+      request<PendingChangesResponse>('/teams/pending-changes', {}, token, orgId),
 
-    approveChanges: (teamId: string, changeIndices?: number[], approveAll = false, token?: string) =>
+    approveChanges: (teamId: string, changeIndices?: number[], approveAll = false, token?: string, orgId?: string) =>
       request<{ approved: number }>(
         `/teams/${teamId}/approve-changes`,
         {
@@ -301,10 +322,11 @@ export const adminApi = {
             approve_all: approveAll,
           }),
         },
-        token
+        token,
+        orgId
       ),
 
-    dismissChanges: (teamId: string, changeIndices?: number[], dismissAll = false, token?: string) =>
+    dismissChanges: (teamId: string, changeIndices?: number[], dismissAll = false, token?: string, orgId?: string) =>
       request<{ dismissed: number }>(
         `/teams/${teamId}/dismiss-changes`,
         {
@@ -314,101 +336,110 @@ export const adminApi = {
             dismiss_all: dismissAll,
           }),
         },
-        token
+        token,
+        orgId
       ),
 
-    triggerDriftSync: (token?: string) =>
-      request<{ status: string }>('/teams/trigger-drift-sync', { method: 'POST' }, token),
+    triggerDriftSync: (token?: string, orgId?: string) =>
+      request<{ status: string }>('/teams/trigger-drift-sync', { method: 'POST' }, token, orgId),
   },
 
   users: {
-    list: (token?: string) =>
-      request<User[]>("/users", {}, token),
+    list: (token?: string, orgId?: string) =>
+      request<User[]>("/users", {}, token, orgId),
 
-    get: (userId: string, token?: string) =>
-      request<User>(`/users/${userId}`, {}, token),
+    get: (userId: string, token?: string, orgId?: string) =>
+      request<User>(`/users/${userId}`, {}, token, orgId),
 
-    create: (data: UserCreate, token?: string) =>
+    create: (data: UserCreate, token?: string, orgId?: string) =>
       request<User>(
         "/users",
         { method: "POST", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    update: (userId: string, data: UserUpdate, token?: string) =>
+    update: (userId: string, data: UserUpdate, token?: string, orgId?: string) =>
       request<User>(
         `/users/${userId}`,
         { method: "PATCH", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    setPassword: (userId: string, password: string, token?: string) =>
+    setPassword: (userId: string, password: string, token?: string, orgId?: string) =>
       request<void>(
         `/users/${userId}/password`,
         { method: "POST", body: JSON.stringify({ password }) },
-        token
+        token,
+        orgId
       ),
 
-    delete: (userId: string, token?: string) =>
-      request<void>(`/users/${userId}`, { method: "DELETE" }, token),
+    delete: (userId: string, token?: string, orgId?: string) =>
+      request<void>(`/users/${userId}`, { method: "DELETE" }, token, orgId),
   },
 
   orgs: {
-    list: (token?: string) =>
-      request<Organization[]>("/orgs", {}, token),
+    list: (token?: string, headerOrgId?: string) =>
+      request<Organization[]>("/orgs", {}, token, headerOrgId),
 
-    get: (orgId: string, token?: string) =>
-      request<Organization>(`/orgs/${orgId}`, {}, token),
+    get: (orgId: string, token?: string, headerOrgId?: string) =>
+      request<Organization>(`/orgs/${orgId}`, {}, token, headerOrgId),
 
-    create: (data: OrganizationCreate, token?: string) =>
+    create: (data: OrganizationCreate, token?: string, headerOrgId?: string) =>
       request<Organization>(
         "/orgs",
         { method: "POST", body: JSON.stringify(data) },
-        token
+        token,
+        headerOrgId
       ),
 
-    update: (orgId: string, data: OrganizationUpdate, token?: string) =>
+    update: (orgId: string, data: OrganizationUpdate, token?: string, headerOrgId?: string) =>
       request<Organization>(
         `/orgs/${orgId}`,
         { method: "PATCH", body: JSON.stringify(data) },
-        token
+        token,
+        headerOrgId
       ),
 
-    delete: (orgId: string, token?: string) =>
-      request<void>(`/orgs/${orgId}`, { method: "DELETE" }, token),
+    delete: (orgId: string, token?: string, headerOrgId?: string) =>
+      request<void>(`/orgs/${orgId}`, { method: "DELETE" }, token, headerOrgId),
 
     members: {
-      list: (orgId: string, token?: string) =>
-        request<Membership[]>(`/orgs/${orgId}/members`, {}, token),
+      list: (orgId: string, token?: string, headerOrgId?: string) =>
+        request<Membership[]>(`/orgs/${orgId}/members`, {}, token, headerOrgId),
 
-      add: (orgId: string, data: MembershipCreate, token?: string) =>
+      add: (orgId: string, data: MembershipCreate, token?: string, headerOrgId?: string) =>
         request<Membership>(
           `/orgs/${orgId}/members`,
           { method: "POST", body: JSON.stringify(data) },
-          token
+          token,
+          headerOrgId
         ),
 
-      updateRole: (orgId: string, userId: string, data: MembershipUpdateRole, token?: string) =>
+      updateRole: (orgId: string, userId: string, data: MembershipUpdateRole, token?: string, headerOrgId?: string) =>
         request<Membership>(
           `/orgs/${orgId}/members/${userId}`,
           { method: "PATCH", body: JSON.stringify(data) },
-          token
+          token,
+          headerOrgId
         ),
 
-      remove: (orgId: string, userId: string, token?: string) =>
-        request<void>(`/orgs/${orgId}/members/${userId}`, { method: "DELETE" }, token),
+      remove: (orgId: string, userId: string, token?: string, headerOrgId?: string) =>
+        request<void>(`/orgs/${orgId}/members/${userId}`, { method: "DELETE" }, token, headerOrgId),
 
-      transferOwnership: (orgId: string, newOwnerUserId: string, token?: string) =>
+      transferOwnership: (orgId: string, newOwnerUserId: string, token?: string, headerOrgId?: string) =>
         request<void>(
           `/orgs/${orgId}/transfer-ownership`,
           { method: "POST", body: JSON.stringify({ new_owner_user_id: newOwnerUserId }) },
-          token
+          token,
+          headerOrgId
         ),
     },
   },
 
   audit: {
-    list: (filters?: AuditLogFilter, limit = 50, offset = 0, token?: string) => {
+    list: (filters?: AuditLogFilter, limit = 50, offset = 0, token?: string, orgId?: string) => {
       const params = new URLSearchParams();
       params.set("limit", String(limit));
       params.set("offset", String(offset));
@@ -417,13 +448,13 @@ export const adminApi = {
           if (value != null) params.set(key, String(value));
         });
       }
-      return request<AuditLogListResponse>(`/audit?${params.toString()}`, {}, token);
+      return request<AuditLogListResponse>(`/audit?${params.toString()}`, {}, token, orgId);
     },
 
-    get: (id: string, token?: string) =>
-      request<AuditLogListResponse["items"][0]>(`/audit/${id}`, {}, token),
+    get: (id: string, token?: string, orgId?: string) =>
+      request<AuditLogListResponse["items"][0]>(`/audit/${id}`, {}, token, orgId),
 
-    export: (format: "json" | "csv" = "json", filters?: AuditLogFilter, token?: string) => {
+    export: (format: "json" | "csv" = "json", filters?: AuditLogFilter, token?: string, orgId?: string) => {
       const params = new URLSearchParams();
       params.set("format", format);
       if (filters) {
@@ -431,105 +462,113 @@ export const adminApi = {
           if (value != null) params.set(key, String(value));
         });
       }
-      return request<Blob>(`/audit/export?${params.toString()}`, {}, token);
+      return request<Blob>(`/audit/export?${params.toString()}`, {}, token, orgId);
     },
 
-    actions: (token?: string) =>
-      request<string[]>("/audit/actions", {}, token),
+    actions: (token?: string, orgId?: string) =>
+      request<string[]>("/audit/actions", {}, token, orgId),
   },
 
   ipAllowlist: {
-    list: (limit = 50, offset = 0, token?: string) =>
+    list: (limit = 50, offset = 0, token?: string, orgId?: string) =>
       request<IPAllowlistListResponse>(
         `/ip-allowlist?limit=${limit}&offset=${offset}`,
         {},
-        token
+        token,
+        orgId
       ),
 
-    get: (id: string, token?: string) =>
-      request<IPAllowlist>(`/ip-allowlist/${id}`, {}, token),
+    get: (id: string, token?: string, orgId?: string) =>
+      request<IPAllowlist>(`/ip-allowlist/${id}`, {}, token, orgId),
 
-    create: (data: IPAllowlistCreate, token?: string) =>
+    create: (data: IPAllowlistCreate, token?: string, orgId?: string) =>
       request<IPAllowlist>(
         "/ip-allowlist",
         { method: "POST", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    update: (id: string, data: IPAllowlistUpdate, token?: string) =>
+    update: (id: string, data: IPAllowlistUpdate, token?: string, orgId?: string) =>
       request<IPAllowlist>(
         `/ip-allowlist/${id}`,
         { method: "PATCH", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    delete: (id: string, token?: string) =>
-      request<void>(`/ip-allowlist/${id}`, { method: "DELETE" }, token),
+    delete: (id: string, token?: string, orgId?: string) =>
+      request<void>(`/ip-allowlist/${id}`, { method: "DELETE" }, token, orgId),
 
-    check: (ipAddress: string, token?: string) =>
+    check: (ipAddress: string, token?: string, orgId?: string) =>
       request<IPCheckResponse>(
         "/ip-allowlist/check",
         { method: "POST", body: JSON.stringify({ ip_address: ipAddress }) },
-        token
+        token,
+        orgId
       ),
   },
 
   retention: {
-    list: (limit = 50, offset = 0, token?: string) =>
+    list: (limit = 50, offset = 0, token?: string, orgId?: string) =>
       request<RetentionPolicyListResponse>(
         `/retention?limit=${limit}&offset=${offset}`,
         {},
-        token
+        token,
+        orgId
       ),
 
-    get: (id: string, token?: string) =>
-      request<RetentionPolicy>(`/retention/${id}`, {}, token),
+    get: (id: string, token?: string, orgId?: string) =>
+      request<RetentionPolicy>(`/retention/${id}`, {}, token, orgId),
 
-    create: (data: RetentionPolicyCreate, token?: string) =>
+    create: (data: RetentionPolicyCreate, token?: string, orgId?: string) =>
       request<RetentionPolicy>(
         "/retention",
         { method: "POST", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    update: (id: string, data: RetentionPolicyUpdate, token?: string) =>
+    update: (id: string, data: RetentionPolicyUpdate, token?: string, orgId?: string) =>
       request<RetentionPolicy>(
         `/retention/${id}`,
         { method: "PATCH", body: JSON.stringify(data) },
-        token
+        token,
+        orgId
       ),
 
-    delete: (id: string, token?: string) =>
-      request<void>(`/retention/${id}`, { method: "DELETE" }, token),
+    delete: (id: string, token?: string, orgId?: string) =>
+      request<void>(`/retention/${id}`, { method: "DELETE" }, token, orgId),
 
-    execute: (id: string, dryRun = true, token?: string) =>
+    execute: (id: string, dryRun = true, token?: string, orgId?: string) =>
       request<RetentionExecuteResponse>(
         `/retention/${id}/execute`,
         { method: "POST", body: JSON.stringify({ dry_run: dryRun }) },
-        token
+        token,
+        orgId
       ),
 
-    resourceTypes: (token?: string) =>
-      request<string[]>("/retention/resource-types", {}, token),
+    resourceTypes: (token?: string, orgId?: string) =>
+      request<string[]>("/retention/resource-types", {}, token, orgId),
   },
 
   impersonation: {
-    start: (targetUserId: string, token?: string) =>
+    start: (targetUserId: string, token?: string, orgId?: string) =>
       request<{
         access_token: string;
         token_type: string;
         expires_in: number;
         impersonated_user: { id: string; email: string; role: string; org_id: string };
-      }>("/impersonate", { method: "POST", body: JSON.stringify({ target_user_id: targetUserId }) }, token),
+      }>("/impersonate", { method: "POST", body: JSON.stringify({ target_user_id: targetUserId }) }, token, orgId),
 
-    stop: (token?: string) =>
+    stop: (token?: string, orgId?: string) =>
       request<{ access_token: string; token_type: string; expires_in: number }>(
-        "/impersonate/stop", { method: "POST" }, token
+        "/impersonate/stop", { method: "POST" }, token, orgId
       ),
 
-    status: (token?: string) =>
+    status: (token?: string, orgId?: string) =>
       request<{ is_impersonating: boolean; impersonated_user_id: string | null; real_user_id: string | null }>(
-        "/impersonate/status", {}, token
+        "/impersonate/status", {}, token, orgId
       ),
   },
 
@@ -539,30 +578,31 @@ export const adminApi = {
   },
 
   licensing: {
-    entitlements: (orgId: string, token?: string) =>
-      licensingRequest<OrgEntitlements>(`/entitlements/${orgId}`, {}, token),
+    entitlements: (orgId: string, token?: string, headerOrgId?: string) =>
+      licensingRequest<OrgEntitlements>(`/entitlements/${orgId}`, {}, token, headerOrgId),
 
-    featureFlags: (token?: string) =>
-      request<FeatureFlag[]>("/feature-flags", {}, token),
+    featureFlags: (token?: string, orgId?: string) =>
+      request<FeatureFlag[]>("/feature-flags", {}, token, orgId),
 
     overrides: {
-      list: (orgId: string, token?: string) =>
-        request<FeatureOverride[]>(`/orgs/${orgId}/feature-overrides`, {}, token),
+      list: (orgId: string, token?: string, headerOrgId?: string) =>
+        request<FeatureOverride[]>(`/orgs/${orgId}/feature-overrides`, {}, token, headerOrgId),
 
-      create: (orgId: string, data: FeatureOverrideCreate, token?: string) =>
+      create: (orgId: string, data: FeatureOverrideCreate, token?: string, headerOrgId?: string) =>
         request<FeatureOverride>(
           `/orgs/${orgId}/feature-overrides`,
           { method: "POST", body: JSON.stringify(data) },
-          token
+          token,
+          headerOrgId
         ),
 
-      delete: (orgId: string, overrideId: string, token?: string) =>
-        request<void>(`/orgs/${orgId}/feature-overrides/${overrideId}`, { method: "DELETE" }, token),
+      delete: (orgId: string, overrideId: string, token?: string, headerOrgId?: string) =>
+        request<void>(`/orgs/${orgId}/feature-overrides/${overrideId}`, { method: "DELETE" }, token, headerOrgId),
     },
   },
 
   platformAudit: {
-    list: (filters?: AuditLogFilter, limit?: number, offset?: number, token?: string) => {
+    list: (filters?: AuditLogFilter, limit?: number, offset?: number, token?: string, orgId?: string) => {
       const params = new URLSearchParams();
       if (limit) params.set("limit", String(limit));
       if (offset) params.set("offset", String(offset));
@@ -571,7 +611,7 @@ export const adminApi = {
           if (v != null) params.set(k, String(v));
         });
       }
-      return request<AuditLogListResponse>(`/platform/audit-logs?${params.toString()}`, {}, token);
+      return request<AuditLogListResponse>(`/platform/audit-logs?${params.toString()}`, {}, token, orgId);
     },
   },
 };

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -40,12 +40,25 @@ import type {
   AuditLogFilter,
 } from "./types";
 
-async function getToken(): Promise<string> {
+interface SessionContext {
+  token: string;
+  orgId: string | undefined;
+}
+
+async function getSessionContext(): Promise<SessionContext> {
   const session = await auth();
   if (!session?.access_token) {
     throw new AdminApiError(401, "Unauthorized", "No access token");
   }
-  return session.access_token;
+  return {
+    token: session.access_token,
+    orgId: session.user?.org_id || undefined,
+  };
+}
+
+async function getToken(): Promise<string> {
+  const ctx = await getSessionContext();
+  return ctx.token;
 }
 
 type ActionResult<T> = { data: T; error?: never } | { data?: never; error: string };
@@ -64,50 +77,50 @@ async function withErrorHandling<T>(fn: () => Promise<T>): Promise<ActionResult<
 
 export async function listUsers(): Promise<ActionResult<User[]>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.users.list(token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.users.list(token, orgId);
   });
 }
 
 export async function getUser(userId: string): Promise<ActionResult<User>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.users.get(userId, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.users.get(userId, token, orgId);
   });
 }
 
 export async function createUser(data: UserCreate): Promise<ActionResult<User>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.users.create(data, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.users.create(data, token, orgId);
   });
 }
 
 export async function updateUser(userId: string, data: UserUpdate): Promise<ActionResult<User>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.users.update(userId, data, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.users.update(userId, data, token, orgId);
   });
 }
 
 export async function deleteUser(userId: string): Promise<ActionResult<void>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.users.delete(userId, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.users.delete(userId, token, orgId);
   });
 }
 
 export async function setUserPassword(userId: string, password: string): Promise<ActionResult<void>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.users.setPassword(userId, password, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.users.setPassword(userId, password, token, orgId);
   });
 }
 
 export async function listCredentials(): Promise<ActionResult<IntegrationCredential[]>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.credentials.list(token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.credentials.list(token, orgId);
   });
 }
 
@@ -115,8 +128,8 @@ export async function createCredential(
   data: IntegrationCredentialCreate
 ): Promise<ActionResult<IntegrationCredential>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    const result = await adminApi.credentials.create(data, token);
+    const { token, orgId } = await getSessionContext();
+    const result = await adminApi.credentials.create(data, token, orgId);
     revalidatePath("/admin/integrations", "page");
     return result;
   });
@@ -128,8 +141,8 @@ export async function testConnection(
   credentials?: Record<string, unknown>
 ): Promise<ActionResult<TestConnectionResponse>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    const result = await adminApi.credentials.test(provider, name, credentials, token);
+    const { token, orgId } = await getSessionContext();
+    const result = await adminApi.credentials.test(provider, name, credentials, token, orgId);
     revalidatePath("/admin/integrations", "page");
     return result;
   });
@@ -140,8 +153,8 @@ export async function deleteCredential(
   name: string
 ): Promise<ActionResult<void>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    const result = await adminApi.credentials.delete(provider, name, token);
+    const { token, orgId } = await getSessionContext();
+    const result = await adminApi.credentials.delete(provider, name, token, orgId);
     revalidatePath("/admin/integrations", "page");
     return result;
   });
@@ -149,8 +162,8 @@ export async function deleteCredential(
 
 export async function listSyncConfigs(): Promise<ActionResult<SyncConfig[]>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.syncConfigs.list(token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.syncConfigs.list(token, orgId);
   });
 }
 
@@ -158,16 +171,16 @@ export async function createSyncConfig(
   data: SyncConfigCreate
 ): Promise<ActionResult<SyncConfig>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.syncConfigs.create(data, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.syncConfigs.create(data, token, orgId);
   });
 }
 
 export async function getSyncConfig(id: string): Promise<ActionResult<SyncConfig>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
+    const { token, orgId } = await getSessionContext();
     // syncConfigs API doesn't have a get-by-id endpoint; filter from list
-    const configs = await adminApi.syncConfigs.list(token);
+    const configs = await adminApi.syncConfigs.list(token, orgId);
     const config = configs.find((c) => c.id === id);
     if (!config) {
       throw new AdminApiError(404, "Not Found", "Sync configuration not found");
@@ -181,8 +194,8 @@ export async function updateSyncConfig(
   data: SyncConfigUpdate
 ): Promise<ActionResult<SyncConfig>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    const result = await adminApi.syncConfigs.update(id, data, token);
+    const { token, orgId } = await getSessionContext();
+    const result = await adminApi.syncConfigs.update(id, data, token, orgId);
     revalidatePath("/admin/sync");
     revalidatePath(`/admin/sync/${id}`);
     return result;
@@ -191,8 +204,8 @@ export async function updateSyncConfig(
 
 export async function deleteSyncConfig(id: string): Promise<ActionResult<void>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    const result = await adminApi.syncConfigs.delete(id, token);
+    const { token, orgId } = await getSessionContext();
+    const result = await adminApi.syncConfigs.delete(id, token, orgId);
     revalidatePath("/admin/sync");
     return result;
   });
@@ -200,8 +213,8 @@ export async function deleteSyncConfig(id: string): Promise<ActionResult<void>> 
 
 export async function triggerSync(id: string): Promise<ActionResult<void>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    const result = await adminApi.syncConfigs.trigger(id, token);
+    const { token, orgId } = await getSessionContext();
+    const result = await adminApi.syncConfigs.trigger(id, token, orgId);
     revalidatePath("/admin/sync");
     revalidatePath(`/admin/sync/${id}`);
     return result;
@@ -210,8 +223,8 @@ export async function triggerSync(id: string): Promise<ActionResult<void>> {
 
 export async function getSyncJobs(id: string): Promise<ActionResult<SyncJob[]>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.syncConfigs.jobs(id, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.syncConfigs.jobs(id, token, orgId);
   });
 }
 
@@ -224,8 +237,8 @@ export async function toggleSyncActive(
 
 export async function listIdentities(): Promise<ActionResult<IdentityMapping[]>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.identities.list(token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.identities.list(token, orgId);
   });
 }
 
@@ -233,15 +246,15 @@ export async function createIdentity(
   data: IdentityMappingCreate
 ): Promise<ActionResult<IdentityMapping>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.identities.create(data, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.identities.create(data, token, orgId);
   });
 }
 
 export async function getIdentity(id: string): Promise<ActionResult<IdentityMapping>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.identities.get(id, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.identities.get(id, token, orgId);
   });
 }
 
@@ -250,36 +263,36 @@ export async function updateIdentity(
   data: IdentityMappingUpdate
 ): Promise<ActionResult<IdentityMapping>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.identities.update(id, data, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.identities.update(id, data, token, orgId);
   });
 }
 
 export async function deleteIdentity(id: string): Promise<ActionResult<void>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.identities.delete(id, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.identities.delete(id, token, orgId);
   });
 }
 
 export async function listTeams(): Promise<ActionResult<TeamMapping[]>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.teams.list(token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.teams.list(token, orgId);
   });
 }
 
 export async function createTeam(data: TeamMappingCreate): Promise<ActionResult<TeamMapping>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.teams.create(data, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.teams.create(data, token, orgId);
   });
 }
 
 export async function getTeam(teamId: string): Promise<ActionResult<TeamMapping>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.teams.get(teamId, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.teams.get(teamId, token, orgId);
   });
 }
 
@@ -288,22 +301,22 @@ export async function updateTeam(
   data: TeamMappingUpdate
 ): Promise<ActionResult<TeamMapping>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.teams.update(teamId, data, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.teams.update(teamId, data, token, orgId);
   });
 }
 
 export async function deleteTeam(teamId: string): Promise<ActionResult<void>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.teams.delete(teamId, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.teams.delete(teamId, token, orgId);
   });
 }
 
 export async function discoverTeams(provider: string): Promise<ActionResult<TeamDiscoverResponse>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.teams.discover(provider, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.teams.discover(provider, token, orgId);
   });
 }
 
@@ -312,15 +325,15 @@ export async function importTeams(
   onConflict: "skip" | "merge"
 ): Promise<ActionResult<TeamImportResponse>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.teams.import({ teams, on_conflict: onConflict }, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.teams.import({ teams, on_conflict: onConflict }, token, orgId);
   });
 }
 
 export async function getPendingTeamChanges(): Promise<ActionResult<PendingChangesResponse>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.teams.pendingChanges(token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.teams.pendingChanges(token, orgId);
   });
 }
 
@@ -330,8 +343,8 @@ export async function approveTeamChanges(
   approveAll = false
 ): Promise<ActionResult<{ approved: number }>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    const result = await adminApi.teams.approveChanges(teamId, changeIndices, approveAll, token);
+    const { token, orgId } = await getSessionContext();
+    const result = await adminApi.teams.approveChanges(teamId, changeIndices, approveAll, token, orgId);
     revalidatePath('/admin/teams');
     return result;
   });
@@ -343,8 +356,8 @@ export async function dismissTeamChanges(
   dismissAll = false
 ): Promise<ActionResult<{ dismissed: number }>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    const result = await adminApi.teams.dismissChanges(teamId, changeIndices, dismissAll, token);
+    const { token, orgId } = await getSessionContext();
+    const result = await adminApi.teams.dismissChanges(teamId, changeIndices, dismissAll, token, orgId);
     revalidatePath('/admin/teams');
     return result;
   });
@@ -352,30 +365,30 @@ export async function dismissTeamChanges(
 
 export async function triggerTeamDriftSync(): Promise<ActionResult<{ status: string }>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.teams.triggerDriftSync(token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.teams.triggerDriftSync(token, orgId);
   });
 }
 
 export async function listSettingCategories(): Promise<ActionResult<string[]>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.settings.listCategories(token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.settings.listCategories(token, orgId);
   });
 }
 
 export async function listSettings(category: string): Promise<ActionResult<Setting[]>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    const response = await adminApi.settings.listByCategory(category, token);
+    const { token, orgId } = await getSessionContext();
+    const response = await adminApi.settings.listByCategory(category, token, orgId);
     return response.settings;
   });
 }
 
 export async function createSetting(data: SettingCreate): Promise<ActionResult<Setting>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.settings.create(data, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.settings.create(data, token, orgId);
   });
 }
 
@@ -385,29 +398,25 @@ export async function updateSetting(
   data: SettingUpdate
 ): Promise<ActionResult<Setting>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.settings.update(category, key, data, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.settings.update(category, key, data, token, orgId);
   });
 }
 
 export async function deleteSetting(category: string, key: string): Promise<ActionResult<void>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.settings.delete(category, key, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.settings.delete(category, key, token, orgId);
   });
 }
 
 export async function getCurrentOrg(): Promise<ActionResult<Organization>> {
   return withErrorHandling(async () => {
-    const session = await auth();
-    if (!session?.access_token) {
-      throw new AdminApiError(401, "Unauthorized", "No access token");
-    }
-    const orgId = session.user?.org_id;
+    const { token, orgId } = await getSessionContext();
     if (!orgId) {
       throw new AdminApiError(400, "Bad Request", "No organization ID in session");
     }
-    return adminApi.orgs.get(orgId, session.access_token);
+    return adminApi.orgs.get(orgId, token, orgId);
   });
 }
 
@@ -415,36 +424,28 @@ export async function updateCurrentOrg(
   data: OrganizationUpdate
 ): Promise<ActionResult<Organization>> {
   return withErrorHandling(async () => {
-    const session = await auth();
-    if (!session?.access_token) {
-      throw new AdminApiError(401, "Unauthorized", "No access token");
-    }
-    const orgId = session.user?.org_id;
+    const { token, orgId } = await getSessionContext();
     if (!orgId) {
       throw new AdminApiError(400, "Bad Request", "No organization ID in session");
     }
-    return adminApi.orgs.update(orgId, data, session.access_token);
+    return adminApi.orgs.update(orgId, data, token, orgId);
   });
 }
 
 export async function deleteCurrentOrg(): Promise<ActionResult<void>> {
   return withErrorHandling(async () => {
-    const session = await auth();
-    if (!session?.access_token) {
-      throw new AdminApiError(401, "Unauthorized", "No access token");
-    }
-    const orgId = session.user?.org_id;
+    const { token, orgId } = await getSessionContext();
     if (!orgId) {
       throw new AdminApiError(400, "Bad Request", "No organization ID in session");
     }
-    return adminApi.orgs.delete(orgId, session.access_token);
+    return adminApi.orgs.delete(orgId, token, orgId);
   });
 }
 
 export async function getSecuritySettings(): Promise<ActionResult<Setting[]>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    const response = await adminApi.settings.listByCategory("security", token);
+    const { token, orgId } = await getSessionContext();
+    const response = await adminApi.settings.listByCategory("security", token, orgId);
     return response.settings;
   });
 }
@@ -454,8 +455,8 @@ export async function updateSecuritySetting(
   value: string
 ): Promise<ActionResult<Setting>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.settings.update("security", key, { value }, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.settings.update("security", key, { value }, token, orgId);
   });
 }
 
@@ -466,8 +467,8 @@ export async function startImpersonation(targetUserId: string): Promise<ActionRe
   impersonated_user: { id: string; email: string; role: string; org_id: string };
 }>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.impersonation.start(targetUserId, token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.impersonation.start(targetUserId, token, orgId);
   });
 }
 
@@ -477,8 +478,8 @@ export async function stopImpersonation(): Promise<ActionResult<{
   expires_in: number;
 }>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.impersonation.stop(token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.impersonation.stop(token, orgId);
   });
 }
 
@@ -488,8 +489,8 @@ export async function getImpersonationStatus(): Promise<ActionResult<{
   real_user_id: string | null;
 }>> {
   return withErrorHandling(async () => {
-    const token = await getToken();
-    return adminApi.impersonation.status(token);
+    const { token, orgId } = await getSessionContext();
+    return adminApi.impersonation.status(token, orgId);
   });
 }
 


### PR DESCRIPTION
## Summary
- Fixes #165 — admin API calls now send the `X-Org-Id` header so the backend resolves the correct organization instead of defaulting to `"default"`.

## Changes
- **`src/lib/admin/api.ts`**: Added `orgId` parameter to `request()` and `licensingRequest()` functions. Updated all `adminApi` methods to accept and forward `orgId`.
- **`src/lib/admin/server.ts`**: Added `getSessionContext()` helper that returns both `token` and `orgId` from the NextAuth session. Updated all org-scoped server actions to use it and pass `orgId` through to the API layer.

## How It Works
1. `getSessionContext()` extracts `org_id` from the NextAuth session (set during login)
2. Every org-scoped server action passes this as `orgId` to the `adminApi` method
3. The `request()` function sets `X-Org-Id: {orgId}` header on the outgoing fetch
4. Backend's `get_org_id` dependency reads this header instead of falling back to `"default"`

Superadmin-only actions continue using `getToken()` without `X-Org-Id` since they operate cross-org.