### PR TITLE
fix(ai): cross-PR consistency fixups for AI workflow views (CHAOS-1715)

### DIFF
--- a/src/app/(app)/ai/impact/page.tsx
+++ b/src/app/(app)/ai/impact/page.tsx
@@ -1,5 +1,6 @@
 import { AIImpactDashboard } from "@/components/ai/AIImpactDashboard";
 import { AIFilterBar } from "@/components/ai/AIFilterBar";
+import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { checkApiHealth } from "@/lib/api/system";
@@ -25,13 +26,9 @@ export default async function AIImpactPage({ searchParams }: AIImpactPageProps) 
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={defaultMetricFilter} active="ai-impact" />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header>
-            <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">AI</p>
-            <h1 className="mt-2 font-(--font-display) text-3xl">AI Impact</h1>
-            <p className="mt-2 max-w-3xl text-sm text-(--ink-muted)">
-              Org-wide view of how AI-assisted workflows appear to influence delivery, review load, quality gaps, and operational drag.
-            </p>
-          </header>
+          <AIPageHeader eyebrow="AI" title="AI Impact">
+            Org-wide view of how AI-assisted workflows appear to influence delivery, review load, quality gaps, and operational drag.
+          </AIPageHeader>
 
           <AIFilterBar filter={filter} />
           <AIImpactDashboard filter={filter} />

--- a/src/app/(app)/ai/review-load/page.tsx
+++ b/src/app/(app)/ai/review-load/page.tsx
@@ -1,5 +1,6 @@
 import { AIReviewLoadDashboard } from "@/components/ai/AIReviewLoadDashboard";
 import { AIFilterBar } from "@/components/ai/AIFilterBar";
+import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { defaultMetricFilter } from "@/lib/filters/defaults";
 import { decodeAIFilter } from "@/lib/filters/ai";
