### PR TITLE
feat(work): add Work Graph explorer and evidence panels (CHAOS-1599, CHAOS-1608)

### DIFF
--- a/src/app/(app)/metrics/page.tsx
+++ b/src/app/(app)/metrics/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { HorizontalBarChart } from "@/components/charts/HorizontalBarChart";
 import { QuadrantPanel } from "@/components/charts/QuadrantPanel";
 import { FilterBar } from "@/components/filters/FilterBar";
-import { MetricCard } from "@/components/metrics/MetricCard";
+import { MetricEvidenceCards } from "@/components/metrics/MetricEvidenceCards";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { checkApiHealth } from "@/lib/api/system";
@@ -247,22 +247,13 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
             </div>
           </section>
 
-          <section className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-            {activeTab.metrics.map((metric) => {
-              const data = getMetric(deltas, metric);
-              return (
-                <MetricCard
-                  key={metric}
-                  label={data?.label ?? metric}
-                  href={buildExploreUrl({ metric, filters, role: activeRole })}
-                  value={placeholderDeltas ? undefined : data?.value}
-                  unit={data?.unit}
-                  delta={placeholderDeltas ? undefined : data?.delta_pct}
-                  spark={data?.spark}
-                />
-              );
-            })}
-          </section>
+          <MetricEvidenceCards
+            metrics={activeTab.metrics}
+            deltas={deltas}
+            filters={filters}
+            activeRole={activeRole}
+            placeholderDeltas={placeholderDeltas}
+          />
 
           <section>
             <QuadrantPanel

--- a/src/components/charts/WorkGraphExplorer.tsx
+++ b/src/components/charts/WorkGraphExplorer.tsx
@@ -40,7 +40,7 @@ type WorkGraphExplorerProps = {
   width?: number | string;
   className?: string;
   style?: CSSProperties;
-  onNodeClick?: (nodeId: string, nodeType: WorkGraphNodeType) => void;
+  onNodeClickAction?: (nodeId: string, nodeType: WorkGraphNodeType) => void;
   selectedNodeId?: string;
 };
 
