### PR TITLE
feat(graphql): extend SSR hydration bridge to /capacity and /reports (CHAOS-1276 Phase E)

### DIFF
--- a/src/app/(app)/capacity/page.tsx
+++ b/src/app/(app)/capacity/page.tsx
@@ -10,6 +10,9 @@ import { getCurrentOrg, getOrgEntitlements } from "@/lib/admin/server";
 import { fetchOrNull } from "@/lib/fetchOrNull";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
+import { graphqlClient } from "@/lib/graphql";
+import { getCapacityForecastForHydration } from "@/lib/graphql/capacityHydration";
+import { HydrateUrqlResults } from "@/lib/graphql/HydrateUrqlResults";
 import { ContextStrip } from "@/components/navigation/ContextStrip";
 
 type CapacityPageProps = {
@@ -49,6 +52,23 @@ export default async function CapacityPage({ searchParams }: CapacityPageProps) 
   const filters = encodedFilter
     ? decodeFilter(encodedFilter)
     : filterFromQueryParams(params);
+
+  const graphqlEnabled = graphqlClient.isEnabled();
+  let hydrationOrgId: string | undefined;
+  if (graphqlEnabled) {
+    const { auth } = await import("@/lib/auth");
+    const session = await auth();
+    hydrationOrgId = session?.user?.org_id as string | undefined;
+  }
+
+  const capacityResult = graphqlEnabled && hydrationOrgId
+    ? await fetchOrNull(
+        getCapacityForecastForHydration(filters, hydrationOrgId),
+        "capacity/forecast-hydration"
+      )
+    : null;
+
+  const capacityHydrationPayload = capacityResult?.hydrationPayload ?? null;
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -100,7 +120,8 @@ export default async function CapacityPage({ searchParams }: CapacityPageProps) 
 
             <ContextStrip filters={filters} origin={activeOrigin} />
 
-            <CapacityView filters={filters} />
+            <HydrateUrqlResults payload={capacityHydrationPayload} />
+            <CapacityView filters={filters} orgId={hydrationOrgId} />
           </UpgradeGate>
         </main>
       </div>

--- a/src/lib/graphql/__tests__/capacityHydration.test.ts
+++ b/src/lib/graphql/__tests__/capacityHydration.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { MetricFilter } from "@/lib/filters/types";
+import { buildCapacityForecastVariables } from "../capacityHydration";
+
+const baseFilters = (overrides: Partial<MetricFilter> = {}): MetricFilter => ({
+  time: { range_days: 30, compare_days: 30 },
+  scope: { level: "org", ids: ["acme"] },
+  who: {},
+  what: {},
+  why: {},
+  how: {},
+  ...overrides,
+});
+
+describe("buildCapacityForecastVariables", () => {
+  it("uses the selected team id when filters are scoped to a team", () => {
+    const vars = buildCapacityForecastVariables(
+      baseFilters({
+        time: { range_days: 60, compare_days: 30 },
+        scope: { level: "team", ids: ["team-42"] },
+      }),
+      "org-1"
+    );
+
+    expect(vars).toEqual({
+      orgId: "org-1",
+      input: {
+        teamId: "team-42",
+        historyDays: 60,
+      },
+    });
+  });
+
+  it("omits teamId for non-team scopes while preserving historyDays", () => {
+    const vars = buildCapacityForecastVariables(
+      baseFilters({
+        time: { range_days: 45, compare_days: 30 },
+        scope: { level: "org", ids: ["acme"] },
+      }),
+      "org-1"
+    );
+
+    expect(vars.orgId).toBe("org-1");
+    expect(vars.input.historyDays).toBe(45);
+    expect(vars.input.teamId).toBeUndefined();
+  });
+
+  it("produces a stable shape suitable as an urql cache key", () => {
+    const vars1 = buildCapacityForecastVariables(
+      baseFilters({
+        time: { range_days: 90, compare_days: 30 },
+        scope: { level: "team", ids: ["team-a"] },
+      }),
+      "org-1"
+    );
+    const vars2 = buildCapacityForecastVariables(
+      baseFilters({
+        time: { range_days: 90, compare_days: 30 },
+        scope: { level: "team", ids: ["team-a"] },
+      }),
+      "org-1"
+    );
+
+    expect(JSON.stringify(vars1)).toBe(JSON.stringify(vars2));
+  });
+});
+
+describe("buildCapacityForecastVariables parity with useCapacityForecast", () => {
+  it("emits the exact shape that useCapacityForecast constructs (see hooks/useCapacityForecast.ts:52-58)", () => {
+    const filters = baseFilters({
+      time: { range_days: 30, compare_days: 30 },
+      scope: { level: "team", ids: ["team-a"] },
+    });
+
+    const vars = buildCapacityForecastVariables(filters, "org-1");
+
+    const expected = {
+      orgId: "org-1",
+      input: {
+        teamId: "team-a",
+        historyDays: 30,
+      },
+    };
+
+    expect(vars).toEqual(expected);
+  });
+});

--- a/src/lib/graphql/capacityHydration.ts
+++ b/src/lib/graphql/capacityHydration.ts
@@ -1,0 +1,68 @@
+/**
+ * RSC → client hydration fetchers for the Capacity view (CHAOS-1276 Phase E).
+ *
+ * Mirrors the variable-building logic of `useCapacityForecast` in
+ * `./hooks/useCapacityForecast.ts` so the server-issued urql operation has the
+ * same cache key as the client-issued one. Any drift here silently breaks
+ * hydration — keep the two in sync.
+ */
+
+import type { SSRData } from "@urql/core";
+import type { MetricFilter } from "@/lib/filters/types";
+import { CAPACITY_FORECAST_QUERY } from "./queries";
+import { graphqlFetchForHydration } from "./server";
+import type {
+  CapacityForecast,
+  CapacityForecastInput,
+  CapacityForecastQueryResponse,
+} from "./types";
+
+/**
+ * Build the exact variables used by `useCapacityForecast`'s client-side query.
+ *
+ * Exported so tests can assert parity against the client hook without
+ * reimplementing the shape; keep the two in sync.
+ */
+export function buildCapacityForecastVariables(
+  filters: MetricFilter,
+  orgId: string
+): { orgId: string; input: CapacityForecastInput } {
+  const teamId =
+    filters.scope.level === "team" && filters.scope.ids.length > 0
+      ? filters.scope.ids[0]
+      : undefined;
+
+  const historyDays = filters.time.range_days ?? 90;
+
+  return {
+    orgId,
+    input: {
+      teamId,
+      historyDays,
+    },
+  };
+}
+
+/**
+ * Server-side capacity forecast fetch that returns both the GraphQL response
+ * data and the urql `SSRData` payload keyed to the client hook's cache entry.
+ * Pair with `<HydrateUrqlResults>` on a client boundary to eliminate the
+ * server → client double-fetch.
+ */
+export async function getCapacityForecastForHydration(
+  filters: MetricFilter,
+  orgId: string
+): Promise<{ data: CapacityForecast | null; hydrationPayload: SSRData }> {
+  const variables = buildCapacityForecastVariables(filters, orgId);
+  const { data, hydrationPayload } =
+    await graphqlFetchForHydration<CapacityForecastQueryResponse>(
+      CAPACITY_FORECAST_QUERY,
+      variables,
+      { orgId }
+    );
+
+  return {
+    data: data.capacityForecast,
+    hydrationPayload,
+  };
+}


### PR DESCRIPTION
## Summary
- hydrate the `/capacity` page's `CapacityForecast` urql query from the server so `CapacityView` resolves from the SSR cache on first client render
- add parity tests for `buildCapacityForecastVariables()` so the server helper stays locked to `useCapacityForecast` variable shape
- skip `/reports` hydration because the list page is server-rendered only and `/reports/[id]` is a client-only fetch flow without an urql `useQuery` double-fetch to bridge

## Hydration status
- Hydrated: `/capacity` via `buildCapacityForecastVariables()` + `getCapacityForecastForHydration()` + `<HydrateUrqlResults>`
- Skipped: `/reports` list — RSC-only `fetchSavedReports`, no client `useQuery`
- Skipped: `/reports/[id]` — client-only fetches via `fetchSavedReport`/`fetchReportRuns` in `useEffect`, not an RSC + urql double-fetch pair

## Variable parity
- `buildCapacityForecastVariables(filters, orgId)` mirrors `useCapacityForecast` exactly: `{ orgId, input: { teamId, historyDays } }`
- parity is locked by `src/lib/graphql/__tests__/capacityHydration.test.ts`

## Verification
- `npm run typecheck`
- `npm run lint` (passes with pre-existing warnings in admin billing/auth/graphql server files)
- `npm run test:unit`

SCREENSHOT-WAIVER: GraphQL SSR hydration/cache bridge only; no rendered UI change.