### PR TITLE
feat: add beta badge indicator across app and marketing pages

### DIFF
--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Dev Health — Where is your engineering effort going?",
+  title: "Dev Health (Beta) — Where is your engineering effort going?",
   description:
     "Dev Health is an open-source analytics platform for team operating modes and developer health. See where effort is invested and what it costs your people.",
   openGraph: {
-    title: "Dev Health — Engineering Effort Analytics",
+    title: "Dev Health (Beta) — Engineering Effort Analytics",
     description:
       "Understand where human effort is actually being invested, and the cost to people when certain work dominates.",
     type: "website",
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Dev Health — Engineering Effort Analytics",
+    title: "Dev Health (Beta) — Engineering Effort Analytics",
     description:
       "Open-source analytics for team operating modes and developer health.",
   },

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { BetaBadge } from "@/components/BetaBadge";
 
 const FEATURES = [
   {
@@ -142,6 +143,7 @@ export default function MarketingPage() {
           <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
             OSS
           </span>
+          <BetaBadge />
         </Link>
         <div className="flex items-center gap-4">
           <Link

--- a/src/components/BetaBadge.tsx
+++ b/src/components/BetaBadge.tsx
@@ -1,0 +1,10 @@
+const showBeta = process.env.NEXT_PUBLIC_BETA !== "false";
+
+export function BetaBadge() {
+  if (!showBeta) return null;
+  return (
+    <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-amber-400">
+      Beta
+    </span>
+  );
+}

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useSyncExternalStore, useCallback } from "react";
+import { BetaBadge } from "@/components/BetaBadge";
 
 import { withFilterParam } from "@/lib/filters/url";
 import type { MetricFilter } from "@/lib/filters/types";
@@ -99,8 +100,8 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
             <p className="text-xs uppercase tracking-[0.4em] text-(--ink-muted)">
               Dev Health Ops
             </p>
-            <p className="mt-3 font-(--font-display) text-lg">
-              Cockpit
+            <p className="mt-3 font-(--font-display) text-lg flex items-center gap-2">
+              Cockpit <BetaBadge />
             </p>
             <p className="mt-2 text-xs text-(--ink-muted)">
               Observe patterns, drill into evidence.


### PR DESCRIPTION
## Summary

- Adds a `<BetaBadge />` component rendering an amber "Beta" pill, controlled by `NEXT_PUBLIC_BETA` env var (shown by default, hidden when set to `"false"`)
- Badge appears in PrimaryNav sidebar header next to "Cockpit" text
- Badge appears in marketing page nav alongside the existing "OSS" badge
- Marketing metadata (title, openGraph, twitter) updated with "(Beta)" indicator

## Files Changed

| File | Change |
|---|---|
| `src/components/BetaBadge.tsx` | **New** — Beta badge component |
| `src/components/navigation/PrimaryNav.tsx` | Added BetaBadge import + usage in sidebar header |
| `src/app/(marketing)/page.tsx` | Added BetaBadge import + usage in marketing nav |
| `src/app/(marketing)/layout.tsx` | Updated metadata titles with "(Beta)" |

## Testing

- All LSP diagnostics clean
- TypeScript compilation passes
- Pure Tailwind styling, no new dependencies

Closes CHAOS-452

TEST-WAIVER: Pure presentational component (BetaBadge renders static markup controlled by build-time env var) and metadata-only changes — no logic paths to test