### PR TITLE
feat(web): platform-admin product telemetry overview + drilldown (CHAOS-1876)

### DIFF
--- a/src/app/(app)/superadmin/product-telemetry/[orgId]/page.tsx
+++ b/src/app/(app)/superadmin/product-telemetry/[orgId]/page.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { ProductTelemetryDashboard } from "@/components/product-telemetry/ProductTelemetryDashboard";
+import { getProductTelemetryDashboardViaGraphQL } from "@/lib/graphql/productTelemetryFetchers";
+
+const isoDate = (date: Date) => date.toISOString().slice(0, 10);
+
+type SearchParams = { [key: string]: string | string[] | undefined };
+
+const firstParam = (value?: string | string[]) => (Array.isArray(value) ? value[0] : value);
+const toDate = (value?: string | string[]) => {
+  const param = firstParam(value);
+  return param ? new Date(param) : null;
+};
+
+export default async function ProductTelemetryOrgDashboardPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ orgId: string }>;
+  searchParams?: Promise<SearchParams>;
+}) {
+  const { orgId } = await params;
+  const rawParams = (await searchParams) ?? {};
+
+  const endDate = toDate(rawParams.endDate) ?? new Date();
+  const startDate = toDate(rawParams.startDate) ?? (() => {
+    const d = new Date(endDate);
+    d.setUTCDate(d.getUTCDate() - 30);
+    return d;
+  })();
+
+  const start = isoDate(startDate);
+  const end = isoDate(endDate);
+  const dashboard = await getProductTelemetryDashboardViaGraphQL({
+    orgId,
+    startDate: start,
+    endDate: end,
+  });
+
+  const backHref = `/superadmin/product-telemetry?startDate=${start}&endDate=${end}`;
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href={backHref}
+        className="inline-flex w-fit items-center rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em] text-(--ink-muted) transition-colors hover:border-(--ink-muted) hover:text-foreground"
+      >
+        ← Back to all orgs
+      </Link>
+      <AdminHeader
+        title={`Product telemetry · ${orgId}`}
+        description="Drilldown view for a single organization, using persisted ClickHouse product telemetry for the selected date range."
+      />
+      <ProductTelemetryDashboard dashboard={dashboard} startDate={start} endDate={end} />
+    </div>
+  );
+}

--- a/src/app/(app)/superadmin/product-telemetry/page.tsx
+++ b/src/app/(app)/superadmin/product-telemetry/page.tsx
@@ -1,42 +1,44 @@
 import { AdminHeader } from "@/components/admin/AdminHeader";
-import { ProductTelemetryDashboard } from "@/components/product-telemetry/ProductTelemetryDashboard";
-import { auth } from "@/lib/auth";
-import { getProductTelemetryDashboardViaGraphQL } from "@/lib/graphql/productTelemetryFetchers";
+import { PlatformProductTelemetryDashboard } from "@/components/product-telemetry/PlatformProductTelemetryDashboard";
+import { getProductTelemetryPlatformDashboardViaGraphQL } from "@/lib/graphql/productTelemetryFetchers";
 
 const isoDate = (date: Date) => date.toISOString().slice(0, 10);
 
