### PR TITLE
feat(work): chart drilldowns to Work Graph (CHAOS-1604)

### DIFF
--- a/src/app/(app)/work/page.tsx
+++ b/src/app/(app)/work/page.tsx
@@ -260,6 +260,7 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
               <HydrateUrqlResults payload={investmentHydrationPayload} />
               <InvestmentView
                 filters={filters}
+                activeRole={activeRole}
               />
             </>
           )}

--- a/src/components/charts/SunburstChart.tsx
+++ b/src/components/charts/SunburstChart.tsx
@@ -37,6 +37,7 @@ type SunburstChartProps = {
         value: number;
         path: string[];
         percent: number;
+        data?: SunburstNode;
     }) => void;
 };
 
@@ -91,14 +92,14 @@ export function SunburstChart({
                 data?: { name?: string; value?: number };
                 treePathInfo?: Array<{ name: string; value: number }>;
             };
-            const nodeData = entry.data;
+            const nodeData = entry.data as SunburstNode | undefined;
             if (!nodeData?.name) return;
 
             const path = entry.treePathInfo?.map((p) => p.name) ?? [nodeData.name];
             const value = nodeData.value ?? 0;
             const percent = calcPercent(value, totalValue);
 
-            onNodeClick({ name: nodeData.name, value, path, percent });
+            onNodeClick({ name: nodeData.name, value, path, percent, data: nodeData });
         },
         [onNodeClick, totalValue]
     );

