### PR TITLE
fix(hydration): plain <script src> to clear CSP nonce mismatch

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
-import Script from "next/script";
 import "./globals.css";
 import { WebVitalsReporter } from "@/components/WebVitalsReporter";
 import { getServerEnv } from "@/lib/config";
@@ -79,8 +78,19 @@ export default function RootLayout({
       <body
         className={`${bodyFont.variable} ${displayFont.variable} ${monoFont.variable} antialiased`}
       >
-        <Script src={runtimeConfigSrc} strategy="beforeInteractive" />
-        <Script src={themeInitSrc} strategy="beforeInteractive" />
+        {/* Plain <script src> — not next/script <Script>. With Turbopack,
+            `<Script strategy="beforeInteractive">` emits an inline bootstrap
+            tag that Next auto-decorates with a CSP nonce; browsers strip
+            that nonce attribute after validating CSP, which produces a
+            server(`nonce=""`) / client(`nonce=undefined`) hydration diff.
+            Plain external scripts have no inline content, so no nonce is
+            ever written or stripped and hydration is clean. Both must load
+            before first paint — runtime-config.js bootstraps window config,
+            theme-init.js applies persisted theme to prevent FOUC. */}
+        {/* eslint-disable-next-line @next/next/no-sync-scripts -- external src is covered by CSP 'self'; must run pre-hydration */}
+        <script src={runtimeConfigSrc} />
+        {/* eslint-disable-next-line @next/next/no-sync-scripts -- external src is covered by CSP 'self'; must run pre-hydration to prevent FOUC */}
+        <script src={themeInitSrc} />
         <WebVitalsReporter />
         {children}
       </body>


### PR DESCRIPTION
## Summary

- `<Script strategy="beforeInteractive">` (from `next/script`) emits an inline bootstrap shim even with an external `src=`. Turbopack decorates that inline tag with a CSP nonce; browsers strip the attribute after validation, leaving a `server:nonce="" ↔ client:nonce=undefined` hydration diff that fires **"A tree hydrated but some attributes of the server rendered HTML didn't match the client properties"** on every first page load in Playwright (visible in auth-setup, 12 lines of log noise per run).
- Swap the two `<Script>` tags in `src/app/layout.tsx` for plain `<script src="…">` — no inline content, no nonce attribute, no diff. Both still run before first paint (runtime-config bootstrap + theme-init FOUC prevention).
- Same approach as the unmerged `origin/fix/script-nonce-hydration` branch (`cb782c8`). PR #245 tried to fix this in Feb but ended on `<Script>` + external src, which still produces the inline shim.

**Upstream context**: vercel/next.js#77952, vercel/next.js#89754

## Test plan

- [x] `pnpm exec playwright test tests/auth.setup.ts` — 1/1 pass, 0 warnings (was 12 lines of nonce diff per run)
- [x] `pnpm exec playwright test tests/flame.spec.ts tests/people.spec.ts` — 7/7 pass, 0 hydration/nonce warnings
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (`@next/next/no-sync-scripts` disabled per-line with inline rationale; perf trade-off is intentional for pre-paint bootstrap)
- [ ] Reviewer sanity-check: verify `/runtime-config.js` and `/theme-init.js` still execute before hydration (view-source → scripts are first children of `<body>`)