### PR TITLE
feat(graphql): default cache-first requestPolicy with per-hook opt-in for freshness (CHAOS-1276 Phase D)

### DIFF
--- a/docs/graphql-client.md
+++ b/docs/graphql-client.md
@@ -37,6 +37,22 @@ GraphQL is enabled by default. To disable:
 NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS=false
 ```
 
+## Request policy defaults
+
+The browser `GraphQLProvider` now defaults urql queries to `requestPolicy: "cache-first"`.
+
+- On hydrated pages, the server seeds the `ssrExchange` before client hooks mount, so the first client render can resolve from cache without an immediate duplicate network request.
+- On non-hydrated pages, `cache-first` still fetches on the first cache miss.
+- Hooks that must refresh eagerly on mount (for example security or other invalidation-sensitive views) should opt in per-query with `requestPolicy: "cache-and-network"`.
+
+```tsx
+const [result] = useQuery({
+  query: SECURITY_OVERVIEW_QUERY,
+  variables: { orgId, filters },
+  requestPolicy: "cache-and-network",
+});
+```
+
 ## Hooks
 
 ### useAnalytics

--- a/src/lib/graphql/__tests__/provider.test.ts
+++ b/src/lib/graphql/__tests__/provider.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SSRData, SSRExchange } from "@urql/core";
+import { createGraphQLClientOptions } from "../providerClient";
+
+vi.mock("@/lib/origin", () => ({
+  resolveOrigin: () => "https://dev-health.test",
+}));
+
+function makeSsrExchange(): SSRExchange {
+  return {
+    restoreData: vi.fn(),
+    extractData: vi.fn(() => ({}) as SSRData),
+  } as unknown as SSRExchange;
+}
+
+describe("createGraphQLClientOptions", () => {
+  it("defaults the browser client to cache-first", () => {
+    const options = createGraphQLClientOptions({
+      orgId: "acme",
+      ssr: makeSsrExchange(),
+    });
+
+    expect(options.requestPolicy).toBe("cache-first");
+    expect(options.url).toBe("https://dev-health.test/graphql?org_id=acme");
+  });
+});

--- a/src/lib/graphql/hooks/useSecurity.ts
+++ b/src/lib/graphql/hooks/useSecurity.ts
@@ -51,6 +51,7 @@ export function useSecurityOverview(filter: SecurityFilter): UseSecurityOverview
     query: SECURITY_OVERVIEW_QUERY,
     variables: { orgId: orgId ?? "", filters },
     pause: !orgId,
+    requestPolicy: "cache-and-network",
   });
 
   return {
@@ -98,6 +99,7 @@ export function useSecurityAlerts(
     query: SECURITY_ALERTS_QUERY,
     variables: { orgId: orgId ?? "", filters, pagination: paginationInput },
     pause: !orgId,
+    requestPolicy: "cache-and-network",
   });
 
   // Merge new edges into accumulated list when data changes

--- a/src/lib/graphql/provider.tsx
+++ b/src/lib/graphql/provider.tsx
@@ -14,16 +14,10 @@ import { createContext, useContext, useMemo, type ReactNode } from "react";
 import {
   UrqlProvider,
   ssrExchange,
-  fetchExchange,
-  cacheExchange,
   createClient,
-  mapExchange,
 } from "@urql/next";
 import type { SSRExchange } from "@urql/core";
-import { resolveOrigin } from "@/lib/origin";
-import { errorExchange, timingExchange } from "./urqlExchanges";
-
-const GRAPHQL_PATH = "/graphql";
+import { createGraphQLClientOptions } from "./providerClient";
 
 interface GraphQLProviderProps {
   children: ReactNode;
@@ -69,43 +63,7 @@ export function GraphQLProvider({
       isClient: typeof window !== "undefined",
     });
 
-    const url = new URL(GRAPHQL_PATH, resolveOrigin());
-    if (orgId) url.searchParams.set("org_id", orgId);
-
-    const client = createClient({
-      url: url.toString(),
-      exchanges: [
-        mapExchange({
-          onOperation(operation) {
-            if (!orgId) return operation;
-            const fetchOptions =
-              typeof operation.context.fetchOptions === "object"
-                ? operation.context.fetchOptions
-                : {};
-            return {
-              ...operation,
-              context: {
-                ...operation.context,
-                fetchOptions: {
-                  ...fetchOptions,
-                  headers: {
-                    ...((fetchOptions.headers ?? {}) as Record<string, string>),
-                    "X-Org-Id": orgId,
-                  },
-                },
-              },
-            };
-          },
-        }),
-        timingExchange,
-        errorExchange,
-        cacheExchange,
-        ssr,
-        fetchExchange,
-      ],
-      requestPolicy: "cache-and-network",
-      suspense: false,
-    });
+    const client = createClient(createGraphQLClientOptions({ orgId, ssr }));
 
     return [client, ssr] as const;
   }, [orgId]);

--- a/src/lib/graphql/providerClient.ts
+++ b/src/lib/graphql/providerClient.ts
@@ -1,0 +1,58 @@
+import {
+  fetchExchange,
+  cacheExchange,
+  mapExchange,
+  type SSRExchange,
+} from "@urql/core";
+import { resolveOrigin } from "@/lib/origin";
+import { errorExchange, timingExchange } from "./urqlExchanges";
+
+const GRAPHQL_PATH = "/graphql";
+
+export interface GraphQLClientOptionsArgs {
+  orgId?: string;
+  ssr: SSRExchange;
+}
+
+export function createGraphQLClientOptions({
+  orgId,
+  ssr,
+}: GraphQLClientOptionsArgs) {
+  const url = new URL(GRAPHQL_PATH, resolveOrigin());
+  if (orgId) url.searchParams.set("org_id", orgId);
+
+  return {
+    url: url.toString(),
+    exchanges: [
+      mapExchange({
+        onOperation(operation) {
+          if (!orgId) return operation;
+          const fetchOptions =
+            typeof operation.context.fetchOptions === "object"
+              ? operation.context.fetchOptions
+              : {};
+          return {
+            ...operation,
+            context: {
+              ...operation.context,
+              fetchOptions: {
+                ...fetchOptions,
+                headers: {
+                  ...((fetchOptions.headers ?? {}) as Record<string, string>),
+                  "X-Org-Id": orgId,
+                },
+              },
+            },
+          };
+        },
+      }),
+      timingExchange,
+      errorExchange,
+      cacheExchange,
+      ssr,
+      fetchExchange,
+    ],
+    requestPolicy: "cache-first" as const,
+    suspense: false,
+  };
+}


### PR DESCRIPTION
## Summary
- flip the browser urql provider default requestPolicy to `cache-first` so SSR-hydrated pages reuse seeded `ssrExchange` data instead of immediately re-fetching on mount
- keep freshness opt-in where it matters by marking security overview + alerts hooks as `cache-and-network`, and document the per-hook override pattern
- add a unit test for the extracted provider client options factory so the default policy stays locked to `cache-first`

## Decision matrix
| Hook name | Query | New policy | Rationale |
| --- | --- | --- | --- |
| `useAnalytics` | `INVESTMENT_BREAKDOWN_QUERY` | `cache-first` | Aggregate analytics tolerate cached reuse and can be manually refetched when filters change. |
| `useCapacityForecast` | `CAPACITY_FORECAST_QUERY` | `cache-first` | Forecast output is parameterized, not live-streamed, and should avoid duplicate hydration fetches. |
| `useCatalog` | `CATALOG_VALUES_QUERY` | `cache-first` | Catalog metadata changes infrequently and benefits from cache reuse. |
| `useDimensionValues` | `CATALOG_VALUES_QUERY` | `cache-first` | Dimension option lists are stable enough for cache reuse and fetch on miss. |
| `useInvestmentMix` | `INVESTMENT_BREAKDOWN_QUERY` | `cache-first` | `/work` hydration now seeds this result server-side; cache-first avoids the Phase D duplicate mount request. |
| `useInvestmentFlow` | `INVESTMENT_FULL_QUERY` | `cache-first` | Flow analytics are filter-driven aggregates, not invalidation-sensitive live state. |
| `useInvestmentRepoTeamFlow` | `INVESTMENT_FULL_QUERY` | `cache-first` | Same aggregate flow use case as above; prioritize hydrated cache hits. |
| `useSecurityOverview` | `SECURITY_OVERVIEW_QUERY` | `cache-and-network` | Security posture summaries should refresh on mount because alert counts/state can change between visits. |
| `useSecurityAlerts` | `SECURITY_ALERTS_QUERY` | `cache-and-network` | Alerts are invalidation-sensitive triage data, so mount should reuse cache but also refresh in the background. |
| `useWorkGraphEdges` | `WORK_GRAPH_EDGES_QUERY` | `cache-first` | Graph edge exploration is filter-scoped and can tolerate cached re-subscription behavior. |

## Verification
- `npm run typecheck`
- `npm run lint` *(passes with the existing 6 warnings only; no new warnings introduced)*
- `npm run test:unit`

## Risk assessment
- Main behavioral risk is stale client data after remounts on non-hydrated pages; this is mitigated by explicit `cache-and-network` opt-in for the security hooks that are most freshness-sensitive.
- Provider exchange ordering is unchanged, including `ssrExchange` placement.
- Server-side `getServerClient` remains `cache-first` and was left untouched.

## Rollback
1. Revert this PR.
2. If needed, restore the provider default to `cache-and-network` in `src/lib/graphql/provider.tsx`.
3. Remove the per-hook security overrides if the global default is restored.

SCREENSHOT-WAIVER: No visual change; caching behavior is invisible in static screenshots.