### PR TITLE
fix/ai automations nav active

### DIFF
--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useSyncExternalStore, useCallback } from "react";
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { BetaBadge } from "@/components/BetaBadge";
 
 import { withFilterParam } from "@/lib/filters/url";
@@ -30,6 +31,11 @@ function getCollapsedState(): Record<string, boolean> {
 function subscribeToStorage(callback: () => void) {
   window.addEventListener("storage", callback);
   return () => window.removeEventListener("storage", callback);
+}
+
+function getLocationHash() {
+  if (typeof window === "undefined") return "";
+  return window.location.hash;
 }
 
 type NavItem = {
@@ -114,11 +120,24 @@ type PrimaryNavProps = {
 };
 
 export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
+  const pathname = usePathname();
+  const [hash, setHash] = useState("");
   const collapsed = useSyncExternalStore(
     subscribeToStorage,
     getCollapsedState,
     () => EMPTY_COLLAPSED
   );
+
+  useEffect(() => {
+    const syncHash = () => setHash(getLocationHash());
+    syncHash();
+    window.addEventListener("hashchange", syncHash);
+    window.addEventListener("popstate", syncHash);
+    return () => {
+      window.removeEventListener("hashchange", syncHash);
+      window.removeEventListener("popstate", syncHash);
+    };
+  }, []);
 
   const toggleGroup = useCallback((groupId: string) => {
     const current = getCollapsedState();
@@ -170,11 +189,15 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
                 
                 <div className={`space-y-2 overflow-hidden transition-all duration-300 ${collapsed[group.id] ? "max-h-0 opacity-0" : "max-h-[500px] opacity-100"}`}>
                   {group.items.map((item) => {
-                    const isActive = active === item.id;
+                    const [itemPath, itemHash] = item.href.split("#", 2);
+                    const hashMatchesItem = Boolean(itemHash) && pathname === itemPath && hash === `#${itemHash}`;
+                    const pageMatchesItem = active === item.id && !(hash && pathname === itemPath);
+                    const isActive = hashMatchesItem || pageMatchesItem;
                     return (
                       <Link
                         key={item.id}
                         href={withFilterParam(item.href, filters, role)}
+                        onClick={itemHash ? () => setHash(`#${itemHash}`) : undefined}
                         aria-current={isActive ? "page" : undefined}
                         className={`group relative flex items-center justify-between rounded-2xl border px-3 py-2 transition ${isActive
                           ? "border-(--accent) bg-(--accent)/15 text-foreground before:absolute before:left-0 before:top-1/4 before:h-1/2 before:w-[3px] before:rounded-full before:bg-(--accent)"

--- a/src/lib/filters/__tests__/url.test.ts
+++ b/src/lib/filters/__tests__/url.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+import { withFilterParam } from "@/lib/filters/url";
+
+describe("withFilterParam", () => {
+  it("places encoded filters before URL fragments", () => {
+    const href = withFilterParam("/ai/impact#opportunities", defaultMetricFilter);
+
+    expect(href).toMatch(/^\/ai\/impact\?f=/);
+    expect(href).toContain("#opportunities");
+    expect(href).not.toContain("#opportunities?f=");
+  });
+});

--- a/src/lib/filters/url.ts
+++ b/src/lib/filters/url.ts
@@ -26,6 +26,7 @@ export const buildExploreUrl = (options: {
 };
 
 export const withFilterParam = (path: string, filters: MetricFilter, role?: string, origin?: string) => {
+  const [pathWithoutHash, hash] = path.split("#", 2);
   const params = new URLSearchParams();
   params.set("f", encodeFilterParam(filters));
   if (role) {
@@ -34,8 +35,9 @@ export const withFilterParam = (path: string, filters: MetricFilter, role?: stri
   if (origin) {
     params.set("origin", origin);
   }
-  if (path.includes("?")) {
-    return `${path}&${params.toString()}`;
+  const suffix = hash ? `#${hash}` : "";
+  if (pathWithoutHash.includes("?")) {
+    return `${pathWithoutHash}&${params.toString()}${suffix}`;
   }
-  return `${path}?${params.toString()}`;
+  return `${pathWithoutHash}?${params.toString()}${suffix}`;
 };

--- a/tests/ai-navigation.spec.ts
+++ b/tests/ai-navigation.spec.ts
@@ -25,6 +25,8 @@ const aiReviewLoadLink = (page: Page) =>
   page.locator('a[href^="/ai/review-load"]').first();
 const aiRiskLink = (page: Page) =>
   page.locator('a[href^="/ai/risk"]').first();
+const aiAutomationsLink = (page: Page) =>
+  page.locator('a[href*="#opportunities"]').first();
 
 test.describe("AI workflow primary navigation", () => {
   test("nav links route between the three AI views", async ({ page }) => {
@@ -46,6 +48,16 @@ test.describe("AI workflow primary navigation", () => {
     await aiImpactLink(page).click();
     await expect(page).toHaveURL(/\/ai\/impact/);
     await expect(page.getByRole("heading", { name: "AI Impact" })).toBeVisible();
+  });
+
+  test("Automations hash link owns the active nav state", async ({ page }) => {
+    await page.goto(`/ai/impact?f=${defaultFilter}`);
+
+    await aiAutomationsLink(page).click();
+
+    await expect(page).toHaveURL(/\/ai\/impact\?[^#]*#opportunities/);
+    await expect(aiAutomationsLink(page)).toHaveAttribute("aria-current", "page");
+    await expect(aiImpactLink(page)).not.toHaveAttribute("aria-current", "page");
   });
 
   test("AIFilterBar updates stay on the current AI route", async ({ page }) => {


### PR DESCRIPTION
## Summary
- preserve hash fragments after encoded filter query params so `/ai/impact#opportunities` remains a valid fragment URL
- make PrimaryNav hash-aware so AI > Automations owns the active state instead of AI > Impact
- add unit and e2e regression coverage for the Automations nav state

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/lib/filters/__tests__/url.test.ts`
- `pnpm exec playwright test tests/ai-navigation.spec.ts --grep "Automations hash link" --project=authenticated --config playwright.config.ts --workers=1 --reporter=line` (2 passed)

SCREENSHOT-WAIVER: visual state verified by focused Playwright assertion (`aria-current=page` moves to Automations and is removed from Impact); local Docker daemon was unavailable for compose-backed screenshot capture.