### PR TITLE
fix: match measure name case from analytics API response

### DIFF
--- a/src/lib/feature-flags/fetchers.ts
+++ b/src/lib/feature-flags/fetchers.ts
@@ -224,15 +224,15 @@ export async function fetchFeatureFlagsData(
       summary: {
         activeFlags,
         activeFlagsDelta: 0,
-        activeFlagsSpark: mergeToSpark(timeseries, "flag_activation_rate"),
+        activeFlagsSpark: mergeToSpark(timeseries, "FLAG_ACTIVATION_RATE"),
         releaseFrictionDelta: Math.round(avgFriction * 10) / 10,
         releaseFrictionSeverity: classifySeverity(avgFriction),
-        releaseFrictionSpark: mergeToSpark(timeseries, "flag_friction_delta"),
+        releaseFrictionSpark: mergeToSpark(timeseries, "FLAG_FRICTION_DELTA"),
         releaseErrorRateDelta: Math.round(-avgError * 10) / 10,
-        releaseErrorRateSpark: mergeToSpark(timeseries, "flag_error_rate_delta"),
+        releaseErrorRateSpark: mergeToSpark(timeseries, "FLAG_ERROR_RATE_DELTA"),
         coverageRatio,
         coverageRatioDelta: 0,
-        coverageRatioSpark: mergeToSpark(timeseries, "flag_coverage_ratio"),
+        coverageRatioSpark: mergeToSpark(timeseries, "FLAG_COVERAGE_RATIO"),
       },
     };
   } catch (error) {


### PR DESCRIPTION
## Summary

- Fixes sparklines not rendering despite valid timeseries data in ClickHouse

## Root Cause

The analytics resolver returns `TimeseriesResult.measure` using the Python enum **attribute name** (uppercase):
```python
measure=ts_req.measure.name  # "FLAG_FRICTION_DELTA"
```

But `mergeToSpark` was filtering with the enum **value** (lowercase):
```ts
mergeToSpark(timeseries, "flag_friction_delta")  // never matches
```

Every sparkline silently got zero matches → empty array → "Trend" placeholder.

## Fix

Match the uppercase enum names the API actually returns:
```ts
mergeToSpark(timeseries, "FLAG_FRICTION_DELTA")
```

TEST-WAIVER: One-line case correction per metric — existing graph helper tests unaffected