### PR TITLE
perf(capacity): parallelize data fetches to eliminate waterfall (CHAOS-1221)

### DIFF
--- a/src/app/(app)/capacity/page.tsx
+++ b/src/app/(app)/capacity/page.tsx
@@ -17,20 +17,26 @@ type CapacityPageProps = {
 };
 
 export default async function CapacityPage({ searchParams }: CapacityPageProps) {
-  // Run health check and org fetch in parallel to eliminate the waterfall.
-  const [health, orgResult] = await Promise.all([
+  // Run health check, org fetch, and entitlements fetch as concurrently as possible.
+  const orgPromise = fetchOrNull(getCurrentOrg(), "capacity/org");
+  const entitlementsPromise = orgPromise.then((orgResult) => {
+    const orgId = orgResult?.data?.id;
+
+    return orgId
+      ? fetchOrNull(getOrgEntitlements(orgId), "capacity/entitlements")
+      : null;
+  });
+
+  const [health, , entitlements] = await Promise.all([
     checkApiHealth(),
-    fetchOrNull(getCurrentOrg(), "capacity/org"),
+    orgPromise,
+    entitlementsPromise,
   ]);
 
   if (!health.ok) {
     return <ServiceUnavailable />;
   }
 
-  const org = orgResult?.data;
-  const entitlements = org?.id
-    ? await fetchOrNull(getOrgEntitlements(org.id), "capacity/entitlements")
-    : null;
   const features = entitlements?.data?.features ?? {};
 
   const params = (await searchParams) ?? {};


### PR DESCRIPTION
## Summary
- Start capacity entitlements fetching as soon as the org lookup resolves, instead of waiting for the health check to finish first.
- Keeps the same data shape and rendering; only the await ordering changes.

## Before
1. `checkApiHealth()` and `getCurrentOrg()` ran together.
2. `getOrgEntitlements(org.id)` was awaited only after both had finished.

## After
```ts
const orgPromise = fetchOrNull(getCurrentOrg(), "capacity/org");
const entitlementsPromise = orgPromise.then((orgResult) => {
  const orgId = orgResult?.data?.id;
  return orgId
    ? fetchOrNull(getOrgEntitlements(orgId), "capacity/entitlements")
    : null;
});

const [health, , entitlements] = await Promise.all([
  checkApiHealth(),
  orgPromise,
  entitlementsPromise,
]);
```

## Timing rationale
This removes the health-check dependency from the entitlements path, so the page no longer waits for an unnecessary serial step. The total latency becomes bounded by the slowest overlapping path rather than stacking the health-check wait in front of entitlements.

SCREENSHOT-WAIVER: No visual change — perf-only refactor that reorders awaits to parallel.
TEST-WAIVER: Perf-only refactor, no new code paths. Existing test coverage for the /capacity page is adequate.