### PR TITLE
fix(ai): show review amplification dates chronologically (CHAOS-1726)

### DIFF
--- a/src/components/ai/AIReviewAmplificationTrend.tsx
+++ b/src/components/ai/AIReviewAmplificationTrend.tsx
@@ -12,29 +12,44 @@ type AIReviewAmplificationTrendProps = {
   loading?: boolean;
 };
 
+export function formatReviewTrendDay(day: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${day}T00:00:00Z`));
+}
+
+export function reviewAmplificationTrendRows(daily: DailyRow[]) {
+  const datedRows = daily.filter((row): row is DailyRow & { day: string } => Boolean(row.day));
+  const days = Array.from(new Set(datedRows.map((row) => row.day))).sort((left, right) => left.localeCompare(right));
+
+  return {
+    rows: datedRows,
+    days,
+    labels: days.map(formatReviewTrendDay),
+  };
+}
+
 export function AIReviewAmplificationTrend({ daily, loading }: AIReviewAmplificationTrendProps) {
   const chartTheme = useChartTheme();
-  const indexed = useMemo(
-    () => daily.map((row, index) => ({ ...row, chartDay: row.day ?? `Point ${index + 1}` })),
-    [daily]
-  );
-  const buckets = useMemo(() => Array.from(new Set(indexed.map((row) => row.bucket))).sort(), [indexed]);
-  const days = useMemo(() => Array.from(new Set(indexed.map((row) => row.chartDay))).sort(), [indexed]);
+  const trend = useMemo(() => reviewAmplificationTrendRows(daily), [daily]);
+  const buckets = useMemo(() => Array.from(new Set(trend.rows.map((row) => row.bucket))).sort(), [trend.rows]);
 
   const option = useMemo(() => ({
     tooltip: { trigger: "axis" as const, confine: true, backgroundColor: chartTheme.background, borderColor: chartTheme.stroke, textStyle: { color: chartTheme.text } },
     legend: { data: buckets, bottom: 0, textStyle: { color: chartTheme.muted } },
     grid: { left: 44, right: 20, top: 20, bottom: 48, containLabel: true },
-    xAxis: { type: "category" as const, data: days, axisLabel: { color: chartTheme.muted, fontSize: 10 }, axisLine: { lineStyle: { color: chartTheme.grid } } },
+    xAxis: { type: "category" as const, data: trend.labels, axisLabel: { color: chartTheme.muted, fontSize: 10 }, axisLine: { lineStyle: { color: chartTheme.grid } } },
     yAxis: { type: "value" as const, axisLabel: { color: chartTheme.muted, fontSize: 10 }, splitLine: { lineStyle: { color: chartTheme.grid, type: "dashed" as const } } },
     series: buckets.map((bucket) => ({
       name: bucket,
       type: "line" as const,
       smooth: true,
       symbol: "circle",
-      data: days.map((day) => indexed.find((row) => row.bucket === bucket && row.chartDay === day)?.reviewAmplification ?? null),
+      data: trend.days.map((day) => trend.rows.find((row) => row.bucket === bucket && row.day === day)?.reviewAmplification ?? null),
     })),
-  }), [buckets, chartTheme, days, indexed]);
+  }), [buckets, chartTheme, trend]);
 
   return (
     <section className="rounded-3xl border border-(--card-stroke) bg-card p-5" data-testid="ai-review-amplification-trend">
@@ -43,7 +58,7 @@ export function AIReviewAmplificationTrend({ daily, loading }: AIReviewAmplifica
         Daily review amplification split by AI attribution bucket.
       </p>
       <div className="mt-4 h-72">
-        {loading ? <p className="text-sm text-(--ink-muted)">Loading trend…</p> : days.length > 0 ? <Chart option={option} /> : <p className="text-sm text-(--ink-muted)">No daily review amplification points appear in this range.</p>}
+        {loading ? <p className="text-sm text-(--ink-muted)">Loading trend…</p> : trend.days.length > 0 ? <Chart option={option} /> : <p className="text-sm text-(--ink-muted)">No daily review amplification points appear in this range.</p>}
       </div>
     </section>
   );

--- a/src/components/ai/__tests__/AIReviewAmplificationTrend.test.tsx
+++ b/src/components/ai/__tests__/AIReviewAmplificationTrend.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { formatReviewTrendDay, reviewAmplificationTrendRows } from "../AIReviewAmplificationTrend";
+
+describe("AIReviewAmplificationTrend helpers", () => {
+  it("formats ISO days as MMM D labels", () => {
+    expect(formatReviewTrendDay("2026-05-05")).toBe("May 5");
+    expect(formatReviewTrendDay("2026-05-12")).toBe("May 12");
+  });
+
+  it("sorts daily rows chronologically by ISO day and keeps bucket series aligned", () => {
+    const trend = reviewAmplificationTrendRows([
+      { day: "2026-05-22", bucket: "AI_ASSISTED", prsTotal: 4, reviewsTotal: 8, reviewAmplification: 2.2 },
+      { day: "2026-05-01", bucket: "AI_ASSISTED", prsTotal: 4, reviewsTotal: 4, reviewAmplification: 1.1 },
+      { day: "2026-05-09", bucket: "AGENT_CREATED", prsTotal: 4, reviewsTotal: 7, reviewAmplification: 1.9 },
+      { day: "2026-05-09", bucket: "AI_ASSISTED", prsTotal: 4, reviewsTotal: 5, reviewAmplification: 1.4 },
+      { bucket: "UNKNOWN", prsTotal: 1, reviewsTotal: 9, reviewAmplification: 9.9 },
+    ]);
+
+    expect(trend.days).toEqual(["2026-05-01", "2026-05-09", "2026-05-22"]);
+    expect(trend.labels).toEqual(["May 1", "May 9", "May 22"]);
+    expect(trend.rows.map((row) => row.day)).not.toContain(undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- Use actual daily row day values for Review amplification trend categories
- Sort ISO days chronologically before rendering x-axis labels
- Format x-axis labels as MMM D and drop synthetic Point N fallback labels
- Add Vitest coverage for date formatting and sort behavior

Closes CHAOS-1726

## Verification
- pnpm typecheck
- pnpm vitest run src/components/ai/__tests__/AIReviewAmplificationTrend.test.tsx src/components/ai/__tests__/AIReviewLoadDashboard.test.tsx
- pnpm build
- Playwright screenshot captured: screenshots/chaos-1726-review-load-xaxis-after.png