### PR TITLE
perf(sentry): lazy-load Replay on admin routes (CHAOS-1223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This will serve the app at [http://localhost:3000](http://localhost:3000) using 
 | `NEXT_PUBLIC_DEMO_MODE` | No | Show demo-only UI tabs and sample-data panels (e.g., Code Hotspots, Investment Expense in the Flow view). Backed by static data, not live APIs | `false` |
 | `DEMO_EXPORT` | No | Enable static export build mode | `false` |
 | `BASE_PATH` | No | Subpath hosting prefix (example: `/app`) | Empty (root) |
+| `NEXT_PUBLIC_SENTRY_DSN` | No | Sentry DSN for client + server + edge error reporting | Empty (Sentry still initializes but events go nowhere) |
+| `NEXT_PUBLIC_SENTRY_REPLAY_ROUTES` | No | Comma-separated path prefixes that activate Sentry Session Replay. Replay is lazy-loaded on-demand so it stays out of the initial client bundle on non-matching routes. Set to an empty string to disable Replay entirely | `/admin,/superadmin` |
 
 Deprecated (still read for compatibility):
 

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,10 +1,63 @@
 import * as Sentry from "@sentry/nextjs";
 
+/**
+ * Sentry Replay gating — rationale
+ * --------------------------------
+ * Session Replay is ~40KB gzipped and runs a MutationObserver over the entire
+ * DOM. Historically we initialized it unconditionally on every route, which
+ * meant 100% of clients paid the bundle + runtime cost even though production
+ * only samples 10% of sessions.
+ *
+ * We now lazy-load Replay via `Sentry.lazyLoadIntegration()` so the Replay SDK
+ * is fetched from the Sentry CDN on-demand and is NOT part of the initial
+ * client bundle for non-admin routes. Error reporting (Sentry.init) remains
+ * active on every route — gating Replay does not change the error-capture
+ * path, nor does it affect `replaysSessionSampleRate` /
+ * `replaysOnErrorSampleRate` (those only apply once Replay is loaded).
+ *
+ * Default gate: `/admin` and `/superadmin` — problem-finding value is highest
+ * on operator/administrator surfaces where session context is diagnostic.
+ *
+ * Override via `NEXT_PUBLIC_SENTRY_REPLAY_ROUTES` (comma-separated path
+ * prefixes). Examples:
+ *   NEXT_PUBLIC_SENTRY_REPLAY_ROUTES="/admin,/superadmin,/reports"
+ *   NEXT_PUBLIC_SENTRY_REPLAY_ROUTES=""       // disables Replay everywhere
+ */
+const DEFAULT_REPLAY_ROUTE_PREFIXES = ["/admin", "/superadmin"] as const;
+
+function getReplayRoutePrefixes(): readonly string[] {
+  const raw = process.env.NEXT_PUBLIC_SENTRY_REPLAY_ROUTES;
+  if (raw === undefined) return DEFAULT_REPLAY_ROUTE_PREFIXES;
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function shouldLoadReplay(): boolean {
+  if (typeof window === "undefined") return false;
+  const prefixes = getReplayRoutePrefixes();
+  if (prefixes.length === 0) return false;
+  const path = window.location.pathname;
+  return prefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
+}
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NODE_ENV,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
   replaysSessionSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
   replaysOnErrorSampleRate: 1.0,
-  integrations: [Sentry.replayIntegration()],
 });
+
+if (shouldLoadReplay()) {
+  void Sentry.lazyLoadIntegration("replayIntegration")
+    .then((replayIntegration) => {
+      if (replayIntegration) {
+        Sentry.addIntegration(replayIntegration());
+      }
+    })
+    .catch((error) => {
+      console.warn("[sentry] Failed to lazy-load Replay integration", error);
+    });
+}


### PR DESCRIPTION
## Summary

Sentry Session Replay was initialized unconditionally in `sentry.client.config.ts` on every page. Replay ships ~40KB gzipped and runs a `MutationObserver` over the whole DOM. Even though production only samples 10% of sessions, the full SDK was bundled into every client — 100% bundle cost for ~0.1× actual usage on most routes.

This PR switches Replay to `Sentry.lazyLoadIntegration("replayIntegration")`, gated to `/admin` and `/superadmin` routes (where session-replay context is diagnostically valuable). On every other route the Replay SDK is **not** in the initial client bundle; it is fetched on-demand from the Sentry CDN only when the gate matches.

### Gate configuration
- **Default:** `/admin,/superadmin`
- **Override:** `NEXT_PUBLIC_SENTRY_REPLAY_ROUTES` — comma-separated path prefixes. Set to `""` to disable Replay entirely. Rationale block is inline in `sentry.client.config.ts` and the env var is documented in `README.md`.

### Error reporting is unchanged
- `Sentry.init()` still runs on every route — the `dsn`, `environment`, `tracesSampleRate`, and both `replays*SampleRate` fields are identical to before. The two replay sample rates are no-ops until Replay is actually loaded; they are kept so that once Replay *is* lazy-loaded on an admin route, sampling behavior matches production today.
- `.catch()` on `lazyLoadIntegration` explicitly logs and swallows — a Replay CDN fetch failure must not take down the error-reporting path.
- `sentry.server.config.ts` and `sentry.edge.config.ts` untouched.

## Linear
CHAOS-1223 — https://linear.app/fullchaos/issue/CHAOS-1223

## Verification

```
npm run typecheck → ✓
npm run lint      → ✓ (no new warnings; my empty-catch warning fixed by logging the error)
npm run test:unit → ✓ 77 files / 683 tests
npm run build     → ✓ (webpack; turbopack panics on the symlinked node_modules in review worktrees — not a PR-scope issue)
```

```
grep -n "replayIntegration" sentry.client.config.ts
54:  void Sentry.lazyLoadIntegration("replayIntegration")
55:    .then((replayIntegration) => {
56:      if (replayIntegration) {
57:        Sentry.addIntegration(replayIntegration());
```
No unconditional `integrations: [Sentry.replayIntegration()]` entry remains.

## Bundle size deltas

Measured by building `--webpack` twice: once on `main` behavior (unconditional `replayIntegration()`), once with this PR's lazy-load gate. Comparing `.next/static/chunks/*.js` (uncompressed):

| Metric | BEFORE (unconditional) | AFTER (lazy-load) | Δ |
|---|---|---|---|
| Total chunk bytes | 3,973,169 B | 3,852,273 B | **−120,896 B (~118 KB)** |
| Chunk count | 48 | 47 | −1 |
| Replay SDK chunk `f835e634-0437e47e194f7925.js` | **present (118,408 B uncompressed)** | **absent** | removed |
| `eventBuffer` symbol in bundle | 1 chunk | 0 chunks | gone |
| `ReplayContainer`, `MutationBuffer` | 0 / 0 | 0 / 0 | (implementation string-obfuscated but confirmed absent) |

Equivalent to the ~40KB-gzipped saving called out in the ticket: the 118KB uncompressed chunk is the Replay SDK body that no longer ships to non-admin routes.

On `/admin` + `/superadmin` routes the SDK is fetched from the Sentry CDN at first render after `Sentry.init()` — no change to UX beyond the one-time async load, and Replay behavior (sampling, session capture) is identical to before.

The residual string matches on `replayIntegration` / `replayCanvasIntegration` that still appear in `57-*.js` and `main-app-*.js` are the `LAZY_LOADABLE_NAMES` constant from Sentry's own `lazyLoadIntegration` helper (just names used to map to CDN URLs) plus our call site. The Replay implementation itself is not bundled.

## TEST-WAIVER

TEST-WAIVER: infrastructure config change; no product logic modified; error reporting path unchanged. Sentry config files are not covered by unit or component tests today and this change is verified by bundle inspection (see Bundle size deltas above) plus build / typecheck / lint / unit-test gates.

SCREENSHOT-WAIVER: no rendered UI is altered — only how Sentry's client SDK is bootstrapped.