### PR TITLE
fix(web): stack bottleneck quadrants vertically at all breakpoints (CHAOS-1765)

### DIFF
--- a/src/app/(app)/bottleneck/page.tsx
+++ b/src/app/(app)/bottleneck/page.tsx
@@ -207,7 +207,7 @@ export default async function BottleneckPage({
           </section>
 
           {/* Quadrant panels */}
-          <section className="grid gap-6 lg:grid-cols-2">
+          <section className="grid gap-6">
             <QuadrantPanel
               title="WIP × Throughput"
               description="Operating modes under work in flight and delivery pace."


### PR DESCRIPTION
## Summary

Closes CHAOS-1765.

The Delivery Bottleneck Summary page rendered WIP × Throughput and Review Load × Review Latency side-by-side via `lg:grid-cols-2`. The quadrant scatter axes were too cramped at the resulting widths to read individual team dots.

## Change

Drop the `lg:grid-cols-2` modifier on the quadrants section in `src/app/(app)/bottleneck/page.tsx`. Quadrants now stack at every breakpoint.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run` — 1092 tests pass

TEST-WAIVER: Pure CSS class change — no component logic affected.

Screenshot before/after attached to the linked Linear issue.