### PR TITLE
fix(superadmin): support global user list and search

### DIFF
--- a/src/app/(app)/superadmin/users/page.tsx
+++ b/src/app/(app)/superadmin/users/page.tsx
@@ -1,10 +1,17 @@
 import Link from "next/link";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { UserTable } from "@/components/superadmin/UserTable";
-import { listUsers } from "@/lib/admin/server";
+import { listPlatformUsers } from "@/lib/admin/server";
 
-export default async function UsersPage() {
-  const { data: users, error } = await listUsers();
+type UsersPageProps = {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+export default async function UsersPage({ searchParams }: UsersPageProps) {
+  const params = (await searchParams) ?? {};
+  const queryParam = Array.isArray(params.q) ? params.q[0] : params.q;
+  const query = typeof queryParam === "string" ? queryParam.trim() : "";
+  const { data: users, error } = await listPlatformUsers(query || undefined);
 
   if (error) {
     return (
@@ -26,12 +33,29 @@ export default async function UsersPage() {
         title="Users"
         description="Manage all users across the platform."
       >
-        <Link
-          href="/superadmin/users/new"
-          className="inline-flex items-center rounded-xl bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90"
-        >
-          Create User
-        </Link>
+        <div className="flex flex-wrap items-center gap-3">
+          <form action="/superadmin/users" method="get" className="flex items-center gap-2">
+            <input
+              name="q"
+              type="search"
+              defaultValue={query}
+              placeholder="Search users..."
+              className="w-64 rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+            />
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-xl border border-(--card-stroke) px-3 py-2 text-sm font-medium text-foreground hover:bg-(--card-70)"
+            >
+              Search
+            </button>
+          </form>
+          <Link
+            href="/superadmin/users/new"
+            className="inline-flex items-center rounded-xl bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90"
+          >
+            Create User
+          </Link>
+        </div>
       </AdminHeader>
       <UserTable users={users || []} />
     </div>

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -8,6 +8,8 @@ vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 import { auth } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 import {
+  listUsers,
+  listPlatformUsers,
   createCredential,
   deleteCredential,
   listCredentials,
@@ -128,6 +130,50 @@ describe("admin/server credential actions", () => {
       expect(revalidatePath).toHaveBeenCalledWith("/admin/integrations", "page");
       fetchSpy.mockRestore();
     });
+  });
+});
+
+describe("admin/server user list actions", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubEnv("BACKEND_URL", "http://test-ops:8000");
+  });
+
+  it("listUsers includes org header and q query", async () => {
+    mockSession();
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+
+    const result = await listUsers("alice");
+
+    expect(result.error).toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toContain("/api/v1/admin/users?q=alice");
+    expect(options?.headers).toMatchObject({
+      Authorization: "Bearer test-token",
+      "X-Org-Id": "org-1",
+    });
+    fetchSpy.mockRestore();
+  });
+
+  it("listPlatformUsers omits org header and supports q query", async () => {
+    mockSession();
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+
+    const result = await listPlatformUsers("bob");
+
+    expect(result.error).toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toContain("/api/v1/admin/users?q=bob");
+    const headers = options?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer test-token");
+    expect(headers["X-Org-Id"]).toBeUndefined();
+    fetchSpy.mockRestore();
   });
 });
 

--- a/src/lib/admin/api.ts
+++ b/src/lib/admin/api.ts
@@ -361,8 +361,15 @@ export const adminApi = {
   },
 
   users: {
-    list: (token?: string, orgId?: string) =>
-      request<User[]>("/users", {}, token, orgId),
+    list: (token?: string, orgId?: string, q?: string) => {
+      const params = new URLSearchParams();
+      if (q && q.trim().length > 0) {
+        params.set("q", q.trim());
+      }
+      const query = params.toString();
+      const path = query ? `/users?${query}` : "/users";
+      return request<User[]>(path, {}, token, orgId);
+    },
 
     get: (userId: string, token?: string, orgId?: string) =>
       request<User>(`/users/${userId}`, {}, token, orgId),

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -86,10 +86,17 @@ async function withErrorHandling<T>(fn: () => Promise<T>): Promise<ActionResult<
   }
 }
 
-export async function listUsers(): Promise<ActionResult<User[]>> {
+export async function listUsers(query?: string): Promise<ActionResult<User[]>> {
   return withErrorHandling(async () => {
     const { token, orgId } = await getSessionContext();
-    return adminApi.users.list(token, orgId);
+    return adminApi.users.list(token, orgId, query);
+  });
+}
+
+export async function listPlatformUsers(query?: string): Promise<ActionResult<User[]>> {
+  return withErrorHandling(async () => {
+    const token = await getToken();
+    return adminApi.users.list(token, undefined, query);
   });
 }
 


### PR DESCRIPTION
## Summary
- add a superadmin-specific users list action that does not send org scoping headers and supports optional `q` search
- update `/superadmin/users` to read `searchParams`, submit search via query string, and call the superadmin-specific list action
- extend admin server tests to verify org-scoped and platform-scoped user list request headers and query handling

## Validation
- `npm run test:unit -- src/lib/admin/__tests__/server.test.ts`
- `npm run typecheck`
- `npm run build`