### PR TITLE
fix: forward auth tokens to backend and add Toaster to auth layout

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,7 +1,14 @@
+import { Toaster } from "sonner";
+
 export default function AuthLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return children;
+  return (
+    <>
+      {children}
+      <Toaster richColors position="top-right" theme="dark" />
+    </>
+  );
 }

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,5 @@
 import { resolveOrigin } from "@/lib/origin";
+import { isServer } from "@/lib/env";
 
 export type ApiQueryParams = Record<
   string,
@@ -24,6 +25,18 @@ const buildUrl = (path: string, params?: ApiQueryParams) => {
   return url.toString();
 };
 
+async function getServerAuthHeaders(): Promise<Record<string, string>> {
+  if (!isServer) return {};
+  try {
+    const { auth } = await import("@/lib/auth");
+    const session = await auth();
+    if (session?.access_token) {
+      return { Authorization: `Bearer ${session.access_token}` };
+    }
+  } catch {}
+  return {};
+}
+
 const inflightRequests = new Map<string, Promise<Response>>();
 
 const request = async (
@@ -34,22 +47,24 @@ const request = async (
   const url = buildUrl(path, params);
   const cacheKey = `${init?.method ?? "GET"}:${url}`;
 
-  // Check for in-flight request to deduplicate concurrent calls
   const existing = inflightRequests.get(cacheKey);
   if (existing) {
     return existing.then((r) => r.clone());
   }
 
-  const promise = fetch(url, init);
+  const authHeaders = await getServerAuthHeaders();
+  const mergedInit: ApiFetchInit = {
+    ...init,
+    headers: { ...authHeaders, ...init?.headers },
+  };
+
+  const promise = fetch(url, mergedInit);
   inflightRequests.set(cacheKey, promise);
 
   try {
     const response = await promise;
-    // We clone because multiple concurrent callers might call .json() or .text()
     return response.clone();
   } finally {
-    // Only deduplicate in-flight requests. Subsequent calls after completion
-    // should perform a new fetch (unless we implement a full data cache).
     inflightRequests.delete(cacheKey);
   }
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,6 +21,8 @@ function isPublicPath(pathname: string): boolean {
 export async function proxy(request: NextRequest) {
     const { pathname } = request.nextUrl;
 
+    let accessToken: string | undefined;
+
     if (!isTestMode && !isPublicPath(pathname)) {
         const session = await auth();
         if (!session || !session.access_token) {
@@ -28,6 +30,7 @@ export async function proxy(request: NextRequest) {
             signInUrl.searchParams.set("callbackUrl", pathname);
             return NextResponse.redirect(signInUrl);
         }
+        accessToken = session.access_token;
     }
 
     const shouldProxy =
@@ -40,6 +43,14 @@ export async function proxy(request: NextRequest) {
 
     const backendUrl = getBackendUrl();
     const targetUrl = new URL(pathname + request.nextUrl.search, backendUrl);
+
+    if (accessToken) {
+        const requestHeaders = new Headers(request.headers);
+        requestHeaders.set("Authorization", `Bearer ${accessToken}`);
+        return NextResponse.rewrite(targetUrl, {
+            request: { headers: requestHeaders },
+        });
+    }
 
     return NextResponse.rewrite(targetUrl);
 }

--- a/tests/auth-signin.spec.ts
+++ b/tests/auth-signin.spec.ts
@@ -20,3 +20,17 @@ test("/auth/signin shows post-registration banner", async ({ page }) => {
     page.getByText("Account created successfully. Please sign in."),
   ).toBeVisible();
 });
+
+test("/auth/signin shows error toast on failed login", async ({ page }) => {
+  await page.goto("/auth/signin");
+
+  // Fill in credentials that will fail (mock backend rejects all logins)
+  await page.getByLabel("Email").fill("bad@example.com");
+  await page.getByLabel("Password").fill("wrongpassword");
+  await page.getByRole("button", { name: "Sign In" }).click();
+
+  // The Toaster component must be mounted in the (auth) layout for this to appear
+  await expect(
+    page.getByText("Invalid email or password"),
+  ).toBeVisible({ timeout: 10_000 });
+});


### PR DESCRIPTION
## Summary

Fixes two bugs introduced by the route group refactor (#199):

1. **Missing toast feedback on auth pages** — `(auth)/layout.tsx` was bare, so `toast.error()` from the LoginForm had no `Toaster` mounted. Users saw nothing when login failed.

2. **401 Unauthorized on analytics endpoints** — Backend ops PR #472 added auth requirements to analytics endpoints. Neither `apiClient` (server-side RSC) nor the proxy (client-side rewrite) forwarded the JWT `access_token` to the backend.

## Changes

- `src/app/(auth)/layout.tsx` — Add `Toaster` component
- `src/lib/apiClient.ts` — Auto-inject `Authorization: Bearer` header on server-side requests via lazy `auth()` import
- `src/proxy.ts` — Forward `access_token` in `Authorization` header when rewriting to backend
- `tests/auth-signin.spec.ts` — Add test for error toast visibility on failed login

## Verification

- `npx tsc --noEmit` — clean
- LSP diagnostics — clean on all changed files
- `npm run build` fails locally due to pre-existing lightningcss native module issue (works in CI/Docker)