### PR TITLE
fix: resolve org_id from session in TestOps fetchers

### DIFF
--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -49,7 +49,7 @@ export default async function CoveragePage({ searchParams }: CoveragePageProps) 
 
   const [health, coverageData] = await Promise.all([
     checkApiHealth(),
-    fetchCoverageMetrics("default-org", {
+    fetchCoverageMetrics({
       timeseries: [
         { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange },
         { dimension: "TEAM", measure: "COVERAGE_BRANCH_PCT", interval: "DAY", dateRange },

--- a/src/app/(app)/testops/page.tsx
+++ b/src/app/(app)/testops/page.tsx
@@ -47,7 +47,7 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
 
   const [health, testOpsData] = await Promise.all([
     checkApiHealth(),
-    fetchTestOpsData("default-org", {
+    fetchTestOpsData({
       timeseries: [
         { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange },
         { dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", interval: "DAY", dateRange },

--- a/src/app/(app)/testops/pipelines/page.tsx
+++ b/src/app/(app)/testops/pipelines/page.tsx
@@ -49,7 +49,7 @@ export default async function PipelinesPage({ searchParams }: PipelinesPageProps
 
   const [health, testOpsData] = await Promise.all([
     checkApiHealth(),
-    fetchTestOpsData("default-org", {
+    fetchTestOpsData({
       timeseries: [
         { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange },
         { dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", interval: "DAY", dateRange },

--- a/src/app/(app)/testops/risk/page.tsx
+++ b/src/app/(app)/testops/risk/page.tsx
@@ -36,7 +36,7 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
 
   const [health, riskData] = await Promise.all([
     checkApiHealth(),
-    fetchRiskMetrics("default-org", {
+    fetchRiskMetrics({
       timeseries: [
         { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange },
         { dimension: "TEAM", measure: "TEST_FLAKE_RATE", interval: "DAY", dateRange },

--- a/src/app/(app)/testops/tests/page.tsx
+++ b/src/app/(app)/testops/tests/page.tsx
@@ -49,7 +49,7 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
 
   const [health, testOpsData] = await Promise.all([
     checkApiHealth(),
-    fetchTestOpsData("default-org", {
+    fetchTestOpsData({
       timeseries: [
         { dimension: "TEAM", measure: "TEST_PASS_RATE", interval: "DAY", dateRange },
         { dimension: "TEAM", measure: "TEST_FAILURE_RATE", interval: "DAY", dateRange },

--- a/src/lib/testops/__tests__/fetchers.test.ts
+++ b/src/lib/testops/__tests__/fetchers.test.ts
@@ -1,10 +1,78 @@
-import { describe, it, expect } from "vitest";
-import { fetchRiskMetrics } from "../fetchers";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Session } from "next-auth";
+
+// Must mock auth and graphqlFetch before importing the module under test
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/graphql/urqlClient", () => ({
+  graphqlFetch: vi.fn(),
+}));
+
+import { fetchRiskMetrics, fetchTestOpsData, fetchCoverageMetrics } from "../fetchers";
 import { SAMPLE_RISK_DATA } from "../sample-data";
+import { auth } from "@/lib/auth";
+import { graphqlFetch } from "@/lib/graphql/urqlClient";
+
+function mockSession(orgId?: string): Session {
+  return {
+    access_token: "test-token",
+    user: {
+      id: "user-1",
+      org_id: orgId,
+    } as Session["user"],
+    expires: new Date(Date.now() + 86400000).toISOString(),
+  };
+}
+
+const emptyAnalytics = { timeseries: [], breakdowns: [] };
 
 describe("fetchRiskMetrics", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
   it("returns sample data when isTestMode is true", async () => {
-    const result = await fetchRiskMetrics("default-org", { timeseries: [], breakdowns: [] }, true);
+    const result = await fetchRiskMetrics({ timeseries: [], breakdowns: [] }, true);
     expect(result).toEqual(SAMPLE_RISK_DATA);
+  });
+});
+
+describe("resolveOrgId via fetchTestOpsData", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("resolves orgId from session and passes it to graphqlFetch", async () => {
+    vi.mocked(auth).mockResolvedValue(mockSession("org-session-123"));
+    vi.mocked(graphqlFetch).mockResolvedValue({ analytics: emptyAnalytics });
+
+    await fetchTestOpsData({ timeseries: [], breakdowns: [] }, false);
+
+    expect(auth).toHaveBeenCalled();
+    expect(graphqlFetch).toHaveBeenCalled();
+    const firstCallVars = vi.mocked(graphqlFetch).mock.calls[0][1] as { orgId: string };
+    expect(firstCallVars.orgId).toBe("org-session-123");
+  });
+
+  it("falls back to 'default-org' when session has no org_id", async () => {
+    vi.mocked(auth).mockResolvedValue(mockSession(undefined));
+    vi.mocked(graphqlFetch).mockResolvedValue({ analytics: emptyAnalytics });
+
+    await fetchCoverageMetrics({ timeseries: [], breakdowns: [] }, false);
+
+    const callVars = vi.mocked(graphqlFetch).mock.calls[0][1] as { orgId: string };
+    expect(callVars.orgId).toBe("default-org");
+  });
+
+  it("uses orgIdOverride when provided, skipping auth lookup", async () => {
+    vi.mocked(graphqlFetch).mockResolvedValue({ analytics: emptyAnalytics });
+
+    await fetchCoverageMetrics({ timeseries: [], breakdowns: [] }, false, "org-override");
+
+    expect(auth).not.toHaveBeenCalled();
+    const callVars = vi.mocked(graphqlFetch).mock.calls[0][1] as { orgId: string };
+    expect(callVars.orgId).toBe("org-override");
   });
 });

--- a/src/lib/testops/fetchers.ts
+++ b/src/lib/testops/fetchers.ts
@@ -1,3 +1,4 @@
+import { auth } from "@/lib/auth";
 import { graphqlFetch } from "@/lib/graphql/urqlClient";
 import { AnalyticsRequestInput, AnalyticsResult } from "@/lib/graphql/schemas/analytics";
 import {
@@ -16,11 +17,19 @@ import {
 
 const EMPTY_ANALYTICS: AnalyticsResult = { timeseries: [], breakdowns: [] };
 
+/** Resolve orgId from the auth session, falling back to "default-org". */
+async function resolveOrgId(orgId?: string): Promise<string> {
+  if (orgId) return orgId;
+  const session = await auth();
+  return (session?.user?.org_id as string | undefined) ?? "default-org";
+}
+
 export async function fetchTestOpsData(
-  orgId: string,
   batch: AnalyticsRequestInput,
-  isTestMode: boolean = false
+  isTestMode: boolean = false,
+  orgIdOverride?: string,
 ): Promise<TestOpsData> {
+  const orgId = await resolveOrgId(orgIdOverride);
   if (isTestMode) {
     return {
       pipelines: SAMPLE_PIPELINES_DATA,
@@ -52,14 +61,15 @@ export async function fetchTestOpsData(
 }
 
 export async function fetchCoverageMetrics(
-  orgId: string,
   batch: AnalyticsRequestInput,
-  isTestMode: boolean = false
+  isTestMode: boolean = false,
+  orgIdOverride?: string,
 ): Promise<AnalyticsResult> {
   if (isTestMode) {
     return SAMPLE_COVERAGE_DATA;
   }
 
+  const orgId = await resolveOrgId(orgIdOverride);
   try {
     const res = await graphqlFetch<{ analytics: AnalyticsResult }>(TESTOPS_COVERAGE_QUERY, { orgId, batch });
     return res.analytics;
@@ -70,14 +80,15 @@ export async function fetchCoverageMetrics(
 }
 
 export async function fetchRiskMetrics(
-  orgId: string,
   batch: AnalyticsRequestInput,
-  isTestMode: boolean = false
+  isTestMode: boolean = false,
+  orgIdOverride?: string,
 ) {
   if (isTestMode) {
     return SAMPLE_RISK_DATA;
   }
 
+  const orgId = await resolveOrgId(orgIdOverride);
   try {
     const res = await graphqlFetch<{ analytics: AnalyticsResult }>(TESTOPS_RISK_QUERY, { orgId, batch });
     const analytics = res.analytics;


### PR DESCRIPTION
## Summary

- Fixes TestOps UI showing "--" placeholders on all pages (overview, pipelines, tests, coverage, risk)
- Root cause: all 5 pages hardcoded \`"default-org"\` when calling the GraphQL fetchers, so queries filtered to a non-existent org and returned no data

## Changes

**Centralize org resolution in the fetchers (not each page):**

- \`lib/testops/fetchers.ts\`: add \`resolveOrgId()\` helper that reads \`session.user.org_id\` via \`auth()\`. Remove the \`orgId\` positional argument from \`fetchTestOpsData\`, \`fetchCoverageMetrics\`, and \`fetchRiskMetrics\`; keep an optional trailing \`orgIdOverride\` for tests/admin.
- All 5 pages under \`app/(app)/testops/\`: drop the hardcoded \`"default-org"\` call-site argument.

This matches the pattern used by the investment fetchers (which were fixed in dev-health-web#392).

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [ ] Manually verify TestOps overview, pipelines, tests, coverage, risk pages show real data