### PR TITLE
style(theme): change default palette to infinity-knot-redux

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -67,7 +67,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" data-theme="dark" data-palette="fullchaos" style={{ colorScheme: "dark" }} suppressHydrationWarning>
+    <html
+      lang="en"
+      data-theme="dark"
+      data-palette="fullchaos-infinity-knot-redux"
+      style={{ colorScheme: "dark" }}
+      suppressHydrationWarning
+    >
       <body
         className={`${bodyFont.variable} ${displayFont.variable} ${monoFont.variable} antialiased`}
       >

--- a/src/components/ThemeToggle.test.tsx
+++ b/src/components/ThemeToggle.test.tsx
@@ -29,7 +29,7 @@ describe("ThemeToggle", () => {
 
     storage.clear();
     document.documentElement.dataset.theme = "dark";
-    document.documentElement.dataset.palette = "fullchaos";
+    document.documentElement.dataset.palette = "fullchaos-infinity-knot-redux";
     document.documentElement.style.colorScheme = "dark";
   });
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -89,7 +89,7 @@ const getThemeSnapshot = (): Theme => {
 
 const getPaletteSnapshot = (): Palette => {
   if (isServer) {
-    return "fullchaos";
+    return "fullchaos-infinity-knot-redux";
   }
   const stored = getStoredPalette();
   if (stored) {
@@ -100,11 +100,11 @@ const getPaletteSnapshot = (): Palette => {
   if (normalized) {
     return normalized;
   }
-  return "fullchaos";
+  return "fullchaos-infinity-knot-redux";
 };
 
 const getThemeServerSnapshot = (): Theme => "light";
-const getPaletteServerSnapshot = (): Palette => "fullchaos";
+const getPaletteServerSnapshot = (): Palette => "fullchaos-infinity-knot-redux";
 
 export function ThemeToggle() {
   const theme = useSyncExternalStore(subscribe, getThemeSnapshot, getThemeServerSnapshot);

--- a/src/components/settings/PreferencesSettings.test.tsx
+++ b/src/components/settings/PreferencesSettings.test.tsx
@@ -29,7 +29,7 @@ describe("PreferencesSettings", () => {
 
     storage.clear();
     document.documentElement.dataset.theme = "dark";
-    document.documentElement.dataset.palette = "fullchaos";
+    document.documentElement.dataset.palette = "fullchaos-infinity-knot-redux";
     document.documentElement.style.colorScheme = "dark";
   });
 

--- a/src/components/settings/PreferencesSettings.tsx
+++ b/src/components/settings/PreferencesSettings.tsx
@@ -79,16 +79,16 @@ const getThemeSnapshot = (): Theme => {
 };
 
 const getPaletteSnapshot = (): Palette => {
-  if (isServer) return "fullchaos";
+  if (isServer) return "fullchaos-infinity-knot-redux";
   const stored = getStoredPalette();
   if (stored) return stored;
   const fromDataset = document.documentElement.dataset.palette ?? null;
   const normalized = normalizePalette(fromDataset);
-  return normalized ?? "fullchaos";
+  return normalized ?? "fullchaos-infinity-knot-redux";
 };
 
 const getThemeServerSnapshot = (): Theme => "light";
-const getPaletteServerSnapshot = (): Palette => "fullchaos";
+const getPaletteServerSnapshot = (): Palette => "fullchaos-infinity-knot-redux";
 
 const PALETTES: { value: Palette; label: string }[] = [
   { value: "fullchaos", label: "Full Chaos" },


### PR DESCRIPTION
## Summary

- Changes the default color palette from `fullchaos` to `fullchaos-infinity-knot-redux` across all fallback paths
- Updates SSR HTML default in root layout, runtime snapshot fallbacks in ThemeToggle and PreferencesSettings, and corresponding tests

TEST-WAIVER: Only test setup values changed to match new default — no component logic affected
SCREENSHOT-WAIVER: Palette default change only visible to new users with empty localStorage — no layout/component changes