### PR TITLE
fix(web): expand sidebar group max-height to fit 10-item group (CHAOS-1778)

### DIFF
--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -268,7 +268,7 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
 
         <div
           className={`space-y-2 overflow-hidden transition-all duration-300 ${
-            groupIsCollapsed ? "max-h-0 opacity-0" : "max-h-[600px] opacity-100"
+            groupIsCollapsed ? "max-h-0 opacity-0" : "max-h-[1200px] opacity-100"
           }`}
         >
           {group.items.map((item) => {


### PR DESCRIPTION
## Summary
- `Improve Delivery Confidence` sidebar group has grown to 10 items (testops, pipelines, tests, quality, coverage, risk, incident-correlation, security, feature-flags, ai-risk).
- Expanded group container in `PrimaryNav.tsx` uses `max-h-[600px] overflow-hidden` as the collapse/expand transition envelope. Rendered group height (~62px × 10 items + 9 × `space-y-2` gaps) now exceeds that cap, clipping the last item.
- Visible symptom: `AI Risk` tile renders only its label; the `QUALITY` description below it is cut off.

## Fix
- Bump expanded-state cap from `max-h-[600px]` → `max-h-[1200px]` in [`PrimaryNav.tsx`](src/components/navigation/PrimaryNav.tsx#L271).
- The cap only governs the transition envelope; the container still shrinks to content. 1200px comfortably accommodates any plausible group going forward.

## Verification
- LSP clean on `src/components/navigation/PrimaryNav.tsx`.
- Playwright manual QA: navigated to `/ai/risk`, sidebar shows all 10 items of `Improve Delivery Confidence` group including `AI Risk` with `QUALITY` sub-label fully rendered.

## Visual evidence
- Screenshot captured locally: `/Users/chris/projects/full-chaos/dev-health/chaos-1778-after-sidebar-ai-risk-uncut.png`
- Note: `gh` CLI cannot upload binary screenshots directly into PR bodies; attach this file via web UI if strict attachment enforcement is required.

Closes CHAOS-1778

TEST-WAIVER: One-line CSS max-height bump; no component logic or rendered structure changed. Existing PrimaryNav tests still cover behavior.