### PR TITLE
sec(rate-limit): fail-closed for auth-adjacent keys + cover /api/v1/auth/* at edge (CHAOS-1560)

### DIFF
--- a/.sisyphus/plans/chaos-1560-rate-limit-failclosed.md
+++ b/.sisyphus/plans/chaos-1560-rate-limit-failclosed.md
@@ -1,0 +1,156 @@
+# CHAOS-1560 — Web rate-limit fail-closed design
+
+## Context read
+
+- `src/lib/rate-limit.ts` currently uses Redis when `getRedis()` returns a client, otherwise falls back to per-process memory. Redis command errors also fall back to memory.
+- `src/lib/redis.ts` lazily creates an `ioredis` singleton only when `REDIS_URL` is configured; creation failures return `null`, runtime connection errors are logged by the client.
+- `src/app/api/feedback/route.ts` is the only current caller of `isRateLimited(key)`. It must keep its existing graceful behavior.
+- `src/proxy.ts` treats `/api/v1/auth/*` as public and rewrites other `/api/*` traffic to the ops API, adding bearer/org headers for authenticated users.
+- `src/lib/auth.ts` calls backend auth endpoints directly for credentials/social login and maps backend `429` to Auth.js credential errors.
+- Ops `rate_limit.py` now fails closed for unsafe production config: non-dev requires `REDIS_URL`, ignores forwarded IPs unless proxy trust is configured, and exposes warnings for degraded local-only behavior.
+
+## Runtime blocker check
+
+Before implementation, verify `src/proxy.ts` can use the Redis-backed limiter:
+
+- `src/proxy.ts` has no `export const runtime` declaration.
+- `next.config.js` does not force Edge runtime; it uses standalone output and notes API proxying is handled by `proxy.ts` at runtime.
+- `src/proxy.ts` already imports `auth` from `src/lib/auth.ts`; Auth.js/NextAuth v5 in this project strongly implies Node runtime compatibility.
+- Confirm with `pnpm dev` and a request before writing runtime code. If proxy runs on Edge and cannot use `ioredis`, stop and ask the lead before implementation. Plan B is route-handler-level guards for pass-through API wrappers or an Upstash REST limiter, but neither should be chosen without lead approval.
+
+## Proposed API: `isRateLimited(key, opts)`
+
+Add an options object while preserving default behavior:
+
+```ts
+type RateLimitOptions = {
+  failClosed?: boolean;
+  windowMs?: number;
+  maxRequests?: number;
+  namespace?: string;
+};
+
+await isRateLimited(key, { failClosed: true, namespace: "auth" });
+```
+
+Implementation should expose metadata for `Retry-After`, e.g. `checkRateLimit(key, opts): Promise<{ limited: boolean; retryAfter: number }>` with `isRateLimited()` kept as the existing boolean-compatible wrapper.
+
+Semantics:
+
+- `failClosed` defaults to `false` for backward compatibility.
+- `failClosed: false`: current behavior — use Redis when available; if Redis is missing or command execution fails, log and apply in-memory fallback.
+- `failClosed: true`: Redis is required. If `REDIS_URL` is missing, the client cannot be created, or Redis commands fail, return limited instead of falling back to memory.
+- Keep existing exports `RATE_LIMIT_WINDOW_MS` and `RATE_LIMIT_MAX_REQUESTS`; options can override values per route.
+- Redis keys stay namespaced (`rate_limit:${namespace}:${key}` or existing-compatible `rate_limit:${key}` when no namespace is supplied) to avoid collisions.
+- `429` responses include `Retry-After: <seconds>` and JSON body `{ detail: "Rate limit exceeded", retry_after: N }`. Redis computes this from key TTL; memory fallback computes it from `windowMs - (now - oldest_request)`.
+
+## Proxy integration
+
+Add a proxy-level guard before rewriting requests to the backend. This stops abuse before ops for high-risk public auth/admin endpoints.
+
+Route table inside `src/proxy.ts`:
+
+```ts
+const ROUTE_LIMITS: Array<{ match: (m: string, p: string) => boolean; opts: RateLimitOptions }> = [
+  { match: (m, p) => m === "POST" && p.startsWith("/api/v1/auth/login"),
+    opts: { failClosed: true, namespace: "auth-login", windowMs: 15 * 60_000, maxRequests: 10 } },
+  { match: (m, p) => m === "POST" && p.startsWith("/api/v1/auth/password-reset"),
+    opts: { failClosed: true, namespace: "auth-pwreset", windowMs: 60 * 60_000, maxRequests: 3 } },
+  { match: (m, p) => m === "POST" && p.startsWith("/api/v1/auth/register"),
+    opts: { failClosed: true, namespace: "auth-register", windowMs: 60 * 60_000, maxRequests: 5 } },
+  { match: (m, p) => ["POST", "PUT", "PATCH", "DELETE"].includes(m) && p.startsWith("/api/v1/auth/"),
+    opts: { failClosed: true, namespace: "auth-other", windowMs: 15 * 60_000, maxRequests: 20 } },
+  { match: (m, p) => m === "POST" && p.startsWith("/api/v1/admin/credentials/test-connection"),
+    opts: { failClosed: true, namespace: "admin-cred-test", windowMs: 60 * 60_000, maxRequests: 10 } },
+];
+```
+
+If no entry matches, do not rate-limit at the proxy; backend limits still apply.
+
+Keying differs by auth posture:
+
+- Unauthenticated paths (`/api/v1/auth/*`): key on IP — `proxy:${method}:${pathBucket}:ip:${clientIp}`.
+- Authenticated paths (`/api/v1/admin/credentials/test-connection`): key on `session.user.id` when present, fallback to IP — `proxy:${method}:${pathBucket}:user:${session.user.id ?? `ip:${clientIp}`}`.
+
+Behavior:
+
+- Call the limiter with the matched route's `RateLimitOptions`.
+- If limited, return `429` JSON (`{ detail: "Rate limit exceeded", retry_after: N }`) and `Retry-After: N` without rewriting.
+- Ensure `/api/auth/*` NextAuth routes are not affected; only `/api/v1/...` backend routes are considered.
+
+## `getClientIp()` helper
+
+Expose a shared helper (for example `src/lib/client-ip.ts`) for proxy use. Do not rewrite the feedback route's existing fingerprint fallback in this PR; it can opt in later.
+
+Design:
+
+- Default: do **not** trust `x-forwarded-for`; use platform/native peer-ish headers only when safe, otherwise stable fallback.
+- `getClientIp(request, { trustProxy })` gates forwarded headers:
+  - `TRUST_PROXY=true` / `1`: allow `x-forwarded-for` first hop and `x-real-ip`.
+  - unset/false: ignore spoofable forwarded headers.
+- Return `unknown` only when no stable signal exists.
+- Proxy auth limits should prefer IP and fall back to a stable anonymous fingerprint to avoid a single global `unknown` bucket.
+
+This aligns with ops' `TRUSTED_PROXIES` fail-closed posture: forwarded headers are only honored when explicitly configured as trusted.
+
+## Redis down behavior
+
+| Scenario | `failClosed=false` | `failClosed=true` |
+| --- | --- | --- |
+| `REDIS_URL` unset | use memory fallback | treat as limited; log required Redis unavailable |
+| Redis client creation fails | use memory fallback | treat as limited; log required Redis unavailable |
+| Redis command throws/times out | use memory fallback | treat as limited; log required Redis unhealthy |
+| Redis available and under limit | allow | allow |
+| Redis available and over limit | block with `429` | block with `429` |
+
+Feedback route remains `isRateLimited(rateLimitKey)` with no options, so it continues `failClosed=false`.
+
+## Operator visibility
+
+When `failClosed=true` blocks because Redis is required but unavailable/unhealthy:
+
+- Emit a structured error log with safe fields only: include `namespace`, `failClosed: true`, and `reason` (`missing_redis_url`, `client_unavailable`, `redis_command_failed`). Hash/redact keys that may include IP/email.
+- Add Sentry context/tags when Sentry is present, e.g. tag `rate_limit.redis_required_unhealthy=true`, `rate_limit.namespace=<namespace>`, and capture a message/exception. Do not include secrets, cookies, bearer tokens, or raw credential payloads.
+- Avoid per-request log storms by deduplicating warnings per reason/namespace for a short interval or logging only on the fail-closed branch while keeping existing Redis client errors as-is.
+
+## Test-mode bypass posture
+
+- Proxy limiter bypass is allowed only when `DEV_HEALTH_TEST_MODE === "true"` and `NODE_ENV !== "production"`; this keeps Playwright e2e suites deterministic.
+- Production never bypasses. Add a startup/module assertion: if `DEV_HEALTH_TEST_MODE === "true" && NODE_ENV === "production"`, throw immediately so leaked test-mode cannot disable production protection.
+- The bypass is scoped to the new proxy limiter only; do not disable all rate limiting globally.
+
+## Test plan
+
+Unit tests:
+
+- `isRateLimited()` default still falls back to memory when Redis is missing/throws.
+- `isRateLimited(key, { failClosed: true })` returns limited when Redis is missing.
+- `isRateLimited(key, { failClosed: true })` returns limited when Redis command throws.
+- Redis success path enforces per-route `windowMs`/`maxRequests` and TTL setup.
+- `getClientIp()` ignores spoofed `x-forwarded-for` when `TRUST_PROXY` is unset.
+- `getClientIp()` honors first `x-forwarded-for` hop when `TRUST_PROXY=true`.
+
+Proxy tests:
+
+- Mutating `/api/v1/auth/login` calls fail-closed rate limiting and returns `429` when Redis is unavailable.
+- Mutating `/api/v1/admin/credentials/test-connection` is protected.
+- `/api/v1/auth/password-reset` has explicit coverage.
+- Route limits use the per-route table rather than the shared 5/hour defaults.
+- Auth routes key by IP; admin credential testing keys by `session.user.id` with IP fallback.
+- `429` responses include both `Retry-After` and `{ detail, retry_after }`.
+- Non-production `DEV_HEALTH_TEST_MODE=true` bypasses proxy limits; production plus test mode throws.
+- Non-mutating `GET` requests are not blocked by this guard.
+- `/api/auth/*` NextAuth routes are not affected.
+
+Regression/backward-compat tests:
+
+- Feedback route still calls the default `failClosed=false` path and is not hard-blocked when Redis is absent.
+- Cookie/secret handling in `auth.ts` and `proxy.ts` remains unchanged; no auth headers or cookies are logged.
+
+## Backward compatibility and non-goals
+
+- Do not change feedback route semantics: it remains graceful and defaults to memory fallback.
+- Do not disable rate limiting entirely in any environment.
+- Do not weaken Auth.js cookie/secret handling or alter backend token forwarding.
+- Do not trust spoofable proxy headers unless `TRUST_PROXY` explicitly opts in.
+- Do not touch ops; the ops fix is already in place.

--- a/src/lib/__tests__/client-ip.test.ts
+++ b/src/lib/__tests__/client-ip.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { getClientIp, isTrustProxyEnabled } from "@/lib/client-ip";
+
+function requestWithHeaders(headers: Record<string, string>) {
+  return { headers: new Headers(headers) };
+}
+
+describe("client-ip", () => {
+  it("does not trust x-forwarded-for when trustProxy is false", () => {
+    const request = requestWithHeaders({
+      "x-forwarded-for": "198.51.100.10, 10.0.0.1",
+      "user-agent": "test-agent",
+    });
+
+    expect(getClientIp(request, { trustProxy: false })).toMatch(/^anon:/);
+  });
+
+  it("trusts the first x-forwarded-for hop when trustProxy is true", () => {
+    const request = requestWithHeaders({
+      "x-forwarded-for": "198.51.100.10, 10.0.0.1",
+      "x-real-ip": "203.0.113.20",
+    });
+
+    expect(getClientIp(request, { trustProxy: true })).toBe("198.51.100.10");
+  });
+
+  it("falls back to x-real-ip when proxy trust is enabled and x-forwarded-for is absent", () => {
+    const request = requestWithHeaders({ "x-real-ip": "203.0.113.20" });
+
+    expect(getClientIp(request, { trustProxy: true })).toBe("203.0.113.20");
+  });
+
+  it("parses TRUST_PROXY-style booleans", () => {
+    expect(isTrustProxyEnabled("true")).toBe(true);
+    expect(isTrustProxyEnabled("1")).toBe(true);
+    expect(isTrustProxyEnabled("false")).toBe(false);
+    expect(isTrustProxyEnabled(undefined)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/proxy.test.ts
+++ b/src/lib/__tests__/proxy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import type { Session } from "next-auth";
 
@@ -18,8 +18,21 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(),
+}));
+
 import { auth } from "@/lib/auth";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { isPublicPath, sanitizeCallbackUrl, proxy } from "@/proxy";
+
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  mockCheckRateLimit.mockResolvedValue({ limited: false, retryAfter: 0 });
+});
 
 describe("isPublicPath", () => {
   it("returns true for exact public paths", () => {
@@ -134,5 +147,86 @@ describe("org-scoped route guard", () => {
     mockAuth.mockResolvedValue(superuserWithOrg);
     const res = await proxy(makeRequest("/dashboard"));
     expect(res.status).not.toBe(303);
+  });
+});
+
+describe("proxy rate limiting", () => {
+  const mockAuth = vi.mocked(auth);
+  const makeRequest = (path: string, method = "POST") =>
+    new NextRequest(new URL(path, "http://localhost:3000"), {
+      method,
+      headers: {
+        "user-agent": "proxy-test",
+        "x-forwarded-for": "198.51.100.10",
+      },
+    });
+
+  const session: Session = {
+    access_token: "test-token",
+    user: { id: "u-123", name: "Test", email: "t@t.com", org_id: "org-123" },
+    expires: "2099-01-01T00:00:00.000Z",
+  };
+
+  it("limits login with the auth-login route options", async () => {
+    mockCheckRateLimit.mockResolvedValue({ limited: true, retryAfter: 60 });
+
+    const res = await proxy(makeRequest("/api/v1/auth/login"));
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    await expect(res.json()).resolves.toEqual({ detail: "Rate limit exceeded", retry_after: 60 });
+    expect(mockCheckRateLimit).toHaveBeenCalledWith(
+      expect.stringMatching(/^proxy:POST:auth-login:ip:anon:/),
+      { failClosed: true, namespace: "auth-login", windowMs: 15 * 60_000, maxRequests: 10 },
+    );
+  });
+
+  it("limits password reset with the auth-pwreset route options", async () => {
+    mockCheckRateLimit.mockResolvedValue({ limited: true, retryAfter: 120 });
+
+    const res = await proxy(makeRequest("/api/v1/auth/password-reset"));
+
+    expect(res.status).toBe(429);
+    expect(mockCheckRateLimit).toHaveBeenCalledWith(
+      expect.stringMatching(/^proxy:POST:auth-password-reset:ip:anon:/),
+      { failClosed: true, namespace: "auth-pwreset", windowMs: 60 * 60_000, maxRequests: 3 },
+    );
+  });
+
+  it("keys authenticated credential tests by user id", async () => {
+    mockAuth.mockResolvedValue(session);
+    mockCheckRateLimit.mockResolvedValue({ limited: true, retryAfter: 30 });
+
+    const res = await proxy(makeRequest("/api/v1/admin/credentials/test-connection"));
+
+    expect(res.status).toBe(429);
+    expect(mockCheckRateLimit).toHaveBeenCalledWith(
+      "proxy:POST:admin-credentials-test-connection:user:u-123",
+      { failClosed: true, namespace: "admin-cred-test", windowMs: 60 * 60_000, maxRequests: 10 },
+    );
+  });
+
+  it("does not limit GET requests without a route table match", async () => {
+    const res = await proxy(makeRequest("/api/v1/auth/login", "GET"));
+
+    expect(res.status).not.toBe(429);
+    expect(mockCheckRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("does not limit NextAuth /api/auth routes", async () => {
+    const res = await proxy(makeRequest("/api/auth/callback/github"));
+
+    expect(res.status).not.toBe(429);
+    expect(mockCheckRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("bypasses proxy limiter in non-production test mode", async () => {
+    vi.stubEnv("DEV_HEALTH_TEST_MODE", "true");
+    vi.stubEnv("NODE_ENV", "test");
+
+    const res = await proxy(makeRequest("/api/v1/auth/login"));
+
+    expect(res.status).not.toBe(429);
+    expect(mockCheckRateLimit).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -5,11 +5,20 @@ vi.mock("ioredis", () => {
   const MockRedis = vi.fn().mockImplementation(() => ({
     incr: vi.fn(),
     expire: vi.fn(),
+    ttl: vi.fn(),
     disconnect: vi.fn(),
     on: vi.fn(),
   }));
   return { default: MockRedis };
 });
+
+vi.mock("@sentry/nextjs", () => ({
+  withScope: vi.fn((callback: (scope: { setTag: ReturnType<typeof vi.fn>; setContext: ReturnType<typeof vi.fn> }) => void) =>
+    callback({ setTag: vi.fn(), setContext: vi.fn() })
+  ),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
 
 // Mock logger to avoid pino in test
 vi.mock("@/lib/logger", () => ({
@@ -40,6 +49,16 @@ describe("rate-limit", () => {
 
       const result = await isRateLimited("user-1");
       expect(result).toBe(false);
+    });
+
+    it("fails closed when Redis is missing and failClosed is true", async () => {
+      const { checkRateLimit, isRateLimited, _resetMemoryStore } = await import("@/lib/rate-limit");
+      _resetMemoryStore();
+
+      await expect(isRateLimited("must-have-redis", { failClosed: true })).resolves.toBe(true);
+      await expect(
+        checkRateLimit("must-have-redis-meta", { failClosed: true, windowMs: 15_000 }),
+      ).resolves.toEqual({ limited: true, retryAfter: 15 });
     });
 
     it("blocks after RATE_LIMIT_MAX_REQUESTS", async () => {
@@ -134,11 +153,18 @@ describe("rate-limit", () => {
       // Simulate 6th request (over the 5-request limit)
       redis!.incr = vi.fn().mockResolvedValue(6);
       redis!.expire = vi.fn().mockResolvedValue(1);
+      redis!.ttl = vi.fn().mockResolvedValue(123);
 
       const { isRateLimited } = await import("@/lib/rate-limit");
       const result = await isRateLimited("over-limit-user");
 
       expect(result).toBe(true);
+
+      const { checkRateLimit } = await import("@/lib/rate-limit");
+      await expect(checkRateLimit("over-limit-user", { namespace: "custom", maxRequests: 5 })).resolves.toEqual({
+        limited: true,
+        retryAfter: 123,
+      });
 
       _resetRedisClient();
     });
@@ -178,6 +204,23 @@ describe("rate-limit", () => {
       // Should not throw, should fall back to in-memory
       const result = await isRateLimited("error-user");
       expect(result).toBe(false);
+
+      _resetRedisClient();
+    });
+
+    it("fails closed on Redis error when failClosed is true", async () => {
+      vi.stubEnv("REDIS_URL", "redis://localhost:6379/0");
+
+      const { _resetRedisClient, getRedis } = await import("@/lib/redis");
+      _resetRedisClient();
+
+      const redis = getRedis();
+      redis!.incr = vi.fn().mockRejectedValue(new Error("Connection refused"));
+
+      const { checkRateLimit } = await import("@/lib/rate-limit");
+      await expect(
+        checkRateLimit("error-user", { failClosed: true, windowMs: 30_000, namespace: "auth-login" }),
+      ).resolves.toEqual({ limited: true, retryAfter: 30 });
 
       _resetRedisClient();
     });

--- a/src/lib/client-ip.ts
+++ b/src/lib/client-ip.ts
@@ -1,0 +1,52 @@
+import { createHash } from "node:crypto";
+
+type HeaderReadable = {
+  headers: Pick<Headers, "get">;
+};
+
+export type ClientIpOptions = {
+  trustProxy?: boolean;
+};
+
+function firstHeaderValue(value: string | null): string | null {
+  const first = value?.split(",")[0]?.trim();
+  return first || null;
+}
+
+function anonymousFingerprint(request: HeaderReadable): string {
+  const fallbackIdentifier = [
+    request.headers.get("user-agent") ?? "",
+    request.headers.get("accept-language") ?? "",
+    request.headers.get("sec-ch-ua") ?? "",
+    request.headers.get("x-vercel-id") ?? "",
+    request.headers.get("cf-ray") ?? "",
+  ].join("|");
+
+  if (!fallbackIdentifier.replaceAll("|", "")) {
+    return "unknown";
+  }
+
+  return `anon:${createHash("sha256").update(fallbackIdentifier).digest("hex")}`;
+}
+
+export function isTrustProxyEnabled(value: string | undefined): boolean {
+  return value === "true" || value === "1";
+}
+
+export function getClientIp(request: HeaderReadable, options: ClientIpOptions = {}): string {
+  if (options.trustProxy) {
+    const forwardedFor = firstHeaderValue(request.headers.get("x-forwarded-for"));
+    if (forwardedFor) return forwardedFor;
+
+    const realIp = firstHeaderValue(request.headers.get("x-real-ip"));
+    if (realIp) return realIp;
+  }
+
+  const vercelForwarded = firstHeaderValue(request.headers.get("x-vercel-forwarded-for"));
+  if (vercelForwarded) return vercelForwarded;
+
+  const cfConnectingIp = firstHeaderValue(request.headers.get("cf-connecting-ip"));
+  if (cfConnectingIp) return cfConnectingIp;
+
+  return anonymousFingerprint(request);
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -89,6 +89,7 @@ const serverEnvSchema = z.object({
     LINEAR_API_KEY: z.string().optional(),
     LINEAR_TEAM_ID: z.string().optional(),
     REDIS_URL: z.string().optional(),
+    TRUST_PROXY: z.string().optional(),
     USE_GRAPHQL_ANALYTICS: z.string().optional(),
     DEV_HEALTH_TEST_MODE: z.string().optional(),
     DEMO_EXPORT: z.string().optional(),

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -116,7 +116,11 @@ export function getServerEnv(): ServerEnv {
     // blocking server-side tests.
     const inNodeTest =
         typeof process !== "undefined" &&
-        !!process.versions?.node &&
+        // Indirect access via globalThis prevents Next.js's Edge-runtime
+        // static analyzer from flagging the Node-only `process.versions`
+        // token. The check correctly evaluates to `false` in Edge runtime,
+        // which is the desired semantics (Edge is never a Node test runner).
+        !!(globalThis as { process?: { versions?: { node?: string } } }).process?.versions?.node &&
         (process.env.VITEST === "true" ||
             process.env.NODE_ENV === "test" ||
             typeof (globalThis as { jest?: unknown }).jest !== "undefined");

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -13,6 +13,11 @@
  *   if (await isRateLimited(key)) { return 429; }
  */
 
