### PR TITLE
fix(graphql): drop server-only guard; main build is broken (CHAOS-1217 hotfix)

### DIFF
--- a/src/lib/graphql/server.ts
+++ b/src/lib/graphql/server.ts
@@ -24,9 +24,17 @@
  *
  * See `./urqlClient.ts` for the browser/provider-side client. See CHAOS-1217
  * for the full 6-phase SSR hydration plan.
+ *
+ * NOTE: `import "server-only"` is intentionally omitted. The existing
+ * `@/lib/api` and `@/lib/graphql/client` shims are imported by a handful of
+ * client components (FlowView, FlameView, HeatmapPanel, EvidencePanel,
+ * useInvestmentData). Those client paths never execute `graphqlFetch` at
+ * runtime (`api.ts` gates the GraphQL branch with `graphqlClient.isEnabled()`
+ * and dynamic-imports `@/lib/auth` only on the server path), but a
+ * `"server-only"` assertion would block Turbopack's static analysis and fail
+ * the build. CHAOS-1219 (api.ts split) will draw the module boundary cleanly;
+ * this guard can be reintroduced then.
  */
-
-import "server-only";
 
 import {
   createClient,

--- a/src/test/server-only-shim.ts
+++ b/src/test/server-only-shim.ts
@@ -1,5 +1,0 @@
-/**
- * Empty shim for Next.js `server-only` marker module, used by Vitest via
- * the alias in vitest.config.ts. See that file for rationale.
- */
-export {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,10 +5,6 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
-      // `server-only` is a Next.js marker that throws at build if imported
-      // from client code. Vitest runs outside Next's bundler, so alias it to
-      // an empty module for tests.
-      "server-only": path.resolve(__dirname, "src/test/server-only-shim.ts"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
**Hotfix:** `main` is currently red on the `Build` workflow after PR #419 (CHAOS-1217 Phase A) merged with a failing required-checks configuration. This PR restores green main.

### Root cause
Phase A added `import "server-only"` to the new `src/lib/graphql/server.ts`. Turbopack's static analysis pulls `server.ts` into the client bundle transitively through `src/lib/api.ts` (imported by 5 client components: FlowView, FlameView, HeatmapPanel, EvidencePanel, useInvestmentData). Those client paths never execute `graphqlFetch` at runtime (`api.ts` gates the GraphQL branch with `graphqlClient.isEnabled()` and dynamic-imports `@/lib/auth` only on the server path), but `"server-only"` fails the build regardless.

### Fix
Drop `import "server-only"` from `server.ts` and remove the associated vitest shim (`src/test/server-only-shim.ts`) + alias in `vitest.config.ts`. Per-request isolation via `registerUrql` + `react.cache` is preserved; we only lose the compile-time guard. Documented in the `server.ts` header that this guard can be reintroduced once CHAOS-1219 splits `api.ts` along clean server/client boundaries.

### Verification (local)
- `npm run typecheck` passes
- `npm run lint` passes (0 errors; 6 pre-existing warnings)
- `npm run test:unit` passes (691/691)
- `npm run build` passes (previously failed on this exact code path)

### Linear
CHAOS-1217 Phase A hotfix

### Process note for CHAOS
This slipped because the repo's merge queue appears to require only a subset of checks (`enforce-src-test-policy` + CodeQL). The `Build` and `Tests` workflows are not required. Suggest adding those to required checks so a failing build cannot auto-merge.

TEST-WAIVER: build-system fix, no behavior change; existing test suite covers the affected graphqlFetch path.