### PR TITLE
fix: auto-refresh expired backend JWT via refresh token

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -100,6 +100,33 @@ const nextAuth = NextAuth({
         token.real_org_id = undefined
       }
 
+      // Auto-refresh: when the backend JWT is expired or within 5 min of expiry,
+      // use the refresh_token to get a new access_token. Skip during impersonation
+      // since the impersonated token has its own lifecycle.
+      const expiresAt = token.expires_at as number | undefined
+      if (
+        expiresAt &&
+        !token.is_impersonating &&
+        token.refresh_token &&
+        Date.now() > expiresAt - 5 * 60 * 1000
+      ) {
+        try {
+          const backendUrl = getBackendUrl()
+          const res = await fetch(`${backendUrl}/api/v1/auth/refresh`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ refresh_token: token.refresh_token }),
+          })
+          if (res.ok) {
+            const data = await res.json()
+            token.access_token = data.access_token
+            token.expires_at = Date.now() + (data.expires_in || 3600) * 1000
+          }
+        } catch {
+          // Refresh failed — token stays expired, user will be redirected to login
+        }
+      }
+
       return token
     },
     async session({ session, token }) {


### PR DESCRIPTION
## Summary

The backend JWT expires after 60 minutes but NextAuth never refreshed it. After an hour, all API calls fail with "Invalid or expired token". This adds automatic token refresh to the NextAuth jwt callback.

## Changes

- **`src/lib/auth.ts`**: Added auto-refresh logic in the jwt callback. When the backend access_token is expired or within 5 minutes of expiry, calls `POST /api/v1/auth/refresh` with the stored refresh_token to obtain a new access_token. Skips refresh during impersonation (those tokens have their own TTL via `IMPERSONATION_TTL_MINUTES`).

## Companion PR

- **dev-health-ops#461**: Fixes the backend `/auth/refresh` endpoint to look up user from DB (previously it read role/is_superuser from the refresh token payload which doesn't carry those fields)

## Testing

- Build passes
- Zero LSP errors