### PR TITLE
perf(ssr): wrap session reads in React.cache() (CHAOS-1220)

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,7 @@ import GitHub from "next-auth/providers/github"
 import Google from "next-auth/providers/google"
 import GitLab from "next-auth/providers/gitlab"
 import { redirect } from "next/navigation"
+import { cache } from "react"
 import { getBackendUrl } from "@/lib/origin"
 import { logger } from "@/lib/logger"
 import { getServerEnv } from "@/lib/config"
@@ -313,24 +314,28 @@ export const { handlers, signIn, signOut } = nextAuth
 
 import type { Session } from "next-auth"
 
-export async function auth(): Promise<Session | null> {
+// Per-request memoized session read. React.cache() dedupes calls within a
+// single RSC render tree so auth()/requireSession()/requireRole()/
+// requireSuperuser() share one next-auth read no matter how many server
+// components or layouts invoke them. Safe because the module is server-only
+// (no "use client" importers) and the getter has no side effects.
+const getServerSession = cache(async (): Promise<Session | null> => {
   try {
-    const session = await nextAuth.auth()
-    if (!session?.access_token) return null
-    if (session.error) return null
-    return session
+    return await nextAuth.auth()
   } catch {
     return null
   }
+})
+
+export async function auth(): Promise<Session | null> {
+  const session = await getServerSession()
+  if (!session?.access_token) return null
+  if (session.error) return null
+  return session
 }
 
 export async function requireSession(callbackUrl?: string): Promise<Session> {
-  let session: Session | null = null
-  try {
-    session = await nextAuth.auth()
-  } catch {
-    session = null
-  }
+  const session = await getServerSession()
   // Surface social login errors (e.g. 409 account conflict) before dropping the session
   if (session?.error) {
     redirect(`/auth/signin?error=${encodeURIComponent(session.error)}`)


### PR DESCRIPTION
## Summary

- Introduces `getServerSession` — a `cache()`-wrapped passthrough to `nextAuth.auth()` in `src/lib/auth.ts`
- Routes `auth()` and `requireSession()` through the cached getter so all 27 server-side callers share one next-auth session read per RSC render tree
- `requireRole()` and `requireSuperuser()` benefit transitively (they delegate to `requireSession()`)

## Why it's safe

- `@/lib/auth` has **27 importers, zero client components** (verified via grep against every file with `"use client"`). `React.cache()` throws in client context, so client-reachability is the critical safety check.
- The cached getter (`getServerSession`) is a **pure passthrough with no side effects** — it returns the raw Session (or null on error). The redirect logic in `requireSession`/`requireRole`/`requireSuperuser` stays in the wrapper functions, unchanged.
- No behavior change for any caller. The wrapped getter returns the same shape as `nextAuth.auth()` (including `.error` field for social-login error propagation).

## Performance impact

Before this change, pages like `/capacity`, `/work`, `/superadmin/billing/*` that use nested server components could call `nextAuth.auth()` 3-6 times per request (layout + page + data-fetchers like `getCapacityForecast`). With `cache()`, next-auth's session read happens exactly **once per request**.

## Helpers skipped + reason

- `src/lib/admin/server.ts` exports — these are **server actions** (\"use server\" directive), not render-time readers. Wrapping them in `cache()` would be semantically wrong: server actions should see fresh data on every invocation.
- `src/lib/billing/actions.ts` — same reasoning.
- `src/lib/graphql/server.ts` — already has per-request isolation via `registerUrql` (CHAOS-1217 Phase A).

## Verification

- \`pnpm typecheck\` — 0 errors
- \`pnpm test:unit\` — 867/867 passing
- \`pnpm lint\` — clean (no new warnings)

Closes CHAOS-1220.

SCREENSHOT-WAIVER: pure SSR performance optimization, no rendered UI changes.
TEST-WAIVER: \`React.cache()\` is runtime memoization from React; helper API + return values are unchanged, so the 867 existing tests cover the behavioral surface. The deduplication is an internal optimization with no observable behavior change to callers.