### PR TITLE
fix(web): clarify expired session signin banner (CHAOS-1770)

### DIFF
--- a/src/components/auth/SocialLoginError.tsx
+++ b/src/components/auth/SocialLoginError.tsx
@@ -10,6 +10,7 @@ const ERROR_MESSAGES: Record<string, string> = {
     "This email is already registered with a different sign-in method. Please sign in with your original method.",
   OAuthCallbackError: "An error occurred during social login. Please try again.",
   AccessDenied: "Access was denied. Please try again.",
+  refresh_failed: "Your previous session expired. Please sign in again with your email and password.",
 }
 
 export function SocialLoginError({ error }: SocialLoginErrorProps) {


### PR DESCRIPTION
## Summary
- Clarifies the `refresh_failed` sign-in banner so expired-session errors do not look like a bad-password failure.
- Leaves existing social login error handling unchanged.

Closes CHAOS-1770

## Verification
- `pnpm lint -- src/components/auth/SocialLoginError.tsx`
- `pnpm typecheck`
- LSP diagnostics: clean for `src/components/auth/SocialLoginError.tsx`
- Playwright verified `/auth/signin?error=refresh_failed` renders: "Your previous session expired. Please sign in again with your email and password."

## Visual evidence
- Screenshot captured via Playwright: `/Users/chris/projects/full-chaos/dev-health/chaos-1770-refresh-failed-banner.png`

TEST-WAIVER: copy-only mapping change for an existing auth error component; verified with lint/typecheck and Playwright-rendered page.
