### PR TITLE
feat(web): add active organization picker (CHAOS-1753)

### DIFF
--- a/src/app/api/auth/organizations/route.ts
+++ b/src/app/api/auth/organizations/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { getBackendUrl } from "@/lib/origin";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const response = await fetch(`${getBackendUrl()}/api/v1/auth/me/organizations`, {
+    headers: {
+      Authorization: `Bearer ${session.access_token}`,
+    },
+    cache: "no-store",
+  });
+
+  const data = await response.json().catch(() => ({ error: "Organization lookup failed" }));
+  return NextResponse.json(data, { status: response.status });
+}

--- a/src/app/api/auth/switch-org/route.ts
+++ b/src/app/api/auth/switch-org/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { getBackendUrl } from "@/lib/origin";
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  let payload: { org_id?: unknown } | null = null;
+  try {
+    payload = (await request.json()) as { org_id?: unknown };
+  } catch {
+    payload = null;
+  }
+  if (!payload || typeof payload.org_id !== "string" || !payload.org_id) {
+    return NextResponse.json({ error: "Organization ID is required" }, { status: 400 });
+  }
+
+  const response = await fetch(`${getBackendUrl()}/api/v1/auth/switch-org`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.access_token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ org_id: payload.org_id }),
+  });
+
+  const data = await response.json().catch(() => ({ error: "Organization switch failed" }));
+  return NextResponse.json(data, { status: response.status });
+}

--- a/src/components/navigation/OrgSwitcher.test.tsx
+++ b/src/components/navigation/OrgSwitcher.test.tsx
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { render } from "@/test/utils";
+import { OrgSwitcher } from "./OrgSwitcher";
+
+const mockRefresh = vi.fn();
+const mockUpdate = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: { user: { org_id: "org-empty" } },
+    update: mockUpdate,
+  }),
+}));
+
+describe("OrgSwitcher", () => {
+  beforeEach(() => {
+    mockRefresh.mockReset();
+    mockUpdate.mockReset();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/auth/organizations") {
+          return Response.json({
+            active_org_id: "org-empty",
+            organizations: [
+              {
+                id: "org-empty",
+                slug: "empty",
+                name: "Empty Org",
+                tier: "community",
+                role: "member",
+                has_data: false,
+                last_metrics_at: null,
+              },
+              {
+                id: "org-data",
+                slug: "data",
+                name: "Data Org",
+                tier: "team",
+                role: "admin",
+                has_data: true,
+                last_metrics_at: "2026-05-02T00:00:00Z",
+              },
+            ],
+          });
+        }
+        return Response.json({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 3600,
+          user: {
+            org_id: "org-data",
+            role: "admin",
+            is_superuser: false,
+          },
+        });
+      })
+    );
+  });
+
+  it("shows data state and updates the session when switching organizations", async () => {
+    render(<OrgSwitcher />);
+
+    const select = await screen.findByLabelText(/organization/i);
+    expect(screen.getByText(/no data yet/i)).toBeInTheDocument();
+
+    fireEvent.change(select, { target: { value: "org-data" } });
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ activeOrg: expect.any(Object) })));
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});

