### PR TITLE
perf(charts): per-component ECharts registration (CHAOS-1222)

### DIFF
--- a/src/components/charts/ConfidenceBandChart.tsx
+++ b/src/components/charts/ConfidenceBandChart.tsx
@@ -3,8 +3,13 @@
 import type { CSSProperties } from "react";
 import { useMemo } from "react";
 
+import { LineChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([LineChart]);
 
 type ConfidenceBandChartProps = {
   backlogSize: number;

--- a/src/components/charts/DonutChart.tsx
+++ b/src/components/charts/DonutChart.tsx
@@ -2,8 +2,13 @@
 
 import type { CSSProperties } from "react";
 
+import { PieChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([PieChart]);
 
 type DonutChartProps = {
   data: Array<{ name: string; value: number }>;

--- a/src/components/charts/FlameDiagram.tsx
+++ b/src/components/charts/FlameDiagram.tsx
@@ -7,11 +7,15 @@ import type {
   CustomSeriesRenderItemAPI,
   CustomSeriesRenderItemParams,
 } from "echarts";
+import { CustomChart } from "echarts/charts";
 
 import type { FlameFrame } from "@/lib/types";
 
 import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([CustomChart]);
 
 const formatDuration = (start: string, end: string) => {
   const startTime = new Date(start).getTime();

--- a/src/components/charts/HeatmapChart.tsx
+++ b/src/components/charts/HeatmapChart.tsx
@@ -4,11 +4,15 @@ import type { CSSProperties } from "react";
 
 // Type-only import from full echarts package (erased at runtime — no bundle impact).
 import type { TooltipComponentFormatterCallbackParams } from "echarts";
+import { HeatmapChart as EChartsHeatmapChart } from "echarts/charts";
 
 import type { HeatmapResponse } from "@/lib/types";
 
 import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([EChartsHeatmapChart]);
 
 type HeatmapChartProps = {
   data: HeatmapResponse;

--- a/src/components/charts/HorizontalBarChart.tsx
+++ b/src/components/charts/HorizontalBarChart.tsx
@@ -3,9 +3,13 @@
 import type { CSSProperties } from "react";
 // Type-only import from full echarts package (erased at runtime — no bundle impact).
 import type { BarSeriesOption } from "echarts";
+import { BarChart } from "echarts/charts";
 
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([BarChart]);
 
 type HorizontalBarChartProps = {
   categories: string[];

--- a/src/components/charts/InvestmentMixSunburst.tsx
+++ b/src/components/charts/InvestmentMixSunburst.tsx
@@ -3,11 +3,16 @@
 import type { CSSProperties } from "react";
 import { useCallback, useMemo } from "react";
 
+import { SunburstChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
 import { buildTooltipHtml, calcPercent } from "@/lib/chartUtils";
 import { formatNumber } from "@/lib/formatters";
 import { titleCase, formatSubcategoryLabel } from "@/lib/investmentMix";
+
+echarts.use([SunburstChart]);
 
 const adjustHex = (hex: string, amount: number) => {
   const normalized = hex.replace("#", "");

--- a/src/components/charts/NestedPieChart2D.tsx
+++ b/src/components/charts/NestedPieChart2D.tsx
@@ -2,8 +2,13 @@
 
 import type { CSSProperties } from "react";
 
+import { PieChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([PieChart]);
 
 const adjustHex = (hex: string, amount: number) => {
   const normalized = hex.replace("#", "");

--- a/src/components/charts/NestedPieChart3D.tsx
+++ b/src/components/charts/NestedPieChart3D.tsx
@@ -2,8 +2,13 @@
 
 import type { CSSProperties } from "react";
 
+import { PieChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([PieChart]);
 
 const adjustHex = (hex: string, amount: number) => {
   const normalized = hex.replace("#", "");

--- a/src/components/charts/QuadrantChart.tsx
+++ b/src/components/charts/QuadrantChart.tsx
@@ -8,12 +8,16 @@ import type {
   MarkAreaComponentOption,
   TooltipComponentFormatterCallbackParams,
 } from "echarts";
+import { ScatterChart } from "echarts/charts";
 
 import type { ZoneOverlay } from "@/lib/quadrantZones";
 import type { QuadrantPoint, QuadrantResponse } from "@/lib/types";
 
 import { Chart } from "./Chart";
 import { type ChartTheme, useChartColors, useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([ScatterChart]);
 
 const formatValue = (value: number, unit: string) => {
   if (!Number.isFinite(value)) {

--- a/src/components/charts/SankeyChart.tsx
+++ b/src/components/charts/SankeyChart.tsx
@@ -2,9 +2,14 @@
 
 import { type CSSProperties, useCallback, useMemo } from "react";
 
+import { SankeyChart as EChartsSankeyChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
 import type { SankeyLink, SankeyNode } from "@/lib/types";
+
+echarts.use([EChartsSankeyChart]);
 
 type SankeyChartProps = {
   nodes: SankeyNode[];

--- a/src/components/charts/SparklineChart.tsx
+++ b/src/components/charts/SparklineChart.tsx
@@ -2,8 +2,13 @@
 
 import type { CSSProperties } from "react";
 
+import { LineChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([LineChart]);
 
 type SparklineChartProps = {
   data: number[];

--- a/src/components/charts/StackedAreaChart.tsx
+++ b/src/components/charts/StackedAreaChart.tsx
@@ -3,9 +3,14 @@
 import type { CSSProperties } from "react";
 import { useCallback, useMemo } from "react";
 
+import { LineChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
 import { calcPercent, createAreaGradient } from "@/lib/chartUtils";
+
+echarts.use([LineChart]);
 
 export type StackedAreaDataPoint = {
     date: string;

--- a/src/components/charts/StackedHorizontalBar.tsx
+++ b/src/components/charts/StackedHorizontalBar.tsx
@@ -3,9 +3,14 @@
 import type { CSSProperties } from "react";
 import { useMemo } from "react";
 
+import { BarChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
 import { formatNumber } from "@/lib/formatters";
+
+echarts.use([BarChart]);
 
 type StackedBarSegment = {
   name: string;

--- a/src/components/charts/SunburstChart.tsx
+++ b/src/components/charts/SunburstChart.tsx
@@ -3,9 +3,14 @@
 import type { CSSProperties } from "react";
 import { useCallback, useMemo } from "react";
 
+import { SunburstChart as EChartsSunburstChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
 import { buildTooltipHtml, calcPercent, lightenByDepth } from "@/lib/chartUtils";
+
+echarts.use([EChartsSunburstChart]);
 
 export type SunburstNode = {
     name: string;

--- a/src/components/charts/ThroughputHistogram.tsx
+++ b/src/components/charts/ThroughputHistogram.tsx
@@ -3,8 +3,13 @@
 import type { CSSProperties } from "react";
 import { useMemo } from "react";
 
+import { BarChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([BarChart]);
 
 type ThroughputHistogramProps = {
   throughputMean: number;

--- a/src/components/charts/TimeseriesChart.tsx
+++ b/src/components/charts/TimeseriesChart.tsx
@@ -2,8 +2,13 @@
 
 import type { CSSProperties } from "react";
 
+import { LineChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([LineChart]);
 
 type TimeseriesChartProps = {
   data: Array<{ day: string; value: number }>;

--- a/src/components/charts/TransitionHeatmapChart.tsx
+++ b/src/components/charts/TransitionHeatmapChart.tsx
@@ -3,9 +3,14 @@
 import type { CSSProperties } from "react";
 import { useCallback, useMemo } from "react";
 
+import { HeatmapChart } from "echarts/charts";
+
 import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
 import { calcPercent } from "@/lib/chartUtils";
+
+echarts.use([HeatmapChart]);
 
 export type TransitionData = {
     fromStatus: string;

--- a/src/components/charts/TreemapChart.tsx
+++ b/src/components/charts/TreemapChart.tsx
@@ -4,10 +4,14 @@ import type { CSSProperties } from "react";
 import { useCallback, useMemo } from "react";
 // Type-only import from full echarts package (erased at runtime — no bundle impact).
 import type { EChartsOption } from "echarts";
+import { TreemapChart as EChartsTreemapChart } from "echarts/charts";
 
 import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
 import { buildTooltipHtml, calcPercent, lightenByDepth } from "@/lib/chartUtils";
+
+echarts.use([EChartsTreemapChart]);
 
 export type TreemapNode = {
     name: string;

--- a/src/components/charts/VerticalBarChart.tsx
+++ b/src/components/charts/VerticalBarChart.tsx
@@ -3,9 +3,13 @@
 import type { CSSProperties } from "react";
 // Type-only import from full echarts package (erased at runtime — no bundle impact).
 import type { BarSeriesOption } from "echarts";
+import { BarChart } from "echarts/charts";
 
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
+
+echarts.use([BarChart]);
 
 type VerticalBarChartProps = {
   categories: string[];

--- a/src/components/charts/WorkGraphExplorer.tsx
+++ b/src/components/charts/WorkGraphExplorer.tsx
@@ -2,14 +2,18 @@
 
 import { type CSSProperties, useCallback, useMemo, useState } from "react";
 import type { EChartsOption } from "echarts";
+import { GraphChart } from "echarts/charts";
 
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
+import { echarts } from "@/lib/echartsInit";
 import type {
   WorkGraphEdge,
   WorkGraphNodeType,
   WorkGraphEdgeType,
 } from "@/lib/graphql/types";
+
+echarts.use([GraphChart]);
 
 type WorkGraphNode = {
   id: string;

--- a/src/lib/echartsInit.ts
+++ b/src/lib/echartsInit.ts
@@ -2,38 +2,26 @@
  * ECharts tree-shaking entry point.
  *
  * Import from this module instead of "echarts" to avoid bundling the full
- * ~1 MB ECharts library. Only the components actually used by this app are
- * registered here.
+ * ~1 MB ECharts library. Only the cross-cutting components needed by every
+ * chart are registered here.
  *
  * Usage:
- *   import * as echarts from "@/lib/echartsInit";
- *   // then use echarts.init(), echarts.use(), etc.
+ *   import { echarts } from "@/lib/echartsInit";
+ *   import { BarChart } from "echarts/charts";
+ *   echarts.use([BarChart]);
  *
- * Registered components cover all chart types used in this codebase:
- *   - Bar (HorizontalBarChart, VerticalBarChart, StackedHorizontalBar)
- *   - Line / Area (TimeseriesChart, StackedAreaChart, ConfidenceBandChart, SparklineChart)
- *   - Scatter (QuadrantChart)
- *   - Pie / Sunburst / Treemap (DonutChart, InvestmentMixSunburst, TreemapChart,
- *                               NestedPieChart2D, NestedPieChart3D, SunburstChart)
- *   - Sankey (SankeyChart)
- *   - Heatmap (HeatmapChart, TransitionHeatmapChart)
- *   - Graph (WorkGraphExplorer)
- *   - Custom (FlameDiagram, HierarchicalFlameGraph)
- *   - Axes, grid, tooltip, legend, data-zoom, mark-area, mark-line
+ * Chart-type registrations (BarChart, LineChart, SankeyChart, etc.) live in
+ * each individual chart component so pages that use only a subset of chart
+ * types ship only those types. `echarts/core`.use(...) is idempotent, so
+ * registering the same chart type in multiple components is safe.
+ *
+ * Registered here (cross-cutting only):
+ *   - Grid, Tooltip, Legend, DataZoom
+ *   - MarkArea, MarkLine, MarkPoint, VisualMap
+ *   - CanvasRenderer
  */
 
 import * as echarts from "echarts/core";
-
-import { BarChart } from "echarts/charts";
-import { LineChart } from "echarts/charts";
-import { ScatterChart } from "echarts/charts";
-import { PieChart } from "echarts/charts";
-import { SunburstChart } from "echarts/charts";
-import { TreemapChart } from "echarts/charts";
-import { SankeyChart } from "echarts/charts";
-import { HeatmapChart } from "echarts/charts";
-import { GraphChart } from "echarts/charts";
-import { CustomChart } from "echarts/charts";
 
 import {
   GridComponent,
@@ -48,20 +36,7 @@ import {
 
 import { CanvasRenderer } from "echarts/renderers";
 
-// Register all required components once at module load time
 echarts.use([
-  // Charts
-  BarChart,
-  LineChart,
-  ScatterChart,
-  PieChart,
-  SunburstChart,
-  TreemapChart,
-  SankeyChart,
-  HeatmapChart,
-  GraphChart,
-  CustomChart,
-  // Components
   GridComponent,
   TooltipComponent,
   LegendComponent,
@@ -70,10 +45,8 @@ echarts.use([
   MarkLineComponent,
   MarkPointComponent,
   VisualMapComponent,
-  // Renderer
   CanvasRenderer,
 ]);
 
-// Re-export the echarts core so callers get the pre-initialised instance
 export * from "echarts/core";
 export { echarts };


### PR DESCRIPTION
## Summary

Move 10 ECharts chart-type registrations from the global `src/lib/echartsInit.ts` into each individual chart component. Only cross-cutting components (Grid, Tooltip, Legend, DataZoom, MarkArea/Line/Point, VisualMap, CanvasRenderer) remain in the shared init.

`echarts/core`'s `.use(...)` is idempotent, so registering the same chart type in multiple components is safe. This enables webpack/Turbopack to tree-shake chart-type modules per-route — pages that use only a subset of chart types no longer pull in the full 10-type registration graph.

Refs [CHAOS-1222](https://linear.app/fullchaos/issue/CHAOS-1222).

## Changes

- `src/lib/echartsInit.ts` — removed 10 chart-type imports + registrations; now exports only cross-cutting components + renderer
- 20 chart components — each imports its own chart type from `echarts/charts` and calls `echarts.use([…])` at module top:
  - **Bar**: HorizontalBarChart, VerticalBarChart, StackedHorizontalBar, ThroughputHistogram
  - **Line**: TimeseriesChart, SparklineChart, ConfidenceBandChart, StackedAreaChart
  - **Scatter**: QuadrantChart
  - **Pie**: DonutChart, NestedPieChart2D, NestedPieChart3D
  - **Sunburst**: SunburstChart, InvestmentMixSunburst
  - **Treemap**: TreemapChart
  - **Sankey**: SankeyChart
  - **Heatmap**: HeatmapChart, TransitionHeatmapChart
  - **Graph**: WorkGraphExplorer
  - **Custom**: FlameDiagram

`HierarchicalFlameGraph.tsx` is pure HTML/CSS (no ECharts) so it is intentionally untouched.

## Verification

- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors, 5 pre-existing warnings unchanged)
- `npm run test:unit` ✓ (77 files / 683 tests pass)
- `npm run build` ✓ (webpack)
- Every chart on `/demo` renders identically — verified via Playwright screenshot (attached)

## Bundle delta

Measured against the same build tool (`next build --webpack`) before/after, with the workspace content otherwise identical.

| Metric | Before | After | Δ |
|---|---|---|---|
| Largest single chunk | 1,120,052 B (≈ 1.07 MB) | 653,348 B (≈ 638 KB) | **−466 KB (−41.7 %)** |
| Total `.next/static/chunks` | 3,973,074 B | 4,068,923 B | +95,849 B (+2.4 %) |

The largest chunk win is the headline: the previously-monolithic echarts-containing chunk has been split into smaller per-route chunks, so each route only pays for the chart types it actually uses. The tiny total-size increase reflects module-boundary overhead from the additional split points and is dominated by the per-route win on any individual page that does not use all 10 chart types (which is every page).

## Screenshot

![charts after](https://raw.githubusercontent.com/full-chaos/dev-health-web/review/chaos-1222-echarts-per-chart/test-results/chaos-1222-charts-after.png)

Also attached in the Linear issue.

TEST-WAIVER: mechanical per-component registration; chart rendering unchanged; existing chart tests (HeatmapChart.test.tsx, QuadrantChart.test.tsx, SankeyChart.test.tsx, TreemapChart.test.tsx) cover output and all pass.