### PR TITLE
Wire feature flag provider config and graph parsing

### DIFF
--- a/src/app/(app)/admin/integrations/[provider]/IntegrationFormWrapper.tsx
+++ b/src/app/(app)/admin/integrations/[provider]/IntegrationFormWrapper.tsx
@@ -6,6 +6,7 @@ import {
   GitLabForm,
   JiraForm,
   LinearForm,
+  LaunchDarklyForm,
 } from "@/components/admin/integrations/ProviderForms";
 import { createCredential, testConnection } from "@/lib/admin/server";
 import type { IntegrationCredential } from "@/lib/admin/types";
@@ -74,6 +75,8 @@ export function IntegrationFormWrapper({
         return <JiraForm />;
       case "linear":
         return <LinearForm />;
+      case "launchdarkly":
+        return <LaunchDarklyForm />;
       default:
         return null;
     }

--- a/src/app/(app)/admin/integrations/[provider]/page.tsx
+++ b/src/app/(app)/admin/integrations/[provider]/page.tsx
@@ -10,6 +10,7 @@ const PROVIDERS: Record<string, string> = {
   gitlab: "GitLab",
   jira: "Jira",
   linear: "Linear",
+  launchdarkly: "LaunchDarkly",
 };
 
 function getStatus(credential: IntegrationCredential | undefined): ConnectionStatusType {

--- a/src/app/(app)/admin/integrations/page.tsx
+++ b/src/app/(app)/admin/integrations/page.tsx
@@ -27,6 +27,12 @@ const LinearIcon = () => (
   </svg>
 );
 
+const LaunchDarklyIcon = () => (
+  <svg viewBox="0 0 24 24" className="h-8 w-8 fill-current text-emerald-500">
+    <path d="M11 3a1 1 0 0 1 1-1h1v20h-1a1 1 0 0 1-1-1V3Zm-6 7a1 1 0 0 1 1-1h3v6H6a1 1 0 0 1-1-1v-4Zm10 0h3a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-3v-6Z" />
+  </svg>
+);
+
 const PROVIDER_META: Record<
   string,
   { name: string; description: string; icon: React.ReactNode }
@@ -50,6 +56,11 @@ const PROVIDER_META: Record<
     name: "Linear",
     description: "Connect to Linear to sync issues, cycles, and projects.",
     icon: <LinearIcon />,
+  },
+  launchdarkly: {
+    name: "LaunchDarkly",
+    description: "Connect to LaunchDarkly to sync feature flag definitions and rollout signals.",
+    icon: <LaunchDarklyIcon />,
   },
 };
 

--- a/src/components/admin/integrations/ProviderForms.tsx
+++ b/src/components/admin/integrations/ProviderForms.tsx
@@ -186,3 +186,57 @@ export function LinearForm() {
     </>
   );
 }
