### PR TITLE
fix: stringify error detail objects from feature gate 402 responses

### DIFF
--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -261,6 +261,27 @@ describe("admin/server IP allowlist actions", () => {
       const result = await listIPAllowlistEntries();
       expect(result.error).toBeDefined();
     });
+
+    it("returns stringified error when backend returns object detail (feature gate)", async () => {
+      mockSession();
+      const featureGateBody = {
+        detail: {
+          error: "feature_not_licensed",
+          feature: "ip_allowlist",
+          required_tier: "enterprise",
+          current_tier: "free",
+        },
+      };
+      const fetchSpy = vi
+        .spyOn(global, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify(featureGateBody), { status: 402 }));
+
+      const result = await listIPAllowlistEntries();
+      expect(result.error).toBeDefined();
+      expect(typeof result.error).toBe("string");
+      expect(result.error).toContain("feature_not_licensed");
+      fetchSpy.mockRestore();
+    });
   });
 
   describe("createIPAllowlistEntry", () => {

--- a/src/lib/admin/api.ts
+++ b/src/lib/admin/api.ts
@@ -92,7 +92,8 @@ async function request<T>(
     let detail: string | undefined;
     try {
       const errorData = await response.json();
-      detail = errorData.detail || errorData.message;
+      const raw = errorData.detail || errorData.message;
+      detail = typeof raw === "string" ? raw : raw != null ? JSON.stringify(raw) : undefined;
     } catch {
       detail = undefined;
     }
@@ -137,7 +138,8 @@ async function licensingRequest<T>(
     let detail: string | undefined;
     try {
       const errorData = await response.json();
-      detail = errorData.detail || errorData.message;
+      const raw = errorData.detail || errorData.message;
+      detail = typeof raw === "string" ? raw : raw != null ? JSON.stringify(raw) : undefined;
     } catch {
       detail = undefined;
     }

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -79,7 +79,8 @@ async function withErrorHandling<T>(fn: () => Promise<T>): Promise<ActionResult<
     return { data };
   } catch (err) {
     if (err instanceof AdminApiError) {
-      return { error: err.detail || err.message };
+      const detail = err.detail || err.message;
+      return { error: typeof detail === "string" ? detail : JSON.stringify(detail) };
     }
     return { error: err instanceof Error ? err.message : "Unknown error" };
   }


### PR DESCRIPTION
## Summary

Fixes the React runtime crash on `/admin/ip-allowlist` (and `/admin/retention`) caused by rendering an error object as a React child.

**Root cause:** The backend's `require_feature` decorator raises `HTTPException(status_code=402, detail={...})` with a dict body containing `{error, feature, required_tier, current_tier}`. The frontend's `request()` function captured this object as `errorData.detail` and passed it through to `AdminApiError.detail` (typed as `string | undefined` but receiving an object at runtime). This object then propagated to `ActionResult.error` via `withErrorHandling`, and when the page rendered `{error}` in JSX, React crashed with "Objects are not valid as a React child".

**Fix:**
- `api.ts`: In both `request()` and `licensingRequest()`, stringify non-string `detail` values before passing to `AdminApiError`
- `server.ts`: Defensive stringify in `withErrorHandling` as a safety net
- Added test verifying feature gate 402 responses with object detail are correctly stringified

## Testing

- All 23 unit tests pass (including new test for object detail stringification)
- LSP diagnostics clean on both changed files