### PR TITLE
perf(reports): dynamic-import react-markdown (CHAOS-1224)

### DIFF
--- a/src/components/reports/MarkdownRenderer.tsx
+++ b/src/components/reports/MarkdownRenderer.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
+import dynamic from "next/dynamic";
 import remarkGfm from "remark-gfm";
+
+const ReactMarkdown = dynamic(() => import("react-markdown"), {
+  ssr: false,
+  loading: () => <div className="h-4 animate-pulse bg-muted/40 rounded" />,
+});
 
 function splitProvenance(md: string): {
   body: string;


### PR DESCRIPTION
## Summary

Wraps `ReactMarkdown` with `next/dynamic({ ssr: false })` inside `src/components/reports/MarkdownRenderer.tsx` so `react-markdown` is split into its own chunk instead of shipping in the main shared bundle. `remark-gfm` stays statically imported (it is small compared to react-markdown + its micromark dependency tree).

A tiny pulse placeholder (`h-4 animate-pulse bg-muted/40 rounded`) renders during the dynamic-import microtask.

**Linear:** [CHAOS-1224](https://linear.app/fullchaos/issue/CHAOS-1224)

## Why

`react-markdown` + `micromark` pulls ~50KB into the main shared chunk, but the only page that renders markdown is `/reports/[id]`. Dynamic-importing removes that cost from every other page's initial payload.

## Verification

- \`npm run typecheck\` — pass
- \`npm run lint\` — pass (0 errors, pre-existing warnings only)
- \`npm run test:unit\` — 649 tests passing (76 files)
- Manual: built production bundle, signed in, navigated to \`/reports/report-1\`; markdown body ("Summary", "Metrics", bullet list) renders identically. Screenshot attached below and to the Linear issue.

## Public API

No change. `MarkdownRenderer` still takes `{ content: string }` and exports the same component symbol.

## Screenshot

![markdown renders correctly post-dynamic-import](https://github.com/full-chaos/dev-health-web/raw/review/chaos-1224-dynamic-markdown/test-results/chaos-1224-markdown-after.png)

_Local file: \`test-results/chaos-1224-markdown-after.png\`_

TEST-WAIVER: mechanical dynamic-import wrapping; no logic change; component API unchanged