### PR TITLE
fix(charts): eliminate 3 'as any' casts in QuadrantChart (CHAOS-1229)

### DIFF
--- a/src/components/charts/QuadrantChart.tsx
+++ b/src/components/charts/QuadrantChart.tsx
@@ -217,7 +217,7 @@ export const buildQuadrantOption = ({
       ];
     })
     : [];
-  const zoneAreas = showInterpretation
+  const zoneAreas: MarkAreaComponentOption["data"] = showInterpretation
     ? (activeZoneOverlay?.zones ?? []).map((zone: import("@/lib/quadrantZones").ZoneRegion) => [
       {
         name: zone.label,
@@ -226,17 +226,17 @@ export const buildQuadrantOption = ({
         itemStyle: buildZoneSurfaceStyle(zone.color, {
           active: highlightOverlayKey === `zone:${zone.id}`,
         }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any,
+      },
       {
         xAxis: zone.xRange[1],
         yAxis: zone.yRange[1],
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any,
+      },
     ])
     : [];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const markAreaData: any = [...annotationAreas, ...zoneAreas];
+  const markAreaData: MarkAreaComponentOption["data"] = [
+    ...(annotationAreas ?? []),
+    ...(zoneAreas ?? []),
+  ];
   const markArea: MarkAreaComponentOption | undefined = markAreaData.length
     ? {
       silent: true,


### PR DESCRIPTION
## Summary

Eliminate 3 `as any` casts and 3 adjacent `eslint-disable` comments in `src/components/charts/QuadrantChart.tsx` used to silence ECharts `markArea` typing.

The escapes were unnecessary — `MarkAreaComponentOption[\"data\"]` (re-exported from `echarts`) already captures the exact shape: a tuple of `MarkArea2DDataItemDimOption` entries carrying `xAxis`, `yAxis`, `name`, and `itemStyle`. The `annotationAreas` branch in this same file already used this type successfully; the fix just applies the same precise annotation to `zoneAreas` and `markAreaData`.

## Changes

- Type `zoneAreas` as `MarkAreaComponentOption[\"data\"]` instead of casting each tuple element with `as any`.
- Type `markAreaData` as `MarkAreaComponentOption[\"data\"]` (no cast) with explicit nullish spreads.
- Remove 3 `eslint-disable-next-line @typescript-eslint/no-explicit-any` comments.

## Linear

- CHAOS-1229: https://linear.app/fullchaos/issue/CHAOS-1229

## Verification

- [x] typecheck ✓ (\`npm run typecheck\`)
- [x] lint ✓ (\`npm run lint\` — 0 errors; pre-existing warnings untouched)
- [x] test ✓ (\`QuadrantChart.test.tsx\` — 3/3 pass; \`src/components/charts/\` — 12/12 pass)
- [x] grep clean: \`as any | @ts-ignore | @ts-expect-error | eslint-disable\` returns empty on this file

## Policy

No behavioral change — pure type-only refactor. Chart renders identically.

TEST-WAIVER: type-only change, existing tests cover the render path

SCREENSHOT-WAIVER: type-only change with no rendered UI diff