### PR TITLE
feat(ai): promote Automations to its own route (CHAOS-1725)

### DIFF
--- a/src/app/(app)/ai/automations/page.tsx
+++ b/src/app/(app)/ai/automations/page.tsx
@@ -1,0 +1,31 @@
+import { AIAutomationsDashboard } from "@/components/ai/AIAutomationsDashboard";
+import { AIFilterBar } from "@/components/ai/AIFilterBar";
+import { AIPageHeader } from "@/components/ai/AIPageHeader";
+import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { decodeAIFilter } from "@/lib/filters/ai";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+
+type AIAutomationsPageProps = {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+export default async function AIAutomationsPage({ searchParams }: AIAutomationsPageProps) {
+  const params = (await searchParams) ?? {};
+  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+  const filter = decodeAIFilter(encodedFilter);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+        <PrimaryNav filters={defaultMetricFilter} active="ai-opportunities" />
+        <main className="flex min-w-0 flex-1 flex-col gap-8">
+          <AIPageHeader eyebrow="AI workflows" title="AI Automations">
+            Candidate patterns for responsible automation, separated from Impact diagnostics so teams can triage opportunities directly.
+          </AIPageHeader>
+          <AIFilterBar filter={filter} />
+          <AIAutomationsDashboard filter={filter} />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ai/AIAutomationsDashboard.tsx
+++ b/src/components/ai/AIAutomationsDashboard.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { ErrorCard } from "@/components/ui/ErrorCard";
+import type { AIFilter } from "@/lib/filters/ai";
+import { useAIOpportunities } from "@/lib/graphql/hooks/useAIImpact";
+import { AIEmptyState } from "./AIEmptyState";
+import { AIOpportunityList } from "./AIOpportunityList";
+import { AIPanelCard } from "./AIPanelCard";
+
+type AIAutomationsDashboardProps = {
+  filter: AIFilter;
+};
+
+export function AIAutomationsDashboard({ filter }: AIAutomationsDashboardProps) {
+  const opportunitiesResult = useAIOpportunities(filter);
+  const opportunities = opportunitiesResult.data?.aiOpportunities;
+
+  if (opportunitiesResult.error) {
+    return (
+      <ErrorCard
+        title="AI automation opportunities could not load"
+        message={opportunitiesResult.error.message ?? "Please retry the request."}
+      />
+    );
+  }
+
+  if (opportunitiesResult.fetching && !opportunities) {
+    return <AutomationsSkeleton />;
+  }
+
+  return (
+    <div className="flex flex-col gap-6" data-testid="ai-automations-dashboard">
+      <AIPanelCard
+        title="Best-fit automation opportunities"
+        description="Candidate patterns for responsible automation once the recommendation engine becomes ready."
+      >
+        <AIOpportunityList detectorReady={opportunities?.detectorReady} recommendations={opportunities?.recommendations} />
+      </AIPanelCard>
+    </div>
+  );
+}
+
+function AutomationsSkeleton() {
+  return (
+    <div className="rounded-3xl border border-(--card-stroke) bg-card p-5" data-testid="ai-automations-loading">
+      <div className="h-40 animate-pulse rounded-2xl bg-(--card-80)" />
+    </div>
+  );
+}

--- a/src/components/ai/AIImpactDashboard.tsx
+++ b/src/components/ai/AIImpactDashboard.tsx
@@ -1,14 +1,15 @@
 "use client";
 
+import Link from "next/link";
+
 import { DonutChart } from "@/components/charts/DonutChart";
 import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
 import { ErrorCard } from "@/components/ui/ErrorCard";
-import { useAIComparison, useAIImpactSummary, useAIOpportunities } from "@/lib/graphql/hooks/useAIImpact";
+import { useAIComparison, useAIImpactSummary } from "@/lib/graphql/hooks/useAIImpact";
 import type { AIFilter } from "@/lib/filters/ai";
 import { AIComparisonCard } from "./AIComparisonCard";
 import { AIEmptyState } from "./AIEmptyState";
 import { AILeverageBars } from "./AILeverageBars";
-import { AIOpportunityList } from "./AIOpportunityList";
 import { AIPanelCard } from "./AIPanelCard";
 import { agentCreatedTrend, assistedWorkShareRows, bucketLabel, formatPercent, safeRatio } from "./utils";
 
@@ -19,20 +20,18 @@ type AIImpactDashboardProps = {
 export function AIImpactDashboard({ filter }: AIImpactDashboardProps) {
   const summaryResult = useAIImpactSummary(filter);
   const comparisonResult = useAIComparison(filter);
-  const opportunitiesResult = useAIOpportunities(filter);
-  const fetching = summaryResult.fetching || comparisonResult.fetching || opportunitiesResult.fetching;
+  const fetching = summaryResult.fetching || comparisonResult.fetching;
   const summary = summaryResult.data?.aiImpactSummary;
   const comparison = comparisonResult.data?.aiComparison;
-  const opportunities = opportunitiesResult.data?.aiOpportunities;
   // Drill-into-evidence is intentionally not wired yet: the PR-row picker
   // and `/ai/impact/PR/summary` route haven't shipped. Panels render
   // without an evidence link rather than pointing at a 404. (CHAOS-1715)
 
-  if (summaryResult.error || comparisonResult.error || opportunitiesResult.error) {
+  if (summaryResult.error || comparisonResult.error) {
     return (
       <ErrorCard
         title="AI impact data could not load"
-        message={(summaryResult.error || comparisonResult.error || opportunitiesResult.error)?.message ?? "Please retry the request."}
+        message={(summaryResult.error || comparisonResult.error)?.message ?? "Please retry the request."}
       />
     );
   }
@@ -120,8 +119,13 @@ export function AIImpactDashboard({ filter }: AIImpactDashboardProps) {
           </AIEmptyState>
         </AIPanelCard>
 
-        <AIPanelCard title="Best-fit automation opportunities" description="Candidate patterns for responsible automation once the recommendation engine becomes ready.">
-          <AIOpportunityList detectorReady={opportunities?.detectorReady} recommendations={opportunities?.recommendations} />
+        <AIPanelCard title="Best-fit automation opportunities" description="Candidate patterns for responsible automation now have a dedicated workflow.">
+          <div className="flex flex-col gap-3 text-sm text-(--ink-muted)">
+            <p>Automation candidates moved out of the Impact dashboard so leverage diagnostics and candidate triage can evolve independently.</p>
+            <Link className="font-medium text-accent underline-offset-4 hover:underline" href="/ai/automations">
+              See AI Automations →
+            </Link>
+          </div>
         </AIPanelCard>
       </div>
 

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -101,7 +101,7 @@ const navGroups: NavGroup[] = [
       { id: "ai-impact", label: "Impact", href: "/ai/impact", description: "Leverage" },
       { id: "ai-review-load", label: "Review Load", href: "/ai/review-load", description: "Pressure" },
       { id: "ai-risk", label: "Risk", href: "/ai/risk", description: "Quality" },
-      { id: "ai-opportunities", label: "Automations", href: "/ai/impact#opportunities", description: "Candidates" },
+      { id: "ai-opportunities", label: "Automations", href: "/ai/automations", description: "Candidates" },
     ],
   },
   {

--- a/tests/ai-navigation.spec.ts
+++ b/tests/ai-navigation.spec.ts
@@ -26,7 +26,7 @@ const aiReviewLoadLink = (page: Page) =>
 const aiRiskLink = (page: Page) =>
   page.locator('a[href^="/ai/risk"]').first();
 const aiAutomationsLink = (page: Page) =>
-  page.locator('a[href*="#opportunities"]').first();
+  page.locator('a[href^="/ai/automations"]').first();
 
 test.describe("AI workflow primary navigation", () => {
   test("nav links route between the three AI views", async ({ page }) => {
@@ -50,12 +50,12 @@ test.describe("AI workflow primary navigation", () => {
     await expect(page.getByRole("heading", { name: "AI Impact" })).toBeVisible();
   });
 
-  test("Automations hash link owns the active nav state", async ({ page }) => {
+  test("Automations link owns the active nav state on its own route", async ({ page }) => {
     await page.goto(`/ai/impact?f=${defaultFilter}`);
 
     await aiAutomationsLink(page).click();
 
-    await expect(page).toHaveURL(/\/ai\/impact\?[^#]*#opportunities/);
+    await expect(page).toHaveURL(/\/ai\/automations/);
     await expect(aiAutomationsLink(page)).toHaveAttribute("aria-current", "page");
     await expect(aiImpactLink(page)).not.toHaveAttribute("aria-current", "page");
   });


### PR DESCRIPTION
## Summary
- Add /ai/automations as a dedicated AI workflow route for automation candidates
- Move opportunity rendering out of AI Impact and replace it with a See AI Automations link
- Update PrimaryNav Automations href to /ai/automations

Closes CHAOS-1725
References CHAOS-1724

## Verification
- pnpm typecheck
- pnpm vitest run src/components/ai/__tests__/AIImpactDashboard.test.tsx
- pnpm build
- Playwright screenshots captured:
  - screenshots/chaos-1725-impact-before-main.png
  - screenshots/chaos-1725-impact-after.png
  - screenshots/chaos-1725-automations-after.png

TEST-WAIVER: Route/nav split reuses existing AIImpactDashboard coverage and only moves the existing opportunities list into an isolated route; local focused Vitest coverage passed.