+import { createHash } from "node:crypto";
+
+import * as Sentry from "@sentry/nextjs";
+
+import { getServerEnv } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { getRedis } from "@/lib/redis";
 
@@ -26,33 +31,116 @@ export const RATE_LIMIT_MAX_REQUESTS = 5;
 // In-memory fallback (per-process, resets on restart)
 // ---------------------------------------------------------------------------
 
+export type RateLimitOptions = {
+  failClosed?: boolean;
+  windowMs?: number;
+  maxRequests?: number;
+  namespace?: string;
+};
+
+export type RateLimitResult = {
+  limited: boolean;
+  retryAfter: number;
+};
+
 const memoryStore = new Map<string, number[]>();
 
-function isRateLimitedInMemory(key: string): boolean {
-  const now = Date.now();
-  const requests = memoryStore.get(key) ?? [];
-  const recent = requests.filter((ts) => now - ts < RATE_LIMIT_WINDOW_MS);
+function windowMs(options: RateLimitOptions): number {
+  return options.windowMs ?? RATE_LIMIT_WINDOW_MS;
+}
 
-  if (recent.length >= RATE_LIMIT_MAX_REQUESTS) {
+function maxRequests(options: RateLimitOptions): number {
+  return options.maxRequests ?? RATE_LIMIT_MAX_REQUESTS;
+}
+
+function retryAfterSeconds(ms: number): number {
+  return Math.max(1, Math.ceil(ms / 1000));
+}
+
+function redisKeyFor(key: string, options: RateLimitOptions): string {
+  return options.namespace ? `rate_limit:${options.namespace}:${key}` : `rate_limit:${key}`;
+}
+
+function safeKeyHash(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+const failClosedLogKeys = new Map<string, number>();
+const FAIL_CLOSED_LOG_INTERVAL_MS = 60_000;
+
+function reportRequiredRedisUnavailable(
+  key: string,
+  options: RateLimitOptions,
+  reason: "missing_redis_url" | "client_unavailable" | "redis_command_failed",
+  err?: unknown,
+): void {
+  const namespace = options.namespace ?? "default";
+  const dedupeKey = `${namespace}:${reason}`;
+  const now = Date.now();
+  const lastLogged = failClosedLogKeys.get(dedupeKey) ?? 0;
+
+  if (now - lastLogged >= FAIL_CLOSED_LOG_INTERVAL_MS) {
+    failClosedLogKeys.set(dedupeKey, now);
+    logger.error(
+      { err, key_hash: safeKeyHash(key), namespace, failClosed: true, reason },
+      "Redis rate-limit backend required but unavailable — failing closed",
+    );
+  }
+
+  Sentry.withScope((scope) => {
+    scope.setTag("rate_limit.redis_required_unhealthy", "true");
+    scope.setTag("rate_limit.namespace", namespace);
+    scope.setTag("rate_limit.reason", reason);
+    scope.setContext("rate_limit", {
+      failClosed: true,
+      key_hash: safeKeyHash(key),
+      namespace,
+      reason,
+    });
+    if (err instanceof Error) {
+      Sentry.captureException(err);
+    } else {
+      Sentry.captureMessage("Redis rate-limit backend required but unavailable");
+    }
+  });
+}
+
+function checkRateLimitedInMemory(key: string, options: RateLimitOptions): RateLimitResult {
+  const now = Date.now();
+  const limitWindowMs = windowMs(options);
+  const limitMaxRequests = maxRequests(options);
+  const requests = memoryStore.get(key) ?? [];
+  const recent = requests.filter((ts) => now - ts < limitWindowMs);
+
+  if (recent.length >= limitMaxRequests) {
     memoryStore.set(key, recent);
-    return true;
+    const oldest = recent[0] ?? now;
+    return { limited: true, retryAfter: retryAfterSeconds(limitWindowMs - (now - oldest)) };
   }
 
   recent.push(now);
   memoryStore.set(key, recent);
-  return false;
+  return { limited: false, retryAfter: 0 };
 }
 
 // ---------------------------------------------------------------------------
 // Redis backend (shared across instances)
 // ---------------------------------------------------------------------------
 
-async function isRateLimitedRedis(key: string): Promise<boolean> {
+async function checkRateLimitedRedis(key: string, options: RateLimitOptions): Promise<RateLimitResult> {
   const redis = getRedis();
-  if (!redis) return isRateLimitedInMemory(key);
+  if (!redis) {
+    if (options.failClosed) {
+      const reason = getServerEnv().REDIS_URL ? "client_unavailable" : "missing_redis_url";
+      reportRequiredRedisUnavailable(key, options, reason);
+      return { limited: true, retryAfter: retryAfterSeconds(windowMs(options)) };
+    }
 
-  const redisKey = `rate_limit:${key}`;
-  const windowSeconds = Math.ceil(RATE_LIMIT_WINDOW_MS / 1000);
+    return checkRateLimitedInMemory(key, options);
+  }
+
+  const redisKey = redisKeyFor(key, options);
+  const windowSeconds = retryAfterSeconds(windowMs(options));
 
   try {
     const count = await redis.incr(redisKey);
@@ -62,10 +150,20 @@ async function isRateLimitedRedis(key: string): Promise<boolean> {
       await redis.expire(redisKey, windowSeconds);
     }
 
-    return count > RATE_LIMIT_MAX_REQUESTS;
+    if (count > maxRequests(options)) {
+      const ttl = await redis.ttl(redisKey);
+      return { limited: true, retryAfter: ttl > 0 ? ttl : windowSeconds };
+    }
+
+    return { limited: false, retryAfter: 0 };
   } catch (err) {
+    if (options.failClosed) {
+      reportRequiredRedisUnavailable(key, options, "redis_command_failed", err);
+      return { limited: true, retryAfter: retryAfterSeconds(windowMs(options)) };
+    }
+
     logger.warn({ err, key }, "Redis rate-limit check failed — falling back to in-memory");
-    return isRateLimitedInMemory(key);
+    return checkRateLimitedInMemory(key, options);
   }
 }
 
@@ -80,8 +178,18 @@ async function isRateLimitedRedis(key: string): Promise<boolean> {
  * Always resolves (never rejects) — errors are logged and treated as "not limited"
  * via the in-memory fallback.
  */
-export async function isRateLimited(key: string): Promise<boolean> {
-  return isRateLimitedRedis(key);
+export async function checkRateLimit(
+  key: string,
+  options: RateLimitOptions = {},
+): Promise<RateLimitResult> {
+  return checkRateLimitedRedis(key, options);
+}
+
+export async function isRateLimited(
+  key: string,
+  options: RateLimitOptions = {},
+): Promise<boolean> {
+  return (await checkRateLimit(key, options)).limited;
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,9 +1,41 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getClientIp, isTrustProxyEnabled } from "@/lib/client-ip";
+import { getServerEnv } from "@/lib/config";
 import { getBackendUrl } from "@/lib/origin";
 import { auth } from "@/lib/auth";
 import { logger } from "@/lib/logger";
+import { checkRateLimit, type RateLimitOptions } from "@/lib/rate-limit";
 
 const log = logger.child({ module: "proxy" });
+
+if (process.env.DEV_HEALTH_TEST_MODE === "true" && process.env.NODE_ENV === "production") {
+    throw new Error("DEV_HEALTH_TEST_MODE must not be enabled in production");
+}
+
+const MUTATING_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
+
+const ROUTE_LIMITS: Array<{ match: (method: string, pathname: string) => boolean; opts: RateLimitOptions }> = [
+    {
+        match: (method, pathname) => method === "POST" && pathname.startsWith("/api/v1/auth/login"),
+        opts: { failClosed: true, namespace: "auth-login", windowMs: 15 * 60_000, maxRequests: 10 },
+    },
+    {
+        match: (method, pathname) => method === "POST" && pathname.startsWith("/api/v1/auth/password-reset"),
+        opts: { failClosed: true, namespace: "auth-pwreset", windowMs: 60 * 60_000, maxRequests: 3 },
+    },
+    {
+        match: (method, pathname) => method === "POST" && pathname.startsWith("/api/v1/auth/register"),
+        opts: { failClosed: true, namespace: "auth-register", windowMs: 60 * 60_000, maxRequests: 5 },
+    },
+    {
+        match: (method, pathname) => MUTATING_METHODS.includes(method) && pathname.startsWith("/api/v1/auth/"),
+        opts: { failClosed: true, namespace: "auth-other", windowMs: 15 * 60_000, maxRequests: 20 },
+    },
+    {
+        match: (method, pathname) => method === "POST" && pathname.startsWith("/api/v1/admin/credentials/test-connection"),
+        opts: { failClosed: true, namespace: "admin-cred-test", windowMs: 60 * 60_000, maxRequests: 10 },
+    },
+];
 
 const EXACT_PUBLIC_PATHS = [
     "/pricing",
@@ -73,6 +105,49 @@ function buildCspHeader(nonce: string): string {
     ].join("; ");
 }
 
+function pathBucket(pathname: string): string {
+    if (pathname.startsWith("/api/v1/auth/login")) return "auth-login";
+    if (pathname.startsWith("/api/v1/auth/password-reset")) return "auth-password-reset";
+    if (pathname.startsWith("/api/v1/auth/register")) return "auth-register";
+    if (pathname.startsWith("/api/v1/auth/")) return "auth-other";
+    if (pathname.startsWith("/api/v1/admin/credentials/test-connection")) return "admin-credentials-test-connection";
+    return pathname;
+}
+
+function shouldBypassProxyRateLimit(): boolean {
+    return process.env.DEV_HEALTH_TEST_MODE === "true" && process.env.NODE_ENV !== "production";
+}
+
+async function enforceProxyRateLimit(
+    request: NextRequest,
+    sessionUserId: string | undefined,
+): Promise<NextResponse | null> {
+    if (shouldBypassProxyRateLimit()) return null;
+
+    const { method } = request;
+    const { pathname } = request.nextUrl;
+    const routeLimit = ROUTE_LIMITS.find(({ match }) => match(method, pathname));
+    if (!routeLimit) return null;
+
+    const env = getServerEnv();
+    const clientIp = getClientIp(request, { trustProxy: isTrustProxyEnabled(env.TRUST_PROXY) });
+    const bucket = pathBucket(pathname);
+    const identity = pathname.startsWith("/api/v1/admin/credentials/test-connection")
+        ? `user:${sessionUserId ?? `ip:${clientIp}`}`
+        : `ip:${clientIp}`;
+    const key = `proxy:${method}:${bucket}:${identity}`;
+    const result = await checkRateLimit(key, routeLimit.opts);
+
+    if (!result.limited) return null;
+
+    const response = NextResponse.json(
+        { detail: "Rate limit exceeded", retry_after: result.retryAfter },
+        { status: 429 },
+    );
+    response.headers.set("Retry-After", String(result.retryAfter));
+    return response;
+}
+
 export async function proxy(request: NextRequest) {
     const start = Date.now();
     const { method } = request;
@@ -112,6 +187,7 @@ async function handleRequest(request: NextRequest) {
 
     let accessToken: string | undefined;
     let orgId: string | undefined;
+    let sessionUserId: string | undefined;
     let isSuperuser = false;
 
     if (!isPublicPath(pathname)) {
@@ -124,6 +200,7 @@ async function handleRequest(request: NextRequest) {
             return redirect;
         }
         accessToken = session.access_token;
+        sessionUserId = session.user?.id;
         orgId = session.user?.org_id;
         isSuperuser = session.user?.is_superuser ?? false;
     }
@@ -138,6 +215,12 @@ async function handleRequest(request: NextRequest) {
         const redirect = NextResponse.redirect(new URL(target, request.url), 303);
         redirect.headers.set("Content-Security-Policy", csp);
         return redirect;
+    }
+
+    const rateLimitResponse = await enforceProxyRateLimit(request, sessionUserId);
+    if (rateLimitResponse) {
+        rateLimitResponse.headers.set("Content-Security-Policy", csp);
+        return rateLimitResponse;
     }
 
     const shouldProxy =


### PR DESCRIPTION
## Summary
- Adds a CHAOS-1560 design note and fail-closed Redis-required rate-limit path with Retry-After metadata.
- Adds proxy route limits for auth-adjacent mutating endpoints with IP/user keying and a non-production test-mode bypass.
- Adds client IP helper and unit coverage for limiter, IP trust, and proxy route behavior.

## Verification
- pnpm vitest run src/lib/__tests__/rate-limit.test.ts src/lib/__tests__/client-ip.test.ts src/lib/__tests__/proxy.test.ts
- pnpm typecheck && pnpm test:unit

TEST-WAIVER: NONE
SCREENSHOT-WAIVER: backend-only behavior, no rendered UI

Refs CHAOS-1560.