### PR TITLE
sec(sentry): centralize DSN + beforeSend PII scrubbing (CHAOS-1561)

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,3 +1,6 @@
+import { publicEnv } from "@/lib/config";
+import { attachBeforeSend } from "@/lib/sentry/scrubber";
+
 import * as Sentry from "@sentry/nextjs";
 
 /**
@@ -42,13 +45,16 @@ function shouldLoadReplay(): boolean {
   return prefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
 }
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NODE_ENV,
-  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-  replaysSessionSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-  replaysOnErrorSampleRate: 1.0,
-});
+Sentry.init(
+  attachBeforeSend({
+    dsn: publicEnv.NEXT_PUBLIC_SENTRY_DSN,
+    environment: process.env.NODE_ENV,
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+    replaysSessionSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+    replaysOnErrorSampleRate: 1.0,
+    sendDefaultPii: false,
+  })
+);
 
 if (shouldLoadReplay()) {
   void Sentry.lazyLoadIntegration("replayIntegration")

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,7 +1,12 @@
 import * as Sentry from "@sentry/nextjs";
+import { publicEnv } from "@/lib/config";
+import { attachBeforeSend } from "@/lib/sentry/scrubber";
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NODE_ENV,
-  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-});
+Sentry.init(
+  attachBeforeSend({
+    dsn: publicEnv.NEXT_PUBLIC_SENTRY_DSN,
+    environment: process.env.NODE_ENV,
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+    sendDefaultPii: false,
+  })
+);

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,7 +1,12 @@
 import * as Sentry from "@sentry/nextjs";
+import { publicEnv } from "@/lib/config";
+import { attachBeforeSend } from "@/lib/sentry/scrubber";
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NODE_ENV,
-  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-});
+Sentry.init(
+  attachBeforeSend({
+    dsn: publicEnv.NEXT_PUBLIC_SENTRY_DSN,
+    environment: process.env.NODE_ENV,
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+    sendDefaultPii: false,
+  })
+);

--- a/src/lib/sentry/__tests__/scrubber.test.ts
+++ b/src/lib/sentry/__tests__/scrubber.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import type { ErrorEvent } from "@sentry/nextjs";
+import { scrubEvent, attachBeforeSend } from "../scrubber";
+
+// Helpers
+function makeEvent(overrides: Partial<ErrorEvent> = {}): ErrorEvent {
+  return {
+    type: undefined,
+    ...overrides,
+  } as ErrorEvent;
+}
+
+describe("scrubEvent", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+
+  it("removes request.cookies", () => {
+    const event = makeEvent({
+      request: {
+        url: "https://example.com/api/data",
+        cookies: { session: "abc123", csrf: "xyz" },
+      },
+    });
+    const result = scrubEvent(event);
+    expect(result?.request?.cookies).toBeUndefined();
+  });
+
+  it("removes Authorization header (case-sensitive key)", () => {
+    const event = makeEvent({
+      request: {
+        url: "https://example.com/api/data",
+        headers: {
+          authorization: "Bearer secret-token",
+          "content-type": "application/json",
+        },
+      },
+    });
+    const result = scrubEvent(event);
+    expect(result?.request?.headers).not.toHaveProperty("authorization");
+    expect(result?.request?.headers).toHaveProperty("content-type");
+  });
+
+  it("removes x-csrf-token header", () => {
+    const event = makeEvent({
+      request: {
+        url: "https://example.com/api/data",
+        headers: {
+          "x-csrf-token": "csrf-secret",
+          "content-type": "application/json",
+        },
+      },
+    });
+    const result = scrubEvent(event);
+    expect(result?.request?.headers).not.toHaveProperty("x-csrf-token");
+    expect(result?.request?.headers).toHaveProperty("content-type");
+  });
+
+  it("drops request.data for /api/v1/auth URL", () => {
+    const event = makeEvent({
+      request: {
+        url: "https://example.com/api/v1/auth",
+        data: JSON.stringify({ username: "admin", password: "secret" }),
+      },
+    });
+    const result = scrubEvent(event);
+    expect(result?.request?.data).toBeUndefined();
+  });
+
+  it("drops request.data for /admin/credentials URL", () => {
+    const event = makeEvent({
+      request: {
+        url: "https://example.com/admin/credentials",
+        data: JSON.stringify({ apiKey: "supersecret" }),
+      },
+    });
+    const result = scrubEvent(event);
+    expect(result?.request?.data).toBeUndefined();
+  });
+
+  it("passes through request.data for non-sensitive URLs", () => {
+    const payload = JSON.stringify({ metric: "build_time", value: 42 });
+    const event = makeEvent({
+      request: {
+        url: "https://example.com/api/metrics",
+        data: payload,
+      },
+    });
+    const result = scrubEvent(event);
+    expect(result?.request?.data).toBe(payload);
+  });
+
+  it("strips user.ip_address in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("SENTRY_INCLUDE_IP", "");
+
+    const event = makeEvent({
+      user: { id: "user-123", email: "test@example.com", ip_address: "1.2.3.4" },
+    });
+    const result = scrubEvent(event);
+    expect(result?.user?.ip_address).toBeUndefined();
+    expect(result?.user?.id).toBe("user-123");
+    expect(result?.user?.email).toBe("test@example.com");
+  });
+
+  it("preserves user.ip_address in production when SENTRY_INCLUDE_IP=true", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("SENTRY_INCLUDE_IP", "true");
+
+    const event = makeEvent({
+      user: { id: "user-123", ip_address: "1.2.3.4" },
+    });
+    const result = scrubEvent(event);
+    expect(result?.user?.ip_address).toBe("1.2.3.4");
+  });
+
+  it("preserves user.ip_address in non-production environments", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("SENTRY_INCLUDE_IP", "");
+
+    const event = makeEvent({
+      user: { id: "user-123", ip_address: "1.2.3.4" },
+    });
+    const result = scrubEvent(event);
+    expect(result?.user?.ip_address).toBe("1.2.3.4");
+  });
+
+  it("handles events with no request gracefully", () => {
+    const event = makeEvent({ message: "standalone error" });
+    const result = scrubEvent(event);
+    expect(result).not.toBeNull();
+    expect(result?.message).toBe("standalone error");
+  });
+});
+
+
+describe("attachBeforeSend", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns a config object with beforeSend set", () => {
+    const config = attachBeforeSend({ dsn: "https://fake@sentry.io/1" });
+    expect(typeof config.beforeSend).toBe("function");
+  });
+
+  it("applies scrubbing when beforeSend is invoked", () => {
+    const config = attachBeforeSend({ dsn: "https://fake@sentry.io/1" });
+    const event = makeEvent({
+      request: {
+        url: "https://example.com/api/data",
+        cookies: { session: "secret" },
+      },
+    });
+    const result = config.beforeSend!(event, { originalException: null, syntheticException: null }) as ErrorEvent | null;
+    expect(result?.request?.cookies).toBeUndefined();
+  });
+
+  it("chains existing beforeSend if provided", () => {
+    const marker = { touched: false };
+    const config = attachBeforeSend({
+      dsn: "https://fake@sentry.io/1",
+      beforeSend(ev) {
+        marker.touched = true;
+        return ev;
+      },
+    });
+    const event = makeEvent({ message: "hello" });
+    config.beforeSend!(event, { originalException: null, syntheticException: null });
+    expect(marker.touched).toBe(true);
+  });
+
+  it("skips existing beforeSend when scrubEvent returns null", () => {
+    // scrubEvent currently never returns null, but test the chain contract
+    // by monkey-patching: we supply a beforeSend that would set marker
+    // and verify flow. Since scrubEvent won't return null for a basic event,
+    // we just verify the result passes through.
+    const config = attachBeforeSend({
+      dsn: "https://fake@sentry.io/1",
+      beforeSend(ev) {
+        return { ...ev, tags: { chained: "yes" } };
+      },
+    });
+    const event = makeEvent({ message: "hi" });
+    const result = config.beforeSend!(event, { originalException: null, syntheticException: null }) as ErrorEvent | null;
+    expect(result?.tags?.chained).toBe("yes");
+  });
+});

--- a/src/lib/sentry/scrubber.ts
+++ b/src/lib/sentry/scrubber.ts
@@ -1,0 +1,83 @@
+/**
+ * Sentry PII scrubber — centralised `beforeSend` logic.
+ *
+ * Exports:
+ *   scrubEvent(event)          — pure transformation; no side-effects.
+ *   attachBeforeSend(config)   — merges `beforeSend` into a Sentry.init() options object.
+ *
+ * PII rules applied (in order):
+ *   1. Remove request.cookies.
+ *   2. Remove request.headers.authorization.
+ *   3. Remove request.headers['x-csrf-token'].
+ *   4. Drop request.data for events whose request.url matches /(auth|admin\/credentials)/.
+ *   5. Strip event.user.ip_address in production unless SENTRY_INCLUDE_IP=true.
+ */
+
+import * as Sentry from "@sentry/nextjs";
+import type { ErrorEvent, EventHint } from "@sentry/nextjs";
+
+/** URLs that must have their POST body dropped entirely. */
+const SENSITIVE_URL_PATTERN = /\/(auth|admin\/credentials)/;
+
+/**
+ * Scrub PII from a Sentry event.
+ * Returns the mutated event (mutation-in-place is safe; Sentry always provides
+ * a fresh object per call) or `null` to drop the event.
+ */
+export function scrubEvent(event: ErrorEvent, _hint?: EventHint): ErrorEvent | null {
+  if (event.request) {
+    // 1. Remove cookies
+    delete event.request.cookies;
+
+    // 2 & 3. Remove sensitive headers
+    if (event.request.headers) {
+      // Work on a shallow copy of headers to avoid mutating across references
+      const headers = { ...event.request.headers } as Record<string, string>;
+      delete headers["authorization"];
+      delete headers["x-csrf-token"];
+      event.request.headers = headers;
+    }
+
+    // 4. Drop body for auth / credential endpoints
+    const url = event.request.url ?? "";
+    if (SENSITIVE_URL_PATTERN.test(url)) {
+      delete event.request.data;
+    }
+  }
+
+  // 5. Strip IP in production unless opt-in flag is set
+  const isProduction = process.env.NODE_ENV === "production";
+  const includeIp = process.env.SENTRY_INCLUDE_IP === "true";
+  if (isProduction && !includeIp && event.user) {
+    delete event.user.ip_address;
+  }
+
+  return event;
+}
+
+type SentryInitOptions = Parameters<typeof Sentry.init>[0];
+
+/**
+ * Attach the `beforeSend` scrubber to an existing Sentry.init() options
+ * object and return the merged configuration.
+ *
+ * If the caller has already supplied a `beforeSend`, the scrubber runs first;
+ * if it returns null the caller's handler is skipped.
+ *
+ * @example
+ *   Sentry.init(attachBeforeSend({ dsn: publicEnv.NEXT_PUBLIC_SENTRY_DSN }));
+ */
+export function attachBeforeSend(
+  config: SentryInitOptions
+): SentryInitOptions {
+  const existing = config?.beforeSend;
+  return {
+    ...config,
+    beforeSend(event: ErrorEvent, hint: EventHint) {
+      const scrubbed = scrubEvent(event, hint);
+      if (scrubbed === null) return null;
+      if (existing) return existing(scrubbed, hint);
+      return scrubbed;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Extracts a shared `beforeSend` scrubber into `src/lib/sentry/scrubber.ts` with `scrubEvent()` and `attachBeforeSend()` helpers
- Wires scrubber into all three Sentry init files (server, client, edge)
- Switches DSN reads from `process.env` to `publicEnv.NEXT_PUBLIC_SENTRY_DSN`
- Adds `sendDefaultPii: false` to all three `Sentry.init()` calls
- Adds 14 unit tests covering all PII scrubbing rules

## PII Rules Applied

1. Removes `request.cookies`
2. Removes `request.headers.authorization`
3. Removes `request.headers['x-csrf-token']`
4. Drops `request.data` for events whose `request.url` matches `/(auth|admin\/credentials)/`
5. Strips `event.user.ip_address` in production unless `SENTRY_INCLUDE_IP=true`

## Related

Closes CHAOS-1561

SCREENSHOT-WAIVER: backend-only Sentry config, no rendered UI