### PR TITLE
fix(layout): use plain script src to avoid nonce hydration mismatch

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
-import Script from "next/script";
+
 import "./globals.css";
 import { WebVitalsReporter } from "@/components/WebVitalsReporter";
 
@@ -43,8 +43,10 @@ export default function RootLayout({
       <body
         className={`${bodyFont.variable} ${displayFont.variable} ${monoFont.variable} antialiased`}
       >
-        <Script src={runtimeConfigSrc} strategy="beforeInteractive" />
-        <Script src={themeInitSrc} strategy="beforeInteractive" />
+        {/* eslint-disable-next-line @next/next/no-sync-scripts -- must run before first paint; external src covered by CSP 'self' */}
+        <script src={runtimeConfigSrc} />
+        {/* eslint-disable-next-line @next/next/no-sync-scripts -- must run before first paint to prevent FOUC; external src covered by CSP 'self' */}
+        <script src={themeInitSrc} />
         <WebVitalsReporter />
         {children}
       </body>


### PR DESCRIPTION
## Summary

Fixes the nonce hydration mismatch that persisted after #245.

**Root cause**: `next/script` `<Script strategy="beforeInteractive">` with Turbopack doesn't render an external `<script src>`. Instead it renders **inline scripts** that push to a queue:
```html
<script nonce="abc">(self.__next_s=self.__next_s||[]).push(["/theme-init.js",{}])</script>
```
Next.js auto-applies the CSP nonce from the `x-nonce` request header. Browser strips nonce from DOM after reading it (`nonce=""` vs `undefined`) → React hydration mismatch. The `<Script>` component doesn't expose `suppressHydrationWarning`.

**Fix**: Use plain `<script src="...">` tags instead. These render as truly external script loads — no inline JS, no nonce attribute, no hydration mismatch. CSP `script-src 'self'` covers same-origin external scripts.

Before:
```html
<script nonce="abc">(self.__next_s=...).push(["/theme-init.js",{}])</script>
```

After:
```html
<script src="/theme-init.js"></script>
```

Ref: vercel/next.js#77952

SCREENSHOT-WAIVER: No visual change — same scripts, different loading mechanism.
TEST-WAIVER: Script loading strategy change — no component logic affected. Verified via lint, typecheck, and build.