### PR TITLE
feat: add in-app bug reporter with Linear integration

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { SessionProvider } from "@/components/auth/SessionProvider";
 import { UserMenu } from "@/components/auth/UserMenu";
 import { ImpersonationBanner } from "@/components/admin/ImpersonationBanner";
+import { BugReportButton } from "@/components/feedback/BugReportButton";
 import { GraphQLProvider } from "@/lib/graphql/provider";
 import { Toaster } from "sonner";
 import { requireSession } from "@/lib/auth";
@@ -20,6 +21,7 @@ export default async function AppLayout({
         </div>
         <ImpersonationBanner />
         {children}
+        <BugReportButton />
         <Toaster richColors position="top-right" theme="dark" />
       </GraphQLProvider>
     </SessionProvider>

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,178 @@
+import { NextResponse } from "next/server";
+
+import type { FeedbackPayload, FeedbackResponse } from "@/components/feedback/types";
+
+const LINEAR_ENDPOINT = "https://api.linear.app/graphql";
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 5;
+
+const requestLog = new Map<string, number[]>();
+
+const ISSUE_CREATE_MUTATION = `
+  mutation IssueCreate($input: IssueCreateInput!) {
+    issueCreate(input: $input) {
+      success
+      issue {
+        id
+        identifier
+        url
+      }
+    }
+  }
+`;
+
+function getClientIp(request: Request): string {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+
+  if (!forwardedFor) {
+    return "unknown";
+  }
+
+  return forwardedFor.split(",")[0]?.trim() || "unknown";
+}
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const requests = requestLog.get(ip) ?? [];
+  const recentRequests = requests.filter((timestamp) => now - timestamp < RATE_LIMIT_WINDOW_MS);
+
+  if (recentRequests.length >= RATE_LIMIT_MAX_REQUESTS) {
+    requestLog.set(ip, recentRequests);
+    return true;
+  }
+
+  recentRequests.push(now);
+  requestLog.set(ip, recentRequests);
+  return false;
+}
+
+function getPriority(type: FeedbackPayload["type"]): number {
+  switch (type) {
+    case "bug":
+      return 2;
+    case "feature":
+      return 3;
+    case "question":
+      return 4;
+    default:
+      return 4;
+  }
+}
+
+function buildDescription(payload: FeedbackPayload): string {
+  return `${payload.description.trim()}\n\n---\n\n**Feedback Metadata**\n- URL: ${payload.url}\n- User Agent: ${payload.userAgent}\n- Timestamp: ${payload.timestamp}\n- Type: ${payload.type}`;
+}
+
+function badRequest(error: string) {
+  const response: FeedbackResponse = {
+    success: false,
+    error,
+  };
+
+  return NextResponse.json(response, { status: 400 });
+}
+
+export async function POST(request: Request) {
+  const linearApiKey = process.env.LINEAR_API_KEY;
+  const linearTeamId = process.env.LINEAR_TEAM_ID;
+
+  if (!linearApiKey || !linearTeamId) {
+    const response: FeedbackResponse = {
+      success: false,
+      error: "Feedback service not configured",
+    };
+
+    return NextResponse.json(response, { status: 503 });
+  }
+
+  const ip = getClientIp(request);
+
+  if (isRateLimited(ip)) {
+    const response: FeedbackResponse = {
+      success: false,
+      error: "Rate limit exceeded. Please try again later.",
+    };
+
+    return NextResponse.json(response, { status: 429 });
+  }
+
+  try {
+    const payload = (await request.json()) as FeedbackPayload;
+
+    if (typeof payload.title !== "string" || payload.title.trim().length === 0) {
+      return badRequest("Title is required");
+    }
+
+    if (typeof payload.description !== "string" || payload.description.trim().length === 0) {
+      return badRequest("Description is required");
+    }
+
+    if (payload.type !== "bug" && payload.type !== "feature" && payload.type !== "question") {
+      return badRequest("Invalid feedback type");
+    }
+
+    const linearResponse = await fetch(LINEAR_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: linearApiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: ISSUE_CREATE_MUTATION,
+        variables: {
+          input: {
+            teamId: linearTeamId,
+            title: payload.title.trim(),
+            description: buildDescription(payload),
+            priority: getPriority(payload.type),
+          },
+        },
+      }),
+    });
+
+    if (!linearResponse.ok) {
+      throw new Error(`Linear API request failed with status ${linearResponse.status}`);
+    }
+
+    const linearData = (await linearResponse.json()) as {
+      data?: {
+        issueCreate?: {
+          success?: boolean;
+          issue?: {
+            id: string;
+            identifier: string;
+            url: string;
+          };
+        };
+      };
+      errors?: Array<{ message?: string }>;
+    };
+
+    if (linearData.errors && linearData.errors.length > 0) {
+      const message = linearData.errors[0]?.message || "Failed to create issue";
+      throw new Error(message);
+    }
+
+    const issueCreate = linearData.data?.issueCreate;
+    const issue = issueCreate?.issue;
+
+    if (!issueCreate?.success || !issue) {
+      throw new Error("Failed to create issue");
+    }
+
+    const response: FeedbackResponse = {
+      success: true,
+      issueId: issue.identifier,
+      issueUrl: issue.url,
+    };
+
+    return NextResponse.json(response);
+  } catch {
+    const response: FeedbackResponse = {
+      success: false,
+      error: "Failed to submit feedback",
+    };
+
+    return NextResponse.json(response, { status: 500 });
+  }
+}

