### PR TITLE
fix: gate enterprise admin features by org tier

### DIFF
--- a/src/app/(app)/admin/audit-logs/page.tsx
+++ b/src/app/(app)/admin/audit-logs/page.tsx
@@ -7,10 +7,8 @@ import { AuditLogFilters } from "@/components/superadmin/AuditLogFilters";
 import { listAuditLogs } from "@/lib/admin/server";
 import type { AuditLog, AuditLogFilter } from "@/lib/admin/types";
 import { UpgradeGate } from "@/components/billing/UpgradeGate";
-import { useAdminTier } from "@/components/admin/AdminTierContext";
 
 export default function OrgAuditLogPage() {
-  const { tier } = useAdminTier();
   const [logs, setLogs] = useState<AuditLog[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -56,7 +54,6 @@ export default function OrgAuditLogPage() {
     <UpgradeGate
       feature="audit_log"
       requiredTier="enterprise"
-      currentTier={tier}
     >
       <div>
         <AdminHeader

--- a/src/app/(app)/admin/ip-allowlist/page.tsx
+++ b/src/app/(app)/admin/ip-allowlist/page.tsx
@@ -10,10 +10,8 @@ import {
 } from "@/lib/admin/server";
 import type { IPAllowlist, IPAllowlistCreate } from "@/lib/admin/types";
 import { UpgradeGate } from "@/components/billing/UpgradeGate";
-import { useAdminTier } from "@/components/admin/AdminTierContext";
 
 export default function IPAllowlistPage() {
-  const { tier } = useAdminTier();
   const [entries, setEntries] = useState<IPAllowlist[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -97,7 +95,6 @@ export default function IPAllowlistPage() {
     <UpgradeGate
       feature="ip_allowlist"
       requiredTier="enterprise"
-      currentTier={tier}
     >
       <div>
         <AdminHeader

--- a/src/app/(app)/admin/layout.tsx
+++ b/src/app/(app)/admin/layout.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { requireRole } from "@/lib/auth";
 import { AdminSidebar } from "@/components/admin/AdminSidebar";
 import { AdminTierProvider } from "@/components/admin/AdminTierContext";
-import { getCurrentOrg } from "@/lib/admin/server";
+import { getOrgEntitlements } from "@/lib/admin/server";
 
 export default async function AdminLayout({
   children,
@@ -17,14 +17,16 @@ export default async function AdminLayout({
     redirect("/superadmin");
   }
 
-  const orgResult = await getCurrentOrg();
-  const tier = orgResult.data?.tier ?? "community";
+  const orgId = session.user.org_id;
+  const entitlements = orgId ? await getOrgEntitlements(orgId) : null;
+  const tier = entitlements?.data?.tier ?? "community";
+  const features = entitlements?.data?.features ?? {};
 
   return (
     <div className="min-h-screen">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
-        <AdminSidebar isSuperuser={isSuperuser} tier={tier} />
-        <AdminTierProvider tier={tier}>
+        <AdminSidebar isSuperuser={isSuperuser} features={features} />
+        <AdminTierProvider tier={tier} features={features}>
           <main className="flex min-w-0 flex-1 flex-col gap-10">
             {children}
           </main>

--- a/src/app/(app)/admin/retention/page.tsx
+++ b/src/app/(app)/admin/retention/page.tsx
@@ -12,10 +12,8 @@ import {
 } from "@/lib/admin/server";
 import type { RetentionPolicy, RetentionPolicyCreate } from "@/lib/admin/types";
 import { UpgradeGate } from "@/components/billing/UpgradeGate";
-import { useAdminTier } from "@/components/admin/AdminTierContext";
 
 export default function RetentionPolicyPage() {
-  const { tier } = useAdminTier();
   const [policies, setPolicies] = useState<RetentionPolicy[]>([]);
   const [resourceTypes, setResourceTypes] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -138,7 +136,6 @@ export default function RetentionPolicyPage() {
     <UpgradeGate
       feature="retention_policies"
       requiredTier="enterprise"
-      currentTier={tier}
     >
       <div>
         <AdminHeader

--- a/src/app/(app)/capacity/page.tsx
+++ b/src/app/(app)/capacity/page.tsx
@@ -6,7 +6,7 @@ import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { CapacityView } from "@/components/work/CapacityView";
 import { checkApiHealth } from "@/lib/api";
-import { getCurrentOrg } from "@/lib/admin/server";
+import { getCurrentOrg, getOrgEntitlements } from "@/lib/admin/server";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
 import { ContextStrip } from "@/components/navigation/ContextStrip";
@@ -23,6 +23,10 @@ export default async function CapacityPage({ searchParams }: CapacityPageProps) 
 
   const orgResult = await getCurrentOrg().catch(() => ({ data: undefined }));
   const org = orgResult.data;
+  const entitlements = org?.id
+    ? await getOrgEntitlements(org.id).catch(() => null)
+    : null;
+  const features = entitlements?.data?.features ?? {};
 
   const params = (await searchParams) ?? {};
   const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
@@ -43,7 +47,7 @@ export default async function CapacityPage({ searchParams }: CapacityPageProps) 
           <UpgradeGate
             feature="capacity_planning"
             requiredTier="team"
-            currentTier={org?.tier ?? "community"}
+            features={features}
           >
             <header className="flex flex-wrap items-center justify-between gap-4">
               <div>

--- a/src/app/(app)/investment/page.tsx
+++ b/src/app/(app)/investment/page.tsx
@@ -6,7 +6,7 @@ import { InvestmentChart } from "@/components/investment/InvestmentChart";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { checkApiHealth, getInvestment } from "@/lib/api";
-import { getCurrentOrg } from "@/lib/admin/server";
+import { getCurrentOrg, getOrgEntitlements } from "@/lib/admin/server";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
 import { formatNumber } from "@/lib/formatters";
@@ -25,6 +25,10 @@ export default async function InvestmentPage({ searchParams }: InvestmentPagePro
 
   const orgResult = await getCurrentOrg().catch(() => ({ data: undefined }));
   const org = orgResult.data;
+  const entitlements = org?.id
+    ? await getOrgEntitlements(org.id).catch(() => null)
+    : null;
+  const features = entitlements?.data?.features ?? {};
 
   const params = (await searchParams) ?? {};
   const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
@@ -48,7 +52,7 @@ export default async function InvestmentPage({ searchParams }: InvestmentPagePro
           <UpgradeGate
             feature="investment_view"
             requiredTier="team"
-            currentTier={org?.tier ?? "community"}
+            features={features}
           >
             <header className="flex flex-wrap items-center justify-between gap-4">
               <div>

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -2,14 +2,13 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { hasAccess } from "@/lib/billing/tiers";
 
 type NavItem = {
   id: string;
   label: string;
   href: string;
   description: string;
-  requiredTier?: string;
+  featureKey?: string;
 };
 
 const navItems: NavItem[] = [
@@ -20,24 +19,24 @@ const navItems: NavItem[] = [
   { id: "sync", label: "Sync Status", href: "/admin/sync", description: "Jobs" },
   { id: "teams", label: "Teams", href: "/admin/teams", description: "Identity" },
   { id: "identities", label: "Identities", href: "/admin/identities", description: "Mapping" },
-  { id: "audit", label: "Audit Logs", href: "/admin/audit-logs", description: "Enterprise", requiredTier: "enterprise" },
-  { id: "ip-allowlist", label: "IP Allowlist", href: "/admin/ip-allowlist", description: "Security", requiredTier: "enterprise" },
-  { id: "retention", label: "Retention", href: "/admin/retention", description: "Compliance", requiredTier: "enterprise" },
+  { id: "audit", label: "Audit Logs", href: "/admin/audit-logs", description: "Enterprise", featureKey: "audit_log" },
+  { id: "ip-allowlist", label: "IP Allowlist", href: "/admin/ip-allowlist", description: "Security", featureKey: "ip_allowlist" },
+  { id: "retention", label: "Retention", href: "/admin/retention", description: "Compliance", featureKey: "retention_policies" },
 ];
 
 type AdminSidebarProps = {
   isSuperuser?: boolean;
-  tier?: string;
+  features?: Record<string, boolean>;
 };
 
-export function AdminSidebar({ isSuperuser, tier }: AdminSidebarProps) {
+export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
   const pathname = usePathname();
 
   const filteredNavItems = navItems.filter((item) => {
     if (isSuperuser && item.id === "organization") {
       return false;
     }
-    if (item.requiredTier && !hasAccess(tier ?? "community", item.requiredTier)) {
+    if (item.featureKey && features?.[item.featureKey] !== true) {
       return false;
     }
     return true;

--- a/src/components/admin/AdminTierContext.tsx
+++ b/src/components/admin/AdminTierContext.tsx
@@ -4,21 +4,25 @@ import { createContext, useContext } from "react";
 
 type AdminTierContextValue = {
   tier: string;
+  features: Record<string, boolean>;
 };
 
 const AdminTierContext = createContext<AdminTierContextValue>({
   tier: "community",
+  features: {},
 });
 
 export function AdminTierProvider({
   tier,
+  features,
   children,
 }: {
   tier: string;
+  features: Record<string, boolean>;
   children: React.ReactNode;
 }) {
   return (
-    <AdminTierContext.Provider value={{ tier }}>
+    <AdminTierContext.Provider value={{ tier, features }}>
       {children}
     </AdminTierContext.Provider>
   );

--- a/src/components/billing/UpgradeGate.tsx
+++ b/src/components/billing/UpgradeGate.tsx
@@ -1,20 +1,27 @@
+"use client";
+
 import Link from "next/link";
-import { hasAccess, TIER_FEATURES } from "@/lib/billing/tiers";
+import { useAdminTier } from "@/components/admin/AdminTierContext";
+import { TIER_FEATURES } from "@/lib/billing/tiers";
 
 type UpgradeGateProps = {
   feature: string;
   requiredTier: string;
-  currentTier: string;
+  features?: Record<string, boolean>;
   children: React.ReactNode;
 };
 
 export function UpgradeGate({
   feature,
   requiredTier,
-  currentTier,
+  features: featuresProp,
   children,
 }: UpgradeGateProps) {
-  if (hasAccess(currentTier, requiredTier)) {
+  const context = useAdminTier();
+  const features = featuresProp ?? context.features;
+  const currentTier = context.tier;
+
+  if (features[feature] === true) {
     return <>{children}</>;
   }
 

--- a/src/lib/billing/__tests__/tiers.test.ts
+++ b/src/lib/billing/__tests__/tiers.test.ts
@@ -1,82 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  hasAccess,
-  FEATURE_TIERS,
-  TIER_HIERARCHY,
-  TIER_LABELS,
-} from "../tiers";
-
-describe("hasAccess", () => {
-  it("community can access community features", () => {
-    expect(hasAccess("community", "community")).toBe(true);
-  });
-
-  it("community cannot access team features", () => {
-    expect(hasAccess("community", "team")).toBe(false);
-  });
-
-  it("community cannot access enterprise features", () => {
-    expect(hasAccess("community", "enterprise")).toBe(false);
-  });
-
-  it("team can access community and team features", () => {
-    expect(hasAccess("team", "community")).toBe(true);
-    expect(hasAccess("team", "team")).toBe(true);
-  });
-
-  it("team cannot access enterprise features", () => {
-    expect(hasAccess("team", "enterprise")).toBe(false);
-  });
-
-  it("enterprise can access all tiers", () => {
-    expect(hasAccess("enterprise", "community")).toBe(true);
-    expect(hasAccess("enterprise", "team")).toBe(true);
-    expect(hasAccess("enterprise", "enterprise")).toBe(true);
-  });
-
-  it("treats 'free' as alias for community", () => {
-    expect(hasAccess("free", "community")).toBe(true);
-    expect(hasAccess("free", "team")).toBe(false);
-  });
-
-  it("treats unknown tier as community (level 0)", () => {
-    expect(hasAccess("unknown", "community")).toBe(true);
-    expect(hasAccess("unknown", "team")).toBe(false);
-  });
-
-  it("is case-insensitive", () => {
-    expect(hasAccess("Enterprise", "enterprise")).toBe(true);
-    expect(hasAccess("TEAM", "team")).toBe(true);
-  });
-});
-
-describe("FEATURE_TIERS", () => {
-  it("maps enterprise features correctly", () => {
-    expect(FEATURE_TIERS["audit_log"]).toBe("enterprise");
-    expect(FEATURE_TIERS["ip_allowlist"]).toBe("enterprise");
-    expect(FEATURE_TIERS["retention_policies"]).toBe("enterprise");
-    expect(FEATURE_TIERS["sso"]).toBe("enterprise");
-    expect(FEATURE_TIERS["priority_support"]).toBe("enterprise");
-  });
-
-  it("maps team features correctly", () => {
-    expect(FEATURE_TIERS["investment_view"]).toBe("team");
-    expect(FEATURE_TIERS["team_dashboard"]).toBe("team");
-    expect(FEATURE_TIERS["custom_integrations"]).toBe("team");
-    expect(FEATURE_TIERS["capacity_planning"]).toBe("team");
-  });
-
-  it("maps community features correctly", () => {
-    expect(FEATURE_TIERS["basic_analytics"]).toBe("community");
-  });
-
-  it("every feature maps to a valid tier", () => {
-    const validTiers = Object.keys(TIER_HIERARCHY);
-    for (const [feature, tier] of Object.entries(FEATURE_TIERS)) {
-      expect(validTiers, `feature "${feature}" has invalid tier "${tier}"`).toContain(tier);
-    }
-  });
-});
+import { TIER_LABELS, TIER_FEATURES } from "../tiers";
 
 describe("TIER_LABELS", () => {
   it("provides display labels for all base tiers", () => {
@@ -87,5 +10,15 @@ describe("TIER_LABELS", () => {
 
   it("maps free alias to Community", () => {
     expect(TIER_LABELS["free"]).toBe("Community");
+  });
+});
+
+describe("TIER_FEATURES", () => {
+  it("provides upgrade description for team tier", () => {
+    expect(TIER_FEATURES["team"]).toContain("insights");
+  });
+
+  it("provides upgrade description for enterprise tier", () => {
+    expect(TIER_FEATURES["enterprise"]).toContain("enterprise");
   });
 });

--- a/src/lib/billing/tiers.ts
+++ b/src/lib/billing/tiers.ts
@@ -1,23 +1,3 @@
-export const TIER_HIERARCHY: Record<string, number> = {
-  community: 0,
-  free: 0, // Alias for community
-  team: 1,
-  enterprise: 2,
-};
-
-export const FEATURE_TIERS: Record<string, string> = {
-  basic_analytics: "community",
-  investment_view: "team",
-  team_dashboard: "team",
-  custom_integrations: "team",
-  capacity_planning: "team",
-  sso: "enterprise",
-  audit_log: "enterprise",
-  ip_allowlist: "enterprise",
-  retention_policies: "enterprise",
-  priority_support: "enterprise",
-};
-
 export const TIER_LABELS: Record<string, string> = {
   community: "Community",
   free: "Community",
@@ -29,9 +9,3 @@ export const TIER_FEATURES: Record<string, string> = {
   team: "Unlock advanced insights, team-level metrics, and capacity planning.",
   enterprise: "Get enterprise-grade security, SSO, and dedicated support.",
 };
-
-export function hasAccess(currentTier: string, requiredTier: string): boolean {
-  const currentLevel = TIER_HIERARCHY[currentTier.toLowerCase()] ?? 0;
-  const requiredLevel = TIER_HIERARCHY[requiredTier.toLowerCase()] ?? 0;
-  return currentLevel >= requiredLevel;
-}


### PR DESCRIPTION
## Summary

- Feature gating now reads from the **database** via `/api/v1/licensing/entitlements/{org_id}` instead of hardcoded static mappings
- This endpoint resolves features through: `Organization.tier` → `FeatureFlag.min_tier` → `OrgLicense.features_override` → `OrgFeatureOverride` (with expiry)
- Per-org overrides, feature flag kill-switches, and trial promotions are now respected by the frontend

## Changes

| File | Change |
|------|--------|
| `src/components/admin/AdminTierContext.tsx` | Context now provides `features: Record<string, boolean>` from DB |
| `src/app/(app)/admin/layout.tsx` | Calls `getOrgEntitlements()` instead of `getCurrentOrg()` for tier + features |
| `src/components/admin/AdminSidebar.tsx` | Filters nav items by `features[featureKey] === true` instead of tier comparison |
| `src/components/billing/UpgradeGate.tsx` | Reads features from context; accepts optional `features` prop for non-admin pages |
| `src/app/(app)/admin/audit-logs/page.tsx` | Simplified — no longer passes `currentTier` prop |
| `src/app/(app)/admin/ip-allowlist/page.tsx` | Simplified — no longer passes `currentTier` prop |
| `src/app/(app)/admin/retention/page.tsx` | Simplified — no longer passes `currentTier` prop |
| `src/app/(app)/capacity/page.tsx` | Fetches entitlements from DB, passes `features` to UpgradeGate |
| `src/app/(app)/investment/page.tsx` | Fetches entitlements from DB, passes `features` to UpgradeGate |
| `src/lib/billing/tiers.ts` | Removed `FEATURE_TIERS`, `hasAccess`, `TIER_HIERARCHY` (no longer needed for gating) |
| `src/lib/billing/__tests__/tiers.test.ts` | Updated — tests display-only exports (`TIER_LABELS`, `TIER_FEATURES`) |

## Architecture

**Before:** Frontend used hardcoded `FEATURE_TIERS` mapping + `hasAccess(tier, requiredTier)` — duplicated backend logic, ignored DB overrides.

**After:** Frontend calls the existing `/api/v1/licensing/entitlements/{org_id}` endpoint which queries:
1. `FeatureFlag` table (`min_tier` per feature, global kill-switch)
2. `OrgLicense.features_override` (per-org license overrides)
3. `OrgFeatureOverride` (per-org feature toggles with expiry)
4. Falls back to `Organization.tier` column

Returns `features: Record<string, boolean>` — the resolved truth from the database.

## Testing

- `npx tsc --noEmit` ✅
- `npx eslint` ✅ (0 errors)
- `npx vitest run` ✅ (151 tests passing)

Closes #202