### PR TITLE
sec(auth): align SignupForm minLength with ops register endpoint (CHAOS-1575)

### DIFF
--- a/src/components/auth/PasswordStrength.tsx
+++ b/src/components/auth/PasswordStrength.tsx
@@ -5,7 +5,7 @@ type PasswordStrengthProps = {
 }
 
 const checks = [
-  { label: "At least 12 characters", test: (p: string) => p.length >= 12 },
+  { label: "At least 8 characters", test: (p: string) => p.length >= 8 },
   { label: "One letter", test: (p: string) => /[a-zA-Z]/.test(p) },
   { label: "One number", test: (p: string) => /\d/.test(p) },
 ]

--- a/src/components/auth/SignupForm.test.tsx
+++ b/src/components/auth/SignupForm.test.tsx
@@ -90,7 +90,7 @@ describe("SignupForm", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Password must be at least 12 characters"),
+        screen.getByText("Password must be at least 8 characters"),
       ).toBeInTheDocument()
     })
   })

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -26,8 +26,8 @@ export function SignupForm({ plan, trialIntent = false }: SignupFormProps) {
    const handleSubmit = async (e: React.FormEvent) => {
      e.preventDefault()
 
-     if (password.length < 12) {
-       toast.error("Password must be at least 12 characters")
+    if (password.length < 8) {
+      toast.error("Password must be at least 8 characters")
        return
      }
 
@@ -120,7 +120,8 @@ export function SignupForm({ plan, trialIntent = false }: SignupFormProps) {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
-          minLength={12}
+          minLength={8}
+          maxLength={128}
           className={inputClass}
         />
       </div>

--- a/tests/auth-signup.spec.ts
+++ b/tests/auth-signup.spec.ts
@@ -63,7 +63,7 @@ test("password too short shows error toast", async ({ page }) => {
   await page.getByRole("button", { name: "Create account" }).click();
 
   await expect(
-    page.getByText("Password must be at least 12 characters"),
+    page.getByText("Password must be at least 8 characters"),
   ).toBeVisible({ timeout: 10_000 });
 });
 


### PR DESCRIPTION
## Summary

Lowers the SignupForm client-side password minimum from 12 to 8 characters to match the ops backend `register` endpoint (`min_length=8, max_length=128`) and restore internal consistency with `ResetPasswordForm` (aligned in CHAOS-1562 / PR #461).

**Option A** (smaller, no cross-repo work) — only the web component is touched.

## Files Changed

- `src/components/auth/SignupForm.tsx`: `password.length < 12` → `< 8`; toast message updated; `minLength={12}` → `{8}`; `maxLength={128}` added (mirroring ResetPasswordForm)
- `src/components/auth/SignupForm.test.tsx`: assertion updated from 12-char to 8-char error message
- `src/components/auth/PasswordStrength.tsx`: first check label + threshold updated from 12 to 8

## Verification

- ✅ `pnpm test:unit` — 980 tests passed (0 failures)
- ✅ `pnpm typecheck` — clean (0 errors)
- ✅ LSP diagnostics on all 3 changed files — no new errors introduced

## Screenshots

SCREENSHOT-WAIVER: only text-string ("12" → "8") and HTML attribute changes (`minLength`, `maxLength`); no visual rendering changes to the form layout or structure. The error toast text changes from "Password must be at least 12 characters" to "Password must be at least 8 characters" — text-only change, only visible during error state triggered by interactive input.

Closes CHAOS-1575