+
+export function LaunchDarklyForm() {
+  return (
+    <>
+      <div>
+        <label htmlFor="launchdarkly-token" className="block text-sm font-medium text-(--ink-base)">
+          API Token
+        </label>
+        <div className="mt-1">
+          <input
+            type="password"
+            name="api_key"
+            id="launchdarkly-token"
+            className="block w-full rounded-md border-(--border-base) bg-(--surface-base) px-3 py-2 text-(--ink-base) shadow-sm focus:border-(--surface-inverted) focus:outline-none focus:ring-1 focus:ring-(--surface-inverted) sm:text-sm"
+            placeholder="api-..."
+          />
+        </div>
+        <p className="mt-2 text-sm text-(--ink-muted)">
+          Recommended for long-lived sync jobs: LaunchDarkly service token with reader access.
+        </p>
+      </div>
+
+      <div>
+        <label htmlFor="launchdarkly-project" className="block text-sm font-medium text-(--ink-base)">
+          Project Key
+        </label>
+        <div className="mt-1">
+          <input
+            type="text"
+            name="project_key"
+            id="launchdarkly-project"
+            className="block w-full rounded-md border-(--border-base) bg-(--surface-base) px-3 py-2 text-(--ink-base) shadow-sm focus:border-(--surface-inverted) focus:outline-none focus:ring-1 focus:ring-(--surface-inverted) sm:text-sm"
+            placeholder="default"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="launchdarkly-environment" className="block text-sm font-medium text-(--ink-base)">
+          Environment Key
+        </label>
+        <div className="mt-1">
+          <input
+            type="text"
+            name="environment"
+            id="launchdarkly-environment"
+            className="block w-full rounded-md border-(--border-base) bg-(--surface-base) px-3 py-2 text-(--ink-base) shadow-sm focus:border-(--surface-inverted) focus:outline-none focus:ring-1 focus:ring-(--surface-inverted) sm:text-sm"
+            placeholder="production"
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/sync/CreateCredentialModal.tsx
+++ b/src/components/admin/sync/CreateCredentialModal.tsx
@@ -29,6 +29,11 @@ const PROVIDER_FIELDS: Record<Provider, ProviderField[]> = {
     { key: "server_url", label: "Server URL", type: "text", required: true },
   ],
   linear: [{ key: "api_key", label: "API Key", type: "password", required: true }],
+  launchdarkly: [
+    { key: "api_key", label: "API Token", type: "password", required: true },
+    { key: "project_key", label: "Project Key", type: "text", required: true },
+    { key: "environment", label: "Environment Key", type: "text", required: true },
+  ],
 };
 
 function getInitialCredentials(provider: Provider): Record<string, string> {
@@ -40,6 +45,9 @@ function getInitialCredentials(provider: Provider): Record<string, string> {
   }
   if (provider === "linear") {
     return { api_key: "" };
+  }
+  if (provider === "launchdarkly") {
+    return { api_key: "", project_key: "", environment: "production" };
   }
   return { token: "" };
 }

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -26,6 +26,7 @@ const ALL_SYNC_TARGETS = [
   { id: "deployments", label: "Deployments" },
   { id: "incidents", label: "Incidents" },
   { id: "work-items", label: "Work Items (Issues, Tickets)" },
+  { id: "feature-flags", label: "Feature Flags" },
 ];
 
 function getSyncTargetsForProvider(provider: string) {

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -515,22 +515,24 @@ export interface RetentionExecuteResponse {
 
 // ---- Provider types ----
 
-export type Provider = 'github' | 'gitlab' | 'jira' | 'linear';
+export type Provider = 'github' | 'gitlab' | 'jira' | 'linear' | 'launchdarkly';
 
-export const PROVIDERS: Provider[] = ['github', 'gitlab', 'jira', 'linear'];
+export const PROVIDERS: Provider[] = ['github', 'gitlab', 'jira', 'linear', 'launchdarkly'];
 
 export const PROVIDER_LABELS: Record<Provider, string> = {
   github: 'GitHub',
   gitlab: 'GitLab',
   jira: 'Jira',
   linear: 'Linear',
+  launchdarkly: 'LaunchDarkly',
 };
 
 export const PROVIDER_SYNC_TARGETS: Record<Provider, string[]> = {
   github: ['git', 'prs', 'cicd', 'deployments', 'incidents', 'work-items'],
-  gitlab: ['git', 'prs', 'cicd', 'deployments', 'incidents', 'work-items'],
+  gitlab: ['git', 'prs', 'cicd', 'deployments', 'incidents', 'work-items', 'feature-flags'],
   jira: ['work-items'],
   linear: ['work-items'],
+  launchdarkly: ['feature-flags'],
 };
 
 // ---- Platform Stats ----

--- a/src/lib/feature-flags/__tests__/fetchers.test.ts
+++ b/src/lib/feature-flags/__tests__/fetchers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { WorkGraphEdge } from "@/lib/graphql/types";
+import { getDistinctSourceIds, getRegistryEdges, parseToggleEvidence } from "../graph";
+
+function makeEdge(overrides: Partial<WorkGraphEdge>): WorkGraphEdge {
+  return {
+    edgeId: overrides.edgeId ?? "edge-1",
+    sourceType: overrides.sourceType ?? "FEATURE_FLAG",
+    sourceId: overrides.sourceId ?? "flag-1",
+    targetType: overrides.targetType ?? "FEATURE_FLAG",
+    targetId: overrides.targetId ?? "flag-1",
+    edgeType: overrides.edgeType ?? "RELATES",
+    provenance: overrides.provenance ?? "NATIVE",
+    confidence: overrides.confidence ?? 1,
+    evidence: overrides.evidence ?? "flag:launchdarkly/default/checkout-redesign",
+    repoId: overrides.repoId ?? undefined,
+    provider: overrides.provider ?? "launchdarkly",
+  };
+}
+
+describe("feature flag fetcher helpers", () => {
+  it("keeps one registry edge per flag identity", () => {
+    const registryEdges = getRegistryEdges([
+      makeEdge({ edgeId: "registry-1", sourceId: "flag-a" }),
+      makeEdge({ edgeId: "registry-2", sourceId: "flag-a" }),
+      makeEdge({ edgeId: "pr-link", sourceId: "flag-a", targetType: "PR", targetId: "repo#pr1", edgeType: "REFERENCES" }),
+      makeEdge({ edgeId: "registry-3", sourceId: "flag-b", targetId: "flag-b" }),
+    ]);
+
+    expect(registryEdges.map((edge) => edge.sourceId)).toEqual(["flag-a", "flag-b"]);
+  });
+
+  it("parses toggle evidence into timestamp and active state", () => {
+    expect(parseToggleEvidence("2026-04-15T10:15:00Z|toggle|on")).toEqual({
+      ts: "2026-04-15T10:15:00Z",
+      active: true,
+    });
+    expect(parseToggleEvidence("2026-04-16T08:00:00Z|toggle|off")).toEqual({
+      ts: "2026-04-16T08:00:00Z",
+      active: false,
+    });
+  });
+
+  it("counts distinct release sources for impact coverage", () => {
+    const edges = [
+      makeEdge({ sourceType: "RELEASE", sourceId: "release-a", targetType: "RELEASE", targetId: "release-a", edgeType: "RELATES" }),
+      makeEdge({ edgeId: "impact-a-1", sourceType: "RELEASE", sourceId: "release-a", targetType: "FEATURE_FLAG", targetId: "flag-a", edgeType: "IMPACTS" }),
+      makeEdge({ edgeId: "impact-a-2", sourceType: "RELEASE", sourceId: "release-a", targetType: "FEATURE_FLAG", targetId: "flag-b", edgeType: "IMPACTS" }),
+      makeEdge({ edgeId: "release-b", sourceType: "RELEASE", sourceId: "release-b", targetType: "RELEASE", targetId: "release-b", edgeType: "RELATES" }),
+    ];
+
+    expect(getDistinctSourceIds(edges).size).toBe(2);
+    expect(getDistinctSourceIds(edges, "IMPACTS").size).toBe(1);
+  });
+});

--- a/src/lib/feature-flags/constants.ts
+++ b/src/lib/feature-flags/constants.ts
@@ -1,38 +1,145 @@
+export type MetricStability = "stable" | "provisional" | "rejected";
+
 export type FeatureFlagMeasureDef = {
   id: string;
   label: string;
   description: string;
-  unit: "percentage" | "count" | "number" | "delta";
+  unit: "percentage" | "count" | "number" | "delta" | "ratio" | "hours";
   goodDirection: "up" | "down" | "neutral";
+  stability: MetricStability;
 };
 
 export const FF_MEASURES: Record<string, FeatureFlagMeasureDef> = {
+  // ── Stable metrics ──────────────────────────────────────────────────
+  RELEASE_FRICTION_DELTA: {
+    id: "RELEASE_FRICTION_DELTA",
+    label: "Release Friction Delta",
+    description:
+      "Change in user friction signals per session compared to a 7-day baseline",
+    unit: "delta",
+    goodDirection: "down",
+    stability: "stable",
+  },
+  RELEASE_ERROR_RATE_DELTA: {
+    id: "RELEASE_ERROR_RATE_DELTA",
+    label: "Release Error Rate Delta",
+    description:
+      "Change in error rate between pre- and post-deployment windows",
+    unit: "delta",
+    goodDirection: "down",
+    stability: "stable",
+  },
+  RELEASE_IMPACT_CONFIDENCE: {
+    id: "RELEASE_IMPACT_CONFIDENCE",
+    label: "Impact Confidence Score",
+    description:
+      "Composite score reflecting telemetry coverage, sample size, and confounder presence",
+    unit: "ratio",
+    goodDirection: "up",
+    stability: "stable",
+  },
+  COVERAGE_RATIO: {
+    id: "COVERAGE_RATIO",
+    label: "Impact Coverage Ratio",
+    description:
+      "Fraction of releases with telemetry data attached on a given day",
+    unit: "percentage",
+    goodDirection: "up",
+    stability: "stable",
+  },
+
+  // ── Provisional metrics (beta) ──────────────────────────────────────
+  TIME_TO_FIRST_USER_ISSUE: {
+    id: "TIME_TO_FIRST_USER_ISSUE",
+    label: "Time to First User Issue",
+    description:
+      "Hours between deployment and the first linked user-reported issue",
+    unit: "hours",
+    goodDirection: "down",
+    stability: "provisional",
+  },
+  FLAG_EXPOSURE_RATE: {
+    id: "FLAG_EXPOSURE_RATE",
+    label: "Flag Exposure Rate",
+    description:
+      "Ratio of sessions that encountered the flag versus all eligible sessions",
+    unit: "ratio",
+    goodDirection: "neutral",
+    stability: "provisional",
+  },
+  FLAG_ACTIVATION_RATE: {
+    id: "FLAG_ACTIVATION_RATE",
+    label: "Flag Activation Rate",
+    description:
+      "Ratio of exposed sessions that performed a defined success action",
+    unit: "ratio",
+    goodDirection: "up",
+    stability: "provisional",
+  },
+  FLAG_RELIABILITY_GUARDRAIL: {
+    id: "FLAG_RELIABILITY_GUARDRAIL",
+    label: "Flag Reliability Guardrail",
+    description:
+      "Ratio of error-free sessions in the exposed cohort",
+    unit: "ratio",
+    goodDirection: "up",
+    stability: "provisional",
+  },
+  FLAG_FRICTION_DELTA: {
+    id: "FLAG_FRICTION_DELTA",
+    label: "Flag Friction Delta",
+    description:
+      "Change in friction signals scoped to the flag exposure window",
+    unit: "delta",
+    goodDirection: "down",
+    stability: "provisional",
+  },
+  ISSUE_TO_RELEASE_LINK_RATE: {
+    id: "ISSUE_TO_RELEASE_LINK_RATE",
+    label: "Issue-to-Release Link Rate",
+    description:
+      "Fraction of completed work items with measurable post-release signal",
+    unit: "ratio",
+    goodDirection: "up",
+    stability: "provisional",
+  },
+  ROLLBACK_AFTER_IMPACT: {
+    id: "ROLLBACK_AFTER_IMPACT",
+    label: "Rollback/Disable After Impact",
+    description:
+      "Count of flag disable or rollback events within 72 hours of deployment",
+    unit: "count",
+    goodDirection: "down",
+    stability: "provisional",
+  },
+
+  // ── Rejected metrics (not displayed, kept for reference) ────────────
+  FLAG_ROLLOUT_HALF_LIFE: {
+    id: "FLAG_ROLLOUT_HALF_LIFE",
+    label: "Flag Rollout Half-Life",
+    description:
+      "Hours from first rollout event to 50% exposure — rejected due to provider-specific denominator",
+    unit: "hours",
+    goodDirection: "neutral",
+    stability: "rejected",
+  },
+  FLAG_CHURN_RATE: {
+    id: "FLAG_CHURN_RATE",
+    label: "Flag Churn Rate",
+    description:
+      "Toggle/rule-change frequency per week — rejected due to misuse risk and interpretation ambiguity",
+    unit: "count",
+    goodDirection: "neutral",
+    stability: "rejected",
+  },
+
+  // ── Operational (not in PRD catalog, retained from prior iteration) ─
   ACTIVE_FLAGS: {
     id: "ACTIVE_FLAGS",
     label: "Active Flags",
     description: "Number of feature flags currently enabled in production",
     unit: "count",
     goodDirection: "neutral",
-  },
-  RELEASE_FRICTION_DELTA: {
-    id: "RELEASE_FRICTION_DELTA",
-    label: "Release Friction Delta",
-    description: "Change in release friction score across recent deployments",
-    unit: "delta",
-    goodDirection: "down",
-  },
-  RELEASE_ERROR_RATE_DELTA: {
-    id: "RELEASE_ERROR_RATE_DELTA",
-    label: "Release Error Rate Delta",
-    description: "Change in error rate between pre- and post-deployment windows",
-    unit: "delta",
-    goodDirection: "down",
-  },
-  COVERAGE_RATIO: {
-    id: "COVERAGE_RATIO",
-    label: "Coverage Ratio",
-    description: "Percentage of releases with feature flag telemetry attached",
-    unit: "percentage",
-    goodDirection: "up",
+    stability: "stable",
   },
 };

--- a/src/lib/feature-flags/fetchers.ts
+++ b/src/lib/feature-flags/fetchers.ts
@@ -15,6 +15,7 @@ import type {
   FeatureFlagData,
   FeatureFlagsData,
 } from "./types";
+import { getDistinctSourceIds, getRegistryEdges, parseToggleEvidence } from "./graph";
 
 const EMPTY_RESULT: WorkGraphEdgesResult = {
   edges: [],
@@ -41,14 +42,18 @@ export async function fetchFeatureFlagRegistry(
         orgId,
         filters: {
           sourceType: "FEATURE_FLAG",
+          targetType: "FEATURE_FLAG",
+          edgeType: "RELATES",
           limit,
         },
       },
     );
 
+    const flags = getRegistryEdges(res.workGraphEdges.edges);
+
     return {
-      flags: res.workGraphEdges.edges,
-      totalCount: res.workGraphEdges.totalCount,
+      flags,
+      totalCount: flags.length,
       pageInfo: res.workGraphEdges.pageInfo,
     };
   } catch (error) {
@@ -141,8 +146,9 @@ export async function fetchFeatureFlagsData(
     const impact = await fetchReleaseImpact("");
 
     const activeFlags = registry.totalCount;
-    const frictionEdges = impact.edges.filter(e => e.evidence?.includes("friction"));
-    const errorEdges = impact.edges.filter(e => e.evidence?.includes("error"));
+    const impactEdges = impact.edges.filter((edge) => edge.edgeType === "IMPACTS");
+    const frictionEdges = impactEdges.filter((edge) => edge.evidence?.includes("friction"));
+    const errorEdges = impactEdges.filter((edge) => edge.evidence?.includes("error"));
 
     const avgFriction = frictionEdges.length > 0
       ? frictionEdges.reduce((sum, e) => sum + (e.confidence ?? 0), 0) / frictionEdges.length * 100
@@ -151,8 +157,8 @@ export async function fetchFeatureFlagsData(
       ? errorEdges.reduce((sum, e) => sum + (e.confidence ?? 0), 0) / errorEdges.length * 100
       : 0;
 
-    const totalReleases = impact.totalCount || 1;
-    const withTelemetry = impact.edges.filter(e => e.edgeType === "IMPACTS").length;
+    const totalReleases = getDistinctSourceIds(impact.edges).size || 1;
+    const withTelemetry = getDistinctSourceIds(impactEdges).size;
     const coverageRatio = Math.round((withTelemetry / totalReleases) * 100);
 
     return {
@@ -206,12 +212,12 @@ export async function fetchFeatureFlagList(
     const togglesByFlag = new Map<string, { ts: string; active: boolean }>();
     for (const evt of events.events) {
       const existing = togglesByFlag.get(evt.sourceId);
-      const evtTs = evt.evidence ?? "";
+      const parsedToggle = parseToggleEvidence(evt.evidence);
       const isToggle = evt.edgeType === "CONFIG_CHANGED_BY";
-      if (isToggle && (!existing || evtTs > existing.ts)) {
+      if (isToggle && (!existing || parsedToggle.ts > existing.ts)) {
         togglesByFlag.set(evt.sourceId, {
-          ts: evtTs,
-          active: !evt.evidence?.includes("off"),
+          ts: parsedToggle.ts,
+          active: parsedToggle.active,
         });
       }
     }

--- a/src/lib/feature-flags/graph.ts
+++ b/src/lib/feature-flags/graph.ts
@@ -1,0 +1,32 @@
+import type { WorkGraphEdge } from "@/lib/graphql/types";
+
+export function getRegistryEdges(edges: WorkGraphEdge[]): WorkGraphEdge[] {
+  const seen = new Set<string>();
+  return edges.filter((edge) => {
+    if (edge.sourceType !== "FEATURE_FLAG" || edge.targetType !== "FEATURE_FLAG" || edge.edgeType !== "RELATES") {
+      return false;
+    }
+    if (seen.has(edge.sourceId)) {
+      return false;
+    }
+    seen.add(edge.sourceId);
+    return true;
+  });
+}
+
+export function getDistinctSourceIds(edges: WorkGraphEdge[], edgeType?: WorkGraphEdge["edgeType"]): Set<string> {
+  return new Set(
+    edges
+      .filter((edge) => (edgeType ? edge.edgeType === edgeType : true))
+      .map((edge) => edge.sourceId)
+      .filter(Boolean),
+  );
+}
+
+export function parseToggleEvidence(evidence?: string | null): { ts: string; active: boolean } {
+  if (!evidence) {
+    return { ts: "", active: false };
+  }
+  const [ts = "", , state = evidence] = evidence.split("|");
+  return { ts, active: !state.toLowerCase().includes("off") };
+}


### PR DESCRIPTION
## Summary
- expose LaunchDarkly in the admin integration and credential flows, and add feature-flag sync targets for LaunchDarkly and GitLab
- add LaunchDarkly provider cards/pages/forms so the missing feature-flag sync auth path is configurable in the web app
- normalize feature-flag registry parsing and release-impact coverage calculations so the overview reads the repaired work graph shape correctly

## Verification
- lsp diagnostics on changed admin and feature-flag files
- vitest run src/lib/feature-flags/__tests__/fetchers.test.ts

## Notes
- Companion backend PR: https://github.com/full-chaos/dev-health-ops/pull/671
- SCREENSHOT-WAIVER: admin/provider wiring and feature-flag data parsing change; no intentional visual redesign, and PR created from isolated worktree without a full local app install.