### PR TITLE
fix: move impersonation to superadmin, hide org settings for platform admins

### DIFF
--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -3,7 +3,6 @@ import { notFound } from "next/navigation";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { getUser } from "@/lib/admin/server";
 import { DeleteUserButton } from "./DeleteUserButton";
-import { ImpersonateUserButton } from "@/components/admin/users/ImpersonateUserButton";
 
 export default async function UserDetailPage({
   params,
@@ -101,7 +100,6 @@ export default async function UserDetailPage({
           <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
             <h3 className="mb-4 text-lg font-medium">Quick Actions</h3>
             <div className="space-y-3">
-              <ImpersonateUserButton user={user} />
               <Link
                 href={`/admin/users/${user.id}/edit`}
                 className="block w-full rounded-lg border border-(--card-stroke) px-4 py-2 text-sm font-medium text-(--ink-muted) hover:bg-(--card-70) hover:text-foreground text-left"

--- a/src/app/superadmin/users/[id]/page.tsx
+++ b/src/app/superadmin/users/[id]/page.tsx
@@ -4,6 +4,7 @@ import { SettingsSection } from "@/components/admin/settings/SettingsSection";
 import { UserEditForm } from "@/components/superadmin/UserEditForm";
 import { UserSetPasswordForm } from "@/components/superadmin/UserSetPasswordForm";
 import { UserDeleteSection } from "@/components/superadmin/UserDeleteSection";
+import { ImpersonateUserButton } from "@/components/admin/users/ImpersonateUserButton";
 import { getUser } from "@/lib/admin/server";
 
 type PageProps = {
@@ -37,6 +38,13 @@ export default async function UserDetailPage({ params }: PageProps) {
         description="Manage user password and security settings."
       >
         <UserSetPasswordForm userId={user.id} />
+      </SettingsSection>
+
+      <SettingsSection
+        title="Impersonation"
+        description="Log in as this user to see what they see."
+      >
+        <ImpersonateUserButton user={user} />
       </SettingsSection>
 
       <UserDeleteSection userId={user.id} userEmail={user.email} />

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -30,6 +30,10 @@ type AdminSidebarProps = {
 export function AdminSidebar({ isSuperuser }: AdminSidebarProps) {
   const pathname = usePathname();
 
+  const filteredNavItems = isSuperuser
+    ? navItems.filter((item) => item.id !== "organization")
+    : navItems;
+
   return (
     <aside className="w-full md:max-w-[220px] md:shrink-0">
       <div className="md:sticky md:top-6">
@@ -51,7 +55,7 @@ export function AdminSidebar({ isSuperuser }: AdminSidebarProps) {
             </p>
           </div>
           <nav className="mt-5 space-y-2 text-sm">
-            {navItems.map((item) => {
+            {filteredNavItems.map((item) => {
               const isActive = pathname === item.href;
               return (
                 <Link

--- a/src/components/admin/users/UserTable.tsx
+++ b/src/components/admin/users/UserTable.tsx
@@ -1,11 +1,6 @@
-"use client";
-
 import React from "react";
 import Link from "next/link";
 import type { User } from "@/lib/admin/types";
-import { useSession } from "next-auth/react";
-import { startImpersonation } from "@/lib/admin/server";
-import { useRouter } from "next/navigation";
 
 export type { User };
 
@@ -24,17 +19,6 @@ function getStatusDisplay(user: User): { label: string; className: string } {
 }
 
 export function UserTable({ users }: UserTableProps) {
-  const { data: session, update } = useSession();
-  const router = useRouter();
-
-  const handleImpersonate = async (userId: string) => {
-    const result = await startImpersonation(userId);
-    if (result.data) {
-      await update({ startImpersonation: result.data });
-      router.push("/");
-    }
-  };
-
   return (
     <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
       <table className="w-full text-left text-sm">
@@ -51,10 +35,6 @@ export function UserTable({ users }: UserTableProps) {
         <tbody className="divide-y divide-(--card-stroke)">
           {users.map((user) => {
             const status = getStatusDisplay(user);
-            const canImpersonate =
-              session?.user?.id !== user.id &&
-              !user.is_superuser &&
-              user.role !== "admin";
 
             return (
               <tr key={user.id} className="hover:bg-(--card-70)/50">
@@ -81,16 +61,7 @@ export function UserTable({ users }: UserTableProps) {
                     ? new Date(user.last_login_at).toLocaleDateString()
                     : "Never"}
                 </td>
-                <td className="px-6 py-4 text-right space-x-4">
-                  {canImpersonate && (
-                    <button
-                      type="button"
-                      onClick={() => handleImpersonate(user.id)}
-                      className="text-amber-500 hover:underline"
-                    >
-                      Impersonate
-                    </button>
-                  )}
+                <td className="px-6 py-4 text-right">
                   <Link
                     href={`/admin/users/${user.id}/edit`}
                     className="text-(--accent) hover:underline"

--- a/src/components/superadmin/UserTable.tsx
+++ b/src/components/superadmin/UserTable.tsx
@@ -1,12 +1,28 @@
+"use client";
+
 import React from "react";
 import Link from "next/link";
 import type { User } from "@/lib/admin/types";
+import { useSession } from "next-auth/react";
+import { startImpersonation } from "@/lib/admin/server";
+import { useRouter } from "next/navigation";
 
 type UserTableProps = {
   users: User[];
 };
 
 export function UserTable({ users }: UserTableProps) {
+  const { data: session, update } = useSession();
+  const router = useRouter();
+
+  const handleImpersonate = async (userId: string) => {
+    const result = await startImpersonation(userId);
+    if (result.data) {
+      await update({ startImpersonation: result.data });
+      router.push("/");
+    }
+  };
+
   return (
     <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
       <table className="w-full text-left text-sm">
@@ -62,7 +78,16 @@ export function UserTable({ users }: UserTableProps) {
                   ? new Date(user.last_login_at).toLocaleDateString()
                   : "-"}
               </td>
-              <td className="px-6 py-4 text-right">
+              <td className="px-6 py-4 text-right space-x-4">
+                {session?.user?.id !== user.id && !user.is_superuser && (
+                  <button
+                    type="button"
+                    onClick={() => handleImpersonate(user.id)}
+                    className="text-amber-500 hover:underline"
+                  >
+                    Impersonate
+                  </button>
+                )}
                 <Link
                   href={`/superadmin/users/${user.id}`}
                   className="text-(--accent) hover:underline"


### PR DESCRIPTION
## Summary

- Moves impersonation UI from `/admin` to `/superadmin` — impersonation is a superuser-only feature
- Hides "Organization" (Settings) nav item from AdminSidebar for platform admins who don't have a meaningful org context

## Changes

### Impersonation moved to superadmin
- **Removed** `ImpersonateUserButton` from `/admin/users/[id]` detail page
- **Removed** inline impersonate button from admin `UserTable` (component is no longer a client component — removed `useSession`, `useRouter`, `startImpersonation` imports)
- **Added** `ImpersonateUserButton` to `/superadmin/users/[id]` detail page in a new "Impersonation" settings section
- **Added** impersonate action to superadmin `UserTable` (now a client component with session/router hooks)

### AdminSidebar
- Filters out the "Organization" (`/admin/settings`) nav item when `isSuperuser` is true

## Testing

- Build passes (`next build`)
- Zero LSP errors on all changed files
- Backend impersonation endpoints unchanged (already at `/api/v1/admin/impersonate` with admin check)