### PR TITLE
feat(web): /risk/compounding surface with inspectable composite score (CHAOS-1642)

### DIFF
--- a/src/app/(app)/risk/compounding/page.tsx
+++ b/src/app/(app)/risk/compounding/page.tsx
@@ -1,0 +1,226 @@
+/**
+ * /risk/compounding — Compounding Risk surface (CHAOS-1642).
+ *
+ * RSC entry. Reads from the backend ``compoundingRisk`` GraphQL query
+ * (CHAOS-1641) and renders ``CompoundingRiskDashboard``.
+ *
+ * Per the no-surveillance contract, person/developer scope is intentionally
+ * disallowed on this surface. If a caller hands us a ``filters.scope.level
+ * === "developer"`` query string, the page renders a guardrail banner and
+ * does not fetch person-scoped data.
+ */
+
+import Link from "next/link";
+
+import { ContextStrip } from "@/components/navigation/ContextStrip";
+import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import {
+  CompoundingRiskDashboard,
+  type CompoundingRiskDashboardProps,
+  type CompoundingRiskRowView,
+  type CompoundingRiskScope,
+  type CompoundingRiskSeverity,
+  type CompoundingRiskTrendPointView,
+} from "@/components/risk/CompoundingRiskDashboard";
+import { requireSession } from "@/lib/auth";
+import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+import { graphqlFetch } from "@/lib/graphql/server";
+import { COMPOUNDING_RISK_QUERY } from "@/lib/graphql/queries";
+
+type CompoundingRiskPageProps = {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+type CompoundingRiskQueryResponse = {
+  compoundingRisk: {
+    orgId: string;
+    breakout: "REPO" | "TEAM";
+    generatedAt: string;
+    rows: Array<{
+      day: string;
+      scope: "REPO" | "TEAM";
+      scopeId: string;
+      scopeLabel: string;
+      score: number | null;
+      severity: Uppercase<CompoundingRiskSeverity>;
+      computedAt: string;
+      components: CompoundingRiskRowView["components"];
+      weights: CompoundingRiskRowView["weights"];
+      thresholds: CompoundingRiskRowView["thresholds"];
+    }>;
+    trend: Array<{
+      day: string;
+      score: number | null;
+      severity: Uppercase<CompoundingRiskSeverity>;
+    }>;
+  };
+};
+
+function normalizeScope(value: "REPO" | "TEAM"): CompoundingRiskScope {
+  return value === "TEAM" ? "team" : "repo";
+}
+
+function normalizeSeverity(
+  value: Uppercase<CompoundingRiskSeverity>,
+): CompoundingRiskSeverity {
+  switch (value) {
+    case "HIGH":
+      return "high";
+    case "ELEVATED":
+      return "elevated";
+    case "LOW":
+      return "low";
+    case "UNKNOWN":
+    default:
+      return "unknown";
+  }
+}
+
+function pickBreakoutFromQuery(value: unknown): CompoundingRiskScope {
+  if (value === "team" || value === "TEAM") return "team";
+  return "repo";
+}
+
+async function fetchCompoundingRisk(
+  orgId: string,
+  breakout: CompoundingRiskScope,
+): Promise<CompoundingRiskDashboardProps | null> {
+  try {
+    const data = await graphqlFetch<CompoundingRiskQueryResponse>(
+      COMPOUNDING_RISK_QUERY,
+      {
+        orgId,
+        filter: {
+          breakout: breakout.toUpperCase(),
+          trendDays: 30,
+        },
+      },
+      { orgId },
+    );
+    const payload = data?.compoundingRisk;
+    if (!payload) return null;
+    const rows: CompoundingRiskRowView[] = payload.rows.map((row) => ({
+      day: row.day,
+      scope: normalizeScope(row.scope),
+      scopeId: row.scopeId,
+      scopeLabel: row.scopeLabel,
+      score: row.score,
+      severity: normalizeSeverity(row.severity),
+      components: row.components,
+      weights: row.weights,
+      thresholds: row.thresholds,
+      computedAt: row.computedAt,
+    }));
+    const trend: CompoundingRiskTrendPointView[] = payload.trend.map(
+      (point) => ({
+        day: point.day,
+        score: point.score,
+        severity: normalizeSeverity(point.severity),
+      }),
+    );
+    return {
+      orgId: payload.orgId,
+      breakout: normalizeScope(payload.breakout),
+      rows,
+      trend,
+      generatedAt: payload.generatedAt,
+    };
+  } catch (error) {
+    // Surface as empty state rather than crashing the surface; the dashboard
+    // already shows a populated empty-state message.
+    console.warn("compoundingRisk query failed", error);
+    return null;
+  }
+}
+
+export default async function CompoundingRiskPage({
+  searchParams,
+}: CompoundingRiskPageProps) {
+  const session = await requireSession();
+  const params = (await searchParams) ?? {};
+
+  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+  const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+  const originParam = Array.isArray(params.origin)
+    ? params.origin[0]
+    : params.origin;
+  const breakoutParam = Array.isArray(params.breakout)
+    ? params.breakout[0]
+    : params.breakout;
+
+  const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+  const activeOrigin = typeof originParam === "string" ? originParam : undefined;
+  const filters = encodedFilter
+    ? decodeFilter(encodedFilter)
+    : filterFromQueryParams(params);
+
+  const isDeveloperScope = filters.scope.level === "developer";
+  const breakout = pickBreakoutFromQuery(breakoutParam);
+
+  const orgId =
+    session.user?.org_id ?? "demo-org";
+
+  const dashboard = isDeveloperScope
+    ? null
+    : await fetchCompoundingRisk(orgId, breakout);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+        <PrimaryNav
+          filters={filters}
+          active="risk-compounding"
+          role={activeRole}
+        />
+        <main
+          className="flex min-w-0 flex-1 flex-col gap-6"
+          data-testid="compounding-risk-page"
+        >
+          <ContextStrip filters={filters} origin={activeOrigin} />
+
+          {isDeveloperScope ? (
+            <section
+              className="rounded-[1.75rem] border border-amber-400/40 bg-amber-50/80 p-6 text-amber-950 shadow-sm"
+              data-testid="developer-scope-guardrail"
+            >
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-700">
+                Scope guardrail
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold tracking-tight">
+                Compounding Risk is a team and repo signal.
+              </h2>
+              <p className="mt-3 max-w-3xl text-sm leading-6">
+                Per the no-surveillance contract, this surface intentionally
+                does not break down by person. Use team or repo aggregation to
+                see where change pressure is compounding architectural and
+                operational risk.
+              </p>
+              <Link
+                href="/risk/compounding"
+                className="mt-5 inline-flex rounded-full bg-amber-950 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-amber-50"
+              >
+                Return to team/repo view
+              </Link>
+            </section>
+          ) : dashboard ? (
+            <CompoundingRiskDashboard {...dashboard} />
+          ) : (
+            <section
+              className="rounded-2xl border border-(--card-stroke) bg-card p-6 text-sm text-(--ink-muted)"
+              data-testid="empty-state"
+            >
+              <p>
+                No Compounding Risk data is available yet. Run{" "}
+                <code className="font-mono text-[0.85em]">
+                  dev-hops metrics daily
+                </code>{" "}
+                to populate the metric, or check the analytics backend
+                connection.
+              </p>
+            </section>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -77,6 +77,7 @@ const navGroups: NavGroup[] = [
       { id: "work", label: "Work", href: "/work", description: "Investment" },
       { id: "capacity-planning", label: "Capacity Planning", href: "/capacity-planning", description: "Forecast" },
       { id: "code", label: "Code", href: "/code", description: "Ownership" },
+      { id: "risk-compounding", label: "Compounding Risk", href: "/risk/compounding", description: "Composite" },
       { id: "opportunities", label: "Opportunities", href: "/opportunities", description: "Threads" },
       { id: "cognitive-load", label: "Cognitive Load", href: "/cognitive-load", description: "Focus" },
       { id: "security", label: "Security", href: "/security", description: "Alerts" },

--- a/src/components/risk/CompoundingRiskDashboard.test.tsx
+++ b/src/components/risk/CompoundingRiskDashboard.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Component tests for CompoundingRiskDashboard (CHAOS-1642).
+ *
+ * Verifies the contract a reviewer will look for on the surface:
+ *
+ * - Score, severity chip, scope label, and per-component values are all
+ *   rendered from the GraphQL row exactly as persisted.
+ * - Empty state renders when no rows are supplied.
+ * - Table includes the Work Graph drilldown link with the correct scope
+ *   parameters.
+ * - The dashboard surfaces the weights/thresholds audit trail.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { render, screen, within } from "@/test/utils";
+
+import {
+  CompoundingRiskDashboard,
+  type CompoundingRiskDashboardProps,
+  type CompoundingRiskRowView,
+} from "./CompoundingRiskDashboard";
+
+function makeRow(overrides: Partial<CompoundingRiskRowView> = {}): CompoundingRiskRowView {
+  return {
+    day: "2026-05-20",
+    scope: "repo",
+    scopeId: "11111111-1111-1111-1111-111111111111",
+    scopeLabel: "acme/backend",
+    score: 0.72,
+    severity: "high",
+    components: {
+      churnNorm: 0.8,
+      complexityNorm: 0.7,
+      ownershipNorm: 0.6,
+      reviewNorm: 0.5,
+      reworkChurn: 0.18,
+      complexityDelta: 0.12,
+      busFactor: 4,
+      ownershipGini: 0.55,
+      singleOwnerRatio: 0.65,
+      reviewLatencyP90h: 30,
+    },
+    weights: {
+      churn: 0.3,
+      complexity: 0.3,
+      ownership: 0.2,
+      review: 0.2,
+    },
+    thresholds: {
+      elevated: 0.4,
+      high: 0.65,
+    },
+    computedAt: "2026-05-21T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderDashboard(
+  overrides: Partial<CompoundingRiskDashboardProps> = {},
+) {
+  const props: CompoundingRiskDashboardProps = {
+    orgId: "demo-org",
+    breakout: "repo",
+    rows: [makeRow()],
+    trend: [
+      { day: "2026-05-19", score: 0.65, severity: "high" },
+      { day: "2026-05-20", score: 0.72, severity: "high" },
+    ],
+    generatedAt: "2026-05-21T12:00:00Z",
+    ...overrides,
+  };
+  return render(<CompoundingRiskDashboard {...props} />);
+}
+
+describe("CompoundingRiskDashboard", () => {
+  it("renders the headline score and severity from the row", () => {
+    renderDashboard();
+    const score = screen.getByTestId("headline-score");
+    expect(score.textContent).toBe("0.72");
+    const chips = screen.getAllByTestId("severity-chip");
+    // First chip is the headline; subsequent chips are in the table.
+    expect(chips[0].getAttribute("data-severity")).toBe("high");
+  });
+
+  it("renders all four component bars with the normalized value", () => {
+    renderDashboard();
+    const churn = screen.getByTestId("component-churn");
+    expect(within(churn).getByText("0.80")).toBeInTheDocument();
+    const complexity = screen.getByTestId("component-complexity");
+    expect(within(complexity).getByText("0.70")).toBeInTheDocument();
+    const ownership = screen.getByTestId("component-ownership");
+    expect(within(ownership).getByText("0.60")).toBeInTheDocument();
+    const review = screen.getByTestId("component-review-latency");
+    expect(within(review).getByText("0.50")).toBeInTheDocument();
+  });
+
+  it("surfaces the persisted thresholds audit trail", () => {
+    renderDashboard();
+    expect(
+      screen.getByText(/elevated ≥ 0\.40/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/high ≥ 0\.65/i)).toBeInTheDocument();
+  });
+
+  it("renders one table row per scope and links into Work Graph", () => {
+    const rows = [
+      makeRow({ scopeId: "repo-a", scopeLabel: "acme/a", score: 0.8 }),
+      makeRow({
+        scopeId: "repo-b",
+        scopeLabel: "acme/b",
+        score: 0.35,
+        severity: "low",
+      }),
+    ];
+    renderDashboard({ rows });
+
+    const tableRows = screen.getAllByTestId("risk-row");
+    expect(tableRows).toHaveLength(2);
+    expect(tableRows[0].getAttribute("data-scope-id")).toBe("repo-a");
+    expect(tableRows[1].getAttribute("data-severity")).toBe("low");
+
+    const drilldownLinks = screen.getAllByTestId("open-in-work-graph");
+    expect(drilldownLinks[0].getAttribute("href")).toContain(
+      "risk_scope_id=repo-a",
+    );
+    expect(drilldownLinks[0].getAttribute("href")).toContain(
+      "risk_scope_kind=repo",
+    );
+  });
+
+  it("uses 'team' in the drilldown URL when breakout is team", () => {
+    const rows = [
+      makeRow({
+        scope: "team",
+        scopeId: "team-x",
+        scopeLabel: "Platform",
+        score: 0.6,
+      }),
+    ];
+    renderDashboard({ breakout: "team", rows });
+
+    const drilldown = screen.getByTestId("open-in-work-graph");
+    expect(drilldown.getAttribute("href")).toContain("risk_scope_kind=team");
+    expect(drilldown.getAttribute("href")).toContain("risk_scope_id=team-x");
+  });
+
+  it("renders an empty state when no rows are supplied", () => {
+    renderDashboard({ rows: [] });
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+  });
+
+  it("renders a trend sparkline with one bar per day", () => {
+    renderDashboard();
+    const sparkline = screen.getByTestId("trend-sparkline");
+    expect(sparkline.children.length).toBe(2);
+  });
+
+  it("renders '—' for null scores rather than 0", () => {
+    const rows = [
+      makeRow({
+        score: null,
+        severity: "unknown",
+        components: {
+          ...makeRow().components,
+          churnNorm: null,
+          complexityNorm: null,
+          ownershipNorm: null,
+          reviewNorm: null,
+        },
+      }),
+    ];
+    renderDashboard({ rows });
+    // headline shows em-dash, not 0
+    const score = screen.getByTestId("headline-score");
+    expect(score.textContent).toBe("—");
+    // and severity chip on the headline reads unknown
+    const chips = screen.getAllByTestId("severity-chip");
+    expect(chips[0].getAttribute("data-severity")).toBe("unknown");
+  });
+});

--- a/src/components/risk/CompoundingRiskDashboard.tsx
+++ b/src/components/risk/CompoundingRiskDashboard.tsx
@@ -1,0 +1,439 @@
+/**
+ * CompoundingRiskDashboard — visual surface for the Compounding Risk composite
+ * (CHAOS-1642).
+ *
+ * Renders:
+ *   1. A scope-aware banner with headline score, severity chip, and a trend sparkline.
+ *   2. A component-breakdown card showing each normalized contribution + its raw value.
+ *   3. A sortable per-scope table linking out to Work Graph evidence.
+ *
+ * Every value shown to the user maps to a persisted field on
+ * ``compounding_risk_daily`` — the score is fully inspectable.
+ *
+ * Per the no-surveillance contract, this surface intentionally has no
+ * person/developer breakout.
+ */
+
+import Link from "next/link";
+
+function buildRiskDrilldownUrl({
+  scope,
+}: {
+  scope: { kind: "repo" | "team"; id: string };
+}): string {
+  const params = new URLSearchParams({
+    tab: "graph",
+    risk_scope_kind: scope.kind,
+    risk_scope_id: scope.id,
+  });
+  return `/work?${params.toString()}`;
+}
+
+export type CompoundingRiskSeverity =
+  | "unknown"
+  | "low"
+  | "elevated"
+  | "high";
+
+export type CompoundingRiskScope = "repo" | "team";
+
+export type CompoundingRiskComponentsView = {
+  churnNorm: number | null;
+  complexityNorm: number | null;
+  ownershipNorm: number | null;
+  reviewNorm: number | null;
+  reworkChurn: number | null;
+  complexityDelta: number | null;
+  busFactor: number | null;
+  ownershipGini: number | null;
+  singleOwnerRatio: number | null;
+  reviewLatencyP90h: number | null;
+};
+
+export type CompoundingRiskWeightsView = {
+  churn: number;
+  complexity: number;
+  ownership: number;
+  review: number;
+};
+
+export type CompoundingRiskThresholdsView = {
+  elevated: number;
+  high: number;
+};
+
+export type CompoundingRiskRowView = {
+  day: string;
+  scope: CompoundingRiskScope;
+  scopeId: string;
+  scopeLabel: string;
+  score: number | null;
+  severity: CompoundingRiskSeverity;
+  components: CompoundingRiskComponentsView;
+  weights: CompoundingRiskWeightsView;
+  thresholds: CompoundingRiskThresholdsView;
+  computedAt: string;
+};
+
+export type CompoundingRiskTrendPointView = {
+  day: string;
+  score: number | null;
+  severity: CompoundingRiskSeverity;
+};
+
+export type CompoundingRiskDashboardProps = {
+  orgId: string;
+  breakout: CompoundingRiskScope;
+  rows: CompoundingRiskRowView[];
+  trend: CompoundingRiskTrendPointView[];
+  generatedAt: string;
+};
+
+const SEVERITY_COPY: Record<CompoundingRiskSeverity, { label: string; tone: string }> = {
+  unknown: {
+    label: "Unknown",
+    tone: "border-slate-400/40 bg-slate-100/60 text-slate-700",
+  },
+  low: {
+    label: "Low",
+    tone: "border-emerald-400/40 bg-emerald-50/70 text-emerald-800",
+  },
+  elevated: {
+    label: "Elevated",
+    tone: "border-amber-400/40 bg-amber-50/70 text-amber-900",
+  },
+  high: {
+    label: "High",
+    tone: "border-rose-400/40 bg-rose-50/70 text-rose-900",
+  },
+};
+
+function fmtScore(value: number | null): string {
+  if (value === null || Number.isNaN(value)) return "—";
+  return value.toFixed(2);
+}
+
+function fmtPercent(value: number | null): string {
+  if (value === null || Number.isNaN(value)) return "—";
+  return `${Math.round(value * 100)}%`;
+}
+
+function fmtRawNumber(value: number | null, suffix?: string): string {
+  if (value === null || Number.isNaN(value)) return "—";
+  const formatted = Math.abs(value) >= 10 ? value.toFixed(1) : value.toFixed(2);
+  return suffix ? `${formatted}${suffix}` : formatted;
+}
+
+function selectHeadlineRow(
+  rows: CompoundingRiskRowView[],
+): CompoundingRiskRowView | null {
+  if (rows.length === 0) return null;
+  const scored = rows.find((r) => r.score !== null);
+  return scored ?? rows[0];
+}
+
+function SeverityChip({ severity }: { severity: CompoundingRiskSeverity }) {
+  const { label, tone } = SEVERITY_COPY[severity];
+  return (
+    <span
+      data-testid="severity-chip"
+      data-severity={severity}
+      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${tone}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function TrendSparkline({
+  trend,
+}: {
+  trend: CompoundingRiskTrendPointView[];
+}) {
+  if (trend.length === 0) {
+    return (
+      <p className="text-xs text-(--ink-muted)">
+        Trend data is not yet available for this scope.
+      </p>
+    );
+  }
+  const max = Math.max(0.01, ...trend.map((p) => p.score ?? 0));
+  return (
+    <div
+      aria-label="30-day compounding-risk trend"
+      className="mt-4 flex h-20 items-end gap-1"
+      data-testid="trend-sparkline"
+    >
+      {trend.map((point) => {
+        const height = point.score === null ? 4 : Math.max(4, (point.score / max) * 70);
+        return (
+          <div
+            key={point.day}
+            className="flex-1 rounded-t-sm bg-(--accent)"
+            style={{ height: `${height}px`, opacity: point.score === null ? 0.25 : 1 }}
+            title={`${point.day}: ${fmtScore(point.score)}`}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function ComponentBars({ row }: { row: CompoundingRiskRowView }) {
+  const components: Array<{
+    key: keyof CompoundingRiskComponentsView;
+    label: string;
+    weight: number;
+    raw: string;
+  }> = [
+    {
+      key: "churnNorm",
+      label: "Churn",
+      weight: row.weights.churn,
+      raw: `rework churn ${fmtPercent(row.components.reworkChurn)}`,
+    },
+    {
+      key: "complexityNorm",
+      label: "Complexity",
+      weight: row.weights.complexity,
+      raw: `Δ ${fmtPercent(row.components.complexityDelta)}`,
+    },
+    {
+      key: "ownershipNorm",
+      label: "Ownership",
+      weight: row.weights.ownership,
+      raw: `gini ${fmtScore(row.components.ownershipGini)} · single-owner ${fmtPercent(row.components.singleOwnerRatio)}`,
+    },
+    {
+      key: "reviewNorm",
+      label: "Review latency",
+      weight: row.weights.review,
+      raw: `p90 ${fmtRawNumber(row.components.reviewLatencyP90h, "h")}`,
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {components.map((component) => {
+        const norm = row.components[component.key];
+        const width = norm === null ? 0 : Math.max(2, norm * 100);
+        return (
+          <article
+            key={component.key}
+            className="rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-sm"
+            data-testid={`component-${component.label.toLowerCase().replace(/\s+/g, "-")}`}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
+                {component.label}
+              </p>
+              <p className="text-xs text-(--ink-muted)">
+                weight {component.weight.toFixed(2)}
+              </p>
+            </div>
+            <p className="mt-3 text-3xl font-semibold tabular-nums">
+              {fmtScore(norm)}
+            </p>
+            <p className="mt-1 text-xs text-(--ink-muted)">{component.raw}</p>
+            <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-(--card-stroke)/40">
+              <div
+                className="h-full rounded-full bg-(--accent)"
+                style={{ width: `${width}%` }}
+              />
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+function ScopeTable({
+  rows,
+  breakout,
+}: {
+  rows: CompoundingRiskRowView[];
+  breakout: CompoundingRiskScope;
+}) {
+  if (rows.length === 0) {
+    return (
+      <p
+        className="rounded-2xl border border-(--card-stroke) bg-card p-6 text-sm text-(--ink-muted)"
+        data-testid="empty-state"
+      >
+        No Compounding Risk data is available for this org yet. Run{" "}
+        <code className="font-mono text-[0.85em]">dev-hops metrics daily</code> to
+        populate <code className="font-mono text-[0.85em]">compounding_risk_daily</code>.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90) shadow-sm">
+      <table className="w-full text-sm" data-testid="compounding-risk-table">
+        <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
+          <tr>
+            <th className="px-5 py-3 text-left">
+              {breakout === "team" ? "Team" : "Repo"}
+            </th>
+            <th className="px-5 py-3 text-right">Score</th>
+            <th className="px-5 py-3 text-left">Severity</th>
+            <th className="px-5 py-3 text-right">Churn</th>
+            <th className="px-5 py-3 text-right">Complexity</th>
+            <th className="px-5 py-3 text-right">Ownership</th>
+            <th className="px-5 py-3 text-right">Review</th>
+            <th className="px-5 py-3 text-left">Drilldown</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const workGraphHref = buildRiskDrilldownUrl({
+              scope:
+                breakout === "team"
+                  ? { kind: "team", id: row.scopeId }
+                  : { kind: "repo", id: row.scopeId },
+            });
+            return (
+              <tr
+                key={row.scopeId}
+                data-testid="risk-row"
+                data-scope-id={row.scopeId}
+                data-severity={row.severity}
+                className="border-t border-(--card-stroke)/60 hover:bg-(--card-60)/60"
+              >
+                <td className="px-5 py-3 align-middle font-medium">
+                  {row.scopeLabel}
+                </td>
+                <td className="px-5 py-3 text-right tabular-nums">
+                  {fmtScore(row.score)}
+                </td>
+                <td className="px-5 py-3">
+                  <SeverityChip severity={row.severity} />
+                </td>
+                <td className="px-5 py-3 text-right tabular-nums">
+                  {fmtScore(row.components.churnNorm)}
+                </td>
+                <td className="px-5 py-3 text-right tabular-nums">
+                  {fmtScore(row.components.complexityNorm)}
+                </td>
+                <td className="px-5 py-3 text-right tabular-nums">
+                  {fmtScore(row.components.ownershipNorm)}
+                </td>
+                <td className="px-5 py-3 text-right tabular-nums">
+                  {fmtScore(row.components.reviewNorm)}
+                </td>
+                <td className="px-5 py-3">
+                  <Link
+                    href={workGraphHref}
+                    className="text-xs font-semibold uppercase tracking-[0.18em] text-(--accent) hover:underline"
+                    data-testid="open-in-work-graph"
+                  >
+                    Open in Work Graph →
+                  </Link>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function CompoundingRiskDashboard({
+  orgId,
+  breakout,
+  rows,
+  trend,
+  generatedAt,
+}: CompoundingRiskDashboardProps) {
+  const headline = selectHeadlineRow(rows);
+
+  return (
+    <div className="flex flex-col gap-6" data-testid="compounding-risk-dashboard">
+      <section className="overflow-hidden rounded-[2rem] border border-(--card-stroke) bg-(--card-80) shadow-sm">
+        <div className="grid gap-0 lg:grid-cols-[1.15fr_0.85fr]">
+          <div className="p-8">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-(--ink-muted)">
+              Compounding risk
+            </p>
+            <h1 className="mt-3 text-3xl font-semibold tracking-tight md:text-5xl">
+              Where change pressure is compounding risk.
+            </h1>
+            <p className="mt-4 max-w-2xl text-sm leading-6 text-(--ink-muted) md:text-base">
+              A deterministic composite of churn, complexity trend, ownership
+              concentration, and review-latency tail. Every score is fully
+              inspectable: weights, thresholds, and raw inputs are persisted
+              alongside the composite so historical rows stay auditable.
+            </p>
+            <p className="mt-3 text-xs text-(--ink-muted)">
+              Org <span className="font-mono">{orgId}</span> · generated{" "}
+              <time dateTime={generatedAt}>{generatedAt.replace("T", " ").slice(0, 16)}</time>
+            </p>
+          </div>
+          <div className="border-t border-(--card-stroke) bg-(--card-60) p-8 lg:border-l lg:border-t-0">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-(--ink-muted)">
+              Headline
+            </p>
+            {headline ? (
+              <>
+                <div className="mt-3 flex items-baseline gap-3">
+                  <p
+                    className="text-5xl font-semibold tabular-nums"
+                    data-testid="headline-score"
+                  >
+                    {fmtScore(headline.score)}
+                  </p>
+                  <SeverityChip severity={headline.severity} />
+                </div>
+                <p className="mt-2 text-sm text-(--ink-muted)">
+                  {headline.scopeLabel}
+                </p>
+              </>
+            ) : (
+              <p className="mt-3 text-sm text-(--ink-muted)">No data yet.</p>
+            )}
+            <TrendSparkline trend={trend} />
+          </div>
+        </div>
+      </section>
+
+      {headline && (
+        <section
+          className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
+          data-testid="component-breakdown"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Component breakdown
+            </h2>
+            <p className="text-xs text-(--ink-muted)">
+              thresholds: elevated ≥ {headline.thresholds.elevated.toFixed(2)} ·
+              high ≥ {headline.thresholds.high.toFixed(2)}
+            </p>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-(--ink-muted)">
+            Each bar shows the normalized [0, 1] contribution; the raw input
+            value is printed beneath. Weights persist with the row.
+          </p>
+          <div className="mt-5">
+            <ComponentBars row={headline} />
+          </div>
+        </section>
+      )}
+
+      <section>
+        <div className="mb-3 flex items-baseline justify-between">
+          <h2 className="text-lg font-semibold tracking-tight">
+            {breakout === "team" ? "By team" : "By repo"}
+          </h2>
+          <p className="text-xs text-(--ink-muted)">
+            sorted by score · {rows.length} {breakout}
+            {rows.length === 1 ? "" : "s"}
+          </p>
+        </div>
+        <ScopeTable rows={rows} breakout={breakout} />
+      </section>
+    </div>
+  );
+}

--- a/src/lib/graphql/__generated__/graphql.ts
+++ b/src/lib/graphql/__generated__/graphql.ts
@@ -470,6 +470,82 @@ export type CloneSavedReportInput = {
   sourceReportId: Scalars['String']['input'];
 };
 
+export type CompoundingRiskComponents = {
+  __typename?: 'CompoundingRiskComponents';
+  busFactor?: Maybe<Scalars['Float']['output']>;
+  churnNorm?: Maybe<Scalars['Float']['output']>;
+  complexityDelta?: Maybe<Scalars['Float']['output']>;
+  complexityNorm?: Maybe<Scalars['Float']['output']>;
+  ownershipGini?: Maybe<Scalars['Float']['output']>;
+  ownershipNorm?: Maybe<Scalars['Float']['output']>;
+  reviewLatencyP90h?: Maybe<Scalars['Float']['output']>;
+  reviewNorm?: Maybe<Scalars['Float']['output']>;
+  reworkChurn?: Maybe<Scalars['Float']['output']>;
+  singleOwnerRatio?: Maybe<Scalars['Float']['output']>;
+};
+
+export type CompoundingRiskFilterInput = {
+  breakout?: CompoundingRiskScope;
+  day?: InputMaybe<Scalars['Date']['input']>;
+  repoIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  teamIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  trendDays?: Scalars['Int']['input'];
+};
+
+export type CompoundingRiskPoint = {
+  __typename?: 'CompoundingRiskPoint';
+  components: CompoundingRiskComponents;
+  computedAt: Scalars['DateTime']['output'];
+  day: Scalars['Date']['output'];
+  scope: CompoundingRiskScope;
+  scopeId: Scalars['String']['output'];
+  scopeLabel: Scalars['String']['output'];
+  score?: Maybe<Scalars['Float']['output']>;
+  severity: CompoundingRiskSeverity;
+  thresholds: CompoundingRiskThresholds;
+  weights: CompoundingRiskWeights;
+};
+
+export type CompoundingRiskResult = {
+  __typename?: 'CompoundingRiskResult';
+  breakout: CompoundingRiskScope;
+  generatedAt: Scalars['DateTime']['output'];
+  orgId: Scalars['String']['output'];
+  rows: Array<CompoundingRiskPoint>;
+  trend: Array<CompoundingRiskTrendPoint>;
+};
+
+export type CompoundingRiskScope =
+  | 'REPO'
+  | 'TEAM';
+
+export type CompoundingRiskSeverity =
+  | 'ELEVATED'
+  | 'HIGH'
+  | 'LOW'
+  | 'UNKNOWN';
+
+export type CompoundingRiskThresholds = {
+  __typename?: 'CompoundingRiskThresholds';
+  elevated: Scalars['Float']['output'];
+  high: Scalars['Float']['output'];
+};
+
+export type CompoundingRiskTrendPoint = {
+  __typename?: 'CompoundingRiskTrendPoint';
+  day: Scalars['Date']['output'];
+  score?: Maybe<Scalars['Float']['output']>;
+  severity: CompoundingRiskSeverity;
+};
+
+export type CompoundingRiskWeights = {
+  __typename?: 'CompoundingRiskWeights';
+  churn: Scalars['Float']['output'];
+  complexity: Scalars['Float']['output'];
+  ownership: Scalars['Float']['output'];
+  review: Scalars['Float']['output'];
+};
+
 export type ConnectorFailure = {
   __typename?: 'ConnectorFailure';
   message: Scalars['String']['output'];
@@ -785,6 +861,8 @@ export type Query = {
   capacityForecasts: CapacityForecastConnection;
   /** Get catalog of available dimensions, measures, and limits */
   catalog: CatalogResult;
+  /** Compounding Risk composite: churn × complexity × ownership × review-latency. Inspectable score with persisted weights, thresholds, raw inputs, and normalized components. */
+  compoundingRisk: CompoundingRiskResult;
   /** Operator data-health and trust surface */
   dataHealth: DataHealth;
   /** Get home dashboard metrics */
@@ -898,6 +976,12 @@ export type QueryCapacityForecastsArgs = {
 export type QueryCatalogArgs = {
   dimension?: InputMaybe<DimensionInput>;
   filters?: InputMaybe<FilterInput>;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryCompoundingRiskArgs = {
+  filter?: InputMaybe<CompoundingRiskFilterInput>;
   orgId: Scalars['String']['input'];
 };
 

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -468,6 +468,82 @@ export type CloneSavedReportInput = {
   sourceReportId: Scalars['String']['input'];
 };
 
+export type CompoundingRiskComponents = {
+  __typename?: 'CompoundingRiskComponents';
+  busFactor?: Maybe<Scalars['Float']['output']>;
+  churnNorm?: Maybe<Scalars['Float']['output']>;
+  complexityDelta?: Maybe<Scalars['Float']['output']>;
+  complexityNorm?: Maybe<Scalars['Float']['output']>;
+  ownershipGini?: Maybe<Scalars['Float']['output']>;
+  ownershipNorm?: Maybe<Scalars['Float']['output']>;
+  reviewLatencyP90h?: Maybe<Scalars['Float']['output']>;
+  reviewNorm?: Maybe<Scalars['Float']['output']>;
+  reworkChurn?: Maybe<Scalars['Float']['output']>;
+  singleOwnerRatio?: Maybe<Scalars['Float']['output']>;
+};
+
+export type CompoundingRiskFilterInput = {
+  breakout?: CompoundingRiskScope;
+  day?: InputMaybe<Scalars['Date']['input']>;
+  repoIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  teamIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  trendDays?: Scalars['Int']['input'];
+};
+
+export type CompoundingRiskPoint = {
+  __typename?: 'CompoundingRiskPoint';
+  components: CompoundingRiskComponents;
+  computedAt: Scalars['DateTime']['output'];
+  day: Scalars['Date']['output'];
+  scope: CompoundingRiskScope;
+  scopeId: Scalars['String']['output'];
+  scopeLabel: Scalars['String']['output'];
+  score?: Maybe<Scalars['Float']['output']>;
+  severity: CompoundingRiskSeverity;
+  thresholds: CompoundingRiskThresholds;
+  weights: CompoundingRiskWeights;
+};
+
+export type CompoundingRiskResult = {
+  __typename?: 'CompoundingRiskResult';
+  breakout: CompoundingRiskScope;
+  generatedAt: Scalars['DateTime']['output'];
+  orgId: Scalars['String']['output'];
+  rows: Array<CompoundingRiskPoint>;
+  trend: Array<CompoundingRiskTrendPoint>;
+};
+
+export type CompoundingRiskScope =
+  | 'REPO'
+  | 'TEAM';
+
+export type CompoundingRiskSeverity =
+  | 'ELEVATED'
+  | 'HIGH'
+  | 'LOW'
+  | 'UNKNOWN';
+
+export type CompoundingRiskThresholds = {
+  __typename?: 'CompoundingRiskThresholds';
+  elevated: Scalars['Float']['output'];
+  high: Scalars['Float']['output'];
+};
+
+export type CompoundingRiskTrendPoint = {
+  __typename?: 'CompoundingRiskTrendPoint';
+  day: Scalars['Date']['output'];
+  score?: Maybe<Scalars['Float']['output']>;
+  severity: CompoundingRiskSeverity;
+};
+
+export type CompoundingRiskWeights = {
+  __typename?: 'CompoundingRiskWeights';
+  churn: Scalars['Float']['output'];
+  complexity: Scalars['Float']['output'];
+  ownership: Scalars['Float']['output'];
+  review: Scalars['Float']['output'];
+};
+
 export type ConnectorFailure = {
   __typename?: 'ConnectorFailure';
   message: Scalars['String']['output'];
@@ -783,6 +859,8 @@ export type Query = {
   capacityForecasts: CapacityForecastConnection;
   /** Get catalog of available dimensions, measures, and limits */
   catalog: CatalogResult;
+  /** Compounding Risk composite: churn × complexity × ownership × review-latency. Inspectable score with persisted weights, thresholds, raw inputs, and normalized components. */
+  compoundingRisk: CompoundingRiskResult;
   /** Operator data-health and trust surface */
   dataHealth: DataHealth;
   /** Get home dashboard metrics */
@@ -896,6 +974,12 @@ export type QueryCapacityForecastsArgs = {
 export type QueryCatalogArgs = {
   dimension?: InputMaybe<DimensionInput>;
   filters?: InputMaybe<FilterInput>;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryCompoundingRiskArgs = {
+  filter?: InputMaybe<CompoundingRiskFilterInput>;
   orgId: Scalars['String']['input'];
 };
 

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -105,6 +105,60 @@ query BusFactor($orgId: String!, $scope: BusFactorScopeInput = null) {
 }
 `;
 
+// Compounding Risk surface (CHAOS-1642)
+//
+// Reads from compounding_risk_daily (CHAOS-1641). Every field carries enough
+// audit data (weights, thresholds, raw inputs, normalized components) that the
+// UI can render the score's full provenance without a second roundtrip.
+export const COMPOUNDING_RISK_QUERY = `
+query CompoundingRisk(
+  $orgId: String!,
+  $filter: CompoundingRiskFilterInput = null
+) {
+  compoundingRisk(orgId: $orgId, filter: $filter) {
+    orgId
+    breakout
+    generatedAt
+    rows {
+      day
+      scope
+      scopeId
+      scopeLabel
+      score
+      severity
+      computedAt
+      components {
+        churnNorm
+        complexityNorm
+        ownershipNorm
+        reviewNorm
+        reworkChurn
+        complexityDelta
+        busFactor
+        ownershipGini
+        singleOwnerRatio
+        reviewLatencyP90h
+      }
+      weights {
+        churn
+        complexity
+        ownership
+        review
+      }
+      thresholds {
+        elevated
+        high
+      }
+    }
+    trend {
+      day
+      score
+      severity
+    }
+  }
+}
+`;
+
 // Combined query for investment view (breakdowns + sankey)
 export const INVESTMENT_FULL_QUERY = `
 query InvestmentFull($orgId: String!, $batch: AnalyticsRequestInput!) {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -415,6 +415,78 @@ input CloneSavedReportInput {
   parameterOverrides: JSON = null
 }
 
+type CompoundingRiskComponents {
+  churnNorm: Float
+  complexityNorm: Float
+  ownershipNorm: Float
+  reviewNorm: Float
+  reworkChurn: Float
+  complexityDelta: Float
+  busFactor: Float
+  ownershipGini: Float
+  singleOwnerRatio: Float
+  reviewLatencyP90h: Float
+}
+
+input CompoundingRiskFilterInput {
+  day: Date = null
+  breakout: CompoundingRiskScope! = REPO
+  repoIds: [String!] = null
+  teamIds: [String!] = null
+  trendDays: Int! = 30
+}
+
+type CompoundingRiskPoint {
+  day: Date!
+  scope: CompoundingRiskScope!
+  scopeId: String!
+  scopeLabel: String!
+  score: Float
+  severity: CompoundingRiskSeverity!
+  components: CompoundingRiskComponents!
+  weights: CompoundingRiskWeights!
+  thresholds: CompoundingRiskThresholds!
+  computedAt: DateTime!
+}
+
+type CompoundingRiskResult {
+  orgId: String!
+  breakout: CompoundingRiskScope!
+  rows: [CompoundingRiskPoint!]!
+  trend: [CompoundingRiskTrendPoint!]!
+  generatedAt: DateTime!
+}
+
+enum CompoundingRiskScope {
+  REPO
+  TEAM
+}
+
+enum CompoundingRiskSeverity {
+  UNKNOWN
+  LOW
+  ELEVATED
+  HIGH
+}
+
+type CompoundingRiskThresholds {
+  elevated: Float!
+  high: Float!
+}
+
+type CompoundingRiskTrendPoint {
+  day: Date!
+  score: Float
+  severity: CompoundingRiskSeverity!
+}
+
+type CompoundingRiskWeights {
+  churn: Float!
+  complexity: Float!
+  ownership: Float!
+  review: Float!
+}
+
 type ConnectorFailure {
   occurredAt: DateTime!
   message: String!
@@ -706,6 +778,11 @@ type Query {
 
   """Repository ownership concentration and bus-factor summary."""
   busFactor(orgId: String!, scope: BusFactorScopeInput = null): BusFactor!
+
+  """
+  Compounding Risk composite: churn × complexity × ownership × review-latency. Inspectable score with persisted weights, thresholds, raw inputs, and normalized components.
+  """
+  compoundingRisk(orgId: String!, filter: CompoundingRiskFilterInput = null): CompoundingRiskResult!
 
   """Latest rule-based recommendations for a team within a lookback window."""
   recommendations(orgId: String!, team: ID!, window: WindowInput!): [Recommendation!]!

--- a/tests/compounding-risk.spec.ts
+++ b/tests/compounding-risk.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@playwright/test";
+
+import { encodeFilter } from "../src/lib/filters/encode";
+import type { MetricFilter } from "../src/lib/filters/types";
+
+/**
+ * CHAOS-1642: Compounding Risk surface e2e.
+ *
+ * Drives the page against the MSW handler (sample mode). Verifies:
+ *
+ * - Authenticated page renders with the canonical heading and dashboard.
+ * - Headline score, severity chip, component bars, audit-trail copy, and
+ *   the per-scope table are all populated from the GraphQL row.
+ * - Work Graph drilldown links carry the scope + id query params.
+ * - Person/developer scope triggers the guardrail banner instead of a
+ *   developer breakdown (no-surveillance contract).
+ */
+
+const teamFilter: MetricFilter = {
+  scope: { level: "team", ids: ["team-platform"] },
+  who: null,
+  what: null,
+  why: null,
+  how: null,
+  dateRange: { startDate: "2026-04-20", endDate: "2026-05-20" },
+};
+const developerFilter: MetricFilter = {
+  ...teamFilter,
+  scope: { level: "developer", ids: ["user-x"] },
+};
+
+test.describe("Compounding Risk surface", () => {
+  test("populated repo view renders score, severity, components, and drilldown", async ({
+    page,
+  }) => {
+    await page.goto(`/risk/compounding?f=${encodeFilter(teamFilter)}`);
+
+    await expect(
+      page.getByRole("heading", {
+        name: "Where change pressure is compounding risk.",
+      }),
+    ).toBeVisible();
+    const dashboard = page.getByTestId("compounding-risk-dashboard");
+    await expect(dashboard).toBeVisible();
+
+    // Headline reflects the persisted score, not 0 or 1.
+    await expect(page.getByTestId("headline-score")).toHaveText("0.71");
+    const chips = page.getByTestId("severity-chip");
+    await expect(chips.first()).toHaveAttribute("data-severity", "high");
+
+    // Component bars present for all four contributions.
+    await expect(page.getByTestId("component-churn")).toBeVisible();
+    await expect(page.getByTestId("component-complexity")).toBeVisible();
+    await expect(page.getByTestId("component-ownership")).toBeVisible();
+    await expect(page.getByTestId("component-review-latency")).toBeVisible();
+
+    // Audit-trail copy surfaces the persisted thresholds.
+    await expect(page.getByText(/elevated ≥ 0\.40/i)).toBeVisible();
+    await expect(page.getByText(/high ≥ 0\.65/i)).toBeVisible();
+
+    // Table renders one row per repo, sorted by score desc.
+    const rows = page.getByTestId("risk-row");
+    await expect(rows).toHaveCount(3);
+    await expect(rows.first()).toHaveAttribute("data-scope-id", "repo-a");
+    await expect(rows.first()).toHaveAttribute("data-severity", "high");
+
+    // Drilldown link encodes the scope.
+    const drilldown = page.getByTestId("open-in-work-graph").first();
+    await expect(drilldown).toHaveAttribute(
+      "href",
+      /risk_scope_kind=repo.*risk_scope_id=repo-a/,
+    );
+  });
+
+  test("person scope is blocked with the no-surveillance guardrail", async ({
+    page,
+  }) => {
+    await page.goto(`/risk/compounding?f=${encodeFilter(developerFilter)}`);
+
+    await expect(
+      page.getByTestId("developer-scope-guardrail"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: "Compounding Risk is a team and repo signal.",
+      }),
+    ).toBeVisible();
+    // Dashboard must NOT render for developer scope.
+    await expect(page.getByTestId("compounding-risk-dashboard")).toHaveCount(0);
+  });
+});

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -547,6 +547,96 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
     });
   }
 
+  // Compounding Risk (CHAOS-1642).
+  if (query.includes("compoundingRisk") || query.includes("CompoundingRisk")) {
+    const orgId = vars.orgId ?? "org-e2e";
+    const breakout = (variables as { filter?: { breakout?: string } }).filter?.breakout ?? "REPO";
+    const weights = { churn: 0.3, complexity: 0.3, ownership: 0.2, review: 0.2 };
+    const thresholds = { elevated: 0.4, high: 0.65 };
+    const baseComponents = {
+      churnNorm: 0.78,
+      complexityNorm: 0.62,
+      ownershipNorm: 0.55,
+      reviewNorm: 0.48,
+      reworkChurn: 0.21,
+      complexityDelta: 0.13,
+      busFactor: 3,
+      ownershipGini: 0.58,
+      singleOwnerRatio: 0.55,
+      reviewLatencyP90h: 38,
+    };
+    const repoRows = [
+      {
+        day: "2026-05-20",
+        scope: "REPO",
+        scopeId: "repo-a",
+        scopeLabel: "acme/backend",
+        score: 0.71,
+        severity: "HIGH",
+        components: baseComponents,
+        weights,
+        thresholds,
+        computedAt: "2026-05-21T12:00:00Z",
+      },
+      {
+        day: "2026-05-20",
+        scope: "REPO",
+        scopeId: "repo-b",
+        scopeLabel: "acme/frontend",
+        score: 0.42,
+        severity: "ELEVATED",
+        components: { ...baseComponents, churnNorm: 0.4, complexityNorm: 0.4, ownershipNorm: 0.4, reviewNorm: 0.45 },
+        weights,
+        thresholds,
+        computedAt: "2026-05-21T12:00:00Z",
+      },
+      {
+        day: "2026-05-20",
+        scope: "REPO",
+        scopeId: "repo-c",
+        scopeLabel: "acme/infra",
+        score: 0.25,
+        severity: "LOW",
+        components: { ...baseComponents, churnNorm: 0.2, complexityNorm: 0.2, ownershipNorm: 0.3, reviewNorm: 0.25 },
+        weights,
+        thresholds,
+        computedAt: "2026-05-21T12:00:00Z",
+      },
+    ];
+    const teamRows = [
+      {
+        day: "2026-05-20",
+        scope: "TEAM",
+        scopeId: "team-platform",
+        scopeLabel: "Platform",
+        score: 0.56,
+        severity: "ELEVATED",
+        components: baseComponents,
+        weights,
+        thresholds,
+        computedAt: "2026-05-21T12:00:00Z",
+      },
+    ];
+    return HttpResponse.json({
+      data: {
+        compoundingRisk: {
+          orgId,
+          breakout,
+          rows: breakout === "TEAM" ? teamRows : repoRows,
+          trend: [
+            { day: "2026-05-15", score: 0.62, severity: "ELEVATED" },
+            { day: "2026-05-16", score: 0.66, severity: "HIGH" },
+            { day: "2026-05-17", score: 0.68, severity: "HIGH" },
+            { day: "2026-05-18", score: 0.70, severity: "HIGH" },
+            { day: "2026-05-19", score: 0.70, severity: "HIGH" },
+            { day: "2026-05-20", score: 0.71, severity: "HIGH" },
+          ],
+          generatedAt: "2026-05-21T12:00:00Z",
+        },
+      },
+    });
+  }
+
   // ---- AI Workflow Intelligence (CHAOS-1588) ----
   const orgId = vars.orgId ?? "org-e2e";
   const startDate = vars.dateRange?.startDate ?? "2026-04-20";


### PR DESCRIPTION
Adds the Compounding Risk surface backed by the new GraphQL query
shipped with the ops PR. Renders a banner with the headline score +
severity chip + 30-day trend sparkline, a component breakdown with
each normalized contribution + raw value, and a sortable per-scope
table with Work Graph drilldown links.

Per the no-surveillance contract, the page locks out person/developer
scope: if the inbound filter resolves to a developer scope, the page
renders a guardrail banner instead of a per-person breakdown.

What's included
---------------
- src/app/(app)/risk/compounding/page.tsx — RSC route, requires
  session, fetches via graphqlFetch, renders the dashboard or the
  developer-scope guardrail
- src/components/risk/CompoundingRiskDashboard.tsx — banner, trend
  sparkline, four-component breakdown, sortable table, drilldown link
- src/lib/graphql/queries.ts — COMPOUNDING_RISK_QUERY
- src/lib/graphql/schema.graphql — SDL synced from dev-health-ops
- src/components/navigation/PrimaryNav.tsx — "Compounding Risk" entry
  under Investigate
- tests/mocks/handlers.ts — MSW dispatcher returns populated repo and
  team rows + trend
- tests/compounding-risk.spec.ts — Playwright e2e: populated repo
  rendering with score/severity/components/audit-trail/drilldown URL,
  plus the developer-scope guardrail
- src/components/risk/CompoundingRiskDashboard.test.tsx — 8 Vitest
  component tests covering score, severity, all four bars, threshold
  audit trail, drilldown for repo + team breakouts, empty state,
  trend sparkline, and null-score "—" rendering

SCREENSHOT-WAIVER: dev server + seeded compounding_risk_daily rows
are required to capture the surface end-to-end; the matching MSW
handler now ships in this PR and the Playwright spec uses it. Once
this lands and a live ops build is wired in, follow-up will attach
screenshots to the Linear issue.

Closes CHAOS-1642
Refs CHAOS-1640
