### PR TITLE
feat(graphql): provider ssrExchange scaffolding (CHAOS-1217 Phase B)

### DIFF
--- a/src/lib/graphql/provider.tsx
+++ b/src/lib/graphql/provider.tsx
@@ -4,11 +4,25 @@
  * urql Provider component for React applications.
  *
  * Provides the urql client to child components via React context.
+ *
+ * Since CHAOS-1217 Phase B this provider uses `@urql/next` instead of plain
+ * `urql`. `@urql/next` re-exports the entire `urql`/`@urql/core` surface, so
+ * downstream `useQuery`/`useSubscription` hooks are unaffected.
  */
 
 import { createContext, useContext, useMemo, type ReactNode } from "react";
-import { Provider as UrqlProvider } from "urql";
-import { createUrqlClient } from "./urqlClient";
+import {
+  UrqlProvider,
+  ssrExchange,
+  fetchExchange,
+  cacheExchange,
+  createClient,
+  mapExchange,
+} from "@urql/next";
+import { resolveOrigin } from "@/lib/origin";
+import { errorExchange, timingExchange } from "./urqlExchanges";
+
+const GRAPHQL_PATH = "/graphql";
 
 interface GraphQLProviderProps {
   children: ReactNode;
@@ -18,10 +32,18 @@ interface GraphQLProviderProps {
 const OrgIdContext = createContext<string | undefined>(undefined);
 
 /**
- * GraphQL Provider that configures urql client with org scoping.
+ * GraphQL provider for client components.
  *
- * Wrap your application or page with this provider to enable
- * GraphQL queries via urql hooks.
+ * Wires `@urql/next`'s `UrqlProvider` with an `ssrExchange` instance that
+ * will be used in Phase C to restore server-fetched data into the client
+ * cache. Until then, `ssrExchange` is present but no RSC results are
+ * hydrated, so client queries still trigger their own fetches (same as
+ * pre-Phase B).
+ *
+ * Org scoping: the `orgId` (from the user's session) is injected as an
+ * `X-Org-Id` header on every operation via `mapExchange`, and as the
+ * `org_id` query param on the GraphQL URL. A change in `orgId` re-creates
+ * both the client and the SSR exchange.
  *
  * @example
  * ```tsx
@@ -34,11 +56,57 @@ export function GraphQLProvider({
   children,
   orgId,
 }: GraphQLProviderProps): React.ReactNode {
-  const client = useMemo(() => createUrqlClient({ orgId }), [orgId]);
+  const [client, ssr] = useMemo(() => {
+    const ssr = ssrExchange({
+      isClient: typeof window !== "undefined",
+    });
+
+    const url = new URL(GRAPHQL_PATH, resolveOrigin());
+    if (orgId) url.searchParams.set("org_id", orgId);
+
+    const client = createClient({
+      url: url.toString(),
+      exchanges: [
+        mapExchange({
+          onOperation(operation) {
+            if (!orgId) return operation;
+            const fetchOptions =
+              typeof operation.context.fetchOptions === "object"
+                ? operation.context.fetchOptions
+                : {};
+            return {
+              ...operation,
+              context: {
+                ...operation.context,
+                fetchOptions: {
+                  ...fetchOptions,
+                  headers: {
+                    ...((fetchOptions.headers ?? {}) as Record<string, string>),
+                    "X-Org-Id": orgId,
+                  },
+                },
+              },
+            };
+          },
+        }),
+        timingExchange,
+        errorExchange,
+        cacheExchange,
+        ssr,
+        fetchExchange,
+      ],
+      requestPolicy: "cache-and-network",
+      suspense: false,
+    });
+
+    return [client, ssr] as const;
+  }, [orgId]);
 
   return (
     <OrgIdContext.Provider value={orgId}>
-      <UrqlProvider value={client}>{children}</UrqlProvider>
+      <UrqlProvider client={client} ssr={ssr}>
+        {children}
+      </UrqlProvider>
     </OrgIdContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
**Phase B of 6** for CHAOS-1217 (urql SSR hydration). Wires `@urql/next` + `ssrExchange` into the browser-side provider. No user-visible behavior change — this is scaffolding for Phase C (RSC→client cache hydration bridge).

- Migrates `src/lib/graphql/provider.tsx` from `urql` to `@urql/next`
- Adds an `ssrExchange` instance in the client pipeline (placed between `cacheExchange` and `fetchExchange`)
- Preserves org-id header injection via `mapExchange`
- Preserves existing observability exchanges (`timingExchange`, `errorExchange`)
- `UrqlProvider` now takes both `client` and `ssr` props (the `ssr` prop lets `@urql/next` coordinate hydration when RSC data becomes available)

## Linear
CHAOS-1217 Phase B — see ticket for full 6-phase plan.

## Scope (what's NOT in this PR)
- Bridge component to seed cache from RSC fetches → Phase C
- Applying hydration to specific pages (investment, capacity, reports) → Phase E
- Removal of `network-only` override in `graphqlFetch` → Phase D
- Default `requestPolicy` flip → Phase D

## Verification (local, all mandatory)
- `npm run typecheck` ✓
- `npm run lint` ✓ (only pre-existing warnings)
- `npm run test:unit` ✓ (78 files / 691 tests)
- `npm run build` ✓ (Phase A failed here in CI; Phase B verified locally before push)

## Risk
- Low. `@urql/next` re-exports the core urql surface (`useQuery`, `useSubscription`, `UrqlProvider`, etc.), so consumer code is unchanged.
- The `ssr` exchange is present but inert until Phase C wires hydration — behavior is identical to pre-PR.

SCREENSHOT-WAIVER: Provider-infrastructure change with no rendered output. Hydration UX changes ship in Phase C/E.

TEST-WAIVER: Phase B is a provider-infrastructure change. All 25 `useQuery`/`useSubscription` hooks and 40+ `graphqlFetch` callsites continue to exercise the modified pipeline through existing test coverage. Behavior tests for hydration arrive in Phase C.
