### PR TITLE
test: shared auth mock helper (CHAOS-1237)

### DIFF
--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -1,12 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Session } from "next-auth";
 
 // Mock dependencies BEFORE importing the module under test
 vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
-import { auth } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
+import { mockAuth } from "@/test/mocks/auth";
 import {
   listUsers,
   listPlatformUsers,
@@ -30,13 +29,8 @@ import {
   listRetentionResourceTypes,
 } from "../server";
 
-// Helper to mock auth session
 function mockSession() {
-  vi.mocked(auth).mockResolvedValue({
-    access_token: "test-token",
-    user: { id: "u-1", org_id: "org-1" },
-    expires: "",
-  } satisfies Session);
+  mockAuth({ user: { id: "u-1", org_id: "org-1" } });
 }
 
 describe("admin/server credential actions", () => {
@@ -73,7 +67,7 @@ describe("admin/server credential actions", () => {
     });
 
     it("returns error when not authenticated", async () => {
-      vi.mocked(auth).mockResolvedValue(null);
+      mockAuth(null);
       const result = await listCredentials();
       expect(result.error).toBeDefined();
     });
@@ -219,7 +213,7 @@ describe("admin/server audit log actions", () => {
     });
 
     it("returns error when not authenticated", async () => {
-      vi.mocked(auth).mockResolvedValue(null);
+      mockAuth(null);
       const result = await listAuditLogs();
       expect(result.error).toBeDefined();
     });
@@ -303,7 +297,7 @@ describe("admin/server IP allowlist actions", () => {
     });
 
     it("returns error when not authenticated", async () => {
-      vi.mocked(auth).mockResolvedValue(null);
+      mockAuth(null);
       const result = await listIPAllowlistEntries();
       expect(result.error).toBeDefined();
     });
@@ -426,7 +420,7 @@ describe("admin/server retention policy actions", () => {
     });
 
     it("returns error when not authenticated", async () => {
-      vi.mocked(auth).mockResolvedValue(null);
+      mockAuth(null);
       const result = await listRetentionPolicies();
       expect(result.error).toBeDefined();
     });

--- a/src/lib/billing/__tests__/actions.test.ts
+++ b/src/lib/billing/__tests__/actions.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Session } from "next-auth";
 
 // Must mock auth before importing the module under test
 vi.mock("@/lib/auth", () => ({
@@ -7,29 +6,7 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 import { getSubscription, getSubscriptions, createRefund, getRefunds, getInvoices } from "../actions";
-import { auth } from "@/lib/auth";
-
-function mockSession(overrides: Omit<Partial<Session>, "user"> & { user?: Partial<Session["user"]> } = {}): Session {
-  const { user: _ignoredUser, ...sessionOverrides } = overrides;
-
-  const user: Session["user"] = {
-    id: overrides.user?.id ?? "user-1",
-    org_id: overrides.user?.org_id ?? "org-123",
-    role: overrides.user?.role,
-    is_superuser: overrides.user?.is_superuser,
-    permissions: overrides.user?.permissions,
-    needs_onboarding: overrides.user?.needs_onboarding,
-    is_impersonating: overrides.user?.is_impersonating,
-    impersonated_user_id: overrides.user?.impersonated_user_id,
-  };
-
-  return {
-    access_token: "test-token",
-    user,
-    expires: new Date(Date.now() + 86400000).toISOString(),
-    ...sessionOverrides,
-  };
-}
+import { mockAuth } from "@/test/mocks/auth";
 
 describe("getSubscription", () => {
   beforeEach(() => {
@@ -38,7 +15,7 @@ describe("getSubscription", () => {
   });
 
   it("returns subscription details when API succeeds", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession());
+    mockAuth();
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
@@ -68,7 +45,7 @@ describe("getSubscription", () => {
   });
 
   it("returns error when API returns non-ok", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession());
+    mockAuth();
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ detail: "Not found" }), { status: 404 }),
@@ -83,7 +60,7 @@ describe("getSubscription", () => {
   });
 
   it("returns error when not authenticated", async () => {
-    vi.mocked(auth).mockResolvedValue(null);
+    mockAuth(null);
 
     const result = await getSubscription();
     expect(result.error).toBeDefined();
@@ -91,7 +68,7 @@ describe("getSubscription", () => {
   });
 
   it("returns canceled subscription details", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession());
+    mockAuth();
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
@@ -120,7 +97,7 @@ describe("getSubscription", () => {
   });
 
   it("handles fetch errors gracefully", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession());
+    mockAuth();
 
     const fetchSpy = vi.spyOn(global, "fetch").mockRejectedValue(
       new Error("Network error"),
@@ -134,9 +111,7 @@ describe("getSubscription", () => {
   });
 
   it("passes org_id when provided", async () => {
-    vi.mocked(auth).mockResolvedValue(
-      mockSession({ user: { is_superuser: true } }),
-    );
+    mockAuth({ user: { is_superuser: true } });
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
@@ -167,9 +142,7 @@ describe("getSubscription", () => {
   });
 
   it("loads subscription list with optional org filter", async () => {
-    vi.mocked(auth).mockResolvedValue(
-      mockSession({ user: { is_superuser: true } }),
-    );
+    mockAuth({ user: { is_superuser: true } });
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
@@ -200,7 +173,7 @@ describe("org scoping authorization", () => {
   });
 
   it("uses session org_id when no orgId is provided", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession({ user: { org_id: "org-session" } }));
+    mockAuth({ user: { org_id: "org-session" } });
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
@@ -231,9 +204,7 @@ describe("org scoping authorization", () => {
   });
 
   it("allows superuser access to another org", async () => {
-    vi.mocked(auth).mockResolvedValue(
-      mockSession({ user: { org_id: "org-session", is_superuser: true } }),
-    );
+    mockAuth({ user: { org_id: "org-session", is_superuser: true } });
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
@@ -264,9 +235,7 @@ describe("org scoping authorization", () => {
   });
 
   it("rejects non-superuser access to another org", async () => {
-    vi.mocked(auth).mockResolvedValue(
-      mockSession({ user: { org_id: "org-session", is_superuser: false } }),
-    );
+    mockAuth({ user: { org_id: "org-session", is_superuser: false } });
 
     const fetchSpy = vi.spyOn(global, "fetch");
 
@@ -278,9 +247,7 @@ describe("org scoping authorization", () => {
   });
 
   it("allows non-superuser access to matching org", async () => {
-    vi.mocked(auth).mockResolvedValue(
-      mockSession({ user: { org_id: "org-session", is_superuser: false } }),
-    );
+    mockAuth({ user: { org_id: "org-session", is_superuser: false } });
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
@@ -318,7 +285,7 @@ describe("refund actions", () => {
   });
 
   it("creates refund successfully", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession());
+    mockAuth();
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
@@ -356,7 +323,7 @@ describe("refund actions", () => {
   });
 
   it("returns refund creation error", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession());
+    mockAuth();
 
     const fetchSpy = vi
       .spyOn(global, "fetch")
@@ -369,7 +336,7 @@ describe("refund actions", () => {
   });
 
   it("loads refunds list", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession());
+    mockAuth();
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(
@@ -390,9 +357,7 @@ describe("refund actions", () => {
   });
 
   it("passes org_id to refunds and invoices queries for superadmin filtering", async () => {
-    vi.mocked(auth).mockResolvedValue(
-      mockSession({ user: { is_superuser: true } }),
-    );
+    mockAuth({ user: { is_superuser: true } });
 
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
       new Response(

--- a/src/lib/testops/__tests__/fetchers.test.ts
+++ b/src/lib/testops/__tests__/fetchers.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Session } from "next-auth";
 
 // Must mock auth and graphqlFetch before importing the module under test
 vi.mock("@/lib/auth", () => ({
@@ -14,17 +13,7 @@ import { fetchRiskMetrics, fetchTestOpsData, fetchCoverageMetrics } from "../fet
 import { SAMPLE_RISK_DATA } from "../sample-data";
 import { auth } from "@/lib/auth";
 import { graphqlFetch } from "@/lib/graphql/urqlClient";
-
-function mockSession(orgId?: string): Session {
-  return {
-    access_token: "test-token",
-    user: {
-      id: "user-1",
-      org_id: orgId,
-    } as Session["user"],
-    expires: new Date(Date.now() + 86400000).toISOString(),
-  };
-}
+import { mockAuth } from "@/test/mocks/auth";
 
 const emptyAnalytics = { timeseries: [], breakdowns: [] };
 
@@ -39,7 +28,7 @@ describe("fetchRiskMetrics", () => {
   });
 
   it("returns undefined metrics when API returns empty timeseries", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession("org-1"));
+    mockAuth({ user: { org_id: "org-1" } });
     vi.mocked(graphqlFetch).mockResolvedValue({ analytics: emptyAnalytics });
 
     const result = await fetchRiskMetrics({ timeseries: [], breakdowns: [] }, false);
@@ -68,7 +57,7 @@ describe("resolveOrgId via fetchTestOpsData", () => {
   });
 
   it("resolves orgId from session and passes it to graphqlFetch", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession("org-session-123"));
+    mockAuth({ user: { org_id: "org-session-123" } });
     vi.mocked(graphqlFetch).mockResolvedValue({ analytics: emptyAnalytics });
 
     await fetchTestOpsData({ timeseries: [], breakdowns: [] }, false);
@@ -80,7 +69,7 @@ describe("resolveOrgId via fetchTestOpsData", () => {
   });
 
   it("falls back to 'default-org' when session has no org_id", async () => {
-    vi.mocked(auth).mockResolvedValue(mockSession(undefined));
+    mockAuth({ user: { org_id: undefined } });
     vi.mocked(graphqlFetch).mockResolvedValue({ analytics: emptyAnalytics });
 
     await fetchCoverageMetrics({ timeseries: [], breakdowns: [] }, false);

--- a/src/test/mocks/auth.ts
+++ b/src/test/mocks/auth.ts
@@ -96,7 +96,7 @@ export function mockAuth(
   return resolved;
 }
 
-function isFullSession(value: Session | MockSessionOverrides): value is Session {
+function isFullSession(value: unknown): value is Session {
   return (
     typeof value === "object" &&
     value !== null &&

--- a/src/test/mocks/auth.ts
+++ b/src/test/mocks/auth.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared vitest helpers for mocking `@/lib/auth`'s `auth()` function.
+ *
+ * Usage
+ * -----
+ *
+ * Because `vi.mock()` calls are hoisted to the top of the file, you still need
+ * to register the mock inline at the top of your test file:
+ *
+ * ```ts
+ * import { vi } from "vitest";
+ *
+ * vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+ *
+ * import { mockAuth, makeMockSession, defaultMockSession } from "@/test/mocks/auth";
+ * import { functionUnderTest } from "../my-module";
+ *
+ * describe("functionUnderTest", () => {
+ *   beforeEach(() => {
+ *     vi.resetAllMocks();
+ *   });
+ *
+ *   it("handles authenticated user", async () => {
+ *     mockAuth();                                   // default session
+ *     // or: mockAuth({ user: { is_superuser: true } });
+ *     // or: mockAuth({ user: { org_id: "org-42" } });
+ *     // or: mockAuth(null);                        // unauthenticated
+ *     await functionUnderTest();
+ *   });
+ * });
+ * ```
+ *
+ * For situations where you need to construct a Session without registering it
+ * against the mock (for example, to pass it into a different code path), use
+ * `makeMockSession(overrides?)` directly.
+ */
+import { vi } from "vitest";
+import type { Session } from "next-auth";
+
+import { auth } from "@/lib/auth";
+
+export type MockSessionOverrides = {
+  access_token?: string;
+  expires?: string;
+  error?: string;
+  user?: Partial<Session["user"]>;
+};
+
+export const defaultMockSession: Session = Object.freeze({
+  access_token: "test-token",
+  user: Object.freeze({
+    id: "user-1",
+    org_id: "org-1",
+  }) as Session["user"],
+  expires: new Date(Date.now() + 86400000).toISOString(),
+}) as Session;
+
+export function makeMockSession(overrides: MockSessionOverrides = {}): Session {
+  const { user: userOverrides, ...rest } = overrides;
+  return {
+    access_token: defaultMockSession.access_token,
+    expires: defaultMockSession.expires,
+    ...rest,
+    user: {
+      ...defaultMockSession.user,
+      ...userOverrides,
+    },
+  };
+}
+
+/**
+ * Configure `vi.mocked(auth)` to resolve to a Session (or `null` for
+ * unauthenticated). Accepts either:
+ *   - `null`           → unauthenticated
+ *   - a full `Session` → used as-is
+ *   - overrides object → merged onto `defaultMockSession`
+ *   - `undefined`      → uses `defaultMockSession`
+ *
+ * Returns the resolved session (or `null`) for convenience.
+ *
+ * Requires `vi.mock("@/lib/auth", () => ({ auth: vi.fn() }))` to have been
+ * registered at the top of the test file.
+ */
+export function mockAuth(
+  sessionOrOverrides?: Session | null | MockSessionOverrides,
+): Session | null {
+  let resolved: Session | null;
+  if (sessionOrOverrides === null) {
+    resolved = null;
+  } else if (sessionOrOverrides && isFullSession(sessionOrOverrides)) {
+    resolved = sessionOrOverrides;
+  } else {
+    resolved = makeMockSession(sessionOrOverrides);
+  }
+  vi.mocked(auth).mockResolvedValue(resolved);
+  return resolved;
+}
+
+function isFullSession(value: Session | MockSessionOverrides): value is Session {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "expires" in value &&
+    typeof (value as Session).expires === "string" &&
+    "user" in value &&
+    typeof (value as Session).user === "object" &&
+    (value as Session).user !== null &&
+    "id" in (value as Session).user
+  );
+}


### PR DESCRIPTION
## Summary

Introduces `src/test/mocks/auth.ts` with a shared `mockAuth(session?)` helper and a typed `defaultMockSession` fixture, and migrates three existing test files to use it. No production code is modified — this is strictly test-infrastructure refactoring.

## Helper API

- `defaultMockSession` — typed `Session` fixture (`user-1` / `org-1`, `access_token: \"test-token\"`, expires +24h).
- `makeMockSession(overrides?)` — pure constructor, shallow-merges overrides onto the default, deep-merges `user`.
- `mockAuth(sessionOrOverrides?)` — wraps `vi.mocked(auth).mockResolvedValue(...)`. Accepts:
  - `undefined` → default session
  - `MockSessionOverrides` → merged onto default
  - a full `Session` → used as-is
  - `null` → unauthenticated

The helper requires tests to still call `vi.mock(\"@/lib/auth\", () => ({ auth: vi.fn() }))` at the top of the file (vitest hoisting rules mean this must stay inline).

## Files migrated

- `src/lib/billing/__tests__/actions.test.ts` — replaced inline `mockSession()` helper; now uses `mockAuth({ user: { ... } })` at every call site.
- `src/lib/admin/__tests__/server.test.ts` — replaced inline `mockSession()` helper and `vi.mocked(auth).mockResolvedValue(null)` with `mockAuth(null)`.
- `src/lib/testops/__tests__/fetchers.test.ts` — replaced inline `mockSession(orgId?)` helper.

No test logic or assertions changed — only the mock setup.

## Linear

- CHAOS-1237: https://linear.app/fullchaos/issue/CHAOS-1237

## Verification

```
npm run test:unit -- billing admin testops  ✓ (156 tests passing)
npm run typecheck                           ✓
npm run lint                                ✓ (no new warnings introduced)
```

## Waivers

SCREENSHOT-WAIVER: test-infrastructure-only PR; no rendered UI changes.

TEST-WAIVER: test-infrastructure-only PR; production src/ is unchanged. All src/ changes are test-file migrations and a new test helper under src/test/.