### PR TITLE
fix(web): round sidebar group focus state

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -609,6 +609,12 @@ body {
   animation: fade-up 300ms ease-out;
 }
 
+.primary-nav-group-button:focus-visible {
+  outline: none;
+  border-radius: 0.75rem;
+  box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--accent);
+}
+
 :focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -207,7 +207,7 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
       <div key={group.id}>
         <button
           onClick={() => toggleGroup(group.id, groupIsCollapsed)}
-          className="flex w-full items-center justify-between py-2 text-xs uppercase tracking-wider text-(--ink-muted) hover:text-foreground transition-colors"
+          className="primary-nav-group-button flex w-full items-center justify-between rounded-xl py-2 text-xs uppercase tracking-wider text-(--ink-muted) transition-colors hover:text-foreground"
         >
           <span>{group.label}</span>
           <svg


### PR DESCRIPTION
## Summary
- replace the default square focus outline on sidebar group toggles with a rounded app-styled focus ring
- scope the focus styling to PrimaryNav group buttons so nav links and global focus behavior stay unchanged

## Verification
- pnpm run lint -- src/components/navigation/PrimaryNav.tsx
- pnpm run typecheck
- pnpm run build
- Playwright manual QA: focused Admin group button computed as borderRadius 12px, outline none, rounded ring shadow

## Visual evidence
- Screenshot captured locally: /Users/chris/projects/full-chaos/dev-health/sidebar-admin-focus-fixed.png
- Note: gh CLI cannot upload binary screenshots directly into PR bodies; attach this file manually if strict PR attachment enforcement is required.

TEST-WAIVER: CSS-only focus-state fix; no component logic changed.
