### PR TITLE
feat(security): enforce CSP — promote Report-Only to Content-Security-Policy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,7 +30,7 @@ const nextConfig = {
             value: "max-age=63072000; includeSubDomains; preload",
           },
           {
-            key: "Content-Security-Policy-Report-Only",
+            key: "Content-Security-Policy",
             value:
               "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://*.vercel.app;",
           },


### PR DESCRIPTION
## Summary

Promotes `Content-Security-Policy-Report-Only` to `Content-Security-Policy` in `next.config.js`, making the CSP policy enforced rather than report-only.

This is a one-line change — the policy directives remain exactly the same.

## Changes

- `next.config.js` — Header key changed from `Content-Security-Policy-Report-Only` to `Content-Security-Policy`

## Context

Part of the auth security audit follow-up. The CSP was initially deployed as report-only to validate it doesn't break anything. Now promoting to enforcement.

TEST-WAIVER: Config-only change — no component logic affected. CSP header key rename with identical policy value.
SCREENSHOT-WAIVER: No rendered UI change — this is a response header configuration.