### PR TITLE
fix(web): preserve forgot-password exit to signin form (CHAOS-1769)

### DIFF
--- a/src/app/(auth)/auth/signin/page.tsx
+++ b/src/app/(auth)/auth/signin/page.tsx
@@ -4,7 +4,7 @@ import { LoginForm } from "@/components/auth/LoginForm"
 import { AuthCard } from "@/components/auth/AuthCard"
 import { SocialLoginError } from "@/components/auth/SocialLoginError"
 
-type SearchParams = Promise<{ registered?: string; plan?: string; trial?: string; error?: string }>
+type SearchParams = Promise<{ registered?: string; plan?: string; trial?: string; error?: string; from?: string }>
 
 export default async function SignInPage({
   searchParams,
@@ -17,7 +17,7 @@ export default async function SignInPage({
   const signupHref = trialIntent ? "/auth/signup?plan=team&trial=true" : "/auth/signup"
 
   const session = await auth()
-  if (session?.user) {
+  if (session?.user && params.from !== "reset") {
     if (session.user.needs_onboarding) {
       redirect(trialIntent ? "/auth/onboard?plan=team&trial=true" : "/auth/onboard")
     }

--- a/src/components/auth/ForgotPasswordForm.test.tsx
+++ b/src/components/auth/ForgotPasswordForm.test.tsx
@@ -44,6 +44,21 @@ describe('ForgotPasswordForm', () => {
     })
   })
 
+  test('success screen back-to-signin link includes ?from=reset (CHAOS-1769)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    })
+
+    renderWithToaster(<ForgotPasswordForm />)
+    await userEvent.type(screen.getByLabelText(/email address/i), 'tester@example.com')
+    await userEvent.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    const backLink = await screen.findByRole('link', { name: /back to sign in/i })
+    expect(backLink).toHaveAttribute('href', '/auth/signin?from=reset')
+  })
+
   test('shows 429 rate limit error', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -48,7 +48,7 @@ export function ForgotPasswordForm() {
           If an account exists with that email, a password reset link has been sent.
         </div>
         <div className="text-center">
-          <Link href="/auth/signin" className="text-sm font-medium text-[var(--accent)] hover:opacity-90">
+          <Link href="/auth/signin?from=reset" className="text-sm font-medium text-[var(--accent)] hover:opacity-90">
             Back to Sign in
           </Link>
         </div>

--- a/tests/auth-forgot-password.spec.ts
+++ b/tests/auth-forgot-password.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * E2E tests for the forgot-password flow.
+ *
+ * CHAOS-1769: An authenticated user who clicks "Back to Sign in" after submitting
+ * the forgot-password form was being silently redirected to /dashboard instead of
+ * seeing the sign-in form.
+ *
+ * Fix (option b): The "Back to Sign in" link in the success state navigates to
+ * /auth/signin?from=reset.  The signin page skips its session-based auto-redirect
+ * when ?from=reset is present, so authenticated users see the login form instead
+ * of being bounced to /dashboard.
+ *
+ * These tests run under the `authenticated` Playwright project (storage state
+ * already injected) so we start each test as a logged-in user — the exact
+ * scenario that triggered the bug.
+ */
+import { expect, test } from "@playwright/test";
+
+test("forgot-password page is accessible while authenticated", async ({ page }) => {
+  await page.goto("/auth/forgot-password");
+
+  await expect(page).toHaveURL(/\/auth\/forgot-password/);
+  await expect(page.getByRole("heading", { name: /forgot your password/i })).toBeVisible();
+  await expect(page.getByLabel("Email address")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Send reset link" })).toBeVisible();
+});
+
+/**
+ * CHAOS-1769 regression test.
+ *
+ * Flow: authenticated user → forgot-password → submit reset-email → success banner
+ *       → click "Back to Sign in" → land on /auth/signin?from=reset (NOT /dashboard).
+ *
+ * The ?from=reset param instructs signin/page.tsx to skip the authenticated-user
+ * redirect so the login form is always rendered after a password-reset flow.
+ */
+test("forgot-password: Back to Sign in after submit lands on sign-in form, not /dashboard (CHAOS-1769)", async ({ page }) => {
+  // 1. Navigate to forgot-password (starting from authenticated state)
+  await page.goto("/auth/forgot-password");
+  await expect(page).toHaveURL(/\/auth\/forgot-password/);
+
+  // 2. Fill and submit the reset-email form
+  await page.getByLabel("Email address").fill("test@example.com");
+  await page.getByRole("button", { name: "Send reset link" }).click();
+
+  // 3. Success banner must appear.
+  await expect(
+    page.getByText("If an account exists with that email, a password reset link has been sent."),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // 4. Click "Back to Sign in"
+  await page.getByRole("link", { name: "Back to Sign in" }).click();
+
+  // 5. Must land on /auth/signin?from=reset — NOT /dashboard.
+  //    The ?from=reset param prevents the authenticated-user redirect in signin/page.tsx.
+  await expect(page).toHaveURL(/\/auth\/signin\?from=reset/, { timeout: 10_000 });
+
+  // 6. Sign-in form must be visible (confirms no dashboard redirect).
+  await expect(page.getByRole("button", { name: /sign in/i })).toBeVisible({ timeout: 10_000 });
+});
+
+test("forgot-password: Remember your password link navigates to sign-in", async ({ page }) => {
+  await page.goto("/auth/forgot-password");
+
+  await page.getByRole("link", { name: "Remember your password?" }).click();
+
+  await expect(page).toHaveURL(/\/auth\/signin/);
+});

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -1514,6 +1514,10 @@ export const handlers = [
     return HttpResponse.json({ registered: true }, { status: 201 });
   }),
 
+  http.post("*/api/v1/auth/forgot-password", () =>
+    HttpResponse.json({ message: "If an account exists, a reset email was sent." }),
+  ),
+
   http.get("*/api/v1/auth/verify", ({ request }) => {
     const url = new URL(request.url);
     const token = url.searchParams.get("token");


### PR DESCRIPTION
## Summary

When a still-authenticated user submitted the forgot-password flow and clicked **Back to Sign in**, they were silently redirected to `/dashboard` because `signin/page.tsx` auto-redirects any authenticated session. The user — having just initiated a password recovery — expected to land on the sign-in form.

## Fix (option b from CHAOS-1769)

Thread a `?from=reset` query param from the recovery-exit link and skip the auto-redirect when present. Minimal, server-side only, no client-side `signOut()` race.

- `ForgotPasswordForm.tsx` — success-state "Back to Sign in" link → `/auth/signin?from=reset`
- `signin/page.tsx` — `auth()` session ignored when `?from=reset` is present
- `tests/mocks/handlers.ts` — adds MSW mock for `/api/v1/auth/forgot-password`
- Unit test (`ForgotPasswordForm.test.tsx`) — success screen exposes `?from=reset` link
- E2E (`tests/auth-forgot-password.spec.ts`) — full flow asserts user lands on signin form, not `/dashboard`

## Out of scope

Backend `POST /api/v1/auth/reset-password` confirm only revokes refresh tokens. Existing access JWTs survive a completed reset. Filed as future work.

Closes CHAOS-1769

SCREENSHOT-WAIVER: routing-only behavior change covered by e2e Playwright test that exercises the rendered UI end-to-end. No visual layout changes.
