### PR TITLE
feat(web): add AI Workflow Intelligence Home entry (CHAOS-1719)

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -47,6 +47,30 @@ const MONITORING_VIEWS = [
   },
 ];
 
+const AI_WORKFLOW_STEPS = [
+  {
+    label: "AI Impact",
+    description: "Start with delivery lift versus review, rework, test, and incident drag.",
+    href: "/ai/impact",
+  },
+  {
+    label: "Review Load / Risk",
+    description:
+      "Check whether AI-attributed work is shifting cost into review or quality signals.",
+    href: "/ai/review-load",
+  },
+  {
+    label: "Governance gaps",
+    description: "Treat unknown attribution and policy violations as trust signals to investigate.",
+    href: "/ai/risk",
+  },
+  {
+    label: "Evidence + intervention",
+    description: "Move from recommendations into the evidence trail and weekly operating review.",
+    href: "/operating-review#ai-workflow-intelligence",
+  },
+];
+
 const loadHome = async (
   filters: Parameters<typeof getHomeData>[0],
 ): Promise<HomeResponse | null> => {
@@ -156,6 +180,58 @@ export default async function Home({ searchParams }: HomePageProps) {
           <FilterBar view="home" />
 
           {/* Minimal freshness indicator only — no integration status UI */}
+
+          <section className="overflow-hidden rounded-[32px] border border-(--card-stroke) bg-(--card-80) p-5 shadow-[0_24px_80px_-48px_rgba(0,0,0,0.55)]">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+              <div className="max-w-2xl">
+                <p className="text-xs uppercase tracking-[0.2em] text-(--accent-2)">
+                  Market entry path
+                </p>
+                <h2 className="mt-3 font-(--font-display) text-3xl leading-tight">
+                  AI Workflow Intelligence
+                </h2>
+                <p className="mt-3 text-sm leading-6 text-(--ink-muted)">
+                  Answer the AI adoption question without turning Dev Health into surveillance: are
+                  AI-assisted workflows improving delivery, or shifting cost into review, rework,
+                  quality risk, and governance gaps?
+                </p>
+                <div className="mt-5 flex flex-wrap gap-3 text-xs uppercase tracking-[0.18em]">
+                  <Link
+                    href={withFilterParam("/ai/impact", filters, activeRole)}
+                    className="rounded-full bg-(--accent) px-4 py-2 font-semibold text-white transition hover:-translate-y-0.5"
+                  >
+                    Start with AI Impact
+                  </Link>
+                  <Link
+                    href={withFilterParam(
+                      "/operating-review#ai-workflow-intelligence",
+                      filters,
+                      activeRole,
+                    )}
+                    className="rounded-full border border-(--card-stroke) bg-(--card) px-4 py-2 text-(--accent-2) transition hover:-translate-y-0.5"
+                  >
+                    Weekly review
+                  </Link>
+                </div>
+              </div>
+              <div className="grid min-w-0 flex-1 gap-3 sm:grid-cols-2">
+                {AI_WORKFLOW_STEPS.map((step, index) => (
+                  <Link
+                    key={step.label}
+                    href={withFilterParam(step.href, filters, activeRole)}
+                    className="group rounded-2xl border border-(--card-stroke) bg-(--card) p-4 transition hover:-translate-y-1"
+                  >
+                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                      <span>{String(index + 1).padStart(2, "0")}</span>
+                      <span className="text-(--accent-2)">Open</span>
+                    </div>
+                    <p className="mt-3 text-sm font-semibold text-foreground">{step.label}</p>
+                    <p className="mt-2 text-xs leading-5 text-(--ink-muted)">{step.description}</p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </section>
 
           <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
             <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -72,6 +72,12 @@ const navGroups: NavGroup[] = [
     items: [
       { id: "home", label: "Home", href: "/dashboard", description: "Overview" },
       {
+        id: "ai-workflow",
+        label: "AI Workflow",
+        href: "/ai/impact",
+        description: "Intelligence",
+      },
+      {
         id: "operating-review",
         label: "Operating Review",
         href: "/operating-review",
@@ -238,11 +244,13 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
     return (
       <div key={group.id}>
         <button
+          type="button"
           onClick={() => toggleGroup(group.id, groupIsCollapsed)}
           className="primary-nav-group-button flex w-full items-center justify-between rounded-xl py-2 text-xs uppercase tracking-wider text-(--ink-muted) transition-colors hover:text-foreground"
         >
           <span>{group.label}</span>
           <svg
+            aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             width="12"
             height="12"

--- a/tests/ai-navigation.spec.ts
+++ b/tests/ai-navigation.spec.ts
@@ -30,6 +30,18 @@ const aiRiskLink = (page: Page) => page.locator('a[href^="/ai/risk"]').first();
 const aiAutomationsLink = (page: Page) => page.locator('a[href^="/ai/automations"]').first();
 
 test.describe("AI workflow primary navigation", () => {
+  test("Home exposes the guided AI Workflow Intelligence entry path", async ({ page }) => {
+    await page.goto(`/dashboard?f=${defaultFilter}`);
+
+    await expect(page.getByRole("heading", { name: "AI Workflow Intelligence" })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Start with AI Impact/ })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Governance gaps/ })).toBeVisible();
+
+    await page.getByRole("link", { name: /Start with AI Impact/ }).click();
+    await expect(page).toHaveURL(/\/ai\/impact/);
+    await expect(page.getByRole("heading", { name: "AI Impact" })).toBeVisible();
+  });
+
   test("nav links route between the three AI views", async ({ page }) => {
     await page.goto(`/ai/impact?f=${defaultFilter}`);
 

--- a/tests/ai-navigation.spec.ts
+++ b/tests/ai-navigation.spec.ts
@@ -23,11 +23,12 @@ const defaultFilter = encodeFilter({
 // PrimaryNav links carry the label + description in their accessible name
 // (e.g. "Review Load Pressure"), so a `/^Review Load$/` regex misses them
 // and `/^Risk/` also matches the TestOps "Risk Confidence" entry. Target the
-// AI sidebar links by their href to stay unambiguous.
-const aiImpactLink = (page: Page) => page.locator('a[href^="/ai/impact"]').first();
-const aiReviewLoadLink = (page: Page) => page.locator('a[href^="/ai/review-load"]').first();
-const aiRiskLink = (page: Page) => page.locator('a[href^="/ai/risk"]').first();
-const aiAutomationsLink = (page: Page) => page.locator('a[href^="/ai/automations"]').first();
+// full accessible names to stay unambiguous.
+const aiImpactLink = (page: Page) => page.getByRole("link", { name: /^AI Impact Leverage$/ });
+const aiReviewLoadLink = (page: Page) => page.getByRole("link", { name: /^Review Load Pressure$/ });
+const aiRiskLink = (page: Page) => page.getByRole("link", { name: /^AI Risk Quality$/ });
+const aiAutomationsLink = (page: Page) =>
+  page.getByRole("link", { name: /^Automations Candidates$/ });
 
 test.describe("AI workflow primary navigation", () => {
   test("Home exposes the guided AI Workflow Intelligence entry path", async ({ page }) => {

--- a/tests/filter-propagation.spec.ts
+++ b/tests/filter-propagation.spec.ts
@@ -72,7 +72,7 @@ test.describe("filter propagation", () => {
       { label: /People/i, path: "/people" },
       { label: /Metrics/i, path: "/metrics" },
       { label: /Landscape/i, path: "/explore/landscape" },
-      { label: /Work/i, path: "/work" },
+      { label: /^Work Investment$/, path: "/work" },
       { label: /Code/i, path: "/code" },
       { label: /Opportunities/i, path: "/opportunities" },
       { label: /Home/i, path: "/dashboard" },
@@ -94,7 +94,7 @@ test.describe("filter propagation", () => {
     expect(updatedFilter).not.toBe(initialFilter);
 
     const nav = page.locator("aside nav");
-    await nav.getByRole("link", { name: /Work/i }).click();
+    await nav.getByRole("link", { name: /^Work Investment$/ }).click();
     await expect.poll(() => new URL(page.url()).pathname).toBe("/work");
     await expectFilterParam(page, updatedFilter);
     await expectDeveloperFilter(page, "metrics-owner");


### PR DESCRIPTION
## Summary
- Add a top-level AI Workflow Intelligence entry path from Home
- Guide users through AI Impact, Review Load / Risk, Governance gaps, and Evidence + intervention
- Add an AI Workflow shortcut to the primary sidebar
- Add E2E coverage for the Home entry path

## Verification
- pnpm exec prettier --check src/app/\(app\)/dashboard/page.tsx src/components/navigation/PrimaryNav.tsx tests/ai-navigation.spec.ts
- pnpm exec tsc --noEmit
- LSP diagnostics clean on changed TS/TSX files
- Manual Playwright MCP QA: dashboard shows AI Workflow Intelligence, Start with AI Impact opens /ai/impact, AI Impact page renders

## Screenshots
- Captured locally during QA: chaos-1719-home-ai-workflow-entry.png
- Captured locally during QA: chaos-1719-1720-ai-workflow-entry.png

## Known pre-existing issue
- Full Playwright spec run is blocked by existing auth setup redirecting back to /auth/signin; manual browser QA passed for the changed flow.

Closes CHAOS-1719