### PR TITLE
test(filters): FilterBarClient coverage as refactor safety net (CHAOS-1239)

### DIFF
--- a/src/components/filters/FilterBarClient.test.tsx
+++ b/src/components/filters/FilterBarClient.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * FilterBarClient component tests — refactor safety net for CHAOS-1226.
+ *
+ * Locks in CURRENT behavior so the upcoming split refactor cannot silently
+ * regress `resolveVisibility`, URL sync, reset, active-pill rendering, or
+ * per-view rendering. Refs CHAOS-1239.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@/test/utils";
+import {
+  FilterBarClient,
+  resolveVisibility,
+  type FilterBarView,
+} from "./FilterBarClient";
+import { encodeFilterParam } from "@/lib/filters/encode";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+import type { MetricFilter } from "@/lib/filters/types";
+
+const mockReplace = vi.fn();
+const mockPush = vi.fn();
+
+let currentSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+    push: mockPush,
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/dashboard",
+  useSearchParams: () => ({
+    get: (key: string) => currentSearchParams.get(key),
+    toString: () => currentSearchParams.toString(),
+    has: (key: string) => currentSearchParams.has(key),
+  }),
+}));
+
+vi.mock("@/lib/apiClient", () => ({
+  apiClient: {
+    getJson: vi.fn().mockResolvedValue({
+      teams: [],
+      repos: [],
+      services: [],
+      developers: [],
+      work_category: [],
+      issue_type: [],
+      flow_stage: [],
+    }),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function setSearchParams(entries: Record<string, string> = {}) {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(entries)) sp.set(k, v);
+  currentSearchParams = sp;
+}
+
+beforeEach(() => {
+  mockReplace.mockClear();
+  mockPush.mockClear();
+  setSearchParams();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("resolveVisibility (pure)", () => {
+  it("returns DEFAULT visibility for unknown/undefined view", () => {
+    const v = resolveVisibility(undefined);
+    expect(v).toEqual({
+      scope: true,
+      repo: true,
+      developer: true,
+      workType: true,
+      flowStage: false,
+      date: true,
+    });
+  });
+
+  it("returns METRICS_DEFAULT for view=metrics (no tab)", () => {
+    const v = resolveVisibility("metrics");
+    expect(v.repo).toBe(true);
+    expect(v.developer).toBe(false);
+    expect(v.flowStage).toBe(false);
+    expect(v.workType).toBe(false);
+  });
+
+  it("returns METRICS_FLOW visibility for view=metrics tab=flow (developer + flowStage enabled)", () => {
+    const v = resolveVisibility("metrics", "flow");
+    expect(v.developer).toBe(true);
+    expect(v.flowStage).toBe(true);
+  });
+
+  it("hides repo for view=work and view=investment (WORK_VISIBILITY)", () => {
+    expect(resolveVisibility("work").repo).toBe(false);
+    expect(resolveVisibility("work").workType).toBe(true);
+    expect(resolveVisibility("investment").repo).toBe(false);
+    expect(resolveVisibility("investment").workType).toBe(true);
+  });
+
+  it("hides scope for view=code (CODE_VISIBILITY)", () => {
+    const v = resolveVisibility("code");
+    expect(v.scope).toBe(false);
+    expect(v.repo).toBe(true);
+    expect(v.developer).toBe(true);
+  });
+
+  it("enables everything for view=explore (EXPLORE_VISIBILITY)", () => {
+    const v = resolveVisibility("explore");
+    expect(v.scope).toBe(true);
+    expect(v.repo).toBe(true);
+    expect(v.developer).toBe(true);
+    expect(v.workType).toBe(true);
+    expect(v.flowStage).toBe(true);
+    expect(v.date).toBe(true);
+  });
+
+  it("hides ALL filters for view=security (managed externally)", () => {
+    const v = resolveVisibility("security");
+    expect(v.scope).toBe(false);
+    expect(v.repo).toBe(false);
+    expect(v.developer).toBe(false);
+    expect(v.workType).toBe(false);
+    expect(v.flowStage).toBe(false);
+    expect(v.date).toBe(false);
+  });
+
+  it("treats quality and testops as METRICS_DEFAULT", () => {
+    expect(resolveVisibility("quality")).toEqual(resolveVisibility("metrics"));
+    expect(resolveVisibility("testops")).toEqual(resolveVisibility("metrics"));
+  });
+
+  it("treats opportunities as WORK_VISIBILITY", () => {
+    expect(resolveVisibility("opportunities")).toEqual(
+      resolveVisibility("work")
+    );
+  });
+
+  it("returns PEOPLE visibility (developer on, repo/workType off)", () => {
+    const v = resolveVisibility("people");
+    expect(v.developer).toBe(true);
+    expect(v.repo).toBe(false);
+    expect(v.workType).toBe(false);
+  });
+});
+
+describe("URL sync on filter change", () => {
+  it("calls router.replace with encoded `f` param when a date preset is clicked", () => {
+    // Seed URL with encoded default filter so the default-write init effect does not fire.
+    setSearchParams({ f: encodeFilterParam(defaultMetricFilter) });
+
+    render(<FilterBarClient view="home" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "30d" }));
+
+    expect(mockReplace).toHaveBeenCalled();
+    const firstCallArg = mockReplace.mock.calls[0][0] as string;
+    expect(firstCallArg).toMatch(/^\/dashboard\?/);
+    expect(firstCallArg).toContain("f=");
+  });
+
+  it("writes default `f` to URL when none is present (initialization effect)", async () => {
+    setSearchParams({});
+    render(<FilterBarClient view="home" />);
+
+    // Init effect runs after mount; yield a microtask before asserting.
+    await Promise.resolve();
+
+    expect(mockReplace).toHaveBeenCalled();
+    const arg = mockReplace.mock.calls[0][0] as string;
+    expect(arg).toContain("f=");
+  });
+});
+
+describe("Reset", () => {
+  it("calls router.replace with the default-encoded filter when Reset clicked", () => {
+    setSearchParams({ f: encodeFilterParam(defaultMetricFilter) });
+
+    render(<FilterBarClient view="home" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+
+    const lastArg = mockReplace.mock.calls.at(-1)?.[0] as string;
+    expect(lastArg).toContain(`f=${encodeFilterParam(defaultMetricFilter)}`);
+  });
+
+  it("clears `q` search param on reset for view=people", () => {
+    setSearchParams({ f: encodeFilterParam(defaultMetricFilter), q: "alice" });
+
+    render(<FilterBarClient view="people" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+
+    const lastArg = mockReplace.mock.calls.at(-1)?.[0] as string;
+    expect(lastArg).not.toContain("q=alice");
+    expect(lastArg).toContain(`f=${encodeFilterParam(defaultMetricFilter)}`);
+  });
+});
+
+describe("Active filter pills", () => {
+  it("renders a FilterPill for each active repo/developer/work_category filter", () => {
+    const filtersWithSelections: MetricFilter = {
+      ...defaultMetricFilter,
+      who: { developers: ["alice"] },
+      what: { repos: ["org/api"] },
+      why: { work_category: ["feature"] },
+    };
+    setSearchParams({ f: encodeFilterParam(filtersWithSelections) });
+
+    render(<FilterBarClient view="explore" />);
+
+    expect(screen.getByText("org/api")).toBeInTheDocument();
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("feature")).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: /remove repo filter/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /remove dev filter/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /remove work filter/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders no pills when filter is the default (no selections)", () => {
+    setSearchParams({ f: encodeFilterParam(defaultMetricFilter) });
+    render(<FilterBarClient view="explore" />);
+
+    expect(screen.queryByRole("button", { name: /remove repo filter/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /remove dev filter/i })).toBeNull();
+  });
+});
+
+describe("Per-view-type rendering smoke", () => {
+  const views: FilterBarView[] = [
+    "home",
+    "metrics",
+    "work",
+    "investment",
+    "people",
+    "code",
+    "quality",
+    "opportunities",
+    "explore",
+    "testops",
+    "security",
+    "feature-flags",
+  ];
+
+  it.each(views)("renders without error for view=%s", (view) => {
+    setSearchParams({ f: encodeFilterParam(defaultMetricFilter) });
+
+    expect(() => render(<FilterBarClient view={view} />)).not.toThrow();
+
+    // Reset button is a cross-view invariant — always rendered regardless of visibility config.
+    expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
+  });
+
+  it("shows search input for view=people only", () => {
+    setSearchParams({ f: encodeFilterParam(defaultMetricFilter) });
+    render(<FilterBarClient view="people" />);
+    expect(screen.getByPlaceholderText(/name or handle/i)).toBeInTheDocument();
+  });
+
+  it("hides the Filters (advanced) toggle on view=people", () => {
+    setSearchParams({ f: encodeFilterParam(defaultMetricFilter) });
+    render(<FilterBarClient view="people" />);
+    expect(
+      screen.queryByRole("button", { name: /^filters$/i })
+    ).toBeNull();
+  });
+});

--- a/src/components/filters/FilterBarClient.tsx
+++ b/src/components/filters/FilterBarClient.tsx
@@ -43,7 +43,7 @@ type FilterOptions = {
   flow_stage: string[];
 };
 
-type FilterBarView =
+export type FilterBarView =
   | "people"
   | "home"
   | "metrics"
@@ -57,7 +57,7 @@ type FilterBarView =
   | "security"
   | "feature-flags";
 
-type FilterVisibility = {
+export type FilterVisibility = {
   scope?: boolean;
   repo?: boolean;
   developer?: boolean;
@@ -129,7 +129,7 @@ const EXPLORE_VISIBILITY: FilterVisibility = {
   date: true,
 };
 
-const resolveVisibility = (
+export const resolveVisibility = (
   view?: FilterBarView,
   tab?: string
 ): FilterVisibility => {


### PR DESCRIPTION
## Summary
- Adds component + unit tests for \`src/components/filters/FilterBarClient.tsx\` (1064 LOC, previously **zero** coverage)
- 30 test cases covering visibility resolution, URL sync, reset, active-pill rendering, per-view-type smoke
- Acts as safety net for the upcoming CHAOS-1226 refactor (FilterBarClient split)

## Linear
CHAOS-1239 (refs CHAOS-1226)

## What's covered
1. **\`resolveVisibility\` (pure)** — 10 cases: default, metrics (+flow tab), work/investment, code, explore, security (all-hidden), quality/testops, opportunities, people
2. **URL sync** — date-preset click → \`router.replace\` with encoded \`f\`; init effect writes default \`f\` when absent
3. **Reset** — default-encoded filter written to URL; \`q\` param cleared on \`view=people\`
4. **Active pills** — repo/developer/work_category pills render with accessible remove buttons; no pills when defaults
5. **Per-view rendering** — 12 parametrized views (home, metrics, work, investment, people, code, quality, opportunities, explore, testops, security, feature-flags) + people-only search input + advanced-filters toggle hidden on people

## Minimal source change
- Exported \`resolveVisibility\`, \`FilterBarView\`, \`FilterVisibility\` from \`FilterBarClient.tsx\` to enable pure-function testing without reaching through React render. No behavior change.

## Verification
\`\`\`bash
npx vitest run src/components/filters/FilterBarClient.test.tsx
# → Test Files 1 passed, Tests 30 passed, Duration ~800ms
npm run typecheck  # ✓
npm run lint       # ✓ (0 errors)
\`\`\`

## Not covered (intentional)
- Advanced filter \`<details>\` panels (Who/What/Why/How text inputs) — covered indirectly by pill assertions
- Date custom-range menu interactions (preset buttons covered; custom date pickers open menu)
- \`copyFilters\` / clipboard — trivial, low risk
- Click-outside menu close behavior — DOM-event-driven, tested by E2E if needed

## Test Policy
Test-only addition — meets governance requirement.

SCREENSHOT-WAIVER: Test-only change, no rendered UI modified.