### PR TITLE
fix: pass session org_id to GraphQL investment fetchers

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -96,7 +96,9 @@ export async function getInvestment(filters: MetricFilter) {
 
   // Feature flag: use GraphQL transport when enabled
   if (graphqlClient.isEnabled()) {
-    return getInvestmentViaGraphQL(normalized);
+    const session = await auth();
+    const orgId = session?.user?.org_id as string | undefined;
+    return getInvestmentViaGraphQL(normalized, orgId);
   }
 
   return postJson<InvestmentResponse>(
@@ -170,9 +172,12 @@ export async function getInvestmentFlow(params: {
 
   // Feature flag: use GraphQL transport when enabled
   if (graphqlClient.isEnabled()) {
+    const session = await auth();
+    const orgId = session?.user?.org_id as string | undefined;
     return getInvestmentFlowViaGraphQL({
       ...params,
       filters: normalized,
+      contextOrgId: orgId,
     });
   }
 
@@ -210,9 +215,12 @@ export async function getInvestmentRepoTeamFlow(params: {
 
   // Feature flag: use GraphQL transport when enabled
   if (graphqlClient.isEnabled()) {
+    const session = await auth();
+    const orgId = session?.user?.org_id as string | undefined;
     return getInvestmentRepoTeamFlowViaGraphQL({
       ...params,
       filters: normalized,
+      contextOrgId: orgId,
     });
   }
 

--- a/src/lib/graphql/investmentFetchers.ts
+++ b/src/lib/graphql/investmentFetchers.ts
@@ -83,9 +83,10 @@ function translateMetricFilterToGraphQL(filters: MetricFilter): FilterInput {
  * Returns data in the same shape as the REST /api/v1/investment endpoint.
  */
 export async function getInvestmentViaGraphQL(
-    filters: MetricFilter
+    filters: MetricFilter,
+    contextOrgId?: string,
 ): Promise<InvestmentResponse> {
-    const orgId = getOrgId(filters);
+    const orgId = getOrgId(filters, contextOrgId);
     const dateRange = buildDateRange(filters);
 
     const batch: AnalyticsRequestInput = {
@@ -219,9 +220,10 @@ export async function getInvestmentFlowViaGraphQL(params: {
     flow_mode?: "team_category_repo" | "team_subcategory_repo" | "team_category_subcategory_repo";
     drill_category?: string | null;
     top_n_repos?: number;
+    contextOrgId?: string;
 }): Promise<SankeyResponse> {
     const { filters } = params;
-    const orgId = getOrgId(filters);
+    const orgId = getOrgId(filters, params.contextOrgId);
     const dateRange = buildDateRange(filters);
     const resolvedTheme = params.drill_category ?? params.theme ?? null;
     const graphqlFilters = translateMetricFilterToGraphQL(filters);
@@ -280,9 +282,10 @@ export async function getInvestmentFlowViaGraphQL(params: {
 export async function getInvestmentRepoTeamFlowViaGraphQL(params: {
     filters: MetricFilter;
     theme?: string | null;
+    contextOrgId?: string;
 }): Promise<SankeyResponse> {
     const { filters } = params;
-    const orgId = getOrgId(filters);
+    const orgId = getOrgId(filters, params.contextOrgId);
     const dateRange = buildDateRange(filters);
 
     const batch: AnalyticsRequestInput = {


### PR DESCRIPTION
## Summary

- Fixes "Investment data unavailable" on the Investment Mix view and all other investment views
- The GraphQL transport (enabled by default) was throwing `org_id is required: not found in filters or context` because `getOrgId(filters)` received `scope.ids=[]` and no `contextOrgId` fallback

## Root Cause

```
web-1 | "org_id is required: not found in filters or context"
web-1 | at getOrgId (investmentFetchers.ts)
web-1 | at getInvestmentViaGraphQL → fetchOrNull returns null → "Investment data unavailable"
```

When `scope.level === "org"` with `scope.ids === []` (the default), `getOrgId()` needs a `contextOrgId` fallback from the session. The REST path worked because the backend extracts `org_id` from `current_user.org_id`, but the GraphQL path required it upfront in the filters.

## Changes

| File | Change |
|------|--------|
| `lib/api.ts` | Resolve `org_id` from `auth()` session before calling all 3 GraphQL investment functions |
| `lib/graphql/investmentFetchers.ts` | Add `contextOrgId?` parameter to `getInvestmentViaGraphQL`, `getInvestmentFlowViaGraphQL`, `getInvestmentRepoTeamFlowViaGraphQL` |

## Test plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Manually verify Investment Mix loads data after rebuild
- [ ] Verify team burden flow and evidence drill-down views