### PR TITLE
fix(superadmin): hide Org Admin link for users without org access (CHAOS-743)

### DIFF
--- a/src/app/(app)/superadmin/layout.tsx
+++ b/src/app/(app)/superadmin/layout.tsx
@@ -2,11 +2,13 @@ import { requireSuperuser } from "@/lib/auth";
 import { SuperadminSidebar } from "@/components/superadmin/SuperadminSidebar";
 
 export default async function SuperadminLayout({ children }: { children: React.ReactNode }) {
-  await requireSuperuser("/superadmin");
+  const session = await requireSuperuser("/superadmin");
+  const hasOrgAccess = !!session.user.org_id && (session.user.role === "admin" || session.user.role === "owner");
+
   return (
     <div className="min-h-screen">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
-        <SuperadminSidebar />
+        <SuperadminSidebar canAccessOrgAdmin={hasOrgAccess} />
         <main className="flex min-w-0 flex-1 flex-col gap-10">{children}</main>
       </div>
     </div>

--- a/src/components/superadmin/SuperadminSidebar.test.tsx
+++ b/src/components/superadmin/SuperadminSidebar.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { SuperadminSidebar } from "./SuperadminSidebar";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/superadmin",
+}));
+
+describe("SuperadminSidebar", () => {
+  it("shows 'Return to org admin' link when canAccessOrgAdmin is true", () => {
+    render(<SuperadminSidebar canAccessOrgAdmin={true} />);
+    expect(screen.getByText(/Return to/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /org admin/i })).toBeInTheDocument();
+  });
+
+  it("hides 'Return to org admin' link when canAccessOrgAdmin is false", () => {
+    render(<SuperadminSidebar canAccessOrgAdmin={false} />);
+    expect(screen.queryByText(/Return to/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /org admin/i })).not.toBeInTheDocument();
+  });
+
+  it("hides 'Return to org admin' link by default", () => {
+    render(<SuperadminSidebar />);
+    expect(screen.queryByText(/Return to/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /org admin/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/superadmin/SuperadminSidebar.tsx
+++ b/src/components/superadmin/SuperadminSidebar.tsx
@@ -17,7 +17,7 @@ const navItems = [
   { id: "billing-audit", label: "Billing Audit", href: "/superadmin/billing/audit", description: "Finance" },
 ];
 
-export function SuperadminSidebar() {
+export function SuperadminSidebar({ canAccessOrgAdmin = false }: { canAccessOrgAdmin?: boolean }) {
   const pathname = usePathname();
 
   return (
@@ -64,9 +64,11 @@ export function SuperadminSidebar() {
               );
             })}
           </nav>
-          <div className="mt-5 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-3 py-3 text-xs text-(--ink-muted)">
-            Return to <Link href="/admin" className="underline hover:text-foreground">org admin</Link>.
-          </div>
+          {canAccessOrgAdmin && (
+            <div className="mt-5 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-3 py-3 text-xs text-(--ink-muted)">
+              Return to <Link href="/admin" className="underline hover:text-foreground">org admin</Link>.
+            </div>
+          )}
         </div>
       </div>
     </aside>

--- a/src/lib/graphql/__generated__/graphql.ts
+++ b/src/lib/graphql/__generated__/graphql.ts
@@ -25,6 +25,7 @@ export type Scalars = {
 export type AnalyticsRequestInput = {
   breakdowns?: Array<BreakdownRequestInput>;
   filters?: InputMaybe<FilterInput>;
+  flowMatrix?: InputMaybe<FlowMatrixRequestInput>;
   sankey?: InputMaybe<SankeyRequestInput>;
   timeseries?: Array<TimeseriesRequestInput>;
   useInvestment?: InputMaybe<Scalars['Boolean']['input']>;
@@ -33,6 +34,7 @@ export type AnalyticsRequestInput = {
 export type AnalyticsResult = {
   __typename?: 'AnalyticsResult';
   breakdowns: Array<BreakdownResult>;
+  flowMatrix?: Maybe<FlowMatrixResult>;
   sankey?: Maybe<SankeyResult>;
   timeseries: Array<TimeseriesResult>;
 };
@@ -195,6 +197,21 @@ export type FilterInput = {
   what?: InputMaybe<WhatFilterInput>;
   who?: InputMaybe<WhoFilterInput>;
   why?: InputMaybe<WhyFilterInput>;
+};
+
+export type FlowMatrixRequestInput = {
+  dateRange: DateRangeInput;
+  dimension: DimensionInput;
+  maxEdges?: Scalars['Int']['input'];
+  maxNodes?: Scalars['Int']['input'];
+  measure: MeasureInput;
+  useInvestment?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type FlowMatrixResult = {
+  __typename?: 'FlowMatrixResult';
+  edges: Array<SankeyEdge>;
+  nodes: Array<SankeyNode>;
 };
 
 export type Freshness = {

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -23,6 +23,7 @@ export type Scalars = {
 export type AnalyticsRequestInput = {
   breakdowns?: Array<BreakdownRequestInput>;
   filters?: InputMaybe<FilterInput>;
+  flowMatrix?: InputMaybe<FlowMatrixRequestInput>;
   sankey?: InputMaybe<SankeyRequestInput>;
   timeseries?: Array<TimeseriesRequestInput>;
   useInvestment?: InputMaybe<Scalars['Boolean']['input']>;
@@ -31,6 +32,7 @@ export type AnalyticsRequestInput = {
 export type AnalyticsResult = {
   __typename?: 'AnalyticsResult';
   breakdowns: Array<BreakdownResult>;
+  flowMatrix?: Maybe<FlowMatrixResult>;
   sankey?: Maybe<SankeyResult>;
   timeseries: Array<TimeseriesResult>;
 };
@@ -193,6 +195,21 @@ export type FilterInput = {
   what?: InputMaybe<WhatFilterInput>;
   who?: InputMaybe<WhoFilterInput>;
   why?: InputMaybe<WhyFilterInput>;
+};
+
+export type FlowMatrixRequestInput = {
+  dateRange: DateRangeInput;
+  dimension: DimensionInput;
+  maxEdges?: Scalars['Int']['input'];
+  maxNodes?: Scalars['Int']['input'];
+  measure: MeasureInput;
+  useInvestment?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type FlowMatrixResult = {
+  __typename?: 'FlowMatrixResult';
+  edges: Array<SankeyEdge>;
+  nodes: Array<SankeyNode>;
 };
 
 export type Freshness = {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -2,6 +2,7 @@ input AnalyticsRequestInput {
   timeseries: [TimeseriesRequestInput!]! = []
   breakdowns: [BreakdownRequestInput!]! = []
   sankey: SankeyRequestInput = null
+  flowMatrix: FlowMatrixRequestInput = null
   useInvestment: Boolean = null
   filters: FilterInput = null
 }
@@ -10,6 +11,7 @@ type AnalyticsResult {
   timeseries: [TimeseriesResult!]!
   breakdowns: [BreakdownResult!]!
   sankey: SankeyResult
+  flowMatrix: FlowMatrixResult
 }
 
 type BreakdownItem {
@@ -167,6 +169,20 @@ input FilterInput {
   what: WhatFilterInput = null
   why: WhyFilterInput = null
   how: HowFilterInput = null
+}
+
+input FlowMatrixRequestInput {
+  dimension: DimensionInput!
+  measure: MeasureInput!
+  dateRange: DateRangeInput!
+  maxNodes: Int! = 100
+  maxEdges: Int! = 500
+  useInvestment: Boolean = null
+}
+
+type FlowMatrixResult {
+  nodes: [SankeyNode!]!
+  edges: [SankeyEdge!]!
 }
 
 type Freshness {


### PR DESCRIPTION
## Summary
Hide 'Return to org admin' link in Super Admin sidebar for users without org admin access. Previously rendered unconditionally.

## Changes
- `SuperadminLayout`: reads session, computes `hasOrgAccess` (`!!session.user.org_id && (role === 'admin' || role === 'owner')`), passes as prop
- `SuperadminSidebar`: accepts `canAccessOrgAdmin?: boolean` prop, renders link conditionally
- Vitest test `SuperadminSidebar.test.tsx` covering visible/hidden/default-hidden states
- Bonus: regenerate `schema.graphql` + `__generated__/*` to include flowMatrix (pre-existing drift unrelated to this PR but blocking the live-e2e schema check)

SCREENSHOT-WAIVER: Tiny conditional UI change covered by unit tests; reviewer can verify locally.

Closes CHAOS-743