### PR TITLE
fix: show toast on impersonation errors and add loading state

### DIFF
--- a/src/components/admin/users/ImpersonateUserButton.tsx
+++ b/src/components/admin/users/ImpersonateUserButton.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import { useState } from "react";
 import { useSession } from "next-auth/react";
 import { startImpersonation } from "@/lib/admin/server";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import type { User } from "@/lib/admin/types";
 
 export function ImpersonateUserButton({ user }: { user: User }) {
   const { data: session, update } = useSession();
   const router = useRouter();
+  const [loading, setLoading] = useState(false);
 
   const canImpersonate =
     session?.user?.id !== user.id &&
@@ -19,10 +22,21 @@ export function ImpersonateUserButton({ user }: { user: User }) {
   }
 
   const handleImpersonate = async () => {
-    const result = await startImpersonation(user.id);
-    if (result.data) {
-      await update({ startImpersonation: result.data });
-      router.push("/");
+    setLoading(true);
+    try {
+      const result = await startImpersonation(user.id);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      if (result.data) {
+        await update({ startImpersonation: result.data });
+        router.push("/");
+      }
+    } catch {
+      toast.error("Failed to start impersonation");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -30,9 +44,10 @@ export function ImpersonateUserButton({ user }: { user: User }) {
     <button
       type="button"
       onClick={handleImpersonate}
-      className="block w-full rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-500 hover:bg-amber-500/20 text-left transition-colors"
+      disabled={loading}
+      className="block w-full rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-500 hover:bg-amber-500/20 text-left transition-colors disabled:opacity-50"
     >
-      Impersonate User
+      {loading ? "Impersonating…" : "Impersonate User"}
     </button>
   );
 }

--- a/src/components/superadmin/UserTable.tsx
+++ b/src/components/superadmin/UserTable.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import Link from "next/link";
 import type { User } from "@/lib/admin/types";
 import { useSession } from "next-auth/react";
 import { startImpersonation } from "@/lib/admin/server";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 type UserTableProps = {
   users: User[];
@@ -14,12 +15,24 @@ type UserTableProps = {
 export function UserTable({ users }: UserTableProps) {
   const { data: session, update } = useSession();
   const router = useRouter();
+  const [impersonatingId, setImpersonatingId] = useState<string | null>(null);
 
   const handleImpersonate = async (userId: string) => {
-    const result = await startImpersonation(userId);
-    if (result.data) {
-      await update({ startImpersonation: result.data });
-      router.push("/");
+    setImpersonatingId(userId);
+    try {
+      const result = await startImpersonation(userId);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      if (result.data) {
+        await update({ startImpersonation: result.data });
+        router.push("/");
+      }
+    } catch {
+      toast.error("Failed to start impersonation");
+    } finally {
+      setImpersonatingId(null);
     }
   };
 
@@ -83,9 +96,10 @@ export function UserTable({ users }: UserTableProps) {
                   <button
                     type="button"
                     onClick={() => handleImpersonate(user.id)}
-                    className="text-amber-500 hover:underline"
+                    disabled={impersonatingId === user.id}
+                    className="text-amber-500 hover:underline disabled:opacity-50"
                   >
-                    Impersonate
+                    {impersonatingId === user.id ? "Impersonating…" : "Impersonate"}
                   </button>
                 )}
                 <Link


### PR DESCRIPTION
## Summary

- `ImpersonateUserButton` and superadmin `UserTable` both silently swallowed errors from `startImpersonation()` — only checked `result.data`, ignored `result.error`
- Now shows `toast.error()` with the backend error message (e.g. "Superuser access required")
- Added loading/disabled state to prevent double-clicks during the request

## Changes

- `src/components/admin/users/ImpersonateUserButton.tsx` — error toast, loading state, try/catch
- `src/components/superadmin/UserTable.tsx` — same pattern, per-row loading via `impersonatingId`