### PR TITLE
docs: add rate-limiting, security-headers, env-vars, github-app-auth (CHAOS-1567)

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -1,0 +1,79 @@
+# Environment Variables
+
+**Source of Truth:** [`src/lib/config.ts`](../src/lib/config.ts) · [`src/lib/runtimeConfig.ts`](../src/lib/runtimeConfig.ts)
+
+All environment variables are validated with Zod at runtime. There are two surfaces:
+
+- **`getServerEnv()`** — server-only vars. Throws if called from a client bundle. Parses fresh on every call (no caching). ([`config.ts:112`](../src/lib/config.ts#L112))
+- **`publicEnv`** — client-safe `NEXT_PUBLIC_*` vars. Exposed as a Proxy that re-parses on every property read. ([`config.ts:48`](../src/lib/config.ts#L48))
+
+All fields are `optional()` in the Zod schema — the app applies its own defaults and guards rather than hard-failing at startup.
+
+---
+
+## Server-only variables
+
+([`config.ts:74–103`](../src/lib/config.ts#L74))
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `NODE_ENV` | string | — | Node environment (`development`, `production`, `test`). |
+| `LOG_LEVEL` | string | — | Pino log level (`trace`, `debug`, `info`, `warn`, `error`). |
+| `LOG_FORMAT` | string | — | Log format (`json` or `pretty`). |
+| `BACKEND_URL` | string | — | Base URL of the dev-health-ops backend API (e.g. `http://localhost:8800`). |
+| `BASE_PATH` | string | — | Next.js `basePath` for sub-path deployments. Also used as `assetPrefix` in static export mode. |
+| `AUTH_SECRET` | string | — | NextAuth v5 secret. Required in production; falls back to `NEXTAUTH_SECRET`, then a dev default. |
+| `NEXTAUTH_SECRET` | string | — | Legacy NextAuth secret alias. Superseded by `AUTH_SECRET`. |
+| `NEXTAUTH_URL` | string | — | Canonical URL for NextAuth callbacks. |
+| `AUTH_GITHUB_ID` | string | — | GitHub OAuth App client ID. Enables GitHub social login when set. |
+| `AUTH_GITHUB_SECRET` | string | — | GitHub OAuth App client secret. Required when `AUTH_GITHUB_ID` is set. |
+| `AUTH_GOOGLE_ID` | string | — | Google OAuth client ID. Enables Google social login when set. |
+| `AUTH_GOOGLE_SECRET` | string | — | Google OAuth client secret. Required when `AUTH_GOOGLE_ID` is set. |
+| `AUTH_GITLAB_ID` | string | — | GitLab OAuth client ID. Enables GitLab social login when set. |
+| `AUTH_GITLAB_SECRET` | string | — | GitLab OAuth client secret. Required when `AUTH_GITLAB_ID` is set. |
+| `LINEAR_API_KEY` | string | — | Linear API key for Linear integration features. |
+| `LINEAR_TEAM_ID` | string | — | Linear team ID scoping Linear API calls. |
+| `REDIS_URL` | string | — | Redis/Valkey connection URL. Required for distributed rate limiting (`failClosed` routes). Without it, rate limiting falls back to per-process in-memory. |
+| `TRUST_PROXY` | string | — | Set to `"true"` to trust `X-Forwarded-For` for client IP detection (needed behind a load balancer). |
+| `USE_GRAPHQL_ANALYTICS` | string | — | Server-side override for GraphQL analytics. Defaults to `true` unless set to `"false"`. |
+| `DEV_HEALTH_TEST_MODE` | string | — | Enables test mode (bypasses rate limiting, uses sample data). **Must not be `"true"` in production.** |
+| `DEMO_EXPORT` | string | — | Set to `"true"` to build a static demo export. Changes Next.js output mode and page extensions. |
+
+---
+
+## Client-side (`NEXT_PUBLIC_*`) variables
+
+([`config.ts:22–31`](../src/lib/config.ts#L22))
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS` | string | `"true"` | Enables GraphQL analytics on the client. Set to `"false"` to disable. |
+| `NEXT_PUBLIC_DOCS_URL` | string | `"/docs"` | Base URL for documentation links. |
+| `NEXT_PUBLIC_DEV_HEALTH_TEST_MODE` | string | — | Client-side test mode flag. Mirrors `DEV_HEALTH_TEST_MODE`. |
+| `NEXT_PUBLIC_DEMO_MODE` | string | — | Enables demo mode UI behaviour. |
+| `NEXT_PUBLIC_BETA` | string | — | Enables beta feature flags in the UI. |
+| `NEXT_PUBLIC_RUM_ENDPOINT` | string | — | Real User Monitoring endpoint URL. |
+| `NEXT_PUBLIC_SENTRY_DSN` | string | — | Sentry DSN for client-side error reporting. |
+| `NODE_ENV` | string | — | Also available in the public schema for client-side environment checks. |
+
+---
+
+## Runtime config (`public/runtime-config.js`)
+
+`NEXT_PUBLIC_*` variables are statically inlined by Next.js at build time. For deployments that need to inject values at container start (without rebuilding), the app supports a runtime override via `public/runtime-config.js`.
+
+The file is served as a static asset and sets `window.__DEV_HEALTH_RUNTIME__`:
+
+```js
+window.__DEV_HEALTH_RUNTIME__ = {
+  publicEnv: {
+    NEXT_PUBLIC_SENTRY_DSN: "...",
+    NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: "true",
+    // ...
+  }
+};
+```
+
+`src/lib/runtimeConfig.ts` reads from `window.__DEV_HEALTH_RUNTIME__.publicEnv` first, falling back to `process.env`. This means runtime-config values take precedence over build-time values for any `NEXT_PUBLIC_*` variable. ([`runtimeConfig.ts`](../src/lib/runtimeConfig.ts))
+
+> **Do not commit `public/runtime-config.js`** — it is generated at container start and contains deployment-specific values. It is listed in `.gitignore`.

--- a/docs/github-app-auth.md
+++ b/docs/github-app-auth.md
@@ -1,0 +1,82 @@
+# GitHub OAuth Authentication
+
+**Source of Truth:** [`src/lib/auth.ts`](../src/lib/auth.ts) · [`src/lib/config.ts`](../src/lib/config.ts)
+
+> **Note:** This document covers **GitHub OAuth (social login)** via NextAuth.js. The app uses a standard GitHub OAuth App — not a GitHub App with installation tokens or private-key JWTs. There is no GitHub App installation flow in this codebase.
+
+## Overview
+
+GitHub social login is an optional provider in NextAuth.js v5. It is enabled only when `AUTH_GITHUB_ID` is set in the environment. ([`auth.ts:119`](../src/lib/auth.ts#L119))
+
+```ts
+...(authEnv.AUTH_GITHUB_ID
+  ? [GitHub({ clientId: authEnv.AUTH_GITHUB_ID, clientSecret: authEnv.AUTH_GITHUB_SECRET! })]
+  : []),
+```
+
+## Configuration
+
+([`config.ts:83–84`](../src/lib/config.ts#L83))
+
+| Variable | Required | Description |
+|---|---|---|
+| `AUTH_GITHUB_ID` | Yes (to enable) | GitHub OAuth App client ID. If absent, GitHub login is disabled. |
+| `AUTH_GITHUB_SECRET` | Yes (when `AUTH_GITHUB_ID` is set) | GitHub OAuth App client secret. |
+
+See [`docs/env-vars.md`](env-vars.md) for the full environment variable reference.
+
+## Authentication flow
+
+```
+User clicks "Sign in with GitHub"
+  → NextAuth redirects to github.com/login/oauth/authorize
+  → User authorises the OAuth App
+  → GitHub redirects to /api/auth/callback/github with ?code=...
+  → NextAuth exchanges code for access_token (github.com/login/oauth/access_token)
+  → NextAuth jwt() callback fires with account.provider = "github"
+  → Frontend POSTs to backend /api/v1/auth/social-login
+      { provider: "github", provider_access_token: <github_access_token> }
+  → Backend validates the token with GitHub, creates/looks up user, returns backend JWT
+  → NextAuth stores backend JWT + user metadata in its own session token
+```
+
+([`auth.ts:138–174`](../src/lib/auth.ts#L138))
+
+## Session data after GitHub login
+
+The same session shape as credentials login:
+
+| Field | Source |
+|---|---|
+| `access_token` | Backend JWT returned by `/api/v1/auth/social-login` |
+| `role` | User's role from backend |
+| `is_superuser` | Boolean from backend |
+| `permissions` | Empty array (social login does not return granular permissions) |
+| `needs_onboarding` | Whether the user needs to complete onboarding |
+
+## Checking which providers are enabled
+
+```ts
+import { getAvailableSocialProviders } from "@/lib/auth"
+// Returns e.g. ["github", "google"] based on which env vars are set
+const providers = getAvailableSocialProviders()
+```
+
+([`auth.ts:369–376`](../src/lib/auth.ts#L369))
+
+## Registering a GitHub OAuth App for local dev
+
+1. Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**.
+2. Set **Homepage URL** to `http://localhost:3000`.
+3. Set **Authorization callback URL** to `http://localhost:3000/api/auth/callback/github`.
+4. Copy the **Client ID** and generate a **Client secret**.
+5. Add to your `.env.local`:
+   ```
+   AUTH_GITHUB_ID=<client_id>
+   AUTH_GITHUB_SECRET=<client_secret>
+   ```
+6. Restart the dev server. The GitHub button will appear on the sign-in page.
+
+## Error handling
+
+If the backend `/api/v1/auth/social-login` call fails or returns a non-OK response, `token.error` is set to `"social_login_failed"` and the session is marked as errored. ([`auth.ts:163–173`](../src/lib/auth.ts#L163))

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,78 @@
+# Rate Limiting
+
+**Source of Truth:** [`src/lib/rate-limit.ts`](../src/lib/rate-limit.ts) · [`src/proxy.ts`](../src/proxy.ts)
+
+## Overview
+
+Rate limiting uses a **Redis fixed-window** strategy when Redis is available, with an **in-memory sliding-window** fallback when it is not. This mirrors the graceful-fallback pattern from dev-health-ops (`api/middleware/rate_limit.py`).
+
+## Defaults
+
+| Constant | Value | Source |
+|---|---|---|
+| `RATE_LIMIT_WINDOW_MS` | `3 600 000` ms (1 hour) | [`rate-limit.ts:25`](../src/lib/rate-limit.ts#L25) |
+| `RATE_LIMIT_MAX_REQUESTS` | `5` | [`rate-limit.ts:28`](../src/lib/rate-limit.ts#L28) |
+
+## Strategies
+
+### Redis (primary) — fixed-window
+
+Uses `INCR` + `EXPIRE` on a namespaced key (`rate_limit:<namespace>:<key>`). TTL is set on the first request in the window. On subsequent requests the remaining TTL is returned as `Retry-After`. ([`rate-limit.ts:130–168`](../src/lib/rate-limit.ts#L130))
+
+### In-memory (fallback) — sliding-window
+
+Stores a per-key timestamp array in a module-level `Map`. Timestamps older than `windowMs` are pruned on each check. **Per-process only** — resets on restart and is not shared across instances. ([`rate-limit.ts:108–124`](../src/lib/rate-limit.ts#L108))
+
+## `RateLimitOptions`
+
+```ts
+type RateLimitOptions = {
+  failClosed?: boolean;   // default: false
+  windowMs?: number;      // default: RATE_LIMIT_WINDOW_MS (1h)
+  maxRequests?: number;   // default: RATE_LIMIT_MAX_REQUESTS (5)
+  namespace?: string;     // prefixes the Redis key
+};
+```
+
+([`rate-limit.ts:34–39`](../src/lib/rate-limit.ts#L34))
+
+## `failClosed` — when it is required
+
+When `failClosed: true`, a missing or unreachable Redis backend causes the limiter to **return 429** instead of falling back to in-memory. This is mandatory for auth-adjacent routes where a per-process fallback would allow an attacker to bypass limits by hitting different pods.
+
+Routes that set `failClosed: true` ([`proxy.ts:17–38`](../src/proxy.ts#L17)):
+
+| Namespace | Method + Path | Window | Max |
+|---|---|---|---|
+| `auth-login` | `POST /api/v1/auth/login` | 15 min | 10 |
+| `auth-pwreset` | `POST /api/v1/auth/password-reset` | 60 min | 3 |
+| `auth-register` | `POST /api/v1/auth/register` | 60 min | 5 |
+| `auth-other` | `MUTATING /api/v1/auth/*` | 15 min | 20 |
+| `admin-cred-test` | `POST /api/v1/admin/credentials/test-connection` | 60 min | 10 |
+
+When Redis is unavailable and `failClosed` is set, the limiter:
+1. Logs an error (deduplicated to once per 60 s per namespace+reason, [`rate-limit.ts:68–106`](../src/lib/rate-limit.ts#L68)).
+2. Captures a Sentry exception/message.
+3. Returns `{ limited: true, retryAfter: <windowSeconds> }`.
+
+## Redis dependency
+
+`getRedis()` is imported from `src/lib/redis.ts`. It returns `null` when `REDIS_URL` is not set or the client fails to initialise.
+
+**Production requirement:** set `REDIS_URL` to a Redis-compatible endpoint (Valkey is supported). Without it, all `failClosed` routes will return 429 for every request.
+
+## Public API
+
+```ts
+// Returns true if the key is over limit.
+isRateLimited(key: string, options?: RateLimitOptions): Promise<boolean>
+
+// Returns { limited, retryAfter } for finer-grained control.
+checkRateLimit(key: string, options?: RateLimitOptions): Promise<RateLimitResult>
+```
+
+Both functions always resolve — they never reject. Redis errors are logged and handled via the fallback or `failClosed` path. ([`rate-limit.ts:181–193`](../src/lib/rate-limit.ts#L181))
+
+## Test bypass
+
+Rate limiting is skipped when `DEV_HEALTH_TEST_MODE=true` and `NODE_ENV !== "production"` ([`proxy.ts:117–119`](../src/proxy.ts#L117)). Never enable `DEV_HEALTH_TEST_MODE` in production — the app throws at startup if both flags are set ([`proxy.ts:11–13`](../src/proxy.ts#L11)).

--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -1,0 +1,71 @@
+# Security Headers
+
+**Source of Truth:** [`next.config.js`](../next.config.js) · [`src/proxy.ts`](../src/proxy.ts)
+
+## Overview
+
+Security headers are applied at two layers:
+
+1. **`next.config.js` static headers** — applied by Next.js to every response via the `headers()` config. These are the fallback/static-export path.
+2. **`src/proxy.ts` middleware CSP** — the middleware generates a per-request nonce and injects a stricter `Content-Security-Policy` for all server-rendered routes, overriding the static-export CSP.
+
+## Headers set in `next.config.js` (all routes, `/(.*)`)
+
+([`next.config.js:24–50`](../next.config.js#L24))
+
+| Header | Value |
+|---|---|
+| `X-Content-Type-Options` | `nosniff` |
+| `X-Frame-Options` | `DENY` |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` |
+| `Content-Security-Policy` | See below |
+
+### Static-export / CDN fallback CSP
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline';
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+font-src 'self' data:;
+connect-src 'self' https://*.vercel.app https://*.sentry.io https://bugs.fullchaos.dev;
+frame-ancestors 'none';
+```
+
+`unsafe-inline` in `script-src` is intentional here — it covers only the static export path where middleware does not run and no nonce is available. ([`next.config.js:38–46`](../next.config.js#L38))
+
+## Middleware nonce-based CSP (server-rendered routes)
+
+For all server-rendered responses, `src/proxy.ts` generates a cryptographically random 16-byte base64url nonce per request and builds a stricter CSP that removes `unsafe-inline` from `script-src`. ([`proxy.ts:77–106`](../src/proxy.ts#L77))
+
+```
+default-src 'self';
+script-src 'self' 'nonce-<random>';
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob:;
+font-src 'self' data:;
+connect-src 'self' https://*.vercel.app https://*.sentry.io https://bugs.fullchaos.dev http://localhost:8800;
+frame-ancestors 'none';
+```
+
+`unsafe-eval` is intentionally excluded — Next.js 13+ App Router does not require it. ([`proxy.ts:92–94`](../src/proxy.ts#L92))
+
+The nonce is injected on every response path in the middleware: redirects, rate-limit 429s, auth redirects, and proxied responses. ([`proxy.ts:177–260`](../src/proxy.ts#L177))
+
+## Environment differences
+
+| Context | CSP source | `unsafe-inline` in script-src |
+|---|---|---|
+| Static export (`DEMO_EXPORT=true`) | `next.config.js` | Yes (no middleware) |
+| Server-rendered (normal) | `src/proxy.ts` middleware | No (nonce used instead) |
+| Local dev (`localhost:8800`) | `src/proxy.ts` middleware | No; `connect-src` includes `http://localhost:8800` |
+
+## Updating headers safely
+
+- **Static headers** (`X-Frame-Options`, `HSTS`, etc.): edit the `headers()` array in [`next.config.js`](../next.config.js#L24). Changes take effect on next build.
+- **CSP for server-rendered routes**: edit `buildCspHeader()` in [`src/proxy.ts`](../src/proxy.ts#L96). The nonce is generated per-request; only the directives need updating.
+- **CSP for static export**: edit the `value` string in [`next.config.js:44–46`](../next.config.js#L44). Keep it in sync with `buildCspHeader()` where possible.
+- Do not add `unsafe-eval` — it is intentionally absent.
+- Do not remove `frame-ancestors 'none'` — it is the clickjacking defence.


### PR DESCRIPTION
## Summary

Adds four operator/developer docs sourced from existing code. Each doc links to its source file(s) as the source of truth.

## New files

- **`docs/rate-limiting.md`** — sourced from `src/lib/rate-limit.ts` and `src/proxy.ts`. Documents Redis fixed-window strategy, in-memory sliding-window fallback, `RateLimitOptions` (`failClosed`, `windowMs`, `maxRequests`, `namespace`), when `failClosed` is required (auth-adjacent routes), Redis dependency, and graceful degradation.

- **`docs/security-headers.md`** — sourced from `next.config.js` and `src/proxy.ts`. Documents all headers set today (CSP, HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy, X-Content-Type-Options), the two-layer approach (static config vs middleware nonce-based CSP), and environment differences.

- **`docs/env-vars.md`** — sourced from `src/lib/config.ts`. Exhaustive table of every env var with name, type, default, and description. Separate sections for server-only and `NEXT_PUBLIC_*` vars. Documents the `public/runtime-config.js` mechanism for runtime injection.

- **`docs/github-app-auth.md`** — sourced from `src/lib/auth.ts` and `src/lib/config.ts`. Documents the GitHub OAuth flow (OAuth App, not GitHub App), configuration env vars (cross-linked to `env-vars.md`), the token exchange flow via `/api/v1/auth/social-login`, and local dev setup steps.

## Linear

Closes CHAOS-1567

SCREENSHOT-WAIVER: docs-only change — no rendered UI affected
TEST-WAIVER: docs-only — no src/ files changed