### PR TITLE
fix(nav): remove duplicate Cognitive Load entry (CHAOS-1747)

### DIFF
--- a/src/components/navigation/PrimaryNav.test.tsx
+++ b/src/components/navigation/PrimaryNav.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/utils";
+import { PrimaryNav } from "./PrimaryNav";
+import type { MetricFilter } from "@/lib/filters/types";
+
+// Stub usePathname so PrimaryNav (a client component) renders deterministically
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard",
+}));
+
+function makeFilter(): MetricFilter {
+  return {
+    scope: { level: "repo", ids: ["my-repo"] },
+    time: {
+      range_days: 30,
+      compare_days: 0,
+      start_date: undefined,
+      end_date: undefined,
+    },
+    who: {},
+    what: {},
+    why: {},
+    how: {},
+  };
+}
+
+describe("PrimaryNav — section composition", () => {
+  it("renders the 'Cognitive Load' nav item exactly once (regression: CHAOS-1747)", () => {
+    render(<PrimaryNav filters={makeFilter()} active="dashboard" />);
+
+    // CHAOS-1747: the entry was duplicated under both Observe and Investigate.
+    // Cognitive Load is a wellbeing/focus surface and belongs only under Observe.
+    const cognitiveLoadLinks = screen.getAllByRole("link", {
+      name: /cognitive load/i,
+    });
+    expect(cognitiveLoadLinks).toHaveLength(1);
+    expect(cognitiveLoadLinks[0]).toHaveAttribute(
+      "href",
+      expect.stringContaining("/cognitive-load")
+    );
+  });
+
+  it("preserves canonical section ordering: Cockpit, Observe, Investigate, TestOps", () => {
+    render(<PrimaryNav filters={makeFilter()} active="dashboard" />);
+
+    const sectionHeadings = screen
+      .getAllByRole("button")
+      .map((b) => b.textContent ?? "")
+      .filter((t) => /cockpit|observe|investigate|testops/i.test(t));
+
+    // Quick sanity that the four primary sections exist and are ordered correctly.
+    // Loose match — exact heading text may include counts/icons.
+    const indexOf = (label: string) =>
+      sectionHeadings.findIndex((h) => new RegExp(label, "i").test(h));
+
+    const cockpitIdx = indexOf("cockpit");
+    const observeIdx = indexOf("observe");
+    const investigateIdx = indexOf("investigate");
+    const testopsIdx = indexOf("testops");
+
+    expect(cockpitIdx).toBeGreaterThanOrEqual(0);
+    expect(observeIdx).toBeGreaterThan(cockpitIdx);
+    expect(investigateIdx).toBeGreaterThan(observeIdx);
+    expect(testopsIdx).toBeGreaterThan(investigateIdx);
+  });
+});

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -79,7 +79,6 @@ const navGroups: NavGroup[] = [
       { id: "code", label: "Code", href: "/code", description: "Ownership" },
       { id: "risk-compounding", label: "Compounding Risk", href: "/risk/compounding", description: "Composite" },
       { id: "opportunities", label: "Opportunities", href: "/opportunities", description: "Threads" },
-      { id: "cognitive-load", label: "Cognitive Load", href: "/cognitive-load", description: "Focus" },
       { id: "security", label: "Security", href: "/security", description: "Alerts" },
     ],
   },


### PR DESCRIPTION
## Bug

`PrimaryNav.tsx` defined the `Cognitive Load` nav item twice — once under **Observe** (correct, group is wellbeing/focus) and once under **Investigate** (duplicate, same href). The sidebar showed two highlighted `Cognitive Load FOCUS` entries simultaneously.

## Fix

Delete the duplicate entry under the `investigate` section. Cognitive Load is a wellbeing/focus surface and belongs only under **Observe**.

```diff
-      { id: "cognitive-load", label: "Cognitive Load", href: "/cognitive-load", description: "Focus" },
```

## Regression test

Added `src/components/navigation/PrimaryNav.test.tsx`:

- Asserts `getAllByRole("link", { name: /cognitive load/i })` returns exactly **1** link
- Asserts canonical section ordering (Cockpit → Observe → Investigate → TestOps)

## Verification

- `pnpm run typecheck` — clean
- `pnpm run test:unit` — 1046 tests passing (including the new regression cases)

## Linear

Closes CHAOS-1747

SCREENSHOT-WAIVER: Authenticated cockpit nav requires login flow; regression test covers the rendered output deterministically. The "before" state is documented in the linked Linear issue, captured from a screenshot the user provided during review of CHAOS-1647.
