### PR TITLE
chore(ci): fix merge-queue compat + docs-only required-check blocks (CHAOS-1277, CHAOS-1278)

### DIFF
--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
   workflow_dispatch:
     inputs:
       tag:
@@ -62,22 +63,28 @@ jobs:
   build:
     name: Build Static Assets
     needs: [changes]
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      startsWith(github.ref, 'refs/tags/') ||
-      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.meta.outputs.version }}
       artifact_name: ${{ steps.meta.outputs.artifact_name }}
 
+    env:
+      SHOULD_BUILD: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.code == 'true' }}
+
     steps:
+      - name: Skip if no relevant changes
+        if: env.SHOULD_BUILD != 'true'
+        run: |
+          echo "No build-relevant files changed; emitting success without building."
+          echo "Keeps 'Build Static Assets' as a consistent required status check regardless of PR scope."
       - name: Checkout code
+        if: env.SHOULD_BUILD == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Generate build metadata
+        if: env.SHOULD_BUILD == 'true'
         id: meta
         run: |
           # Use shared script to generate version tag
@@ -96,26 +103,32 @@ jobs:
           GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Setup Node.js
+        if: env.SHOULD_BUILD == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
+        if: env.SHOULD_BUILD == 'true'
         run: npm ci
 
       - name: Run linting
+        if: env.SHOULD_BUILD == 'true'
         run: npm run lint
 
       - name: Run unit tests
+        if: env.SHOULD_BUILD == 'true'
         run: npm run test:unit
 
       - name: Build application
+        if: env.SHOULD_BUILD == 'true'
         env:
           BACKEND_URL: ${{ secrets.BACKEND_URL || 'https://api.dev-health.io' }}
         run: npm run build
 
       - name: Create build metadata
+        if: env.SHOULD_BUILD == 'true'
         run: |
           mkdir -p .next/meta
           cat > .next/meta/build-info.json << EOF
@@ -135,6 +148,7 @@ jobs:
           echo "${{ github.sha }}" > .next/meta/commit.txt
 
       - name: Upload build artifact
+        if: env.SHOULD_BUILD == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.meta.outputs.artifact_name }}
@@ -148,6 +162,7 @@ jobs:
           compression-level: 9
 
       - name: Output build results
+        if: env.SHOULD_BUILD == 'true'
         run: |
           echo "### Build Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -43,22 +44,30 @@ jobs:
 
   test:
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Skip if no relevant changes
+        if: needs.changes.outputs.code != 'true'
+        run: |
+          echo "No test-relevant files changed; emitting success without running the suite."
+          echo "Keeps 'test' as a consistent required status check regardless of PR scope."
       - name: Checkout
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Node
+        if: needs.changes.outputs.code == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 25
           cache: npm
       - name: Install dependencies
+        if: needs.changes.outputs.code == 'true'
         run: npm ci
       - name: Run CI test contract
+        if: needs.changes.outputs.code == 'true'
         run: bash ci/run_tests.sh ci
       - name: Upload Playwright report
-        if: always()
+        if: always() && needs.changes.outputs.code == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report-${{ github.run_id }}-${{ github.run_attempt }}
@@ -66,7 +75,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
       - name: Upload Playwright raw results and JUnit
-        if: always()
+        if: always() && needs.changes.outputs.code == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-results-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
## Summary

Two independent CI-infrastructure bugs surfaced during CHAOS-1275's branch-protection rollout. Both block PR merging in different ways; this PR fixes both in the same two files.

## Bugs Fixed

### CHAOS-1278 — workflows missing `merge_group` triggers

When the GitHub merge queue creates a test merge commit, it fires a `merge_group` event. No workflow in this repo listened for `merge_group`, so the required-check workflows never ran on queued merge commits. Queue entries sat in `AWAITING_CHECKS` until the 60-minute timeout.

**Fix**: add `merge_group:` to the `on:` triggers of `tests.yml` and `build-static.yml`.

### CHAOS-1277 — docs-only PRs stuck on required checks

The required-check jobs (`test`, `Build Static Assets`) both have `if: needs.changes.outputs.code == 'true'` at the **job** level. When a PR only touches docs/workflows/scripts, the whole job is skipped. GitHub treats a skipped check as *not-passing*, so docs-only PRs cannot merge through the queue.

**Fix**: remove the job-level `if:` and move the conditional to individual steps. A new 'Skip if no relevant changes' step echoes a success note when the suite doesn't need to run; every other step gets `if: needs.changes.outputs.code == 'true'` (or `SHOULD_BUILD == 'true'` in the build workflow). The job now always emits a `success` conclusion.

## Scope

- Modified: `.github/workflows/tests.yml`, `.github/workflows/build-static.yml`
- Untouched: `changes` jobs (paths-filter logic stays intact); `test-e2e` job (not a required check); other workflows (not required checks)

## Verification

- YAML parses cleanly via `yaml.safe_load()`.
- Both required-check jobs: zero job-level `if:`, every step guarded at step level, first-step echo emits `success` for docs-only runs.
- `merge_group` now in `on:` triggers for both.

---

TEST-WAIVER: This PR only touches `.github/workflows/`. No src/ code changed; code tests are not meaningful. Verification is behavioral and happens on the next PR.

SCREENSHOT-WAIVER: No UI changed; CI-configuration only.

Refs CHAOS-1277, CHAOS-1278. Follows CHAOS-1275.