### PR TITLE
sec(rate-limit): trust-proxy gate for /api/feedback IP keying (CHAOS-1563)

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,9 +1,8 @@
-import { createHash } from "node:crypto";
-
 import { NextResponse } from "next/server";
 
 import type { FeedbackPayload, FeedbackResponse } from "@/components/feedback/types";
 import { auth } from "@/lib/auth";
+import { getClientIp, isTrustProxyEnabled } from "@/lib/client-ip";
 import { getServerEnv } from "@/lib/config";
 import { ApiErrors, linearApiRequestFailedMessage } from "@/lib/constants/errors";
 import { isRateLimited } from "@/lib/rate-limit";
@@ -22,36 +21,6 @@ const ISSUE_CREATE_MUTATION = `
     }
   }
 `;
-
-function getClientIp(request: Request): string {
-  // In production behind a reverse proxy, X-Forwarded-For is set by the proxy.
-  // WARNING: This header is spoofable if the app is not behind a trusted proxy.
-  // For stronger guarantees, use the platform's native IP detection (e.g., Vercel's
-  // x-real-ip header) or move rate limiting to an edge middleware / WAF.
-  const realIp = request.headers.get("x-real-ip");
-  if (realIp) return realIp;
-
-  const forwardedFor = request.headers.get("x-forwarded-for");
-  const trustedProxyHeader = request.headers.get("x-forwarded-proto") || request.headers.get("via");
-
-  if (forwardedFor && trustedProxyHeader) {
-    return forwardedFor.split(",")[0]?.trim() || "unknown";
-  }
-
-  const fallbackIdentifier = [
-    request.headers.get("user-agent") ?? "",
-    request.headers.get("accept-language") ?? "",
-    request.headers.get("sec-ch-ua") ?? "",
-    request.headers.get("x-vercel-id") ?? "",
-    request.headers.get("cf-ray") ?? "",
-  ].join("|");
-
-  if (!fallbackIdentifier.replaceAll("|", "")) {
-    return "unknown";
-  }
-
-  return `anon:${createHash("sha256").update(fallbackIdentifier).digest("hex")}`;
-}
 
 function getPriority(type: FeedbackPayload["type"]): number {
   switch (type) {
@@ -116,7 +85,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const ip = getClientIp(request);
+  const ip = getClientIp(request, { trustProxy: isTrustProxyEnabled(env.TRUST_PROXY) });
   const rateLimitKey = session.user?.id ?? ip;
 
   if (await isRateLimited(rateLimitKey)) {

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -226,3 +226,44 @@ describe("rate-limit", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// getClientIp — TRUST_PROXY gate (CHAOS-1563)
+// ---------------------------------------------------------------------------
+describe("getClientIp trust-proxy gate", () => {
+  function makeRequest(headers: Record<string, string>) {
+    return { headers: new Headers(headers) };
+  }
+
+  it("ignores X-Forwarded-For when TRUST_PROXY is false (spoofing prevention)", async () => {
+    const { getClientIp, isTrustProxyEnabled } = await import("@/lib/client-ip");
+    const request = makeRequest({
+      "x-forwarded-for": "1.2.3.4, 10.0.0.1",
+      "user-agent": "test-browser",
+    });
+    const ip = getClientIp(request, { trustProxy: isTrustProxyEnabled("false") });
+    expect(ip).not.toBe("1.2.3.4");
+    // Should fall back to anon fingerprint
+    expect(ip).toMatch(/^anon:/);
+  });
+
+  it("returns the leftmost X-Forwarded-For hop when TRUST_PROXY is true", async () => {
+    const { getClientIp, isTrustProxyEnabled } = await import("@/lib/client-ip");
+    const request = makeRequest({
+      "x-forwarded-for": "1.2.3.4, 10.0.0.1",
+    });
+    const ip = getClientIp(request, { trustProxy: isTrustProxyEnabled("true") });
+    expect(ip).toBe("1.2.3.4");
+  });
+
+  it("ignores X-Forwarded-For when TRUST_PROXY env is undefined (default false)", async () => {
+    const { getClientIp, isTrustProxyEnabled } = await import("@/lib/client-ip");
+    const request = makeRequest({
+      "x-forwarded-for": "1.2.3.4",
+      "user-agent": "test-browser",
+    });
+    const ip = getClientIp(request, { trustProxy: isTrustProxyEnabled(undefined) });
+    expect(ip).not.toBe("1.2.3.4");
+  });
+});
+

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -89,6 +89,13 @@ const serverEnvSchema = z.object({
     LINEAR_API_KEY: z.string().optional(),
     LINEAR_TEAM_ID: z.string().optional(),
     REDIS_URL: z.string().optional(),
+    /**
+     * When set to "true" or "1", the application trusts the `X-Forwarded-For`
+     * header for client IP extraction (used by rate limiting). Only enable this
+     * when the app is deployed behind a trusted reverse proxy that strips or
+     * rewrites forwarded headers. Defaults to false (untrusted) to prevent IP
+     * spoofing attacks.
+     */
     TRUST_PROXY: z.string().optional(),
     USE_GRAPHQL_ANALYTICS: z.string().optional(),
     DEV_HEALTH_TEST_MODE: z.string().optional(),

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -8,6 +8,22 @@
  * In-memory strategy: sliding-window timestamp array (matches the original
  * feedback route implementation).
  *
+ * ## Client IP trust model
+ *
+ * Rate-limit keys that incorporate a client IP MUST be derived via
+ * `getClientIp()` from `@/lib/client-ip`, NOT by reading `x-forwarded-for`
+ * directly. The helper enforces the following policy:
+ *
+ *   - `TRUST_PROXY=true`  → reads the leftmost `X-Forwarded-For` hop, then
+ *     falls back to `X-Real-IP`. Use only when the app is deployed behind a
+ *     known, trusted reverse proxy that strips/rewrites these headers.
+ *   - `TRUST_PROXY=false` (default) → ignores `X-Forwarded-For` entirely to
+ *     prevent IP spoofing. Falls back to platform-injected headers
+ *     (`x-vercel-forwarded-for`, `cf-connecting-ip`) and then to an
+ *     anonymous SHA-256 fingerprint of stable request headers.
+ *
+ * Never read `X-Forwarded-For` outside of `getClientIp()` in this module.
+ *
  * Usage:
  *   import { isRateLimited, RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS } from "@/lib/rate-limit";
  *   if (await isRateLimited(key)) { return 429; }


### PR DESCRIPTION
## Summary

Fixes IP spoofing vulnerability in the `/api/feedback` rate-limit key derivation. Previously, the route trusted `X-Forwarded-For` whenever a sibling proxy header (`x-forwarded-proto` or `via`) was present — a weak signal that is trivially spoofable. This PR introduces an explicit `TRUST_PROXY` env gate and centralizes the IP extraction helper.

Closes: https://linear.app/fullchaos/issue/CHAOS-1563

## Trust model

| Condition | IP source |
|-----------|-----------|
| `TRUST_PROXY=true` | Leftmost `X-Forwarded-For` hop, then `X-Real-IP` |
| `TRUST_PROXY=false` (default) | Platform-injected headers (`x-vercel-forwarded-for`, `cf-connecting-ip`), then anon SHA-256 fingerprint |

Never trust raw `X-Forwarded-For` without `TRUST_PROXY=true`.

## Changes

### `src/lib/client-ip.ts` (pre-existing, unchanged)
Centralized `getClientIp(request, { trustProxy })` helper + `isTrustProxyEnabled()` parser.

### `src/app/api/feedback/route.ts`
- **Removed** the local `getClientIp` function (lines 26–54) that blindly trusted `X-Forwarded-For` when `x-forwarded-proto` or `via` was present
- **Replaced** with import of `getClientIp` + `isTrustProxyEnabled` from `@/lib/client-ip`
- IP is now derived via `getClientIp(request, { trustProxy: isTrustProxyEnabled(env.TRUST_PROXY) })`

### `src/lib/rate-limit.ts`
- Added header comment documenting the trust model and pointing to `getClientIp` as the required helper for IP-keyed rate limiting

### `src/lib/config.ts`
- Added JSDoc comment for `TRUST_PROXY` in the server env schema explaining when to enable it and the security implications

### `src/lib/__tests__/rate-limit.test.ts`
- Added 3 new tests in `describe("getClientIp trust-proxy gate")`:
  - Spoofed `X-Forwarded-For` is ignored when `TRUST_PROXY=false` → falls back to anon fingerprint
  - Leftmost `X-Forwarded-For` hop is returned when `TRUST_PROXY=true`
  - `TRUST_PROXY=undefined` (default) also ignores `X-Forwarded-For`

## Acceptance criteria checklist

- [x] `getClientIp(request)` centralized in `src/lib/client-ip.ts` (exported)
- [x] Feedback route imports the shared helper (local copy removed)
- [x] `X-Forwarded-For` only trusted when `TRUST_PROXY=true`
- [x] `TRUST_PROXY` in server env schema with JSDoc, default `false`
- [x] Header comment in `rate-limit.ts` documents trust model
- [x] Unit test: spoofed `X-Forwarded-For: 1.2.3.4` ignored when `TRUST_PROXY=false`
- [x] Unit test: `X-Forwarded-For: 1.2.3.4` returned when `TRUST_PROXY=true`
- [x] Anon-hash fallback path preserved

## Verification

```
npm run lint      # 0 errors (1 pre-existing warning in sentry/scrubber.ts, unrelated)
npm run typecheck # clean
npm run test:unit src/lib/__tests__/rate-limit.test.ts  # 13 passed
npm run test:unit src/lib/__tests__/client-ip.test.ts   # 4 passed
```

SCREENSHOT-WAIVER: backend-only — no rendered UI changed