### PR TITLE
docs: align web env setup with feedback integration (CHAOS-515)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,13 +8,19 @@
 # Backend API URL (required for full-stack mode)
 BACKEND_URL=http://127.0.0.1:8000
 
+# Optional: override backend URL used by pricing marketing page
+# NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
+
 # =============================================================================
 # Feature Flags
 # =============================================================================
 
 # Enable GraphQL analytics (Investment View, Work Graph)
-# Set to "true" to use GraphQL API instead of REST
+# Defaults to true unless explicitly set to "false"
 NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS=false
+
+# Optional server-only override used at runtime config generation
+# USE_GRAPHQL_ANALYTICS=true
 
 # Use sample data instead of live API (for testing/demos)
 # Set to "true" to bypass API calls and use static data
@@ -35,6 +41,10 @@ BASE_PATH=
 # Documentation URL (shown in UI help links)
 NEXT_PUBLIC_DOCS_URL=
 
+# Optional: hide/show beta badge in marketing nav (default shown)
+# Set to "false" to hide
+# NEXT_PUBLIC_BETA=true
+
 # =============================================================================
 # Authentication
 # =============================================================================
@@ -42,6 +52,17 @@ NEXT_PUBLIC_DOCS_URL=
 # Auth.js secret (required in production, auto-generated for dev)
 # Generate with: openssl rand -base64 32
 AUTH_SECRET=
+
+# Deprecated alias for AUTH_SECRET (kept for backward compatibility)
+# NEXTAUTH_SECRET=
+
+# =============================================================================
+# Feedback -> Linear Integration (Optional)
+# =============================================================================
+# The /api/feedback route returns 503 unless both vars are set.
+# Use a Linear API key in Authorization header format (for example: "Bearer lin_api_xxx")
+# LINEAR_API_KEY=
+# LINEAR_TEAM_ID=
 
 # =============================================================================
 # Development Only

--- a/README.md
+++ b/README.md
@@ -52,14 +52,22 @@ This will serve the app at [http://localhost:3000](http://localhost:3000) using 
 
 ## Environment Variables
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `BACKEND_URL` | Backend API URL | `http://127.0.0.1:8000` |
-| `NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS` | Enable GraphQL analytics | `false` |
-| `NEXT_PUBLIC_DEV_HEALTH_TEST_MODE` | Use sample data (for testing) | `false` |
-| `NEXT_PUBLIC_DOCS_URL` | Documentation link URL | — |
-| `DEMO_EXPORT` | Enable static export mode | `false` |
-| `BASE_PATH` | Subpath for hosting (e.g., `/app`) | — |
+| Variable | Required | Purpose | Default / Notes |
+|----------|----------|---------|-----------------|
+| `BACKEND_URL` | No | Backend API base URL | `http://127.0.0.1:8000` |
+| `AUTH_SECRET` | Prod: Yes, Dev: No | Auth.js signing/encryption secret | Falls back to a dev-only in-code value |
+| `LINEAR_API_KEY` | Optional feature | Enables `POST /api/feedback` Linear issue creation | Must be set with `LINEAR_TEAM_ID`; route returns `503` if missing |
+| `LINEAR_TEAM_ID` | Optional feature | Linear team target for feedback issues | Must be set with `LINEAR_API_KEY` |
+| `NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS` | No | Client/runtime GraphQL analytics toggle | Enabled unless set to `false` |
+| `USE_GRAPHQL_ANALYTICS` | No | Server-side runtime fallback for GraphQL toggle | Used when the public flag is absent |
+| `NEXT_PUBLIC_DOCS_URL` | No | Docs/help link URL in UI | `/docs` |
+| `NEXT_PUBLIC_DEV_HEALTH_TEST_MODE` | No | Use sample data in test/demo paths | `false` |
+| `DEMO_EXPORT` | No | Enable static export build mode | `false` |
+| `BASE_PATH` | No | Subpath hosting prefix (example: `/app`) | Empty (root) |
+
+Deprecated (still read for compatibility):
+
+- `NEXTAUTH_SECRET` -> use `AUTH_SECRET`.
 
 Copy `.env.example` to `.env.local` and configure as needed.
 


### PR DESCRIPTION
## Summary
- document `LINEAR_API_KEY` and `LINEAR_TEAM_ID` requirements for `POST /api/feedback`
- update environment variable guidance to reflect current runtime behavior and compatibility notes
- improve `.env.example` comments for GraphQL toggle semantics and optional hosting flags

## Validation
- `npm run typecheck`

## Tracking
- CHAOS-515
- SCREENSHOT-WAIVER: docs-only change; no rendered UI behavior updated