--- a/src/components/feedback/BugReportButton.tsx
+++ b/src/components/feedback/BugReportButton.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+import type { FeedbackPayload, FeedbackResponse, FeedbackType } from "@/components/feedback/types";
+
+const inputClassName =
+  "w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground placeholder:text-(--ink-muted) focus:border-(--accent) focus:outline-none";
+
+type FeedbackFormState = {
+  title: string;
+  description: string;
+  type: FeedbackType;
+};
+
+const initialFormState: FeedbackFormState = {
+  title: "",
+  description: "",
+  type: "bug",
+};
+
+function BugIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-5 w-5"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 6v12" />
+      <path d="M8 8h8" />
+      <path d="M8 16h8" />
+      <path d="M7 10 4 8" />
+      <path d="M7 14 4 16" />
+      <path d="M17 10l3-2" />
+      <path d="M17 14l3 2" />
+      <path d="M15 5a3 3 0 1 0-6 0" />
+      <rect x="7" y="6" width="10" height="12" rx="5" />
+    </svg>
+  );
+}
+
+export function BugReportButton() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [formState, setFormState] = useState<FeedbackFormState>(initialFormState);
+
+  const closePanel = () => {
+    if (isLoading) {
+      return;
+    }
+
+    setIsOpen(false);
+  };
+
+  const handleSubmit = async (event: React.SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsLoading(true);
+
+    const payload: FeedbackPayload = {
+      title: formState.title,
+      description: formState.description,
+      type: formState.type,
+      url: window.location.pathname,
+      userAgent: window.navigator.userAgent,
+      timestamp: new Date().toISOString(),
+    };
+
+    try {
+      const response = await fetch("/api/feedback", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const data = (await response.json()) as FeedbackResponse;
+
+      if (!response.ok || !data.success) {
+        toast.error(data.error || "Failed to submit feedback");
+        return;
+      }
+
+      toast.success(`Issue created: ${data.issueId} ${data.issueUrl ?? ""}`.trim());
+      setFormState(initialFormState);
+      setIsOpen(false);
+    } catch {
+      toast.error("Failed to submit feedback");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full border border-(--card-stroke) bg-(--card-80) text-foreground shadow-xl transition hover:border-(--accent) hover:text-(--accent)"
+        onClick={() => setIsOpen(true)}
+        aria-label="Report an issue"
+      >
+        <BugIcon />
+      </button>
+
+      {isOpen ? (
+        <>
+          <button
+            type="button"
+            aria-label="Close issue report panel"
+            className="fixed inset-0 z-50 bg-black/50"
+            onClick={closePanel}
+          />
+          <div
+            className="fixed right-0 top-0 bottom-0 z-50 w-full max-w-md translate-x-0 border-l border-(--card-stroke) bg-(--card-80) shadow-2xl transition-transform duration-300 ease-out"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="bug-report-title"
+          >
+            <div className="flex h-full flex-col">
+              <div className="flex items-center justify-between border-b border-(--card-stroke) px-5 py-4">
+                <h2 id="bug-report-title" className="font-(--font-display) text-lg text-foreground">
+                  Report an Issue
+                </h2>
+                <button
+                  type="button"
+                  className="rounded-md p-2 text-(--ink-muted) transition hover:text-foreground"
+                  onClick={closePanel}
+                  aria-label="Close"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    className="h-5 w-5"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  >
+                    <path d="m6 6 12 12" />
+                    <path d="m18 6-12 12" />
+                  </svg>
+                </button>
+              </div>
+
+              <form className="flex flex-1 flex-col gap-4 px-5 py-5" onSubmit={handleSubmit}>
+                <label className="space-y-2">
+                  <span className="text-sm text-foreground">Title</span>
+                  <input
+                    type="text"
+                    required
+                    placeholder="Brief summary..."
+                    className={inputClassName}
+                    value={formState.title}
+                    onChange={(event) => setFormState((current) => ({ ...current, title: event.target.value }))}
+                  />
+                </label>
+
+                <label className="space-y-2">
+                  <span className="text-sm text-foreground">Type</span>
+                  <select
+                    className={inputClassName}
+                    value={formState.type}
+                    onChange={(event) =>
+                      setFormState((current) => ({
+                        ...current,
+                        type: event.target.value as FeedbackType,
+                      }))
+                    }
+                  >
+                    <option value="bug">Bug</option>
+                    <option value="feature">Feature Request</option>
+                    <option value="question">Question</option>
+                  </select>
+                </label>
+
+                <label className="space-y-2">
+                  <span className="text-sm text-foreground">Description</span>
+                  <textarea
+                    required
+                    rows={6}
+                    placeholder="What happened? Steps to reproduce..."
+                    className={inputClassName}
+                    value={formState.description}
+                    onChange={(event) => setFormState((current) => ({ ...current, description: event.target.value }))}
+                  />
+                </label>
+
+                <div className="mt-auto pt-2">
+                  <button
+                    type="submit"
+                    disabled={isLoading}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2.5 text-sm font-medium text-foreground transition hover:border-(--accent) disabled:cursor-not-allowed disabled:opacity-70"
+                  >
+                    {isLoading ? <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" /> : null}
+                    {isLoading ? "Submitting..." : "Submit Report"}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/feedback/types.ts
+++ b/src/components/feedback/types.ts
@@ -1,0 +1,17 @@
+export type FeedbackType = "bug" | "feature" | "question";
+
+export type FeedbackPayload = {
+  title: string;
+  description: string;
+  type: FeedbackType;
+  url: string;
+  userAgent: string;
+  timestamp: string;
+};
+
+export type FeedbackResponse = {
+  success: boolean;
+  issueUrl?: string;
+  issueId?: string;
+  error?: string;
+};

--- a/src/lib/__tests__/api/feedback-route.test.ts
+++ b/src/lib/__tests__/api/feedback-route.test.ts
@@ -1,0 +1,845 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+describe("POST /api/feedback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    // Clear environment variables
+    delete process.env.LINEAR_API_KEY;
+    delete process.env.LINEAR_TEAM_ID;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 503 when LINEAR_API_KEY is missing", async () => {
+    process.env.LINEAR_TEAM_ID = "team-123";
+    delete process.env.LINEAR_API_KEY;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: new Date().toISOString(),
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(503);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Feedback service not configured");
+  });
+
+  it("returns 503 when LINEAR_TEAM_ID is missing", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    delete process.env.LINEAR_TEAM_ID;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: new Date().toISOString(),
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(503);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Feedback service not configured");
+  });
+
+  it("returns 400 when title is empty", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: new Date().toISOString(),
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Title is required");
+  });
+
+  it("returns 400 when title is only whitespace", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "   ",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: new Date().toISOString(),
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Title is required");
+  });
+
+  it("returns 400 when description is empty", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: new Date().toISOString(),
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Description is required");
+  });
+
+  it("returns 400 when description is only whitespace", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "   ",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: new Date().toISOString(),
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Description is required");
+  });
+
+  it("returns 400 when type is invalid", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "Test description",
+        type: "invalid",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: new Date().toISOString(),
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Invalid feedback type");
+  });
+
+  it("returns 200 with success response on valid bug submission", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: {
+                  id: "issue-123",
+                  identifier: "ENG-456",
+                  url: "https://linear.app/issue/ENG-456",
+                },
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as {
+      success: boolean;
+      issueId?: string;
+      issueUrl?: string;
+    };
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.issueId).toBe("ENG-456");
+    expect(data.issueUrl).toBe("https://linear.app/issue/ENG-456");
+
+    // Verify fetch was called with correct parameters
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const callArgs = mockFetch.mock.calls[0];
+    expect(callArgs[0]).toBe("https://api.linear.app/graphql");
+    expect(callArgs[1]?.method).toBe("POST");
+    expect(callArgs[1]?.headers).toEqual({
+      Authorization: "key-123",
+      "Content-Type": "application/json",
+    });
+
+    const body = JSON.parse(callArgs[1]?.body as string);
+    expect(body.variables.input.teamId).toBe("team-123");
+    expect(body.variables.input.title).toBe("Test Bug");
+    expect(body.variables.input.priority).toBe(2); // bug priority
+  });
+
+  it("returns 200 with success response on valid feature submission", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: {
+                  id: "issue-789",
+                  identifier: "ENG-789",
+                  url: "https://linear.app/issue/ENG-789",
+                },
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "New Feature",
+        description: "Feature description",
+        type: "feature",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as {
+      success: boolean;
+      issueId?: string;
+      issueUrl?: string;
+    };
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+
+    // Verify priority mapping for feature
+    const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+    expect(body.variables.input.priority).toBe(3); // feature priority
+  });
+
+  it("returns 200 with success response on valid question submission", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: {
+                  id: "issue-999",
+                  identifier: "ENG-999",
+                  url: "https://linear.app/issue/ENG-999",
+                },
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Question",
+        description: "Question description",
+        type: "question",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as {
+      success: boolean;
+      issueId?: string;
+      issueUrl?: string;
+    };
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+
+    // Verify priority mapping for question
+    const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+    expect(body.variables.input.priority).toBe(4); // question priority
+  });
+
+  it("includes metadata in description sent to Linear", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: {
+                  id: "issue-123",
+                  identifier: "ENG-456",
+                  url: "https://linear.app/issue/ENG-456",
+                },
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const testUrl = "http://example.com/page";
+    const testUserAgent = "Mozilla/5.0 Test";
+    const testTimestamp = "2024-01-01T12:00:00Z";
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "Original description",
+        type: "bug",
+        url: testUrl,
+        userAgent: testUserAgent,
+        timestamp: testTimestamp,
+      }),
+    });
+
+    await POST(request);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+    const description = body.variables.input.description;
+
+    expect(description).toContain("Original description");
+    expect(description).toContain(`URL: ${testUrl}`);
+    expect(description).toContain(`User Agent: ${testUserAgent}`);
+    expect(description).toContain(`Timestamp: ${testTimestamp}`);
+    expect(description).toContain("Type: bug");
+  });
+
+  it("returns 500 when Linear API returns error response", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            errors: [{ message: "Authentication failed" }],
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Failed to submit feedback");
+  });
+
+  it("returns 500 when Linear API returns non-ok status", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(new Response("Internal Server Error", { status: 500 }))
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Failed to submit feedback");
+  });
+
+  it("returns 500 when issueCreate.success is false", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: false,
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Failed to submit feedback");
+  });
+
+  it("returns 500 when issue is missing from response", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: null,
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Failed to submit feedback");
+  });
+
+  it("returns 429 when rate limit is exceeded (6th request from same IP)", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: {
+                  id: "issue-123",
+                  identifier: "ENG-456",
+                  url: "https://linear.app/issue/ENG-456",
+                },
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const testIp = "192.168.1.1";
+
+    // Make 5 successful requests
+    for (let i = 0; i < 5; i++) {
+      const request = new Request("http://localhost/api/feedback", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": testIp,
+        },
+        body: JSON.stringify({
+          title: `Test Bug ${i}`,
+          description: "Test description",
+          type: "bug",
+          url: "http://example.com",
+          userAgent: "Mozilla/5.0",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    }
+
+    // 6th request should be rate limited
+    const rateLimitedRequest = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-forwarded-for": testIp,
+      },
+      body: JSON.stringify({
+        title: "Test Bug 6",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    });
+
+    const response = await POST(rateLimitedRequest);
+    const data = (await response.json()) as { success: boolean; error?: string };
+
+    expect(response.status).toBe(429);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Rate limit exceeded. Please try again later.");
+  });
+
+  it("allows requests from different IPs independently", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: {
+                  id: "issue-123",
+                  identifier: "ENG-456",
+                  url: "https://linear.app/issue/ENG-456",
+                },
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    // Make 5 requests from IP1
+    for (let i = 0; i < 5; i++) {
+      const request = new Request("http://localhost/api/feedback", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": "192.168.1.1",
+        },
+        body: JSON.stringify({
+          title: `Test Bug ${i}`,
+          description: "Test description",
+          type: "bug",
+          url: "http://example.com",
+          userAgent: "Mozilla/5.0",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+      });
+
+      await POST(request);
+    }
+
+    // Make 5 requests from IP2 - should all succeed
+    for (let i = 0; i < 5; i++) {
+      const request = new Request("http://localhost/api/feedback", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": "192.168.1.2",
+        },
+        body: JSON.stringify({
+          title: `Test Bug ${i}`,
+          description: "Test description",
+          type: "bug",
+          url: "http://example.com",
+          userAgent: "Mozilla/5.0",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    }
+  });
+
+  it("handles missing x-forwarded-for header gracefully", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: {
+                  id: "issue-123",
+                  identifier: "ENG-456",
+                  url: "https://linear.app/issue/ENG-456",
+                },
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test Bug",
+        description: "Test description",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+  });
+
+  it("trims whitespace from title and description", async () => {
+    process.env.LINEAR_API_KEY = "key-123";
+    process.env.LINEAR_TEAM_ID = "team-123";
+
+    const mockFetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: {
+                  id: "issue-123",
+                  identifier: "ENG-456",
+                  url: "https://linear.app/issue/ENG-456",
+                },
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    global.fetch = mockFetch;
+
+    const { POST } = await import("@/app/api/feedback/route");
+
+    const request = new Request("http://localhost/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "  Test Bug  ",
+        description: "  Test description  ",
+        type: "bug",
+        url: "http://example.com",
+        userAgent: "Mozilla/5.0",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+    expect(body.variables.input.title).toBe("Test Bug");
+    expect(body.variables.input.description).toContain("Test description");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a floating bug report button (FAB) visible on all authenticated pages
- Clicking opens a slide-out panel with a form (Title, Type, Description)
- Form submits to `/api/feedback` Next.js API route that proxies to Linear GraphQL API
- Auto-collects metadata: pathname, userAgent, timestamp
- Toast feedback via sonner on success (with issue ID) or error

## Architecture

```
BugReportButton (client) → POST /api/feedback → Linear GraphQL API
```

- `LINEAR_API_KEY` and `LINEAR_TEAM_ID` stay server-side only (never exposed to client)
- IP-based rate limiting: 5 requests per hour per IP (in-memory Map)
- Priority mapping: bug=2 (urgent), feature=3 (medium), question=4 (low)

## Files Changed

| File | Change |
|---|---|
| `src/components/feedback/types.ts` | **New** — FeedbackPayload, FeedbackResponse, FeedbackType |
| `src/app/api/feedback/route.ts` | **New** — Linear API proxy with rate limiting + validation |
| `src/components/feedback/BugReportButton.tsx` | **New** — FAB + slide-out panel + form |
| `src/app/(app)/layout.tsx` | Added BugReportButton before Toaster |

## Configuration

Requires two environment variables:
- `LINEAR_API_KEY` — Linear API key for issue creation
- `LINEAR_TEAM_ID` — Linear team ID to create issues in

Returns 503 gracefully if not configured.

## Testing

- All LSP diagnostics clean
- TypeScript compilation passes
- Pure Tailwind styling, no new dependencies (uses existing sonner for toasts)

Closes CHAOS-449