### PR TITLE
feat/chaos 1638 cognitive load view

### DIFF
--- a/src/app/(app)/cognitive-load/page.tsx
+++ b/src/app/(app)/cognitive-load/page.tsx
@@ -1,0 +1,137 @@
+import { FilterBar } from "@/components/filters/FilterBar";
+import { ContextStrip } from "@/components/navigation/ContextStrip";
+import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+
+type CognitiveLoadPageProps = {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+const signals = [
+  {
+    label: "PR interruption load",
+    value: "18",
+    delta: "-12% vs prior week",
+    description: "Reviews, first-review events, and review feedback interrupting focused delivery.",
+  },
+  {
+    label: "Context spread",
+    value: "7",
+    delta: "+2 active contexts",
+    description: "Distinct repos, PRs, reviews, and touched file areas in the selected team scope.",
+  },
+  {
+    label: "Review request load",
+    value: "11",
+    delta: "+4 requests",
+    description: "Aggregate review requests handled by the team, never a person-level queue ranking.",
+  },
+  {
+    label: "After-hours trend",
+    value: "14%",
+    delta: "flat 3-week trend",
+    description: "Existing commit-time rollups outside weekday business hours.",
+  },
+  {
+    label: "Weekend trend",
+    value: "6%",
+    delta: "down 3 points",
+    description: "Existing weekend activity ratio, aggregated before it reaches this surface.",
+  },
+];
+
+const trend = [28, 34, 26, 31, 24, 20, 18];
+
+export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadPageProps) {
+  const params = (await searchParams) ?? {};
+  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+  const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+  const originParam = Array.isArray(params.origin) ? params.origin[0] : params.origin;
+  const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+  const activeOrigin = typeof originParam === "string" ? originParam : undefined;
+  const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+        <PrimaryNav filters={filters} active="cognitive-load" role={activeRole} />
+        <main className="flex min-w-0 flex-1 flex-col gap-6" data-testid="cognitive-load-dashboard">
+          <ContextStrip filters={filters} origin={activeOrigin} />
+          <FilterBar view="work" />
+
+          <section className="overflow-hidden rounded-[2rem] border border-(--card-stroke) bg-(--card-80) shadow-sm">
+            <div className="grid gap-0 lg:grid-cols-[1.15fr_0.85fr]">
+              <div className="p-8">
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-(--ink-muted)">
+                  Privacy-first cognitive load
+                </p>
+                <h1 className="mt-3 text-3xl font-semibold tracking-tight md:text-5xl">
+                  Focus fragmentation, not surveillance.
+                </h1>
+                <p className="mt-4 max-w-2xl text-sm leading-6 text-(--ink-muted) md:text-base">
+                  This surface uses existing PR, review, work-item, and commit-time rollups to show where attention is being split. It does not collect IDE, keystroke, prompt, or session telemetry.
+                </p>
+              </div>
+              <div className="border-t border-(--card-stroke) bg-(--card-60) p-8 lg:border-l lg:border-t-0">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-(--ink-muted)">
+                  Guardrail
+                </p>
+                <div className="mt-4 space-y-3 text-sm text-(--ink-muted)">
+                  <p>No leaderboards. No peer rankings. Team and repo aggregation comes first.</p>
+                  <p>Single-person views are limited to explicit self-reflection or coaching context.</p>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+            {signals.map((signal) => (
+              <article key={signal.label} className="rounded-3xl border border-(--card-stroke) bg-card p-5 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
+                  {signal.label}
+                </p>
+                <p className="mt-5 text-4xl font-semibold tabular-nums">{signal.value}</p>
+                <p className="mt-2 text-xs font-medium text-emerald-600">{signal.delta}</p>
+                <p className="mt-4 text-sm leading-6 text-(--ink-muted)">{signal.description}</p>
+              </article>
+            ))}
+          </section>
+
+          <section className="grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+            <div className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-(--ink-muted)">
+                Aggregation contract
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold tracking-tight">Team/repo-first by default</h2>
+              <p className="mt-3 text-sm leading-6 text-(--ink-muted)">
+                Cognitive-load signals are presented as system pressure: review queues, context spread, after-hours trend, and weekend trend. They are coaching prompts, not performance judgments.
+              </p>
+            </div>
+
+            <div className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-(--ink-muted)">
+                    Fragmentation trend
+                  </p>
+                  <h2 className="mt-2 text-2xl font-semibold tracking-tight">Seven-day load index</h2>
+                </div>
+                <span className="rounded-full border border-(--card-stroke) px-3 py-1 text-xs text-(--ink-muted)">
+                  Sample data
+                </span>
+              </div>
+              <div className="mt-8 flex h-32 items-end gap-3" aria-label="Seven-day load index sample bars">
+                {trend.map((value, index) => (
+                  <div key={`${value}-${index}`} className="flex flex-1 flex-col items-center gap-2">
+                    <div className="w-full rounded-t-2xl bg-(--accent)" style={{ height: `${value * 3}px` }} />
+                    <span className="text-[0.65rem] text-(--ink-muted)">D{index + 1}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/cognitive-load/page.tsx
+++ b/src/app/(app)/cognitive-load/page.tsx
@@ -1,4 +1,3 @@
-import { FilterBar } from "@/components/filters/FilterBar";
 import { ContextStrip } from "@/components/navigation/ContextStrip";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
@@ -57,7 +56,6 @@ export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadP
         <PrimaryNav filters={filters} active="cognitive-load" role={activeRole} />
         <main className="flex min-w-0 flex-1 flex-col gap-6" data-testid="cognitive-load-dashboard">
           <ContextStrip filters={filters} origin={activeOrigin} />
-          <FilterBar view="work" />
 
           <section className="overflow-hidden rounded-[2rem] border border-(--card-stroke) bg-(--card-80) shadow-sm">
             <div className="grid gap-0 lg:grid-cols-[1.15fr_0.85fr]">

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -66,6 +66,7 @@ const navGroups: NavGroup[] = [
     items: [
       { id: "metrics", label: "Metrics", href: "/metrics?tab=dora", description: "Trends" },
       { id: "people", label: "People", href: "/people", description: "Individual" },
+      { id: "cognitive-load", label: "Cognitive Load", href: "/cognitive-load", description: "Focus" },
       { id: "landscape", label: "Landscape", href: "/explore/landscape", description: "Quadrants" },
     ],
   },
@@ -77,6 +78,7 @@ const navGroups: NavGroup[] = [
       { id: "capacity-planning", label: "Capacity Planning", href: "/capacity-planning", description: "Forecast" },
       { id: "code", label: "Code", href: "/code", description: "Ownership" },
       { id: "opportunities", label: "Opportunities", href: "/opportunities", description: "Threads" },
+      { id: "cognitive-load", label: "Cognitive Load", href: "/cognitive-load", description: "Focus" },
       { id: "security", label: "Security", href: "/security", description: "Alerts" },
     ],
   },

--- a/tests/cognitive-load.spec.ts
+++ b/tests/cognitive-load.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Cognitive Load dashboard", () => {
+  test("renders privacy-first team/repo cognitive load signals", async ({ page }) => {
+    await page.goto("/cognitive-load");
+
+    const dashboard = page.getByTestId("cognitive-load-dashboard");
+    await expect(dashboard).toBeVisible();
+    await expect(dashboard.getByRole("heading", { name: /Focus fragmentation, not surveillance/i })).toBeVisible();
+    await expect(dashboard.getByText("PR interruption load")).toBeVisible();
+    await expect(dashboard.getByText("Context spread", { exact: true })).toBeVisible();
+    await expect(dashboard.getByText("Review request load", { exact: true })).toBeVisible();
+    await expect(dashboard.getByText("After-hours trend", { exact: true })).toBeVisible();
+    await expect(dashboard.getByText("Weekend trend", { exact: true })).toBeVisible();
+  });
+
+  test("states the no-surveillance guardrails", async ({ page }) => {
+    await page.goto("/cognitive-load");
+
+    const dashboard = page.getByTestId("cognitive-load-dashboard");
+    await expect(dashboard.getByText(/No leaderboards/i)).toBeVisible();
+    await expect(dashboard.getByText(/No peer rankings/i)).toBeVisible();
+    await expect(dashboard.getByText(/self-reflection/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Add /cognitive-load surface for privacy-first cognitive load wedge
- Link Cognitive Load from primary navigation
- Keep the page self-contained with sample team/repo-first signals and no live backend dependency
- Add Playwright coverage for signal cards and no-surveillance guardrails

## Verification
- pnpm typecheck
- pnpm exec playwright test tests/cognitive-load.spec.ts
- pnpm build

## Visual evidence
Screenshot captured locally: /Users/chris/projects/full-chaos/dev-health/cognitive-load-chaos-1638.png

Closes CHAOS-1638