### PR TITLE
fix: right-align focus text in persona cards on marketing page

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -332,7 +332,7 @@ export default function MarketingPage() {
                   <span className="rounded-full bg-(--accent)/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-(--accent)">
                     {persona.tag}
                   </span>
-                  <span className="text-[10px] uppercase tracking-[0.2em] text-(--accent-2)">
+                  <span className="text-right text-[10px] uppercase tracking-[0.2em] text-(--accent-2)">
                     {persona.focus}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary

- Adds `text-right` to the persona focus label span in the "Who it's for" section, fixing misaligned text that should be right-aligned within the card header (e.g., "QUALITY & THROUGHPUT" next to "VP / CTO").

TEST-WAIVER: CSS-only change — no component logic affected
SCREENSHOT-WAIVER: CSS-only text alignment fix — visual evidence provided by reporter