### PR TITLE
fix: route signup through proxy and allow unauthenticated auth API calls

### DIFF
--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { toast } from "sonner"
-import { getBackendUrl } from "@/lib/origin"
+import { resolveOrigin } from "@/lib/origin"
 
 export function SignupForm() {
    const router = useRouter()
@@ -30,7 +30,7 @@ export function SignupForm() {
      setLoading(true)
 
      try {
-       const backendUrl = getBackendUrl()
+       const backendUrl = resolveOrigin()
        const res = await fetch(`${backendUrl}/api/v1/auth/register`, {
          method: "POST",
          headers: { "Content-Type": "application/json" },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,7 @@ const PUBLIC_PATHS = [
     "/auth/signup",
     "/auth/error",
     "/api/auth",
+    "/api/v1/auth",
     "/_next",
     "/favicon.ico",
     "/runtime-config.js",


### PR DESCRIPTION
## Summary

- **SignupForm** was calling `getBackendUrl()` which resolves to `http://127.0.0.1:8000` in the browser — unreachable in Docker since the API container has no exposed ports. Switched to `resolveOrigin()` so requests route through the Next.js proxy.
- Added `/api/v1/auth` to `PUBLIC_PATHS` in `proxy.ts` so unauthenticated users can register/login through the proxy without being redirected to signin.

## Root Cause

`getBackendUrl()` is a server-only function that reads `process.env.BACKEND_URL`. In the browser, this env var is undefined (not `NEXT_PUBLIC_`), so it falls back to `http://127.0.0.1:8000`. The signup form is a client component, so it was hitting localhost directly instead of routing through the proxy.

## Related

- Companion PR in dev-health-ops: fix/auth-email-case-sensitivity (email case normalization)

SCREENSHOT-WAIVER: No visual changes — networking/proxy fix only

TEST-WAIVER: Proxy routing fix — no component logic affected, requires live Docker environment to verify