### PR TITLE
fix(csp): resolve nonce hydration mismatch in root layout

### DIFF
--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,23 @@
+// Synchronous theme initialiser — runs before first paint to prevent FOUC.
+// Reads persisted theme/palette from localStorage and applies them to <html>.
+(function () {
+  try {
+    var storedTheme = localStorage.getItem("theme");
+    var storedPalette = localStorage.getItem("palette");
+    var normalizedPalette =
+      storedPalette === "tailwind" ? "echarts" : storedPalette;
+    if (
+      normalizedPalette === "material" ||
+      normalizedPalette === "echarts" ||
+      normalizedPalette === "fullchaos" ||
+      normalizedPalette === "fullchaos-cosmic-train" ||
+      normalizedPalette === "flat"
+    ) {
+      document.documentElement.dataset.palette = normalizedPalette;
+    }
+    if (storedTheme === "light" || storedTheme === "dark") {
+      document.documentElement.dataset.theme = storedTheme;
+      document.documentElement.style.colorScheme = storedTheme;
+    }
+  } catch { /* localStorage unavailable */ }
+})();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
-import { headers } from "next/headers";
+import Script from "next/script";
 import "./globals.css";
 import { WebVitalsReporter } from "@/components/WebVitalsReporter";
 
@@ -30,49 +30,21 @@ export const metadata: Metadata = {
   description: "Developer Health Ops cockpit.",
 };
 
-const themeScript = `
-(() => {
-  try {
-    const storedTheme = localStorage.getItem("theme");
-    const storedPalette = localStorage.getItem("palette");
-    const normalizedPalette = storedPalette === "tailwind" ? "echarts" : storedPalette;
-    if (
-      normalizedPalette === "material" ||
-      normalizedPalette === "echarts" ||
-      normalizedPalette === "fullchaos" ||
-      normalizedPalette === "fullchaos-cosmic-train" ||
-      normalizedPalette === "flat"
-    ) {
-      document.documentElement.dataset.palette = normalizedPalette;
-    }
-    if (storedTheme === "light" || storedTheme === "dark") {
-      document.documentElement.dataset.theme = storedTheme;
-      document.documentElement.style.colorScheme = storedTheme;
-    }
-  } catch {}
-})();
-`;
-
 const runtimeConfigSrc = `${process.env.BASE_PATH ?? ""}/runtime-config.js`;
+const themeInitSrc = `${process.env.BASE_PATH ?? ""}/theme-init.js`;
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Read the per-request nonce injected by the middleware CSP implementation.
-  // Falls back to undefined in static export mode (no middleware, no nonce).
-  const headersList = await headers();
-  const nonce = headersList.get("x-nonce") ?? undefined;
-
   return (
     <html lang="en" data-theme="dark" data-palette="fullchaos" style={{ colorScheme: "dark" }} suppressHydrationWarning>
       <body
         className={`${bodyFont.variable} ${displayFont.variable} ${monoFont.variable} antialiased`}
       >
-        {/* eslint-disable-next-line @next/next/no-sync-scripts -- must run before paint to prevent FOUC */}
-        <script src={runtimeConfigSrc} nonce={nonce} suppressHydrationWarning />
-        <script nonce={nonce} suppressHydrationWarning dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <Script src={runtimeConfigSrc} strategy="beforeInteractive" />
+        <Script src={themeInitSrc} strategy="beforeInteractive" />
         <WebVitalsReporter />
         {children}
       </body>


### PR DESCRIPTION
## Summary

Fixes the nonce hydration mismatch in `src/app/layout.tsx` that causes React hydration errors.

**Root cause:** Browsers strip the `nonce` DOM attribute after reading it (security hardening). When the server renders `<script nonce="abc">`, the client DOM shows `nonce=""` → React detects a mismatch and logs hydration errors.

**Fix:** Replace raw `<script>` tags and inline JS with `next/script` `<Script>` components pointing to external files served from `public/`.

- Externalize theme init logic → `public/theme-init.js`
- Use `<Script strategy="beforeInteractive">` for both `runtime-config.js` and `theme-init.js`
- Remove nonce prop entirely — CSP `script-src 'self'` already covers same-origin external scripts
- Drop `async` layout function and `headers()` import (nonce no longer needed)
- Layout becomes a regular (non-async) React function component

SCREENSHOT-WAIVER: No visual change — theme init behavior is identical, only the delivery mechanism changed (inline → external file).
TEST-WAIVER: Infrastructure change (script loading strategy) — no component logic affected. Verified via full lint, typecheck, build, and 333 unit tests passing.