-export default async function ProductTelemetryDashboardPage() {
-  const session = await auth();
-  const orgId = session?.user?.org_id;
-  const endDate = new Date();
-  const startDate = new Date(endDate);
-  startDate.setUTCDate(startDate.getUTCDate() - 30);
+type SearchParams = { startDate?: string; endDate?: string };
 
-  if (!orgId) {
-    return (
-      <div className="space-y-6">
-        <AdminHeader
-          title="Product telemetry"
-          description="First-party product usage analytics backed by ClickHouse."
-        />
-        <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 text-sm text-(--ink-muted)">
-          Select an organization to view product telemetry.
-        </div>
-      </div>
-    );
-  }
+export default async function ProductTelemetryDashboardPage({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParams>;
+}) {
+  const params = (await searchParams) ?? {};
+  const endDate = params.endDate ? new Date(params.endDate) : new Date();
+  const startDate = params.startDate
+    ? new Date(params.startDate)
+    : (() => {
+        const d = new Date(endDate);
+        d.setUTCDate(d.getUTCDate() - 30);
+        return d;
+      })();
 
   const start = isoDate(startDate);
   const end = isoDate(endDate);
-  const dashboard = await getProductTelemetryDashboardViaGraphQL({ orgId, startDate: start, endDate: end });
+  const dashboard = await getProductTelemetryPlatformDashboardViaGraphQL({
+    startDate: start,
+    endDate: end,
+  });
 
   return (
     <div className="space-y-6">
       <AdminHeader
         title="Product telemetry"
-        description="First-party product usage analytics backed by persisted ClickHouse events."
+        description="Cross-org first-party product usage analytics backed by persisted ClickHouse events. Click any organization to drill down."
       />
-      <ProductTelemetryDashboard dashboard={dashboard} startDate={start} endDate={end} />
+      <PlatformProductTelemetryDashboard
+        dashboard={dashboard}
+        startDate={start}
+        endDate={end}
+      />
     </div>
   );
 }

--- a/src/components/product-telemetry/PlatformProductTelemetryDashboard.test.tsx
+++ b/src/components/product-telemetry/PlatformProductTelemetryDashboard.test.tsx
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@/test/utils";
+
+import { PlatformProductTelemetryDashboard } from "./PlatformProductTelemetryDashboard";
+import type { ProductTelemetryPlatformDashboardData } from "@/lib/graphql/productTelemetryFetchers";
+
+const startDate = "2026-05-01";
+const endDate = "2026-05-25";
+
+const baseDashboard: ProductTelemetryPlatformDashboardData = {
+  dailyActiveUsers: [{ day: "2026-05-24", activeAnonymousUsers: 7 }],
+  topRoutes: [],
+  featureViews: [],
+  filterChanges: [],
+  chartInteractions: [],
+  clientErrors: [],
+  sessionSummary: {},
+  totals: {
+    activeOrgs: 7,
+    anonymousUsers: 320,
+    sessions: 1100,
+    events: 15000,
+  },
+  topOrgs: [],
+};
+
+describe("PlatformProductTelemetryDashboard", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    global.ResizeObserver = class ResizeObserver {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    };
+  });
+
+  it("renders the four totals stat cards", () => {
+    render(
+      <PlatformProductTelemetryDashboard
+        dashboard={baseDashboard}
+        startDate={startDate}
+        endDate={endDate}
+      />,
+    );
+
+    const expectStat = (label: string, value: string) => {
+      const card = screen.getByText(label).closest("div");
+      expect(card).not.toBeNull();
+      expect(within(card as HTMLElement).getByText(value)).toBeInTheDocument();
+    };
+
+    expectStat("Active orgs", "7");
+    expectStat("Anonymous users", "320");
+    expectStat("Sessions", "1,100");
+    expectStat("Events", "15,000");
+  });
+
+  it("renders top-orgs table rows with drilldown links for resolved orgs", () => {
+    const orgId = "org_acme_123";
+    const orgIdHash = "unresolved_org_hash_abcdef1234567890";
+
+    render(
+      <PlatformProductTelemetryDashboard
+        dashboard={{
+          ...baseDashboard,
+          topOrgs: [
+            {
+              orgId,
+              orgName: "Acme Corp",
+              orgIdHash: "resolved_hash_1234567890abcdef",
+              events: 250,
+              sessions: 40,
+              anonymousUsers: 22,
+            },
+            {
+              orgIdHash,
+              events: 180,
+              sessions: 33,
+              anonymousUsers: 11,
+            },
+          ],
+        }}
+        startDate={startDate}
+        endDate={endDate}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Acme Corp" })).toHaveAttribute(
+      "href",
+      `/superadmin/product-telemetry/${orgId}?startDate=${startDate}&endDate=${endDate}`,
+    );
+
+    const hashLabel = `${orgIdHash.slice(0, 12)}…`;
+    expect(screen.getByText(hashLabel)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: hashLabel })).toBeNull();
+  });
+
+  it("renders an empty state when no top orgs exist", () => {
+    render(
+      <PlatformProductTelemetryDashboard
+        dashboard={baseDashboard}
+        startDate={startDate}
+        endDate={endDate}
+      />,
+    );
+
+    expect(
+      screen.getByText("No orgs reported product telemetry in this window."),
+    ).toBeInTheDocument();
+  });
+
+  it("delegates section payloads to the embedded per-org dashboard", () => {
+    render(
+      <PlatformProductTelemetryDashboard
+        dashboard={{
+          ...baseDashboard,
+          topRoutes: [
+            {
+              routePattern: "/metrics",
+              events: 90,
+              sessions: 33,
+              anonymousUsers: 25,
+            },
+          ],
+        }}
+        startDate={startDate}
+        endDate={endDate}
+      />,
+    );
+
+    expect(screen.getAllByText("/metrics").length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/product-telemetry/PlatformProductTelemetryDashboard.tsx
+++ b/src/components/product-telemetry/PlatformProductTelemetryDashboard.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link";
+
+import { ProductTelemetryDashboard } from "@/components/product-telemetry/ProductTelemetryDashboard";
+import type { ProductTelemetryPlatformDashboardData } from "@/lib/graphql/productTelemetryFetchers";
+
+type PlatformProductTelemetryDashboardProps = {
+  dashboard: ProductTelemetryPlatformDashboardData;
+  startDate: string;
+  endDate: string;
+};
+
+const formatNumber = (value: number | null | undefined) =>
+  value === null || value === undefined ? "--" : new Intl.NumberFormat("en-US").format(value);
+
+function StatCard({
+  label,
+  value,
+  caption,
+}: {
+  label: string;
+  value: string;
+  caption: string;
+}) {
+  return (
+    <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+      <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">{label}</p>
+      <p className="mt-3 font-(--font-display) text-3xl font-semibold text-foreground">
+        {value}
+      </p>
+      <p className="mt-2 text-xs text-(--ink-muted)">{caption}</p>
+    </div>
+  );
+}
+
+function TopOrgsTable({
+  rows,
+  startDate,
+  endDate,
+}: {
+  rows: ProductTelemetryPlatformDashboardData["topOrgs"];
+  startDate: string;
+  endDate: string;
+}) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-8 text-center text-sm text-(--ink-muted)">
+        No orgs reported product telemetry in this window.
+      </div>
+    );
+  }
+
+  // Drilldown only when the hash resolves to a known Postgres org. Unknown
+  // hashes are listed but cannot be drilled into without a real id.
+  const drilldownHref = (org: ProductTelemetryPlatformDashboardData["topOrgs"][number]) =>
+    org.orgId
+      ? `/superadmin/product-telemetry/${org.orgId}?startDate=${startDate}&endDate=${endDate}`
+      : null;
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-left text-sm">
+        <thead className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
+          <tr className="border-b border-(--card-stroke)">
+            <th className="py-2 pr-4 font-medium">Organization</th>
+            <th className="py-2 pr-4 font-medium">Events</th>
+            <th className="py-2 pr-4 font-medium">Sessions</th>
+            <th className="py-2 pr-4 font-medium">Anonymous users</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-(--card-stroke)">
+          {rows.map((org) => {
+            const label =
+              org.orgName ||
+              org.orgSlug ||
+              `${org.orgIdHash.slice(0, 12)}\u2026`;
+            const href = drilldownHref(org);
+            return (
+              <tr key={org.orgIdHash}>
+                <td className="py-3 pr-4">
+                  {href ? (
+                    <Link
+                      href={href}
+                      className="font-medium text-foreground underline-offset-4 hover:underline"
+                    >
+                      {label}
+                    </Link>
+                  ) : (
+                    <span
+                      className="font-medium text-(--ink-muted)"
+                      title="No matching organization in Postgres — drilldown unavailable."
+                    >
+                      {label}
+                    </span>
+                  )}
+                </td>
+                <td className="py-3 pr-4 text-(--ink-muted)">{formatNumber(org.events)}</td>
+                <td className="py-3 pr-4 text-(--ink-muted)">{formatNumber(org.sessions)}</td>
+                <td className="py-3 pr-4 text-(--ink-muted)">
+                  {formatNumber(org.anonymousUsers)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function PlatformProductTelemetryDashboard({
+  dashboard,
+  startDate,
+  endDate,
+}: PlatformProductTelemetryDashboardProps) {
+  const totals = dashboard.totals;
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <StatCard
+          label="Active orgs"
+          value={formatNumber(totals.activeOrgs)}
+          caption="Distinct tenants with events in window"
+        />
+        <StatCard
+          label="Anonymous users"
+          value={formatNumber(totals.anonymousUsers)}
+          caption="Distinct anon users across all orgs"
+        />
+        <StatCard
+          label="Sessions"
+          value={formatNumber(totals.sessions)}
+          caption="Distinct sessions across all orgs"
+        />
+        <StatCard
+          label="Events"
+          value={formatNumber(totals.events)}
+          caption="Total raw events in window"
+        />
+      </div>
+
+      <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)]">
+        <div className="mb-4 flex items-baseline justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Top organizations</h2>
+            <p className="mt-1 text-sm text-(--ink-muted)">
+              Tenants ranked by event volume. Click an org to drill down into its
+              per-org product telemetry.
+            </p>
+          </div>
+        </div>
+        <TopOrgsTable rows={dashboard.topOrgs} startDate={startDate} endDate={endDate} />
+      </section>
+
+      <ProductTelemetryDashboard
+        dashboard={dashboard}
+        startDate={startDate}
+        endDate={endDate}
+      />
+    </div>
+  );
+}

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -972,6 +972,27 @@ export type ProductTelemetryFilterChangeType = {
   view: Scalars['String']['output'];
 };
 
+export type ProductTelemetryPlatformDashboardType = {
+  __typename?: 'ProductTelemetryPlatformDashboardType';
+  chartInteractions: Array<ProductTelemetryChartInteractionType>;
+  clientErrors: Array<ProductTelemetryClientErrorType>;
+  dailyActiveUsers: Array<ProductTelemetryDailyActiveUsersType>;
+  featureViews: Array<ProductTelemetryFeatureViewType>;
+  filterChanges: Array<ProductTelemetryFilterChangeType>;
+  sessionSummary: ProductTelemetrySessionSummaryType;
+  topOrgs: Array<ProductTelemetryTopOrgType>;
+  topRoutes: Array<ProductTelemetryRouteUsageType>;
+  totals: ProductTelemetryPlatformTotalsType;
+};
+
+export type ProductTelemetryPlatformTotalsType = {
+  __typename?: 'ProductTelemetryPlatformTotalsType';
+  activeOrgs: Scalars['Int']['output'];
+  anonymousUsers: Scalars['Int']['output'];
+  events: Scalars['Int']['output'];
+  sessions: Scalars['Int']['output'];
+};
+
 export type ProductTelemetryRouteUsageType = {
   __typename?: 'ProductTelemetryRouteUsageType';
   anonymousUsers: Scalars['Int']['output'];
@@ -988,6 +1009,17 @@ export type ProductTelemetrySessionSummaryType = {
   p75DurationMs?: Maybe<Scalars['Int']['output']>;
   p90DurationMs?: Maybe<Scalars['Int']['output']>;
   p95DurationMs?: Maybe<Scalars['Int']['output']>;
+};
+
+export type ProductTelemetryTopOrgType = {
+  __typename?: 'ProductTelemetryTopOrgType';
+  anonymousUsers: Scalars['Int']['output'];
+  events: Scalars['Int']['output'];
+  orgId?: Maybe<Scalars['String']['output']>;
+  orgIdHash: Scalars['String']['output'];
+  orgName?: Maybe<Scalars['String']['output']>;
+  orgSlug?: Maybe<Scalars['String']['output']>;
+  sessions: Scalars['Int']['output'];
 };
 
 export type Query = {
@@ -1032,6 +1064,8 @@ export type Query = {
   operatingReview: OperatingReview;
   /** Get first-party product telemetry dashboard metrics */
   productTelemetryDashboard: ProductTelemetryDashboardType;
+  /** Cross-org product telemetry dashboard for platform/super admins. Requires is_superuser. Returns global aggregates plus a top-orgs rollup with org names resolved from Postgres. */
+  productTelemetryPlatformDashboard: ProductTelemetryPlatformDashboardType;
   /** Latest rule-based recommendations for a team within a lookback window. */
   recommendations: Array<Recommendation>;
   /** List report runs for a saved report */
@@ -1179,6 +1213,11 @@ export type QueryOperatingReviewArgs = {
 export type QueryProductTelemetryDashboardArgs = {
   input: ProductTelemetryDashboardInput;
   orgId: Scalars['String']['input'];
+};
+
+
+export type QueryProductTelemetryPlatformDashboardArgs = {
+  input: ProductTelemetryDashboardInput;
 };
 
 

--- a/src/lib/graphql/__tests__/productTelemetryFetchers.test.ts
+++ b/src/lib/graphql/__tests__/productTelemetryFetchers.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getProductTelemetryDashboardViaGraphQL } from "../productTelemetryFetchers";
+import {
+  getProductTelemetryDashboardViaGraphQL,
+  getProductTelemetryPlatformDashboardViaGraphQL,
+} from "../productTelemetryFetchers";
 
 vi.mock("../server", () => ({
   graphqlFetch: vi.fn(),
@@ -48,5 +51,90 @@ describe("getProductTelemetryDashboardViaGraphQL", () => {
       input: { startDate: "2026-05-01", endDate: "2026-05-25" },
     });
     expect(callArgs[2]).toEqual({ orgId: "org-1" });
+  });
+});
+
+describe("getProductTelemetryPlatformDashboardViaGraphQL", () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  it("requests all platform dashboard sections and returns the platform payload", async () => {
+    const platformDashboard = {
+      totals: {
+        activeOrgs: 12,
+        anonymousUsers: 345,
+        sessions: 789,
+        events: 1234,
+      },
+      dailyActiveUsers: [],
+      topRoutes: [],
+      featureViews: [],
+      filterChanges: [],
+      chartInteractions: [],
+      clientErrors: [],
+      sessionSummary: {
+        p50DurationMs: 120,
+        p75DurationMs: 250,
+        p90DurationMs: 480,
+        p95DurationMs: 700,
+        avgPagesViewed: 3.2,
+        avgInteractions: 8.4,
+      },
+      topOrgs: [
+        {
+          orgIdHash: "hash-1",
+          events: 444,
+          sessions: 222,
+          anonymousUsers: 111,
+          orgId: "org-1",
+          orgName: "Acme Corp",
+          orgSlug: "acme",
+        },
+      ],
+    };
+
+    mockedFetch.mockResolvedValueOnce({
+      productTelemetryPlatformDashboard: platformDashboard,
+    });
+
+    const result = await getProductTelemetryPlatformDashboardViaGraphQL({
+      startDate: "2026-05-01",
+      endDate: "2026-05-25",
+    });
+
+    const callArgs = mockedFetch.mock.calls[0];
+    expect(callArgs[0]).toContain("productTelemetryPlatformDashboard");
+    expect(callArgs[0]).toContain("totals");
+    expect(callArgs[0]).toContain("topOrgs");
+    expect(callArgs[0]).toContain("dailyActiveUsers");
+    expect(callArgs[0]).toContain("topRoutes");
+    expect(callArgs[0]).toContain("featureViews");
+    expect(callArgs[0]).toContain("filterChanges");
+    expect(callArgs[0]).toContain("chartInteractions");
+    expect(callArgs[0]).toContain("clientErrors");
+    expect(callArgs[0]).toContain("sessionSummary");
+    expect(callArgs[1]).toEqual({
+      input: { startDate: "2026-05-01", endDate: "2026-05-25" },
+    });
+    expect(callArgs[2]).toEqual({ orgId: "" });
+    expect(result).toEqual(platformDashboard);
+    expect(result.totals).toEqual({
+      activeOrgs: 12,
+      anonymousUsers: 345,
+      sessions: 789,
+      events: 1234,
+    });
+    expect(result.topOrgs).toEqual([
+      {
+        orgIdHash: "hash-1",
+        events: 444,
+        sessions: 222,
+        anonymousUsers: 111,
+        orgId: "org-1",
+        orgName: "Acme Corp",
+        orgSlug: "acme",
+      },
+    ]);
   });
 });

--- a/src/lib/graphql/productTelemetryFetchers.ts
+++ b/src/lib/graphql/productTelemetryFetchers.ts
@@ -118,3 +118,123 @@ export async function getProductTelemetryDashboardViaGraphQL({
 
   return response.productTelemetryDashboard;
 }
+
+// =============================================================================
+// Platform-admin (cross-org) dashboard. Requires is_superuser on the backend.
+// Reuses the same per-section shapes as the per-org dashboard so the existing
+// ProductTelemetryDashboard component can render the section payloads, while
+// the totals + topOrgs rollups feed the Super-admin overview.
+// =============================================================================
+
+export const PRODUCT_TELEMETRY_PLATFORM_DASHBOARD_QUERY = `
+query ProductTelemetryPlatformDashboard($input: ProductTelemetryDashboardInput!) {
+  productTelemetryPlatformDashboard(input: $input) {
+    totals {
+      activeOrgs
+      anonymousUsers
+      sessions
+      events
+    }
+    dailyActiveUsers {
+      day
+      activeAnonymousUsers
+    }
+    topRoutes {
+      routePattern
+      events
+      sessions
+      anonymousUsers
+    }
+    featureViews {
+      feature
+      surface
+      views
+      anonymousUsers
+    }
+    filterChanges {
+      view
+      filterKey
+      changes
+      avgValueCount
+    }
+    chartInteractions {
+      chart
+      action
+      surface
+      interactions
+      sessions
+    }
+    clientErrors {
+      routePattern
+      boundary
+      errorClass
+      errors
+      affectedAnonymousUsers
+    }
+    sessionSummary {
+      p50DurationMs
+      p75DurationMs
+      p90DurationMs
+      p95DurationMs
+      avgPagesViewed
+      avgInteractions
+    }
+    topOrgs {
+      orgIdHash
+      events
+      sessions
+      anonymousUsers
+      orgId
+      orgName
+      orgSlug
+    }
+  }
+}
+`;
+
+export type ProductTelemetryPlatformTotals = {
+  activeOrgs: number;
+  anonymousUsers: number;
+  sessions: number;
+  events: number;
+};
+
+export type ProductTelemetryTopOrg = {
+  orgIdHash: string;
+  events: number;
+  sessions: number;
+  anonymousUsers: number;
+  orgId?: string | null;
+  orgName?: string | null;
+  orgSlug?: string | null;
+};
+
+export type ProductTelemetryPlatformDashboardData = ProductTelemetryDashboardData & {
+  totals: ProductTelemetryPlatformTotals;
+  topOrgs: ProductTelemetryTopOrg[];
+};
+
+type ProductTelemetryPlatformDashboardResponse = {
+  productTelemetryPlatformDashboard: ProductTelemetryPlatformDashboardData;
+};
+
+type ProductTelemetryPlatformDashboardParams = {
+  startDate: string;
+  endDate: string;
+};
+
+export async function getProductTelemetryPlatformDashboardViaGraphQL({
+  startDate,
+  endDate,
+}: ProductTelemetryPlatformDashboardParams): Promise<ProductTelemetryPlatformDashboardData> {
+  // No orgId — the resolver is gated by is_superuser and aggregates across
+  // every tenant. The graphqlFetch helper still receives an empty orgId so
+  // existing org-scoped middleware doesn't reject the call.
+  const response = await graphqlFetch<ProductTelemetryPlatformDashboardResponse>(
+    PRODUCT_TELEMETRY_PLATFORM_DASHBOARD_QUERY,
+    { input: { startDate, endDate } },
+    { orgId: "" },
+  );
+
+  return response.productTelemetryPlatformDashboard;
+}

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -853,6 +853,20 @@ type ProductTelemetryDashboardType {
   sessionSummary: ProductTelemetrySessionSummaryType!
 }
 
+type ProductTelemetryFeatureViewType {
+  feature: String!
+  surface: String!
+  views: Int!
+  anonymousUsers: Int!
+}
+
+type ProductTelemetryFilterChangeType {
+  view: String!
+  filterKey: String!
+  changes: Int!
+  avgValueCount: Float
+}
+
 type ProductTelemetryPlatformDashboardType {
   totals: ProductTelemetryPlatformTotalsType!
   dailyActiveUsers: [ProductTelemetryDailyActiveUsersType!]!
@@ -872,30 +886,6 @@ type ProductTelemetryPlatformTotalsType {
   events: Int!
 }
 
-type ProductTelemetryTopOrgType {
-  orgIdHash: String!
-  events: Int!
-  sessions: Int!
-  anonymousUsers: Int!
-  orgId: String
-  orgName: String
-  orgSlug: String
-}
-
-type ProductTelemetryFeatureViewType {
-  feature: String!
-  surface: String!
-  views: Int!
-  anonymousUsers: Int!
-}
-
-type ProductTelemetryFilterChangeType {
-  view: String!
-  filterKey: String!
-  changes: Int!
-  avgValueCount: Float
-}
-
 type ProductTelemetryRouteUsageType {
   routePattern: String!
   events: Int!
@@ -910,6 +900,16 @@ type ProductTelemetrySessionSummaryType {
   p95DurationMs: Int
   avgPagesViewed: Float
   avgInteractions: Float
+}
+
+type ProductTelemetryTopOrgType {
+  orgIdHash: String!
+  events: Int!
+  sessions: Int!
+  anonymousUsers: Int!
+  orgId: String
+  orgName: String
+  orgSlug: String
 }
 
 type Query {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -853,6 +853,35 @@ type ProductTelemetryDashboardType {
   sessionSummary: ProductTelemetrySessionSummaryType!
 }
 
+type ProductTelemetryPlatformDashboardType {
+  totals: ProductTelemetryPlatformTotalsType!
+  dailyActiveUsers: [ProductTelemetryDailyActiveUsersType!]!
+  topRoutes: [ProductTelemetryRouteUsageType!]!
+  featureViews: [ProductTelemetryFeatureViewType!]!
+  filterChanges: [ProductTelemetryFilterChangeType!]!
+  chartInteractions: [ProductTelemetryChartInteractionType!]!
+  clientErrors: [ProductTelemetryClientErrorType!]!
+  sessionSummary: ProductTelemetrySessionSummaryType!
+  topOrgs: [ProductTelemetryTopOrgType!]!
+}
+
+type ProductTelemetryPlatformTotalsType {
+  activeOrgs: Int!
+  anonymousUsers: Int!
+  sessions: Int!
+  events: Int!
+}
+
+type ProductTelemetryTopOrgType {
+  orgIdHash: String!
+  events: Int!
+  sessions: Int!
+  anonymousUsers: Int!
+  orgId: String
+  orgName: String
+  orgSlug: String
+}
+
 type ProductTelemetryFeatureViewType {
   feature: String!
   surface: String!
@@ -892,6 +921,11 @@ type Query {
 
   """Get first-party product telemetry dashboard metrics"""
   productTelemetryDashboard(orgId: String!, input: ProductTelemetryDashboardInput!): ProductTelemetryDashboardType!
+
+  """
+  Cross-org product telemetry dashboard for platform/super admins. Requires is_superuser. Returns global aggregates plus a top-orgs rollup with org names resolved from Postgres.
+  """
+  productTelemetryPlatformDashboard(input: ProductTelemetryDashboardInput!): ProductTelemetryPlatformDashboardType!
 
   """Get home dashboard metrics"""
   home(orgId: String!, filters: FilterInput = null): HomeResult!


### PR DESCRIPTION
## Summary

Wires `/superadmin/product-telemetry` to the new cross-org GraphQL resolver (CHAOS-1875, dev-health-ops PR #791) and adds a dynamic drilldown route into each org's existing per-org dashboard.

Closes the gap where the page was gated by `is_superuser` in `proxy.ts` but only ever rendered a "Select an organization" message because the underlying resolver was org-scoped.

## Changes

### Schema
`src/lib/graphql/schema.graphql`
- New types: `ProductTelemetryPlatformDashboardType`, `ProductTelemetryPlatformTotalsType`, `ProductTelemetryTopOrgType`.
- New query: `productTelemetryPlatformDashboard(input: ProductTelemetryDashboardInput!): ProductTelemetryPlatformDashboardType!`.
- Matches the SDL exported by dev-health-ops PR #791. Schema-drift CI will validate.

### Fetcher
`src/lib/graphql/productTelemetryFetchers.ts`
- New `getProductTelemetryPlatformDashboardViaGraphQL({ startDate, endDate })` — no orgId, calls `graphqlFetch` with an empty X-Org-Id header (resolver is gated by `is_superuser`).
- `ProductTelemetryPlatformDashboardData` type-extends per-org payload with `totals` and `topOrgs` so the existing dashboard component renders section payloads unchanged.

### Components
`src/components/product-telemetry/PlatformProductTelemetryDashboard.tsx` (new)
- Totals stat cards (active orgs / users / sessions / events).
- Top-orgs table with drilldown links **only for orgs resolved by Postgres**; unresolved hashes are listed as hash-only (no link), with a tooltip explaining the missing match.
- Embeds the existing `ProductTelemetryDashboard` for cross-org section payloads.

### Pages
`src/app/(app)/superadmin/product-telemetry/page.tsx` (rewritten)
- Uses the platform fetcher. No more "Select an organization" short-circuit.
- Accepts optional `startDate` / `endDate` search params so drilldown back-links preserve the selected window.

`src/app/(app)/superadmin/product-telemetry/[orgId]/page.tsx` (new)
- Dynamic drilldown route. Reuses the existing per-org fetcher + dashboard component.
- "← Back to all orgs" link preserves the date range.

### Tests

`src/lib/graphql/__tests__/productTelemetryFetchers.test.ts` — new describe for the platform fetcher: query includes `totals` + `topOrgs` + every section, variables omit `orgId`, options pass `orgId: ""`, returned payload shape matches.

`src/components/product-telemetry/PlatformProductTelemetryDashboard.test.tsx` (new, 4 cases):
- Renders the four totals stat cards.
- Resolved orgs render as drilldown links; unresolved hashes render as text only.
- Empty top-orgs shows the empty-state message.
- Embedded per-org dashboard receives section payload (top-routes verification).

## Verification

\`\`\`bash
cd web
pnpm vitest run src/lib/graphql/__tests__/productTelemetryFetchers.test.ts src/components/product-telemetry
# → 3 files, 8 tests passed
pnpm typecheck
# → clean
pnpm lint
# → 0 errors (3 pre-existing warnings unrelated)
\`\`\`

## Dependencies

- **dev-health-ops PR #791** (CHAOS-1875) — provides the backend resolver this PR talks to. Frontend will 500 against an unupgraded backend.
- **dev-health-ops PR #792** (CHAOS-1877) — multi-org seeder. Required for the platform overview to show meaningful data locally.

SCREENSHOT-WAIVER: End-to-end visual verification requires the companion backend (PR #791) and seeded fixtures (PR #792) deployed locally. Screenshots will be captured in a follow-up comment on this PR and on CHAOS-1876 once #791 and #792 land and a seeded local stack is available. The schema-drift CI plus typecheck + unit tests cover correctness for now.

Closes CHAOS-1876
Refs CHAOS-1874