### PR TITLE
fix(CHAOS-1196): wire sparkline trends and deltas into Risk page KPI cards

### DIFF
--- a/src/app/(app)/testops/risk/page.tsx
+++ b/src/app/(app)/testops/risk/page.tsx
@@ -114,6 +114,8 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
               href="#"
               value={riskData.release_confidence ? riskData.release_confidence * 100 : undefined}
               unit="%"
+              delta={riskData.confidence_delta}
+              spark={riskData.confidence_spark}
               caption="Overall confidence score for deployments"
             />
             <MetricCard
@@ -121,6 +123,8 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
               href="#"
               value={riskData.quality_drag_hours}
               unit="h"
+              delta={riskData.drag_delta}
+              spark={riskData.drag_spark}
               caption="Hours lost to test/pipeline issues"
             />
             <MetricCard
@@ -128,6 +132,8 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
               href="#"
               value={riskData.pipeline_stability ? riskData.pipeline_stability * 100 : undefined}
               unit="%"
+              delta={riskData.stability_delta}
+              spark={riskData.stability_spark}
               caption="Stability score across all pipelines"
             />
           </section>

--- a/src/lib/testops/__tests__/fetchers.test.ts
+++ b/src/lib/testops/__tests__/fetchers.test.ts
@@ -37,6 +37,15 @@ describe("fetchRiskMetrics", () => {
     const result = await fetchRiskMetrics({ timeseries: [], breakdowns: [] }, true);
     expect(result).toEqual(SAMPLE_RISK_DATA);
   });
+
+  it("sample data includes sparkline and delta fields for KPI cards", () => {
+    expect(SAMPLE_RISK_DATA.confidence_spark.length).toBeGreaterThan(1);
+    expect(SAMPLE_RISK_DATA.drag_spark.length).toBeGreaterThan(1);
+    expect(SAMPLE_RISK_DATA.stability_spark.length).toBeGreaterThan(1);
+    expect(typeof SAMPLE_RISK_DATA.confidence_delta).toBe("number");
+    expect(typeof SAMPLE_RISK_DATA.drag_delta).toBe("number");
+    expect(typeof SAMPLE_RISK_DATA.stability_delta).toBe("number");
+  });
 });
 
 describe("resolveOrgId via fetchTestOpsData", () => {

--- a/src/lib/testops/fetchers.ts
+++ b/src/lib/testops/fetchers.ts
@@ -132,13 +132,42 @@ export async function fetchRiskMetrics(
       test_pass_rate: 100 - latestTestFlake
     })) || [];
 
+    const toSpark = (buckets: { date: string; value: number }[]) =>
+      buckets.map(b => ({ ts: b.date, value: b.value }));
+
+    const delta = (buckets: { value: number }[]) => {
+      if (buckets.length < 2) return undefined;
+      const prev = buckets[0].value;
+      const curr = buckets[buckets.length - 1].value;
+      return prev === 0 ? undefined : ((curr - prev) / Math.abs(prev)) * 100;
+    };
+
+    const confidenceSpark = timeseries.map(b => ({
+      ts: b.date,
+      value: (1 - b.riskScore) * 100,
+    }));
+
+    const dragSpark = timeseries.map((b, i) => {
+      const fr = Math.max(0, 100 - (pipelineSuccess[i]?.value || 0));
+      const tf = testFlake[i]?.value || 0;
+      return { ts: b.date, value: (tf * 2) + (fr * 1.5) };
+    });
+
+    const stabilitySpark = toSpark(pipelineSuccess);
+
     return {
       release_confidence: releaseConfidence,
       quality_drag_hours: qualityDragHours,
       pipeline_stability: latestPipelineSuccess / 100,
       timeseries,
       quality_drag_breakdown: qualityDragBreakdown,
-      quadrant_data: quadrantData
+      quadrant_data: quadrantData,
+      confidence_spark: confidenceSpark,
+      confidence_delta: delta(confidenceSpark),
+      drag_spark: dragSpark,
+      drag_delta: delta(dragSpark),
+      stability_spark: stabilitySpark,
+      stability_delta: delta(pipelineSuccess),
     };
   } catch (error) {
     console.error("Failed to fetch risk metrics:", error);

--- a/src/lib/testops/sample-data.ts
+++ b/src/lib/testops/sample-data.ts
@@ -245,7 +245,37 @@ export const SAMPLE_RISK_DATA = {
     { id: "mobile-app", pipeline_success_rate: 70, test_pass_rate: 92 },
     { id: "data-pipeline", pipeline_success_rate: 60, test_pass_rate: 85 },
     { id: "auth-service", pipeline_success_rate: 98, test_pass_rate: 100 },
-  ]
+  ],
+  confidence_spark: [
+    { ts: "2024-01-01", value: 60 },
+    { ts: "2024-01-02", value: 65 },
+    { ts: "2024-01-03", value: 55 },
+    { ts: "2024-01-04", value: 70 },
+    { ts: "2024-01-05", value: 75 },
+    { ts: "2024-01-06", value: 80 },
+    { ts: "2024-01-07", value: 82 },
+  ],
+  confidence_delta: 36.7,
+  drag_spark: [
+    { ts: "2024-01-01", value: 22 },
+    { ts: "2024-01-02", value: 19 },
+    { ts: "2024-01-03", value: 24 },
+    { ts: "2024-01-04", value: 17 },
+    { ts: "2024-01-05", value: 15.5 },
+    { ts: "2024-01-06", value: 14.8 },
+    { ts: "2024-01-07", value: 14.5 },
+  ],
+  drag_delta: -34.1,
+  stability_spark: [
+    { ts: "2024-01-01", value: 80 },
+    { ts: "2024-01-02", value: 82 },
+    { ts: "2024-01-03", value: 78 },
+    { ts: "2024-01-04", value: 85 },
+    { ts: "2024-01-05", value: 86 },
+    { ts: "2024-01-06", value: 87 },
+    { ts: "2024-01-07", value: 88 },
+  ],
+  stability_delta: 10.0,
 };
 
 export const SAMPLE_PR_TESTOPS_DATA = {


### PR DESCRIPTION
## Summary

- **`fetchRiskMetrics`** now computes and returns per-KPI sparkline arrays (`confidence_spark`, `drag_spark`, `stability_spark`) and period-over-period deltas from existing timeseries data — no new API calls needed.
- **Risk page** passes `spark` and `delta` props to each `MetricCard`, replacing the dashed placeholder with actual sparkline charts and trend indicators.

Fixes [CHAOS-1196](https://linear.app/fullchaos/issue/CHAOS-1196)

## Note on Failure Patterns "None" label

The "Failure Patterns" heatmap on the Pipelines page groups by TEAM dimension. The "None" label appears because existing fixture data has `team_id: null` on TestOps records. This is fixed in [dev-health-ops PR #652](https://github.com/full-chaos/dev-health-ops/pull/652) — regenerating fixtures will populate team_ids.

## Test Plan

All 7 testops unit tests pass (`vitest run src/lib/testops/__tests__/`).

SCREENSHOT-WAIVER: Cannot capture live screenshots without running backend + regenerated fixtures. The sparkline components are already tested via existing MetricCard/SparklineChart tests.