### PR TITLE
fix: remove sample data fallbacks — show empty states instead of fake numbers

### DIFF
--- a/src/app/(app)/testops/risk/page.tsx
+++ b/src/app/(app)/testops/risk/page.tsx
@@ -42,7 +42,7 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
     }, isTestMode),
   ]);
 
-  if (!health.ok && !isTestMode) {
+  if ((!health.ok && !isTestMode) || !riskData) {
     return <ServiceUnavailable />;
   }
 

--- a/src/lib/reports/fetchers.ts
+++ b/src/lib/reports/fetchers.ts
@@ -27,7 +27,7 @@ export async function fetchSavedReports(
     return res.savedReports;
   } catch (error) {
     console.error("Failed to fetch saved reports:", error);
-    return { items: sampleReports, total: sampleReports.length };
+    return { items: [], total: 0 };
   }
 }
 
@@ -48,7 +48,7 @@ export async function fetchSavedReport(
     return res.savedReport;
   } catch (error) {
     console.error("Failed to fetch saved report:", error);
-    return sampleReports.find((r) => r.id === reportId) || null;
+    return null;
   }
 }
 
@@ -71,8 +71,7 @@ export async function fetchReportRuns(
     return res.reportRuns;
   } catch (error) {
     console.error("Failed to fetch report runs:", error);
-    const runs = sampleRuns[reportId] || [];
-    return { items: runs, total: runs.length };
+    return { items: [], total: 0 };
   }
 }
 

--- a/src/lib/testops/fetchers.ts
+++ b/src/lib/testops/fetchers.ts
@@ -14,6 +14,8 @@ import {
   SAMPLE_RISK_DATA,
 } from "./sample-data";
 
+const EMPTY_ANALYTICS: AnalyticsResult = { timeseries: [], breakdowns: [] };
+
 export async function fetchTestOpsData(
   orgId: string,
   batch: AnalyticsRequestInput,
@@ -42,9 +44,9 @@ export async function fetchTestOpsData(
   } catch (error) {
     console.error("Failed to fetch TestOps data:", error);
     return {
-      pipelines: SAMPLE_PIPELINES_DATA,
-      tests: SAMPLE_TESTS_DATA,
-      coverage: SAMPLE_COVERAGE_DATA,
+      pipelines: EMPTY_ANALYTICS,
+      tests: EMPTY_ANALYTICS,
+      coverage: EMPTY_ANALYTICS,
     };
   }
 }
@@ -53,7 +55,7 @@ export async function fetchCoverageMetrics(
   orgId: string,
   batch: AnalyticsRequestInput,
   isTestMode: boolean = false
-) {
+): Promise<AnalyticsResult> {
   if (isTestMode) {
     return SAMPLE_COVERAGE_DATA;
   }
@@ -63,7 +65,7 @@ export async function fetchCoverageMetrics(
     return res.analytics;
   } catch (error) {
     console.error("Failed to fetch coverage metrics:", error);
-    return SAMPLE_COVERAGE_DATA;
+    return EMPTY_ANALYTICS;
   }
 }
 
@@ -90,7 +92,7 @@ export async function fetchRiskMetrics(
 
     const testPassRateImplied = Math.max(0, 100 - latestTestFlake);
     const releaseConfidence = (latestPipelineSuccess / 100) * (testPassRateImplied / 100) * (latestCoverage / 100);
-    
+
     const failureRate = Math.max(0, 100 - latestPipelineSuccess);
     const qualityDragHours = (latestTestFlake * 2) + (failureRate * 1.5);
 
@@ -117,19 +119,18 @@ export async function fetchRiskMetrics(
       id: item.key,
       pipeline_success_rate: item.value,
       test_pass_rate: 100 - latestTestFlake
-    })) || SAMPLE_RISK_DATA.quadrant_data;
+    })) || [];
 
     return {
       release_confidence: releaseConfidence,
       quality_drag_hours: qualityDragHours,
       pipeline_stability: latestPipelineSuccess / 100,
-      timeseries: timeseries.length > 0 ? timeseries : SAMPLE_RISK_DATA.timeseries,
+      timeseries,
       quality_drag_breakdown: qualityDragBreakdown,
       quadrant_data: quadrantData
     };
   } catch (error) {
     console.error("Failed to fetch risk metrics:", error);
-    return SAMPLE_RISK_DATA;
+    return null;
   }
 }
-


### PR DESCRIPTION
## Problem
Every TestOps and Reports fetcher catch block returned hardcoded sample data on error. This means any GraphQL failure (auth, network, empty DB) shows fake numbers that look real — misleading and impossible to distinguish from actual data.

## Fix
- **TestOps fetchers**: error catch returns `EMPTY_ANALYTICS` (`{ timeseries: [], breakdowns: [] }`) or `null` (risk)
- **Reports fetchers**: error catch returns `{ items: [], total: 0 }` or `null`
- **Risk page**: handles `null` from `fetchRiskMetrics` by showing `ServiceUnavailable`
- **`isTestMode` path unchanged** — sample data still used for Playwright tests only

## Changes
- `src/lib/testops/fetchers.ts` — replace SAMPLE_* fallbacks with empty objects/null
- `src/lib/reports/fetchers.ts` — replace sample fallbacks with empty arrays/null
- `src/app/(app)/testops/risk/page.tsx` — handle null riskData

TEST-WAIVER: Existing fetcher tests cover isTestMode=true path which is unchanged. Error path now returns empty/null which is the correct behavior.