@@ -194,7 +194,7 @@ export function WorkGraphExplorer({
   width = "100%",
   className,
   style,
-  onNodeClick,
+  onNodeClickAction,
   selectedNodeId,
 }: WorkGraphExplorerProps) {
   const chartTheme = useChartTheme();
@@ -230,6 +230,10 @@ export function WorkGraphExplorer({
   );
 
   const option: EChartsOption = useMemo(() => {
+    const totalGraphics = nodes.length + links.length;
+    const animateGraph = totalGraphics < 2000;
+    const useForceLayout = totalGraphics < 900;
+    const showNodeLabels = nodes.length <= 120;
     const echartsNodes = nodes.map((node) => ({
       id: node.id,
       name: node.name,
@@ -242,7 +246,7 @@ export function WorkGraphExplorer({
         borderWidth: selectedNodeId === node.id ? 2 : 0,
       },
       label: {
-        show: node.symbolSize > 25,
+        show: showNodeLabels && node.symbolSize > 25,
         position: "bottom" as const,
         fontSize: 10,
         color: chartTheme.text,
@@ -268,6 +272,8 @@ export function WorkGraphExplorer({
     });
 
     return {
+      animation: animateGraph,
+      animationThreshold: 2000,
       tooltip: {
         trigger: "item",
         backgroundColor: chartTheme.background,
@@ -289,24 +295,31 @@ export function WorkGraphExplorer({
       series: [
         {
           type: "graph",
-          layout: "force",
-          animation: true,
+          layout: useForceLayout ? "force" : "circular",
+          animation: animateGraph,
           data: echartsNodes,
           links: echartsLinks,
           categories,
-          left: 24,
-          right: 24,
-          top: 24,
-          bottom: 24,
-          center: ["50%", "54%"],
+          left: 56,
+          right: 56,
+          top: 48,
+          bottom: 48,
+          center: ["50%", "50%"],
           roam: true,
-          draggable: true,
-          force: {
-            repulsion: 150,
-            gravity: 0.18,
-            edgeLength: [60, 150],
-            layoutAnimation: true,
-          },
+          draggable: useForceLayout,
+          force: useForceLayout
+            ? {
+                repulsion: 150,
+                gravity: 0.18,
+                edgeLength: [60, 150],
+                layoutAnimation: animateGraph,
+              }
+            : undefined,
+          circular: useForceLayout
+            ? undefined
+            : {
+                rotateLabel: false,
+              },
           emphasis: {
             focus: "adjacency",
             lineStyle: { width: 4 },
@@ -314,8 +327,8 @@ export function WorkGraphExplorer({
           label: {
             show: false,
           },
-          edgeSymbol: ["none", "arrow"],
-          edgeSymbolSize: [0, 8],
+          edgeSymbol: useForceLayout ? ["none", "arrow"] : ["none", "none"],
+          edgeSymbolSize: useForceLayout ? [0, 8] : [0, 0],
         },
       ],
     };
@@ -325,13 +338,13 @@ export function WorkGraphExplorer({
     () => ({
       click: (params: unknown) => {
         const p = params as { dataType?: string; data?: { id?: string } };
-        if (p.dataType === "node" && p.data?.id && onNodeClick) {
+        if (p.dataType === "node" && p.data?.id && onNodeClickAction) {
           const [type, id] = p.data.id.split(":");
-          onNodeClick(id, type as WorkGraphNodeType);
+          onNodeClickAction(id, type as WorkGraphNodeType);
         }
       },
     }),
-    [onNodeClick]
+    [onNodeClickAction]
   );
 
   if (edges.length === 0) {
@@ -352,9 +365,14 @@ export function WorkGraphExplorer({
   return (
     <div className={className} style={{ width, ...style }}>
       {FILTERABLE_NODE_TYPES.length > 0 && (
-        <div className="mb-2 flex items-center gap-3 px-1">
+        <div className="mb-2 flex flex-wrap items-center gap-2 px-1 text-[11px]">
+          <span className="mr-1 uppercase tracking-[0.16em] text-(--ink-muted)">Show</span>
           {FILTERABLE_NODE_TYPES.map((type) => (
-            <label key={type} className="flex cursor-pointer items-center gap-1.5 text-xs">
+            <label
+              key={type}
+              title={NODE_TYPE_LABELS[type]}
+              className="flex cursor-pointer items-center gap-1.5 rounded-full border border-(--card-stroke) bg-(--card-90) px-2 py-1 text-(--ink-muted) transition-colors hover:text-foreground"
+            >
               <input
                 type="checkbox"
                 checked={!hiddenNodeTypes.has(type)}
@@ -366,7 +384,7 @@ export function WorkGraphExplorer({
                 className="inline-block h-2.5 w-2.5 rounded-sm"
                 style={{ backgroundColor: NODE_TYPE_COLORS[type] }}
               />
-              <span className="text-(--ink-muted)">
+              <span>
                 {NODE_TYPE_LABELS[type]}
               </span>
             </label>
@@ -388,42 +406,120 @@ const LEGEND_EDGE_TYPES: WorkGraphEdgeType[] = [
   "INTRODUCED_BY", "CONFIG_CHANGED_BY", "GUARDS", "IMPACTS",
 ];
 
-export function WorkGraphLegend() {
+const LEGEND_EDGE_LABELS: Record<WorkGraphEdgeType, string> = {
+  BLOCKS: "blocks",
+  IS_BLOCKED_BY: "is blocked by",
+  FIXES: "fixes",
+  IMPLEMENTS: "implements",
+  REFERENCES: "references",
+  RELATES: "relates",
+  INTRODUCED_BY: "introduced by",
+  CONFIG_CHANGED_BY: "config changed by",
+  GUARDS: "guards",
+  IMPACTS: "impacts",
+  CONTAINS: "contains",
+  TOUCHES: "touches",
+  DEPLOYS: "deploys",
+  LINKED_INCIDENT: "linked incident",
+  IS_RELATED_TO: "is related to",
+  DUPLICATES: "duplicates",
+  IS_DUPLICATE_OF: "is duplicate of",
+  PARENT_OF: "parent of",
+  CHILD_OF: "child of",
+  HAS_AI_WORKFLOW: "has AI workflow",
+  GENERATES: "generates",
+  HAS_REVIEW_OUTCOME: "has review outcome",
+};
+
+type WorkGraphLegendProps = {
+  collapsed?: boolean;
+  onToggleAction?: () => void;
+};
+
+export function WorkGraphLegend({ collapsed = false, onToggleAction }: WorkGraphLegendProps) {
+  if (collapsed) {
+    return (
+      <div className="flex flex-col items-center gap-3 text-(--ink-muted)">
+        <button
+          type="button"
+          onClick={onToggleAction}
+          className="flex h-9 w-9 items-center justify-center rounded-xl border border-(--card-stroke) text-sm transition-colors hover:border-(--accent)/40 hover:text-foreground"
+          aria-label="Expand legend"
+          title="Expand legend"
+        >
+          ◀
+        </button>
+        <div className="flex flex-col items-center gap-1.5" aria-label="Node color key">
+          {ALL_NODE_TYPES.slice(0, 7).map((type) => (
+            <span
+              key={type}
+              className="h-2.5 w-2.5 rounded-full"
+              title={NODE_TYPE_LABELS[type]}
+              style={{ backgroundColor: NODE_TYPE_COLORS[type] }}
+            />
+          ))}
+        </div>
+        <span className="[writing-mode:vertical-rl] rotate-180 text-[10px] uppercase tracking-[0.2em]">
+          Legend
+        </span>
+      </div>
+    );
+  }
+
   return (
-    <div className="space-y-3 text-[11px]">
-      <div className="space-y-2">
-        <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-(--ink-muted)">
-          Node Types
-        </p>
-        <div className="space-y-2">
+    <div className="text-xs text-(--ink-muted)">
+      <div className="flex items-center justify-between gap-3 px-1 py-1">
+        <div>
+          <p className="text-[10px] font-medium uppercase tracking-[0.18em]">Legend</p>
+          <p className="mt-0.5 text-[11px]">Node colors + edge styles</p>
+        </div>
+        <button
+          type="button"
+          onClick={onToggleAction}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-(--card-stroke) text-sm transition-colors hover:border-(--accent)/40 hover:text-foreground"
+          aria-label="Collapse legend"
+          title="Collapse legend"
+        >
+          ▶
+        </button>
+      </div>
+      <div className="mt-3 space-y-4 border-t border-(--card-stroke) pt-3">
+        <section className="space-y-2">
+          <p className="text-[10px] font-medium uppercase tracking-[0.18em]">
+            Node Types
+          </p>
+          <div className="grid grid-cols-2 gap-x-3 gap-y-2">
           {ALL_NODE_TYPES.map((type) => (
             <div
               key={type}
-              className="flex items-center gap-2 rounded-xl border border-(--card-stroke) px-2 py-2"
+              title={NODE_TYPE_LABELS[type]}
+              className="flex min-w-0 items-center gap-2"
             >
               <span
-                className="h-3 w-3 shrink-0 rounded-sm"
+                className="h-2.5 w-2.5 shrink-0 rounded-full"
                 style={{ backgroundColor: NODE_TYPE_COLORS[type] }}
               />
-              <span className="leading-none">{NODE_TYPE_LABELS[type]}</span>
+              <span className="min-w-0 truncate leading-none text-foreground/85">{NODE_TYPE_LABELS[type]}</span>
             </div>
           ))}
-        </div>
-      </div>
-      <div className="space-y-2">
-        <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-(--ink-muted)">
-          Edge Types
-        </p>
-        <div className="space-y-2">
+          </div>
+        </section>
+        <section className="space-y-2">
+          <p className="text-[10px] font-medium uppercase tracking-[0.18em]">
+            Edge Types
+          </p>
+          <div className="grid gap-y-2">
           {LEGEND_EDGE_TYPES.map((type) => {
             const edgeStyle = EDGE_TYPE_STYLES[type];
+            const label = LEGEND_EDGE_LABELS[type];
             return (
               <div
                 key={type}
-                className="flex items-center gap-2 rounded-xl border border-(--card-stroke) px-2 py-2"
+                title={label}
+                className="flex min-w-0 items-center gap-2"
               >
                 <span
-                  className="h-0.5 w-4 shrink-0"
+                  className="h-0.5 w-5 shrink-0"
                   style={{
                     backgroundColor: edgeStyle?.color ?? "#6b7280",
                     borderBottom: edgeStyle?.type === "dashed"
@@ -433,13 +529,14 @@ export function WorkGraphLegend() {
                         : undefined,
                   }}
                 />
-                <span className="leading-tight">
-                  {type.toLowerCase().replace(/_/g, " ")}
+                <span className="min-w-0 truncate leading-tight text-foreground/85">
+                  {label}
                 </span>
               </div>
             );
           })}
-        </div>
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/src/components/evidence/EvidenceContext.tsx
+++ b/src/components/evidence/EvidenceContext.tsx
@@ -18,26 +18,30 @@ export function EvidenceContext({ data }: EvidenceContextProps) {
     const activeRole = useActiveRole();
     const roleConfig = getRoleConfig(activeRole);
 
-    const trendColor = data.trend === "up" ? "text-green-400" : data.trend === "down" ? "text-red-400" : "text-(--ink-muted)";
+    const trendTone = data.trend === "up"
+        ? "border-green-400/20 bg-green-400/10 text-green-300"
+        : data.trend === "down"
+            ? "border-red-400/20 bg-red-400/10 text-red-300"
+            : "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)";
     const trendIcon = data.trend === "up" ? "↗" : data.trend === "down" ? "↘" : "→";
 
     return (
-        <section className="space-y-4">
+        <section className="space-y-3 rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4">
             <div className="flex items-center justify-between">
                 <p className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
                     Context
                 </p>
                 {data.trend && (
-                    <div className={`flex items-center gap-1 text-xs font-medium ${trendColor} bg-${trendColor}/10 px-2 py-1 rounded-full border border-${trendColor}/20`}>
+                    <div className={`flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-medium ${trendTone}`}>
                         <span>{trendIcon}</span>
                         <span>{data.magnitude || "Moderate"} shift</span>
                     </div>
                 )}
             </div>
 
-            <div className="p-4 rounded-2xl bg-(--card-90) border border-(--card-stroke)">
-                <p className="text-sm leading-relaxed text-foreground">
-                    <span className="font-semibold text-(--accent-2)">{roleConfig.framing}</span>{" "}
+            <div className="rounded-xl border border-(--card-stroke) bg-background/35 p-3">
+                <p className="text-sm leading-6 text-foreground">
+                    <span className="font-semibold text-(--accent)">{roleConfig.framing}</span>{" "}
                     {data.summary || "No summary available for this metric."}
                 </p>
             </div>
@@ -45,7 +49,7 @@ export function EvidenceContext({ data }: EvidenceContextProps) {
             {data.why_it_matters && (
                 <div className="space-y-2">
                     <h4 className="text-xs font-semibold text-foreground">Why this matters</h4>
-                    <p className="text-xs text-(--ink-muted) leading-relaxed">
+                    <p className="text-xs leading-5 text-(--ink-muted)">
                         {data.why_it_matters}
                     </p>
                 </div>

--- a/src/components/evidence/EvidenceItems.tsx
+++ b/src/components/evidence/EvidenceItems.tsx
@@ -18,10 +18,15 @@ export function EvidenceItems({ items }: EvidenceItemsProps) {
     if (!items || items.length === 0) return null;
 
     return (
-        <section className="space-y-3">
-            <p className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
-                Supporting Evidence
-            </p>
+        <section className="space-y-3 rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4">
+            <div className="flex items-center justify-between gap-3">
+                <p className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
+                    Supporting Evidence
+                </p>
+                <span className="rounded-full border border-(--card-stroke) px-2 py-0.5 text-[10px] text-(--ink-muted)">
+                    {items.length} artifacts
+                </span>
+            </div>
             <div className="space-y-2">
                 {items.map((item) => (
                     <Link
@@ -29,28 +34,28 @@ export function EvidenceItems({ items }: EvidenceItemsProps) {
                         href={item.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="block p-3 rounded-xl border border-(--card-stroke) bg-card hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 transition-all group"
+                        className="group block rounded-xl border border-(--card-stroke) bg-background/35 p-3 transition-all hover:border-(--accent)/40 hover:bg-(--accent)/5"
                     >
                         <div className="flex items-start justify-between gap-3">
-                            <div className="space-y-1">
+                            <div className="min-w-0 space-y-1.5">
                                 <div className="flex items-center gap-2">
-                                    <span className="text-[10px] uppercase font-bold text-(--ink-muted) bg-(--card-90) px-1.5 py-0.5 rounded">
+                                    <span className="rounded border border-(--card-stroke) bg-(--card-70) px-1.5 py-0.5 text-[10px] font-bold uppercase text-(--ink-muted)">
                                         {item.type}
                                     </span>
-                                    <span className="text-xs font-mono text-(--ink-muted)">
+                                    <span className="truncate font-mono text-xs text-(--ink-muted)">
                                         {item.id}
                                     </span>
                                 </div>
-                                <p className="text-sm font-medium text-foreground group-hover:text-(--accent-2) line-clamp-2">
+                                <p className="line-clamp-2 text-sm font-medium leading-5 text-foreground group-hover:text-(--accent)">
                                     {item.title}
                                 </p>
                             </div>
-                            <span className="text-(--ink-muted) group-hover:text-(--accent-2) opacity-0 group-hover:opacity-100 transition-opacity">
+                            <span className="text-(--ink-muted) opacity-0 transition-opacity group-hover:text-(--accent) group-hover:opacity-100">
                                 ↗
                             </span>
                         </div>
                         {item.meta && (
-                            <p className="mt-2 text-[11px] text-(--ink-muted)">
+                            <p className="mt-2 text-[11px] leading-4 text-(--ink-muted)">
                                 {item.meta}
                             </p>
                         )}

--- a/src/components/evidence/EvidencePanel.test.tsx
+++ b/src/components/evidence/EvidencePanel.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@/test/utils";
+import { describe, expect, it, vi } from "vitest";
+
+import { EvidencePanel } from "./EvidencePanel";
+import type { MetricFilter } from "@/lib/filters/types";
+
+const { mockGetExplainData } = vi.hoisted(() => ({
+  mockGetExplainData: vi.fn(),
+}));
+
+vi.mock("@/lib/api/home", () => ({
+  getExplainData: mockGetExplainData,
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const filters = {
+  scope: { level: "org", ids: ["org-1"] },
+  time: { range_days: 30 },
+  who: {},
+  what: {},
+  why: {},
+  how: {},
+} as MetricFilter;
+
+describe("EvidencePanel", () => {
+  it("renders provenance and contributing artifacts", async () => {
+    mockGetExplainData.mockResolvedValue({
+      metric: "cycle_time",
+      label: "Cycle Time",
+      value: 4,
+      unit: "days",
+      delta_pct: -12,
+      summary: "Cycle time appears lower in this window.",
+      evidence: [
+        {
+          id: "PR-1",
+          title: "Shorten review queue",
+          url: "/prs/PR-1",
+          type: "pr",
+          meta: "merged in 2d",
+        },
+      ],
+      actions: [],
+      provenance: {
+        source: "workGraphEdges",
+        quality: "high",
+        last_sync: "2026-05-20T00:00:00Z",
+        identity_confidence: 0.92,
+      },
+    });
+
+    render(
+        <EvidencePanel
+        isOpen
+        onCloseAction={() => undefined}
+        title="Cycle Time"
+        metric="cycle_time"
+        filters={filters}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText("Quality + provenance")).toBeInTheDocument());
+    expect(screen.getByText(/Source: workGraphEdges/i)).toBeInTheDocument();
+    expect(screen.getByText(/Identity confidence: 92%/i)).toBeInTheDocument();
+    expect(screen.getByText("Shorten review queue")).toBeInTheDocument();
+  });
+
+  it("makes empty evidence explicit as partial data", async () => {
+    mockGetExplainData.mockResolvedValue({
+      metric: "throughput",
+      label: "Throughput",
+      value: 0,
+      unit: "items",
+      delta_pct: 0,
+      drivers: [],
+      contributors: [],
+      actions: [],
+    });
+
+    render(
+        <EvidencePanel
+        isOpen
+        onCloseAction={() => undefined}
+        title="Throughput"
+        metric="throughput"
+        filters={filters}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText(/Partial evidence/i)).toBeInTheDocument());
+    expect(screen.getByText(/No contributing artifacts were returned/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -21,6 +21,14 @@ type EvidenceItem = {
     meta?: string;
 };
 
+type EvidenceProvenance = {
+    last_sync?: string | null;
+    source?: string | null;
+    identity_confidence?: number | null;
+    quality?: string | null;
+    partial?: boolean;
+};
+
 type Action = {
     id: string;
     label: string;
@@ -38,11 +46,12 @@ type EvidencePanelData = {
     why_it_matters?: string;
     evidence: EvidenceItem[];
     actions: Action[];
+    provenance?: EvidenceProvenance;
 };
 
 export type EvidencePanelProps = {
     isOpen: boolean;
-    onClose: () => void;
+    onCloseAction: () => void;
     title: string;
     apiUrl?: string;
     metric?: string;
@@ -51,7 +60,7 @@ export type EvidencePanelProps = {
 
 export function EvidencePanel({
     isOpen,
-    onClose,
+    onCloseAction,
     title,
     apiUrl,
     metric,
@@ -63,11 +72,11 @@ export function EvidencePanel({
 
     useEffect(() => {
         const handleEscape = (e: KeyboardEvent) => {
-            if (e.key === "Escape") onClose();
+            if (e.key === "Escape") onCloseAction();
         };
         window.addEventListener("keydown", handleEscape);
         return () => window.removeEventListener("keydown", handleEscape);
-    }, [onClose]);
+    }, [onCloseAction]);
 
     useEffect(() => {
         if (isOpen && (apiUrl || metric)) {
@@ -117,6 +126,14 @@ export function EvidencePanel({
 
                         const actions = result.actions || definition?.suggestedActions || [];
 
+                        const provenance: EvidenceProvenance = result.provenance || {
+                            last_sync: result.last_sync ?? null,
+                            source: result.source ?? "metrics API",
+                            identity_confidence: result.identity_confidence ?? null,
+                            quality: evidence.length > 0 ? "moderate" : "partial",
+                            partial: evidence.length === 0,
+                        };
+
                         setData({
                             ...result,
                             summary: result.summary || `${result.label || title} is ${trend} by ${Math.abs(deltaPct)}%`,
@@ -124,7 +141,8 @@ export function EvidencePanel({
                             magnitude,
                             why_it_matters: result.why_it_matters || definition?.whyItMatters,
                             evidence,
-                            actions
+                            actions,
+                            provenance,
                         });
                     }
                 } catch (err) {
@@ -151,11 +169,11 @@ export function EvidencePanel({
         <div className="fixed inset-0 z-50 flex justify-end">
             <div 
                 className="absolute inset-0 bg-black/50 transition-opacity"
-                onClick={onClose}
+                onClick={onCloseAction}
             />
 
-            <div className="relative z-10 flex h-full w-full flex-col bg-(--card-80) shadow-2xl md:w-[480px] animate-in fade-in slide-in-from-right-4 duration-300 rounded-l-3xl border-l border-(--card-stroke)">
-                <header className="flex items-center justify-between border-b border-(--card-stroke) p-6">
+            <div className="relative z-10 flex h-full w-full flex-col rounded-l-3xl border-l border-(--card-stroke) bg-card shadow-2xl animate-in fade-in slide-in-from-right-4 duration-300 md:w-[520px]">
+                <header className="flex items-center justify-between border-b border-(--card-stroke) bg-(--card-90) p-6">
                     <div>
                         <p className="text-[10px] uppercase tracking-widest text-(--ink-muted)">
                             Evidence & Context
@@ -165,15 +183,15 @@ export function EvidencePanel({
                         </h2>
                     </div>
                     <button
-                        onClick={onClose}
-                        className="rounded-full border border-(--card-stroke) p-2 text-xs uppercase tracking-widest text-(--ink-muted) hover:bg-(--card-70) transition-colors"
+                        onClick={onCloseAction}
+                        className="rounded-full border border-(--card-stroke) p-2 text-xs uppercase tracking-widest text-(--ink-muted) transition-colors hover:bg-(--card-70) hover:text-foreground"
                         title="Close panel"
                     >
                         ✕
                     </button>
                 </header>
 
-                <div className="flex-1 overflow-y-auto p-6 space-y-8">
+                <div className="flex-1 space-y-4 overflow-y-auto p-6">
                     {loading ? (
                         <div className="space-y-4 animate-pulse">
                             <div className="h-24 bg-(--card-70) rounded-2xl" />
@@ -186,22 +204,61 @@ export function EvidencePanel({
                         </div>
                     ) : data ? (
                         <>
+                            <EvidenceProvenanceStrip provenance={data.provenance} />
                             <EvidenceContext data={data} />
-                            <EvidenceItems items={data.evidence || []} />
+                            {data.evidence?.length ? (
+                                <EvidenceItems items={data.evidence} />
+                            ) : (
+                                <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-90) p-4 text-sm leading-6 text-(--ink-muted)">
+                                    No contributing artifacts were returned for this metric and filter window. This is a partial-data state, not a zero signal.
+                                </div>
+                            )}
                             <SuggestedActions actions={data.actions || []} />
                         </>
                     ) : null}
                 </div>
 
-                <footer className="border-t border-(--card-stroke) p-6 bg-(--card-90)">
+                <footer className="border-t border-(--card-stroke) bg-(--card-90) p-6">
                     <Link 
                         href={exploreUrl}
-                        className="flex items-center justify-center w-full py-3 px-4 rounded-xl bg-(--accent-2)/10 text-(--accent-2) border border-(--accent-2)/20 hover:bg-(--accent-2)/20 transition-colors text-sm font-medium"
+                        className="flex w-full items-center justify-center rounded-xl border border-(--accent)/20 bg-(--accent)/10 px-4 py-3 text-sm font-medium text-(--accent) transition-colors hover:bg-(--accent)/20"
                     >
                         Open in Explore View ↗
                     </Link>
                 </footer>
             </div>
         </div>
+    );
+}
+
+function EvidenceProvenanceStrip({ provenance }: { provenance?: EvidenceProvenance }) {
+    const confidence = provenance?.identity_confidence;
+
+    return (
+        <section className="grid gap-3 rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4 text-xs text-(--ink-muted)">
+            <p className="text-[10px] uppercase tracking-[0.2em]">Quality + provenance</p>
+            <div className="grid gap-2 sm:grid-cols-2">
+                <EvidenceProvenanceItem label="Source" value={provenance?.source || "metrics API"} />
+                <EvidenceProvenanceItem label="Quality" value={provenance?.quality || "partial"} />
+                <EvidenceProvenanceItem label="Last sync" value={provenance?.last_sync || "not reported"} />
+                <EvidenceProvenanceItem
+                    label="Identity confidence"
+                    value={typeof confidence === "number" ? `${Math.round(confidence * 100)}%` : "not reported"}
+                />
+            </div>
+            {provenance?.partial && (
+                <p className="rounded-xl bg-amber-500/10 px-3 py-2 text-amber-300">
+                    Partial evidence: the backend did not return a complete artifact list for this selection.
+                </p>
+            )}
+        </section>
+    );
+}
+
+function EvidenceProvenanceItem({ label, value }: { label: string; value: string }) {
+    return (
+        <span className="rounded-xl border border-(--card-stroke) bg-background/35 px-3 py-2 leading-5">
+            {label}: {value}
+        </span>
     );
 }

--- a/src/components/evidence/SuggestedActions.tsx
+++ b/src/components/evidence/SuggestedActions.tsx
@@ -14,7 +14,7 @@ export function SuggestedActions({ actions }: SuggestedActionsProps) {
     if (!actions || actions.length === 0) return null;
 
     return (
-        <section className="space-y-3">
+        <section className="space-y-3 rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4">
             <p className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
                 Suggested Actions
             </p>
@@ -22,7 +22,7 @@ export function SuggestedActions({ actions }: SuggestedActionsProps) {
                 {actions.map((action) => (
                     <div
                         key={action.id}
-                        className="px-3 py-1.5 rounded-full border border-(--accent-2)/20 bg-(--accent-2)/5 text-xs text-(--accent-2) font-medium"
+                        className="rounded-full border border-(--accent)/20 bg-(--accent)/5 px-3 py-1.5 text-xs font-medium text-(--accent)"
                     >
                         {action.label}
                     </div>

--- a/src/components/home/CockpitClient.tsx
+++ b/src/components/home/CockpitClient.tsx
@@ -57,7 +57,7 @@ export function CockpitClient({
         <>
             <EvidencePanel
                 isOpen={panelState.isOpen}
-                onClose={closePanel}
+                onCloseAction={closePanel}
                 title={panelState.title}
                 apiUrl={panelState.apiUrl}
                 metric={panelState.metric}

--- a/src/components/metrics/MetricEvidenceCards.tsx
+++ b/src/components/metrics/MetricEvidenceCards.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+
+import { EvidencePanel } from "@/components/evidence";
+import { SparklineChart } from "@/components/charts/SparklineChart";
+import { buildExploreUrl } from "@/lib/filters/url";
+import { formatDelta, formatMetricValue } from "@/lib/formatters";
+import type { MetricFilter } from "@/lib/filters/types";
+import type { MetricDelta } from "@/lib/types";
+
+type MetricEvidenceCardsProps = {
+  metrics: string[];
+  deltas: MetricDelta[];
+  filters: MetricFilter;
+  activeRole?: string;
+  placeholderDeltas: boolean;
+};
+
+const deltaTone = (value?: number) => {
+  if (value === undefined || value === null) return "text-(--ink-muted)";
+  return value > 0
+    ? "text-(--accent-3)"
+    : value < 0
+      ? "text-(--accent-negative)"
+      : "text-(--ink-muted)";
+};
+
+const getMetric = (deltas: MetricDelta[], metric: string) =>
+  deltas.find((item) => item.metric === metric);
+
+export function MetricEvidenceCards({
+  metrics,
+  deltas,
+  filters,
+  activeRole,
+  placeholderDeltas,
+}: MetricEvidenceCardsProps) {
+  const [activeMetric, setActiveMetric] = useState<MetricDelta | null>(null);
+
+  return (
+    <>
+      <EvidencePanel
+        isOpen={Boolean(activeMetric)}
+        onCloseAction={() => setActiveMetric(null)}
+        title={activeMetric?.label ?? "Metric evidence"}
+        metric={activeMetric?.metric}
+        filters={filters}
+      />
+
+      <section className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {metrics.map((metric) => {
+          const data = getMetric(deltas, metric);
+          const label = data?.label ?? metric;
+          const sparkValues = data?.spark?.map((point) => point.value) ?? [];
+          const sparkLabels = data?.spark?.map((point) => point.ts) ?? [];
+
+          return (
+            <article
+              key={metric}
+              className="group rounded-3xl border border-(--card-stroke) bg-card p-4 transition hover:-translate-y-1 hover:shadow-lg"
+            >
+              <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                <span>{label}</span>
+                <span className={deltaTone(data?.delta_pct)}>
+                  {placeholderDeltas || data?.delta_pct === undefined ? "--" : formatDelta(data.delta_pct)}
+                </span>
+              </div>
+              <div className="mt-3 flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-2xl font-semibold metric-hero">
+                    {placeholderDeltas || data?.value === undefined
+                      ? "--"
+                      : formatMetricValue(data.value, data.unit ?? "")}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setActiveMetric(data ?? { metric, label, value: 0, unit: "", delta_pct: 0, spark: [] })}
+                    className="mt-2 text-left text-xs text-(--accent-2) underline-offset-4 hover:underline"
+                  >
+                    See evidence
+                  </button>
+                </div>
+                <div className="h-16 w-full">
+                  {sparkValues.length > 1 ? (
+                    <SparklineChart data={sparkValues} categories={sparkLabels} height={64} />
+                  ) : (
+                    <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
+                      Trend
+                    </div>
+                  )}
+                </div>
+              </div>
+              <a
+                href={buildExploreUrl({ metric, filters, role: activeRole })}
+                className="mt-3 block text-[11px] uppercase tracking-[0.18em] text-(--ink-muted) hover:text-foreground"
+              >
+                Open in Explore
+              </a>
+            </article>
+          );
+        })}
+      </section>
+    </>
+  );
+}

--- a/src/components/navigation/WorkTabNav.test.tsx
+++ b/src/components/navigation/WorkTabNav.test.tsx
@@ -25,7 +25,7 @@ const filters: MetricFilter = {
 describe("WorkTabNav", () => {
   it("renders all tab labels", () => {
     render(<WorkTabNav activeTab="landscape" filters={filters} />);
-    for (const label of ["Landscape", "Heatmap", "Flow", "Investment", "Capacity", "Flame", "Evidence", "Connections"]) {
+    for (const label of ["Landscape", "Heatmap", "Flow", "Investment", "Capacity", "Flame", "Evidence", "Work Graph"]) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
   });

--- a/src/components/navigation/WorkTabNav.tsx
+++ b/src/components/navigation/WorkTabNav.tsx
@@ -20,12 +20,12 @@ const tabs = [
     { id: "capacity", label: "Capacity" },
     { id: "flame", label: "Flame" },
     { id: "evidence", label: "Evidence" },
-    { id: "graph", label: "Connections" },
+    { id: "graph", label: "Work Graph" },
 ] as const;
 
 export function WorkTabNav({ activeTab, filters, role }: WorkTabNavProps) {
     return (
-        <div className="flex items-center gap-1 border-b border-(--card-stroke) overflow-x-auto whitespace-nowrap scrollbar-hide">
+        <div className="flex items-center gap-1 overflow-x-auto whitespace-nowrap border-b border-(--card-stroke) px-1 scrollbar-hide">
             {tabs.map((tab) => {
                 const isActive = activeTab === tab.id;
                 const href = withFilterParam(`/work?tab=${tab.id}`, filters, role);
@@ -35,9 +35,9 @@ export function WorkTabNav({ activeTab, filters, role }: WorkTabNavProps) {
                         key={tab.id}
                         href={href}
                         aria-current={isActive ? "page" : undefined}
-                        className={`px-4 py-3 text-[10px] uppercase tracking-[0.2em] transition-all border-b-2 -mb-px ${isActive
-                            ? "border-(--accent-2) text-foreground font-semibold"
-                            : "border-transparent text-(--ink-muted) hover:text-foreground hover:border-(--card-stroke)/40"
+                        className={`-mb-px border-b-2 px-3.5 py-3 text-[10px] uppercase tracking-[0.18em] transition-all ${isActive
+                            ? "border-(--accent) text-foreground font-semibold"
+                            : "border-transparent text-(--ink-muted) hover:border-(--card-stroke) hover:text-foreground"
                             }`}
                     >
                         {tab.label}

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@/test/utils";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GraphView } from "@/components/work/GraphView";
 import type { MetricFilter } from "@/lib/filters/types";
@@ -24,7 +25,8 @@ vi.mock("@/components/charts/WorkGraphExplorer", () => ({
 describe("GraphView", () => {
   const filters = {
     scope: { level: "org" as const, ids: ["org-1"] },
-    dateRange: { start: "2024-01-01", end: "2024-12-31" },
+    time: { range_days: 30 },
+    what: { repos: ["repo-1"] },
   } as unknown as MetricFilter;
 
   beforeEach(() => {
@@ -73,6 +75,105 @@ describe("GraphView", () => {
     expect(screen.getByTestId("work-graph-explorer")).toBeInTheDocument();
     expect(screen.getByTestId("work-graph-legend")).toBeInTheDocument();
     expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
+    expect(mockUseWorkGraphEdges).toHaveBeenCalledWith({
+      orgId: "org-1",
+      filters: { repoIds: ["repo-1"], limit: 1000 },
+      pause: false,
+    });
+  });
+
+  it("caps the interactive render and explains partial graph output", () => {
+    mockUseWorkGraphEdges.mockReturnValue({
+      edges: Array.from({ length: 760 }, (_, index) => ({
+        edgeId: `e${index}`,
+        sourceType: "ISSUE",
+        sourceId: `ISS-${index}`,
+        targetType: "PR",
+        targetId: `PR-${index}`,
+        edgeType: "FIXES",
+        provenance: "NATIVE",
+        confidence: 1.0,
+        evidence: "test",
+      })),
+      loading: false,
+      error: null,
+      totalCount: 1200,
+      refetch: vi.fn(),
+    });
+
+    render(<GraphView filters={filters} />);
+
+    expect(screen.getByText(/Showing 750 work → prs edges/i)).toBeInTheDocument();
+    expect(screen.getByText(/additional backend edges are available/i)).toBeInTheDocument();
+  });
+
+  it("defaults to a connection hierarchy slice instead of rendering every edge type", () => {
+    mockUseWorkGraphEdges.mockReturnValue({
+      edges: [
+        {
+          edgeId: "e1",
+          sourceType: "ISSUE",
+          sourceId: "ISS-1",
+          targetType: "PR",
+          targetId: "PR-1",
+          edgeType: "FIXES",
+          provenance: "NATIVE",
+          confidence: 1.0,
+          evidence: "test",
+        },
+        {
+          edgeId: "e2",
+          sourceType: "COMMIT",
+          sourceId: "sha-1",
+          targetType: "FILE",
+          targetId: "app.ts",
+          edgeType: "TOUCHES",
+          provenance: "NATIVE",
+          confidence: 1.0,
+          evidence: "test",
+        },
+      ],
+      loading: false,
+      error: null,
+      totalCount: 2,
+      refetch: vi.fn(),
+    });
+
+    render(<GraphView filters={filters} />);
+
+    expect(screen.getByLabelText(/Connection type/i)).toHaveValue("work-to-change");
+    expect(screen.getByText(/1 fetched edges hidden by connection type/i)).toBeInTheDocument();
+  });
+
+  it("shows theme and subcategory filter context without recomputing graph data", async () => {
+    const user = userEvent.setup();
+    mockUseWorkGraphEdges.mockReturnValue({
+      edges: [
+        {
+          edgeId: "e1",
+          sourceType: "ISSUE",
+          sourceId: "ISS-1",
+          targetType: "PR",
+          targetId: "PR-1",
+          edgeType: "FIXES",
+          provenance: "NATIVE",
+          confidence: 1.0,
+          evidence: "Fixes ISS-1",
+        },
+      ],
+      loading: false,
+      error: null,
+      totalCount: 1,
+      refetch: vi.fn(),
+    });
+
+    render(<GraphView filters={filters} />);
+
+    await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
+    await user.selectOptions(screen.getByLabelText(/Subcategory/i), "quality.bugfix");
+
+    expect(screen.getByText(/Quality \/ Quality \/ Bugfix/i)).toBeInTheDocument();
+    expect(screen.getByText(/persisted distributions drive the selected theme context/i)).toBeInTheDocument();
   });
 
   it("does NOT fall back to sample data when edges are empty", () => {

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -7,9 +7,10 @@ import {
   WorkGraphLegend,
 } from "@/components/charts/WorkGraphExplorer";
 import { useWorkGraphEdges } from "@/lib/graphql/hooks";
-import type { WorkGraphEdge, WorkGraphNodeType } from "@/lib/graphql/types";
+import type { WorkGraphEdge, WorkGraphEdgeType, WorkGraphNodeType } from "@/lib/graphql/types";
 import type { MetricFilter } from "@/lib/filters/types";
 import { useOrgId } from "@/lib/graphql/provider";
+import { INVESTMENT_SUBCATEGORIES, INVESTMENT_THEMES, labelInvestmentKey } from "@/lib/workGraph/taxonomy";
 
 type SelectedNode = {
   id: string;
@@ -21,19 +22,81 @@ type GraphViewProps = {
   activeRole?: string;
 };
 
+const GRAPH_EDGE_QUERY_LIMIT = 1000;
+const GRAPH_RENDER_EDGE_LIMIT = 750;
+
+type ConnectionSlice = {
+  id: string;
+  label: string;
+  description: string;
+  edgeTypes: WorkGraphEdgeType[];
+};
+
+const CONNECTION_SLICES: ConnectionSlice[] = [
+  {
+    id: "work-to-change",
+    label: "Work → PRs",
+    description: "Issues connected to pull requests.",
+    edgeTypes: ["FIXES", "IMPLEMENTS", "REFERENCES"],
+  },
+  {
+    id: "change-to-code",
+    label: "PRs → Commits → Files",
+    description: "Pull requests, commits, and touched files.",
+    edgeTypes: ["CONTAINS", "TOUCHES"],
+  },
+  {
+    id: "release-risk",
+    label: "Deployments → Incidents",
+    description: "Release and incident relationships.",
+    edgeTypes: ["DEPLOYS", "LINKED_INCIDENT", "INTRODUCED_BY"],
+  },
+  {
+    id: "dependencies",
+    label: "Dependencies",
+    description: "Blocking, related, duplicate, and parent-child links.",
+    edgeTypes: ["BLOCKS", "IS_BLOCKED_BY", "RELATES", "IS_RELATED_TO", "DUPLICATES", "IS_DUPLICATE_OF", "PARENT_OF", "CHILD_OF"],
+  },
+  {
+    id: "all",
+    label: "All connections",
+    description: "Every fetched edge type. Best for narrow filters only.",
+    edgeTypes: [],
+  },
+];
+
 export function GraphView({ filters, activeRole }: GraphViewProps) {
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
+  const [theme, setTheme] = useState("all");
+  const [subcategory, setSubcategory] = useState("all");
+  const [connectionSliceId, setConnectionSliceId] = useState(CONNECTION_SLICES[0].id);
+  const [isLegendCollapsed, setIsLegendCollapsed] = useState(true);
   const graphHeight = 580;
 
   const contextOrgId = useOrgId();
   const orgId = filters.scope.ids[0] || contextOrgId || "";
   const { edges, loading, error, totalCount } = useWorkGraphEdges({
     orgId,
-    filters: { limit: 500 },
+    filters: { repoIds: filters.what?.repos, limit: GRAPH_EDGE_QUERY_LIMIT },
     pause: !orgId,
   });
 
-  const displayEdges = edges;
+  const activeConnectionSlice = CONNECTION_SLICES.find((slice) => slice.id === connectionSliceId) ?? CONNECTION_SLICES[0];
+  const slicedEdges = useMemo(
+    () => activeConnectionSlice.edgeTypes.length
+      ? edges.filter((edge) => activeConnectionSlice.edgeTypes.includes(edge.edgeType))
+      : edges,
+    [activeConnectionSlice, edges]
+  );
+  const displayEdges = useMemo(
+    () => slicedEdges.slice(0, GRAPH_RENDER_EDGE_LIMIT),
+    [slicedEdges]
+  );
+  const hiddenEdgeCount = Math.max(0, slicedEdges.length - displayEdges.length);
+  const visibleSubcategories = useMemo(
+    () => INVESTMENT_SUBCATEGORIES.filter((item) => theme === "all" || item.startsWith(`${theme}.`)),
+    [theme]
+  );
 
   const handleNodeClick = useCallback((nodeId: string, nodeType: WorkGraphNodeType) => {
     setSelectedNode((prev) =>
@@ -58,8 +121,8 @@ export function GraphView({ filters, activeRole }: GraphViewProps) {
   void activeRole;
 
   return (
-    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(10rem,20%)] xl:items-start">
-      <div className="order-2 space-y-4 xl:order-1">
+    <div className={`grid gap-4 2xl:items-start ${isLegendCollapsed ? "2xl:grid-cols-[minmax(0,1fr)_3.25rem]" : "2xl:grid-cols-[minmax(0,1fr)_17rem]"}`}>
+      <div className="order-1 min-w-0 space-y-4">
         <div className="bg-card rounded-lg border border-(--card-stroke) p-4">
           <div className="mb-4 flex items-center justify-between gap-4">
             <div>
@@ -73,6 +136,73 @@ export function GraphView({ filters, activeRole }: GraphViewProps) {
             </div>
           </div>
 
+          <div className="mb-4 rounded-2xl border border-(--card-stroke) bg-(--card-70) p-3 text-xs">
+            <div className="grid gap-3 lg:grid-cols-[minmax(13rem,1.1fr)_minmax(11rem,0.9fr)_minmax(14rem,1.2fr)]">
+            <label className="grid min-w-0 gap-1">
+              <span className="uppercase tracking-[0.18em] text-(--ink-muted)">Connection type</span>
+              <select
+                value={connectionSliceId}
+                onChange={(event) => {
+                  setConnectionSliceId(event.target.value);
+                  setSelectedNode(null);
+                }}
+                className="min-w-0 rounded-xl border border-(--card-stroke) bg-background px-3 py-2 text-foreground"
+              >
+                {CONNECTION_SLICES.map((slice) => (
+                  <option key={slice.id} value={slice.id}>{slice.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="grid min-w-0 gap-1">
+              <span className="uppercase tracking-[0.18em] text-(--ink-muted)">Theme</span>
+              <select
+                value={theme}
+                onChange={(event) => {
+                  setTheme(event.target.value);
+                  setSubcategory("all");
+                }}
+                className="min-w-0 rounded-xl border border-(--card-stroke) bg-background px-3 py-2 text-foreground"
+              >
+                <option value="all">All themes</option>
+                {INVESTMENT_THEMES.map((item) => (
+                  <option key={item} value={item}>{labelInvestmentKey(item)}</option>
+                ))}
+              </select>
+            </label>
+            <label className="grid min-w-0 gap-1">
+              <span className="uppercase tracking-[0.18em] text-(--ink-muted)">Subcategory</span>
+              <select
+                value={subcategory}
+                onChange={(event) => setSubcategory(event.target.value)}
+                className="min-w-0 rounded-xl border border-(--card-stroke) bg-background px-3 py-2 text-foreground"
+              >
+                <option value="all">All subcategories</option>
+                {visibleSubcategories.map((item) => (
+                  <option key={item} value={item}>{labelInvestmentKey(item)}</option>
+                ))}
+              </select>
+            </label>
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-1 border-t border-(--card-stroke) pt-3 text-[11px] text-(--ink-muted)">
+              <span title={activeConnectionSlice.description}>{activeConnectionSlice.description}</span>
+              <span>
+                {theme !== "all" || subcategory !== "all"
+                  ? `Selected context: ${theme === "all" ? "all themes" : labelInvestmentKey(theme)} / ${subcategory === "all" ? "all subcategories" : labelInvestmentKey(subcategory)}. `
+                  : ""}
+                Theme/subcategory are context only; persisted distributions drive the selected theme context.
+              </span>
+            </div>
+          </div>
+
+          {(hiddenEdgeCount > 0 || totalCount > edges.length || slicedEdges.length !== edges.length) && (
+            <div className="mb-4 rounded-xl bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+              Showing {displayEdges.length} {activeConnectionSlice.label.toLowerCase()} edges for browser responsiveness
+              {slicedEdges.length !== edges.length ? ` (${edges.length - slicedEdges.length} fetched edges hidden by connection type)` : ""}
+              {hiddenEdgeCount > 0 ? `; ${hiddenEdgeCount} sliced edges summarized outside the canvas` : ""}
+              {totalCount > edges.length ? `; ${totalCount - edges.length} additional backend edges are available through narrower filters` : ""}.
+            </div>
+          )}
+
           {error && (
             <div className="mb-4 rounded border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-400">
               Failed to load work graph: {error.message}
@@ -84,12 +214,15 @@ export function GraphView({ filters, activeRole }: GraphViewProps) {
               No work graph data available for this scope and window.
             </div>
           ) : (
-            <WorkGraphExplorer
-              edges={displayEdges}
-              height={graphHeight}
-              onNodeClick={handleNodeClick}
-              selectedNodeId={selectedNode ? `${selectedNode.type}:${selectedNode.id}` : undefined}
-            />
+            <div data-testid="work-graph-panel" className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-background/30">
+              <WorkGraphExplorer
+                edges={displayEdges}
+                height={graphHeight}
+                className="p-2"
+                onNodeClickAction={handleNodeClick}
+                selectedNodeId={selectedNode ? `${selectedNode.type}:${selectedNode.id}` : undefined}
+              />
+            </div>
           )}
         </div>
 
@@ -103,9 +236,12 @@ export function GraphView({ filters, activeRole }: GraphViewProps) {
         )}
       </div>
 
-      <div className="order-1 xl:order-2 xl:sticky xl:top-4">
-        <div className="bg-card rounded-2xl border border-(--card-stroke) p-3.5">
-          <WorkGraphLegend />
+      <div className="order-2 2xl:sticky 2xl:top-4">
+        <div className={`rounded-2xl border border-(--card-stroke) bg-card transition-all ${isLegendCollapsed ? "p-2" : "p-3.5"}`}>
+          <WorkGraphLegend
+            collapsed={isLegendCollapsed}
+            onToggleAction={() => setIsLegendCollapsed((collapsed) => !collapsed)}
+          />
         </div>
       </div>
     </div>
@@ -218,12 +354,20 @@ function EdgeList({ title, subtitle, edges, getLabel, getRelation }: EdgeListPro
         {edges.map((edge) => (
           <li
             key={edge.edgeId}
-            className="flex items-center justify-between text-sm bg-white/5 rounded px-2 py-1"
+            className="grid gap-1 text-sm bg-white/5 rounded px-2 py-1"
           >
-            <span className="font-mono text-xs truncate">{getLabel(edge)}</span>
-            <span className="text-xs text-(--ink-muted) ml-2">
-              {getRelation(edge).toLowerCase().replace(/_/g, " ")}
+            <span className="flex items-center justify-between gap-2">
+              <span className="font-mono text-xs truncate">{getLabel(edge)}</span>
+              <span className="text-xs text-(--ink-muted)">
+                {getRelation(edge).toLowerCase().replace(/_/g, " ")}
+              </span>
             </span>
+            <span className="text-[11px] text-(--ink-muted)">
+              {edge.provenance.toLowerCase().replace(/_/g, " ")} · {Math.round(edge.confidence * 100)}% confidence
+            </span>
+            {edge.evidence && (
+              <q className="text-[11px] text-(--ink-muted)">{edge.evidence}</q>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- Add a performant Work Graph Explorer with connection hierarchy filters, render caps, node detail provenance, and side-collapsing legend rail
- Add reusable metric EvidencePanel flows and wire evidence launchers into the Metrics page
- Rename the Work tab from Connections to Work Graph

Closes CHAOS-1599
Closes CHAOS-1608

## Verification
- pnpm test:unit src/components/work/GraphView.test.tsx src/components/evidence/EvidencePanel.test.tsx src/components/navigation/WorkTabNav.test.tsx
- pnpm typecheck
- pnpm lint (0 errors; existing warnings in AIAutomationsDashboard, sentry scrubber, size-sensor stub)
- pnpm build
- Browser smoke: verified Work Graph controls, side-collapsing legend rail, and duplicate scope/date removal against a local mock backend

SCREENSHOT-WAIVER: visual behavior was manually verified in Playwright against a local mock backend; this CLI environment cannot upload image attachments directly to the PR body.