### PR TITLE
fix: Docker Alpine build — add dev target, regenerate pnpm-lock.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ RUN npm install -g pnpm
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
+FROM node:25-alpine AS dev
+WORKDIR /app
+RUN npm install -g pnpm
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json pnpm-lock.yaml ./
+EXPOSE 3000
+CMD ["npm", "run", "dev"]
+
 FROM node:25-alpine AS builder
 WORKDIR /app
 RUN npm install -g pnpm

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         specifier: ^5.10.0
         version: 5.10.1
       next:
-        specifier: ^16.2.3
+        specifier: ^16
         version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^5.0.0-beta.30
@@ -76,7 +76,7 @@ importers:
         specifier: ^0.10.3
         version: 0.10.3(msw@2.13.0(@types/node@25.5.2)(typescript@6.0.2))
       '@next/eslint-plugin-next':
-        specifier: ^16.2.3
+        specifier: ^16.2.2
         version: 16.2.3
       '@playwright/test':
         specifier: ^1.59.1
@@ -109,7 +109,7 @@ importers:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
-        specifier: ^16.2.3
+        specifier: ^16
         version: 16.2.3(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2)
       express:
         specifier: ^5.2.1
@@ -6881,7 +6881,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@6.0.2)
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -7806,7 +7806,7 @@ snapshots:
       get-tsconfig: 4.13.7
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))


### PR DESCRIPTION
## Problem
Docker Compose web service fails with `sh: next: not found` because:
1. The Dockerfile `runner` stage is standalone production (no node_modules)
2. Compose overrides CMD to `npm run dev` which needs `next` from node_modules
3. PR #384's `pnpm update` wrote mismatched specifiers (`^16.2.3`) into pnpm-lock.yaml while package.json has `^16`, causing `pnpm install --frozen-lockfile` to reject

## Fix
1. **Added `dev` multi-stage target** between `deps` and `builder` — carries `node_modules` from the `deps` stage for dev-mode bind-mount containers
2. **Regenerated `pnpm-lock.yaml`** from scratch — specifiers now match package.json exactly, resolving to Next.js 16.2.3

## Verified
```
docker compose build web --no-cache  ✓
docker compose up web -d -V          ✓
▲ Next.js 16.2.3 (Turbopack) — Ready in 160ms
```

Note: The root `compose.yml` (outside this repo) also needs `target: dev` added to the web service build config. That file is not version-controlled.

SCREENSHOT-WAIVER: Dockerfile + lockfile change — no rendered UI affected
TEST-WAIVER: Dockerfile + lockfile change — no component logic affected