@@ -18,13 +19,9 @@ export default async function AIReviewLoadPage({ searchParams }: AIReviewLoadPag
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={defaultMetricFilter} active="ai-review-load" />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header>
-            <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">AI workflows</p>
-            <h1 className="mt-2 font-(--font-display) text-3xl">AI Review Load</h1>
-            <p className="mt-2 max-w-3xl text-sm text-(--ink-muted)">
-              Diagnostic view for AI-generated review pressure, comparing AI-attributed work against the human baseline without person-level rankings.
-            </p>
-          </header>
+          <AIPageHeader eyebrow="AI workflows" title="AI Review Load">
+            Diagnostic view for AI-generated review pressure, comparing AI-attributed work against the human baseline without person-level rankings.
+          </AIPageHeader>
           <AIFilterBar filter={filter} />
           <AIReviewLoadDashboard filter={filter} />
         </main>

--- a/src/app/(app)/ai/risk/page.tsx
+++ b/src/app/(app)/ai/risk/page.tsx
@@ -1,5 +1,6 @@
 import { AIRiskDashboard } from "@/components/ai/AIRiskDashboard";
 import { AIFilterBar } from "@/components/ai/AIFilterBar";
+import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { defaultMetricFilter } from "@/lib/filters/defaults";
 import { decodeAIFilter } from "@/lib/filters/ai";
@@ -18,13 +19,9 @@ export default async function AIRiskPage({ searchParams }: AIRiskPageProps) {
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={defaultMetricFilter} active="ai-risk" />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header>
-            <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">AI workflows</p>
-            <h1 className="mt-2 font-(--font-display) text-3xl">AI Risk</h1>
-            <p className="mt-2 max-w-3xl text-sm text-(--ink-muted)">
-              Quality-risk diagnostics for AI-associated work, including baseline deltas, explicit missing-data states, and governance findings.
-            </p>
-          </header>
+          <AIPageHeader eyebrow="AI workflows" title="AI Risk">
+            Quality-risk diagnostics for AI-associated work, including baseline deltas, explicit missing-data states, and governance findings.
+          </AIPageHeader>
           <AIFilterBar filter={filter} />
           <AIRiskDashboard filter={filter} />
         </main>

--- a/src/components/ai/AIEmptyState.tsx
+++ b/src/components/ai/AIEmptyState.tsx
@@ -1,5 +1,15 @@
 import type { ReactNode } from "react";
 
+/**
+ * Whole-view "no data exists for this scope yet" marker.
+ *
+ * Use when an entire AI dashboard cannot render anything meaningful because
+ * upstream ingestion hasn't produced rows for the selected scope. The
+ * implication is "data does not exist", not "this feature isn't built".
+ *
+ * For "the metric exists in spec but the schema doesn't expose it yet",
+ * use {@link AIMissingDataPanel} instead.
+ */
 export function AIEmptyState({ title, children }: { title: string; children?: ReactNode }) {
   return (
     <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-80) p-6 text-sm text-(--ink-muted)">

--- a/src/components/ai/AIImpactDashboard.tsx
+++ b/src/components/ai/AIImpactDashboard.tsx
@@ -5,13 +5,12 @@ import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
 import { ErrorCard } from "@/components/ui/ErrorCard";
 import { useAIComparison, useAIImpactSummary, useAIOpportunities } from "@/lib/graphql/hooks/useAIImpact";
 import type { AIFilter } from "@/lib/filters/ai";
-import { encodeAIFilterParam } from "@/lib/filters/ai";
 import { AIComparisonCard } from "./AIComparisonCard";
 import { AIEmptyState } from "./AIEmptyState";
 import { AILeverageBars } from "./AILeverageBars";
 import { AIOpportunityList } from "./AIOpportunityList";
 import { AIPanelCard } from "./AIPanelCard";
-import { agentCreatedTrend, assistedWorkShareRows, bucketLabel, formatPercent } from "./utils";
+import { agentCreatedTrend, assistedWorkShareRows, bucketLabel, formatPercent, safeRatio } from "./utils";
 
 type AIImpactDashboardProps = {
   filter: AIFilter;
@@ -25,7 +24,9 @@ export function AIImpactDashboard({ filter }: AIImpactDashboardProps) {
   const summary = summaryResult.data?.aiImpactSummary;
   const comparison = comparisonResult.data?.aiComparison;
   const opportunities = opportunitiesResult.data?.aiOpportunities;
-  const evidenceHref = `/ai/impact/PR/summary?f=${encodeURIComponent(encodeAIFilterParam(filter))}`;
+  // Drill-into-evidence is intentionally not wired yet: the PR-row picker
+  // and `/ai/impact/PR/summary` route haven't shipped. Panels render
+  // without an evidence link rather than pointing at a 404. (CHAOS-1715)
 
   if (summaryResult.error || comparisonResult.error || opportunitiesResult.error) {
     return (
@@ -65,7 +66,7 @@ export function AIImpactDashboard({ filter }: AIImpactDashboardProps) {
         <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
           <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Agent-created work share</p>
           <p className="mt-2 text-4xl font-semibold tabular-nums">{summary?.agentCreatedPrs ?? 0}</p>
-          <p className="mt-2 text-sm text-(--ink-muted)">{formatPercent((summary?.agentCreatedPrs ?? 0) / Math.max(summary?.totalPrs ?? 1, 1))} of PRs appear agent-created.</p>
+          <p className="mt-2 text-sm text-(--ink-muted)">{formatPercent(safeRatio(summary?.agentCreatedPrs, summary?.totalPrs))} of PRs appear agent-created.</p>
         </div>
         <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
           <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Unknown attribution</p>
@@ -75,11 +76,11 @@ export function AIImpactDashboard({ filter }: AIImpactDashboardProps) {
       </div>
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
-        <AIPanelCard title="AI-assisted work share" description="PR attribution mix across human, assisted, review, agent, and unknown buckets." evidenceHref={evidenceHref}>
+        <AIPanelCard title="AI-assisted work share" description="PR attribution mix across human, assisted, review, agent, and unknown buckets.">
           {donutRows.length ? <DonutChart data={donutRows} height={260} /> : <AIEmptyState title="Attribution mix has no rows yet" />}
         </AIPanelCard>
 
-        <AIPanelCard title="Agent-created work share" description="Absolute agent-created PR count with a scoped trend." evidenceHref={evidenceHref}>
+        <AIPanelCard title="Agent-created work share" description="Absolute agent-created PR count with a scoped trend.">
           <div className="flex items-end justify-between gap-4">
             <div>
               <p className="text-4xl font-semibold tabular-nums">{agentBucket?.agentCreatedPrCount ?? summary?.agentCreatedPrs ?? 0}</p>
@@ -90,23 +91,23 @@ export function AIImpactDashboard({ filter }: AIImpactDashboardProps) {
           {trend.length ? <TimeseriesChart data={trend} height={180} /> : <AIEmptyState title="Agent-created trend has no rows yet" />}
         </AIPanelCard>
 
-        <AIPanelCard title="Net delivery lift" description="AI Operating Leverage broken into signed delivery and drag components." evidenceHref={evidenceHref}>
+        <AIPanelCard title="Net delivery lift" description="AI Operating Leverage broken into signed delivery and drag components.">
           <AILeverageBars components={leverage} />
         </AIPanelCard>
 
-        <AIPanelCard title="Review amplification" description="Reviews per PR on the AI side compared with the non-AI baseline." evidenceHref={evidenceHref}>
+        <AIPanelCard title="Review amplification" description="Reviews per PR on the AI side compared with the non-AI baseline.">
           <AIComparisonCard label="Reviews per PR" aiSide={comparison?.aiSide} baselineSide={comparison?.baselineSide} delta={comparison?.delta.reviewsPerPrDelta} metric="reviewsPerPr" percent={false} />
         </AIPanelCard>
 
-        <AIPanelCard title="Rework drag" description="Rework rate suggests where assisted flow may add iteration load." evidenceHref={evidenceHref}>
+        <AIPanelCard title="Rework drag" description="Rework rate suggests where assisted flow may add iteration load.">
           <AIComparisonCard label="Rework rate" aiSide={comparison?.aiSide} baselineSide={comparison?.baselineSide} delta={comparison?.delta.reworkRateDelta} metric="reworkRate" />
         </AIPanelCard>
 
-        <AIPanelCard title="Test gap rate" description="Test gaps show where confidence may lag behind generated or assisted change." evidenceHref={evidenceHref}>
+        <AIPanelCard title="Test gap rate" description="Test gaps show where confidence may lag behind generated or assisted change.">
           <AIComparisonCard label="Test gap rate" aiSide={comparison?.aiSide} baselineSide={comparison?.baselineSide} delta={comparison?.delta.testGapRateDelta} metric="testGapRate" />
         </AIPanelCard>
 
-        <AIPanelCard title="Revert + incident drag" description="Operational drag indicators compared with the baseline side." evidenceHref={evidenceHref}>
+        <AIPanelCard title="Revert + incident drag" description="Operational drag indicators compared with the baseline side.">
           <div className="grid gap-3 md:grid-cols-2">
             <AIComparisonCard label="Revert rate" aiSide={comparison?.aiSide} baselineSide={comparison?.baselineSide} delta={comparison?.delta.revertRateDelta} metric="revertRate" />
             <AIComparisonCard label="Incident rate" aiSide={comparison?.aiSide} baselineSide={comparison?.baselineSide} delta={comparison?.delta.incidentRateDelta} metric="incidentRate" />
@@ -119,7 +120,7 @@ export function AIImpactDashboard({ filter }: AIImpactDashboardProps) {
           </AIEmptyState>
         </AIPanelCard>
 
-        <AIPanelCard title="Best-fit automation opportunities" description="Candidate patterns for responsible automation once the recommendation engine becomes ready." evidenceHref={evidenceHref}>
+        <AIPanelCard title="Best-fit automation opportunities" description="Candidate patterns for responsible automation once the recommendation engine becomes ready.">
           <AIOpportunityList detectorReady={opportunities?.detectorReady} recommendations={opportunities?.recommendations} />
         </AIPanelCard>
       </div>

--- a/src/components/ai/AIMissingDataPanel.tsx
+++ b/src/components/ai/AIMissingDataPanel.tsx
@@ -4,6 +4,19 @@ type AIMissingDataPanelProps = {
   needed?: string;
 };
 
+/**
+ * Per-card "this metric is intentionally not shipped yet" marker.
+ *
+ * Use when a specific card in an otherwise-populated dashboard cannot
+ * render because the underlying signal isn't exposed in the schema yet or
+ * was deliberately deferred (e.g. reviewer concentration, deferred until
+ * an aggregate-only distribution ships without per-person ranking). The
+ * implication is "this is on the roadmap; here's the data source needed",
+ * not "data does not exist".
+ *
+ * For whole-view "no data exists for this scope" coverage, use
+ * {@link AIEmptyState} instead.
+ */
 export function AIMissingDataPanel({ title, reason, needed }: AIMissingDataPanelProps) {
   return (
     <section className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-80) p-5" data-testid="ai-missing-data-panel">

--- a/src/components/ai/AIPageHeader.tsx
+++ b/src/components/ai/AIPageHeader.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+type AIPageHeaderProps = {
+  eyebrow: string;
+  title: string;
+  children: ReactNode;
+};
+
+/**
+ * Shared page header for the three top-level AI workflow views
+ * (Impact, Review Load, Risk). Keeps eyebrow + title + lede consistent
+ * across the cluster so copy tone doesn't drift between pages.
+ */
+export function AIPageHeader({ eyebrow, title, children }: AIPageHeaderProps) {
+  return (
+    <header>
+      <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">{eyebrow}</p>
+      <h1 className="mt-2 font-(--font-display) text-3xl">{title}</h1>
+      <p className="mt-2 max-w-3xl text-sm text-(--ink-muted)">{children}</p>
+    </header>
+  );
+}

--- a/src/components/ai/__tests__/AIImpactDashboard.test.tsx
+++ b/src/components/ai/__tests__/AIImpactDashboard.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/components/charts/SparklineChart", () => ({
   SparklineChart: ({ data }: { data: number[] }) => <div data-testid="sparkline-chart">{data.join(",")}</div>,
 }));
 
-import { AIImpactDashboard } from "./AIImpactDashboard";
+import { AIImpactDashboard } from "../AIImpactDashboard";
 import type { AIFilter } from "@/lib/filters/ai";
 
 const filter: AIFilter = { startDate: "2026-04-20", endDate: "2026-05-19" };

--- a/src/components/ai/__tests__/AIReviewLoadDashboard.test.tsx
+++ b/src/components/ai/__tests__/AIReviewLoadDashboard.test.tsx
@@ -8,7 +8,7 @@ const { mockUseAIReviewLoad } = vi.hoisted(() => ({ mockUseAIReviewLoad: vi.fn()
 vi.mock("@/lib/graphql/hooks/useAIReviewRisk", async () => {
   return {
     useAIReviewLoad: mockUseAIReviewLoad,
-    findBucketRow: <T extends { bucket: string }>(rows: T[] | undefined, bucket = "AI_ASSISTED") => rows?.find((row) => row.bucket === bucket) ?? rows?.find((row) => row.bucket !== "HUMAN"),
+    findBucketRow: <T extends { bucket: string }>(rows: T[] | undefined, bucket = "AI_ASSISTED") => rows?.find((row) => row.bucket === bucket),
     valueDelta: (value?: number | null, baseline?: number | null) => value == null || baseline == null ? undefined : value - baseline,
     approvalFriction: (row?: { changesRequestedPerPr?: number | null; reviewsPerPr?: number | null }) => !row?.reviewsPerPr || row.changesRequestedPerPr == null ? undefined : row.changesRequestedPerPr / row.reviewsPerPr,
   };

--- a/src/components/ai/__tests__/AIRiskDashboard.test.tsx
+++ b/src/components/ai/__tests__/AIRiskDashboard.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@/lib/graphql/hooks/useAIReviewRisk", async () => {
   return {
     useAIRiskBreakdown: mockUseAIRiskBreakdown,
     useAIGovernanceSummary: mockUseAIGovernanceSummary,
-    findBucketRow: <T extends { bucket: string }>(rows: T[] | undefined, bucket = "AI_ASSISTED") => rows?.find((row) => row.bucket === bucket) ?? rows?.find((row) => row.bucket !== "HUMAN"),
+    findBucketRow: <T extends { bucket: string }>(rows: T[] | undefined, bucket = "AI_ASSISTED") => rows?.find((row) => row.bucket === bucket),
     prViolationRows: (summary?: { recentViolations?: Array<{ subjectType: string }> }) => (summary?.recentViolations ?? []).filter((violation) => violation.subjectType.toLowerCase() === "pr"),
   };
 });

--- a/src/components/ai/__tests__/useAIReviewRisk.adapters.test.ts
+++ b/src/components/ai/__tests__/useAIReviewRisk.adapters.test.ts
@@ -22,10 +22,11 @@ describe("useAIReviewRisk adapters", () => {
     });
   });
 
-  it("finds the requested bucket and falls back to non-human AI bucket", () => {
+  it("returns the requested bucket and undefined when it is absent (no silent fallback)", () => {
     const rows = [{ bucket: "HUMAN", value: 1 }, { bucket: "AGENT_CREATED", value: 2 }];
     expect(findBucketRow(rows, "HUMAN")?.value).toBe(1);
-    expect(findBucketRow(rows)?.value).toBe(2);
+    expect(findBucketRow(rows)).toBeUndefined();
+    expect(findBucketRow(rows, "AGENT_CREATED")?.value).toBe(2);
   });
 
   it("derives deltas and approval friction only when inputs exist", () => {

--- a/src/components/ai/utils.ts
+++ b/src/components/ai/utils.ts
@@ -15,6 +15,18 @@ export function formatPercent(value?: number | null): string {
   return `${(value * 100).toFixed(1)}%`;
 }
 
+/**
+ * Compute a ratio guarded against zero / missing denominators. Returns
+ * null when the ratio cannot be expressed, which `formatPercent` renders
+ * as “—”. Avoids the `denom ?? 1` antipattern that silently treats a
+ * missing denominator as 1 and emits absurd percents like 1200.0%.
+ */
+export function safeRatio(numerator?: number | null, denominator?: number | null): number | null {
+  if (numerator == null || denominator == null) return null;
+  if (denominator === 0) return null;
+  return numerator / denominator;
+}
+
 export function formatNumber(value?: number | null, digits = 1): string {
   if (value == null || Number.isNaN(value)) return "—";
   return value.toFixed(digits);
@@ -27,7 +39,7 @@ export function formatSigned(value?: number | null, suffix = ""): string {
 }
 
 export function assistedWorkShareRows(rows: AiImpactBucketTotals[]) {
-  const assistedBuckets = new Set(["AI_ASSISTED", "AI_REVIEW", "AGENT_CREATED", "HUMAN", "UNKNOWN"]);
+  const assistedBuckets = new Set<string>(AI_BUCKETS);
   return rows
     .filter((row) => assistedBuckets.has(row.bucket))
     .map((row) => ({ name: bucketLabel(row.bucket), value: row.prsTotal }));

--- a/src/lib/filters/ai.ts
+++ b/src/lib/filters/ai.ts
@@ -1,3 +1,4 @@
+import { AI_BUCKETS } from "@/components/ai/utils";
 import { isServer } from "@/lib/env";
 import type { AiAttributionBucketInput } from "@/lib/graphql/__generated__/types";
 
@@ -13,7 +14,7 @@ export type AIFilter = {
 };
 
 const ALLOWED_KEYS = new Set(["startDate", "endDate", "teamId", "repoId", "workType", "buckets"]);
-const BUCKETS = new Set(["AI_ASSISTED", "AI_REVIEW", "AGENT_CREATED", "HUMAN", "UNKNOWN"]);
+const BUCKETS = new Set<string>(AI_BUCKETS);
 
 // Next.js polyfills `Buffer` in the browser bundle, but the polyfill does
 // NOT support the `base64url` encoding (Node 16+ only). Falling back to a

--- a/src/lib/graphql/hooks/useAIReviewRisk.ts
+++ b/src/lib/graphql/hooks/useAIReviewRisk.ts
@@ -57,8 +57,14 @@ export function toAIQueryInputs(filter: AIFilter): AIInputs {
   };
 }
 
+/**
+ * Strict bucket lookup. Returns `undefined` when the requested bucket is
+ * absent so the caller's missing-data branch fires honestly rather than
+ * silently substituting an unrelated bucket (e.g. AGENT_CREATED or
+ * UNKNOWN) when AI_ASSISTED rows haven't populated yet.
+ */
 export function findBucketRow<T extends { bucket: string }>(rows: T[] | undefined, bucket: AIBucket | string = "AI_ASSISTED"): T | undefined {
-  return rows?.find((row) => row.bucket === bucket) ?? rows?.find((row) => row.bucket !== "HUMAN");
+  return rows?.find((row) => row.bucket === bucket);
 }
 
 export function valueDelta(value: number | null | undefined, baseline: number | null | undefined): number | undefined {


### PR DESCRIPTION
## Summary

Polish follow-up from the holistic CHAOS-1584/1585 review (see CHAOS-1578 comments). Addresses every cross-PR finding that was flagged out-of-scope for CHAOS-1588 in one focused PR. No behavioral changes beyond the dead-link removal and the `findBucketRow` tightening.

## What's in here

### P1 — Important

**Remove dead `evidenceHref`**
- `src/components/ai/AIImpactDashboard.tsx`: drops `evidenceHref = "/ai/impact/PR/summary?…"` and its 7 callsite usages on `<AIPanelCard>`. The route never existed, so "View evidence" rendered a dead link. Panels now render without the link until the PR-row picker ships; a comment explains why.
- `AIPanelCard`'s `evidenceHref` prop is left in place (it's still optional and will be re-wired when the drilldown route exists).

**Fix unsafe ratio formatting**
- `AIImpactDashboard.tsx` L68 previously did `formatPercent((agentCreatedPrs ?? 0) / Math.max(totalPrs ?? 1, 1))`. When `totalPrs` was missing the denominator became `1`, which would render values like `1200.0%` instead of `—`. Replaced with a new `utils.safeRatio()` helper that returns `null` on missing/zero denominators; `formatPercent` already renders `null` as `—`.

### P2 — Tightening

**Strict `findBucketRow`**
- `useAIReviewRisk.ts`: `findBucketRow` no longer falls back to the first non-HUMAN bucket when the requested bucket is absent. Returns `undefined` so the caller's missing-data branch fires honestly instead of silently substituting `AGENT_CREATED` or `UNKNOWN` as if it were `AI_ASSISTED`.
- Tests updated:
  - `useAIReviewRisk.adapters.test.ts` now asserts `undefined` when the requested bucket is missing.
  - `AIReviewLoadDashboard.test.tsx` + `AIRiskDashboard.test.tsx` drop the old fallback from their mocks. Existing fixtures already include `AI_ASSISTED`, so dashboard coverage is unaffected.

### P3 — Polish

**Extract `AIPageHeader`**
- New `components/ai/AIPageHeader.tsx` encapsulates the eyebrow + title + lede block that was repeated near-verbatim across `/ai/impact`, `/ai/review-load`, and `/ai/risk`. All three pages now use it.

**Dedupe `AI_BUCKETS`**
- `lib/filters/ai.ts` replaces an inline duplicate set with the canonical `AI_BUCKETS` constant imported from `components/ai/utils.ts`.
- `utils.ts` `assistedWorkShareRows()` also stops re-listing the bucket literals and derives from `AI_BUCKETS`.

**Move misplaced test file**
- `src/components/ai/AIImpactDashboard.test.tsx` → `src/components/ai/__tests__/AIImpactDashboard.test.tsx`. Matches the CHAOS-1585 layout where every AI test lives under `__tests__/`.

**Document idiom distinction**
- `AIEmptyState.tsx`: JSDoc clarifies it is the **whole-view** "no data exists for this scope" marker.
- `AIMissingDataPanel.tsx`: JSDoc clarifies it is the **per-card** "this metric is intentionally not shipped yet" marker.
- Out of scope: a forced unification of these two idioms — they encode different intents and the JSDoc + cross-link keeps that visible.

## Out of scope (deliberate)

- The `unit="%"` coupling on `AIComparisonMetricCard` — addressing it would require renaming every callsite across CHAOS-1584 and CHAOS-1585.

## Verification

- ` ` `vitest run src/components/ai src/lib/filters src/lib/graphql` → **53/53 passing**
- ` ` `lsp_diagnostics` clean on every touched file
- AIFilterBar regression test from CHAOS-1588 still passes
- No production logic changes beyond P1 + P2

## Screenshots

SCREENSHOT-WAIVER: no rendered UI changes beyond removing the dead "View evidence" links from the AI Impact panels. Behavior verified via existing unit tests.

## Closes / refs

Closes CHAOS-1715. Parent CHAOS-1578.
