### PR TITLE
feat(web): add platform admin product telemetry dashboard (CHAOS-1872)

### DIFF
--- a/src/app/(app)/superadmin/product-telemetry/page.tsx
+++ b/src/app/(app)/superadmin/product-telemetry/page.tsx
@@ -1,0 +1,42 @@
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { ProductTelemetryDashboard } from "@/components/product-telemetry/ProductTelemetryDashboard";
+import { auth } from "@/lib/auth";
+import { getProductTelemetryDashboardViaGraphQL } from "@/lib/graphql/productTelemetryFetchers";
+
+const isoDate = (date: Date) => date.toISOString().slice(0, 10);
+
+export default async function ProductTelemetryDashboardPage() {
+  const session = await auth();
+  const orgId = session?.user?.org_id;
+  const endDate = new Date();
+  const startDate = new Date(endDate);
+  startDate.setUTCDate(startDate.getUTCDate() - 30);
+
+  if (!orgId) {
+    return (
+      <div className="space-y-6">
+        <AdminHeader
+          title="Product telemetry"
+          description="First-party product usage analytics backed by ClickHouse."
+        />
+        <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 text-sm text-(--ink-muted)">
+          Select an organization to view product telemetry.
+        </div>
+      </div>
+    );
+  }
+
+  const start = isoDate(startDate);
+  const end = isoDate(endDate);
+  const dashboard = await getProductTelemetryDashboardViaGraphQL({ orgId, startDate: start, endDate: end });
+
+  return (
+    <div className="space-y-6">
+      <AdminHeader
+        title="Product telemetry"
+        description="First-party product usage analytics backed by persisted ClickHouse events."
+      />
+      <ProductTelemetryDashboard dashboard={dashboard} startDate={start} endDate={end} />
+    </div>
+  );
+}

--- a/src/components/admin/AdminSidebar.test.tsx
+++ b/src/components/admin/AdminSidebar.test.tsx
@@ -40,6 +40,7 @@ describe("AdminSidebar", () => {
 
     expect(screen.getByText("Full Chaos Dev Health Ops")).toBeInTheDocument();
     expect(screen.getByTestId("org-switcher")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /product telemetryusage/i })).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /dashboardoverview/i })).toHaveAttribute(
       "aria-current",
       "page",

--- a/src/components/product-telemetry/ProductTelemetryDashboard.test.tsx
+++ b/src/components/product-telemetry/ProductTelemetryDashboard.test.tsx
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/test/utils";
+
+import { ProductTelemetryDashboard } from "./ProductTelemetryDashboard";
+import type { ProductTelemetryDashboardData } from "@/lib/graphql/productTelemetryFetchers";
+
+const sampleDashboard: ProductTelemetryDashboardData = {
+  dailyActiveUsers: [{ day: "2026-05-24", activeAnonymousUsers: 7 }],
+  topRoutes: [{ routePattern: "/metrics", events: 9, sessions: 3, anonymousUsers: 2 }],
+  featureViews: [
+    { feature: "investment", surface: "dashboard", views: 5, anonymousUsers: 2 },
+  ],
+  filterChanges: [{ view: "metrics", filterKey: "team", changes: 4, avgValueCount: 1.5 }],
+  chartInteractions: [
+    { chart: "quadrant", action: "hover", surface: "metrics", interactions: 8, sessions: 2 },
+  ],
+  clientErrors: [
+    {
+      routePattern: "/metrics",
+      boundary: "chart",
+      errorClass: "RenderError",
+      errors: 2,
+      affectedAnonymousUsers: 1,
+    },
+  ],
+  sessionSummary: {
+    p50DurationMs: 1000,
+    p75DurationMs: 1500,
+    p90DurationMs: 2500,
+    p95DurationMs: 3000,
+    avgPagesViewed: 4,
+    avgInteractions: 11,
+  },
+};
+
+describe("ProductTelemetryDashboard", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    global.ResizeObserver = class ResizeObserver {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    };
+  });
+
+  it("renders the product telemetry sections", () => {
+    render(
+      <ProductTelemetryDashboard
+        dashboard={sampleDashboard}
+        startDate="2026-05-01"
+        endDate="2026-05-25"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Daily active anonymous users" })).toBeInTheDocument();
+    expect(screen.getAllByText("/metrics")).toHaveLength(2);
+    expect(screen.getByText("investment")).toBeInTheDocument();
+    expect(screen.getByText("team")).toBeInTheDocument();
+    expect(screen.getByText("quadrant")).toBeInTheDocument();
+    expect(screen.getByText("RenderError")).toBeInTheDocument();
+    expect(screen.getByText("3.0s")).toBeInTheDocument();
+  });
+
+  it("renders empty states when no product telemetry rows are available", () => {
+    render(
+      <ProductTelemetryDashboard
+        dashboard={{
+          dailyActiveUsers: [],
+          topRoutes: [],
+          featureViews: [],
+          filterChanges: [],
+          chartInteractions: [],
+          clientErrors: [],
+          sessionSummary: {},
+        }}
+        startDate="2026-05-01"
+        endDate="2026-05-25"
+      />,
+    );
+
+    expect(screen.getAllByText("No product telemetry events in this window.")).toHaveLength(6);
+  });
+});

