### PR TITLE
Stabilize flaky people/filter-propagation Playwright tests

### DIFF
--- a/tests/filter-propagation.spec.ts
+++ b/tests/filter-propagation.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect, Page } from "@playwright/test";
 
+import { decodeFilter } from "../src/lib/filters/encode";
+
 const getFilterParam = (url: string) => new URL(url).searchParams.get("f");
 
 const waitForFilterParam = async (page: Page) => {
-  await page.waitForLoadState("networkidle");
   await page.waitForFunction(
     () => new URL(window.location.href).searchParams.get("f"),
     { timeout: 10000 }
@@ -15,6 +16,9 @@ const waitForFilterParam = async (page: Page) => {
 
 const updateDeveloperFilter = async (page: Page, value: string, previous: string) => {
   // Click "Filters" button to expand the advanced filters panel
+  await expect(page.getByRole("button", { name: "Filters" })).toBeVisible({
+    timeout: 15000,
+  });
   await page.getByRole("button", { name: "Filters" }).click();
   await page.locator("summary", { hasText: "Who" }).click();
   await page.getByPlaceholder("alice, bob").fill(value);
@@ -42,6 +46,16 @@ const expectFilterParam = async (page: Page, expected: string) => {
   );
 };
 
+const expectDeveloperFilter = async (page: Page, expected: string) => {
+  await expect
+    .poll(() => {
+      const encoded = getFilterParam(page.url());
+      const filters = decodeFilter(encoded);
+      return filters.who.developers?.join(",") ?? "";
+    })
+    .toBe(expected);
+};
+
 test.describe("filter propagation", () => {
   test("primary routes retain filter param", async ({ page }) => {
     await page.goto("/dashboard");
@@ -55,19 +69,22 @@ test.describe("filter propagation", () => {
     const nav = page.locator("aside nav");
     // Routes that exist in the primary navigation
     const routes = [
-      { label: /People/i, url: /\/people/ },
-      { label: /Metrics/i, url: /\/metrics/ },
-      { label: /Landscape/i, url: /\/explore\/landscape/ },
-      { label: /Work/i, url: /\/work/ },
-      { label: /Code/i, url: /\/code/ },
-      { label: /Opportunities/i, url: /\/opportunities/ },
-      { label: /Home/i, url: /\/dashboard\?f=/ },
+      { label: /People/i, path: "/people" },
+      { label: /Metrics/i, path: "/metrics" },
+      { label: /Landscape/i, path: "/explore/landscape" },
+      { label: /Work/i, path: "/work" },
+      { label: /Code/i, path: "/code" },
+      { label: /Opportunities/i, path: "/opportunities" },
+      { label: /Home/i, path: "/dashboard" },
     ];
 
     for (const route of routes) {
       await nav.getByRole("link", { name: route.label }).click();
-      await expect(page).toHaveURL(route.url);
+      await expect
+        .poll(() => new URL(page.url()).pathname)
+        .toBe(route.path);
       await expectFilterParam(page, updatedFilter);
+      await expectDeveloperFilter(page, "dev-health-web");
     }
   });
 
@@ -83,7 +100,10 @@ test.describe("filter propagation", () => {
 
     const nav = page.locator("aside nav");
     await nav.getByRole("link", { name: /Work/i }).click();
-    await expect(page).toHaveURL(/\/work/);
+    await expect
+      .poll(() => new URL(page.url()).pathname)
+      .toBe("/work");
     await expectFilterParam(page, updatedFilter);
+    await expectDeveloperFilter(page, "metrics-owner");
   });
 });

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -528,6 +528,18 @@ export const handlers = [
     }),
   ),
 
+  http.get("*/api/v1/filters/options", () =>
+    HttpResponse.json({
+      teams: ["core", "growth", "infra", "platform"],
+      repos: ["dev-health-web", "dev-health-ops", "frontend-web"],
+      services: ["web", "api", "analytics"],
+      developers: ["Alex Harper", "Jordan Lee", "metrics-owner", "dev-health-web"],
+      work_category: ["feature", "maintenance", "support"],
+      issue_type: ["bug", "story", "task"],
+      flow_stage: ["review", "build", "deploy"],
+    }),
+  ),
+
   http.get("*/api/v1/billing/plans", ({ request }) => {
     const url = new URL(request.url);
     const includeInactive = url.searchParams.get("include_inactive") === "true";

--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -1,18 +1,24 @@
 import { test, expect } from "@playwright/test";
 
 test("people search opens individual and metric evidence", async ({ page }) => {
-  // Navigate directly with query param to avoid the FilterBar → router.replace
-  // → server re-render → debounce chain which is unreliable in slow CI.
   await page.goto("/people?q=alex");
 
-  await expect(page.getByText("Alex Harper")).toBeVisible({ timeout: 15000 });
-  await page.getByText("Alex Harper").click();
-  await expect(page).toHaveURL(/\/people\/person-123/);
+  const personLink = page
+    .locator('a[href*="/people/person-123"]')
+    .filter({ hasText: "Alex Harper" });
+  await expect(personLink).toBeVisible({ timeout: 15000 });
+  await expect(personLink).toHaveAttribute("href", /\/people\/person-123\?f=/);
+  await personLink.click();
+  await expect(page).toHaveURL(/\/people\/person-123(?:\?|$)/);
 
   await expect(page.getByText("Individual view")).toBeVisible({ timeout: 10000 });
 
-  await page.getByRole("link", { name: "Cycle Time" }).first().click();
-  await expect(page).toHaveURL(/\/people\/person-123\/metrics\/cycle_time/);
+  const cycleTimeLink = page.locator(
+    'a[href*="/people/person-123/metrics/cycle_time"]'
+  );
+  await expect(cycleTimeLink.first()).toBeVisible({ timeout: 10000 });
+  await cycleTimeLink.first().click();
+  await expect(page).toHaveURL(/\/people\/person-123\/metrics\/cycle_time(?:\?|$)/);
 
   await page.getByRole("link", { name: "PRs" }).click();
   await expect(page.getByRole("heading", { name: "Evidence" })).toBeVisible();


### PR DESCRIPTION
## Summary
- harden tests/people.spec.ts by using deterministic href-scoped link locators and URL assertions that allow preserved query params
- harden tests/filter-propagation.spec.ts by removing networkidle dependency, adding explicit filter-button readiness checks, and validating developer filters semantically via decoded f params
- add missing mock endpoint GET /api/v1/filters/options in tests/mocks/handlers.ts to eliminate fallback warning/error-path behavior during test runs

## Validation
- npm run test:e2e -- --project=authenticated tests/people.spec.ts tests/filter-propagation.spec.ts
- result: 5 passed

SCREENSHOT-WAIVER: test-only changes; no rendered UI behavior was modified
