### PR TITLE
fix: show human-readable messages for feature gate errors

### DIFF
--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -262,7 +262,7 @@ describe("admin/server IP allowlist actions", () => {
       expect(result.error).toBeDefined();
     });
 
-    it("returns stringified error when backend returns object detail (feature gate)", async () => {
+    it("returns human-readable error when backend returns feature gate detail", async () => {
       mockSession();
       const featureGateBody = {
         detail: {
@@ -279,7 +279,9 @@ describe("admin/server IP allowlist actions", () => {
       const result = await listIPAllowlistEntries();
       expect(result.error).toBeDefined();
       expect(typeof result.error).toBe("string");
-      expect(result.error).toContain("feature_not_licensed");
+      expect(result.error).toContain("enterprise");
+      expect(result.error).toContain("free");
+      expect(result.error).not.toContain("{");
       fetchSpy.mockRestore();
     });
   });

--- a/src/lib/admin/api.ts
+++ b/src/lib/admin/api.ts
@@ -61,6 +61,22 @@ export class AdminApiError extends Error {
   }
 }
 
+function formatErrorDetail(raw: unknown): string | undefined {
+  if (typeof raw === "string") return raw;
+  if (raw == null) return undefined;
+  if (typeof raw === "object" && "error" in raw) {
+    const obj = raw as Record<string, string>;
+    if (obj.error === "feature_not_licensed") {
+      const tier = obj.required_tier || "a higher";
+      return `This feature requires the ${tier} plan (current plan: ${obj.current_tier || "community"}).`;
+    }
+    if (obj.error === "limit_exceeded") {
+      return `Plan limit reached: ${obj.limit || "resource"} (${obj.current}/${obj.maximum}).`;
+    }
+  }
+  return JSON.stringify(raw);
+}
+
 async function request<T>(
   path: string,
   options: RequestInit = {},
@@ -92,8 +108,7 @@ async function request<T>(
     let detail: string | undefined;
     try {
       const errorData = await response.json();
-      const raw = errorData.detail || errorData.message;
-      detail = typeof raw === "string" ? raw : raw != null ? JSON.stringify(raw) : undefined;
+      detail = formatErrorDetail(errorData.detail || errorData.message);
     } catch {
       detail = undefined;
     }
@@ -138,8 +153,7 @@ async function licensingRequest<T>(
     let detail: string | undefined;
     try {
       const errorData = await response.json();
-      const raw = errorData.detail || errorData.message;
-      detail = typeof raw === "string" ? raw : raw != null ? JSON.stringify(raw) : undefined;
+      detail = formatErrorDetail(errorData.detail || errorData.message);
     } catch {
       detail = undefined;
     }


### PR DESCRIPTION
## Summary

Replaces raw JSON error strings with user-friendly messages for feature-gating errors.

**Before:** `{"error":"feature_not_licensed","feature":"ip_allowlist","required_tier":"enterprise","current_tier":"community"}`

**After:** `This feature requires the enterprise plan (current plan: community).`

Adds `formatErrorDetail()` helper that recognizes known backend error shapes (`feature_not_licensed`, `limit_exceeded`) and formats them. Unknown objects still fall back to `JSON.stringify`. Used by both `request()` and `licensingRequest()`.

## Testing

- 23 unit tests pass (updated existing feature-gate test to verify human-readable output)
- LSP diagnostics clean