### PR TITLE
ci(live-e2e): set ENVIRONMENT=development so ops API can start without REDIS_URL (CHAOS-1574)

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -140,6 +140,10 @@ jobs:
           CLICKHOUSE_URI: clickhouse://ch:ch@localhost:8123/default
           POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           CORS_ALLOWED_ORIGINS: "http://127.0.0.1:3002,http://localhost:3002,http://127.0.0.1:8000"
+          # Ops CHAOS-1553/1554 fail-closed rate-limit posture refuses to start
+          # without REDIS_URL unless ENVIRONMENT=development. Live-e2e runs a
+          # single ops replica and does not need shared Redis state.
+          ENVIRONMENT: development
           # Backend auth service requires a JWT signing secret; derivation
           # from SETTINGS_ENCRYPTION_KEY was removed. Without this every
           # /api/v1/auth/login responds 500 (the AuthService singleton


### PR DESCRIPTION
Closes CHAOS-1574.

## Summary
One-line CI fix. After dev-health-ops landed CHAOS-1553/1554 (fail-closed rate-limit posture), the ops API refuses to start in non-development environments unless \`REDIS_URL\` is configured. The live-e2e workflow does not provision Redis and does not set \`ENVIRONMENT\`, so backend startup now fails with:

\`\`\`
RuntimeError: REDIS_URL must be set in non-development environments.
In-memory rate-limit storage (memory://) is per-process and ineffective
across multiple replicas. Set REDIS_URL, or set ENVIRONMENT=development to suppress.
\`\`\`

This unblocks the three currently failing PRs once they rebase:
- #461 sec(auth): password bounds (CHAOS-1562)
- #462 sec(sentry): PII scrubbing (CHAOS-1561)
- #463 sec(rate-limit): fail-closed (CHAOS-1560)

## Why \`ENVIRONMENT=development\` instead of provisioning Redis
Live-e2e runs a single ops replica, so shared rate-limit state across replicas is not a concern. Setting \`ENVIRONMENT=development\` matches the ops error message's own suggested resolution. If we ever need a multi-replica live-e2e in the future, file a separate ticket to add a Redis service container — out of scope here.

## Test plan
After merge, re-run live-e2e on any of #461 / #462 / #463 (rebasing onto main pulls this fix). Expect green.

SCREENSHOT-WAIVER: CI workflow change, no rendered UI.
TEST-WAIVER: CI workflow itself is the test surface; verification is the resulting green live-e2e run on a follow-up PR.