### PR TITLE
refactor(filters): split FilterBarClient.tsx into focused section components (CHAOS-1226)

### DIFF
--- a/src/components/filters/FilterBar.tsx
+++ b/src/components/filters/FilterBar.tsx
@@ -4,141 +4,16 @@
  * This server component resolves static configuration (visibility flags and
  * scope lock) based on the `view` and `tab` props, then passes the computed
  * values to the interactive FilterBarClient component.
- *
- * Benefits over a pure client component:
- *  - Visibility and scopeLock logic runs once on the server; the client
- *    component receives plain boolean props instead of re-running JS logic.
- *  - No JavaScript needed for config resolution on the client.
  */
 
 import { Suspense } from "react";
 import { FilterBarClient } from "./FilterBarClient";
-import type { FilterBarClientProps } from "./FilterBarClient";
-
-type FilterBarView =
-  | "people"
-  | "home"
-  | "metrics"
-  | "work"
-  | "investment"
-  | "code"
-  | "quality"
-  | "opportunities"
-  | "explore"
-  | "testops"
-  | "security"
-  | "feature-flags";
-
-type FilterVisibility = {
-  scope?: boolean;
-  repo?: boolean;
-  developer?: boolean;
-  workType?: boolean;
-  flowStage?: boolean;
-  date?: boolean;
-};
-
-const DEFAULT_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: true,
-  developer: true,
-  workType: true,
-  flowStage: false,
-  date: true,
-};
-
-const METRICS_DEFAULT_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: true,
-  developer: false,
-  workType: false,
-  flowStage: false,
-  date: true,
-};
-
-const METRICS_FLOW_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: true,
-  developer: true,
-  workType: false,
-  flowStage: true,
-  date: true,
-};
-
-const WORK_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: false,
-  developer: false,
-  workType: true,
-  flowStage: false,
-  date: true,
-};
-
-const PEOPLE_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: false,
-  developer: true,
-  workType: false,
-  flowStage: false,
-  date: true,
-};
-
-const CODE_VISIBILITY: FilterVisibility = {
-  scope: false,
-  repo: true,
-  developer: true,
-  workType: false,
-  flowStage: false,
-  date: true,
-};
-
-const EXPLORE_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: true,
-  developer: true,
-  workType: true,
-  flowStage: true,
-  date: true,
-};
-
-function resolveVisibility(view?: FilterBarView, tab?: string): FilterVisibility {
-  if (view === "metrics") {
-    return tab === "flow" ? METRICS_FLOW_VISIBILITY : METRICS_DEFAULT_VISIBILITY;
-  }
-  if (view === "work" || view === "investment") return WORK_VISIBILITY;
-  if (view === "people") return PEOPLE_VISIBILITY;
-  if (view === "code") return CODE_VISIBILITY;
-  if (view === "quality" || view === "testops") return METRICS_DEFAULT_VISIBILITY;
-  if (view === "opportunities") return WORK_VISIBILITY;
-  if (view === "explore") return EXPLORE_VISIBILITY;
-  if (view === "security") {
-    // Security uses its own URL-based filter state (SecurityFilter / encodeSecurityFilter).
-    // Hide all MetricFilter chips so the legacy bar renders as an empty shell on this view.
-    return {
-      scope: false,
-      repo: false,
-      developer: false,
-      workType: false,
-      flowStage: false,
-      date: false,
-    };
-  }
-  return DEFAULT_VISIBILITY;
-}
-
-function resolveScopeLock(view?: FilterBarView): "team" | null {
-  const lockedViews: FilterBarView[] = [
-    "metrics",
-    "quality",
-    "testops",
-    "work",
-    "investment",
-    "opportunities",
-    "home",
-    "people",
-  ];
-  return view && lockedViews.includes(view) ? "team" : null;
-}
+import {
+  type FilterBarClientProps,
+  type FilterBarView,
+  resolveScopeLock,
+  resolveVisibility,
+} from "./filterBarConfig";
 
 type FilterBarProps = {
   condensed?: boolean;
@@ -146,12 +21,6 @@ type FilterBarProps = {
   tab?: string;
 };
 
-/**
- * RSC wrapper — computes config on the server and passes to client.
- *
- * FilterBarClient is wrapped in Suspense because it calls useSearchParams()
- * which requires a Suspense boundary in Next.js 13+.
- */
 export function FilterBar({ condensed, view, tab }: FilterBarProps) {
   const resolvedVisibility = resolveVisibility(view, tab);
   const resolvedScopeLock = resolveScopeLock(view);

--- a/src/components/filters/FilterBarClient.tsx
+++ b/src/components/filters/FilterBarClient.tsx
@@ -15,6 +15,9 @@ import {
   toLocalDate,
 } from "@/lib/dateUtils";
 import { FilterPill } from "./FilterPill";
+import { toggleValue } from "./filterBarUtils";
+import { OptionList } from "./sections/OptionList";
+import { ScopeSection } from "./sections/ScopeSection";
 import { TimeRangeSection } from "./sections/TimeRangeSection";
 
 const DATE_PRESETS = [
@@ -190,13 +193,6 @@ const formatSelection = (values: string[], emptyLabel: string) => {
     return values.join(", ");
   }
   return `${values.length} selected`;
-};
-
-const toggleValue = (values: string[], value: string) => {
-  if (values.includes(value)) {
-    return values.filter((item) => item !== value);
-  }
-  return [...values, value];
 };
 
 const scopeLabelMap: Record<MetricFilter["scope"]["level"], string> = {
@@ -437,40 +433,6 @@ export function FilterBarClient({
   const endDate = resolvedStart > resolvedEnd ? resolvedStart : resolvedEnd;
   const dateValue = `${formatDateInput(startDate)} - ${formatDateInput(endDate)}`;
 
-  const renderOptionList = (
-    items: string[],
-    selected: string[],
-    emptyLabel: string,
-    onChange: (nextValues: string[]) => void
-  ) => (
-    <div className="space-y-2 text-xs">
-      <label className="flex items-center gap-2">
-        <input
-          type="checkbox"
-          checked={!selected.length}
-          onChange={() => onChange([])}
-        />
-        <span>{emptyLabel}</span>
-      </label>
-      {items.length ? (
-        items.map((item) => (
-          <label key={item} className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={selected.includes(item)}
-              onChange={() => onChange(toggleValue(selected, item))}
-            />
-            <span>{item}</span>
-          </label>
-        ))
-      ) : (
-        <p className="text-[11px] text-(--ink-muted)">
-          No options yet. Use Advanced filters to type values.
-        </p>
-      )}
-    </div>
-  );
-
   return (
     <section
       ref={barRef}
@@ -480,59 +442,20 @@ export function FilterBarClient({
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex flex-wrap items-center gap-3">
             {visibility.scope && (
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => setOpenMenu(openMenu === "scope" ? null : "scope")}
-                  className="flex items-center gap-2 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs"
-                  aria-expanded={openMenu === "scope"}
-                >
-                  <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
-                    {scopeLabel}:
-                  </span>
-                  <span className="text-foreground">{scopeValue}</span>
-                  <span className="text-(--ink-muted)">▾</span>
-                </button>
-                {openMenu === "scope" && (
-                  <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
-                    {!scopeLock && (
-                      <label className="flex flex-col gap-2 text-xs">
-                        <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
-                          Scope level
-                        </span>
-                        <select
-                          className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2 text-sm"
-                          value={scopeLevel}
-                          onChange={(event) =>
-                            updateFilters({
-                              ...filters,
-                              scope: {
-                                ...filters.scope,
-                                level: event.target.value as MetricFilter["scope"]["level"],
-                                ids: [],
-                              },
-                            })
-                          }
-                        >
-                          <option value="org">Org</option>
-                          <option value="team">Team</option>
-                          <option value="repo">Repo</option>
-                          <option value="service">Service</option>
-                          <option value="developer">Developer</option>
-                        </select>
-                      </label>
-                    )}
-                    <div className="mt-3 max-h-56 overflow-auto">
-                      {renderOptionList(scopeOptions, effectiveScopeIds, scopeEmptyLabel, (next) =>
-                        updateFilters({
-                          ...filters,
-                          scope: { ...filters.scope, level: scopeLevel, ids: next },
-                        })
-                      )}
-                    </div>
-                  </div>
-                )}
-              </div>
+              <ScopeSection
+                effectiveScopeIds={effectiveScopeIds}
+                filters={filters}
+                openMenu={openMenu}
+                scopeEmptyLabel={scopeEmptyLabel}
+                scopeLabel={scopeLabel}
+                scopeLevel={scopeLevel}
+                scopeLock={scopeLock}
+                scopeOptions={scopeOptions}
+                scopeValue={scopeValue}
+                setOpenMenu={setOpenMenu}
+                toggleValue={toggleValue}
+                updateFilters={updateFilters}
+              />
             )}
 
             {visibility.date && (
@@ -565,12 +488,18 @@ export function FilterBarClient({
                 {openMenu === "repo" && (
                   <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
                     <div className="max-h-56 overflow-auto">
-                      {renderOptionList(options.repos, repos, "All", (next) =>
-                        updateFilters({
-                          ...filters,
-                          what: { ...filters.what, repos: next },
-                        })
-                      )}
+                      <OptionList
+                        emptyLabel="All"
+                        items={options.repos}
+                        onChange={(next) =>
+                          updateFilters({
+                            ...filters,
+                            what: { ...filters.what, repos: next },
+                          })
+                        }
+                        selected={repos}
+                        toggleValue={toggleValue}
+                      />
                     </div>
                   </div>
                 )}
@@ -595,12 +524,18 @@ export function FilterBarClient({
                 {openMenu === "developer" && (
                   <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
                     <div className="max-h-56 overflow-auto">
-                      {renderOptionList(options.developers, developers, "All", (next) =>
-                        updateFilters({
-                          ...filters,
-                          who: { ...filters.who, developers: next },
-                        })
-                      )}
+                      <OptionList
+                        emptyLabel="All"
+                        items={options.developers}
+                        onChange={(next) =>
+                          updateFilters({
+                            ...filters,
+                            who: { ...filters.who, developers: next },
+                          })
+                        }
+                        selected={developers}
+                        toggleValue={toggleValue}
+                      />
                     </div>
                   </div>
                 )}
@@ -623,12 +558,18 @@ export function FilterBarClient({
                 {openMenu === "work" && (
                   <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
                     <div className="max-h-56 overflow-auto">
-                      {renderOptionList(options.work_category, workCategory, "All", (next) =>
-                        updateFilters({
-                          ...filters,
-                          why: { ...filters.why, work_category: next },
-                        })
-                      )}
+                      <OptionList
+                        emptyLabel="All"
+                        items={options.work_category}
+                        onChange={(next) =>
+                          updateFilters({
+                            ...filters,
+                            why: { ...filters.why, work_category: next },
+                          })
+                        }
+                        selected={workCategory}
+                        toggleValue={toggleValue}
+                      />
                     </div>
                   </div>
                 )}
@@ -651,12 +592,18 @@ export function FilterBarClient({
                 {openMenu === "flow" && (
                   <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
                     <div className="max-h-56 overflow-auto">
-                      {renderOptionList(options.flow_stage, flowStage, "All", (next) =>
-                        updateFilters({
-                          ...filters,
-                          how: { ...filters.how, flow_stage: next },
-                        })
-                      )}
+                      <OptionList
+                        emptyLabel="All"
+                        items={options.flow_stage}
+                        onChange={(next) =>
+                          updateFilters({
+                            ...filters,
+                            how: { ...filters.how, flow_stage: next },
+                          })
+                        }
+                        selected={flowStage}
+                        toggleValue={toggleValue}
+                      />
                     </div>
                   </div>
                 )}

--- a/src/components/filters/FilterBarClient.tsx
+++ b/src/components/filters/FilterBarClient.tsx
@@ -1,437 +1,55 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-
-import { logger } from "@/lib/logger";
-import { defaultMetricFilter } from "@/lib/filters/defaults";
-import { decodeFilter, encodeFilterParam } from "@/lib/filters/encode";
 import type { MetricFilter } from "@/lib/filters/types";
-import { apiClient } from "@/lib/apiClient";
-import {
-  addDays,
-  formatDateInput,
-  parseDateInput,
-  toLocalDate,
-} from "@/lib/dateUtils";
-import { FilterPill } from "./FilterPill";
+import { type FilterBarClientProps } from "./filterBarConfig";
 import { toggleValue } from "./filterBarUtils";
-import { OptionList } from "./sections/OptionList";
+import { useFilterBarState } from "./useFilterBarState";
+import { ActiveFilterPills } from "./sections/ActiveFilterPills";
+import { AdvancedFiltersPanel } from "./sections/AdvancedFiltersPanel";
+import { QuickFilterMenu } from "./sections/QuickFilterMenu";
 import { ScopeSection } from "./sections/ScopeSection";
 import { TimeRangeSection } from "./sections/TimeRangeSection";
+import { ToolbarActions } from "./sections/ToolbarActions";
 
-const DATE_PRESETS = [
-  { label: "7d", days: 7 },
-  { label: "14d", days: 14 },
-  { label: "30d", days: 30 },
-  { label: "90d", days: 90 },
-];
+export { resolveVisibility } from "./filterBarConfig";
+export type { FilterBarView } from "./filterBarConfig";
 
-const toList = (value: string) =>
-  value
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
-
-const toValue = (value?: string[]) =>
-  value && value.length ? value.join(", ") : "";
-
-type FilterOptions = {
-  teams: string[];
-  repos: string[];
-  services: string[];
-  developers: string[];
-  work_category: string[];
-  issue_type: string[];
-  flow_stage: string[];
-};
-
-export type FilterBarView =
-  | "people"
-  | "home"
-  | "metrics"
-  | "work"
-  | "investment"
-  | "code"
-  | "quality"
-  | "opportunities"
-  | "explore"
-  | "testops"
-  | "security"
-  | "feature-flags";
-
-export type FilterVisibility = {
-  scope?: boolean;
-  repo?: boolean;
-  developer?: boolean;
-  workType?: boolean;
-  flowStage?: boolean;
-  date?: boolean;
-};
-
-const DEFAULT_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: true,
-  developer: true,
-  workType: true,
-  flowStage: false,
-  date: true,
-};
-
-const METRICS_DEFAULT_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: true,
-  developer: false,
-  workType: false,
-  flowStage: false,
-  date: true,
-};
-
-const METRICS_FLOW_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: true,
-  developer: true,
-  workType: false,
-  flowStage: true,
-  date: true,
-};
-
-const WORK_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: false,
-  developer: false,
-  workType: true,
-  flowStage: false,
-  date: true,
-};
-
-const PEOPLE_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: false,
-  developer: true,
-  workType: false,
-  flowStage: false,
-  date: true,
-};
-
-const CODE_VISIBILITY: FilterVisibility = {
-  scope: false,
-  repo: true,
-  developer: true,
-  workType: false,
-  flowStage: false,
-  date: true,
-};
-
-const EXPLORE_VISIBILITY: FilterVisibility = {
-  scope: true,
-  repo: true,
-  developer: true,
-  workType: true,
-  flowStage: true,
-  date: true,
-};
-
-export const resolveVisibility = (
-  view?: FilterBarView,
-  tab?: string
-): FilterVisibility => {
-  if (view === "metrics") {
-    if (tab === "flow") {
-      return METRICS_FLOW_VISIBILITY;
-    }
-    return METRICS_DEFAULT_VISIBILITY;
-  }
-  if (view === "work" || view === "investment") {
-    return WORK_VISIBILITY;
-  }
-  if (view === "people") {
-    return PEOPLE_VISIBILITY;
-  }
-  if (view === "code") {
-    return CODE_VISIBILITY;
-  }
-  if (view === "quality" || view === "testops") {
-    return METRICS_DEFAULT_VISIBILITY;
-  }
-  if (view === "opportunities") {
-    return WORK_VISIBILITY;
-  }
-  if (view === "explore") {
-    return EXPLORE_VISIBILITY;
-  }
-  if (view === "security") {
-    // Security manages its own URL-based filter state; hide all MetricFilter chips.
-    return {
-      scope: false,
-      repo: false,
-      developer: false,
-      workType: false,
-      flowStage: false,
-      date: false,
-    };
-  }
-  return DEFAULT_VISIBILITY;
-};
-
-export type FilterBarClientProps = {
-  condensed?: boolean;
-  view?: FilterBarView;
-  tab?: string;
-  /** Pre-computed by RSC wrapper — avoids re-running on every client render */
-  resolvedVisibility?: FilterVisibility;
-  /** Pre-computed by RSC wrapper */
-  resolvedScopeLock?: MetricFilter["scope"]["level"] | null;
-};
-
-
-const formatSelection = (values: string[], emptyLabel: string) => {
-  if (!values.length) {
-    return emptyLabel;
-  }
-  if (values.length <= 2) {
-    return values.join(", ");
-  }
-  return `${values.length} selected`;
-};
-
-const scopeLabelMap: Record<MetricFilter["scope"]["level"], string> = {
-  org: "Org",
-  team: "Team",
-  repo: "Repo",
-  service: "Service",
-  developer: "Developer",
-};
-
-export function FilterBarClient({
-  condensed,
-  view,
-  tab,
-  resolvedVisibility,
-  resolvedScopeLock,
-}: FilterBarClientProps) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  const encoded = searchParams.get("f");
-  const initialFilters = useMemo(() => decodeFilter(encoded), [encoded]);
-  const [filters, setFilters] = useState<MetricFilter>(initialFilters);
-  const [showAdvanced, setShowAdvanced] = useState(false);
-  const [openMenu, setOpenMenu] = useState<string | null>(null);
-  const barRef = useRef<HTMLElement | null>(null);
-  const didSetDefaultRef = useRef(false);
-  const queryParam = searchParams.get("q") ?? "";
-  const [peopleQuery, setPeopleQuery] = useState(queryParam);
-  const [options, setOptions] = useState<FilterOptions>({
-    teams: [],
-    repos: [],
-    services: [],
-    developers: [],
-    work_category: [],
-    issue_type: [],
-    flow_stage: [],
-  });
-
-  useEffect(() => {
-    setFilters(initialFilters);
-  }, [initialFilters]);
-
-  useEffect(() => {
-    if (!encoded && !didSetDefaultRef.current) {
-      didSetDefaultRef.current = true;
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("f", encodeFilterParam(defaultMetricFilter));
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-    }
-  }, [encoded, pathname, router, searchParams]);
-
-  useEffect(() => {
-    if (view !== "people") {
-      return;
-    }
-    setPeopleQuery(queryParam);
-  }, [queryParam, view]);
-
-  useEffect(() => {
-    let active = true;
-    apiClient
-      .getJson<FilterOptions>("/api/v1/filters/options")
-      .then((payload) => {
-        if (!active) {
-          return;
-        }
-        setOptions({
-          teams: payload.teams ?? [],
-          repos: payload.repos ?? [],
-          services: payload.services ?? [],
-          developers: payload.developers ?? [],
-          work_category: payload.work_category ?? [],
-          issue_type: payload.issue_type ?? [],
-          flow_stage: payload.flow_stage ?? [],
-        });
-      })
-      .catch((err) => {
-        if (active) {
-          logger.warn({ err }, "FilterBarClient: failed to load filter options");
-          setOptions((prev) => ({ ...prev }));
-        }
-      });
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    const handleClick = (event: MouseEvent) => {
-      if (!openMenu) {
-        return;
-      }
-      const target = event.target;
-      if (barRef.current && target instanceof Node && !barRef.current.contains(target)) {
-        setOpenMenu(null);
-      }
-    };
-    window.addEventListener("mousedown", handleClick);
-    return () => {
-      window.removeEventListener("mousedown", handleClick);
-    };
-  }, [openMenu]);
-
-  const updateUrl = useCallback(
-    (nextFilters: MetricFilter) => {
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("f", encodeFilterParam(nextFilters));
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-    },
-    [pathname, router, searchParams]
-  );
-
-  const updatePeopleQuery = (nextQuery: string) => {
-    setPeopleQuery(nextQuery);
-    const params = new URLSearchParams(searchParams.toString());
-    if (nextQuery.trim()) {
-      params.set("q", nextQuery);
-    } else {
-      params.delete("q");
-    }
-    params.set("f", encodeFilterParam(filters));
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-  };
-
-  const updateFilters = (nextFilters: MetricFilter) => {
-    setFilters(nextFilters);
-    updateUrl(nextFilters);
-  };
-
-  const resetFilters = () => {
-    if (view === "people") {
-      const params = new URLSearchParams(searchParams.toString());
-      params.delete("q");
-      params.set("f", encodeFilterParam(defaultMetricFilter));
-      setFilters(defaultMetricFilter);
-      setPeopleQuery("");
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-      return;
-    }
-    updateFilters(defaultMetricFilter);
-  };
-
-  const copyFilters = async () => {
-    const payload = JSON.stringify(filters, null, 2);
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(payload);
-    }
-  };
-
-  const handleDatePreset = (days: number) => {
-    const nextEnd = toLocalDate(new Date());
-    const nextStart = addDays(nextEnd, -(days - 1));
-    updateFilters({
-      ...filters,
-      time: {
-        ...filters.time,
-        range_days: days,
-        compare_days: days,
-        start_date: formatDateInput(nextStart),
-        end_date: formatDateInput(nextEnd),
-      },
-    });
-  };
-
-  const visibility = resolvedVisibility ?? resolveVisibility(view, tab);
-  const allowAdvanced = view !== "people";
-  const scopeLock: MetricFilter["scope"]["level"] | null =
-    resolvedScopeLock !== undefined
-      ? resolvedScopeLock
-      : (view === "metrics" ||
-          view === "quality" ||
-          view === "testops" ||
-          view === "work" ||
-          view === "investment" ||
-          view === "opportunities" ||
-          view === "home" ||
-          view === "people"
-          ? "team"
-          : null);
-  const scopeLevel = scopeLock ?? filters.scope.level;
-  const effectiveScopeIds =
-    scopeLock && filters.scope.level !== scopeLock ? [] : filters.scope.ids;
-
-  useEffect(() => {
-    if (!scopeLock || filters.scope.level === scopeLock) {
-      return;
-    }
-    const nextFilters = {
-      ...filters,
-      scope: { ...filters.scope, level: scopeLock, ids: [] },
-    };
-    setFilters(nextFilters);
-    updateUrl(nextFilters);
-  }, [filters, scopeLock, updateUrl]);
-
-  const scopeOptions = useMemo(() => {
-    if (scopeLevel === "team") {
-      return options.teams;
-    }
-    if (scopeLevel === "repo") {
-      return options.repos;
-    }
-    if (scopeLevel === "developer") {
-      return options.developers;
-    }
-    if (scopeLevel === "service") {
-      return options.services;
-    }
-    return [];
-  }, [scopeLevel, options]);
-
-  const developers = filters.who.developers ?? [];
-  const roles = filters.who.roles ?? [];
-  const repos = filters.what.repos ?? [];
-  const artifacts = filters.what.artifacts ?? [];
-  const workCategory = filters.why.work_category ?? [];
-  const issueType = filters.why.issue_type ?? [];
-  const flowStage = filters.how.flow_stage ?? [];
-
-  const scopeLabel = scopeLabelMap[scopeLevel] ?? "Team";
-  const scopeEmptyLabel = scopeLevel === "team" ? "All Teams" : "All";
-  const scopeValue = formatSelection(effectiveScopeIds, scopeEmptyLabel);
-  const safeRangeDays = Math.max(1, filters.time.range_days);
-  const today = toLocalDate(new Date());
-  const parsedStart = filters.time.start_date
-    ? parseDateInput(filters.time.start_date)
-    : null;
-  const parsedEnd = filters.time.end_date
-    ? parseDateInput(filters.time.end_date)
-    : null;
-  const resolvedEnd = toLocalDate(parsedEnd ?? today);
-  const resolvedStart = toLocalDate(
-    parsedStart ?? addDays(resolvedEnd, -(safeRangeDays - 1))
-  );
-  const startDate = resolvedStart > resolvedEnd ? resolvedEnd : resolvedStart;
-  const endDate = resolvedStart > resolvedEnd ? resolvedStart : resolvedEnd;
-  const dateValue = `${formatDateInput(startDate)} - ${formatDateInput(endDate)}`;
+export function FilterBarClient({ condensed, view, tab, resolvedVisibility, resolvedScopeLock }: FilterBarClientProps) {
+  const {
+    allowAdvanced,
+    artifacts,
+    barRef,
+    copyFilters,
+    dateValue,
+    developers,
+    effectiveScopeIds,
+    endDate,
+    filters,
+    flowStage,
+    handleDatePreset,
+    isCustomDateRange,
+    issueType,
+    openMenu,
+    options,
+    peopleQuery,
+    repos,
+    resetFilters,
+    roles,
+    scopeEmptyLabel,
+    scopeLabel,
+    scopeLevel,
+    scopeLock,
+    scopeOptions,
+    scopeValue,
+    setOpenMenu,
+    setShowAdvanced,
+    showAdvanced,
+    startDate,
+    updateFilters,
+    updatePeopleQuery,
+    visibility,
+    workCategory,
+  } = useFilterBarState({ view, tab, resolvedVisibility, resolvedScopeLock });
 
   return (
     <section
@@ -463,7 +81,7 @@ export function FilterBarClient({
                 dateValue={dateValue}
                 endDate={endDate}
                 filters={filters}
-                isCustomDateRange={!DATE_PRESETS.some((p) => p.days === filters.time.range_days)}
+                isCustomDateRange={isCustomDateRange}
                 onDatePreset={handleDatePreset}
                 openMenu={openMenu}
                 setOpenMenu={setOpenMenu}
@@ -473,447 +91,172 @@ export function FilterBarClient({
             )}
 
             {visibility.repo && (
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => setOpenMenu(openMenu === "repo" ? null : "repo")}
-                  className={`flex items-center gap-2 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs ${repos.length ? "border-(--accent) text-(--accent)" : ""}`}
-                  aria-expanded={openMenu === "repo"}
-                >
-                  <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
-                    Repo
-                  </span>
-                  <span className="text-(--ink-muted)">▾</span>
-                </button>
-                {openMenu === "repo" && (
-                  <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
-                    <div className="max-h-56 overflow-auto">
-                      <OptionList
-                        emptyLabel="All"
-                        items={options.repos}
-                        onChange={(next) =>
-                          updateFilters({
-                            ...filters,
-                            what: { ...filters.what, repos: next },
-                          })
-                        }
-                        selected={repos}
-                        toggleValue={toggleValue}
-                      />
-                    </div>
-                  </div>
-                )}
-              </div>
+              <QuickFilterMenu
+                active={repos}
+                emptyLabel="All"
+                items={options.repos}
+                label="Repo"
+                menuKey="repo"
+                onChange={(next) =>
+                  updateFilters({
+                    ...filters,
+                    what: { ...filters.what, repos: next },
+                  })
+                }
+                openMenu={openMenu}
+                setOpenMenu={setOpenMenu}
+                toggleValue={toggleValue}
+              />
             )}
 
             {visibility.developer && (
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() =>
-                    setOpenMenu(openMenu === "developer" ? null : "developer")
-                  }
-                  className={`flex items-center gap-2 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs ${developers.length ? "border-(--accent) text-(--accent)" : ""}`}
-                  aria-expanded={openMenu === "developer"}
-                >
-                  <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
-                    Developer
-                  </span>
-                  <span className="text-(--ink-muted)">▾</span>
-                </button>
-                {openMenu === "developer" && (
-                  <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
-                    <div className="max-h-56 overflow-auto">
-                      <OptionList
-                        emptyLabel="All"
-                        items={options.developers}
-                        onChange={(next) =>
-                          updateFilters({
-                            ...filters,
-                            who: { ...filters.who, developers: next },
-                          })
-                        }
-                        selected={developers}
-                        toggleValue={toggleValue}
-                      />
-                    </div>
-                  </div>
-                )}
-              </div>
+              <QuickFilterMenu
+                active={developers}
+                emptyLabel="All"
+                items={options.developers}
+                label="Developer"
+                menuKey="developer"
+                onChange={(next) =>
+                  updateFilters({
+                    ...filters,
+                    who: { ...filters.who, developers: next },
+                  })
+                }
+                openMenu={openMenu}
+                setOpenMenu={setOpenMenu}
+                toggleValue={toggleValue}
+              />
             )}
 
             {visibility.workType && (
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => setOpenMenu(openMenu === "work" ? null : "work")}
-                  className={`flex items-center gap-2 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs ${workCategory.length ? "border-(--accent) text-(--accent)" : ""}`}
-                  aria-expanded={openMenu === "work"}
-                >
-                  <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
-                    Work
-                  </span>
-                  <span className="text-(--ink-muted)">▾</span>
-                </button>
-                {openMenu === "work" && (
-                  <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
-                    <div className="max-h-56 overflow-auto">
-                      <OptionList
-                        emptyLabel="All"
-                        items={options.work_category}
-                        onChange={(next) =>
-                          updateFilters({
-                            ...filters,
-                            why: { ...filters.why, work_category: next },
-                          })
-                        }
-                        selected={workCategory}
-                        toggleValue={toggleValue}
-                      />
-                    </div>
-                  </div>
-                )}
-              </div>
+              <QuickFilterMenu
+                active={workCategory}
+                emptyLabel="All"
+                items={options.work_category}
+                label="Work"
+                menuKey="work"
+                onChange={(next) =>
+                  updateFilters({
+                    ...filters,
+                    why: { ...filters.why, work_category: next },
+                  })
+                }
+                openMenu={openMenu}
+                setOpenMenu={setOpenMenu}
+                toggleValue={toggleValue}
+              />
             )}
 
             {visibility.flowStage && (
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => setOpenMenu(openMenu === "flow" ? null : "flow")}
-                  className={`flex items-center gap-2 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs ${flowStage.length ? "border-(--accent) text-(--accent)" : ""}`}
-                  aria-expanded={openMenu === "flow"}
-                >
-                  <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
-                    Flow
-                  </span>
-                  <span className="text-(--ink-muted)">▾</span>
-                </button>
-                {openMenu === "flow" && (
-                  <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
-                    <div className="max-h-56 overflow-auto">
-                      <OptionList
-                        emptyLabel="All"
-                        items={options.flow_stage}
-                        onChange={(next) =>
-                          updateFilters({
-                            ...filters,
-                            how: { ...filters.how, flow_stage: next },
-                          })
-                        }
-                        selected={flowStage}
-                        toggleValue={toggleValue}
-                      />
-                    </div>
-                  </div>
-                )}
-              </div>
+              <QuickFilterMenu
+                active={flowStage}
+                emptyLabel="All"
+                items={options.flow_stage}
+                label="Flow"
+                menuKey="flow"
+                onChange={(next) =>
+                  updateFilters({
+                    ...filters,
+                    how: { ...filters.how, flow_stage: next },
+                  })
+                }
+                openMenu={openMenu}
+                setOpenMenu={setOpenMenu}
+                toggleValue={toggleValue}
+              />
             )}
           </div>
 
-          <div className="flex flex-wrap items-center gap-2">
-            {view === "people" && (
-              <label className="flex items-center gap-2 text-xs">
-                <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
-                  Search:
-                </span>
-                <input
-                  value={peopleQuery}
-                  onChange={(event) => updatePeopleQuery(event.target.value)}
-                  placeholder="Name or handle"
-                  className="w-full sm:w-56 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs"
-                />
-              </label>
-            )}
-
-            {allowAdvanced && (
-              <button
-                type="button"
-                onClick={() => setShowAdvanced((prev) => !prev)}
-                className={`rounded-full border px-4 py-2 text-xs uppercase tracking-[0.2em] transition-colors ${
-                  showAdvanced
-                    ? "border-(--accent) bg-(--accent-10) text-(--accent)"
-                    : "border-(--card-stroke) bg-(--card-70) hover:border-(--ink-muted)"
-                }`}
-                aria-expanded={showAdvanced}
-              >
-                Filters
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={resetFilters}
-              className="rounded-full border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-xs uppercase tracking-[0.2em]"
-            >
-              Reset
-            </button>
-            <button
-              type="button"
-              onClick={copyFilters}
-              className="rounded-full border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-xs uppercase tracking-[0.2em]"
-            >
-              Copy
-            </button>
-          </div>
+          <ToolbarActions
+            allowAdvanced={allowAdvanced}
+            copyFilters={copyFilters}
+            peopleQuery={peopleQuery}
+            resetFilters={resetFilters}
+            setShowAdvanced={setShowAdvanced}
+            showAdvanced={showAdvanced}
+            updatePeopleQuery={updatePeopleQuery}
+            view={view}
+          />
         </div>
 
-        <div className="flex flex-wrap gap-2">
-          {repos.map((repo) => (
-            <FilterPill
-              key={`repo-${repo}`}
-              label="Repo"
-              value={repo}
-              onClear={() =>
-                updateFilters({
-                  ...filters,
-                  what: { ...filters.what, repos: toggleValue(repos, repo) },
-                })
-              }
-            />
-          ))}
-          {developers.map((dev) => (
-            <FilterPill
-              key={`dev-${dev}`}
-              label="Dev"
-              value={dev}
-              onClear={() =>
-                updateFilters({
-                  ...filters,
-                  who: { ...filters.who, developers: toggleValue(developers, dev) },
-                })
-              }
-            />
-          ))}
-          {roles.map((role) => (
-            <FilterPill
-              key={`role-${role}`}
-              label="Role"
-              value={role}
-              onClear={() =>
-                updateFilters({
-                  ...filters,
-                  who: { ...filters.who, roles: toggleValue(roles, role) },
-                })
-              }
-            />
-          ))}
-          {workCategory.map((cat) => (
-            <FilterPill
-              key={`cat-${cat}`}
-              label="Work"
-              value={cat}
-              onClear={() =>
-                updateFilters({
-                  ...filters,
-                  why: { ...filters.why, work_category: toggleValue(workCategory, cat) },
-                })
-              }
-            />
-          ))}
-          {issueType.map((type) => (
-            <FilterPill
-              key={`type-${type}`}
-              label="Type"
-              value={type}
-              onClear={() =>
-                updateFilters({
-                  ...filters,
-                  why: { ...filters.why, issue_type: toggleValue(issueType, type) },
-                })
-              }
-            />
-          ))}
-          {flowStage.map((stage) => (
-            <FilterPill
-              key={`stage-${stage}`}
-              label="Stage"
-              value={stage}
-              onClear={() =>
-                updateFilters({
-                  ...filters,
-                  how: { ...filters.how, flow_stage: toggleValue(flowStage, stage) },
-                })
-              }
-            />
-          ))}
-          {artifacts.map((art) => (
-            <FilterPill
-              key={`art-${art}`}
-              label="Artifact"
-              value={art}
-              onClear={() =>
-                updateFilters({
-                  ...filters,
-                  what: {
-                    ...filters.what,
-                    artifacts: toggleValue(artifacts, art) as MetricFilter["what"]["artifacts"],
-                  },
-                })
-              }
-            />
-          ))}
-          {filters.how.blocked && (
-            <FilterPill
-              label="Status"
-              value="Blocked"
-              onClear={() =>
-                updateFilters({
-                  ...filters,
-                  how: { ...filters.how, blocked: false },
-                })
-              }
-            />
-          )}
-        </div>
+        <ActiveFilterPills
+          artifacts={artifacts}
+          blocked={filters.how.blocked ?? false}
+          developers={developers}
+          flowStage={flowStage}
+          issueType={issueType}
+          onClearArtifact={(value) =>
+            updateFilters({
+              ...filters,
+              what: {
+                ...filters.what,
+                artifacts: toggleValue(artifacts, value) as MetricFilter["what"]["artifacts"],
+              },
+            })
+          }
+          onClearBlocked={() =>
+            updateFilters({
+              ...filters,
+              how: { ...filters.how, blocked: false },
+            })
+          }
+          onClearDeveloper={(value) =>
+            updateFilters({
+              ...filters,
+              who: { ...filters.who, developers: toggleValue(developers, value) },
+            })
+          }
+          onClearFlowStage={(value) =>
+            updateFilters({
+              ...filters,
+              how: { ...filters.how, flow_stage: toggleValue(flowStage, value) },
+            })
+          }
+          onClearIssueType={(value) =>
+            updateFilters({
+              ...filters,
+              why: { ...filters.why, issue_type: toggleValue(issueType, value) },
+            })
+          }
+          onClearRepo={(value) =>
+            updateFilters({
+              ...filters,
+              what: { ...filters.what, repos: toggleValue(repos, value) },
+            })
+          }
+          onClearRole={(value) =>
+            updateFilters({
+              ...filters,
+              who: { ...filters.who, roles: toggleValue(roles, value) },
+            })
+          }
+          onClearWorkCategory={(value) =>
+            updateFilters({
+              ...filters,
+              why: {
+                ...filters.why,
+                work_category: toggleValue(workCategory, value),
+              },
+            })
+          }
+          repos={repos}
+          roles={roles}
+          workCategory={workCategory}
+        />
 
         {allowAdvanced && showAdvanced && (
-          <div className="mt-4 grid gap-3 md:grid-cols-2">
-            <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
-              <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                Who
-              </summary>
-              <div className="mt-3 space-y-3 text-sm">
-                <label className="flex flex-col gap-2">
-                  <span className="text-xs text-(--ink-muted)">Developers</span>
-                  <input
-                    className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2"
-                    placeholder="alice, bob"
-                    value={toValue(developers)}
-                    onChange={(event) =>
-                      updateFilters({
-                        ...filters,
-                        who: { ...filters.who, developers: toList(event.target.value) },
-                      })
-                    }
-                  />
-                </label>
-                <label className="flex flex-col gap-2">
-                  <span className="text-xs text-(--ink-muted)">Roles</span>
-                  <input
-                    className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2"
-                    placeholder="maintainer, reviewer"
-                    value={toValue(roles)}
-                    onChange={(event) =>
-                      updateFilters({
-                        ...filters,
-                        who: { ...filters.who, roles: toList(event.target.value) },
-                      })
-                    }
-                  />
-                </label>
-              </div>
-            </details>
-
-            <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
-              <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                What
-              </summary>
-              <div className="mt-3 space-y-3 text-sm">
-                <label className="flex flex-col gap-2">
-                  <span className="text-xs text-(--ink-muted)">Repos</span>
-                  <input
-                    className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
-                    placeholder="org/api, org/ui"
-                    value={toValue(repos)}
-                    onChange={(event) =>
-                      updateFilters({
-                        ...filters,
-                        what: { ...filters.what, repos: toList(event.target.value) },
-                      })
-                    }
-                  />
-                </label>
-                <label className="flex flex-col gap-2">
-                  <span className="text-xs text-(--ink-muted)">Artifacts</span>
-                  <input
-                    className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
-                    placeholder="pr, issue"
-                    value={toValue(artifacts)}
-                    onChange={(event) =>
-                      updateFilters({
-                        ...filters,
-                        what: {
-                          ...filters.what,
-                          artifacts: toList(event.target.value) as MetricFilter["what"]["artifacts"],
-                        },
-                      })
-                    }
-                  />
-                </label>
-              </div>
-            </details>
-
-            <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
-              <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                Why
-              </summary>
-              <div className="mt-3 space-y-3 text-sm">
-                <label className="flex flex-col gap-2">
-                  <span className="text-xs text-(--ink-muted)">Work category</span>
-                  <input
-                    className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
-                    placeholder="feature, maintenance"
-                    value={toValue(workCategory)}
-                    onChange={(event) =>
-                      updateFilters({
-                        ...filters,
-                        why: { ...filters.why, work_category: toList(event.target.value) },
-                      })
-                    }
-                  />
-                </label>
-                <label className="flex flex-col gap-2">
-                  <span className="text-xs text-(--ink-muted)">Issue type</span>
-                  <input
-                    className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
-                    placeholder="bug, story"
-                    value={toValue(issueType)}
-                    onChange={(event) =>
-                      updateFilters({
-                        ...filters,
-                        why: { ...filters.why, issue_type: toList(event.target.value) },
-                      })
-                    }
-                  />
-                </label>
-              </div>
-            </details>
-
-            <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
-              <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                How
-              </summary>
-              <div className="mt-3 space-y-3 text-sm">
-                <label className="flex flex-col gap-2">
-                  <span className="text-xs text-(--ink-muted)">Flow stage</span>
-                  <input
-                    className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
-                    placeholder="review, build"
-                    value={toValue(flowStage)}
-                    onChange={(event) =>
-                      updateFilters({
-                        ...filters,
-                        how: { ...filters.how, flow_stage: toList(event.target.value) },
-                      })
-                    }
-                  />
-                </label>
-                <label className="flex items-center gap-2 text-xs text-(--ink-muted)">
-                  <input
-                    type="checkbox"
-                    checked={filters.how.blocked ?? false}
-                    onChange={(event) =>
-                      updateFilters({
-                        ...filters,
-                        how: { ...filters.how, blocked: event.target.checked },
-                      })
-                    }
-                  />
-                  Blocked only
-                </label>
-              </div>
-            </details>
-          </div>
+          <AdvancedFiltersPanel
+            artifacts={artifacts}
+            blocked={filters.how.blocked ?? false}
+            developers={developers}
+            filters={filters}
+            flowStage={flowStage}
+            issueType={issueType}
+            repos={repos}
+            roles={roles}
+            updateFilters={updateFilters}
+            workCategory={workCategory}
+          />
         )}
       </div>
     </section>

--- a/src/components/filters/FilterBarClient.tsx
+++ b/src/components/filters/FilterBarClient.tsx
@@ -10,12 +10,12 @@ import type { MetricFilter } from "@/lib/filters/types";
 import { apiClient } from "@/lib/apiClient";
 import {
   addDays,
-  diffDaysInclusive,
   formatDateInput,
   parseDateInput,
   toLocalDate,
 } from "@/lib/dateUtils";
 import { FilterPill } from "./FilterPill";
+import { TimeRangeSection } from "./sections/TimeRangeSection";
 
 const DATE_PRESETS = [
   { label: "7d", days: 7 },
@@ -536,107 +536,17 @@ export function FilterBarClient({
             )}
 
             {visibility.date && (
-              <div className="flex items-center rounded-full border border-(--card-stroke) bg-card p-1">
-                {DATE_PRESETS.map((preset) => (
-                  <button
-                    key={preset.days}
-                    type="button"
-                    onClick={() => handleDatePreset(preset.days)}
-                    className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                      filters.time.range_days === preset.days
-                        ? "bg-(--accent) text-white"
-                        : "text-(--ink-muted) hover:text-foreground"
-                    }`}
-                  >
-                    {preset.label}
-                  </button>
-                ))}
-                <div className="relative ml-1 border-l border-(--card-stroke) pl-1">
-                  <button
-                    type="button"
-                    onClick={() => setOpenMenu(openMenu === "date" ? null : "date")}
-                    className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                      !DATE_PRESETS.some((p) => p.days === filters.time.range_days)
-                        ? "bg-(--accent) text-white"
-                        : "text-(--ink-muted) hover:text-foreground"
-                    }`}
-                  >
-                    {!DATE_PRESETS.some((p) => p.days === filters.time.range_days)
-                      ? dateValue
-                      : "Custom"}
-                  </button>
-                  {openMenu === "date" && (
-                    <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
-                      <div className="grid gap-3 text-xs">
-                        <label className="flex flex-col gap-2">
-                          <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
-                            Start date
-                          </span>
-                          <input
-                            className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2 text-sm"
-                            type="date"
-                            value={formatDateInput(startDate)}
-                            onChange={(event) => {
-                              const parsed = parseDateInput(event.target.value);
-                              if (!parsed) {
-                                return;
-                              }
-                              const nextStart = toLocalDate(parsed);
-                              let nextEnd = endDate;
-                              if (nextStart > nextEnd) {
-                                nextEnd = nextStart;
-                              }
-                              const nextRangeDays = diffDaysInclusive(nextStart, nextEnd);
-                              updateFilters({
-                                ...filters,
-                                time: {
-                                  ...filters.time,
-                                  range_days: nextRangeDays,
-                                  compare_days: nextRangeDays,
-                                  start_date: formatDateInput(nextStart),
-                                  end_date: formatDateInput(nextEnd),
-                                },
-                              });
-                            }}
-                          />
-                        </label>
-                        <label className="flex flex-col gap-2">
-                          <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
-                            End date
-                          </span>
-                          <input
-                            className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2 text-sm"
-                            type="date"
-                            value={formatDateInput(endDate)}
-                            onChange={(event) => {
-                              const parsed = parseDateInput(event.target.value);
-                              if (!parsed) {
-                                return;
-                              }
-                              const nextEnd = toLocalDate(parsed);
-                              let nextStart = startDate;
-                              if (nextEnd < nextStart) {
-                                nextStart = nextEnd;
-                              }
-                              const nextRangeDays = diffDaysInclusive(nextStart, nextEnd);
-                              updateFilters({
-                                ...filters,
-                                time: {
-                                  ...filters.time,
-                                  range_days: nextRangeDays,
-                                  compare_days: nextRangeDays,
-                                  start_date: formatDateInput(nextStart),
-                                  end_date: formatDateInput(nextEnd),
-                                },
-                              });
-                            }}
-                          />
-                        </label>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
+              <TimeRangeSection
+                dateValue={dateValue}
+                endDate={endDate}
+                filters={filters}
+                isCustomDateRange={!DATE_PRESETS.some((p) => p.days === filters.time.range_days)}
+                onDatePreset={handleDatePreset}
+                openMenu={openMenu}
+                setOpenMenu={setOpenMenu}
+                startDate={startDate}
+                updateFilters={updateFilters}
+              />
             )}
 
             {visibility.repo && (

--- a/src/components/filters/filterBarConfig.ts
+++ b/src/components/filters/filterBarConfig.ts
@@ -1,0 +1,153 @@
+import type { MetricFilter } from "@/lib/filters/types";
+
+export type FilterBarView =
+  | "people"
+  | "home"
+  | "metrics"
+  | "work"
+  | "investment"
+  | "code"
+  | "quality"
+  | "opportunities"
+  | "explore"
+  | "testops"
+  | "security"
+  | "feature-flags";
+
+export type FilterVisibility = {
+  scope?: boolean;
+  repo?: boolean;
+  developer?: boolean;
+  workType?: boolean;
+  flowStage?: boolean;
+  date?: boolean;
+};
+
+export type FilterBarClientProps = {
+  condensed?: boolean;
+  view?: FilterBarView;
+  tab?: string;
+  resolvedVisibility?: FilterVisibility;
+  resolvedScopeLock?: MetricFilter["scope"]["level"] | null;
+};
+
+const DEFAULT_VISIBILITY: FilterVisibility = {
+  scope: true,
+  repo: true,
+  developer: true,
+  workType: true,
+  flowStage: false,
+  date: true,
+};
+
+const METRICS_DEFAULT_VISIBILITY: FilterVisibility = {
+  scope: true,
+  repo: true,
+  developer: false,
+  workType: false,
+  flowStage: false,
+  date: true,
+};
+
+const METRICS_FLOW_VISIBILITY: FilterVisibility = {
+  scope: true,
+  repo: true,
+  developer: true,
+  workType: false,
+  flowStage: true,
+  date: true,
+};
+
+const WORK_VISIBILITY: FilterVisibility = {
+  scope: true,
+  repo: false,
+  developer: false,
+  workType: true,
+  flowStage: false,
+  date: true,
+};
+
+const PEOPLE_VISIBILITY: FilterVisibility = {
+  scope: true,
+  repo: false,
+  developer: true,
+  workType: false,
+  flowStage: false,
+  date: true,
+};
+
+const CODE_VISIBILITY: FilterVisibility = {
+  scope: false,
+  repo: true,
+  developer: true,
+  workType: false,
+  flowStage: false,
+  date: true,
+};
+
+const EXPLORE_VISIBILITY: FilterVisibility = {
+  scope: true,
+  repo: true,
+  developer: true,
+  workType: true,
+  flowStage: true,
+  date: true,
+};
+
+export const resolveVisibility = (
+  view?: FilterBarView,
+  tab?: string
+): FilterVisibility => {
+  if (view === "metrics") {
+    if (tab === "flow") {
+      return METRICS_FLOW_VISIBILITY;
+    }
+    return METRICS_DEFAULT_VISIBILITY;
+  }
+  if (view === "work" || view === "investment") {
+    return WORK_VISIBILITY;
+  }
+  if (view === "people") {
+    return PEOPLE_VISIBILITY;
+  }
+  if (view === "code") {
+    return CODE_VISIBILITY;
+  }
+  if (view === "quality" || view === "testops") {
+    return METRICS_DEFAULT_VISIBILITY;
+  }
+  if (view === "opportunities") {
+    return WORK_VISIBILITY;
+  }
+  if (view === "explore") {
+    return EXPLORE_VISIBILITY;
+  }
+  if (view === "security") {
+    return {
+      scope: false,
+      repo: false,
+      developer: false,
+      workType: false,
+      flowStage: false,
+      date: false,
+    };
+  }
+  return DEFAULT_VISIBILITY;
+};
+
+export const resolveScopeLock = (
+  view?: FilterBarView
+): MetricFilter["scope"]["level"] | null => {
+  const lockedViews: FilterBarView[] = [
+    "metrics",
+    "quality",
+    "testops",
+    "work",
+    "investment",
+    "opportunities",
+    "home",
+    "people",
+  ];
+
+  return view && lockedViews.includes(view) ? "team" : null;
+};

--- a/src/components/filters/filterBarUtils.ts
+++ b/src/components/filters/filterBarUtils.ts
@@ -1,0 +1,62 @@
+import type { MetricFilter } from "@/lib/filters/types";
+
+export const DATE_PRESETS = [
+  { label: "7d", days: 7 },
+  { label: "14d", days: 14 },
+  { label: "30d", days: 30 },
+  { label: "90d", days: 90 },
+];
+
+export type FilterOptions = {
+  teams: string[];
+  repos: string[];
+  services: string[];
+  developers: string[];
+  work_category: string[];
+  issue_type: string[];
+  flow_stage: string[];
+};
+
+export const EMPTY_FILTER_OPTIONS: FilterOptions = {
+  teams: [],
+  repos: [],
+  services: [],
+  developers: [],
+  work_category: [],
+  issue_type: [],
+  flow_stage: [],
+};
+
+export const toList = (value: string) =>
+  value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+export const toValue = (value?: string[]) =>
+  value && value.length ? value.join(", ") : "";
+
+export const formatSelection = (values: string[], emptyLabel: string) => {
+  if (!values.length) {
+    return emptyLabel;
+  }
+  if (values.length <= 2) {
+    return values.join(", ");
+  }
+  return `${values.length} selected`;
+};
+
+export const toggleValue = (values: string[], value: string) => {
+  if (values.includes(value)) {
+    return values.filter((item) => item !== value);
+  }
+  return [...values, value];
+};
+
+export const scopeLabelMap: Record<MetricFilter["scope"]["level"], string> = {
+  org: "Org",
+  team: "Team",
+  repo: "Repo",
+  service: "Service",
+  developer: "Developer",
+};

--- a/src/components/filters/sections/ActiveFilterPills.tsx
+++ b/src/components/filters/sections/ActiveFilterPills.tsx
@@ -1,0 +1,96 @@
+import { FilterPill } from "../FilterPill";
+
+type ActiveFilterPillsProps = {
+  artifacts: string[];
+  blocked: boolean;
+  developers: string[];
+  flowStage: string[];
+  issueType: string[];
+  onClearArtifact: (value: string) => void;
+  onClearBlocked: () => void;
+  onClearDeveloper: (value: string) => void;
+  onClearFlowStage: (value: string) => void;
+  onClearIssueType: (value: string) => void;
+  onClearRepo: (value: string) => void;
+  onClearRole: (value: string) => void;
+  onClearWorkCategory: (value: string) => void;
+  repos: string[];
+  roles: string[];
+  workCategory: string[];
+};
+
+export function ActiveFilterPills({
+  artifacts,
+  blocked,
+  developers,
+  flowStage,
+  issueType,
+  onClearArtifact,
+  onClearBlocked,
+  onClearDeveloper,
+  onClearFlowStage,
+  onClearIssueType,
+  onClearRepo,
+  onClearRole,
+  onClearWorkCategory,
+  repos,
+  roles,
+  workCategory,
+}: ActiveFilterPillsProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {repos.map((repo) => (
+        <FilterPill key={`repo-${repo}`} label="Repo" value={repo} onClear={() => onClearRepo(repo)} />
+      ))}
+      {developers.map((dev) => (
+        <FilterPill
+          key={`dev-${dev}`}
+          label="Dev"
+          value={dev}
+          onClear={() => onClearDeveloper(dev)}
+        />
+      ))}
+      {roles.map((role) => (
+        <FilterPill
+          key={`role-${role}`}
+          label="Role"
+          value={role}
+          onClear={() => onClearRole(role)}
+        />
+      ))}
+      {workCategory.map((cat) => (
+        <FilterPill
+          key={`cat-${cat}`}
+          label="Work"
+          value={cat}
+          onClear={() => onClearWorkCategory(cat)}
+        />
+      ))}
+      {issueType.map((type) => (
+        <FilterPill
+          key={`type-${type}`}
+          label="Type"
+          value={type}
+          onClear={() => onClearIssueType(type)}
+        />
+      ))}
+      {flowStage.map((stage) => (
+        <FilterPill
+          key={`stage-${stage}`}
+          label="Stage"
+          value={stage}
+          onClear={() => onClearFlowStage(stage)}
+        />
+      ))}
+      {artifacts.map((art) => (
+        <FilterPill
+          key={`art-${art}`}
+          label="Artifact"
+          value={art}
+          onClear={() => onClearArtifact(art)}
+        />
+      ))}
+      {blocked && <FilterPill label="Status" value="Blocked" onClear={onClearBlocked} />}
+    </div>
+  );
+}

--- a/src/components/filters/sections/AdvancedFiltersPanel.tsx
+++ b/src/components/filters/sections/AdvancedFiltersPanel.tsx
@@ -1,0 +1,112 @@
+import type { MetricFilter } from "@/lib/filters/types";
+import { toList, toValue } from "../filterBarUtils";
+import { HowSection } from "./HowSection";
+import { WhatSection } from "./WhatSection";
+import { WhoSection } from "./WhoSection";
+import { WhySection } from "./WhySection";
+
+type AdvancedFiltersPanelProps = {
+  artifacts: string[];
+  blocked: boolean;
+  developers: string[];
+  filters: MetricFilter;
+  flowStage: string[];
+  issueType: string[];
+  repos: string[];
+  roles: string[];
+  updateFilters: (nextFilters: MetricFilter) => void;
+  workCategory: string[];
+};
+
+export function AdvancedFiltersPanel({
+  artifacts,
+  blocked,
+  developers,
+  filters,
+  flowStage,
+  issueType,
+  repos,
+  roles,
+  updateFilters,
+  workCategory,
+}: AdvancedFiltersPanelProps) {
+  return (
+    <div className="mt-4 grid gap-3 md:grid-cols-2">
+      <WhoSection
+        developers={developers}
+        roles={roles}
+        toList={toList}
+        toValue={toValue}
+        updateDevelopers={(nextValues) =>
+          updateFilters({
+            ...filters,
+            who: { ...filters.who, developers: nextValues },
+          })
+        }
+        updateRoles={(nextValues) =>
+          updateFilters({
+            ...filters,
+            who: { ...filters.who, roles: nextValues },
+          })
+        }
+      />
+      <WhatSection
+        artifacts={artifacts}
+        repos={repos}
+        toList={toList}
+        toValue={toValue}
+        updateArtifacts={(nextValues) =>
+          updateFilters({
+            ...filters,
+            what: {
+              ...filters.what,
+              artifacts: nextValues as MetricFilter["what"]["artifacts"],
+            },
+          })
+        }
+        updateRepos={(nextValues) =>
+          updateFilters({
+            ...filters,
+            what: { ...filters.what, repos: nextValues },
+          })
+        }
+      />
+      <WhySection
+        issueType={issueType}
+        toList={toList}
+        toValue={toValue}
+        updateIssueType={(nextValues) =>
+          updateFilters({
+            ...filters,
+            why: { ...filters.why, issue_type: nextValues },
+          })
+        }
+        updateWorkCategory={(nextValues) =>
+          updateFilters({
+            ...filters,
+            why: { ...filters.why, work_category: nextValues },
+          })
+        }
+        workCategory={workCategory}
+      />
+      <HowSection
+        blocked={blocked}
+        flowStage={flowStage}
+        toList={toList}
+        toValue={toValue}
+        updateBlocked={(nextValue) =>
+          updateFilters({
+            ...filters,
+            how: { ...filters.how, blocked: nextValue },
+          })
+        }
+        updateFlowStage={(nextValues) =>
+          updateFilters({
+            ...filters,
+            how: { ...filters.how, flow_stage: nextValues },
+          })
+        }
+      />
+    </div>
+  );
+}

--- a/src/components/filters/sections/HowSection.tsx
+++ b/src/components/filters/sections/HowSection.tsx
@@ -1,0 +1,44 @@
+type HowSectionProps = {
+  blocked: boolean;
+  flowStage: string[];
+  toList: (value: string) => string[];
+  toValue: (value?: string[]) => string;
+  updateBlocked: (nextValue: boolean) => void;
+  updateFlowStage: (nextValues: string[]) => void;
+};
+
+export function HowSection({
+  blocked,
+  flowStage,
+  toList,
+  toValue,
+  updateBlocked,
+  updateFlowStage,
+}: HowSectionProps) {
+  return (
+    <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+      <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+        How
+      </summary>
+      <div className="mt-3 space-y-3 text-sm">
+        <label className="flex flex-col gap-2">
+          <span className="text-xs text-(--ink-muted)">Flow stage</span>
+          <input
+            className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+            placeholder="review, build"
+            value={toValue(flowStage)}
+            onChange={(event) => updateFlowStage(toList(event.target.value))}
+          />
+        </label>
+        <label className="flex items-center gap-2 text-xs text-(--ink-muted)">
+          <input
+            type="checkbox"
+            checked={blocked}
+            onChange={(event) => updateBlocked(event.target.checked)}
+          />
+          Blocked only
+        </label>
+      </div>
+    </details>
+  );
+}

--- a/src/components/filters/sections/OptionList.tsx
+++ b/src/components/filters/sections/OptionList.tsx
@@ -1,0 +1,40 @@
+type OptionListProps = {
+  emptyLabel: string;
+  items: string[];
+  onChange: (nextValues: string[]) => void;
+  selected: string[];
+  toggleValue: (values: string[], value: string) => string[];
+};
+
+export function OptionList({
+  emptyLabel,
+  items,
+  onChange,
+  selected,
+  toggleValue,
+}: OptionListProps) {
+  return (
+    <div className="space-y-2 text-xs">
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={!selected.length} onChange={() => onChange([])} />
+        <span>{emptyLabel}</span>
+      </label>
+      {items.length ? (
+        items.map((item) => (
+          <label key={item} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={selected.includes(item)}
+              onChange={() => onChange(toggleValue(selected, item))}
+            />
+            <span>{item}</span>
+          </label>
+        ))
+      ) : (
+        <p className="text-[11px] text-(--ink-muted)">
+          No options yet. Use Advanced filters to type values.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/filters/sections/QuickFilterMenu.tsx
+++ b/src/components/filters/sections/QuickFilterMenu.tsx
@@ -1,0 +1,58 @@
+import { OptionList } from "./OptionList";
+
+type QuickFilterMenuProps = {
+  active: string[];
+  emptyLabel: string;
+  items: string[];
+  label: string;
+  menuKey: string;
+  onChange: (nextValues: string[]) => void;
+  openMenu: string | null;
+  setOpenMenu: (value: string | null) => void;
+  toggleValue: (values: string[], value: string) => string[];
+  variant?: "default" | "accent";
+};
+
+export function QuickFilterMenu({
+  active,
+  emptyLabel,
+  items,
+  label,
+  menuKey,
+  onChange,
+  openMenu,
+  setOpenMenu,
+  toggleValue,
+  variant = "accent",
+}: QuickFilterMenuProps) {
+  const isActive = active.length > 0;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpenMenu(openMenu === menuKey ? null : menuKey)}
+        className={`flex items-center gap-2 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs ${
+          variant === "accent" && isActive ? "border-(--accent) text-(--accent)" : ""
+        }`}
+        aria-expanded={openMenu === menuKey}
+      >
+        <span className="uppercase tracking-[0.2em] text-(--ink-muted)">{label}</span>
+        <span className="text-(--ink-muted)">▾</span>
+      </button>
+      {openMenu === menuKey && (
+        <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
+          <div className="max-h-56 overflow-auto">
+            <OptionList
+              emptyLabel={emptyLabel}
+              items={items}
+              onChange={onChange}
+              selected={active}
+              toggleValue={toggleValue}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/filters/sections/ScopeSection.tsx
+++ b/src/components/filters/sections/ScopeSection.tsx
@@ -1,0 +1,92 @@
+import type { MetricFilter } from "@/lib/filters/types";
+import { OptionList } from "./OptionList";
+
+type ScopeSectionProps = {
+  effectiveScopeIds: string[];
+  filters: MetricFilter;
+  openMenu: string | null;
+  scopeEmptyLabel: string;
+  scopeLabel: string;
+  scopeLevel: MetricFilter["scope"]["level"];
+  scopeLock: MetricFilter["scope"]["level"] | null;
+  scopeOptions: string[];
+  scopeValue: string;
+  setOpenMenu: (value: string | null) => void;
+  toggleValue: (values: string[], value: string) => string[];
+  updateFilters: (nextFilters: MetricFilter) => void;
+};
+
+export function ScopeSection({
+  effectiveScopeIds,
+  filters,
+  openMenu,
+  scopeEmptyLabel,
+  scopeLabel,
+  scopeLevel,
+  scopeLock,
+  scopeOptions,
+  scopeValue,
+  setOpenMenu,
+  toggleValue,
+  updateFilters,
+}: ScopeSectionProps) {
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpenMenu(openMenu === "scope" ? null : "scope")}
+        className="flex items-center gap-2 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs"
+        aria-expanded={openMenu === "scope"}
+      >
+        <span className="uppercase tracking-[0.2em] text-(--ink-muted)">{scopeLabel}:</span>
+        <span className="text-foreground">{scopeValue}</span>
+        <span className="text-(--ink-muted)">▾</span>
+      </button>
+      {openMenu === "scope" && (
+        <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
+          {!scopeLock && (
+            <label className="flex flex-col gap-2 text-xs">
+              <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
+                Scope level
+              </span>
+              <select
+                className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2 text-sm"
+                value={scopeLevel}
+                onChange={(event) =>
+                  updateFilters({
+                    ...filters,
+                    scope: {
+                      ...filters.scope,
+                      level: event.target.value as MetricFilter["scope"]["level"],
+                      ids: [],
+                    },
+                  })
+                }
+              >
+                <option value="org">Org</option>
+                <option value="team">Team</option>
+                <option value="repo">Repo</option>
+                <option value="service">Service</option>
+                <option value="developer">Developer</option>
+              </select>
+            </label>
+          )}
+          <div className="mt-3 max-h-56 overflow-auto">
+            <OptionList
+              emptyLabel={scopeEmptyLabel}
+              items={scopeOptions}
+              onChange={(next) =>
+                updateFilters({
+                  ...filters,
+                  scope: { ...filters.scope, level: scopeLevel, ids: next },
+                })
+              }
+              selected={effectiveScopeIds}
+              toggleValue={toggleValue}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/filters/sections/TimeRangeSection.tsx
+++ b/src/components/filters/sections/TimeRangeSection.tsx
@@ -1,0 +1,134 @@
+import {
+  diffDaysInclusive,
+  formatDateInput,
+  parseDateInput,
+  toLocalDate,
+} from "@/lib/dateUtils";
+import type { MetricFilter } from "@/lib/filters/types";
+import { DATE_PRESETS } from "../filterBarUtils";
+
+type TimeRangeSectionProps = {
+  dateValue: string;
+  endDate: Date;
+  filters: MetricFilter;
+  isCustomDateRange: boolean;
+  onDatePreset: (days: number) => void;
+  openMenu: string | null;
+  setOpenMenu: (value: string | null) => void;
+  startDate: Date;
+  updateFilters: (nextFilters: MetricFilter) => void;
+};
+
+export function TimeRangeSection({
+  dateValue,
+  endDate,
+  filters,
+  isCustomDateRange,
+  onDatePreset,
+  openMenu,
+  setOpenMenu,
+  startDate,
+  updateFilters,
+}: TimeRangeSectionProps) {
+  return (
+    <div className="flex items-center rounded-full border border-(--card-stroke) bg-card p-1">
+      {DATE_PRESETS.map((preset) => (
+        <button
+          key={preset.days}
+          type="button"
+          onClick={() => onDatePreset(preset.days)}
+          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+            filters.time.range_days === preset.days
+              ? "bg-(--accent) text-white"
+              : "text-(--ink-muted) hover:text-foreground"
+          }`}
+        >
+          {preset.label}
+        </button>
+      ))}
+      <div className="relative ml-1 border-l border-(--card-stroke) pl-1">
+        <button
+          type="button"
+          onClick={() => setOpenMenu(openMenu === "date" ? null : "date")}
+          className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+            isCustomDateRange
+              ? "bg-(--accent) text-white"
+              : "text-(--ink-muted) hover:text-foreground"
+          }`}
+        >
+          {isCustomDateRange ? dateValue : "Custom"}
+        </button>
+        {openMenu === "date" && (
+          <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
+            <div className="grid gap-3 text-xs">
+              <label className="flex flex-col gap-2">
+                <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
+                  Start date
+                </span>
+                <input
+                  className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2 text-sm"
+                  type="date"
+                  value={formatDateInput(startDate)}
+                  onChange={(event) => {
+                    const parsed = parseDateInput(event.target.value);
+                    if (!parsed) {
+                      return;
+                    }
+                    const nextStart = toLocalDate(parsed);
+                    let nextEnd = endDate;
+                    if (nextStart > nextEnd) {
+                      nextEnd = nextStart;
+                    }
+                    const nextRangeDays = diffDaysInclusive(nextStart, nextEnd);
+                    updateFilters({
+                      ...filters,
+                      time: {
+                        ...filters.time,
+                        range_days: nextRangeDays,
+                        compare_days: nextRangeDays,
+                        start_date: formatDateInput(nextStart),
+                        end_date: formatDateInput(nextEnd),
+                      },
+                    });
+                  }}
+                />
+              </label>
+              <label className="flex flex-col gap-2">
+                <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
+                  End date
+                </span>
+                <input
+                  className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2 text-sm"
+                  type="date"
+                  value={formatDateInput(endDate)}
+                  onChange={(event) => {
+                    const parsed = parseDateInput(event.target.value);
+                    if (!parsed) {
+                      return;
+                    }
+                    const nextEnd = toLocalDate(parsed);
+                    let nextStart = startDate;
+                    if (nextEnd < nextStart) {
+                      nextStart = nextEnd;
+                    }
+                    const nextRangeDays = diffDaysInclusive(nextStart, nextEnd);
+                    updateFilters({
+                      ...filters,
+                      time: {
+                        ...filters.time,
+                        range_days: nextRangeDays,
+                        compare_days: nextRangeDays,
+                        start_date: formatDateInput(nextStart),
+                        end_date: formatDateInput(nextEnd),
+                      },
+                    });
+                  }}
+                />
+              </label>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/filters/sections/ToolbarActions.tsx
+++ b/src/components/filters/sections/ToolbarActions.tsx
@@ -1,0 +1,66 @@
+type ToolbarActionsProps = {
+  allowAdvanced: boolean;
+  copyFilters: () => Promise<void>;
+  peopleQuery: string;
+  resetFilters: () => void;
+  setShowAdvanced: (value: boolean | ((prev: boolean) => boolean)) => void;
+  showAdvanced: boolean;
+  updatePeopleQuery: (nextQuery: string) => void;
+  view?: string;
+};
+
+export function ToolbarActions({
+  allowAdvanced,
+  copyFilters,
+  peopleQuery,
+  resetFilters,
+  setShowAdvanced,
+  showAdvanced,
+  updatePeopleQuery,
+  view,
+}: ToolbarActionsProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {view === "people" && (
+        <label className="flex items-center gap-2 text-xs">
+          <span className="uppercase tracking-[0.2em] text-(--ink-muted)">Search:</span>
+          <input
+            value={peopleQuery}
+            onChange={(event) => updatePeopleQuery(event.target.value)}
+            placeholder="Name or handle"
+            className="w-full sm:w-56 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs"
+          />
+        </label>
+      )}
+
+      {allowAdvanced && (
+        <button
+          type="button"
+          onClick={() => setShowAdvanced((prev) => !prev)}
+          className={`rounded-full border px-4 py-2 text-xs uppercase tracking-[0.2em] transition-colors ${
+            showAdvanced
+              ? "border-(--accent) bg-(--accent-10) text-(--accent)"
+              : "border-(--card-stroke) bg-(--card-70) hover:border-(--ink-muted)"
+          }`}
+          aria-expanded={showAdvanced}
+        >
+          Filters
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={resetFilters}
+        className="rounded-full border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+      >
+        Reset
+      </button>
+      <button
+        type="button"
+        onClick={copyFilters}
+        className="rounded-full border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+      >
+        Copy
+      </button>
+    </div>
+  );
+}

--- a/src/components/filters/sections/WhatSection.tsx
+++ b/src/components/filters/sections/WhatSection.tsx
@@ -1,0 +1,45 @@
+type WhatSectionProps = {
+  artifacts: string[];
+  repos: string[];
+  toList: (value: string) => string[];
+  toValue: (value?: string[]) => string;
+  updateArtifacts: (nextValues: string[]) => void;
+  updateRepos: (nextValues: string[]) => void;
+};
+
+export function WhatSection({
+  artifacts,
+  repos,
+  toList,
+  toValue,
+  updateArtifacts,
+  updateRepos,
+}: WhatSectionProps) {
+  return (
+    <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+      <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+        What
+      </summary>
+      <div className="mt-3 space-y-3 text-sm">
+        <label className="flex flex-col gap-2">
+          <span className="text-xs text-(--ink-muted)">Repos</span>
+          <input
+            className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+            placeholder="org/api, org/ui"
+            value={toValue(repos)}
+            onChange={(event) => updateRepos(toList(event.target.value))}
+          />
+        </label>
+        <label className="flex flex-col gap-2">
+          <span className="text-xs text-(--ink-muted)">Artifacts</span>
+          <input
+            className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+            placeholder="pr, issue"
+            value={toValue(artifacts)}
+            onChange={(event) => updateArtifacts(toList(event.target.value))}
+          />
+        </label>
+      </div>
+    </details>
+  );
+}

--- a/src/components/filters/sections/WhoSection.tsx
+++ b/src/components/filters/sections/WhoSection.tsx
@@ -1,0 +1,45 @@
+type WhoSectionProps = {
+  developers: string[];
+  roles: string[];
+  toList: (value: string) => string[];
+  toValue: (value?: string[]) => string;
+  updateDevelopers: (nextValues: string[]) => void;
+  updateRoles: (nextValues: string[]) => void;
+};
+
+export function WhoSection({
+  developers,
+  roles,
+  toList,
+  toValue,
+  updateDevelopers,
+  updateRoles,
+}: WhoSectionProps) {
+  return (
+    <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+      <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+        Who
+      </summary>
+      <div className="mt-3 space-y-3 text-sm">
+        <label className="flex flex-col gap-2">
+          <span className="text-xs text-(--ink-muted)">Developers</span>
+          <input
+            className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2"
+            placeholder="alice, bob"
+            value={toValue(developers)}
+            onChange={(event) => updateDevelopers(toList(event.target.value))}
+          />
+        </label>
+        <label className="flex flex-col gap-2">
+          <span className="text-xs text-(--ink-muted)">Roles</span>
+          <input
+            className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2"
+            placeholder="maintainer, reviewer"
+            value={toValue(roles)}
+            onChange={(event) => updateRoles(toList(event.target.value))}
+          />
+        </label>
+      </div>
+    </details>
+  );
+}

--- a/src/components/filters/sections/WhySection.tsx
+++ b/src/components/filters/sections/WhySection.tsx
@@ -1,0 +1,45 @@
+type WhySectionProps = {
+  issueType: string[];
+  toList: (value: string) => string[];
+  toValue: (value?: string[]) => string;
+  updateIssueType: (nextValues: string[]) => void;
+  updateWorkCategory: (nextValues: string[]) => void;
+  workCategory: string[];
+};
+
+export function WhySection({
+  issueType,
+  toList,
+  toValue,
+  updateIssueType,
+  updateWorkCategory,
+  workCategory,
+}: WhySectionProps) {
+  return (
+    <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+      <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+        Why
+      </summary>
+      <div className="mt-3 space-y-3 text-sm">
+        <label className="flex flex-col gap-2">
+          <span className="text-xs text-(--ink-muted)">Work category</span>
+          <input
+            className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+            placeholder="feature, maintenance"
+            value={toValue(workCategory)}
+            onChange={(event) => updateWorkCategory(toList(event.target.value))}
+          />
+        </label>
+        <label className="flex flex-col gap-2">
+          <span className="text-xs text-(--ink-muted)">Issue type</span>
+          <input
+            className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+            placeholder="bug, story"
+            value={toValue(issueType)}
+            onChange={(event) => updateIssueType(toList(event.target.value))}
+          />
+        </label>
+      </div>
+    </details>
+  );
+}

--- a/src/components/filters/useFilterBarState.ts
+++ b/src/components/filters/useFilterBarState.ts
@@ -1,0 +1,293 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { apiClient } from "@/lib/apiClient";
+import {
+  addDays,
+  formatDateInput,
+  parseDateInput,
+  toLocalDate,
+} from "@/lib/dateUtils";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+import { decodeFilter, encodeFilterParam } from "@/lib/filters/encode";
+import type { MetricFilter } from "@/lib/filters/types";
+import { logger } from "@/lib/logger";
+import {
+  type FilterBarClientProps,
+  resolveScopeLock,
+  resolveVisibility,
+} from "./filterBarConfig";
+import {
+  DATE_PRESETS,
+  EMPTY_FILTER_OPTIONS,
+  formatSelection,
+  scopeLabelMap,
+  type FilterOptions,
+} from "./filterBarUtils";
+
+export function useFilterBarState({
+  view,
+  tab,
+  resolvedVisibility,
+  resolvedScopeLock,
+}: Pick<
+  FilterBarClientProps,
+  "view" | "tab" | "resolvedVisibility" | "resolvedScopeLock"
+>) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const encoded = searchParams.get("f");
+  const initialFilters = useMemo(() => decodeFilter(encoded), [encoded]);
+  const [filters, setFilters] = useState<MetricFilter>(initialFilters);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
+  const barRef = useRef<HTMLElement | null>(null);
+  const didSetDefaultRef = useRef(false);
+  const queryParam = searchParams.get("q") ?? "";
+  const [peopleQuery, setPeopleQuery] = useState(queryParam);
+  const [options, setOptions] = useState<FilterOptions>(EMPTY_FILTER_OPTIONS);
+
+  useEffect(() => {
+    setFilters(initialFilters);
+  }, [initialFilters]);
+
+  useEffect(() => {
+    if (!encoded && !didSetDefaultRef.current) {
+      didSetDefaultRef.current = true;
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("f", encodeFilterParam(defaultMetricFilter));
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    }
+  }, [encoded, pathname, router, searchParams]);
+
+  useEffect(() => {
+    if (view !== "people") {
+      return;
+    }
+    setPeopleQuery(queryParam);
+  }, [queryParam, view]);
+
+  useEffect(() => {
+    let active = true;
+
+    apiClient
+      .getJson<FilterOptions>("/api/v1/filters/options")
+      .then((payload) => {
+        if (!active) {
+          return;
+        }
+
+        setOptions({
+          teams: payload.teams ?? [],
+          repos: payload.repos ?? [],
+          services: payload.services ?? [],
+          developers: payload.developers ?? [],
+          work_category: payload.work_category ?? [],
+          issue_type: payload.issue_type ?? [],
+          flow_stage: payload.flow_stage ?? [],
+        });
+      })
+      .catch((err) => {
+        if (active) {
+          logger.warn({ err }, "FilterBarClient: failed to load filter options");
+          setOptions((prev) => ({ ...prev }));
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (!openMenu) {
+        return;
+      }
+
+      const target = event.target;
+      if (barRef.current && target instanceof Node && !barRef.current.contains(target)) {
+        setOpenMenu(null);
+      }
+    };
+
+    window.addEventListener("mousedown", handleClick);
+    return () => {
+      window.removeEventListener("mousedown", handleClick);
+    };
+  }, [openMenu]);
+
+  const updateUrl = useCallback(
+    (nextFilters: MetricFilter) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("f", encodeFilterParam(nextFilters));
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [pathname, router, searchParams]
+  );
+
+  const updateFilters = useCallback(
+    (nextFilters: MetricFilter) => {
+      setFilters(nextFilters);
+      updateUrl(nextFilters);
+    },
+    [updateUrl]
+  );
+
+  const updatePeopleQuery = useCallback(
+    (nextQuery: string) => {
+      setPeopleQuery(nextQuery);
+      const params = new URLSearchParams(searchParams.toString());
+      if (nextQuery.trim()) {
+        params.set("q", nextQuery);
+      } else {
+        params.delete("q");
+      }
+      params.set("f", encodeFilterParam(filters));
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [filters, pathname, router, searchParams]
+  );
+
+  const resetFilters = useCallback(() => {
+    if (view === "people") {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("q");
+      params.set("f", encodeFilterParam(defaultMetricFilter));
+      setFilters(defaultMetricFilter);
+      setPeopleQuery("");
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+      return;
+    }
+
+    updateFilters(defaultMetricFilter);
+  }, [pathname, router, searchParams, updateFilters, view]);
+
+  const copyFilters = useCallback(async () => {
+    const payload = JSON.stringify(filters, null, 2);
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(payload);
+    }
+  }, [filters]);
+
+  const handleDatePreset = useCallback(
+    (days: number) => {
+      const nextEnd = toLocalDate(new Date());
+      const nextStart = addDays(nextEnd, -(days - 1));
+      updateFilters({
+        ...filters,
+        time: {
+          ...filters.time,
+          range_days: days,
+          compare_days: days,
+          start_date: formatDateInput(nextStart),
+          end_date: formatDateInput(nextEnd),
+        },
+      });
+    },
+    [filters, updateFilters]
+  );
+
+  const visibility = resolvedVisibility ?? resolveVisibility(view, tab);
+  const allowAdvanced = view !== "people";
+  const scopeLock =
+    resolvedScopeLock !== undefined ? resolvedScopeLock : resolveScopeLock(view);
+  const scopeLevel = scopeLock ?? filters.scope.level;
+  const effectiveScopeIds =
+    scopeLock && filters.scope.level !== scopeLock ? [] : filters.scope.ids;
+
+  useEffect(() => {
+    if (!scopeLock || filters.scope.level === scopeLock) {
+      return;
+    }
+
+    const nextFilters = {
+      ...filters,
+      scope: { ...filters.scope, level: scopeLock, ids: [] },
+    };
+    setFilters(nextFilters);
+    updateUrl(nextFilters);
+  }, [filters, scopeLock, updateUrl]);
+
+  const scopeOptions = useMemo(() => {
+    if (scopeLevel === "team") {
+      return options.teams;
+    }
+    if (scopeLevel === "repo") {
+      return options.repos;
+    }
+    if (scopeLevel === "developer") {
+      return options.developers;
+    }
+    if (scopeLevel === "service") {
+      return options.services;
+    }
+    return [];
+  }, [scopeLevel, options]);
+
+  const developers = filters.who.developers ?? [];
+  const roles = filters.who.roles ?? [];
+  const repos = filters.what.repos ?? [];
+  const artifacts = filters.what.artifacts ?? [];
+  const workCategory = filters.why.work_category ?? [];
+  const issueType = filters.why.issue_type ?? [];
+  const flowStage = filters.how.flow_stage ?? [];
+
+  const scopeLabel = scopeLabelMap[scopeLevel] ?? "Team";
+  const scopeEmptyLabel = scopeLevel === "team" ? "All Teams" : "All";
+  const scopeValue = formatSelection(effectiveScopeIds, scopeEmptyLabel);
+  const safeRangeDays = Math.max(1, filters.time.range_days);
+  const today = toLocalDate(new Date());
+  const parsedStart = filters.time.start_date
+    ? parseDateInput(filters.time.start_date)
+    : null;
+  const parsedEnd = filters.time.end_date ? parseDateInput(filters.time.end_date) : null;
+  const resolvedEnd = toLocalDate(parsedEnd ?? today);
+  const resolvedStart = toLocalDate(
+    parsedStart ?? addDays(resolvedEnd, -(safeRangeDays - 1))
+  );
+  const startDate = resolvedStart > resolvedEnd ? resolvedEnd : resolvedStart;
+  const endDate = resolvedStart > resolvedEnd ? resolvedStart : resolvedEnd;
+  const dateValue = `${formatDateInput(startDate)} - ${formatDateInput(endDate)}`;
+  const isCustomDateRange = !DATE_PRESETS.some((preset) => preset.days === filters.time.range_days);
+
+  return {
+    allowAdvanced,
+    artifacts,
+    barRef,
+    copyFilters,
+    dateValue,
+    developers,
+    effectiveScopeIds,
+    endDate,
+    filters,
+    flowStage,
+    handleDatePreset,
+    isCustomDateRange,
+    issueType,
+    openMenu,
+    options,
+    peopleQuery,
+    repos,
+    resetFilters,
+    roles,
+    scopeEmptyLabel,
+    scopeLabel,
+    scopeLevel,
+    scopeLock,
+    scopeOptions,
+    scopeValue,
+    setOpenMenu,
+    setShowAdvanced,
+    showAdvanced,
+    startDate,
+    updateFilters,
+    updatePeopleQuery,
+    visibility,
+    workCategory,
+  };
+}


### PR DESCRIPTION
## Summary
- split `src/components/filters/FilterBarClient.tsx` into a thin orchestration layer backed by `useFilterBarState` plus focused section components for time, scope, quick menus, active pills, and advanced Who/What/Why/How inputs
- centralized shared visibility/scope-lock config in `src/components/filters/filterBarConfig.ts` so the RSC wrapper and client stay behaviorally aligned during the split
- preserved the existing FilterBar safety-net test file from PR #410 unchanged; all `FilterBarClient` cases and the full unit suite pass after the refactor

## Before / After LOC
| File | Before | After |
| --- | ---: | ---: |
| `src/components/filters/FilterBarClient.tsx` | 1064 | 264 |
| `src/components/filters/useFilterBarState.ts` | n/a | 293 |
| `src/components/filters/sections/TimeRangeSection.tsx` | n/a | 134 |
| `src/components/filters/sections/ScopeSection.tsx` | n/a | 92 |
| `src/components/filters/sections/QuickFilterMenu.tsx` | n/a | 58 |
| `src/components/filters/sections/ActiveFilterPills.tsx` | n/a | 96 |
| `src/components/filters/sections/AdvancedFiltersPanel.tsx` | n/a | 112 |
| `src/components/filters/sections/WhoSection.tsx` | n/a | 45 |
| `src/components/filters/sections/WhatSection.tsx` | n/a | 45 |
| `src/components/filters/sections/WhySection.tsx` | n/a | 45 |
| `src/components/filters/sections/HowSection.tsx` | n/a | 44 |
| `src/components/filters/sections/ToolbarActions.tsx` | n/a | 66 |
| `src/components/filters/sections/OptionList.tsx` | n/a | 40 |

## Decomposition rationale
- `useFilterBarState.ts` owns URL sync, option loading, scope locking, people search sync, clipboard copy, and shared derived state
- `TimeRangeSection` keeps the preset/custom date UI isolated from the rest of the bar
- `ScopeSection` owns scope-level selection and scoped option picking
- `QuickFilterMenu` handles the repeated dropdown pill menus used by repo/developer/work/flow selectors
- `ActiveFilterPills` owns rendering and clear actions for active chip state
- `AdvancedFiltersPanel` composes `WhoSection`, `WhatSection`, `WhySection`, and `HowSection` so each advanced filter concern stays under 300 LOC and single-purpose

## Verification
- `npm run typecheck`
- `npm run lint -- --max-warnings 6` *(6 pre-existing warnings, no new warnings)*
- `npm run test:unit -- FilterBarClient`
- `npm run test:unit`

## Test results
- `FilterBarClient.test.tsx`: 30 / 30 passing unchanged
- Full unit suite: 703 / 703 passing

## Safety net note
The comprehensive `src/components/filters/FilterBarClient.test.tsx` suite added in PR #410 was left unchanged and is fully passing after the split.

## Screenshots
SCREENSHOT-WAIVER: local `/work` screenshot capture was impractical in this worktree because the page redirects to auth (`/auth/signin?callbackUrl=%2Fwork`) even with local test-mode flags, so I could not produce a reliable before/after visual comparison without interactive credentials.

## Extra files touched outside `src/components/filters/`
- None.

TEST-WAIVER: refactor only; existing FilterBar safety-net tests remained unchanged and the full unit suite passed.