### PR TITLE
fix(web): use canonical `repo_id:number` rootId for aiWorkflowDrilldown (CHAOS-1739)

### DIFF
--- a/src/components/ai/AIDrilldownModal.test.tsx
+++ b/src/components/ai/AIDrilldownModal.test.tsx
@@ -132,18 +132,18 @@ describe("AIDrilldownModal", () => {
       data: {
         orgId: "org-test",
         rootType: "PR",
-        rootId: "11111111-1111-1111-1111-111111111111#42",
+        rootId: "11111111-1111-1111-1111-111111111111:42",
         partial: false,
         dataAvailable: true,
         nodes: [
-          { nodeType: "pr", nodeId: "11111111-1111-1111-1111-111111111111#42" },
+          { nodeType: "pr", nodeId: "11111111-1111-1111-1111-111111111111:42" },
           { nodeType: "ai_workflow_run", nodeId: "run-1" },
         ],
         edges: [
           {
             edgeId: "edge-1",
             sourceType: "pr",
-            sourceId: "11111111-1111-1111-1111-111111111111#42",
+            sourceId: "11111111-1111-1111-1111-111111111111:42",
             targetType: "ai_workflow_run",
             targetId: "run-1",
             edgeType: "has_ai_workflow",
@@ -163,7 +163,7 @@ describe("AIDrilldownModal", () => {
     await userEvent.click(within(row).getByText("Add feature flag"));
 
     const lastCall = mockUseDrilldown.mock.calls.at(-1);
-    expect(lastCall?.[0]).toBe("11111111-1111-1111-1111-111111111111#42");
+    expect(lastCall?.[0]).toBe("11111111-1111-1111-1111-111111111111:42");
 
     expect(screen.getByTestId("ai-drilldown-evidence")).toBeInTheDocument();
     expect(screen.getByText(/has_ai_workflow/i)).toBeInTheDocument();

--- a/src/components/ai/AIDrilldownModal.tsx
+++ b/src/components/ai/AIDrilldownModal.tsx
@@ -19,7 +19,7 @@ type AIDrilldownModalProps = {
 
 
 function prRowKey(pr: AiAttributedPr): string {
-  return `${pr.repoId}#${pr.number}`;
+  return `${pr.repoId}:${pr.number}`;
 }
 
 function formatMergedAt(value: string | null | undefined): string {
@@ -107,7 +107,7 @@ function PrTable({
 }
 
 function EvidencePanel({ selected }: { selected: AiAttributedPr | null }) {
-  const rootId = selected ? `${selected.repoId}#${selected.number}` : null;
+  const rootId = selected ? prRowKey(selected) : null;
   const { data: drilldown, fetching, error } = useAIWorkflowDrilldownForPr(rootId);
 
   if (!selected) {


### PR DESCRIPTION
prRowKey was building `${repoId}#${pr.number}` but the Work Graph
extractor and ai_workflow_artifact_edges store PR ids as
`${repo_id}:${pr_number}`. Drilldown calls therefore never matched
any edges. Switch the separator to ':' so we hit the canonical id
format. The EvidencePanel now derives rootId via prRowKey() to keep the
single source of truth.

Component tests + ai-review-load.spec.ts both still green.
