### PR TITLE
fix(charts): stabilize chart resize after loading fallbacks

### DIFF
--- a/src/components/charts/Chart.tsx
+++ b/src/components/charts/Chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { usePathname } from "next/navigation";
 import type { CSSProperties } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 // Type-only import from full echarts package (types are erased at runtime — no bundle impact).
@@ -31,6 +32,7 @@ export function Chart({
   chartColors: colorsProp,
 }: ChartProps) {
   const [isReady, setIsReady] = useState(false);
+  const pathname = usePathname();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const chartInstanceRef = useRef<{ resize?: () => void } | null>(null);
   // Use provided theme/colors if available to avoid duplicate subscriptions
@@ -77,6 +79,45 @@ export function Chart({
       observer.disconnect();
     };
   }, []);
+
+  useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
+    void pathname;
+
+    let frameA: number | null = null;
+    let frameB: number | null = null;
+    let timeoutId: number | null = null;
+
+    const resize = () => {
+      chartInstanceRef.current?.resize?.();
+    };
+
+    frameA = requestAnimationFrame(() => {
+      resize();
+      frameB = requestAnimationFrame(() => {
+        resize();
+      });
+    });
+
+    timeoutId = window.setTimeout(() => {
+      resize();
+    }, 180);
+
+    return () => {
+      if (frameA !== null) {
+        cancelAnimationFrame(frameA);
+      }
+      if (frameB !== null) {
+        cancelAnimationFrame(frameB);
+      }
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [isReady, pathname]);
 
   return (
     <div

--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -34,8 +34,15 @@ export function MetricCard({
   spark,
   caption,
 }: MetricCardProps) {
-  const sparkValues = spark?.map((point) => point.value) ?? [];
-  const sparkLabels = spark?.map((point) => point.ts) ?? [];
+  const sparkPoints = (spark ?? []).filter((point) =>
+    Number.isFinite(point.value)
+  );
+  const sparkValues = sparkPoints.map((point) => point.value);
+  const sparkLabels = sparkPoints.map((point) => point.ts);
+  const sparklineValues =
+    sparkValues.length === 1 ? [sparkValues[0], sparkValues[0]] : sparkValues;
+  const sparklineLabels =
+    sparkLabels.length === 1 ? [sparkLabels[0], sparkLabels[0]] : sparkLabels;
 
   return (
     <Link
@@ -60,10 +67,10 @@ export function MetricCard({
           </p>
         </div>
         <div className="h-16 w-28">
-          {sparkValues.length > 1 ? (
+          {sparklineValues.length > 1 ? (
             <SparklineChart
-              data={sparkValues}
-              categories={sparkLabels}
+              data={sparklineValues}
+              categories={sparklineLabels}
               height={64}
             />
           ) : (


### PR DESCRIPTION
## Summary
- harden `Chart` resize timing across route transitions by forcing post-mount and delayed resizes after suspense/loading fallback swaps
- normalize `MetricCard` sparkline input and render single-point spark data as a flat 2-point line instead of showing the dashed `Trend` fallback
- keep changes scoped to chart mount/render behavior without touching API fetch paths or removing loading skeletons

## Validation
- `npx vitest run --project components`
- `npm run build`

TEST-WAIVER: No test files changed; behavior-only rendering fix covered by existing component suite and full build.
SCREENSHOT-WAIVER: CLI-only fix in this session; no Playwright screenshot capture was run.