### PR TITLE
perf(graphql): use cache-first requestPolicy for useCatalog (CHAOS-1225)

### DIFF
--- a/src/lib/graphql/hooks/useCatalog.ts
+++ b/src/lib/graphql/hooks/useCatalog.ts
@@ -28,10 +28,16 @@ interface UseCatalogResult {
 export function useCatalog(options: UseCatalogOptions): UseCatalogResult {
   const { orgId, dimension, pause = false } = options;
 
+  // Catalog values (teams, repos, services, dimensions) are semi-static
+  // reference data that rarely changes within a session. Override the client
+  // default (`cache-and-network`) with `cache-first` so mounting a filter
+  // dropdown doesn't trigger a network request every time — the cache is
+  // authoritative until an explicit `reexecute()` call. (CHAOS-1225)
   const [result, reexecute] = useQuery<{ catalog: CatalogResult }>({
     query: CATALOG_VALUES_QUERY,
     variables: { orgId, dimension },
     pause,
+    requestPolicy: "cache-first",
   });
 
   return {
@@ -75,6 +81,7 @@ export function useDimensionValues(
     query: CATALOG_VALUES_QUERY,
     variables: { orgId, dimension },
     pause,
+    requestPolicy: "cache-first",
   });
 
   return {


### PR DESCRIPTION
## Summary

Completes the CHAOS-1225 per-hook requestPolicy review (unblocked now that CHAOS-1217 landed). Applies one targeted change: **\`useCatalog\` + \`useDimensionValues\` switch from the client default \`cache-and-network\` to \`cache-first\`**.

## Review findings

| Hook | Current | Reviewed policy | Action |
|---|---|---|---|
| \`useSecurity\` | explicit \`cache-and-network\` | correct | **no change** |
| \`useInvestment\` (x3) | default \`cache-and-network\` | correct for dashboard freshness | **no change** |
| \`useAnalytics\` | default \`cache-and-network\` | correct for dashboard freshness | **no change** |
| \`useCapacityForecast\` | default \`cache-and-network\` | correct \u2014 forecast changes with inputs | **no change** |
| \`useWorkGraph\` (x2) | default \`cache-and-network\` | correct \u2014 edges change as work progresses | **no change** |
| \`useCatalog\` + \`useDimensionValues\` | default \`cache-and-network\` | **too eager** for static reference data | **\u2192 cache-first** (this PR) |

## Why useCatalog is different

Catalog values (teams, repos, services, dimension values) are **semi-static reference data** that rarely changes within a session. With \`cache-and-network\`, every mount of a filter dropdown triggers a background refetch \u2014 wasteful HTTP chatter for data that virtually never changes.

With \`cache-first\`:
- Serve from cache immediately, no network request on mount
- Components can still call \`reexecute()\` to force a refresh when needed
- **Net effect**: fewer HTTP calls when users open filter menus, no perceived latency

## Why others stay on the default

- \`useInvestment\` / \`useAnalytics\`: dashboard data where \"slightly stale cache while we refresh in background\" is the ideal UX.
- \`useCapacityForecast\`: forecast output depends on user-selected inputs \u2014 freshness matters.
- \`useWorkGraph\`: work-graph edges shift as items move through stages \u2014 background refresh keeps the view current.
- \`useSecurity\`: already explicitly cache-and-network; keep for parity with the others.

## Why no other hooks were made explicit

Adding explicit \`requestPolicy: \"cache-and-network\"\` everywhere would just duplicate the client default with no behavior change. Pure churn. The 5-line comment on \`useCatalog\` documents *why* that hook deviates \u2014 that's the only place where explicitness adds signal.

## Verification

- \`pnpm typecheck\` \u2192 clean
- \`pnpm test:unit\` \u2192 867/867 passing
- \`pnpm lint\` \u2192 clean

Closes CHAOS-1225. Depends on CHAOS-1217 (urql SSR baseline, shipped).

SCREENSHOT-WAIVER: pure cache-policy optimization, no rendered UI changes.
TEST-WAIVER: requestPolicy affects runtime cache strategy; no behavioral change to the hook's return shape. Existing tests continue to cover the hook contract.