### PR TITLE
feat(operating-review): wire All Teams aggregate (CHAOS-1755)

### DIFF
--- a/src/app/(app)/operating-review/page.tsx
+++ b/src/app/(app)/operating-review/page.tsx
@@ -9,9 +9,7 @@ import { auth } from "@/lib/auth";
 import { fetchOrNull } from "@/lib/fetchOrNull";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
-import { CATALOG_VALUES_QUERY } from "@/lib/graphql/queries";
 import { getOperatingReviewViaGraphQL } from "@/lib/graphql/operatingReviewFetchers";
-import { graphqlFetch } from "@/lib/graphql/urqlClient";
 import type { OperatingReview, OperatingReviewMetric } from "@/lib/graphql/types";
 
 
@@ -51,38 +49,23 @@ export default async function OperatingReviewPage({ searchParams }: OperatingRev
   // downstream review fetch.
   const orgId = session?.user?.org_id ?? undefined;
 
-  // Auto-select the first synced team when the URL doesn't specify one so
-  // the page lands on a real review rather than an empty hint. Tracked for
-  // a proper cross-team aggregate in CHAOS-1755.
-  const requestedTeamId = teamId;
-  let availableTeams: string[] = [];
-  let effectiveTeamId = requestedTeamId;
-  if (orgId && !requestedTeamId) {
-    const teamsResult = await fetchOrNull(
-      graphqlFetch<{ catalog: { values: { value: string; count: number }[] } }>(
-        CATALOG_VALUES_QUERY,
-        { orgId, dimension: "TEAM" },
-        { orgId }
-      ),
-      "catalog/teams"
-    );
-    availableTeams = teamsResult?.catalog?.values?.map((v) => v.value) ?? [];
-    effectiveTeamId = availableTeams[0];
-  }
+  // CHAOS-1755: when no team is selected, request the cross-team aggregate
+  // ("All Teams" mode) from the backend by passing teamId: null. The
+  // resolver returns an aggregate payload with documented per-metric
+  // aggregation rules (see ops docs/api/operating-review.md); the response
+  // surfaces teamId: null so we render an explicit "All Teams" badge rather
+  // than pretending a single team was chosen.
+  const review = orgId
+    ? await fetchOrNull(
+        getOperatingReviewViaGraphQL(orgId, {
+          teamId: teamId ?? null,
+          weekStart,
+        }),
+        "operating-review/data"
+      )
+    : null;
 
-  const review =
-    orgId && effectiveTeamId
-      ? await fetchOrNull(
-          getOperatingReviewViaGraphQL(orgId, {
-            teamId: effectiveTeamId,
-            weekStart,
-          }),
-          "operating-review/data"
-        )
-      : null;
-
-  const usingDefaultTeam = !requestedTeamId && Boolean(effectiveTeamId);
-  const noTeamsSynced = !requestedTeamId && availableTeams.length === 0;
+  const isAllTeams = !teamId;
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -117,9 +100,8 @@ export default async function OperatingReviewPage({ searchParams }: OperatingRev
 
           <ContextStrip filters={filters} origin={activeOrigin} />
 
-          {usingDefaultTeam ? <DefaultTeamBanner teamId={effectiveTeamId!} /> : null}
-          {noTeamsSynced ? <NoTeamsHint /> : null}
-          {effectiveTeamId && !review ? <EmptyReviewState teamId={effectiveTeamId} weekStart={weekStart} /> : null}
+          {isAllTeams ? <AllTeamsBadge /> : null}
+          {!review ? <EmptyReviewState teamId={teamId} weekStart={weekStart} /> : null}
           {review ? <OperatingReviewAgenda review={review} /> : null}
         </main>
       </div>
@@ -127,22 +109,13 @@ export default async function OperatingReviewPage({ searchParams }: OperatingRev
   );
 }
 
-function DefaultTeamBanner({ teamId }: { teamId: string }) {
+function AllTeamsBadge() {
   return (
     <section className="rounded-2xl border border-(--card-stroke) bg-(--card-80) px-5 py-3 text-xs text-(--ink-muted)">
-      Showing <span className="font-medium text-foreground">{teamId}</span> by default. Use the{" "}
-      <span className="font-medium text-foreground">Team</span> filter above to switch teams.
-    </section>
-  );
-}
-
-function NoTeamsHint() {
-  return (
-    <section className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-8 text-sm text-(--ink-muted)">
-      <h2 className="text-lg font-semibold text-foreground">No teams synced yet</h2>
-      <p className="mt-2">
-        Connect a provider in <Link href="/data-health" className="font-medium text-foreground underline underline-offset-4">data connections</Link> to start syncing teams.
-      </p>
+      Showing the cross-team aggregate{" "}
+      <span className="font-medium text-foreground">(All Teams)</span>. Pick a team from
+      the <span className="font-medium text-foreground">Team</span> filter above to scope
+      to one.
     </section>
   );
 }
@@ -270,12 +243,23 @@ function CalloutColumn({ title, tone, items }: { title: string; tone: "improved"
   );
 }
 
-function EmptyReviewState({ teamId, weekStart }: { teamId: string; weekStart: string }) {
+function EmptyReviewState({
+  teamId,
+  weekStart,
+}: {
+  teamId: string | undefined;
+  weekStart: string;
+}) {
+  const scopeLabel = teamId ? (
+    <>team <span className="font-medium text-foreground">{teamId}</span></>
+  ) : (
+    <>the cross-team aggregate <span className="font-medium text-foreground">(All Teams)</span></>
+  );
   return (
     <section className="rounded-[1.75rem] border border-dashed border-border bg-card/70 p-8">
       <h2 className="text-lg font-semibold">No operating review data yet</h2>
       <p className="mt-2 text-sm text-muted-foreground">
-        The surface is ready for team <span className="font-medium text-foreground">{teamId}</span> for week {weekStart}, but no backend payload was returned.
+        The surface is ready for {scopeLabel} for week {weekStart}, but no backend payload was returned.
       </p>
       <Link className="mt-4 inline-flex text-sm font-medium text-primary" href="/settings">
         Check data connections

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -781,7 +781,7 @@ export type OperatingReview = {
   recommendations: Array<Scalars['String']['output']>;
   recommendationsEmptyState: Scalars['String']['output'];
   sections: Array<OperatingReviewSection>;
-  teamId: Scalars['String']['output'];
+  teamId?: Maybe<Scalars['String']['output']>;
   weekStart: Scalars['Date']['output'];
 };
 
@@ -795,7 +795,7 @@ export type OperatingReviewDelta = {
 };
 
 export type OperatingReviewInput = {
-  teamId: Scalars['String']['input'];
+  teamId?: InputMaybe<Scalars['String']['input']>;
   weekStart: Scalars['Date']['input'];
 };
 

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -705,7 +705,7 @@ type OperatingReviewDelta {
 }
 
 input OperatingReviewInput {
-  teamId: String
+  teamId: String = null
   weekStart: Date!
 }
 

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -688,7 +688,7 @@ type Mutation {
 
 type OperatingReview {
   orgId: String!
-  teamId: String!
+  teamId: String
   weekStart: Date!
   priorWeekStart: Date!
   sections: [OperatingReviewSection!]!
@@ -705,7 +705,7 @@ type OperatingReviewDelta {
 }
 
 input OperatingReviewInput {
-  teamId: String!
+  teamId: String
   weekStart: Date!
 }
 

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -395,7 +395,7 @@ export interface ThroughputForecastQueryResponse {
 // ==== Operating Review Types ====
 
 export interface OperatingReviewInput {
-    teamId: string;
+    teamId: string | null;
     weekStart: string;
 }
 
@@ -428,7 +428,7 @@ export interface OperatingReviewSection {
 
 export interface OperatingReview {
     orgId: string;
-    teamId: string;
+    teamId: string | null;
     weekStart: string;
     priorWeekStart: string;
     sections: OperatingReviewSection[];

--- a/tests/operating-review.spec.ts
+++ b/tests/operating-review.spec.ts
@@ -1,34 +1,41 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Operating Review", () => {
-  test("renders page header and auto-selects first synced team", async ({ page }) => {
+  test("renders page header and the All Teams aggregate when no team is pinned", async ({
+    page,
+  }) => {
     await page.goto("/operating-review");
 
-    // The standard page chrome is always present (matches /investment, /quality).
+    // Standard page chrome shared with /investment, /quality.
     await expect(
       page.getByRole("heading", { name: "Engineering Operating Review" })
     ).toBeVisible();
 
-    // The page reaches one of three terminal states:
-    //   (a) auto-default banner — the org has teams and the URL did not pin one;
-    //   (b) no-teams hint — the org has zero synced teams;
-    //   (c) operating-review agenda — the URL pinned a team OR the auto-default
-    //       picked one and a review payload exists.
-    const defaultBanner = page.getByText(/Showing .* by default\. Use the/);
-    const noTeamsHint = page.getByRole("heading", { name: "No teams synced yet" });
-    const agenda = page.getByRole("heading", { name: "Recommendations" });
+    // CHAOS-1755: no team in the URL means we request the cross-team
+    // aggregate from the backend. The "All Teams" badge is the explicit
+    // signal that the rendered payload is org-wide, not single-team.
+    await expect(page.getByText(/Showing the cross-team aggregate/)).toBeVisible();
 
-    await expect(defaultBanner.or(noTeamsHint).or(agenda)).toBeVisible();
+    // The body lands on either the agenda (when the backend returns data)
+    // or the empty-state (when the mock returns nothing). Both are valid
+    // terminal states for the aggregate path.
+    const agenda = page.getByRole("heading", { name: "Recommendations" });
+    const emptyState = page.getByRole("heading", {
+      name: "No operating review data yet",
+    });
+    await expect(agenda.or(emptyState)).toBeVisible();
   });
 
-  test("pinned team in URL skips the auto-default banner", async ({ page }) => {
-    // When ?team=X is present the page renders that team directly and does not
-    // surface the "Showing <team> by default" banner — the user is in control.
+  test("pinned team in URL switches off the All Teams aggregate", async ({
+    page,
+  }) => {
+    // When ?team=X is present the page renders that single team and the
+    // All Teams badge is NOT shown — the user is explicitly in control.
     await page.goto("/operating-review?team=team-platform&week=2026-05-18");
 
     await expect(
       page.getByRole("heading", { name: "Engineering Operating Review" })
     ).toBeVisible();
-    await expect(page.getByText(/Showing .* by default/)).toHaveCount(0);
+    await expect(page.getByText(/Showing the cross-team aggregate/)).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

Frontend half of CHAOS-1755. The backend ([full-chaos/dev-health-ops#766](https://github.com/full-chaos/dev-health-ops/pull/766), merged) made `OperatingReviewInput.teamId` and `OperatingReview.teamId` optional and added a cross-team aggregate path with documented per-metric aggregation rules ([ops docs/api/operating-review.md](https://github.com/full-chaos/dev-health-ops/blob/main/docs/api/operating-review.md)).

This PR drops the CHAOS-1751 auto-select fallback — the page now honestly requests the aggregate from the backend when no team is selected, and surfaces an explicit "All Teams" badge so the user knows what they're seeing.

## Behavior

| URL state | Backend call | Rendered |
|---|---|---|
| `/operating-review` (no team) | `operatingReview(orgId, input: { teamId: null, weekStart })` | Page header + FilterBar + ContextStrip + **"Showing the cross-team aggregate (All Teams)" badge** + (agenda or empty-state) |
| `/operating-review?team=team-3` | `operatingReview(orgId, input: { teamId: "team-3", weekStart })` | Same chrome, no aggregate badge, single-team payload |

The agenda body is unchanged in both modes — the backend handles aggregation per the contract doc.

## Changes

- **`src/lib/graphql/schema.graphql`**
  - `OperatingReviewInput.teamId: String!` → `String` (nullable).
  - `OperatingReview.teamId: String!` → `String` (nullable).

  These match the ops/main schema; the live-e2e schema-drift check will pass.

- **`src/lib/graphql/types.ts`**
  - `OperatingReviewInput.teamId: string` → `string | null`.
  - `OperatingReview.teamId: string` → `string | null`.

- **`src/app/(app)/operating-review/page.tsx`**
  - Drops the `CATALOG_VALUES_QUERY` + `graphqlFetch` imports and the CHAOS-1751 auto-default fallback (no more catalog roundtrip just to discover a default team).
  - Single `getOperatingReviewViaGraphQL(orgId, { teamId: teamId ?? null, weekStart })` call.
  - New `AllTeamsBadge` replaces the old `DefaultTeamBanner` and `NoTeamsHint`. Text:
    > Showing the cross-team aggregate **(All Teams)**. Pick a team from the **Team** filter above to scope to one.
  - `EmptyReviewState` adapts its copy: "the cross-team aggregate (All Teams)" vs. "team &lt;X&gt;" depending on mode.

- **`tests/operating-review.spec.ts`**
  - Test 1: no team in URL → page header + "Showing the cross-team aggregate" badge + (agenda OR empty-state) visible.
  - Test 2: `?team=team-platform` in URL → no aggregate badge (single-team mode).

## Verification

```
$ npx tsc --noEmit
(clean — no errors)

$ npx vitest run src/lib
578 tests passed (53 files)
```

The badge is a text-only swap inside the same `<section>` element used by the previous default-team banner (same border, padding, typography tokens). Live screenshot was blocked by an expired NextAuth session in my browser context — pre-existing session token won't refresh and the dev passwords aren't on hand. The visible change is:

```diff
-Showing <team-1> by default. Use the Team filter above to switch teams.
+Showing the cross-team aggregate (All Teams). Pick a team from the Team filter above to scope to one.
```

SCREENSHOT-WAIVER: the page layout and chrome are unchanged from the CHAOS-1751 screenshot ([attached to that PR](https://github.com/full-chaos/dev-health-web/pull/508)); the only visible delta is the badge text shown in the diff snippet above. CI's e2e suite asserts the new "Showing the cross-team aggregate" copy is rendered in the SSR HTML.

Closes CHAOS-1755 (web side; backend side closed by full-chaos/dev-health-ops#766)