### PR TITLE
refactor(logging,errors): structured logger + error constants (CHAOS-1230, CHAOS-1232)

### DIFF
--- a/src/app/(app)/reports/[id]/page.tsx
+++ b/src/app/(app)/reports/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { MarkdownRenderer } from "@/components/reports/MarkdownRenderer";
 import { defaultMetricFilter } from "@/lib/filters/defaults";
+import { logger } from "@/lib/logger";
 import { ReportStatus, SavedReport, ReportRun } from "@/lib/reports/types";
 import {
   fetchSavedReport,
@@ -228,7 +229,7 @@ export default function SingleReportPage() {
             setIsRunning(false);
           }
         } catch (pollErr) {
-          console.error("Report run polling failed:", pollErr);
+          logger.error({ err: pollErr }, "Report run polling failed");
           stopPolling();
           setIsRunning(false);
         }

--- a/src/app/(app)/superadmin/billing/audit/actions.ts
+++ b/src/app/(app)/superadmin/billing/audit/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { auth } from "@/lib/auth";
+import { ValidationErrors } from "@/lib/constants/errors";
 import { getBackendUrl } from "@/lib/origin";
 import type { ActionResult } from "@/lib/result";
 
@@ -8,7 +9,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 function validateId(id: string): string {
   if (!UUID_RE.test(id)) {
-    throw new Error("Invalid audit entry ID");
+    throw new Error(ValidationErrors.InvalidAuditEntryId);
   }
   return id;
 }

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import type { FeedbackPayload, FeedbackResponse } from "@/components/feedback/types";
 import { auth } from "@/lib/auth";
 import { getServerEnv } from "@/lib/config";
+import { ApiErrors, linearApiRequestFailedMessage } from "@/lib/constants/errors";
 import { isRateLimited } from "@/lib/rate-limit";
 
 const LINEAR_ENDPOINT = "https://api.linear.app/graphql";
