### PR TITLE
chore(ci): require Build + Tests status checks on main (CHAOS-1275)

### DIFF
--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -1,0 +1,4 @@
+# Required status checks
+
+Updated GitHub ruleset on 2026-04-16 to require `enforce-src-test-policy`, `Analyze (actions)`, `Analyze (javascript-typescript)`, `Build Static Assets`, and `test`.
+Rule: https://github.com/full-chaos/dev-health-web/rules/11469284


### PR DESCRIPTION
## Summary
Updated the repository ruleset for `main` so the merge queue requires the build/test checks that were previously allowed to pass non-blocking.

## Required checks
Old required checks:
- `enforce-src-test-policy`
- `Analyze (actions)`
- `Analyze (javascript-typescript)`

New required checks:
- `enforce-src-test-policy`
- `Analyze (actions)`
- `Analyze (javascript-typescript)`
- `Build Static Assets`
- `test`

## Evidence
- Ruleset: https://github.com/full-chaos/dev-health-web/rules/11469284
- API verification: `gh api repos/full-chaos/dev-health-web/rulesets/11469284 --jq '{id,name,rules:(.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks),updated_at:.updated_at,html:(._links.html.href)}'`

SCREENSHOT-WAIVER: CI/infra change only; no UI is affected.
TEST-WAIVER: branch-protection/ruleset change only; no application code or workflow logic changed.