### PR TITLE
fix: logger numeric levels + testops hardcoded dates

### DIFF
--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -41,16 +41,20 @@ export default async function CoveragePage({ searchParams }: CoveragePageProps) 
 
   const isTestMode = process.env.DEV_HEALTH_TEST_MODE === "true" || process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
+  const startDate = filters?.time?.start_date ?? "2024-01-01";
+  const endDate = filters?.time?.end_date ?? "2024-01-07";
+  const dateRange = { startDate, endDate };
+
   const [health, coverageData] = await Promise.all([
     checkApiHealth(),
     fetchCoverageMetrics("default-org", {
       timeseries: [
-        { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "COVERAGE_BRANCH_PCT", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "COVERAGE_DELTA_PCT", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
+        { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "COVERAGE_BRANCH_PCT", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "COVERAGE_DELTA_PCT", interval: "DAY", dateRange },
       ],
       breakdowns: [
-        { dimension: "REPO", measure: "COVERAGE_LINE_PCT", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" }, topN: 10 }
+        { dimension: "REPO", measure: "COVERAGE_LINE_PCT", dateRange, topN: 10 }
       ],
     }, isTestMode),
   ]);

--- a/src/app/(app)/testops/page.tsx
+++ b/src/app/(app)/testops/page.tsx
@@ -39,17 +39,21 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
 
   const isTestMode = process.env.DEV_HEALTH_TEST_MODE === "true" || process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
+  const startDate = filters?.time?.start_date ?? "2024-01-01";
+  const endDate = filters?.time?.end_date ?? "2024-01-07";
+  const dateRange = { startDate, endDate };
+
   const [health, testOpsData] = await Promise.all([
     checkApiHealth(),
     fetchTestOpsData("default-org", {
       timeseries: [
-        { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "PIPELINE_DURATION_P95", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "PIPELINE_QUEUE_TIME", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "PIPELINE_RERUN_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "TEST_FLAKE_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
+        { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "PIPELINE_DURATION_P95", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "PIPELINE_QUEUE_TIME", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "PIPELINE_RERUN_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "TEST_FLAKE_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange },
       ],
       breakdowns: [],
     }, isTestMode),

--- a/src/app/(app)/testops/pipelines/page.tsx
+++ b/src/app/(app)/testops/pipelines/page.tsx
@@ -41,18 +41,22 @@ export default async function PipelinesPage({ searchParams }: PipelinesPageProps
 
   const isTestMode = process.env.DEV_HEALTH_TEST_MODE === "true" || process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
+  const startDate = filters?.time?.start_date ?? "2024-01-01";
+  const endDate = filters?.time?.end_date ?? "2024-01-07";
+  const dateRange = { startDate, endDate };
+
   const [health, testOpsData] = await Promise.all([
     checkApiHealth(),
     fetchTestOpsData("default-org", {
       timeseries: [
-        { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "PIPELINE_DURATION_P95", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "PIPELINE_QUEUE_TIME", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "PIPELINE_RERUN_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
+        { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "PIPELINE_DURATION_P95", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "PIPELINE_QUEUE_TIME", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "PIPELINE_RERUN_RATE", interval: "DAY", dateRange },
       ],
       breakdowns: [
-        { dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" }, topN: 10 }
+        { dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", dateRange, topN: 10 }
       ],
     }, isTestMode),
   ]);

--- a/src/app/(app)/testops/risk/page.tsx
+++ b/src/app/(app)/testops/risk/page.tsx
@@ -28,16 +28,20 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
 
   const isTestMode = process.env.DEV_HEALTH_TEST_MODE === "true" || process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
+  const startDate = filters?.time?.start_date ?? "2024-01-01";
+  const endDate = filters?.time?.end_date ?? "2024-01-07";
+  const dateRange = { startDate, endDate };
+
   const [health, riskData] = await Promise.all([
     checkApiHealth(),
     fetchRiskMetrics("default-org", {
       timeseries: [
-        { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "TEST_FLAKE_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
+        { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "TEST_FLAKE_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange },
       ],
       breakdowns: [
-        { dimension: "REPO", measure: "PIPELINE_SUCCESS_RATE", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" }, topN: 10 }
+        { dimension: "REPO", measure: "PIPELINE_SUCCESS_RATE", dateRange, topN: 10 }
       ],
     }, isTestMode),
   ]);

--- a/src/app/(app)/testops/tests/page.tsx
+++ b/src/app/(app)/testops/tests/page.tsx
@@ -41,17 +41,21 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
 
   const isTestMode = process.env.DEV_HEALTH_TEST_MODE === "true" || process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
+  const startDate = filters?.time?.start_date ?? "2024-01-01";
+  const endDate = filters?.time?.end_date ?? "2024-01-07";
+  const dateRange = { startDate, endDate };
+
   const [health, testOpsData] = await Promise.all([
     checkApiHealth(),
     fetchTestOpsData("default-org", {
       timeseries: [
-        { dimension: "TEAM", measure: "TEST_PASS_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "TEST_FAILURE_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "TEST_FLAKE_RATE", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
-        { dimension: "TEAM", measure: "TEST_SUITE_DURATION_P95", interval: "DAY", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" } },
+        { dimension: "TEAM", measure: "TEST_PASS_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "TEST_FAILURE_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "TEST_FLAKE_RATE", interval: "DAY", dateRange },
+        { dimension: "TEAM", measure: "TEST_SUITE_DURATION_P95", interval: "DAY", dateRange },
       ],
       breakdowns: [
-        { dimension: "TEAM", measure: "TEST_FLAKE_RATE", dateRange: { startDate: "2024-01-01", endDate: "2024-01-07" }, topN: 10 }
+        { dimension: "TEAM", measure: "TEST_FLAKE_RATE", dateRange, topN: 10 }
       ],
     }, isTestMode),
   ]);

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -88,6 +88,9 @@ function createServerLogger(): Logger {
   const pino = require("pino");
   return pino({
     level: LOG_LEVEL,
+    formatters: {
+      level: (label: string) => ({ level: label }),
+    },
     ...(LOG_FORMAT === "pretty"
       ? {
           transport: {


### PR DESCRIPTION
## Summary
- **Logger regression**: pino outputs numeric log levels (`"level":30`) instead of strings (`"level":"info"`) in JSON mode. Added `formatters.level` to convert.
- **TestOps empty dashboards**: All 5 testops pages hardcoded `dateRange` to `2024-01-01`/`2024-01-07` instead of reading from URL filter params. Since fixtures generate data for recent dates, queries always returned empty.

## Changes
- `src/lib/logger.ts` — add `formatters.level` to pino config
- `src/app/(app)/testops/{page,risk,pipelines,tests,coverage}/page.tsx` — extract `startDate`/`endDate` from decoded `filters.time` and use in fetch calls

SCREENSHOT-WAIVER: No visual changes — fixes data plumbing (date params) and log output format

TEST-WAIVER: Logger format change is config-only, testops date fix is param wiring — no component logic affected