### PR TITLE
feat: make Sentry replay conditional for GlitchTip compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,14 +85,28 @@ AUTH_SECRET=
 # =============================================================================
 # Observability
 # =============================================================================
+#
+# Error tracking is powered by the Sentry SDK and is compatible with:
+#   - Sentry SaaS (sentry.io) or self-hosted Sentry
+#   - GlitchTip (open-source, Sentry-protocol compatible: https://glitchtip.com)
+#
+# Set NEXT_PUBLIC_SENTRY_DSN to the DSN from either service to enable tracking.
+# Session replay is disabled by default (GlitchTip does not support it); set
+# NEXT_PUBLIC_SENTRY_REPLAY_ENABLED=true only when using Sentry SaaS/self-hosted.
 
-# Sentry DSN — set to enable error tracking and performance monitoring.
-# Get your DSN from https://sentry.io → Project → Settings → Client Keys.
+# Sentry / GlitchTip DSN — set to enable error tracking and performance monitoring.
+# Sentry:     get from https://sentry.io → Project → Settings → Client Keys
+# GlitchTip: get from your GlitchTip instance → Project → Settings → DSN
 # NEXT_PUBLIC_SENTRY_DSN=https://xxxx@oXXXXXX.ingest.sentry.io/XXXXXXX
 # SENTRY_DSN=https://xxxx@oXXXXXX.ingest.sentry.io/XXXXXXX
 
+# Session replay — Sentry SaaS/self-hosted only (not supported by GlitchTip).
+# Defaults to false; set to true to enable browser session recording.
+NEXT_PUBLIC_SENTRY_REPLAY_ENABLED=false
+
 # Sentry auth token — required to upload source maps during `next build`.
 # Create at https://sentry.io → Settings → Auth Tokens → New Token (scope: project:releases).
+# Not needed when using GlitchTip.
 # SENTRY_AUTH_TOKEN=
 
 # Minimum log level (trace | debug | info | warn | error | fatal).

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,10 +1,17 @@
 import * as Sentry from "@sentry/nextjs";
 
+// Session replay is only supported by Sentry SaaS/self-hosted, not GlitchTip.
+// Disable by default so GlitchTip works out of the box; opt in via env var.
+const replayEnabled =
+  process.env.NEXT_PUBLIC_SENTRY_REPLAY_ENABLED === "true";
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NODE_ENV,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-  replaysSessionSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-  replaysOnErrorSampleRate: 1.0,
-  integrations: [Sentry.replayIntegration()],
+  ...(replayEnabled && {
+    replaysSessionSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+    replaysOnErrorSampleRate: 1.0,
+    integrations: [Sentry.replayIntegration()],
+  }),
 });

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 
+// Compatible with GlitchTip (Sentry-protocol compatible) and Sentry SaaS/self-hosted.
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NODE_ENV,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 
+// Compatible with GlitchTip (Sentry-protocol compatible) and Sentry SaaS/self-hosted.
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NODE_ENV,


### PR DESCRIPTION
## Summary

- Make Sentry session replay integration conditional via `NEXT_PUBLIC_SENTRY_REPLAY_ENABLED` env var
- Defaults to `false` so GlitchTip (Sentry-protocol compatible, no replay support) works out of the box
- Add GlitchTip compatibility comments to `sentry.server.config.ts` and `sentry.edge.config.ts`
- Update `.env.example` with observability section explaining Sentry vs GlitchTip setup

### How it works

When `NEXT_PUBLIC_SENTRY_REPLAY_ENABLED !== "true"`:
- `replaysSessionSampleRate`, `replaysOnErrorSampleRate`, and `Sentry.replayIntegration()` are **omitted entirely** from `Sentry.init()` via conditional spread
- No SDK errors or warnings — the keys are simply absent

When `NEXT_PUBLIC_SENTRY_REPLAY_ENABLED=true`:
- Replay works exactly as before (10% session / 100% error in production)

### Related

- Companion PR in dev-health-ops adds SigNoz + GlitchTip to Docker Compose
- See `docs/ops/observability-tooling.md` in dev-health-ops for full analysis

## Test plan

- [ ] `NEXT_PUBLIC_SENTRY_REPLAY_ENABLED` unset — Sentry inits without replay keys, no console errors
- [ ] `NEXT_PUBLIC_SENTRY_REPLAY_ENABLED=false` — same behavior as unset
- [ ] `NEXT_PUBLIC_SENTRY_REPLAY_ENABLED=true` — replay integration active, session recording works
- [ ] Existing Sentry SaaS users: add `NEXT_PUBLIC_SENTRY_REPLAY_ENABLED=true` to `.env` to maintain current behavior

TEST-WAIVER: Config-only change to root-level Sentry config files, no src/ logic affected.