### PR TITLE
fix: use non-admin org profile endpoint for settings save

### DIFF
--- a/src/components/admin/settings/GeneralSettings.tsx
+++ b/src/components/admin/settings/GeneralSettings.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { SettingsSection } from "./SettingsSection";
-import { updateCurrentOrg } from "@/lib/admin/server";
+import { updateOrgProfile } from "@/lib/admin/server";
 import type { Organization } from "@/lib/admin/types";
 
 type GeneralSettingsProps = {
@@ -18,9 +18,9 @@ export function GeneralSettings({ org }: GeneralSettingsProps) {
      setIsLoading(true);
 
      const formData = new FormData(e.currentTarget);
-     const result = await updateCurrentOrg({
+     const result = await updateOrgProfile({
        name: formData.get("name") as string,
-       description: formData.get("description") as string || undefined,
+       description: (formData.get("description") as string) || undefined,
      });
 
      setIsLoading(false);

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -443,6 +443,45 @@ export async function updateCurrentOrg(
   });
 }
 
+/**
+ * Self-service org profile update — calls /api/v1/orgs/me (non-admin endpoint)
+ * so that org owners/admins can update name & description without superuser.
+ */
+export async function updateOrgProfile(
+  data: { name?: string; description?: string | null }
+): Promise<ActionResult<Organization>> {
+  return withErrorHandling(async () => {
+    const { token, orgId } = await getSessionContext();
+    if (!orgId) {
+      throw new AdminApiError(400, "Bad Request", "No organization ID in session");
+    }
+
+    const baseUrl = (await import("@/lib/origin")).getBackendUrl();
+    const response = await fetch(`${baseUrl}/api/v1/orgs/me`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+        "X-Org-Id": orgId,
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      let detail: string | undefined;
+      try {
+        const errorData = await response.json();
+        detail = errorData.detail || errorData.message;
+      } catch {
+        detail = undefined;
+      }
+      throw new AdminApiError(response.status, response.statusText, detail);
+    }
+
+    return (await response.json()) as Organization;
+  });
+}
+
 export async function deleteCurrentOrg(): Promise<ActionResult<void>> {
   return withErrorHandling(async () => {
     const { token, orgId } = await getSessionContext();

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -337,6 +337,22 @@ export const handlers = [
     });
   }),
 
+  // ---- Org self-service profile update ----
+  http.patch("*/api/v1/orgs/me", async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown> | null;
+    return HttpResponse.json({
+      id: "org-e2e",
+      slug: "my-organization-e2e",
+      name: typeof body?.name === "string" ? body.name : "My Organization",
+      description: typeof body?.description === "string" ? body.description : null,
+      tier: "community",
+      settings: {},
+      is_active: true,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: new Date().toISOString(),
+    });
+  }),
+
   // ---- Health & Meta ----
   http.get("*/health", () =>
     HttpResponse.json({ status: "ok", services: { api: "mock" } }),


### PR DESCRIPTION
## Summary

- Add `updateOrgProfile()` server action that calls `PATCH /api/v1/orgs/me` (non-admin endpoint)
- Update `GeneralSettings.tsx` to use `updateOrgProfile` instead of `updateCurrentOrg` which went through the superuser-gated admin API
- Add mock handler for `PATCH /api/v1/orgs/me` in E2E test server

## Problem

Org owners/admins could not update their org display name or description on `/admin/settings` because `updateCurrentOrg` routes through `PATCH /api/v1/admin/orgs/{id}` which requires superuser access.

## Solution

New `updateOrgProfile()` action bypasses the admin API and calls `PATCH /api/v1/orgs/me` directly. This endpoint (to be added in dev-health-ops) only allows `name` and `description` updates, requiring org admin/owner role instead of superuser.

**Depends on:** Backend endpoint `PATCH /api/v1/orgs/me` in dev-health-ops (CHAOS-511)

TEST-WAIVER: Mock handler added for new endpoint; no new component logic to unit test — the change swaps one server action for another with identical signature.
SCREENSHOT-WAIVER: No visual changes — same form, same button, just different API call path.

Fixes CHAOS-511