### PR TITLE
test(lib): add unit tests for fetchOrNull, sankey, origin (CHAOS-1241)

### DIFF
--- a/src/lib/__tests__/fetchOrNull.test.ts
+++ b/src/lib/__tests__/fetchOrNull.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted above imports; mock logger before fetchOrNull imports it.
+vi.mock("@/lib/logger", () => ({
+    logger: {
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+        fatal: vi.fn(),
+        child: vi.fn(),
+    },
+}));
+
+import { fetchOrNull } from "@/lib/fetchOrNull";
+import { logger } from "@/lib/logger";
+
+const warnSpy = logger.warn as unknown as ReturnType<typeof vi.fn>;
+
+describe("fetchOrNull", () => {
+    beforeEach(() => {
+        warnSpy.mockClear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("happy path", () => {
+        it("returns the resolved value for a string", async () => {
+            const result = await fetchOrNull(Promise.resolve("hello"), "string-label");
+            expect(result).toBe("hello");
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it("returns the resolved value for an object", async () => {
+            const payload = { id: 42, name: "widget" };
+            const result = await fetchOrNull(Promise.resolve(payload), "obj-label");
+            expect(result).toEqual(payload);
+            expect(result).toBe(payload);
+        });
+
+        it("returns the resolved value for an array", async () => {
+            const arr = [1, 2, 3];
+            const result = await fetchOrNull(Promise.resolve(arr), "array-label");
+            expect(result).toEqual([1, 2, 3]);
+        });
+
+        it("returns falsy primitives unchanged (0, false, empty string)", async () => {
+            expect(await fetchOrNull(Promise.resolve(0), "zero")).toBe(0);
+            expect(await fetchOrNull(Promise.resolve(false), "false")).toBe(false);
+            expect(await fetchOrNull(Promise.resolve(""), "empty")).toBe("");
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it("passes through an explicit null resolution without logging a warning", async () => {
+            const result = await fetchOrNull(Promise.resolve(null), "null-value");
+            expect(result).toBeNull();
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it("returns undefined when the promise resolves to undefined", async () => {
+            const result = await fetchOrNull(Promise.resolve(undefined), "undef-value");
+            expect(result).toBeUndefined();
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it("awaits slow-resolving promises", async () => {
+            const slow = new Promise<string>((resolve) =>
+                setTimeout(() => resolve("later"), 5),
+            );
+            const result = await fetchOrNull(slow, "slow");
+            expect(result).toBe("later");
+        });
+    });
+
+    describe("error path", () => {
+        it("returns null when the promise rejects with an Error", async () => {
+            const err = new Error("boom");
+            const result = await fetchOrNull(Promise.reject(err), "err-label");
+            expect(result).toBeNull();
+        });
+
+        it("returns null for rejection with a string", async () => {
+            const result = await fetchOrNull(
+                Promise.reject("string reason"),
+                "string-reject",
+            );
+            expect(result).toBeNull();
+        });
+
+        it("returns null for rejection with undefined / null", async () => {
+            expect(
+                await fetchOrNull(Promise.reject(undefined), "undef-reject"),
+            ).toBeNull();
+            expect(
+                await fetchOrNull(Promise.reject(null), "null-reject"),
+            ).toBeNull();
+        });
+
+        it("returns null when the underlying promise throws synchronously (async function body)", async () => {
+            const thrower = (async () => {
+                throw new Error("sync throw in async");
+            })();
+            const result = await fetchOrNull(thrower, "thrower");
+            expect(result).toBeNull();
+        });
+
+        it("resolves (does not reject) when the underlying promise rejects", async () => {
+            await expect(
+                fetchOrNull(Promise.reject(new Error("x")), "swallow"),
+            ).resolves.toBeNull();
+        });
+    });
+
+    describe("logging", () => {
+        it("logs a warning that includes the label and the thrown error", async () => {
+            const err = new Error("network down");
+            await fetchOrNull(Promise.reject(err), "home-data");
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            const [logArg, message] = warnSpy.mock.calls[0];
+            expect(logArg).toEqual({ err, label: "home-data" });
+            expect(message).toBe("fetchOrNull: home-data failed, returning null");
+        });
+
+        it("logs only once per failure", async () => {
+            await fetchOrNull(Promise.reject(new Error("once")), "label1");
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("propagates distinct labels into log calls", async () => {
+            await fetchOrNull(Promise.reject(new Error("a")), "label-a");
+            await fetchOrNull(Promise.reject(new Error("b")), "label-b");
+            expect(warnSpy).toHaveBeenCalledTimes(2);
+            expect(warnSpy.mock.calls[0][1]).toContain("label-a");
+            expect(warnSpy.mock.calls[1][1]).toContain("label-b");
+        });
+
+        it("does not log on success even for potentially falsy values", async () => {
+            await fetchOrNull(Promise.resolve(null), "null-ok");
+            await fetchOrNull(Promise.resolve(undefined), "undef-ok");
+            await fetchOrNull(Promise.resolve(0), "zero-ok");
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("generic type behavior", () => {
+        it("preserves the generic return type for typed promises", async () => {
+            interface Widget {
+                id: number;
+            }
+            const p: Promise<Widget> = Promise.resolve({ id: 7 });
+            const result = await fetchOrNull(p, "typed");
+            expect(result?.id).toBe(7);
+        });
+    });
+});

--- a/src/lib/__tests__/origin.test.ts
+++ b/src/lib/__tests__/origin.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.hoisted: module mocks must read from a value declared above the
+// hoisted vi.mock calls. This lets each test flip isBrowser / BACKEND_URL.
+const mocks = vi.hoisted(() => ({
+    isBrowser: false,
+    serverEnv: {} as { BACKEND_URL?: string },
+}));
+
+vi.mock("@/lib/env", () => ({
+    get isBrowser() {
+        return mocks.isBrowser;
+    },
+    get isServer() {
+        return !mocks.isBrowser;
+    },
+}));
+
+vi.mock("@/lib/config", () => ({
+    getServerEnv: () => mocks.serverEnv,
+}));
+
+import { getBackendUrl, resolveOrigin } from "@/lib/origin";
+
+const DEFAULT_BACKEND = "http://127.0.0.1:8000";
+
+describe("resolveOrigin", () => {
+    beforeEach(() => {
+        mocks.isBrowser = false;
+        mocks.serverEnv = {};
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    describe("server environment", () => {
+        it("returns BACKEND_URL from getServerEnv when set", () => {
+            mocks.serverEnv = { BACKEND_URL: "https://api.production.example.com" };
+            expect(resolveOrigin()).toBe("https://api.production.example.com");
+        });
+
+        it("returns the default backend URL when BACKEND_URL is undefined", () => {
+            mocks.serverEnv = {};
+            expect(resolveOrigin()).toBe(DEFAULT_BACKEND);
+        });
+
+        it("preserves a backend URL with a custom port", () => {
+            mocks.serverEnv = { BACKEND_URL: "http://backend.internal:9090" };
+            expect(resolveOrigin()).toBe("http://backend.internal:9090");
+        });
+
+        it("returns an empty BACKEND_URL as-is (?? does not treat '' as missing)", () => {
+            mocks.serverEnv = { BACKEND_URL: "" };
+            expect(resolveOrigin()).toBe("");
+        });
+    });
+
+    describe("browser environment", () => {
+        it("returns window.location.origin when isBrowser is true", () => {
+            mocks.isBrowser = true;
+            vi.stubGlobal("window", {
+                location: { origin: "https://app.example.com" },
+            });
+            expect(resolveOrigin()).toBe("https://app.example.com");
+        });
+
+        it("prefers window.location.origin over BACKEND_URL when in a browser", () => {
+            mocks.isBrowser = true;
+            mocks.serverEnv = { BACKEND_URL: "https://ignored-backend.example" };
+            vi.stubGlobal("window", {
+                location: { origin: "https://browser.example.com" },
+            });
+            expect(resolveOrigin()).toBe("https://browser.example.com");
+        });
+
+        it("handles browser origins with a port", () => {
+            mocks.isBrowser = true;
+            vi.stubGlobal("window", {
+                location: { origin: "http://localhost:3000" },
+            });
+            expect(resolveOrigin()).toBe("http://localhost:3000");
+        });
+    });
+});
+
+describe("getBackendUrl", () => {
+    beforeEach(() => {
+        mocks.isBrowser = false;
+        mocks.serverEnv = {};
+    });
+
+    it("returns the BACKEND_URL from server env when set", () => {
+        mocks.serverEnv = { BACKEND_URL: "https://backend.example.com" };
+        expect(getBackendUrl()).toBe("https://backend.example.com");
+    });
+
+    it("returns the default backend URL when BACKEND_URL is undefined", () => {
+        mocks.serverEnv = {};
+        expect(getBackendUrl()).toBe(DEFAULT_BACKEND);
+    });
+
+    it("ignores the browser/window context (always reads server env)", () => {
+        mocks.isBrowser = true;
+        mocks.serverEnv = { BACKEND_URL: "http://backend-only.example" };
+        vi.stubGlobal("window", {
+            location: { origin: "https://ignored.example" },
+        });
+        expect(getBackendUrl()).toBe("http://backend-only.example");
+    });
+
+    it("reflects BACKEND_URL changes between successive calls", () => {
+        mocks.serverEnv = { BACKEND_URL: "http://first.example" };
+        expect(getBackendUrl()).toBe("http://first.example");
+        mocks.serverEnv = { BACKEND_URL: "http://second.example" };
+        expect(getBackendUrl()).toBe("http://second.example");
+    });
+
+    it("returns an empty BACKEND_URL as-is (?? does not treat '' as missing)", () => {
+        mocks.serverEnv = { BACKEND_URL: "" };
+        expect(getBackendUrl()).toBe("");
+    });
+});

--- a/src/lib/__tests__/sankey.test.ts
+++ b/src/lib/__tests__/sankey.test.ts
@@ -1,23 +1,468 @@
 import { describe, expect, it } from "vitest";
 
-import { SANKEY_MODES, buildSankeyDataset } from "@/lib/sankey";
+import { decodeFilter } from "@/lib/filters/encode";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+import type { MetricFilter } from "@/lib/filters/types";
+import {
+    SANKEY_MODES,
+    buildSankeyDataset,
+    buildSankeyEvidenceUrl,
+    computeSankeyMetrics,
+    filterSankeyToTeam,
+    getSankeyDefinition,
+    limitRepoNodes,
+} from "@/lib/sankey";
+import type { SankeyLink, SankeyNode } from "@/lib/types";
+
+describe("SANKEY_MODES", () => {
+    it("declares every required mode with label/description/unit", () => {
+        const ids = SANKEY_MODES.map((m) => m.id).sort();
+        expect(ids).toEqual(["expense", "hotspot", "investment", "state"]);
+        SANKEY_MODES.forEach((mode) => {
+            expect(mode.label.length).toBeGreaterThan(0);
+            expect(mode.description.length).toBeGreaterThan(0);
+            expect(mode.unit.length).toBeGreaterThan(0);
+        });
+    });
+});
+
+describe("getSankeyDefinition", () => {
+    it("returns the matching definition for a known mode", () => {
+        const def = getSankeyDefinition("investment");
+        expect(def.id).toBe("investment");
+        expect(def.label).toBe("Investment flow");
+        expect(def.unit).toBe("items");
+    });
+
+    it("returns the first mode as a fallback for an unknown mode", () => {
+        const def = getSankeyDefinition(
+            "does-not-exist" as unknown as (typeof SANKEY_MODES)[number]["id"],
+        );
+        expect(def).toBe(SANKEY_MODES[0]);
+    });
+
+    it("returns the state mode with expected metadata", () => {
+        const def = getSankeyDefinition("state");
+        expect(def.id).toBe("state");
+        expect(def.label).toBe("State flow");
+    });
+});
 
 describe("buildSankeyDataset", () => {
-  SANKEY_MODES.forEach((mode) => {
-    it(`builds ${mode.id} with nodes and links`, () => {
-      const dataset = buildSankeyDataset(mode.id);
-      expect(dataset.nodes.length).toBeGreaterThan(0);
-      expect(dataset.links.length).toBeGreaterThan(0);
-      const names = dataset.nodes.map((node) => node.name);
-      expect(new Set(names).size).toBe(names.length);
+    SANKEY_MODES.forEach((mode) => {
+        it(`builds ${mode.id} with unique, non-empty nodes and links`, () => {
+            const dataset = buildSankeyDataset(mode.id);
+            expect(dataset.mode).toBe(mode.id);
+            expect(dataset.label).toBe(mode.label);
+            expect(dataset.description).toBe(mode.description);
+            expect(dataset.unit).toBe(mode.unit);
+            expect(dataset.nodes.length).toBeGreaterThan(0);
+            expect(dataset.links.length).toBeGreaterThan(0);
+            const names = dataset.nodes.map((node) => node.name);
+            expect(new Set(names).size).toBe(names.length);
+        });
     });
-  });
 
-  it("builds state flow with issue, PR, and deployment nodes", () => {
-    const dataset = buildSankeyDataset("state");
-    const names = dataset.nodes.map((node) => node.name);
-    expect(names).toContain("Issue Backlog");
-    expect(names).toContain("PR Draft");
-    expect(names).toContain("Deployment Build");
-  });
+    it("includes expected state-flow node names", () => {
+        const dataset = buildSankeyDataset("state");
+        const names = dataset.nodes.map((node) => node.name);
+        expect(names).toContain("Issue Backlog");
+        expect(names).toContain("PR Draft");
+        expect(names).toContain("Deployment Build");
+    });
+
+    it("tags state-flow nodes with group='state'", () => {
+        const dataset = buildSankeyDataset("state");
+        expect(dataset.nodes.every((n) => n.group === "state")).toBe(true);
+    });
+
+    it("all link endpoints refer to existing node names", () => {
+        SANKEY_MODES.forEach((mode) => {
+            const dataset = buildSankeyDataset(mode.id);
+            const names = new Set(dataset.nodes.map((n) => n.name));
+            dataset.links.forEach((link) => {
+                expect(names.has(link.source)).toBe(true);
+                expect(names.has(link.target)).toBe(true);
+            });
+        });
+    });
+});
+
+describe("buildSankeyEvidenceUrl", () => {
+    const filters: MetricFilter = defaultMetricFilter;
+
+    it("returns a path that starts with /explore and encodes the metric", () => {
+        const url = buildSankeyEvidenceUrl({ mode: "investment", filters });
+        expect(url.startsWith("/explore?")).toBe(true);
+        const query = new URLSearchParams(url.slice("/explore?".length));
+        expect(query.get("metric")).toBe("throughput");
+        expect(query.get("api")).toBe("/api/v1/drilldown/issues");
+        expect(query.has("f")).toBe(true);
+    });
+
+    it("uses the PR drilldown API when label contains 'pr'", () => {
+        const url = buildSankeyEvidenceUrl({
+            mode: "investment",
+            filters,
+            label: "PR authors",
+        });
+        const query = new URLSearchParams(url.slice("/explore?".length));
+        expect(query.get("api")).toBe("/api/v1/drilldown/prs");
+    });
+
+    it("uses the issues drilldown API when label contains 'issue'", () => {
+        const url = buildSankeyEvidenceUrl({
+            mode: "hotspot",
+            filters,
+            label: "issue tickets",
+        });
+        const query = new URLSearchParams(url.slice("/explore?".length));
+        expect(query.get("api")).toBe("/api/v1/drilldown/issues");
+    });
+
+    it("falls back to the default API per mode when label does not match PR/issue", () => {
+        const hotspotUrl = buildSankeyEvidenceUrl({
+            mode: "hotspot",
+            filters,
+            label: "some other label",
+        });
+        const hq = new URLSearchParams(hotspotUrl.slice("/explore?".length));
+        expect(hq.get("api")).toBe("/api/v1/drilldown/prs");
+
+        const expenseUrl = buildSankeyEvidenceUrl({
+            mode: "expense",
+            filters,
+        });
+        const eq = new URLSearchParams(expenseUrl.slice("/explore?".length));
+        expect(eq.get("api")).toBe("/api/v1/drilldown/issues");
+    });
+
+    it("includes category and breakdown when label and linkLabel are provided", () => {
+        const url = buildSankeyEvidenceUrl({
+            mode: "state",
+            filters,
+            label: "Review",
+            linkLabel: "Approved",
+        });
+        const q = new URLSearchParams(url.slice("/explore?".length));
+        expect(q.get("category")).toBe("Review");
+        expect(q.get("breakdown")).toBe("Approved");
+    });
+
+    it("omits category when label is null or undefined", () => {
+        const urlUndef = buildSankeyEvidenceUrl({ mode: "state", filters });
+        const urlNull = buildSankeyEvidenceUrl({
+            mode: "state",
+            filters,
+            label: null,
+            linkLabel: null,
+        });
+        expect(new URLSearchParams(urlUndef.slice("/explore?".length)).has("category")).toBe(
+            false,
+        );
+        expect(new URLSearchParams(urlNull.slice("/explore?".length)).has("category")).toBe(
+            false,
+        );
+        expect(new URLSearchParams(urlNull.slice("/explore?".length)).has("breakdown")).toBe(
+            false,
+        );
+    });
+
+    it("applies a window to filters when window_start and window_end are provided", () => {
+        const url = buildSankeyEvidenceUrl({
+            mode: "investment",
+            filters,
+            window_start: "2024-01-01",
+            window_end: "2024-01-08",
+        });
+        const q = new URLSearchParams(url.slice("/explore?".length));
+        const decoded = decodeFilter(q.get("f"));
+        expect(decoded.time.start_date).toBe("2024-01-01");
+        expect(decoded.time.end_date).toBe("2024-01-08");
+        expect(decoded.time.range_days).toBe(7);
+    });
+
+    it("leaves filters untouched when no window is provided", () => {
+        const url = buildSankeyEvidenceUrl({ mode: "investment", filters });
+        const q = new URLSearchParams(url.slice("/explore?".length));
+        const decoded = decodeFilter(q.get("f"));
+        expect(decoded.time.start_date).toBeUndefined();
+        expect(decoded.time.end_date).toBeUndefined();
+        expect(decoded.time.range_days).toBe(defaultMetricFilter.time.range_days);
+    });
+
+    it("uses the correct default metric per mode", () => {
+        const cases: Array<{ mode: Parameters<typeof buildSankeyEvidenceUrl>[0]["mode"]; metric: string }> = [
+            { mode: "investment", metric: "throughput" },
+            { mode: "expense", metric: "churn" },
+            { mode: "state", metric: "cycle_time" },
+            { mode: "hotspot", metric: "churn" },
+        ];
+        cases.forEach(({ mode, metric }) => {
+            const url = buildSankeyEvidenceUrl({ mode, filters });
+            const q = new URLSearchParams(url.slice("/explore?".length));
+            expect(q.get("metric")).toBe(metric);
+        });
+    });
+});
+
+describe("computeSankeyMetrics", () => {
+    it("returns zero totals for empty input", () => {
+        const result = computeSankeyMetrics([], []);
+        expect(result.incomingTotals.size).toBe(0);
+        expect(result.outgoingTotals.size).toBe(0);
+        expect(result.nodeValueByName.size).toBe(0);
+        expect(result.totalFlow).toBe(0);
+    });
+
+    it("computes incoming, outgoing, and nodeValueByName for a simple chain A → B → C", () => {
+        const nodes: SankeyNode[] = [
+            { name: "A" },
+            { name: "B" },
+            { name: "C" },
+        ];
+        const links: SankeyLink[] = [
+            { source: "A", target: "B", value: 10 },
+            { source: "B", target: "C", value: 10 },
+        ];
+        const { incomingTotals, outgoingTotals, nodeValueByName, totalFlow } =
+            computeSankeyMetrics(nodes, links);
+
+        expect(incomingTotals.get("A")).toBeUndefined();
+        expect(incomingTotals.get("B")).toBe(10);
+        expect(incomingTotals.get("C")).toBe(10);
+        expect(outgoingTotals.get("A")).toBe(10);
+        expect(outgoingTotals.get("B")).toBe(10);
+        expect(outgoingTotals.get("C")).toBeUndefined();
+        expect(nodeValueByName.get("A")).toBe(10);
+        expect(nodeValueByName.get("B")).toBe(10);
+        expect(nodeValueByName.get("C")).toBe(10);
+
+        expect(totalFlow).toBe(10);
+    });
+
+    it("computes totals for a branching structure", () => {
+        const nodes: SankeyNode[] = [
+            { name: "Root" },
+            { name: "Left" },
+            { name: "Right" },
+        ];
+        const links: SankeyLink[] = [
+            { source: "Root", target: "Left", value: 3 },
+            { source: "Root", target: "Right", value: 7 },
+        ];
+        const result = computeSankeyMetrics(nodes, links);
+        expect(result.outgoingTotals.get("Root")).toBe(10);
+        expect(result.incomingTotals.get("Left")).toBe(3);
+        expect(result.incomingTotals.get("Right")).toBe(7);
+        expect(result.nodeValueByName.get("Root")).toBe(10);
+        expect(result.totalFlow).toBe(10);
+    });
+
+    it("sums parallel edges between the same pair", () => {
+        const nodes: SankeyNode[] = [{ name: "A" }, { name: "B" }];
+        const links: SankeyLink[] = [
+            { source: "A", target: "B", value: 2 },
+            { source: "A", target: "B", value: 5 },
+        ];
+        const { incomingTotals, outgoingTotals, totalFlow } =
+            computeSankeyMetrics(nodes, links);
+        expect(outgoingTotals.get("A")).toBe(7);
+        expect(incomingTotals.get("B")).toBe(7);
+        expect(totalFlow).toBe(7);
+    });
+
+    it("falls back to summing all link values when no root node exists", () => {
+        const nodes: SankeyNode[] = [{ name: "A" }, { name: "B" }];
+        const links: SankeyLink[] = [
+            { source: "A", target: "B", value: 4 },
+            { source: "B", target: "A", value: 1 },
+        ];
+        const { totalFlow } = computeSankeyMetrics(nodes, links);
+        expect(totalFlow).toBe(5);
+    });
+});
+
+describe("limitRepoNodes", () => {
+    const buildFlow = () => ({
+        nodes: [
+            { name: "cat:Initiative", group: "category" } as SankeyNode,
+            { name: "repo:alpha", group: "repo" } as SankeyNode,
+            { name: "repo:beta", group: "repo" } as SankeyNode,
+            { name: "repo:gamma", group: "repo" } as SankeyNode,
+            { name: "repo:delta", group: "repo" } as SankeyNode,
+        ],
+        links: [
+            { source: "cat:Initiative", target: "repo:alpha", value: 50 } as SankeyLink,
+            { source: "cat:Initiative", target: "repo:beta", value: 30 } as SankeyLink,
+            { source: "cat:Initiative", target: "repo:gamma", value: 15 } as SankeyLink,
+            { source: "cat:Initiative", target: "repo:delta", value: 5 } as SankeyLink,
+        ],
+    });
+
+    it("returns the flow unchanged when repo count is at or below topN", () => {
+        const flow = buildFlow();
+        const unchanged = limitRepoNodes(flow, 10);
+        expect(unchanged).toBe(flow);
+        const atThreshold = limitRepoNodes(flow, 4);
+        expect(atThreshold).toBe(flow);
+    });
+
+    it("keeps the top N repos by value and aggregates the rest under 'Other repos'", () => {
+        const flow = buildFlow();
+        const limited = limitRepoNodes(flow, 2);
+        const names = limited.nodes.map((n) => n.name);
+        expect(names).toContain("repo:alpha");
+        expect(names).toContain("repo:beta");
+        expect(names).not.toContain("repo:gamma");
+        expect(names).not.toContain("repo:delta");
+        expect(names).toContain("repo:Other repos");
+
+        const otherLink = limited.links.find(
+            (l) => l.target === "repo:Other repos",
+        );
+        expect(otherLink?.value).toBe(20);
+    });
+
+    it("keeps non-repo nodes untouched", () => {
+        const flow = buildFlow();
+        const limited = limitRepoNodes(flow, 1);
+        expect(limited.nodes.find((n) => n.name === "cat:Initiative")).toBeDefined();
+    });
+
+    it("uses a custom otherReposLabel when provided", () => {
+        const flow = buildFlow();
+        const limited = limitRepoNodes(flow, 2, "More repos");
+        const names = limited.nodes.map((n) => n.name);
+        expect(names).toContain("repo:More repos");
+        expect(names).not.toContain("repo:Other repos");
+    });
+
+    it("orders repos by total value descending, ties broken alphabetically", () => {
+        const flow = {
+            nodes: [
+                { name: "cat:x", group: "category" } as SankeyNode,
+                { name: "repo:b", group: "repo" } as SankeyNode,
+                { name: "repo:a", group: "repo" } as SankeyNode,
+                { name: "repo:c", group: "repo" } as SankeyNode,
+            ],
+            links: [
+                { source: "cat:x", target: "repo:a", value: 10 } as SankeyLink,
+                { source: "cat:x", target: "repo:b", value: 10 } as SankeyLink,
+                { source: "cat:x", target: "repo:c", value: 1 } as SankeyLink,
+            ],
+        };
+        const limited = limitRepoNodes(flow, 2);
+        const repoNames = limited.nodes
+            .filter((n) => n.group === "repo" && n.name !== "repo:Other repos")
+            .map((n) => n.name);
+        expect(repoNames).toEqual(["repo:a", "repo:b"]);
+    });
+
+    it("drops links whose endpoints no longer exist after limiting", () => {
+        const flow = buildFlow();
+        const limited = limitRepoNodes(flow, 2);
+        const nodeNames = new Set(limited.nodes.map((n) => n.name));
+        limited.links.forEach((link) => {
+            expect(nodeNames.has(link.source)).toBe(true);
+            expect(nodeNames.has(link.target)).toBe(true);
+        });
+    });
+
+    it("deduplicates node names in the resulting nodes array", () => {
+        const flow = buildFlow();
+        const limited = limitRepoNodes(flow, 2);
+        const names = limited.nodes.map((n) => n.name);
+        expect(new Set(names).size).toBe(names.length);
+    });
+});
+
+describe("filterSankeyToTeam", () => {
+    const flow = {
+        nodes: [
+            { name: "team:platform", group: "team" } as SankeyNode,
+            { name: "team:data", group: "team" } as SankeyNode,
+            { name: "repo:platform-api", group: "repo" } as SankeyNode,
+            { name: "repo:data-pipeline", group: "repo" } as SankeyNode,
+            { name: "cat:work", group: "category" } as SankeyNode,
+        ],
+        links: [
+            { source: "team:platform", target: "repo:platform-api", value: 5 } as SankeyLink,
+            { source: "team:data", target: "repo:data-pipeline", value: 3 } as SankeyLink,
+            { source: "repo:platform-api", target: "cat:work", value: 5 } as SankeyLink,
+            { source: "repo:data-pipeline", target: "cat:work", value: 3 } as SankeyLink,
+        ],
+    };
+
+    it("returns null when given a null flow", () => {
+        expect(filterSankeyToTeam(null, "platform")).toBeNull();
+    });
+
+    it("returns the flow unchanged when teamName is null", () => {
+        const result = filterSankeyToTeam(flow, null);
+        expect(result).toBe(flow);
+    });
+
+    it("returns the flow unchanged when no matching team node is found", () => {
+        const result = filterSankeyToTeam(flow, "does-not-exist");
+        expect(result).toBe(flow);
+    });
+
+    it("filters to nodes and links reachable from the team (prefixed name)", () => {
+        const result = filterSankeyToTeam(flow, "platform");
+        expect(result).not.toBeNull();
+        const names = result!.nodes.map((n) => n.name).sort();
+        expect(names).toEqual(
+            ["cat:work", "repo:platform-api", "team:platform"].sort(),
+        );
+        result!.links.forEach((link) => {
+            expect(names).toContain(link.source);
+            expect(names).toContain(link.target);
+        });
+    });
+
+    it("accepts a team name that matches a node without the 'team:' prefix", () => {
+        const unprefixedFlow = {
+            nodes: [
+                { name: "alpha", group: "team" } as SankeyNode,
+                { name: "repo:one", group: "repo" } as SankeyNode,
+            ],
+            links: [
+                { source: "alpha", target: "repo:one", value: 1 } as SankeyLink,
+            ],
+        };
+        const result = filterSankeyToTeam(unprefixedFlow, "alpha");
+        expect(result).not.toBeNull();
+        expect(result!.nodes.map((n) => n.name).sort()).toEqual([
+            "alpha",
+            "repo:one",
+        ]);
+    });
+
+    it("excludes nodes that are unreachable from the chosen team", () => {
+        const result = filterSankeyToTeam(flow, "platform");
+        const names = result!.nodes.map((n) => n.name);
+        expect(names).not.toContain("team:data");
+        expect(names).not.toContain("repo:data-pipeline");
+    });
+
+    it("follows transitive edges (BFS) to include multi-hop neighbors", () => {
+        const layered = {
+            nodes: [
+                { name: "team:x", group: "team" } as SankeyNode,
+                { name: "mid", group: "category" } as SankeyNode,
+                { name: "leaf", group: "repo" } as SankeyNode,
+            ],
+            links: [
+                { source: "team:x", target: "mid", value: 2 } as SankeyLink,
+                { source: "mid", target: "leaf", value: 2 } as SankeyLink,
+            ],
+        };
+        const result = filterSankeyToTeam(layered, "x");
+        expect(result!.nodes.map((n) => n.name).sort()).toEqual([
+            "leaf",
+            "mid",
+            "team:x",
+        ]);
+    });
 });


### PR DESCRIPTION
## Summary

Adds dedicated Vitest unit test coverage for three critical `src/lib` utilities that were previously exercised only indirectly (sankey) or not at all (fetchOrNull, origin).

Closes/Addresses **CHAOS-1241** (part of the [CHAOS-1216 Test Coverage](https://linear.app/full-chaos/issue/CHAOS-1216) epic).

## Changes

Three atomic commits, one per utility:

| Commit | File | New test cases |
|--------|------|----------------|
| `test(lib): add unit tests for fetchOrNull` | `src/lib/__tests__/fetchOrNull.test.ts` (new) | 17 |
| `test(lib): expand unit tests for sankey utilities` | `src/lib/__tests__/sankey.test.ts` (expanded from 4 → 39) | +35 |
| `test(lib): add unit tests for origin helpers` | `src/lib/__tests__/origin.test.ts` (new) | 12 |

**Total new/added test cases: 64** (suite grows from 708 → 772 passing).

## Coverage by utility

### `src/lib/fetchOrNull.ts` — 17 tests
- **Happy path:** resolves strings, objects, arrays, falsy primitives (`0`, `false`, `""`), explicit `null` / `undefined`, and slow-resolving promises.
- **Error path:** rejections with `Error`, strings, `null`/`undefined`; synchronous throw in async body; verifies the function does **not** rethrow.
- **Logging contract:** asserts exact log shape `{ err, label }` + message `"fetchOrNull: <label> failed, returning null"`; single call per failure; no logging on success.
- **Generic type preservation** round-trip.
- Branch coverage: **100%** (one `try/catch` branch, both sides covered).

### `src/lib/sankey.ts` — 39 tests
Expands the existing smoke test (which only covered `buildSankeyDataset`) to exercise every exported symbol:
- `SANKEY_MODES` — mode inventory and metadata.
- `getSankeyDefinition` — known mode, unknown-mode fallback, metadata parity.
- `buildSankeyDataset` — all 4 modes (investment, expense, state, hotspot); node/link integrity; `group='state'` tagging; link-endpoint references point to real nodes.
- `buildSankeyEvidenceUrl` — metric-by-mode mapping, PR/issue label inference, default-API fallback, category/breakdown params, null-label handling, window-to-filter propagation (verified by decoding the `f=` param).
- `computeSankeyMetrics` — empty input, chains, branching, parallel edges, `totalFlow` fallback when no root node exists.
- `limitRepoNodes` — below-threshold no-op, aggregation into `Other repos`, custom label, descending-value ordering with alphabetical tiebreak, link pruning, node dedup.
- `filterSankeyToTeam` — null flow, null team, no-match, BFS traversal, prefixed and unprefixed team names, exclusion of unreachable nodes.
- Branch coverage: estimated **≥90%** across all six exported symbols.

### `src/lib/origin.ts` — 12 tests
Uses `vi.hoisted` + module mocks for `@/lib/env` and `@/lib/config` so each test can flip between browser/server and toggle `BACKEND_URL` without polluting `process.env`.
- `resolveOrigin`: server with `BACKEND_URL` set, server with default, custom port, empty-string behavior (`??` does not coalesce `""`); browser returns `window.location.origin`; browser precedence over server env.
- `getBackendUrl`: returns env value, returns default, ignores browser context, reflects mutation between calls, empty-string pass-through.
- Branch coverage: **100%** on both exported functions.

## Quality gates

- `pnpm exec vitest run` — **772 passing** (all test files, unit + components projects).
- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec eslint <new-files>` — clean.
- `lsp_diagnostics` on all three new/modified files — no errors.

## Notes

- No production code was modified. Per task constraints, any bugs discovered would be documented here as follow-ups; none were found — each utility behaved consistently with the tests asserting its contract (including `??` vs `""` semantics, which is documented in test names rather than changed).
- The `@vitest/coverage-v8` package is not currently installed; coverage percentages above are derived from manual branch enumeration of each target file. If desired as a follow-up, adding the package and a `test:coverage` script would let CI enforce these percentages automatically.

## Waivers

- `SCREENSHOT-WAIVER: Pure test addition — no rendered UI is affected by this change.`
- No `TEST-WAIVER` needed — this PR **is** the test addition.