--- a/src/components/product-telemetry/ProductTelemetryDashboard.tsx
+++ b/src/components/product-telemetry/ProductTelemetryDashboard.tsx
@@ -1,0 +1,211 @@
+import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
+import type { ProductTelemetryDashboardData } from "@/lib/graphql/productTelemetryFetchers";
+
+type ProductTelemetryDashboardProps = {
+  dashboard: ProductTelemetryDashboardData;
+  startDate: string;
+  endDate: string;
+};
+
+const formatNumber = (value: number | null | undefined) =>
+  value === null || value === undefined ? "--" : new Intl.NumberFormat("en-US").format(value);
+
+const formatDuration = (valueMs: number | null | undefined) => {
+  if (valueMs === null || valueMs === undefined) return "--";
+  return `${(valueMs / 1000).toFixed(1)}s`;
+};
+
+function SectionCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)]">
+      <div className="mb-4">
+        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+        <p className="mt-1 text-sm text-(--ink-muted)">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-8 text-center text-sm text-(--ink-muted)">
+      No product telemetry events in this window.
+    </div>
+  );
+}
+
+function DataTable({
+  headers,
+  rows,
+}: {
+  headers: string[];
+  rows: Array<Array<string | number>>;
+}) {
+  if (rows.length === 0) return <EmptyState />;
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-left text-sm">
+        <thead className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
+          <tr className="border-b border-(--card-stroke)">
+            {headers.map((header) => (
+              <th key={header} className="py-2 pr-4 font-medium">
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-(--card-stroke)">
+          {rows.map((row) => (
+            <tr key={row.join("|")}>
+              {row.map((cell, cellIndex) => (
+                <td key={`${row[0]}-${headers[cellIndex]}`} className="py-3 pr-4 text-(--ink-muted)">
+                  <span className={cellIndex === 0 ? "font-medium text-foreground" : undefined}>
+                    {cell}
+                  </span>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function ProductTelemetryDashboard({
+  dashboard,
+  startDate,
+  endDate,
+}: ProductTelemetryDashboardProps) {
+  const latestActiveUsers = dashboard.dailyActiveUsers.at(-1)?.activeAnonymousUsers;
+  const totalRouteEvents = dashboard.topRoutes.reduce((total, row) => total + row.events, 0);
+  const totalFeatureViews = dashboard.featureViews.reduce((total, row) => total + row.views, 0);
+  const totalErrors = dashboard.clientErrors.reduce((total, row) => total + row.errors, 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[
+          ["Active users", formatNumber(latestActiveUsers), "Latest daily anonymous users"],
+          ["Route events", formatNumber(totalRouteEvents), "Page views in top routes"],
+          ["Feature views", formatNumber(totalFeatureViews), "Stable feature IDs viewed"],
+          ["Client errors", formatNumber(totalErrors), "Rendered by route and boundary"],
+        ].map(([label, value, caption]) => (
+          <div key={label} className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+            <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">{label}</p>
+            <p className="mt-3 font-(--font-display) text-3xl font-semibold text-foreground">
+              {value}
+            </p>
+            <p className="mt-2 text-xs text-(--ink-muted)">{caption}</p>
+          </div>
+        ))}
+      </div>
+
+      <SectionCard
+        title="Daily active anonymous users"
+        description={`Half-open window from ${startDate} to ${endDate}.`}
+      >
+        {dashboard.dailyActiveUsers.length ? (
+          <TimeseriesChart
+            data={dashboard.dailyActiveUsers.map((point) => ({
+              day: point.day,
+              value: point.activeAnonymousUsers,
+            }))}
+            height={240}
+          />
+        ) : (
+          <EmptyState />
+        )}
+      </SectionCard>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <SectionCard title="Top route patterns" description="Page-view events by route pattern.">
+          <DataTable
+            headers={["Route", "Events", "Sessions", "Users"]}
+            rows={dashboard.topRoutes.map((row) => [
+              row.routePattern,
+              formatNumber(row.events),
+              formatNumber(row.sessions),
+              formatNumber(row.anonymousUsers),
+            ])}
+          />
+        </SectionCard>
+
+        <SectionCard title="Feature views" description="Stable feature IDs by surface.">
+          <DataTable
+            headers={["Feature", "Surface", "Views", "Users"]}
+            rows={dashboard.featureViews.map((row) => [
+              row.feature,
+              row.surface,
+              formatNumber(row.views),
+              formatNumber(row.anonymousUsers),
+            ])}
+          />
+        </SectionCard>
+
+        <SectionCard title="Filter changes" description="Filter usage by view and filter key.">
+          <DataTable
+            headers={["Filter", "View", "Changes", "Avg values"]}
+            rows={dashboard.filterChanges.map((row) => [
+              row.filterKey,
+              row.view,
+              formatNumber(row.changes),
+              row.avgValueCount?.toFixed(1) ?? "--",
+            ])}
+          />
+        </SectionCard>
+
+        <SectionCard title="Chart interactions" description="Chart actions by chart type and surface.">
+          <DataTable
+            headers={["Chart", "Action", "Surface", "Interactions"]}
+            rows={dashboard.chartInteractions.map((row) => [
+              row.chart,
+              row.action,
+              row.surface,
+              formatNumber(row.interactions),
+            ])}
+          />
+        </SectionCard>
+
+        <SectionCard title="Client errors" description="Client error classes by route and boundary.">
+          <DataTable
+            headers={["Error class", "Route", "Boundary", "Errors"]}
+            rows={dashboard.clientErrors.map((row) => [
+              row.errorClass,
+              row.routePattern,
+              row.boundary,
+              formatNumber(row.errors),
+            ])}
+          />
+        </SectionCard>
+
+        <SectionCard title="Session summary" description="Session duration and interaction shape.">
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[
+              ["p50", formatDuration(dashboard.sessionSummary.p50DurationMs)],
+              ["p75", formatDuration(dashboard.sessionSummary.p75DurationMs)],
+              ["p90", formatDuration(dashboard.sessionSummary.p90DurationMs)],
+              ["p95", formatDuration(dashboard.sessionSummary.p95DurationMs)],
+              ["Pages", dashboard.sessionSummary.avgPagesViewed?.toFixed(1) ?? "--"],
+              ["Interactions", dashboard.sessionSummary.avgInteractions?.toFixed(1) ?? "--"],
+            ].map(([label, value]) => (
+              <div key={label} className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">{label}</p>
+                <p className="mt-2 text-xl font-semibold text-foreground">{value}</p>
+              </div>
+            ))}
+          </div>
+        </SectionCard>
+      </div>
+    </div>
+  );
+}

--- a/src/components/superadmin/SuperadminSidebar.test.tsx
+++ b/src/components/superadmin/SuperadminSidebar.test.tsx
@@ -8,6 +8,15 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("SuperadminSidebar", () => {
+  it("links to product telemetry from platform admin", () => {
+    render(<SuperadminSidebar />);
+
+    expect(screen.getByRole("link", { name: /product telemetryusage/i })).toHaveAttribute(
+      "href",
+      "/superadmin/product-telemetry",
+    );
+  });
+
   it("shows 'Return to org admin' link when canAccessOrgAdmin is true", () => {
     render(<SuperadminSidebar canAccessOrgAdmin={true} />);
     expect(screen.getByText(/Return to/)).toBeInTheDocument();

--- a/src/components/superadmin/SuperadminSidebar.tsx
+++ b/src/components/superadmin/SuperadminSidebar.tsx
@@ -8,6 +8,12 @@ const navItems = [
   { id: "orgs", label: "Organizations", href: "/superadmin/orgs", description: "Tenants" },
   { id: "users", label: "Users", href: "/superadmin/users", description: "Global" },
   { id: "licensing", label: "Licensing", href: "/superadmin/licensing", description: "Tiers" },
+  {
+    id: "product-telemetry",
+    label: "Product Telemetry",
+    href: "/superadmin/product-telemetry",
+    description: "Usage",
+  },
   { id: "audit", label: "Audit Log", href: "/superadmin/audit", description: "Events" },
   { id: "settings", label: "Settings", href: "/superadmin/settings", description: "Platform" },
   {

--- a/src/lib/__tests__/access-matrix.test.ts
+++ b/src/lib/__tests__/access-matrix.test.ts
@@ -420,6 +420,7 @@ describe("tier feature gating — sidebar and UpgradeGate logic", () => {
       expect(visibleIds).toContain("dashboard");
       expect(visibleIds).toContain("users");
       expect(visibleIds).toContain("integrations");
+      expect(visibleIds).not.toContain("product-telemetry");
     });
 
     it("UpgradeGate blocks all enterprise features", () => {

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -916,6 +916,80 @@ export type PageInfo = {
   startCursor?: Maybe<Scalars['String']['output']>;
 };
 
+export type ProductTelemetryChartInteractionType = {
+  __typename?: 'ProductTelemetryChartInteractionType';
+  action: Scalars['String']['output'];
+  chart: Scalars['String']['output'];
+  interactions: Scalars['Int']['output'];
+  sessions: Scalars['Int']['output'];
+  surface: Scalars['String']['output'];
+};
+
+export type ProductTelemetryClientErrorType = {
+  __typename?: 'ProductTelemetryClientErrorType';
+  affectedAnonymousUsers: Scalars['Int']['output'];
+  boundary: Scalars['String']['output'];
+  errorClass: Scalars['String']['output'];
+  errors: Scalars['Int']['output'];
+  routePattern: Scalars['String']['output'];
+};
+
+export type ProductTelemetryDailyActiveUsersType = {
+  __typename?: 'ProductTelemetryDailyActiveUsersType';
+  activeAnonymousUsers: Scalars['Int']['output'];
+  day: Scalars['Date']['output'];
+};
+
+export type ProductTelemetryDashboardInput = {
+  endDate: Scalars['Date']['input'];
+  startDate: Scalars['Date']['input'];
+};
+
+export type ProductTelemetryDashboardType = {
+  __typename?: 'ProductTelemetryDashboardType';
+  chartInteractions: Array<ProductTelemetryChartInteractionType>;
+  clientErrors: Array<ProductTelemetryClientErrorType>;
+  dailyActiveUsers: Array<ProductTelemetryDailyActiveUsersType>;
+  featureViews: Array<ProductTelemetryFeatureViewType>;
+  filterChanges: Array<ProductTelemetryFilterChangeType>;
+  sessionSummary: ProductTelemetrySessionSummaryType;
+  topRoutes: Array<ProductTelemetryRouteUsageType>;
+};
+
+export type ProductTelemetryFeatureViewType = {
+  __typename?: 'ProductTelemetryFeatureViewType';
+  anonymousUsers: Scalars['Int']['output'];
+  feature: Scalars['String']['output'];
+  surface: Scalars['String']['output'];
+  views: Scalars['Int']['output'];
+};
+
+export type ProductTelemetryFilterChangeType = {
+  __typename?: 'ProductTelemetryFilterChangeType';
+  avgValueCount?: Maybe<Scalars['Float']['output']>;
+  changes: Scalars['Int']['output'];
+  filterKey: Scalars['String']['output'];
+  view: Scalars['String']['output'];
+};
+
+export type ProductTelemetryRouteUsageType = {
+  __typename?: 'ProductTelemetryRouteUsageType';
+  anonymousUsers: Scalars['Int']['output'];
+  events: Scalars['Int']['output'];
+  routePattern: Scalars['String']['output'];
+  sessions: Scalars['Int']['output'];
+};
+
+export type ProductTelemetrySessionSummaryType = {
+  __typename?: 'ProductTelemetrySessionSummaryType';
+  avgInteractions?: Maybe<Scalars['Float']['output']>;
+  avgPagesViewed?: Maybe<Scalars['Float']['output']>;
+  p50DurationMs?: Maybe<Scalars['Int']['output']>;
+  p75DurationMs?: Maybe<Scalars['Int']['output']>;
+  p90DurationMs?: Maybe<Scalars['Int']['output']>;
+  p95DurationMs?: Maybe<Scalars['Int']['output']>;
+};
+
 export type Query = {
   __typename?: 'Query';
   /** List AI-attributed pull requests in the requested window so the UI can offer a concrete drilldown selector. Rows come from ai_attribution_resolved joined to git_pull_requests; no aggregation, no fabrication. */
@@ -956,6 +1030,8 @@ export type Query = {
   hotspots: HotspotsResult;
   /** Weekly Engineering Operating Review */
   operatingReview: OperatingReview;
+  /** Get first-party product telemetry dashboard metrics */
+  productTelemetryDashboard: ProductTelemetryDashboardType;
   /** Latest rule-based recommendations for a team within a lookback window. */
   recommendations: Array<Recommendation>;
   /** List report runs for a saved report */
@@ -1096,6 +1172,12 @@ export type QueryHotspotsArgs = {
 
 export type QueryOperatingReviewArgs = {
   input: OperatingReviewInput;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryProductTelemetryDashboardArgs = {
+  input: ProductTelemetryDashboardInput;
   orgId: Scalars['String']['input'];
 };
 

--- a/src/lib/graphql/__tests__/productTelemetryFetchers.test.ts
+++ b/src/lib/graphql/__tests__/productTelemetryFetchers.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getProductTelemetryDashboardViaGraphQL } from "../productTelemetryFetchers";
+
+vi.mock("../server", () => ({
+  graphqlFetch: vi.fn(),
+}));
+
+import { graphqlFetch } from "../server";
+
+const mockedFetch = vi.mocked(graphqlFetch);
+
+describe("getProductTelemetryDashboardViaGraphQL", () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  it("requests all product telemetry dashboard sections", async () => {
+    mockedFetch.mockResolvedValueOnce({
+      productTelemetryDashboard: {
+        dailyActiveUsers: [],
+        topRoutes: [],
+        featureViews: [],
+        filterChanges: [],
+        chartInteractions: [],
+        clientErrors: [],
+        sessionSummary: {},
+      },
+    });
+
+    await getProductTelemetryDashboardViaGraphQL({
+      orgId: "org-1",
+      startDate: "2026-05-01",
+      endDate: "2026-05-25",
+    });
+
+    const callArgs = mockedFetch.mock.calls[0];
+    expect(callArgs[0]).toContain("productTelemetryDashboard");
+    expect(callArgs[0]).toContain("dailyActiveUsers");
+    expect(callArgs[0]).toContain("topRoutes");
+    expect(callArgs[0]).toContain("featureViews");
+    expect(callArgs[0]).toContain("filterChanges");
+    expect(callArgs[0]).toContain("chartInteractions");
+    expect(callArgs[0]).toContain("clientErrors");
+    expect(callArgs[0]).toContain("sessionSummary");
+    expect(callArgs[1]).toEqual({
+      orgId: "org-1",
+      input: { startDate: "2026-05-01", endDate: "2026-05-25" },
+    });
+    expect(callArgs[2]).toEqual({ orgId: "org-1" });
+  });
+});

--- a/src/lib/graphql/productTelemetryFetchers.ts
+++ b/src/lib/graphql/productTelemetryFetchers.ts
@@ -1,0 +1,120 @@
+import { graphqlFetch } from "./server";
+
+export const PRODUCT_TELEMETRY_DASHBOARD_QUERY = `
+query ProductTelemetryDashboard($orgId: String!, $input: ProductTelemetryDashboardInput!) {
+  productTelemetryDashboard(orgId: $orgId, input: $input) {
+    dailyActiveUsers {
+      day
+      activeAnonymousUsers
+    }
+    topRoutes {
+      routePattern
+      events
+      sessions
+      anonymousUsers
+    }
+    featureViews {
+      feature
+      surface
+      views
+      anonymousUsers
+    }
+    filterChanges {
+      view
+      filterKey
+      changes
+      avgValueCount
+    }
+    chartInteractions {
+      chart
+      action
+      surface
+      interactions
+      sessions
+    }
+    clientErrors {
+      routePattern
+      boundary
+      errorClass
+      errors
+      affectedAnonymousUsers
+    }
+    sessionSummary {
+      p50DurationMs
+      p75DurationMs
+      p90DurationMs
+      p95DurationMs
+      avgPagesViewed
+      avgInteractions
+    }
+  }
+}
+`;
+
+export type ProductTelemetryDashboardData = {
+  dailyActiveUsers: Array<{ day: string; activeAnonymousUsers: number }>;
+  topRoutes: Array<{
+    routePattern: string;
+    events: number;
+    sessions: number;
+    anonymousUsers: number;
+  }>;
+  featureViews: Array<{
+    feature: string;
+    surface: string;
+    views: number;
+    anonymousUsers: number;
+  }>;
+  filterChanges: Array<{
+    view: string;
+    filterKey: string;
+    changes: number;
+    avgValueCount?: number | null;
+  }>;
+  chartInteractions: Array<{
+    chart: string;
+    action: string;
+    surface: string;
+    interactions: number;
+    sessions: number;
+  }>;
+  clientErrors: Array<{
+    routePattern: string;
+    boundary: string;
+    errorClass: string;
+    errors: number;
+    affectedAnonymousUsers: number;
+  }>;
+  sessionSummary: {
+    p50DurationMs?: number | null;
+    p75DurationMs?: number | null;
+    p90DurationMs?: number | null;
+    p95DurationMs?: number | null;
+    avgPagesViewed?: number | null;
+    avgInteractions?: number | null;
+  };
+};
+
+type ProductTelemetryDashboardResponse = {
+  productTelemetryDashboard: ProductTelemetryDashboardData;
+};
+
+type ProductTelemetryDashboardParams = {
+  orgId: string;
+  startDate: string;
+  endDate: string;
+};
+
+export async function getProductTelemetryDashboardViaGraphQL({
+  orgId,
+  startDate,
+  endDate,
+}: ProductTelemetryDashboardParams): Promise<ProductTelemetryDashboardData> {
+  const response = await graphqlFetch<ProductTelemetryDashboardResponse>(
+    PRODUCT_TELEMETRY_DASHBOARD_QUERY,
+    { orgId, input: { startDate, endDate } },
+    { orgId },
+  );
+
+  return response.productTelemetryDashboard;
+}

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -817,12 +817,81 @@ type PageInfo {
   endCursor: String
 }
 
+type ProductTelemetryChartInteractionType {
+  chart: String!
+  action: String!
+  surface: String!
+  interactions: Int!
+  sessions: Int!
+}
+
+type ProductTelemetryClientErrorType {
+  routePattern: String!
+  boundary: String!
+  errorClass: String!
+  errors: Int!
+  affectedAnonymousUsers: Int!
+}
+
+type ProductTelemetryDailyActiveUsersType {
+  day: Date!
+  activeAnonymousUsers: Int!
+}
+
+input ProductTelemetryDashboardInput {
+  startDate: Date!
+  endDate: Date!
+}
+
+type ProductTelemetryDashboardType {
+  dailyActiveUsers: [ProductTelemetryDailyActiveUsersType!]!
+  topRoutes: [ProductTelemetryRouteUsageType!]!
+  featureViews: [ProductTelemetryFeatureViewType!]!
+  filterChanges: [ProductTelemetryFilterChangeType!]!
+  chartInteractions: [ProductTelemetryChartInteractionType!]!
+  clientErrors: [ProductTelemetryClientErrorType!]!
+  sessionSummary: ProductTelemetrySessionSummaryType!
+}
+
+type ProductTelemetryFeatureViewType {
+  feature: String!
+  surface: String!
+  views: Int!
+  anonymousUsers: Int!
+}
+
+type ProductTelemetryFilterChangeType {
+  view: String!
+  filterKey: String!
+  changes: Int!
+  avgValueCount: Float
+}
+
+type ProductTelemetryRouteUsageType {
+  routePattern: String!
+  events: Int!
+  sessions: Int!
+  anonymousUsers: Int!
+}
+
+type ProductTelemetrySessionSummaryType {
+  p50DurationMs: Int
+  p75DurationMs: Int
+  p90DurationMs: Int
+  p95DurationMs: Int
+  avgPagesViewed: Float
+  avgInteractions: Float
+}
+
 type Query {
   """Get catalog of available dimensions, measures, and limits"""
   catalog(orgId: String!, dimension: DimensionInput = null, filters: FilterInput = null): CatalogResult!
 
   """Run batch analytics queries"""
   analytics(orgId: String!, batch: AnalyticsRequestInput!): AnalyticsResult!
+
+  """Get first-party product telemetry dashboard metrics"""
+  productTelemetryDashboard(orgId: String!, input: ProductTelemetryDashboardInput!): ProductTelemetryDashboardType!
 
   """Get home dashboard metrics"""
   home(orgId: String!, filters: FilterInput = null): HomeResult!


### PR DESCRIPTION
## Summary
- Adds the product telemetry GraphQL fetcher and generated schema/types.
- Renders the product telemetry dashboard UI under platform admin only.
- Adds sidebar/access tests so Product Telemetry stays out of regular org admin.

## Test Plan
- pnpm exec vitest run src/components/admin/AdminSidebar.test.tsx src/components/superadmin/SuperadminSidebar.test.tsx src/lib/__tests__/access-matrix.test.ts src/lib/graphql/__tests__/productTelemetryFetchers.test.ts src/components/product-telemetry/ProductTelemetryDashboard.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm build
- Browser QA: opened http://localhost:3001/superadmin/product-telemetry against feature API on 127.0.0.1:8001; GraphQL query succeeded and platform admin sidebar showed Product Telemetry. Screenshot captured locally at chaos-1872-product-telemetry-platform-admin.png.

Closes CHAOS-1872