### PR TITLE
fix(web): stack sidebar nav item label and description vertically (CHAOS-1766)

### DIFF
--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -245,7 +245,7 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
                 href={withFilterParam(item.href, filters, role)}
                 onClick={itemHash ? () => setHash(`#${itemHash}`) : undefined}
                 aria-current={isActive ? "page" : undefined}
-                className={`group relative flex items-center justify-between rounded-2xl border px-3 py-2 transition ${
+                className={`group relative flex flex-col gap-0.5 rounded-2xl border px-3 py-2 transition ${
                   isActive
                     ? "border-(--accent) bg-(--accent)/15 text-foreground before:absolute before:left-0 before:top-1/4 before:h-1/2 before:w-[3px] before:rounded-full before:bg-(--accent)"
                     : "border-transparent bg-(--card-70) text-(--ink-muted) hover:border-(--card-stroke) hover:text-foreground"


### PR DESCRIPTION
## Summary

Closes CHAOS-1766.

The sidebar nav items rendered label and description side-by-side via `flex items-center justify-between`. At the 220px sidebar width, multi-word descriptors (`WIP + REVIEW`, `CHANGE FAILURE`, `COMPOSITE`) wrapped awkwardly and visually competed with the primary label.

## Change

Switch the `<Link>` wrapper in `PrimaryNav.tsx` from `flex items-center justify-between` to `flex flex-col gap-0.5`. Label sits on top, smaller secondary descriptor sits beneath it. Predictable, never wraps, scans cleanly at every sidebar width.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run --project=components navigation` — 16 tests pass (no DOM assertions affected)

TEST-WAIVER: Pure CSS class change. DOM structure unchanged (still `<span>label</span><span>description</span>` inside the Link). Existing tests cover content, not layout direction.

Screenshot before/after attached to the linked Linear issue.