### PR TITLE
feat(web): add Trust/Security marketing page (CHAOS-2009)

### DIFF
--- a/src/app/marketing/security/page.tsx
+++ b/src/app/marketing/security/page.tsx
@@ -4,7 +4,7 @@ import { LegalDocument, type LegalSection } from "@/components/shared/LegalDocum
 export const metadata: Metadata = {
   title: "Security — Full Chaos Dev Health",
   description:
-    "How Full Chaos Dev Health handles repository metadata, GitHub credentials, and customer data deletion.",
+    "How Full Chaos Dev Health handles repository metadata, code hosting provider credentials, and customer data deletion.",
 };
 
 const sections: LegalSection[] = [
@@ -12,13 +12,13 @@ const sections: LegalSection[] = [
     title: "Code storage",
     paragraphs: [
       "Full Chaos Dev Health does not clone, check out, or store customer repository source code.",
-      "The product uses authorized GitHub API access to collect operational metadata and derived analytics. We read the metadata required to compute engineering-flow, investment-mix, quality, and developer-health metrics, and we persist only those operational records and the metrics derived from them.",
+      "The product uses authorized API access to connected code hosting providers, such as GitHub and GitLab, to collect operational metadata and derived analytics. We read the metadata required to compute engineering-flow, investment-mix, quality, and developer-health metrics, and we persist only those operational records and the metrics derived from them.",
     ],
   },
   {
     title: "What repository data we collect",
     paragraphs: [
-      "We retain operational and metadata records obtained through authorized GitHub API access. We do not retain repository source code. The data we retain includes:",
+      "We retain operational and metadata records obtained through authorized code hosting provider API access (for example, GitHub and GitLab). We do not retain repository source code. The data we retain includes:",
     ],
     items: [
       "Repository identifiers and repository names.",
@@ -31,9 +31,9 @@ const sections: LegalSection[] = [
     ],
   },
   {
-    title: "GitHub token security",
+    title: "Credential and token security",
     paragraphs: [
-      "GitHub credentials are secrets. Full Chaos Dev Health supports GitHub personal access tokens (PAT) and GitHub App authentication.",
+      "Provider credentials are secrets. For code hosting providers, Full Chaos Dev Health supports GitHub personal access tokens (PATs) or GitHub App authentication and GitLab access tokens; connected work-item providers such as Jira and Linear use their own API credentials. Local Git analysis uses a repository path and requires no stored provider credential.",
       "Credentials are encrypted at rest and are used server-side only for authorized API operations. Credential records are scoped by organization and workspace so they are accessible only within the tenant that provided them.",
       "Tokens are not exposed in dashboards, reports, exports, analytics views, client-side code, logs, or error traces.",
     ],
@@ -51,7 +51,7 @@ const sections: LegalSection[] = [
       "When a trial ends and the customer does not convert, Full Chaos Dev Health removes the customer workspace and associated retained data from active systems. Deleting an organization removes credentials, sync configuration, scheduled jobs, imported metadata, cached analysis records, and derived metrics from active systems. Specifically, offboarding:",
     ],
     items: [
-      "Deletes the stored GitHub and integration credentials for the workspace.",
+      "Deletes the stored provider credentials for the workspace, including GitHub, GitLab, and any other connected integrations.",
       "Disables scheduled sync jobs and queued sync state for the workspace.",
       "Removes imported repository, pull request, commit, review, and security/dependency alert metadata for the workspace.",
       "Removes cached analysis records and derived metrics for the workspace from active systems.",
@@ -62,14 +62,14 @@ const sections: LegalSection[] = [
   {
     title: "Customer-controlled revocation",
     paragraphs: [
-      "Customers can revoke Full Chaos Dev Health's access to GitHub at any time, directly from GitHub, without waiting on us.",
-      "To revoke access, uninstall the GitHub App from your organization or revoke the authorization for the personal access token used to connect. Once access is revoked, further API collection stops.",
+      "Customers can revoke Full Chaos Dev Health's access to a connected code hosting provider at any time, directly from that provider, without waiting on us.",
+      "On GitHub, uninstall the GitHub App from your organization or revoke the personal access token used to connect. On GitLab, revoke the access token used to connect. Once access is revoked, further API collection from that provider stops.",
     ],
   },
   {
     title: "Security review summary",
     paragraphs: [
-      "For security questionnaires, the key points are: source code is never cloned or stored; only operational metadata and derived analytics are retained through authorized GitHub API access; GitHub credentials are encrypted at rest, scoped by organization and workspace, used server-side only, and never surfaced in product output or logs; deleting an organization removes credentials, sync configuration, scheduled jobs, imported metadata, cached analysis records, and derived metrics from active systems; and customers can revoke access directly through GitHub at any time.",
+      "For security questionnaires, the key points are: source code is never cloned or stored; only operational metadata and derived analytics are retained through authorized code hosting provider API access (such as GitHub and GitLab); provider credentials are encrypted at rest, scoped by organization and workspace, used server-side only, and never surfaced in product output or logs; deleting an organization removes credentials, sync configuration, scheduled jobs, imported metadata, cached analysis records, and derived metrics from active systems; and customers can revoke access directly through their code hosting provider at any time.",
     ],
   },
   {
@@ -85,7 +85,7 @@ export default function SecurityPage() {
     <LegalDocument
       eyebrow="Trust"
       title="Security and Repository Data Handling"
-      summary="How Full Chaos Dev Health handles source code, repository metadata, GitHub credentials, and trial offboarding."
+      summary="How Full Chaos Dev Health handles source code, repository metadata, code hosting provider credentials, and trial offboarding."
       lastUpdated="June 1, 2026"
       sections={sections}
     />

--- a/src/app/marketing/security/page.tsx
+++ b/src/app/marketing/security/page.tsx
@@ -1,0 +1,93 @@
+import type { Metadata } from "next";
+import { LegalDocument, type LegalSection } from "@/components/shared/LegalDocument";
+
+export const metadata: Metadata = {
+  title: "Security — Full Chaos Dev Health",
+  description:
+    "How Full Chaos Dev Health handles repository metadata, GitHub credentials, and customer data deletion.",
+};
+
+const sections: LegalSection[] = [
+  {
+    title: "Code storage",
+    paragraphs: [
+      "Full Chaos Dev Health does not clone, check out, or store customer repository source code.",
+      "The product uses authorized GitHub API access to collect operational metadata and derived analytics. We read the metadata required to compute engineering-flow, investment-mix, quality, and developer-health metrics, and we persist only those operational records and the metrics derived from them.",
+    ],
+  },
+  {
+    title: "What repository data we collect",
+    paragraphs: [
+      "We retain operational and metadata records obtained through authorized GitHub API access. We do not retain repository source code. The data we retain includes:",
+    ],
+    items: [
+      "Repository identifiers and repository names.",
+      "Pull requests, reviews, and review activity.",
+      "Commits, commit statistics, and authorship metadata.",
+      "File path and change metadata where needed to compute metrics.",
+      "CI and deployment metadata.",
+      "Security and dependency alert metadata where authorized.",
+      "Cached analysis records and the derived metrics produced from the data above.",
+    ],
+  },
+  {
+    title: "GitHub token security",
+    paragraphs: [
+      "GitHub credentials are secrets. Full Chaos Dev Health supports GitHub personal access tokens (PAT) and GitHub App authentication.",
+      "Credentials are encrypted at rest and are used server-side only for authorized API operations. Credential records are scoped by organization and workspace so they are accessible only within the tenant that provided them.",
+      "Tokens are not exposed in dashboards, reports, exports, analytics views, client-side code, logs, or error traces.",
+    ],
+  },
+  {
+    title: "Tenant and workspace isolation",
+    paragraphs: [
+      "Integration credentials and the data they unlock are scoped to the organization and workspace that authorized them. One customer's credentials and metrics are not visible to, or usable by, another customer.",
+      "Server-side access to a credential is limited to the authorized API operations performed on behalf of the workspace that owns it.",
+    ],
+  },
+  {
+    title: "Trial offboarding and data deletion",
+    paragraphs: [
+      "When a trial ends and the customer does not convert, Full Chaos Dev Health removes the customer workspace and associated retained data from active systems. Deleting an organization removes credentials, sync configuration, scheduled jobs, imported metadata, cached analysis records, and derived metrics from active systems. Specifically, offboarding:",
+    ],
+    items: [
+      "Deletes the stored GitHub and integration credentials for the workspace.",
+      "Disables scheduled sync jobs and queued sync state for the workspace.",
+      "Removes imported repository, pull request, commit, review, and security/dependency alert metadata for the workspace.",
+      "Removes cached analysis records and derived metrics for the workspace from active systems.",
+      "Invalidates workspace membership and access records.",
+      "Lets backups expire under the platform backup retention policy, unless a stricter contractual requirement applies.",
+    ],
+  },
+  {
+    title: "Customer-controlled revocation",
+    paragraphs: [
+      "Customers can revoke Full Chaos Dev Health's access to GitHub at any time, directly from GitHub, without waiting on us.",
+      "To revoke access, uninstall the GitHub App from your organization or revoke the authorization for the personal access token used to connect. Once access is revoked, further API collection stops.",
+    ],
+  },
+  {
+    title: "Security review summary",
+    paragraphs: [
+      "For security questionnaires, the key points are: source code is never cloned or stored; only operational metadata and derived analytics are retained through authorized GitHub API access; GitHub credentials are encrypted at rest, scoped by organization and workspace, used server-side only, and never surfaced in product output or logs; deleting an organization removes credentials, sync configuration, scheduled jobs, imported metadata, cached analysis records, and derived metrics from active systems; and customers can revoke access directly through GitHub at any time.",
+    ],
+  },
+  {
+    title: "Contact",
+    paragraphs: [
+      "Questions about this page or our security practices, including security-review and questionnaire requests, can be sent to support@fullchaos.studio, or through the Full Chaos Dev Health project contact channels published on our website or GitHub repository.",
+    ],
+  },
+];
+
+export default function SecurityPage() {
+  return (
+    <LegalDocument
+      eyebrow="Trust"
+      title="Security and Repository Data Handling"
+      summary="How Full Chaos Dev Health handles source code, repository metadata, GitHub credentials, and trial offboarding."
+      lastUpdated="June 1, 2026"
+      sections={sections}
+    />
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -60,6 +60,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.3,
     },
     {
+      url: `${BASE_URL}/marketing/security`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
       url: `${BASE_URL}/marketing/terms`,
       lastModified: now,
       changeFrequency: "yearly",

--- a/src/components/marketing/MarketingShell.tsx
+++ b/src/components/marketing/MarketingShell.tsx
@@ -47,8 +47,13 @@ const FOOTER_LINKS: Record<
   ],
   Legal: [
     { label: "Privacy", href: "/marketing/privacy" },
+    { label: "Security", href: "/marketing/security" },
     { label: "Terms", href: "/marketing/terms" },
-    { label: "Contact", href: "mailto:support@fullchaos.studio", external: true },
+    {
+      label: "Contact",
+      href: "mailto:support@fullchaos.studio",
+      external: true,
+    },
   ],
 };
 


### PR DESCRIPTION
## Summary

Adds a buyer-facing **Trust/Security** page at `/marketing/security` that answers common security-review / questionnaire questions about how Full Chaos Dev Health handles repository data, GitHub credentials, tenant isolation, and trial offboarding.

- New page `src/app/marketing/security/page.tsx` reuses the existing `LegalDocument` component (same pattern as the privacy page).
- Sections: Code storage, What repository data we collect, GitHub token security, Tenant and workspace isolation, Trial offboarding and data deletion, Customer-controlled revocation, Security review summary, Contact.
- Wires a **Security** link into the `MarketingShell` footer Legal group (between Privacy and Terms).
- Adds `/marketing/security` to the sitemap.

### Deletion language
Offboarding copy is **concrete** to match the org deletion/offboarding service landing ahead of this page: "Deleting an organization removes credentials, sync configuration, scheduled jobs, imported metadata, cached analysis records, and derived metrics from active systems." Backups are described as expiring under the platform retention policy (no permanent-backup-deletion claim).

### No overclaiming
No SOC 2 / ISO 27001 / HIPAA / GDPR certification claims, no deletion SLAs, no AST ingestion, no source-cloning/in-memory claims. States plainly that source code is never cloned or stored.

## Explicitly answers
- Whether source code is cloned or stored — no.
- How GitHub tokens are protected — encrypted at rest, scoped by org/workspace, server-side only, never surfaced in output/logs.
- How data is deleted at end of trial — credentials, sync config, scheduled jobs, imported metadata, cached analysis, derived metrics removed from active systems.
- How a customer revokes GitHub access — uninstall the GitHub App or revoke the PAT authorization.

## Verification
- prettier: clean
- eslint: clean (exit 0)
- `tsc --noEmit`: clean (exit 0)

TEST-WAIVER: Net-new static marketing content page (JSX copy) reusing the already-tested `LegalDocument` component; no component logic or data transforms added.

Closes CHAOS-2009