### PR TITLE
fix: sync session fields from refresh response to prevent stale claims

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -121,6 +121,15 @@ const nextAuth = NextAuth({
             const data = await res.json()
             token.access_token = data.access_token
             token.expires_at = Date.now() + (data.expires_in || 3600) * 1000
+            // Sync session fields from the refreshed user info so they
+            // stay accurate even if a previous refresh produced stale claims.
+            if (data.user) {
+              token.id = data.user.id
+              token.email = data.user.email
+              token.org_id = data.user.org_id
+              token.role = data.user.role
+              token.is_superuser = data.user.is_superuser ?? false
+            }
           }
         } catch {
           // Refresh failed — token stays expired, user will be redirected to login


### PR DESCRIPTION
## Summary

- After a token refresh, the NextAuth JWT callback now syncs `id`, `email`, `org_id`, `role`, and `is_superuser` from the backend's refresh response
- Prevents stale claims from persisting when a previous refresh produced incorrect values

## Root Cause

The session's `access_token` had `is_superuser: false`, `email: ""`, `role: "member"` — all from a refresh that happened before ops#461 fixed the backend. The auto-refresh only updated `access_token` and `expires_at`, leaving stale session fields. Now it also syncs user identity fields from the `user` object in the refresh response.

Depends on: full-chaos/dev-health-ops#464 (backend returns user info in refresh response)