### PR TITLE
fix: hide UserMenu on auth pages to prevent stale session display

### DIFF
--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import { useSession, signOut } from "next-auth/react"
+import { usePathname } from "next/navigation"
 import Link from "next/link"
 import { useState, useRef, useEffect } from "react"
 
 export function UserMenu() {
   const { data: session, status } = useSession()
+  const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -18,6 +20,12 @@ export function UserMenu() {
     document.addEventListener("mousedown", handleClickOutside)
     return () => document.removeEventListener("mousedown", handleClickOutside)
   }, [])
+
+  // Don't render on auth pages (sign-in, sign-up) — the server-side session
+  // may be invalidated while the client-side useSession() still has stale data.
+  if (pathname?.startsWith("/auth/")) {
+    return null
+  }
 
   if (status === "loading") {
     return <div className="h-8 w-8 animate-pulse rounded-full bg-[var(--card-stroke)]" />


### PR DESCRIPTION
## Summary

- Hide `UserMenu` component on `/auth/*` routes to prevent showing stale user data on the sign-in page

## Problem

When a session expires or is invalidated (user deleted, token expired after long inactivity), the server-side `auth()` correctly returns `null` and redirects to `/auth/signin`. However, the client-side `useSession()` in `UserMenu` still has cached session data from the `SessionProvider`, causing the "admin" avatar to appear in the top-right corner of the sign-in page.

## Fix

`UserMenu` now checks `usePathname()` and returns `null` on `/auth/*` routes. The sign-in page should never show a user menu — if the user is authenticated, the page redirects to `/`; if not, there's no user to display.

TEST-WAIVER: single-line pathname guard with no branching logic to test