### PR TITLE
fix: set X-Org-Id header in proxy from server-side session

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -32,6 +32,7 @@ export async function proxy(request: NextRequest) {
     }
 
     let accessToken: string | undefined;
+    let orgId: string | undefined;
 
     if (!isTestMode && !isPublicPath(pathname)) {
         const session = await auth();
@@ -41,6 +42,7 @@ export async function proxy(request: NextRequest) {
             return NextResponse.redirect(signInUrl);
         }
         accessToken = session.access_token;
+        orgId = session.user?.org_id;
     }
 
     const shouldProxy =
@@ -57,6 +59,9 @@ export async function proxy(request: NextRequest) {
     if (accessToken) {
         const requestHeaders = new Headers(request.headers);
         requestHeaders.set("Authorization", `Bearer ${accessToken}`);
+        if (orgId) {
+            requestHeaders.set("X-Org-Id", orgId);
+        }
         return NextResponse.rewrite(targetUrl, {
             request: { headers: requestHeaders },
         });


### PR DESCRIPTION
## Summary

- Adds `X-Org-Id` header to all proxied requests from the server-side session — the proxy already had the authenticated session with `org_id` but was only forwarding `Authorization`
- This makes org scoping authoritative at the proxy layer (server-side session), not reliant on client-side header injection
- Companion to [dev-health-ops PR #486](https://github.com/full-chaos/dev-health-ops/pull/486) which adds `OrgIdMiddleware` on the backend

## What changed

`src/proxy.ts`: 3 lines added — extract `session.user.org_id` alongside `accessToken`, set `X-Org-Id` header on proxied requests.

## What did NOT change

The 3 client-side locations that also set `X-Org-Id` (`urqlClient.ts`, `client.ts`, `admin/api.ts`) are left as-is — they're harmless redundancy and support non-proxied use cases (test mode, direct API calls).

SCREENSHOT-WAIVER: No rendered UI changes — proxy middleware only, no component or page changes.
TEST-WAIVER: Proxy middleware change only — no component logic affected. The proxy is tested via live e2e suite which requires a running backend.