### PR TITLE
fix(proxy): add /theme-init.js to PUBLIC_PATHS

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,6 +16,7 @@ const PUBLIC_PATHS = [
     "/_next",
     "/favicon.ico",
     "/runtime-config.js",
+    "/theme-init.js",
 ];
 
 function isPublicPath(pathname: string): boolean {


### PR DESCRIPTION
## Summary

The externalized theme init script (`public/theme-init.js`, introduced in #245) was not listed in `PUBLIC_PATHS` in `proxy.ts`. This caused the proxy middleware to redirect `/theme-init.js` requests to `/auth/signin`, preventing the FOUC-prevention script from loading.

- Add `/theme-init.js` to `PUBLIC_PATHS` (same treatment as `runtime-config.js`)

TEST-WAIVER: Single-line config change adding a static file path to the public paths allowlist — no component logic affected.