--- a/src/components/navigation/OrgSwitcher.tsx
+++ b/src/components/navigation/OrgSwitcher.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { useEffect, useMemo, useState, useTransition } from "react";
+
+type OrganizationOption = {
+  id: string;
+  slug: string;
+  name: string;
+  tier?: string | null;
+  role: string;
+  joined_at?: string | null;
+  has_data: boolean;
+  last_metrics_at?: string | null;
+};
+
+type OrganizationsResponse = {
+  active_org_id?: string | null;
+  organizations: OrganizationOption[];
+};
+
+type SwitchOrgResponse = {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  user: {
+    org_id?: string | null;
+    role?: string;
+    is_superuser?: boolean;
+  };
+};
+
+function dataLabel(org: OrganizationOption) {
+  if (!org.has_data) return "No data yet";
+  if (!org.last_metrics_at) return "Has data";
+  return `Data through ${new Date(org.last_metrics_at).toLocaleDateString()}`;
+}
+
+export function OrgSwitcher() {
+  const router = useRouter();
+  const { data: session, update } = useSession();
+  const [state, setState] = useState<OrganizationsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    let ignore = false;
+    async function loadOrganizations() {
+      try {
+        const response = await fetch("/api/auth/organizations", { cache: "no-store" });
+        if (!response.ok) return;
+        const data = (await response.json()) as OrganizationsResponse;
+        if (!ignore) setState(data);
+      } catch {
+        if (!ignore) setError("Could not load organizations");
+      }
+    }
+    loadOrganizations();
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  const activeOrgId = state?.active_org_id ?? session?.user?.org_id ?? "";
+  const activeOrg = useMemo(
+    () => state?.organizations.find((org) => org.id === activeOrgId),
+    [activeOrgId, state?.organizations]
+  );
+
+  if (!state || state.organizations.length <= 1) {
+    return null;
+  }
+
+  async function switchOrg(orgId: string) {
+    if (!orgId || orgId === activeOrgId || isPending) return;
+    setError(null);
+    startTransition(async () => {
+      const response = await fetch("/api/auth/switch-org", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ org_id: orgId }),
+      });
+      if (!response.ok) {
+        setError("Could not switch organization");
+        return;
+      }
+      const data = (await response.json()) as SwitchOrgResponse;
+      await update({ activeOrg: data });
+      setState((current) => current ? { ...current, active_org_id: data.user.org_id ?? orgId } : current);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="mt-4 rounded-2xl border border-(--card-stroke) bg-(--card-70) p-3">
+      <label htmlFor="org-switcher" className="text-[10px] uppercase tracking-widest text-(--ink-muted)">
+        Organization
+      </label>
+      <select
+        id="org-switcher"
+        value={activeOrgId}
+        disabled={isPending}
+        onChange={(event) => switchOrg(event.target.value)}
+        className="mt-2 w-full rounded-xl border border-(--card-stroke) bg-(--background) px-3 py-2 text-sm text-foreground outline-none transition focus:border-(--accent) disabled:opacity-60"
+        aria-describedby="org-switcher-data"
+      >
+        {state.organizations.map((org) => (
+          <option key={org.id} value={org.id}>
+            {org.name} {org.has_data ? "• data" : "• empty"}
+          </option>
+        ))}
+      </select>
+      <p id="org-switcher-data" className="mt-2 text-[11px] text-(--ink-muted)">
+        {activeOrg ? dataLabel(activeOrg) : "Choose the organization used for dashboards."}
+      </p>
+      {error ? <p className="mt-2 text-[11px] text-red-400">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/components/navigation/PrimaryNav.test.tsx
+++ b/src/components/navigation/PrimaryNav.test.tsx
@@ -1,11 +1,20 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@/test/utils";
+import { screen } from "@testing-library/react";
+import { render } from "@/test/utils";
 import { PrimaryNav } from "./PrimaryNav";
 import type { MetricFilter } from "@/lib/filters/types";
 
 // Stub usePathname so PrimaryNav (a client component) renders deterministically
 vi.mock("next/navigation", () => ({
   usePathname: () => "/dashboard",
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: { user: { org_id: "org-1" } },
+    update: vi.fn(),
+  }),
 }));
 
 function makeFilter(): MetricFilter {

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { BetaBadge } from "@/components/BetaBadge";
+import { OrgSwitcher } from "@/components/navigation/OrgSwitcher";
 
 import { withFilterParam } from "@/lib/filters/url";
 import type { MetricFilter } from "@/lib/filters/types";
@@ -168,6 +169,8 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
               Observe patterns, drill into evidence.
             </p>
           </div>
+
+          <OrgSwitcher />
 
           <nav className="mt-4 space-y-4 text-sm">
             {navGroups.map((group) => (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -183,6 +183,18 @@ const nextAuth = NextAuth({
         token.expires_at = Date.now() + (session.onboardComplete.expires_in || 3600) * 1000
       }
 
+      if (trigger === "update" && session?.activeOrg) {
+        token.access_token = session.activeOrg.access_token
+        token.refresh_token = session.activeOrg.refresh_token
+        token.org_id = session.activeOrg.user.org_id
+        token.role = session.activeOrg.user.role
+        token.is_superuser = session.activeOrg.user.is_superuser ?? false
+        token.needs_onboarding = false
+        token.expires_at = Date.now() + (session.activeOrg.expires_in || 3600) * 1000
+        token.last_validated = Date.now()
+        token.error = undefined
+      }
+
       // For superusers: sync impersonation state from backend at most every 30s.
       // This ensures router.refresh() picks up the current impersonation state
       // without hammering the backend on every JWT callback.


### PR DESCRIPTION
## Summary
- add authenticated proxy routes for organization list and active-org switching
- add a PrimaryNav organization picker with data/no-data indicators
- persist backend-issued active-org tokens into the NextAuth session

## Verification
- pnpm exec vitest run src/components/navigation/OrgSwitcher.test.tsx src/components/navigation/PrimaryNav.test.tsx
- ./node_modules/.bin/tsc --noEmit
- pnpm exec eslint src/lib/auth.ts src/app/api/auth/organizations/route.ts src/app/api/auth/switch-org/route.ts src/components/navigation/OrgSwitcher.tsx src/components/navigation/PrimaryNav.tsx src/components/navigation/OrgSwitcher.test.tsx src/components/navigation/PrimaryNav.test.tsx
- pnpm build

Closes CHAOS-1753
SCREENSHOT-WAIVER: auth-gated multi-organization picker requires a live multi-org session fixture; behavior is covered by component tests and backend API tests.