### PR TITLE
fix: compute dateRange from range_days when absolute dates absent

### DIFF
--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -41,8 +41,10 @@ export default async function CoveragePage({ searchParams }: CoveragePageProps) 
 
   const isTestMode = process.env.DEV_HEALTH_TEST_MODE === "true" || process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
-  const startDate = filters?.time?.start_date ?? "2024-01-01";
-  const endDate = filters?.time?.end_date ?? "2024-01-07";
+  const rangeDays = filters?.time?.range_days ?? 14;
+  const today = new Date();
+  const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
+  const startDate = filters?.time?.start_date ?? new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
   const dateRange = { startDate, endDate };
 
   const [health, coverageData] = await Promise.all([

--- a/src/app/(app)/testops/page.tsx
+++ b/src/app/(app)/testops/page.tsx
@@ -39,8 +39,10 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
 
   const isTestMode = process.env.DEV_HEALTH_TEST_MODE === "true" || process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
-  const startDate = filters?.time?.start_date ?? "2024-01-01";
-  const endDate = filters?.time?.end_date ?? "2024-01-07";
+  const rangeDays = filters?.time?.range_days ?? 14;
+  const today = new Date();
+  const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
+  const startDate = filters?.time?.start_date ?? new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
   const dateRange = { startDate, endDate };
 
   const [health, testOpsData] = await Promise.all([

--- a/src/app/(app)/testops/pipelines/page.tsx
+++ b/src/app/(app)/testops/pipelines/page.tsx
@@ -41,8 +41,10 @@ export default async function PipelinesPage({ searchParams }: PipelinesPageProps
 
   const isTestMode = process.env.DEV_HEALTH_TEST_MODE === "true" || process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
-  const startDate = filters?.time?.start_date ?? "2024-01-01";
-  const endDate = filters?.time?.end_date ?? "2024-01-07";
+  const rangeDays = filters?.time?.range_days ?? 14;
+  const today = new Date();
+  const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
+  const startDate = filters?.time?.start_date ?? new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
   const dateRange = { startDate, endDate };
 
   const [health, testOpsData] = await Promise.all([

--- a/src/app/(app)/testops/risk/page.tsx
+++ b/src/app/(app)/testops/risk/page.tsx
@@ -28,8 +28,10 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
 
   const isTestMode = process.env.DEV_HEALTH_TEST_MODE === "true" || process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
-  const startDate = filters?.time?.start_date ?? "2024-01-01";
-  const endDate = filters?.time?.end_date ?? "2024-01-07";
+  const rangeDays = filters?.time?.range_days ?? 14;
+  const today = new Date();
+  const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
+  const startDate = filters?.time?.start_date ?? new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
   const dateRange = { startDate, endDate };
 
   const [health, riskData] = await Promise.all([

--- a/src/app/(app)/testops/tests/page.tsx
+++ b/src/app/(app)/testops/tests/page.tsx
@@ -41,8 +41,10 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
 
   const isTestMode = process.env.DEV_HEALTH_TEST_MODE === "true" || process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
-  const startDate = filters?.time?.start_date ?? "2024-01-01";
-  const endDate = filters?.time?.end_date ?? "2024-01-07";
+  const rangeDays = filters?.time?.range_days ?? 14;
+  const today = new Date();
+  const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
+  const startDate = filters?.time?.start_date ?? new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
   const dateRange = { startDate, endDate };
 
   const [health, testOpsData] = await Promise.all([


### PR DESCRIPTION
## Summary
- Follow-up to #389. Filters may specify only `range_days` (e.g. 14) without explicit `start_date`/`end_date`. The previous fix still fell back to hardcoded 2024 defaults in that case.
- Now computes `endDate = today`, `startDate = today - range_days` when absolute dates are absent.

## Changes
- `src/app/(app)/testops/{page,risk,pipelines,tests,coverage}/page.tsx` — derive `startDate`/`endDate` from `filters.time.range_days` relative to today

SCREENSHOT-WAIVER: No visual changes — fixes date param derivation logic

TEST-WAIVER: Pure date arithmetic wiring in server component props — no component logic affected