### PR TITLE
feat(web): operating review surface (CHAOS-1614)

### DIFF
--- a/src/app/(app)/operating-review/page.tsx
+++ b/src/app/(app)/operating-review/page.tsx
@@ -1,0 +1,269 @@
+import Link from "next/link";
+
+import { FilterBar } from "@/components/filters/FilterBar";
+import { ContextStrip } from "@/components/navigation/ContextStrip";
+import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { checkApiHealth } from "@/lib/api/system";
+import { getCurrentOrg } from "@/lib/admin/server";
+import { fetchOrNull } from "@/lib/fetchOrNull";
+import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+import { getOperatingReviewViaGraphQL } from "@/lib/graphql/operatingReviewFetchers";
+import type { OperatingReview, OperatingReviewMetric } from "@/lib/graphql/types";
+
+type OperatingReviewPageProps = {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+const sectionDescriptions: Record<string, string> = {
+  delivery_movement: "Cycle time, throughput, and WIP movement for the week.",
+  bottleneck: "State duration, review latency, and WIP age signals that shape flow.",
+  risk: "Hotspots, ownership concentration, complexity, and bus-factor exposure.",
+  reliability: "DORA-adjacent delivery and incident reliability signals.",
+  investment: "KTLO, new-value, security, and infrastructure allocation.",
+};
+
+export default async function OperatingReviewPage({ searchParams }: OperatingReviewPageProps) {
+  const params = (await searchParams) ?? {};
+  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+  const originParam = Array.isArray(params.origin) ? params.origin[0] : params.origin;
+  const activeOrigin = typeof originParam === "string" ? originParam : undefined;
+  const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+  const teamId = singleParam(params.team) ?? firstTeamFromFilters(filters);
+  const weekStart = normalizeWeekStart(singleParam(params.week));
+
+  const [health, orgResult] = await Promise.all([
+    checkApiHealth(),
+    getCurrentOrg().catch(() => ({ data: undefined })),
+  ]);
+
+  if (!health.ok) {
+    return <ServiceUnavailable />;
+  }
+
+  const orgId = orgResult.data?.id;
+  const review = orgId && teamId
+    ? await fetchOrNull(
+        getOperatingReviewViaGraphQL(orgId, { teamId, weekStart }),
+        "operating-review/data"
+      )
+    : null;
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+        <PrimaryNav filters={filters} active="operating-review" />
+        <main className="flex min-w-0 flex-1 flex-col gap-6">
+          <ContextStrip filters={filters} origin={activeOrigin} />
+          <FilterBar view="work" />
+
+          <section className="rounded-[2rem] border border-border bg-card/80 p-8 shadow-sm">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+              <div className="max-w-3xl space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+                  Weekly mode
+                </p>
+                <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">
+                  Engineering Operating Review
+                </h1>
+                <p className="text-sm leading-6 text-muted-foreground md:text-base">
+                  A Monday-ready agenda for delivery movement, bottlenecks, risk,
+                  reliability, investment, and recommendations. Every callout compares
+                  the selected week against the prior week.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-border bg-background/70 p-4 text-sm text-muted-foreground">
+                <div>Team: <span className="font-medium text-foreground">{teamId ?? "Select a team"}</span></div>
+                <div>Week: <span className="font-medium text-foreground">{weekStart}</span></div>
+              </div>
+            </div>
+          </section>
+
+          {!teamId ? <MissingTeamState weekStart={weekStart} /> : null}
+          {teamId && !review ? <EmptyReviewState teamId={teamId} weekStart={weekStart} /> : null}
+          {review ? <OperatingReviewAgenda review={review} /> : null}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function OperatingReviewAgenda({ review }: { review: OperatingReview }) {
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-4 lg:grid-cols-5">
+        {review.sections.map((section) => (
+          <a
+            key={section.key}
+            href={`#${section.key}`}
+            className="rounded-2xl border border-border bg-card p-4 transition hover:border-primary/50"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              Section
+            </p>
+            <h2 className="mt-2 text-base font-semibold">{section.title}</h2>
+            <p className="mt-2 text-xs text-muted-foreground">
+              {section.improved.length} improved · {section.worsened.length} worsened · {section.changed.length} changed
+            </p>
+          </a>
+        ))}
+      </section>
+
+      {review.sections.map((section) => (
+        <section
+          id={section.key}
+          key={section.key}
+          className="rounded-[1.75rem] border border-border bg-card/90 p-6 shadow-sm"
+        >
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+                Fixed agenda section
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold tracking-tight">{section.title}</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {sectionDescriptions[section.key] ?? "Weekly operating signal."}
+              </p>
+            </div>
+            <DeltaPill improved={section.improved.length} worsened={section.worsened.length} changed={section.changed.length} />
+          </div>
+
+          <div className="mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {section.metrics.map((metric) => (
+              <MetricCard key={metric.key} metric={metric} />
+            ))}
+          </div>
+
+          <div className="mt-6 grid gap-4 md:grid-cols-3">
+            <CalloutColumn title="Improved" tone="improved" items={section.improved} />
+            <CalloutColumn title="Worsened" tone="worsened" items={section.worsened} />
+            <CalloutColumn title="Changed" tone="changed" items={section.changed} />
+          </div>
+        </section>
+      ))}
+
+      <section className="rounded-[1.75rem] border border-border bg-card/90 p-6 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+          Rule engine
+        </p>
+        <h2 className="mt-2 text-2xl font-semibold tracking-tight">Recommendations</h2>
+        {review.recommendations.length ? (
+          <ul className="mt-4 space-y-3">
+            {review.recommendations.map((recommendation) => (
+              <li key={recommendation} className="rounded-2xl border border-border bg-background/70 p-4 text-sm">
+                {recommendation}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="mt-4 rounded-2xl border border-dashed border-border bg-background/60 p-6 text-sm text-muted-foreground">
+            {review.recommendationsEmptyState}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function MetricCard({ metric }: { metric: OperatingReviewMetric }) {
+  return (
+    <div className="rounded-2xl border border-border bg-background/70 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm font-medium text-muted-foreground">{metric.label}</p>
+        <span className={statusClass(metric.delta.status)}>{metric.delta.status}</span>
+      </div>
+      <div className="mt-3 text-2xl font-semibold tracking-tight">
+        {formatMetricValue(metric.value)}
+        <span className="ml-1 text-sm font-normal text-muted-foreground">{metric.unit}</span>
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Prior: {formatMetricValue(metric.delta.priorValue)} · Δ {formatSigned(metric.delta.absolute)}
+        {metric.delta.percent === null || metric.delta.percent === undefined
+          ? ""
+          : ` (${formatSigned(metric.delta.percent)}%)`}
+      </p>
+    </div>
+  );
+}
+
+function DeltaPill({ improved, worsened, changed }: { improved: number; worsened: number; changed: number }) {
+  return (
+    <div className="flex flex-wrap gap-2 text-xs font-medium">
+      <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-emerald-700 dark:text-emerald-300">{improved} improved</span>
+      <span className="rounded-full bg-rose-500/10 px-3 py-1 text-rose-700 dark:text-rose-300">{worsened} worsened</span>
+      <span className="rounded-full bg-sky-500/10 px-3 py-1 text-sky-700 dark:text-sky-300">{changed} changed</span>
+    </div>
+  );
+}
+
+function CalloutColumn({ title, tone, items }: { title: string; tone: "improved" | "worsened" | "changed"; items: string[] }) {
+  return (
+    <div className="rounded-2xl border border-border bg-background/60 p-4">
+      <h3 className="text-sm font-semibold">{title}</h3>
+      {items.length ? (
+        <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+          {items.map((item) => <li key={item}>• {item}</li>)}
+        </ul>
+      ) : (
+        <p className="mt-3 text-sm text-muted-foreground">No {tone} signals this week.</p>
+      )}
+    </div>
+  );
+}
+
+function MissingTeamState({ weekStart }: { weekStart: string }) {
+  return (
+    <section className="rounded-[1.75rem] border border-dashed border-border bg-card/70 p-8 text-sm text-muted-foreground">
+      Add <code className="rounded bg-muted px-1 py-0.5">?team=&lt;id&gt;&week={weekStart}</code> to open a weekly review.
+    </section>
+  );
+}
+
+function EmptyReviewState({ teamId, weekStart }: { teamId: string; weekStart: string }) {
+  return (
+    <section className="rounded-[1.75rem] border border-dashed border-border bg-card/70 p-8">
+      <h2 className="text-lg font-semibold">No operating review data yet</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        The surface is ready for team <span className="font-medium text-foreground">{teamId}</span> for week {weekStart}, but no backend payload was returned.
+      </p>
+      <Link className="mt-4 inline-flex text-sm font-medium text-primary" href="/settings">
+        Check data connections
+      </Link>
+    </section>
+  );
+}
+
+function singleParam(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function firstTeamFromFilters(filters: ReturnType<typeof filterFromQueryParams>): string | undefined {
+  return filters.scope.level === "team" ? filters.scope.ids[0] : undefined;
+}
+
+function normalizeWeekStart(value: string | undefined): string {
+  if (value && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value;
+  }
+  const now = new Date();
+  const day = now.getUTCDay();
+  const diffToMonday = (day + 6) % 7;
+  const monday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - diffToMonday));
+  return monday.toISOString().slice(0, 10);
+}
+
+function formatMetricValue(value: number): string {
+  return Number.isInteger(value) ? value.toString() : value.toFixed(1);
+}
+
+function formatSigned(value: number): string {
+  return `${value >= 0 ? "+" : ""}${formatMetricValue(value)}`;
+}
+
+function statusClass(status: string): string {
+  const base = "rounded-full px-2 py-1 text-xs font-medium capitalize";
+  if (status === "improved") return `${base} bg-emerald-500/10 text-emerald-700 dark:text-emerald-300`;
+  if (status === "worsened") return `${base} bg-rose-500/10 text-rose-700 dark:text-rose-300`;
+  if (status === "changed") return `${base} bg-sky-500/10 text-sky-700 dark:text-sky-300`;
+  return `${base} bg-muted text-muted-foreground`;
+}

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -55,7 +55,10 @@ const navGroups: NavGroup[] = [
   {
     id: "cockpit",
     label: "Cockpit",
-    items: [{ id: "home", label: "Home", href: "/dashboard", description: "Overview" }],
+    items: [
+      { id: "home", label: "Home", href: "/dashboard", description: "Overview" },
+      { id: "operating-review", label: "Operating Review", href: "/operating-review", description: "Weekly" },
+    ],
   },
   {
     id: "observe",

--- a/src/lib/__tests__/operatingReviewFetchers.test.ts
+++ b/src/lib/__tests__/operatingReviewFetchers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/graphql/urqlClient", () => ({
+  graphqlFetch: vi.fn(),
+}));
+
+import { graphqlFetch } from "@/lib/graphql/urqlClient";
+import { OPERATING_REVIEW_QUERY } from "@/lib/graphql/queries";
+import { getOperatingReviewViaGraphQL } from "@/lib/graphql/operatingReviewFetchers";
+import type { OperatingReview } from "@/lib/graphql/types";
+
+describe("getOperatingReviewViaGraphQL", () => {
+  it("fetches a team/week operating review with org scoping", async () => {
+    const payload: OperatingReview = {
+      orgId: "org-1",
+      teamId: "team-a",
+      weekStart: "2026-05-18",
+      priorWeekStart: "2026-05-11",
+      sections: [],
+      recommendations: [],
+      recommendationsEmptyState: "No operating review rules are configured.",
+    };
+    vi.mocked(graphqlFetch).mockResolvedValue({ operatingReview: payload });
+
+    const result = await getOperatingReviewViaGraphQL("org-1", {
+      teamId: "team-a",
+      weekStart: "2026-05-18",
+    });
+
+    expect(result).toBe(payload);
+    expect(graphqlFetch).toHaveBeenCalledWith(
+      OPERATING_REVIEW_QUERY,
+      {
+        orgId: "org-1",
+        input: { teamId: "team-a", weekStart: "2026-05-18" },
+      },
+      { orgId: "org-1" }
+    );
+  });
+});

--- a/src/lib/graphql/__generated__/graphql.ts
+++ b/src/lib/graphql/__generated__/graphql.ts
@@ -574,6 +574,50 @@ export type MutationUpdateSavedReportArgs = {
   reportId: Scalars['String']['input'];
 };
 
+export type OperatingReview = {
+  __typename?: 'OperatingReview';
+  orgId: Scalars['String']['output'];
+  priorWeekStart: Scalars['Date']['output'];
+  recommendations: Array<Scalars['String']['output']>;
+  recommendationsEmptyState: Scalars['String']['output'];
+  sections: Array<OperatingReviewSection>;
+  teamId: Scalars['String']['output'];
+  weekStart: Scalars['Date']['output'];
+};
+
+export type OperatingReviewDelta = {
+  __typename?: 'OperatingReviewDelta';
+  absolute: Scalars['Float']['output'];
+  percent?: Maybe<Scalars['Float']['output']>;
+  priorValue: Scalars['Float']['output'];
+  status: Scalars['String']['output'];
+  value: Scalars['Float']['output'];
+};
+
+export type OperatingReviewInput = {
+  teamId: Scalars['String']['input'];
+  weekStart: Scalars['Date']['input'];
+};
+
+export type OperatingReviewMetric = {
+  __typename?: 'OperatingReviewMetric';
+  delta: OperatingReviewDelta;
+  key: Scalars['String']['output'];
+  label: Scalars['String']['output'];
+  unit: Scalars['String']['output'];
+  value: Scalars['Float']['output'];
+};
+
+export type OperatingReviewSection = {
+  __typename?: 'OperatingReviewSection';
+  changed: Array<Scalars['String']['output']>;
+  improved: Array<Scalars['String']['output']>;
+  key: Scalars['String']['output'];
+  metrics: Array<OperatingReviewMetric>;
+  title: Scalars['String']['output'];
+  worsened: Array<Scalars['String']['output']>;
+};
+
 export type PageInfo = {
   __typename?: 'PageInfo';
   endCursor?: Maybe<Scalars['String']['output']>;
@@ -608,6 +652,8 @@ export type Query = {
   catalog: CatalogResult;
   /** Get home dashboard metrics */
   home: HomeResult;
+  /** Weekly Engineering Operating Review */
+  operatingReview: OperatingReview;
   /** List report runs for a saved report */
   reportRuns: ReportRunConnection;
   /** Get a saved report by ID */
@@ -618,6 +664,8 @@ export type Query = {
   securityAlerts: SecurityAlertConnection;
   /** Aggregated security posture for the dashboard */
   securityOverview: SecurityOverview;
+  /** Compute throughput-based capacity forecast */
+  throughputForecast?: Maybe<ThroughputForecast>;
   /** Query work graph edges with optional filters */
   workGraphEdges: WorkGraphEdgesResult;
 };
@@ -706,6 +754,12 @@ export type QueryHomeArgs = {
 };
 
 
+export type QueryOperatingReviewArgs = {
+  input: OperatingReviewInput;
+  orgId: Scalars['String']['input'];
+};
+
+
 export type QueryReportRunsArgs = {
   limit?: Scalars['Int']['input'];
   orgId: Scalars['String']['input'];
@@ -735,6 +789,12 @@ export type QuerySecurityAlertsArgs = {
 
 export type QuerySecurityOverviewArgs = {
   filters?: InputMaybe<SecurityAlertFilterInput>;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryThroughputForecastArgs = {
+  input: ThroughputForecastInput;
   orgId: Scalars['String']['input'];
 };
 
@@ -991,6 +1051,50 @@ export type TaskStatus = {
   status: Scalars['String']['output'];
   taskId: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];
+};
+
+export type ThroughputForecast = {
+  __typename?: 'ThroughputForecast';
+  backlogSize: Scalars['Int']['output'];
+  computedAt: Scalars['String']['output'];
+  forecastId: Scalars['String']['output'];
+  historyWeeks: Scalars['Int']['output'];
+  incidentLoad: ThroughputRiskOverlay;
+  insufficientHistory: Scalars['Boolean']['output'];
+  p50Weeks?: Maybe<Scalars['Int']['output']>;
+  p75Weeks?: Maybe<Scalars['Int']['output']>;
+  p90Weeks?: Maybe<Scalars['Int']['output']>;
+  primaryRisk: ThroughputRiskOverlay;
+  reviewBottleneck: ThroughputRiskOverlay;
+  rollingWindows: Array<ThroughputRollingWindow>;
+  teamId: Scalars['String']['output'];
+  wipCongestion: ThroughputRiskOverlay;
+  workScopeId?: Maybe<Scalars['String']['output']>;
+};
+
+export type ThroughputForecastInput = {
+  backlogSize: Scalars['Int']['input'];
+  historyWeeks?: Scalars['Int']['input'];
+  teamId: Scalars['String']['input'];
+  workScopeId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ThroughputRiskOverlay = {
+  __typename?: 'ThroughputRiskOverlay';
+  active: Scalars['Boolean']['output'];
+  kind: Scalars['String']['output'];
+  label: Scalars['String']['output'];
+  score: Scalars['Float']['output'];
+  threshold: Scalars['Float']['output'];
+  value: Scalars['Float']['output'];
+};
+
+export type ThroughputRollingWindow = {
+  __typename?: 'ThroughputRollingWindow';
+  insufficientHistory: Scalars['Boolean']['output'];
+  meanWeeklyThroughput: Scalars['Float']['output'];
+  sampleCount: Scalars['Int']['output'];
+  windowWeeks: Scalars['Int']['output'];
 };
 
 export type TimeseriesBucket = {

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -572,6 +572,50 @@ export type MutationUpdateSavedReportArgs = {
   reportId: Scalars['String']['input'];
 };
 
+export type OperatingReview = {
+  __typename?: 'OperatingReview';
+  orgId: Scalars['String']['output'];
+  priorWeekStart: Scalars['Date']['output'];
+  recommendations: Array<Scalars['String']['output']>;
+  recommendationsEmptyState: Scalars['String']['output'];
+  sections: Array<OperatingReviewSection>;
+  teamId: Scalars['String']['output'];
+  weekStart: Scalars['Date']['output'];
+};
+
+export type OperatingReviewDelta = {
+  __typename?: 'OperatingReviewDelta';
+  absolute: Scalars['Float']['output'];
+  percent?: Maybe<Scalars['Float']['output']>;
+  priorValue: Scalars['Float']['output'];
+  status: Scalars['String']['output'];
+  value: Scalars['Float']['output'];
+};
+
+export type OperatingReviewInput = {
+  teamId: Scalars['String']['input'];
+  weekStart: Scalars['Date']['input'];
+};
+
+export type OperatingReviewMetric = {
+  __typename?: 'OperatingReviewMetric';
+  delta: OperatingReviewDelta;
+  key: Scalars['String']['output'];
+  label: Scalars['String']['output'];
+  unit: Scalars['String']['output'];
+  value: Scalars['Float']['output'];
+};
+
+export type OperatingReviewSection = {
+  __typename?: 'OperatingReviewSection';
+  changed: Array<Scalars['String']['output']>;
+  improved: Array<Scalars['String']['output']>;
+  key: Scalars['String']['output'];
+  metrics: Array<OperatingReviewMetric>;
+  title: Scalars['String']['output'];
+  worsened: Array<Scalars['String']['output']>;
+};
+
 export type PageInfo = {
   __typename?: 'PageInfo';
   endCursor?: Maybe<Scalars['String']['output']>;
@@ -606,6 +650,8 @@ export type Query = {
   catalog: CatalogResult;
   /** Get home dashboard metrics */
   home: HomeResult;
+  /** Weekly Engineering Operating Review */
+  operatingReview: OperatingReview;
   /** List report runs for a saved report */
   reportRuns: ReportRunConnection;
   /** Get a saved report by ID */
@@ -616,6 +662,8 @@ export type Query = {
   securityAlerts: SecurityAlertConnection;
   /** Aggregated security posture for the dashboard */
   securityOverview: SecurityOverview;
+  /** Compute throughput-based capacity forecast */
+  throughputForecast?: Maybe<ThroughputForecast>;
   /** Query work graph edges with optional filters */
   workGraphEdges: WorkGraphEdgesResult;
 };
@@ -704,6 +752,12 @@ export type QueryHomeArgs = {
 };
 
 
+export type QueryOperatingReviewArgs = {
+  input: OperatingReviewInput;
+  orgId: Scalars['String']['input'];
+};
+
+
 export type QueryReportRunsArgs = {
   limit?: Scalars['Int']['input'];
   orgId: Scalars['String']['input'];
@@ -733,6 +787,12 @@ export type QuerySecurityAlertsArgs = {
 
 export type QuerySecurityOverviewArgs = {
   filters?: InputMaybe<SecurityAlertFilterInput>;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryThroughputForecastArgs = {
+  input: ThroughputForecastInput;
   orgId: Scalars['String']['input'];
 };
 
@@ -989,6 +1049,50 @@ export type TaskStatus = {
   status: Scalars['String']['output'];
   taskId: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];
+};
+
+export type ThroughputForecast = {
+  __typename?: 'ThroughputForecast';
+  backlogSize: Scalars['Int']['output'];
+  computedAt: Scalars['String']['output'];
+  forecastId: Scalars['String']['output'];
+  historyWeeks: Scalars['Int']['output'];
+  incidentLoad: ThroughputRiskOverlay;
+  insufficientHistory: Scalars['Boolean']['output'];
+  p50Weeks?: Maybe<Scalars['Int']['output']>;
+  p75Weeks?: Maybe<Scalars['Int']['output']>;
+  p90Weeks?: Maybe<Scalars['Int']['output']>;
+  primaryRisk: ThroughputRiskOverlay;
+  reviewBottleneck: ThroughputRiskOverlay;
+  rollingWindows: Array<ThroughputRollingWindow>;
+  teamId: Scalars['String']['output'];
+  wipCongestion: ThroughputRiskOverlay;
+  workScopeId?: Maybe<Scalars['String']['output']>;
+};
+
+export type ThroughputForecastInput = {
+  backlogSize: Scalars['Int']['input'];
+  historyWeeks?: Scalars['Int']['input'];
+  teamId: Scalars['String']['input'];
+  workScopeId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ThroughputRiskOverlay = {
+  __typename?: 'ThroughputRiskOverlay';
+  active: Scalars['Boolean']['output'];
+  kind: Scalars['String']['output'];
+  label: Scalars['String']['output'];
+  score: Scalars['Float']['output'];
+  threshold: Scalars['Float']['output'];
+  value: Scalars['Float']['output'];
+};
+
+export type ThroughputRollingWindow = {
+  __typename?: 'ThroughputRollingWindow';
+  insufficientHistory: Scalars['Boolean']['output'];
+  meanWeeklyThroughput: Scalars['Float']['output'];
+  sampleCount: Scalars['Int']['output'];
+  windowWeeks: Scalars['Int']['output'];
 };
 
 export type TimeseriesBucket = {

--- a/src/lib/graphql/operatingReviewFetchers.ts
+++ b/src/lib/graphql/operatingReviewFetchers.ts
@@ -1,0 +1,20 @@
+import { graphqlFetch } from "./urqlClient";
+import { OPERATING_REVIEW_QUERY } from "./queries";
+import type {
+  OperatingReview,
+  OperatingReviewInput,
+  OperatingReviewQueryResponse,
+} from "./types";
+
+export async function getOperatingReviewViaGraphQL(
+  orgId: string,
+  input: OperatingReviewInput
+): Promise<OperatingReview> {
+  const response = await graphqlFetch<OperatingReviewQueryResponse>(
+    OPERATING_REVIEW_QUERY,
+    { orgId, input },
+    { orgId }
+  );
+
+  return response.operatingReview;
+}

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -233,6 +233,41 @@ query CapacityForecasts($orgId: String!, $filters: CapacityForecastFilterInput) 
 }
 `;
 
+// ==== Operating Review Queries ====
+
+export const OPERATING_REVIEW_QUERY = `
+query OperatingReview($orgId: String!, $input: OperatingReviewInput!) {
+  operatingReview(orgId: $orgId, input: $input) {
+    orgId
+    teamId
+    weekStart
+    priorWeekStart
+    sections {
+      key
+      title
+      changed
+      improved
+      worsened
+      metrics {
+        key
+        label
+        value
+        unit
+        delta {
+          value
+          priorValue
+          absolute
+          percent
+          status
+        }
+      }
+    }
+    recommendations
+    recommendationsEmptyState
+  }
+}
+`;
+
 export const WORK_GRAPH_EDGES_QUERY = `
 query WorkGraphEdges($orgId: String!, $filters: WorkGraphEdgeFilterInput) {
   workGraphEdges(orgId: $orgId, filters: $filters) {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -503,6 +503,46 @@ type Mutation {
   triggerReport(orgId: String!, reportId: String!): ReportRunType
 }
 
+type OperatingReview {
+  orgId: String!
+  teamId: String!
+  weekStart: Date!
+  priorWeekStart: Date!
+  sections: [OperatingReviewSection!]!
+  recommendations: [String!]!
+  recommendationsEmptyState: String!
+}
+
+type OperatingReviewDelta {
+  value: Float!
+  priorValue: Float!
+  absolute: Float!
+  percent: Float
+  status: String!
+}
+
+input OperatingReviewInput {
+  teamId: String!
+  weekStart: Date!
+}
+
+type OperatingReviewMetric {
+  key: String!
+  label: String!
+  value: Float!
+  unit: String!
+  delta: OperatingReviewDelta!
+}
+
+type OperatingReviewSection {
+  key: String!
+  title: String!
+  metrics: [OperatingReviewMetric!]!
+  changed: [String!]!
+  improved: [String!]!
+  worsened: [String!]!
+}
+
 type PageInfo {
   hasNextPage: Boolean!
   hasPreviousPage: Boolean!
@@ -543,6 +583,12 @@ type Query {
 
   """List persisted capacity forecasts"""
   capacityForecasts(orgId: String!, filters: CapacityForecastFilterInput = null): CapacityForecastConnection!
+
+  """Compute throughput-based capacity forecast"""
+  throughputForecast(orgId: String!, input: ThroughputForecastInput!): ThroughputForecast
+
+  """Weekly Engineering Operating Review"""
+  operatingReview(orgId: String!, input: OperatingReviewInput!): OperatingReview!
 
   """AI workflow impact summary across the requested time range."""
   aiImpactSummary(orgId: String!, dateRange: AIDateRangeInput!, scope: AIScopeInput = null): AIImpactSummary!
@@ -789,6 +835,47 @@ type TaskStatus {
   message: String
   result: String
   updatedAt: DateTime!
+}
+
+type ThroughputForecast {
+  forecastId: String!
+  computedAt: String!
+  teamId: String!
+  workScopeId: String
+  backlogSize: Int!
+  historyWeeks: Int!
+  p50Weeks: Int
+  p75Weeks: Int
+  p90Weeks: Int
+  rollingWindows: [ThroughputRollingWindow!]!
+  primaryRisk: ThroughputRiskOverlay!
+  wipCongestion: ThroughputRiskOverlay!
+  reviewBottleneck: ThroughputRiskOverlay!
+  incidentLoad: ThroughputRiskOverlay!
+  insufficientHistory: Boolean!
+}
+
+input ThroughputForecastInput {
+  teamId: String!
+  workScopeId: String = null
+  backlogSize: Int!
+  historyWeeks: Int! = 12
+}
+
+type ThroughputRiskOverlay {
+  kind: String!
+  score: Float!
+  label: String!
+  value: Float!
+  threshold: Float!
+  active: Boolean!
+}
+
+type ThroughputRollingWindow {
+  windowWeeks: Int!
+  meanWeeklyThroughput: Float!
+  sampleCount: Int!
+  insufficientHistory: Boolean!
 }
 
 type TimeseriesBucket {

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -306,6 +306,7 @@ export interface CapacityForecastsQueryResponse {
     capacityForecasts: CapacityForecastConnection;
 }
 
+
 export interface ThroughputForecastInput {
     teamId: string;
     workScopeId?: string;
@@ -350,6 +351,57 @@ export interface ThroughputForecast {
 export interface ThroughputForecastQueryResponse {
     throughputForecast: ThroughputForecast | null;
 }
+
+
+
+// ==== Operating Review Types ====
+
+export interface OperatingReviewInput {
+    teamId: string;
+    weekStart: string;
+}
+
+export type OperatingReviewDeltaStatus = "changed" | "improved" | "worsened" | "unchanged";
+
+export interface OperatingReviewDelta {
+    value: number;
+    priorValue: number;
+    absolute: number;
+    percent?: number | null;
+    status: OperatingReviewDeltaStatus;
+}
+
+export interface OperatingReviewMetric {
+    key: string;
+    label: string;
+    value: number;
+    unit: string;
+    delta: OperatingReviewDelta;
+}
+
+export interface OperatingReviewSection {
+    key: string;
+    title: string;
+    metrics: OperatingReviewMetric[];
+    changed: string[];
+    improved: string[];
+    worsened: string[];
+}
+
+export interface OperatingReview {
+    orgId: string;
+    teamId: string;
+    weekStart: string;
+    priorWeekStart: string;
+    sections: OperatingReviewSection[];
+    recommendations: string[];
+    recommendationsEmptyState: string;
+}
+
+export interface OperatingReviewQueryResponse {
+    operatingReview: OperatingReview;
+}
+
 
 // ==== Work Graph Types ====
 


### PR DESCRIPTION
## Summary
- Adds a server-rendered /operating-review surface for team/week tuples.
- Fetches the Operating Review GraphQL payload through the existing server fetcher pattern.
- Renders fixed delivery, bottleneck, risk, reliability, investment, and recommendations sections with delta callouts.
- Adds Operating Review to primary navigation.

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build

## Visual evidence
SCREENSHOT-WAIVER: local dev server starts, but authenticated app routes redirect to /auth/signin without a live session and live backend/org data. No production UI screenshot could be captured in this worktree; route build/typecheck verification is green.

## Test waiver
TEST-WAIVER: UI route is a server-rendered GraphQL surface with no existing page-level test harness; local lint, typecheck, and production build passed, and the ops PR includes pure compute unit coverage for the payload contract.

Sibling PR: https://github.com/full-chaos/dev-health-ops/pull/751

Closes CHAOS-1614