### PR TITLE
fix(proxy): exempt /api/health from auth gate and backend proxy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,6 +11,7 @@ const PUBLIC_PATHS = [
     "/auth/signup",
     "/auth/error",
     "/api/auth",
+    "/api/health",
     "/api/v1/auth",
     "/_next",
     "/favicon.ico",
@@ -95,7 +96,7 @@ export async function proxy(request: NextRequest) {
 
     const shouldProxy =
         pathname === "/graphql" ||
-        (pathname.startsWith("/api/") && !pathname.startsWith("/api/auth") && !pathname.startsWith("/api/v1/llm-proxy"));
+        (pathname.startsWith("/api/") && !pathname.startsWith("/api/auth") && !pathname.startsWith("/api/health") && !pathname.startsWith("/api/v1/llm-proxy"));
 
     if (!shouldProxy) {
         const response = NextResponse.next({


### PR DESCRIPTION
## Summary

- Add `/api/health` to `PUBLIC_PATHS` in `src/proxy.ts` so health probes are not redirected to `/auth/signin`
- Exclude `/api/health` from the `shouldProxy` check so the request hits the local Next.js route handler instead of being rewritten to the backend

The health endpoint is used by Docker HEALTHCHECK and load-balancer probes — it must respond without authentication and independently of backend availability.

TEST-WAIVER: Proxy middleware routing logic — no component rendering affected