### PR TITLE
docs(auth): add AUTH_URL to .env.example and auth docs (CHAOS-559)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,13 @@ NEXT_PUBLIC_DOCS_URL=
 # Generate with: openssl rand -base64 32
 AUTH_SECRET=
 
+# Auth.js base URL (required for non-localhost environments)
+# Set to the full URL where the app is hosted (e.g., https://app.example.com)
+# Required for CSRF origin validation — without this, sign-in/sign-up will fail
+# with a 'request origin validation' error in Docker, reverse proxy, or production.
+# In local dev on localhost:3000, Auth.js auto-detects this, so it's optional.
+# AUTH_URL=http://localhost:3000
+
 # Deprecated alias for AUTH_SECRET (kept for backward compatibility)
 # NEXTAUTH_SECRET=
 

--- a/docs/auth-system.md
+++ b/docs/auth-system.md
@@ -90,3 +90,28 @@ Support for "Login as User" functionality:
 | `src/proxy.ts` | Network-level auth enforcement and header injection |
 | `src/lib/auth.ts` (guards) | Server-side redirect logic (`requireSession`, `requireRole`, `requireSuperuser`) |
 | `src/components/auth/ImpersonationBanner.tsx` | UI indicator for active impersonation |
+
+## Environment Variables
+
+Auth-related environment variables (see `.env.example` for full list):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AUTH_SECRET` | Production | Secret used to sign/encrypt JWTs. Generate with `openssl rand -base64 32`. Auto-generated in dev. |
+| `AUTH_URL` | Non-localhost | Full URL where the app is hosted (e.g., `https://app.example.com`). Required for CSRF origin validation in Docker, reverse proxy, or production environments. Without this, sign-in/sign-up fails with a "request origin validation" error. Auto-detected on `localhost`. |
+| `BACKEND_URL` | Always | URL of the dev-health-ops backend API (default: `http://127.0.0.1:8000`). |
+
+### Troubleshooting: "request origin validation" error
+
+If you see this error during sign-in or sign-up, Auth.js cannot match the request's `Origin` header against the expected URL. This happens when:
+
+1. Running behind a reverse proxy (nginx, Caddy, etc.)
+2. Running in Docker with port mapping
+3. Deployed to production without `AUTH_URL` set
+
+**Fix:** Set `AUTH_URL` to the publicly accessible URL of the app:
+
+```bash
+AUTH_URL=https://app.example.com  # production
+AUTH_URL=http://localhost:3000     # local dev (usually auto-detected)
+```


### PR DESCRIPTION
## Summary

- Add `AUTH_URL` to `.env.example` with inline documentation explaining when and why it's needed
- Add Environment Variables section to `docs/auth-system.md` with a troubleshooting guide for the "request origin validation" error

## Context

Auth.js v5 requires `AUTH_URL` for CSRF origin validation in non-localhost environments (Docker, reverse proxy, production). Without it, users get a "request origin validation" error during sign-in/sign-up. This variable was missing from all setup documentation.

Closes CHAOS-559

SCREENSHOT-WAIVER: Docs-only changes — no rendered UI affected
TEST-WAIVER: Documentation-only changes — no component logic affected