### PR TITLE
fix(sentry): resolve deprecation warnings and add instrumentation hook (CHAOS-640)

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,14 @@
+import * as Sentry from "@sentry/nextjs";
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./sentry.server.config");
+  }
+
+  if (process.env.NEXT_RUNTIME === "edge") {
+    await import("./sentry.edge.config");
+  }
+}
+
+// Capture errors from Server Components, middleware, and proxies
+export const onRequestError = Sentry.captureRequestError;

--- a/next.config.js
+++ b/next.config.js
@@ -57,11 +57,11 @@ module.exports = withSentryConfig(nextConfig, {
   authToken: process.env.SENTRY_AUTH_TOKEN,
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
-  // Disable source map upload if auth token is not set (local dev)
-  disableServerWebpackPlugin: !process.env.SENTRY_AUTH_TOKEN,
-  disableClientWebpackPlugin: !process.env.SENTRY_AUTH_TOKEN,
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
-  // Enables automatic instrumentation of Vercel Cron Monitors
-  automaticVercelMonitors: false,
+  // Webpack-specific options
+  webpack: {
+    // Tree-shake Sentry logger statements to reduce bundle size
+    treeshake: {
+      removeDebugLogging: true,
+    },
+  },
 });

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,4 +1,5 @@
 "use client";
+import * as Sentry from "@sentry/nextjs";
 
 /**
  * Global error boundary — catches errors that bubble past all route-level
@@ -16,7 +17,8 @@ interface GlobalErrorProps {
 
 export default function GlobalError({ error, reset }: GlobalErrorProps) {
   useEffect(() => {
-    // Log to console — Sentry can be re-added later when compatible
+    // Capture error to Sentry and log to console as fallback
+    Sentry.captureException(error);
     console.error("[GlobalError]", error);
   }, [error]);
 
@@ -81,6 +83,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
             )}
           </p>
           <button
+            type="button"
             onClick={reset}
             style={{
               padding: "0.625rem 1.5rem",


### PR DESCRIPTION
## Summary

Fixes Sentry v10 deprecation warnings and completes the instrumentation setup for Next.js 16.

- Remove deprecated `withSentryConfig` options (`disableLogger`, `automaticVercelMonitors`, `disableServerWebpackPlugin`, `disableClientWebpackPlugin`)
- Use `webpack.treeshake.removeDebugLogging` (v10 replacement)
- Add `instrumentation.ts` with `register()` for server/edge Sentry init and `onRequestError` for Server Component/middleware error capture
- Wire `Sentry.captureException` into `global-error.tsx` (was `console.error` only)

Closes CHAOS-640

SCREENSHOT-WAIVER: No visual changes — config and instrumentation only.
TEST-WAIVER: Sentry SDK init configuration — no component logic affected. Verified via lint, typecheck, and build (no deprecation warnings).