### PR TITLE
fix(health): move endpoint from /api/health to /health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,10 @@ COPY --from=builder /app/next.config.js ./next.config.js
 
 EXPOSE 3000
 
-# Health check — polls the app's /api/health endpoint every 30 s.
+# Health check — polls the app's /health endpoint every 30 s.
 # start-period gives Next.js time to fully initialise before checks begin.
 # Container is marked unhealthy after 3 consecutive failures (90 s total).
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD wget -qO- http://localhost:3000/api/health || exit 1
+  CMD wget -qO- http://localhost:3000/health || exit 1
 
 CMD ["npm", "run", "start"]

--- a/src/app/health/route.ts
+++ b/src/app/health/route.ts
@@ -1,5 +1,5 @@
 /**
- * GET /api/health
+ * GET /health
  *
  * Liveness/readiness endpoint for Docker HEALTHCHECK and load-balancer probes.
  * Returns 200 OK with a JSON body when the Next.js server is running.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,7 +11,7 @@ const PUBLIC_PATHS = [
     "/auth/signup",
     "/auth/error",
     "/api/auth",
-    "/api/health",
+    "/health",
     "/api/v1/auth",
     "/_next",
     "/favicon.ico",
@@ -96,7 +96,7 @@ export async function proxy(request: NextRequest) {
 
     const shouldProxy =
         pathname === "/graphql" ||
-        (pathname.startsWith("/api/") && !pathname.startsWith("/api/auth") && !pathname.startsWith("/api/health") && !pathname.startsWith("/api/v1/llm-proxy"));
+        (pathname.startsWith("/api/") && !pathname.startsWith("/api/auth") && !pathname.startsWith("/api/v1/llm-proxy"));
 
     if (!shouldProxy) {
         const response = NextResponse.next({


### PR DESCRIPTION
## Summary

- Move health route from `src/app/api/health/` → `src/app/health/` so it serves at `/health` instead of `/api/health`
- Update proxy `PUBLIC_PATHS` to exempt `/health` from auth
- Update Dockerfile `HEALTHCHECK` to `wget /health`

Health checks belong at `/health` (or `/-/health`), not under `/api/`. The compose.yml already expected `/health` — the route was in the wrong place.

TEST-WAIVER: Route file move + proxy config — no component rendering affected