--- a/src/components/work/FlowView.tsx
+++ b/src/components/work/FlowView.tsx
@@ -236,6 +236,8 @@ export function FlowView({ filters, activeRole }: FlowViewProps) {
                     selection={selection}
                     evidenceUrl={evidenceUrl}
                     flameUrl={flameUrl}
+                    filters={filters}
+                    activeRole={activeRole}
                     contextEntityLabel={contextEntityLabel}
                     contextZone={contextZone}
                     onClearContext={clearContext}

--- a/src/components/work/FlowView/Chart.tsx
+++ b/src/components/work/FlowView/Chart.tsx
@@ -20,7 +20,7 @@ type ChartProps = {
     investmentMixLoading: boolean;
     investmentMixFocusTheme: string | null;
     dataset: SankeyDataset | null;
-    onTreemapClick: (node: { name: string; value: number; path: string[]; percent: number }, view: FlowSubTab, unit: string) => void;
+    onTreemapClick: (node: { name: string; value: number; path: string[]; percent: number; data?: HierarchyNode }, view: FlowSubTab, unit: string) => void;
     onInvestmentMixClick: (key: string, type: "theme" | "subcategory") => void;
     onAreaClick: (params: { seriesName: string; date: string; value: number; percent: number }) => void;
     onSankeyClick: (item: { type: "node" | "link"; name?: string; source?: string; target?: string; value?: number }) => void;

--- a/src/components/work/FlowView/InspectPanel.test.tsx
+++ b/src/components/work/FlowView/InspectPanel.test.tsx
@@ -1,0 +1,120 @@
+import { screen } from "@testing-library/react";
+import { render } from "@/test/utils";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MetricFilter } from "@/lib/filters/types";
+import { decodeFilter } from "@/lib/filters/encode";
+import { InspectPanel, buildFlowWorkGraphUrl, type FlowSelection } from "./InspectPanel";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const filters: MetricFilter = {
+  scope: { level: "team", ids: ["team-1"] },
+  time: { range_days: 14, compare_days: 0 },
+  who: {},
+  what: { repos: ["repo-1"] },
+  why: {},
+  how: {},
+};
+
+const selection: FlowSelection = {
+  view: "state_flow",
+  path: ["Todo", "Done"],
+  key: "done",
+  metricValue: 42,
+  percentTotal: 12.5,
+  unit: "items",
+};
+
+describe("InspectPanel Work Graph drilldown", () => {
+  it("builds a work-to-change graph link for state flow selections with filters and role", () => {
+    render(
+      <InspectPanel
+        selection={selection}
+        evidenceUrl="/evidence"
+        flameUrl="/flame"
+        filters={filters}
+        activeRole="manager"
+        contextEntityLabel={null}
+        contextZone={null}
+        onClearContext={vi.fn()}
+      />
+    );
+
+    const link = screen.getByText("Open Work Graph").closest("a");
+    expect(link).toHaveAttribute("href", expect.stringContaining("/work?tab=graph&"));
+    expect(link).toHaveAttribute("href", expect.stringContaining("f="));
+    expect(link).toHaveAttribute("href", expect.stringContaining("role=manager"));
+    expect(link).toHaveAttribute("href", expect.stringContaining("graph_connection=work-to-change"));
+  });
+
+  it("omits graph_connection for investment selections", () => {
+    const href = buildFlowWorkGraphUrl({ view: "investment_mix" }, filters);
+
+    expect(href).toContain("/work?tab=graph&f=");
+    expect(href).not.toContain("graph_connection=");
+  });
+
+  it("adds theme and subcategory context for investment mix selections", () => {
+    const href = buildFlowWorkGraphUrl(
+      {
+        view: "investment_mix",
+        investment: {
+          themeKey: "quality",
+          subcategoryKey: "quality.bugfix",
+        },
+      },
+      filters
+    );
+
+    expect(href).toContain("graph_theme=quality");
+    expect(href).toContain("graph_subcategory=quality.bugfix");
+    expect(href).not.toContain("graph_connection=");
+  });
+
+  it("builds a code hotspot graph link with repo-scoped filters and selected file node", () => {
+    const hotspotSelection: FlowSelection = {
+      view: "code_hotspots",
+      path: ["All", "repo:web-app", "src", "app", "page.tsx"],
+      key: "page.tsx",
+      metricValue: 9,
+      percentTotal: 42,
+      unit: "changes",
+      hotspot: {
+        repoId: "repo:web-app",
+        filePath: "src/app/page.tsx",
+      },
+    };
+
+    render(
+      <InspectPanel
+        selection={hotspotSelection}
+        evidenceUrl="/evidence"
+        flameUrl="/flame"
+        filters={{ ...filters, what: { repos: ["repo:api"] } }}
+        activeRole="manager"
+        contextEntityLabel={null}
+        contextZone={null}
+        onClearContext={vi.fn()}
+      />
+    );
+
+    const link = screen.getByText("Open Work Graph").closest("a");
+    expect(link).toHaveAttribute("href", expect.stringContaining("/work?tab=graph&"));
+    expect(link).toHaveAttribute("href", expect.stringContaining("graph_connection=change-to-code"));
+    expect(link).toHaveAttribute("href", expect.stringContaining("graph_node=FILE%3Asrc%2Fapp%2Fpage.tsx"));
+
+    const href = link?.getAttribute("href") ?? "";
+    const decodedFilters = decodeFilter(new URLSearchParams(href.split("?")[1]).get("f"));
+    expect(decodedFilters.what.repos).toEqual(["repo:web-app"]);
+    expect(decodedFilters.time).toEqual(filters.time);
+    expect(decodedFilters.scope).toEqual(filters.scope);
+  });
+});

--- a/src/components/work/FlowView/InspectPanel.tsx
+++ b/src/components/work/FlowView/InspectPanel.tsx
@@ -1,6 +1,41 @@
 import Link from "next/link";
+import type { MetricFilter } from "@/lib/filters/types";
+import { withFilterParam } from "@/lib/filters/url";
 import { formatNumber } from "@/lib/formatters";
 import type { FlowSubTab } from "./Tabs";
+
+const WORK_GRAPH_CONNECTION_BY_VIEW: Partial<Record<string, string>> = {
+    state_flow: "work-to-change",
+    code_hotspots: "change-to-code",
+};
+
+export const buildFlowWorkGraphUrl = (
+    selection: Pick<FlowSelection, "view" | "hotspot" | "investment">,
+    filters: MetricFilter,
+    activeRole?: string
+) => {
+    const drilldownFilters: MetricFilter = selection.hotspot?.repoId
+        ? { ...filters, what: { ...filters.what, repos: [selection.hotspot.repoId] } }
+        : filters;
+    const baseHref = withFilterParam("/work?tab=graph", drilldownFilters, activeRole);
+    const connection = WORK_GRAPH_CONNECTION_BY_VIEW[selection.view];
+    const [path, query = ""] = baseHref.split("?", 2);
+    const params = new URLSearchParams(query);
+    if (connection) {
+        params.set("graph_connection", connection);
+    }
+    if (selection.hotspot?.filePath) {
+        params.set("graph_node", `FILE:${selection.hotspot.filePath}`);
+    }
+    if (selection.investment?.themeKey) {
+        params.set("graph_theme", selection.investment.themeKey);
+    }
+    if (selection.investment?.subcategoryKey) {
+        params.set("graph_subcategory", selection.investment.subcategoryKey);
+    }
+
+    return `${path}?${params.toString()}`;
+};
 
 export type FlowSelection = {
     view: FlowSubTab;
@@ -12,12 +47,22 @@ export type FlowSelection = {
     children?: Array<{ name: string; value: number }>;
     transition?: { from: string; to: string };
     outcomes?: string[];
+    hotspot?: {
+        repoId?: string;
+        filePath?: string;
+    };
+    investment?: {
+        themeKey: string;
+        subcategoryKey?: string;
+    };
 };
 
 type InspectPanelProps = {
     selection: FlowSelection | null;
     evidenceUrl: string | null;
     flameUrl: string | null;
+    filters: MetricFilter;
+    activeRole?: string;
     contextEntityLabel: string | null;
     contextZone: string | null;
     onClearContext: () => void;
@@ -27,6 +72,8 @@ export function InspectPanel({
     selection,
     evidenceUrl,
     flameUrl,
+    filters,
+    activeRole,
     contextEntityLabel,
     contextZone,
     onClearContext,
@@ -108,6 +155,13 @@ export function InspectPanel({
                                 className="flex items-center justify-between rounded-xl border border-(--card-stroke) bg-card px-4 py-3 text-xs uppercase tracking-widest text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
                             >
                                 <span>Open Representative Flame</span>
+                                <span className="text-(--accent-2) group-hover:translate-x-0.5 transition-transform">↗</span>
+                            </Link>
+                            <Link
+                                href={buildFlowWorkGraphUrl(selection, filters, activeRole)}
+                                className="flex items-center justify-between rounded-xl border border-(--card-stroke) bg-card px-4 py-3 text-xs uppercase tracking-widest text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
+                            >
+                                <span>Open Work Graph</span>
                                 <span className="text-(--accent-2) group-hover:translate-x-0.5 transition-transform">↗</span>
                             </Link>
                         </div>

--- a/src/components/work/FlowView/useFlowHandlers.ts
+++ b/src/components/work/FlowView/useFlowHandlers.ts
@@ -22,7 +22,20 @@ export function useFlowHandlers({
         value: number;
         path: string[];
         percent: number;
+        data?: { children?: unknown[] };
     }, view: FlowSubTab, unit: string) => {
+        const hotspotPath = node.path[0] === "All" ? node.path.slice(1) : node.path;
+        const hasChildren = Array.isArray(node.data?.children) && node.data.children.length > 0;
+        let hotspot: FlowSelection["hotspot"];
+        if (view === "code_hotspots") {
+            const repoId = hotspotPath[0];
+            const filePath = hotspotPath.length > 1 && !hasChildren ? hotspotPath.slice(1).join("/") : undefined;
+            hotspot = {
+                ...(repoId ? { repoId } : {}),
+                ...(filePath ? { filePath } : {}),
+            };
+        }
+
         const outcomesMap: Record<string, string[]> = {
             "code_hotspots": [
                 "Change frequency verified",
@@ -38,6 +51,7 @@ export function useFlowHandlers({
             metricValue: node.value,
             percentTotal: node.percent,
             unit,
+            hotspot,
             outcomes: outcomesMap[view]
         });
     }, [setSelection]);
@@ -52,14 +66,18 @@ export function useFlowHandlers({
         let value = 0;
         const total = Object.values(investmentMix.theme_distribution).reduce((a, b) => a + b, 0);
 
+        let investment: FlowSelection["investment"];
+
         if (type === "theme") {
             path = [titleCase(key)];
             value = investmentMix.theme_distribution[key] ?? 0;
+            investment = { themeKey: key };
             setInvestmentMixFocusTheme(current => current === key ? null : key);
         } else {
             const [themeKey] = key.split(".", 1);
             path = [titleCase(themeKey || ""), formatSubcategoryLabel(key, true)];
             value = investmentMix.subcategory_distribution[key] ?? 0;
+            investment = { themeKey: themeKey || key, subcategoryKey: key };
             setInvestmentMixFocusTheme(themeKey || null);
         }
 
@@ -80,6 +98,7 @@ export function useFlowHandlers({
             metricValue: value,
             percentTotal: total > 0 ? (value / total) * 100 : 0,
             unit: investmentMix.unit ?? "units",
+            investment,
             outcomes,
         });
     }, [investmentMix, setSelection, setInvestmentMixFocusTheme]);

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -4,9 +4,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GraphView } from "@/components/work/GraphView";
 import type { MetricFilter } from "@/lib/filters/types";
 
-const { mockUseWorkGraphEdges, mockUseOrgId } = vi.hoisted(() => ({
+const { mockUseSearchParams, mockUseWorkGraphEdges, mockUseOrgId } = vi.hoisted(() => ({
+  mockUseSearchParams: vi.fn(() => new URLSearchParams()),
   mockUseWorkGraphEdges: vi.fn(),
   mockUseOrgId: vi.fn(() => "org-1"),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: mockUseSearchParams,
 }));
 
 vi.mock("@/lib/graphql/hooks", () => ({
@@ -31,6 +36,7 @@ describe("GraphView", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
   });
 
   it("shows empty state when no edges returned", () => {
@@ -174,6 +180,42 @@ describe("GraphView", () => {
 
     expect(screen.getByText(/Quality \/ Quality \/ Bugfix/i)).toBeInTheDocument();
     expect(screen.getByText(/persisted distributions drive the selected theme context/i)).toBeInTheDocument();
+  });
+
+  it("hydrates graph drilldown state from URL search params", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams({
+      graph_connection: "change-to-code",
+      graph_theme: "quality",
+      graph_subcategory: "quality.bugfix",
+      graph_node: "FILE:src/app/page.tsx",
+    }));
+    mockUseWorkGraphEdges.mockReturnValue({
+      edges: [
+        {
+          edgeId: "e1",
+          sourceType: "COMMIT",
+          sourceId: "sha-1",
+          targetType: "FILE",
+          targetId: "src/app/page.tsx",
+          edgeType: "TOUCHES",
+          provenance: "NATIVE",
+          confidence: 1.0,
+          evidence: "Touches src/app/page.tsx",
+        },
+      ],
+      loading: false,
+      error: null,
+      totalCount: 1,
+      refetch: vi.fn(),
+    });
+
+    render(<GraphView filters={filters} />);
+
+    expect(screen.getByLabelText(/Connection type/i)).toHaveValue("change-to-code");
+    expect(screen.getByLabelText(/Theme/i)).toHaveValue("quality");
+    expect(screen.getByLabelText(/Subcategory/i)).toHaveValue("quality.bugfix");
+    expect(screen.getByText(/Quality \/ Quality \/ Bugfix/i)).toBeInTheDocument();
+    expect(screen.getByText("src/app/page.tsx")).toBeInTheDocument();
   });
 
   it("does NOT fall back to sample data when edges are empty", () => {

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 
 import {
   WorkGraphExplorer,
@@ -65,13 +66,84 @@ const CONNECTION_SLICES: ConnectionSlice[] = [
   },
 ];
 
+const NODE_TYPES: WorkGraphNodeType[] = [
+  "ISSUE",
+  "PR",
+  "COMMIT",
+  "FILE",
+  "RELEASE",
+  "FEATURE_FLAG",
+  "AI_WORKFLOW_RUN",
+  "DIFF",
+  "REVIEW_OUTCOME",
+  "DEPLOYMENT",
+  "INCIDENT",
+];
+
+const DEFAULT_CONNECTION_SLICE_ID = CONNECTION_SLICES[0].id;
+
+function isConnectionSliceId(value: string | null): value is ConnectionSlice["id"] {
+  return Boolean(value && CONNECTION_SLICES.some((slice) => slice.id === value));
+}
+
+function isInvestmentTheme(value: string | null): value is (typeof INVESTMENT_THEMES)[number] {
+  return Boolean(value && INVESTMENT_THEMES.includes(value as (typeof INVESTMENT_THEMES)[number]));
+}
+
+function isInvestmentSubcategory(value: string | null): value is (typeof INVESTMENT_SUBCATEGORIES)[number] {
+  return Boolean(value && INVESTMENT_SUBCATEGORIES.includes(value as (typeof INVESTMENT_SUBCATEGORIES)[number]));
+}
+
+function parseGraphNode(value: string | null): SelectedNode | null {
+  if (!value) return null;
+  const separatorIndex = value.indexOf(":");
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) return null;
+
+  const type = value.slice(0, separatorIndex);
+  if (!NODE_TYPES.includes(type as WorkGraphNodeType)) return null;
+
+  return {
+    type: type as WorkGraphNodeType,
+    id: value.slice(separatorIndex + 1),
+  };
+}
+
+function getGraphSearchState(searchParams: URLSearchParams) {
+  const subcategoryParam = searchParams.get("graph_subcategory");
+  const themeParam = searchParams.get("graph_theme");
+  const connectionParam = searchParams.get("graph_connection");
+  const subcategory = isInvestmentSubcategory(subcategoryParam) ? subcategoryParam : "all";
+  const subcategoryTheme = subcategory === "all" ? null : subcategory.split(".", 1)[0];
+  const theme = isInvestmentTheme(themeParam)
+    ? themeParam
+    : isInvestmentTheme(subcategoryTheme)
+      ? subcategoryTheme
+      : "all";
+
+  return {
+    theme,
+    subcategory,
+    connectionSliceId: isConnectionSliceId(connectionParam) ? connectionParam : DEFAULT_CONNECTION_SLICE_ID,
+    selectedNode: parseGraphNode(searchParams.get("graph_node")),
+  };
+}
+
 export function GraphView({ filters, activeRole }: GraphViewProps) {
-  const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
-  const [theme, setTheme] = useState("all");
-  const [subcategory, setSubcategory] = useState("all");
-  const [connectionSliceId, setConnectionSliceId] = useState(CONNECTION_SLICES[0].id);
+  const searchParams = useSearchParams();
+  const searchState = useMemo(() => getGraphSearchState(searchParams), [searchParams]);
+  const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(searchState.selectedNode);
+  const [theme, setTheme] = useState(searchState.theme);
+  const [subcategory, setSubcategory] = useState(searchState.subcategory);
+  const [connectionSliceId, setConnectionSliceId] = useState(searchState.connectionSliceId);
   const [isLegendCollapsed, setIsLegendCollapsed] = useState(true);
   const graphHeight = 580;
+
+  useEffect(() => {
+    setTheme(searchState.theme);
+    setSubcategory(searchState.subcategory);
+    setConnectionSliceId(searchState.connectionSliceId);
+    setSelectedNode(searchState.selectedNode);
+  }, [searchState]);
 
   const contextOrgId = useOrgId();
   const orgId = filters.scope.ids[0] || contextOrgId || "";

--- a/src/components/work/InvestmentView.tsx
+++ b/src/components/work/InvestmentView.tsx
@@ -20,9 +20,10 @@ import { InvestmentWorkUnitList } from "./investment/InvestmentWorkUnitList";
 
 type InvestmentViewProps = {
   filters: MetricFilter;
+  activeRole?: string;
 };
 
-export function InvestmentView({ filters }: InvestmentViewProps) {
+export function InvestmentView({ filters, activeRole }: InvestmentViewProps) {
   const data = useInvestmentData({ filters });
 
   const effortUnit = useMemo(() => {
@@ -138,11 +139,13 @@ export function InvestmentView({ filters }: InvestmentViewProps) {
 
       <InvestmentCharts
         filters={data.filters}
+        activeRole={activeRole}
         workUnits={data.workUnits}
         isLoading={data.isLoading}
         investmentMix={data.investmentMix}
         isMixLoading={data.isMixLoading}
         focusTheme={data.focusTheme}
+        focusSubcategory={data.focusSubcategory}
         setFocusTheme={data.setFocusTheme}
         setFocusSubcategory={data.setFocusSubcategory}
         selectedCategory={data.selectedCategory}

--- a/src/components/work/investment/InvestmentCharts.tsx
+++ b/src/components/work/investment/InvestmentCharts.tsx
@@ -11,11 +11,13 @@ import { useInvestmentColorMaps } from "./charts/useInvestmentColorMaps";
 
 type InvestmentChartsProps = {
   filters: MetricFilter;
+  activeRole?: string;
   workUnits: WorkUnitInvestment[];
   isLoading: boolean;
   investmentMix: ReturnType<typeof import("@/lib/investmentMix").normalizeInvestmentMix> | null;
   isMixLoading: boolean;
   focusTheme: string | null;
+  focusSubcategory?: string | null;
   setFocusTheme: (value: string | null) => void;
   setFocusSubcategory: (value: string | null) => void;
   selectedCategory: string | null;
@@ -34,11 +36,13 @@ type InvestmentChartsProps = {
 
 export function InvestmentCharts({
   filters,
+  activeRole,
   workUnits,
   isLoading,
   investmentMix,
   isMixLoading,
   focusTheme,
+  focusSubcategory,
   setFocusTheme,
   setFocusSubcategory,
   selectedCategory,
@@ -87,12 +91,15 @@ export function InvestmentCharts({
   return (
     <>
       <InvestmentMixSection
+        filters={filters}
+        activeRole={activeRole}
         investmentMix={investmentMix}
         isLoading={isLoading}
         isMixLoading={isMixLoading}
         workUnits={workUnits}
         effortUnit={effortUnit}
         focusTheme={focusTheme}
+        focusSubcategory={focusSubcategory ?? null}
         setFocusTheme={setFocusTheme}
         setFocusSubcategory={setFocusSubcategory}
         themeColorMap={themeColorMap}

--- a/src/components/work/investment/charts/InvestmentMixSection.tsx
+++ b/src/components/work/investment/charts/InvestmentMixSection.tsx
@@ -1,36 +1,45 @@
 import { useCallback, useMemo, useState } from "react";
+import Link from "next/link";
 import { ChartTypeToggle, TREEMAP_SUNBURST_OPTIONS, type TreemapSunburstType } from "@/components/charts/ChartTypeToggle";
 import { InvestmentMixSunburst } from "@/components/charts/InvestmentMixSunburst";
 import { TreemapChart, type TreemapNode } from "@/components/charts/TreemapChart";
 import { useChartTheme } from "@/components/charts/chartTheme";
 import { buildTooltipHtml, calcPercent } from "@/lib/chartUtils";
+import type { MetricFilter } from "@/lib/filters/types";
 import { formatNumber } from "@/lib/formatters";
 import { adjustHex, clamp, formatQuality, formatSubcategoryLabel, titleCase } from "@/lib/investment";
 import { getSortedSubcategories, getSortedThemes } from "@/lib/investmentMix";
 import type { WorkUnitInvestment } from "@/lib/types";
+import { buildInvestmentWorkGraphUrl } from "@/lib/workGraphDrilldownUrl";
 import type { TreemapSelection } from "../types";
 
 type InvestmentMix = ReturnType<typeof import("@/lib/investmentMix").normalizeInvestmentMix>;
 
 type InvestmentMixSectionProps = {
+  filters: MetricFilter;
+  activeRole?: string;
   investmentMix: InvestmentMix | null;
   isLoading: boolean;
   isMixLoading: boolean;
   workUnits: WorkUnitInvestment[];
   effortUnit: string;
   focusTheme: string | null;
+  focusSubcategory: string | null;
   setFocusTheme: (value: string | null) => void;
   setFocusSubcategory: (value: string | null) => void;
   themeColorMap: Map<string, string>;
 };
 
 export function InvestmentMixSection({
+  filters,
+  activeRole,
   investmentMix,
   isLoading,
   isMixLoading,
   workUnits,
   effortUnit,
   focusTheme,
+  focusSubcategory,
   setFocusTheme,
   setFocusSubcategory,
   themeColorMap,
@@ -50,6 +59,24 @@ export function InvestmentMixSection({
     if (!focusTheme) return [];
     return mixSubcategories.filter((entry) => entry.themeKey === focusTheme);
   }, [focusTheme, mixSubcategories]);
+  const focusedWorkGraphUrl = useMemo(() => {
+    if (!focusTheme) return null;
+    return buildInvestmentWorkGraphUrl({
+      filters,
+      role: activeRole,
+      themeKey: focusTheme,
+      subcategoryKey: focusSubcategory?.startsWith(`${focusTheme}.`) ? focusSubcategory : null,
+    });
+  }, [activeRole, filters, focusSubcategory, focusTheme]);
+  const treemapWorkGraphUrl = useMemo(() => {
+    if (!treemapSelection?.themeKey) return null;
+    return buildInvestmentWorkGraphUrl({
+      filters,
+      role: activeRole,
+      themeKey: treemapSelection.themeKey,
+      subcategoryKey: treemapSelection.type === "subcategory" ? treemapSelection.subcategoryId : null,
+    });
+  }, [activeRole, filters, treemapSelection]);
 
   const handleThemeClick = useCallback(
     (themeKey: string) => {
@@ -267,6 +294,11 @@ export function InvestmentMixSection({
                   )}
                 </>
               )}
+              {treemapWorkGraphUrl && (
+                <Link href={treemapWorkGraphUrl} className="ml-auto rounded-full border border-(--card-stroke) px-3 py-1 text-[10px] uppercase tracking-[0.2em] text-(--accent-2) hover:border-(--accent-2)/40">
+                  Open in Work Graph ↗
+                </Link>
+              )}
             </div>
             {isLoading ? (
               <p className="text-sm text-(--ink-muted)">Loading work units...</p>
@@ -306,6 +338,15 @@ export function InvestmentMixSection({
                 <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">{focusTheme ? "Subcategory breakdown" : "Themes"}</p>
                 {focusTheme && <span className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">{titleCase(focusTheme)}</span>}
               </div>
+              {focusedWorkGraphUrl && (
+                <Link
+                  href={focusedWorkGraphUrl}
+                  className="mt-3 flex items-center justify-between rounded-xl border border-(--card-stroke) bg-card px-3 py-2 text-[10px] uppercase tracking-[0.2em] text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
+                >
+                  <span>Open in Work Graph</span>
+                  <span className="text-(--accent-2) group-hover:translate-x-0.5 transition-transform">↗</span>
+                </Link>
+              )}
               <div className="mt-3 space-y-2 text-sm">
                 {focusTheme ? (
                   focusedThemeSubcategories.length ? (

--- a/src/lib/__tests__/workGraphDrilldownUrl.test.ts
+++ b/src/lib/__tests__/workGraphDrilldownUrl.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeFilter } from "@/lib/filters/encode";
+import type { MetricFilter } from "@/lib/filters/types";
+import { buildInvestmentWorkGraphUrl } from "@/lib/workGraphDrilldownUrl";
+
+const filters: MetricFilter = {
+  scope: { level: "team", ids: ["team-1"] },
+  time: { range_days: 14, compare_days: 0 },
+  who: {},
+  what: { repos: ["repo-1"] },
+  why: {},
+  how: {},
+};
+
+describe("buildInvestmentWorkGraphUrl", () => {
+  it("preserves filters and role while adding theme context", () => {
+    const href = buildInvestmentWorkGraphUrl({
+      filters,
+      role: "manager",
+      themeKey: "quality",
+    });
+    const url = new URL(href, "http://localhost");
+    const encodedFilter = url.searchParams.get("f");
+
+    expect(url.pathname).toBe("/work");
+    expect(url.searchParams.get("tab")).toBe("graph");
+    expect(url.searchParams.get("role")).toBe("manager");
+    expect(url.searchParams.get("graph_theme")).toBe("quality");
+    expect(url.searchParams.get("graph_subcategory")).toBeNull();
+    expect(encodedFilter).toBeTruthy();
+    expect(decodeFilter(encodedFilter)).toEqual(filters);
+  });
+
+  it("adds subcategory context when provided", () => {
+    const href = buildInvestmentWorkGraphUrl({
+      filters,
+      themeKey: "quality",
+      subcategoryKey: "quality.bugfix",
+    });
+    const url = new URL(href, "http://localhost");
+
+    expect(url.searchParams.get("graph_theme")).toBe("quality");
+    expect(url.searchParams.get("graph_subcategory")).toBe("quality.bugfix");
+  });
+});

--- a/src/lib/workGraphDrilldownUrl.ts
+++ b/src/lib/workGraphDrilldownUrl.ts
@@ -1,0 +1,22 @@
+import type { MetricFilter } from "@/lib/filters/types";
+import { withFilterParam } from "@/lib/filters/url";
+
+type InvestmentWorkGraphUrlOptions = {
+  filters: MetricFilter;
+  role?: string;
+  themeKey: string;
+  subcategoryKey?: string | null;
+};
+
+export const buildInvestmentWorkGraphUrl = ({
+  filters,
+  role,
+  themeKey,
+  subcategoryKey,
+}: InvestmentWorkGraphUrlOptions) => {
+  const graphParams = new URLSearchParams({ graph_theme: themeKey });
+  if (subcategoryKey) {
+    graphParams.set("graph_subcategory", subcategoryKey);
+  }
+  return `${withFilterParam("/work?tab=graph", filters, role)}&${graphParams.toString()}`;
+};

--- a/tests/live/onboarding-ui.spec.ts
+++ b/tests/live/onboarding-ui.spec.ts
@@ -144,5 +144,5 @@ test("full signup then login reaches dashboard", async ({ page, request }) => {
   // Should reach dashboard and see main navigation
   await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
   // Verify the page has rendered (not just a redirect)
-  await expect(page.locator("main")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByRole("heading", { name: "Developer Health Ops Cockpit" })).toBeVisible({ timeout: 10_000 });
 });


### PR DESCRIPTION
## Summary
- Add URL hydration for Work Graph drilldown state (theme, subcategory, connection slice, selected node)
- Add Flow and hotspot Work Graph drilldown CTAs preserving filter/time/scope context
- Add Investment drilldown links for theme/subcategory slices with role preservation

## Verification
- pnpm exec tsc --noEmit --pretty false
- pnpm exec vitest run (123 files / 1018 tests)
- pnpm exec eslint changed files
- pnpm build
- compose web health check
- authenticated Playwright Work Graph smoke: expected=2 unexpected=0 flaky=0 skipped=0

SCREENSHOT-WAIVER: functional drilldown/link-routing change using existing Work UI link styles; no new visual design or layout treatment introduced.

Closes CHAOS-1604
Closes CHAOS-1605
Closes CHAOS-1606
Closes CHAOS-1607