@@ -162,7 +163,7 @@ export async function POST(request: Request) {
     });
 
     if (!linearResponse.ok) {
-      throw new Error(`Linear API request failed with status ${linearResponse.status}`);
+      throw new Error(linearApiRequestFailedMessage(linearResponse.status));
     }
 
     const linearData = (await linearResponse.json()) as {
@@ -180,7 +181,7 @@ export async function POST(request: Request) {
     };
 
     if (linearData.errors && linearData.errors.length > 0) {
-      const message = linearData.errors[0]?.message || "Failed to create issue";
+      const message = linearData.errors[0]?.message || ApiErrors.FailedToCreateIssue;
       throw new Error(message);
     }
 
@@ -188,7 +189,7 @@ export async function POST(request: Request) {
     const issue = issueCreate?.issue;
 
     if (!issueCreate?.success || !issue) {
-      throw new Error("Failed to create issue");
+      throw new Error(ApiErrors.FailedToCreateIssue);
     }
 
     const response: FeedbackResponse = {

--- a/src/components/admin/billing/PlanManager.tsx
+++ b/src/components/admin/billing/PlanManager.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
+import { ValidationErrors } from "@/lib/constants/errors";
 import {
   createBillingPlan,
   deleteBillingPlan,
@@ -64,7 +65,7 @@ function mapPlanToForm(plan: BillingPlanRecord): PlanFormState {
 function parsePriceJson(input: string): BillingPriceInput[] {
   const parsed = JSON.parse(input) as BillingPriceInput[];
   if (!Array.isArray(parsed)) {
-    throw new Error("Prices JSON must be an array");
+    throw new Error(ValidationErrors.PricesJsonMustBeArray);
   }
   return parsed;
 }

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { getExplainData } from "@/lib/api";
+import { ValidationErrors } from "@/lib/constants/errors";
 import { logger } from "@/lib/logger";
 import { MetricFilter } from "@/lib/filters/types";
 import { Contributor } from "@/lib/types";
@@ -78,7 +79,7 @@ export function EvidencePanel({
                     let result;
                     if (apiUrl) {
                         const res = await fetch(apiUrl);
-                        if (!res.ok) throw new Error("Failed to fetch evidence");
+                        if (!res.ok) throw new Error(ValidationErrors.FailedToFetchEvidence);
                         result = await res.json();
                     } else if (metric) {
                         result = await getExplainData({ 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   WorkUnitExplanation,
 } from "@/lib/types";
 import type { MetricFilter } from "@/lib/filters/types";
+import { AuthErrors } from "@/lib/constants/errors";
 import { encodeFilterParam } from "@/lib/filters/encode";
 import { applyWindowToFilters } from "@/lib/filters/time";
 import { apiClient } from "@/lib/apiClient";
@@ -507,7 +508,7 @@ export async function getCapacityForecast(params: {
     orgId = session?.user?.org_id;
   }
   if (!orgId) {
-    throw new Error("org_id is required: not provided and not found in session");
+    throw new Error(AuthErrors.OrgIdRequiredFromSession);
   }
   return getCapacityForecastViaGraphQL(orgId, params.input);
 }

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,5 +1,6 @@
 import { resolveOrigin } from "@/lib/origin";
 import { isServer } from "@/lib/env";
+import { ApiErrors, apiErrorMessage } from "@/lib/constants/errors";
 
 /**
  * Generate a unique request ID for distributed tracing.
@@ -104,9 +105,9 @@ const fetchJson = async <T>(
   const response = await request(path, init, params);
   if (!response.ok) {
     if (response.status === 429) {
-      throw new Error("Rate limit exceeded. Please try again later.");
+      throw new Error(ApiErrors.RateLimitExceeded);
     }
-    throw new Error(`API error: ${response.status}`);
+    throw new Error(apiErrorMessage(response.status));
   }
   // Use text() and trim() to handle keep-alive pings (leading/trailing whitespace)
   const text = await response.text();
@@ -198,11 +199,11 @@ const fetchWithFallback = async <T, C>(
 
   if (lastError instanceof Response) {
     if (lastError.status === 429) {
-      throw new Error("Rate limit exceeded. Please try again later.");
+      throw new Error(ApiErrors.RateLimitExceeded);
     }
-    throw new Error(`API error: ${lastError.status}`);
+    throw new Error(apiErrorMessage(lastError.status));
   }
-  throw lastError ?? new Error("API error");
+  throw lastError ?? new Error(ApiErrors.GenericApiError);
 };
 
 export const apiClient = {
@@ -214,4 +215,3 @@ export const apiClient = {
   sendBeacon,
   fetchWithFallback,
 };
-

--- a/src/lib/billing/actions.ts
+++ b/src/lib/billing/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import { getServerEnv } from "@/lib/config";
+import { AuthErrors, ValidationErrors, requestFailedMessage } from "@/lib/constants/errors";
 import type { ActionResult } from "@/lib/result";
 
 export type SubscriptionDetails = {
@@ -179,7 +180,7 @@ export type BillingPlanUpsert = {
 const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 function sanitizeId(id: string): string {
   if (!SAFE_ID_RE.test(id)) {
-    throw new Error("Invalid ID format");
+    throw new Error(ValidationErrors.InvalidIdFormat);
   }
   return id;
 }
@@ -229,7 +230,7 @@ function getBackendUrl(): string {
 async function getAuthHeadersOrThrow(): Promise<Record<string, string>> {
   const session = await auth();
   if (!session?.access_token) {
-    throw new Error("Unauthorized");
+    throw new Error(AuthErrors.Unauthorized);
   }
   return {
     "Content-Type": "application/json",
@@ -258,7 +259,7 @@ async function apiRequest<T>(path: string, init?: RequestInit): Promise<T> {
 
   if (!response.ok) {
     const detail = await response.json().catch(() => ({ detail: response.statusText }));
-    throw new Error(detail.detail || `Request failed (${response.status})`);
+    throw new Error(detail.detail || requestFailedMessage(response.status));
   }
 
   return (await response.json()) as T;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,6 +17,7 @@
  * CHAOS-1233 PR body for the full exception list.
  */
 import { z } from "zod";
+import { ValidationErrors } from "@/lib/constants/errors";
 
 const publicEnvSchema = z.object({
     NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: z.string().optional(),
@@ -121,7 +122,7 @@ export function getServerEnv(): ServerEnv {
 
     if (typeof window !== "undefined" && !inNodeTest) {
         throw new Error(
-            "getServerEnv() called from client bundle — server-only env is not available at runtime.",
+            ValidationErrors.ServerEnvCalledFromClientBundle,
         );
     }
     return serverEnvSchema.parse(process.env);

--- a/src/lib/constants/errors.ts
+++ b/src/lib/constants/errors.ts
@@ -1,0 +1,33 @@
+export const AuthErrors = {
+  Unauthorized: "Unauthorized",
+  OrgIdRequiredFromSession: "org_id is required: not provided and not found in session",
+  OrgIdRequiredFromGraphQLContext: "org_id is required: not found in filters or GraphQL context",
+  OrgIdRequiredFromContext: "org_id is required: not found in filters or context",
+} as const;
+
+export const ValidationErrors = {
+  InvalidIdFormat: "Invalid ID format",
+  InvalidAuditEntryId: "Invalid audit entry ID",
+  PricesJsonMustBeArray: "Prices JSON must be an array",
+  FailedToFetchEvidence: "Failed to fetch evidence",
+  GraphQLResponseMissingData: "GraphQL response missing data",
+  ServerEnvCalledFromClientBundle:
+    "getServerEnv() called from client bundle — server-only env is not available at runtime.",
+} as const;
+
+export const ApiErrors = {
+  RateLimitExceeded: "Rate limit exceeded. Please try again later.",
+  GenericApiError: "API error",
+  FailedToCreateIssue: "Failed to create issue",
+} as const;
+
+export const apiErrorMessage = (status: number): string => `API error: ${status}`;
+
+export const requestFailedMessage = (status: number): string => `Request failed (${status})`;
+
+export const graphQlErrorMessage = (message: string): string => `GraphQL error: ${message}`;
+
+export const validationFailedMessage = (details: string): string => `Validation failed: ${details}`;
+
+export const linearApiRequestFailedMessage = (status: number): string =>
+  `Linear API request failed with status ${status}`;

--- a/src/lib/feature-flags/fetchers.ts
+++ b/src/lib/feature-flags/fetchers.ts
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth";
 import { graphqlFetch } from "@/lib/graphql/urqlClient";
 import type { WorkGraphEdgesResult } from "@/lib/graphql/types";
+import { logger } from "@/lib/logger";
 import {
   FEATURE_FLAG_REGISTRY_QUERY,
   FEATURE_FLAG_EVENTS_QUERY,
@@ -60,7 +61,7 @@ export async function fetchFeatureFlagRegistry(
       pageInfo: res.workGraphEdges.pageInfo,
     };
   } catch (error) {
-    console.error("Failed to fetch feature flag registry:", error);
+    logger.error({ err: error }, "Failed to fetch feature flag registry");
     return { flags: [], totalCount: 0, pageInfo: EMPTY_RESULT.pageInfo };
   }
 }
@@ -91,7 +92,7 @@ export async function fetchFeatureFlagEvents(
       pageInfo: res.workGraphEdges.pageInfo,
     };
   } catch (error) {
-    console.error("Failed to fetch feature flag events:", error);
+    logger.error({ err: error }, "Failed to fetch feature flag events");
     return { events: [], totalCount: 0, pageInfo: EMPTY_RESULT.pageInfo };
   }
 }
@@ -122,7 +123,7 @@ export async function fetchReleaseImpact(
       pageInfo: res.workGraphEdges.pageInfo,
     };
   } catch (error) {
-    console.error("Failed to fetch release impact:", error);
+    logger.error({ err: error }, "Failed to fetch release impact");
     return { edges: [], totalCount: 0, pageInfo: EMPTY_RESULT.pageInfo };
   }
 }
@@ -236,7 +237,7 @@ export async function fetchFeatureFlagsData(
       },
     };
   } catch (error) {
-    console.error("Failed to fetch feature flags summary:", error);
+    logger.error({ err: error }, "Failed to fetch feature flags summary");
     return {
       summary: {
         activeFlags: 0,
@@ -306,7 +307,7 @@ export async function fetchFeatureFlagList(
       hasNextPage: offset + limit < items.length,
     };
   } catch (error) {
-    console.error("Failed to fetch feature flag list:", error);
+    logger.error({ err: error }, "Failed to fetch feature flag list");
     return { items: [], totalCount: 0, hasNextPage: false };
   }
 }
@@ -325,7 +326,7 @@ export async function fetchFeatureFlagData(
 
     return { registry, events, releaseImpact };
   } catch (error) {
-    console.error("Failed to fetch feature flag data:", error);
+    logger.error({ err: error }, "Failed to fetch feature flag data");
     return {
       registry: { flags: [], totalCount: 0, pageInfo: EMPTY_RESULT.pageInfo },
       events: { events: [], totalCount: 0, pageInfo: EMPTY_RESULT.pageInfo },

--- a/src/lib/graphql/hooks/useInvestment.ts
+++ b/src/lib/graphql/hooks/useInvestment.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "urql";
 import { useMemo } from "react";
+import { AuthErrors } from "@/lib/constants/errors";
 import { INVESTMENT_BREAKDOWN_QUERY, INVESTMENT_FULL_QUERY } from "../queries";
 import type { MetricFilter } from "@/lib/filters/types";
 import type { InvestmentResponse, SankeyResponse } from "@/lib/types";
@@ -21,7 +22,7 @@ function getOrgId(filters: MetricFilter, contextOrgId?: string): string {
   if (contextOrgId) {
     return contextOrgId;
   }
-  throw new Error("org_id is required: not found in filters or GraphQL context");
+  throw new Error(AuthErrors.OrgIdRequiredFromGraphQLContext);
 }
 
 function buildDateRange(filters: MetricFilter): { startDate: string; endDate: string } {

--- a/src/lib/graphql/investmentFetchers.ts
+++ b/src/lib/graphql/investmentFetchers.ts
@@ -6,6 +6,7 @@
  * Toggle with USE_GRAPHQL_ANALYTICS=true (runtime) or NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS=true.
  */
 
+import { AuthErrors } from "@/lib/constants/errors";
 import type { MetricFilter } from "@/lib/filters/types";
 import type { InvestmentResponse, SankeyResponse, SankeyNode, SankeyLink } from "@/lib/types";
 import { formatSubcategoryLabel } from "@/lib/investmentMix";
@@ -35,7 +36,7 @@ export function getOrgId(filters: MetricFilter, contextOrgId?: string): string {
         return contextOrgId;
     }
     // Throw error if no org can be determined
-    throw new Error("org_id is required: not found in filters or context");
+    throw new Error(AuthErrors.OrgIdRequiredFromContext);
 }
 
 /**

--- a/src/lib/graphql/server.ts
+++ b/src/lib/graphql/server.ts
@@ -46,6 +46,7 @@ import {
   type TypedDocumentNode,
 } from "@urql/core";
 import { registerUrql } from "@urql/next/rsc";
+import { ValidationErrors, graphQlErrorMessage } from "@/lib/constants/errors";
 import { resolveOrigin } from "@/lib/origin";
 import { errorExchange, timingExchange } from "./urqlExchanges";
 
@@ -125,11 +126,11 @@ export async function graphqlFetch<T>(
     : await client.query<T>(query, variables, operationContext).toPromise();
 
   if (result.error) {
-    throw new Error(`GraphQL error: ${result.error.message}`);
+    throw new Error(graphQlErrorMessage(result.error.message));
   }
 
   if (!result.data) {
-    throw new Error("GraphQL response missing data");
+    throw new Error(ValidationErrors.GraphQLResponseMissingData);
   }
 
   return result.data;
@@ -191,11 +192,11 @@ export async function graphqlFetchForHydration<T>(
     : await client.query<T>(query, variables, operationContext).toPromise();
 
   if (result.error) {
-    throw new Error(`GraphQL error: ${result.error.message}`);
+    throw new Error(graphQlErrorMessage(result.error.message));
   }
 
   if (!result.data) {
-    throw new Error("GraphQL response missing data");
+    throw new Error(ValidationErrors.GraphQLResponseMissingData);
   }
 
   return { data: result.data, hydrationPayload: ssr.extractData() };

--- a/src/lib/graphql/validate.ts
+++ b/src/lib/graphql/validate.ts
@@ -5,6 +5,7 @@
  */
 
 import { type ZodSchema, ZodError } from "zod";
+import { validationFailedMessage } from "@/lib/constants/errors";
 import {
   AnalyticsResultSchema,
   CatalogResultSchema,
@@ -77,7 +78,7 @@ export function validateOrThrow<T>(schema: ZodSchema<T>, data: unknown): T {
     const issues = result.error?.issues
       .map((i) => `${i.path}: ${i.message}`)
       .join("; ");
-    throw new Error(`Validation failed: ${issues || result.error?.message}`);
+    throw new Error(validationFailedMessage(issues || result.error?.message || "Unknown validation error"));
   }
   return result.data!;
 }

--- a/src/lib/reports/fetchers.ts
+++ b/src/lib/reports/fetchers.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/logger";
 import { graphqlFetch } from "@/lib/graphql/urqlClient";
 import {
   SavedReport,
@@ -35,7 +36,7 @@ export async function fetchSavedReports(
     );
     return res.savedReports;
   } catch (error) {
-    console.error("Failed to fetch saved reports:", error);
+    logger.error({ err: error }, "Failed to fetch saved reports");
     return { items: [], total: 0 };
   }
 }
@@ -56,7 +57,7 @@ export async function fetchSavedReport(
     );
     return res.savedReport;
   } catch (error) {
-    console.error("Failed to fetch saved report:", error);
+    logger.error({ err: error }, "Failed to fetch saved report");
     return null;
   }
 }
@@ -79,7 +80,7 @@ export async function fetchReportRuns(
     );
     return res.reportRuns;
   } catch (error) {
-    console.error("Failed to fetch report runs:", error);
+    logger.error({ err: error }, "Failed to fetch report runs");
     return { items: [], total: 0 };
   }
 }

--- a/src/lib/testops/fetchers.ts
+++ b/src/lib/testops/fetchers.ts
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth";
 import { graphqlFetch } from "@/lib/graphql/urqlClient";
 import { AnalyticsRequestInput, AnalyticsResult } from "@/lib/graphql/schemas/analytics";
+import { logger } from "@/lib/logger";
 import {
   TESTOPS_PIPELINE_QUERY,
   TESTOPS_TEST_QUERY,
@@ -51,7 +52,7 @@ export async function fetchTestOpsData(
       coverage: coverageRes.analytics,
     };
   } catch (error) {
-    console.error("Failed to fetch TestOps data:", error);
+    logger.error({ err: error }, "Failed to fetch TestOps data");
     return {
       pipelines: EMPTY_ANALYTICS,
       tests: EMPTY_ANALYTICS,
@@ -74,7 +75,7 @@ export async function fetchCoverageMetrics(
     const res = await graphqlFetch<{ analytics: AnalyticsResult }>(TESTOPS_COVERAGE_QUERY, { orgId, batch });
     return res.analytics;
   } catch (error) {
-    console.error("Failed to fetch coverage metrics:", error);
+    logger.error({ err: error }, "Failed to fetch coverage metrics");
     return EMPTY_ANALYTICS;
   }
 }
@@ -176,7 +177,7 @@ export async function fetchRiskMetrics(
       stability_delta: delta(pipelineSuccess),
     };
   } catch (error) {
-    console.error("Failed to fetch risk metrics:", error);
+    logger.error({ err: error }, "Failed to fetch risk metrics");
     return null;
   }
 }


### PR DESCRIPTION
## Summary
| Refactor | Result |
| --- | --- |
| console.* → logger | 13 expected sites migrated; 0 remaining under src/ after excluding src/lib/logger.ts and test files |
| new Error literal/template → constants/helpers | 22 non-test sites migrated; 0 remaining literal/template `new Error(...)` sites under src/ after excluding test files |

## Notes
- Added `src/lib/constants/errors.ts` with grouped constant objects and template helpers for dynamic message formats.
- Preserved exact error string outputs so existing `error.message` consumers keep working.
- Split the branch into focused logging/API/billing/GraphQL/surface commits for reviewability.

SCREENSHOT-WAIVER: pure refactor, no UI changes.
TEST-WAIVER: Logger/error message literals are non-behavioral strings; existing tests still pass unchanged.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

## References
- CHAOS-1230
- CHAOS-1232