### PR TITLE
feat(admin): org deletion dry-run preview + offboarding wiring (CHAOS-2019, CHAOS-2020)

### DIFF
--- a/src/components/admin/settings/DangerZone.tsx
+++ b/src/components/admin/settings/DangerZone.tsx
@@ -4,7 +4,8 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { SettingsSection } from "./SettingsSection";
-import { deleteCurrentOrg } from "@/lib/admin/server";
+import { deleteCurrentOrg, dryRunDeleteCurrentOrg } from "@/lib/admin/server";
+import { DeletionPlanPreview, type DeletionResult } from "./DeletionPlanPreview";
 
 type DangerZoneProps = {
   orgName?: string;
@@ -15,6 +16,19 @@ export function DangerZone({ orgName }: DangerZoneProps) {
   const [isPending, startTransition] = useTransition();
   const [showConfirm, setShowConfirm] = useState(false);
   const [confirmText, setConfirmText] = useState("");
+  const [plan, setPlan] = useState<DeletionResult | null>(null);
+
+  const handleStartDelete = () => {
+    startTransition(async () => {
+      const result = await dryRunDeleteCurrentOrg();
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        setPlan(result.data ?? null);
+        setShowConfirm(true);
+      }
+    });
+  };
 
   const handleDelete = () => {
     if (confirmText !== orgName) return;
@@ -46,48 +60,28 @@ export function DangerZone({ orgName }: DangerZoneProps) {
           </div>
           <button
             type="button"
-            onClick={() => setShowConfirm(true)}
-            className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            onClick={handleStartDelete}
+            disabled={isPending}
+            className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50"
           >
-            Delete Organization
+            {isPending ? "Loading..." : "Delete Organization"}
           </button>
         </div>
-      ) : (
-        <div className="space-y-4">
-          <p className="text-sm text-(--foreground)">
-            Type <strong>{orgName}</strong> to confirm deletion:
-          </p>
-          <input
-            type="text"
-            value={confirmText}
-            onChange={(e) => setConfirmText(e.target.value)}
-            placeholder="Organization name"
-            disabled={isPending}
-            className="block w-full rounded-md border border-red-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500 disabled:opacity-50"
-          />
-          <div className="flex gap-3">
-            <button
-              type="button"
-              onClick={() => {
-                setShowConfirm(false);
-                setConfirmText("");
-              }}
-              disabled={isPending}
-              className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm font-medium text-(--foreground) hover:bg-(--card-70) disabled:opacity-50"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={handleDelete}
-              disabled={confirmText !== orgName || isPending}
-              className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50"
-            >
-              {isPending ? "Deleting..." : "Delete Forever"}
-            </button>
-          </div>
-        </div>
-      )}
+      ) : plan ? (
+        <DeletionPlanPreview
+          plan={plan}
+          onConfirm={handleDelete}
+          onCancel={() => {
+            setShowConfirm(false);
+            setConfirmText("");
+            setPlan(null);
+          }}
+          isPending={isPending}
+          confirmText={confirmText}
+          expectedConfirmText={orgName || ""}
+          setConfirmText={setConfirmText}
+        />
+      ) : null}
     </SettingsSection>
   );
 }

--- a/src/components/admin/settings/DeletionPlanPreview.test.tsx
+++ b/src/components/admin/settings/DeletionPlanPreview.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DeletionPlanPreview, type DeletionResult } from "./DeletionPlanPreview";
+
+const plan: DeletionResult = {
+  organizationId: "org-1",
+  dryRun: true,
+  timestamp: "2026-01-01T00:00:00Z",
+  deletedCounts: { organizations: 1, settings: 2, repo_metrics_daily: 3 },
+  disabledJobCount: 2,
+  credentialDeletionCount: 1,
+  warnings: ["ClickHouse URI not configured; analytics tables were not verified."],
+};
+
+function renderPreview(overrides: Partial<Parameters<typeof DeletionPlanPreview>[0]> = {}) {
+  const props = {
+    plan,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+    isPending: false,
+    confirmText: "",
+    expectedConfirmText: "org-1",
+    setConfirmText: vi.fn(),
+    ...overrides,
+  };
+  render(<DeletionPlanPreview {...props} />);
+  return props;
+}
+
+describe("DeletionPlanPreview", () => {
+  it("renders per-category counts, jobs, credentials, total and warnings", () => {
+    renderPreview();
+    expect(screen.getByText("Deletion Plan Preview")).toBeTruthy();
+    expect(screen.getByText("Scheduled Jobs (Disabled)")).toBeTruthy();
+    expect(screen.getByText("Credentials")).toBeTruthy();
+    expect(screen.getByText("Total Records")).toBeTruthy();
+    // total = 1 + 2 + 3
+    expect(screen.getByText("6")).toBeTruthy();
+    expect(screen.getByText(/ClickHouse URI not configured/)).toBeTruthy();
+  });
+
+  it("disables confirm until the confirmation text matches", () => {
+    renderPreview({ confirmText: "" });
+    const button = screen.getByRole("button", {
+      name: "Delete Forever",
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it("enables confirm and fires onConfirm when text matches", () => {
+    const onConfirm = vi.fn();
+    renderPreview({ confirmText: "org-1", onConfirm });
+    const button = screen.getByRole("button", {
+      name: "Delete Forever",
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    fireEvent.click(button);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/admin/settings/DeletionPlanPreview.tsx
+++ b/src/components/admin/settings/DeletionPlanPreview.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import type { DeletionPlan } from "@/lib/admin/types";
+
+export type DeletionResult = DeletionPlan;
+
+type DeletionPlanPreviewProps = {
+  plan: DeletionResult;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isPending: boolean;
+  confirmText: string;
+  expectedConfirmText: string;
+  setConfirmText: (text: string) => void;
+};
+
+export function DeletionPlanPreview({
+  plan,
+  onConfirm,
+  onCancel,
+  isPending,
+  confirmText,
+  expectedConfirmText,
+  setConfirmText,
+}: DeletionPlanPreviewProps) {
+  const totalDeleted = Object.values(plan.deletedCounts).reduce((a, b) => a + b, 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-md bg-red-50 p-4 dark:bg-red-900/20">
+        <h3 className="text-sm font-medium text-red-800 dark:text-red-200">
+          Deletion Plan Preview
+        </h3>
+        <div className="mt-2 text-sm text-red-700 dark:text-red-300">
+          <p>The following data will be permanently deleted. This action cannot be undone.</p>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-md border border-(--card-stroke)">
+        <table className="min-w-full divide-y divide-(--card-stroke)">
+          <thead className="bg-(--card-70)">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider">
+                Category
+              </th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-(--ink-muted) uppercase tracking-wider">
+                Records to Delete
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-(--card-stroke) bg-(--background)">
+            {Object.entries(plan.deletedCounts).map(([category, count]) => (
+              <tr key={category}>
+                <td className="px-4 py-3 text-sm text-(--foreground) capitalize">
+                  {category.replace(/_/g, " ")}
+                </td>
+                <td className="px-4 py-3 text-sm text-right text-(--foreground) font-mono">
+                  {count.toLocaleString()}
+                </td>
+              </tr>
+            ))}
+            {plan.disabledJobCount > 0 && (
+              <tr>
+                <td className="px-4 py-3 text-sm text-(--foreground)">Scheduled Jobs (Disabled)</td>
+                <td className="px-4 py-3 text-sm text-right text-(--foreground) font-mono">
+                  {plan.disabledJobCount.toLocaleString()}
+                </td>
+              </tr>
+            )}
+            {plan.credentialDeletionCount > 0 && (
+              <tr>
+                <td className="px-4 py-3 text-sm text-(--foreground)">Credentials</td>
+                <td className="px-4 py-3 text-sm text-right text-(--foreground) font-mono">
+                  {plan.credentialDeletionCount.toLocaleString()}
+                </td>
+              </tr>
+            )}
+            <tr className="bg-(--card-70) font-medium">
+              <td className="px-4 py-3 text-sm text-(--foreground)">Total Records</td>
+              <td className="px-4 py-3 text-sm text-right text-(--foreground) font-mono">
+                {totalDeleted.toLocaleString()}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {plan.warnings && plan.warnings.length > 0 && (
+        <div className="rounded-md bg-yellow-50 p-4 dark:bg-yellow-900/20">
+          <h3 className="text-sm font-medium text-yellow-800 dark:text-yellow-200">Warnings</h3>
+          <ul className="mt-2 list-disc pl-5 text-sm text-yellow-700 dark:text-yellow-300">
+            {plan.warnings.map((warning, i) => (
+              <li key={i}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="space-y-4 pt-4 border-t border-(--card-stroke)">
+        <p className="text-sm text-(--foreground)">
+          Type <strong>{expectedConfirmText}</strong> to confirm deletion:
+        </p>
+        <input
+          type="text"
+          value={confirmText}
+          onChange={(e) => setConfirmText(e.target.value)}
+          placeholder={expectedConfirmText}
+          disabled={isPending}
+          className="block w-full rounded-md border border-red-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500 disabled:opacity-50"
+        />
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isPending}
+            className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm font-medium text-(--foreground) hover:bg-(--card-70) disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={confirmText !== expectedConfirmText || isPending}
+            className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50"
+          >
+            {isPending ? "Deleting..." : "Delete Forever"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/superadmin/OrgDeleteSection.tsx
+++ b/src/components/superadmin/OrgDeleteSection.tsx
@@ -3,8 +3,12 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { deleteOrganization } from "@/lib/admin/server";
+import { deleteOrganization, dryRunDeleteOrganization } from "@/lib/admin/server";
 import { SettingsSection } from "@/components/admin/settings/SettingsSection";
+import {
+  DeletionPlanPreview,
+  type DeletionResult,
+} from "@/components/admin/settings/DeletionPlanPreview";
 
 type OrgDeleteSectionProps = {
   orgId: string;
@@ -15,7 +19,20 @@ export function OrgDeleteSection({ orgId, orgSlug }: OrgDeleteSectionProps) {
   const router = useRouter();
   const [isDeleting, setIsDeleting] = useState(false);
   const [confirmSlug, setConfirmSlug] = useState("");
+  const [plan, setPlan] = useState<DeletionResult | null>(null);
 
+  async function handleStartDelete() {
+    setIsDeleting(true);
+    const result = await dryRunDeleteOrganization(orgId);
+
+    if (result.error) {
+      toast.error(result.error);
+      setIsDeleting(false);
+    } else {
+      setPlan(result.data ?? null);
+      setIsDeleting(false);
+    }
+  }
   async function handleDelete() {
     if (confirmSlug !== orgSlug) return;
 
@@ -52,29 +69,44 @@ export function OrgDeleteSection({ orgId, orgSlug }: OrgDeleteSectionProps) {
           </div>
         </div>
 
-        <div>
-          <label htmlFor="confirm-slug" className="block text-sm font-medium text-(--foreground)">
-            Type <span className="font-mono font-bold">{orgSlug}</span> to confirm
-          </label>
-          <div className="mt-1 flex gap-4">
-            <input
-              type="text"
-              id="confirm-slug"
-              value={confirmSlug}
-              onChange={(e) => setConfirmSlug(e.target.value)}
-              className="block w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
-              placeholder={orgSlug}
-            />
-            <button
-              type="button"
-              onClick={handleDelete}
-              disabled={isDeleting || confirmSlug !== orgSlug}
-              className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50"
-            >
-              {isDeleting ? "Deleting..." : "Delete Organization"}
-            </button>
+        {!plan ? (
+          <div>
+            <label htmlFor="confirm-slug" className="block text-sm font-medium text-(--foreground)">
+              Type <span className="font-mono font-bold">{orgSlug}</span> to confirm
+            </label>
+            <div className="mt-1 flex gap-4">
+              <input
+                type="text"
+                id="confirm-slug"
+                value={confirmSlug}
+                onChange={(e) => setConfirmSlug(e.target.value)}
+                className="block w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+                placeholder={orgSlug}
+              />
+              <button
+                type="button"
+                onClick={handleStartDelete}
+                disabled={isDeleting || confirmSlug !== orgSlug}
+                className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50"
+              >
+                {isDeleting ? "Loading..." : "Delete Organization"}
+              </button>
+            </div>
           </div>
-        </div>
+        ) : (
+          <DeletionPlanPreview
+            plan={plan}
+            onConfirm={handleDelete}
+            onCancel={() => {
+              setPlan(null);
+              setConfirmSlug("");
+            }}
+            isPending={isDeleting}
+            confirmText={confirmSlug}
+            expectedConfirmText={orgSlug}
+            setConfirmText={setConfirmSlug}
+          />
+        )}
       </div>
     </SettingsSection>
   );

--- a/src/lib/__tests__/deletion-normalize.test.ts
+++ b/src/lib/__tests__/deletion-normalize.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { normalizeDeletionResult } from "../admin/api/orgs";
+import type { DeletionResultRaw } from "../admin/types";
+
+const raw: DeletionResultRaw = {
+  organization_id: "org-1",
+  dry_run: true,
+  timestamp: "2026-01-01T00:00:00Z",
+  postgres: {
+    total: 5,
+    tables: { organizations: 1, settings: 2, scheduled_jobs: 0, teams: 2 },
+  },
+  clickhouse: {
+    total: 7,
+    tables: { repo_metrics_daily: 3, teams: 4, ai_attribution: 0 },
+  },
+  disabled_jobs: 2,
+  credentials_deleted: 3,
+  warnings: ["ClickHouse URI not configured; analytics tables were not verified."],
+};
+
+describe("normalizeDeletionResult", () => {
+  it("maps snake_case backend result to camelCase UI plan", () => {
+    const plan = normalizeDeletionResult(raw);
+    expect(plan.organizationId).toBe("org-1");
+    expect(plan.dryRun).toBe(true);
+    expect(plan.timestamp).toBe("2026-01-01T00:00:00Z");
+    expect(plan.disabledJobCount).toBe(2);
+    expect(plan.credentialDeletionCount).toBe(3);
+    expect(plan.warnings).toHaveLength(1);
+  });
+
+  it("omits zero-count tables and disambiguates analytics name collisions", () => {
+    const plan = normalizeDeletionResult(raw);
+    // zero-count tables are dropped from the preview
+    expect(plan.deletedCounts).not.toHaveProperty("scheduled_jobs");
+    expect(plan.deletedCounts).not.toHaveProperty("ai_attribution");
+    // postgres tables surface directly
+    expect(plan.deletedCounts.organizations).toBe(1);
+    expect(plan.deletedCounts.settings).toBe(2);
+    // collision: postgres "teams" kept, clickhouse "teams" suffixed (not merged)
+    expect(plan.deletedCounts.teams).toBe(2);
+    expect(plan.deletedCounts["teams (analytics)"]).toBe(4);
+    // non-colliding clickhouse table surfaces directly
+    expect(plan.deletedCounts.repo_metrics_daily).toBe(3);
+  });
+
+  it("defaults counts and warnings when fields are absent", () => {
+    const plan = normalizeDeletionResult({
+      organization_id: "org-2",
+      dry_run: false,
+      timestamp: "2026-01-01T00:00:00Z",
+      postgres: { total: 0, tables: {} },
+      clickhouse: { total: 0, tables: {} },
+      disabled_jobs: 0,
+      credentials_deleted: 0,
+      warnings: [],
+    });
+    expect(plan.deletedCounts).toEqual({});
+    expect(plan.warnings).toEqual([]);
+    expect(plan.disabledJobCount).toBe(0);
+  });
+});

--- a/src/lib/admin/api/orgs.ts
+++ b/src/lib/admin/api/orgs.ts
@@ -6,7 +6,37 @@ import type {
   Membership,
   MembershipCreate,
   MembershipUpdateRole,
+  DeletionPlan,
+  DeletionResultRaw,
 } from "../types";
+
+/**
+ * Normalize the backend DeletionResult (snake_case, postgres/clickhouse split)
+ * into the camelCase DeletionPlan the UI preview renders. Tables with zero rows
+ * are omitted; ClickHouse tables that collide with a Postgres table name are
+ * suffixed so counts are not silently merged.
+ */
+export function normalizeDeletionResult(raw: DeletionResultRaw): DeletionPlan {
+  const deletedCounts: Record<string, number> = {};
+  for (const [table, count] of Object.entries(raw.postgres?.tables ?? {})) {
+    if (count > 0) deletedCounts[table] = count;
+  }
+  for (const [table, count] of Object.entries(raw.clickhouse?.tables ?? {})) {
+    if (count > 0) {
+      const key = table in deletedCounts ? `${table} (analytics)` : table;
+      deletedCounts[key] = count;
+    }
+  }
+  return {
+    organizationId: raw.organization_id,
+    dryRun: raw.dry_run,
+    timestamp: raw.timestamp,
+    deletedCounts,
+    disabledJobCount: raw.disabled_jobs ?? 0,
+    credentialDeletionCount: raw.credentials_deleted ?? 0,
+    warnings: raw.warnings ?? [],
+  };
+}
 
 export const orgsApi = {
   list: (token?: string, headerOrgId?: string) =>
@@ -33,6 +63,20 @@ export const orgsApi = {
 
   delete: (orgId: string, token?: string, headerOrgId?: string) =>
     request<void>(`/orgs/${orgId}`, { method: "DELETE" }, token, headerOrgId),
+
+  dryRunDelete: async (
+    orgId: string,
+    token?: string,
+    headerOrgId?: string,
+  ): Promise<DeletionPlan> => {
+    const raw = await request<DeletionResultRaw>(
+      `/orgs/${orgId}?dry_run=true`,
+      { method: "DELETE" },
+      token,
+      headerOrgId,
+    );
+    return normalizeDeletionResult(raw);
+  },
 
   members: {
     list: (orgId: string, token?: string, headerOrgId?: string) =>
@@ -71,7 +115,10 @@ export const orgsApi = {
     ) =>
       request<void>(
         `/orgs/${orgId}/transfer-ownership`,
-        { method: "POST", body: JSON.stringify({ new_owner_user_id: newOwnerUserId }) },
+        {
+          method: "POST",
+          body: JSON.stringify({ new_owner_user_id: newOwnerUserId }),
+        },
         token,
         headerOrgId,
       ),

--- a/src/lib/admin/server/orgs.ts
+++ b/src/lib/admin/server/orgs.ts
@@ -10,6 +10,7 @@ import type {
   PlatformStats,
   AuditLogListResponse,
   AuditLogFilter,
+  DeletionPlan,
 } from "../types";
 import { getSessionContext, requireSuperuserToken, withErrorHandling } from "./_shared";
 
@@ -118,6 +119,16 @@ export async function deleteCurrentOrg(): Promise<ActionResult<void>> {
   });
 }
 
+export async function dryRunDeleteCurrentOrg(): Promise<ActionResult<DeletionPlan>> {
+  return withErrorHandling(async () => {
+    const { token, orgId } = await getSessionContext();
+    if (!orgId) {
+      throw new AdminApiError(400, "Bad Request", "No organization ID in session");
+    }
+    return adminApi.orgs.dryRunDelete(orgId, token, orgId);
+  });
+}
+
 // ---- Impersonation ----
 
 export async function startImpersonation(targetUserId: string): Promise<
@@ -194,6 +205,13 @@ export async function deleteOrganization(orgId: string): Promise<ActionResult<vo
   return withErrorHandling(async () => {
     const token = await requireSuperuserToken();
     return adminApi.orgs.delete(orgId, token);
+  });
+}
+
+export async function dryRunDeleteOrganization(orgId: string): Promise<ActionResult<DeletionPlan>> {
+  return withErrorHandling(async () => {
+    const token = await requireSuperuserToken();
+    return adminApi.orgs.dryRunDelete(orgId, token);
   });
 }
 

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -599,3 +599,34 @@ export interface OrgEntitlements {
   is_valid: boolean;
   limits: Record<string, number | null>;
 }
+
+// ---- Organization Deletion ----
+
+/** Raw deletion scope from dev-health-ops (snake_case). */
+export interface DeletionScopeRaw {
+  total: number;
+  tables: Record<string, number>;
+}
+
+/** Raw deletion result from dev-health-ops DELETE /orgs/{id} (snake_case). */
+export interface DeletionResultRaw {
+  organization_id: string;
+  dry_run: boolean;
+  timestamp: string;
+  postgres: DeletionScopeRaw;
+  clickhouse: DeletionScopeRaw;
+  disabled_jobs: number;
+  credentials_deleted: number;
+  warnings: string[];
+}
+
+/** Normalized deletion plan consumed by the UI deletion-plan preview. */
+export interface DeletionPlan {
+  organizationId: string;
+  dryRun: boolean;
+  timestamp: string;
+  deletedCounts: Record<string, number>;
+  disabledJobCount: number;
+  credentialDeletionCount: number;
+  warnings: string[];
+}

--- a/tests/live/org-deletion.spec.ts
+++ b/tests/live/org-deletion.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/test";
+import {
+  authHeaders,
+  getSuperuserToken,
+  liveBackendUrl,
+  loginUser,
+  registerUser,
+  testEmail,
+  verifyUser,
+} from "./helpers";
+
+/**
+ * Live e2e for organization deletion / offboarding (CHAOS-2020).
+ *
+ * Verifies, against a real dev-health-ops backend, that:
+ *  - dry-run returns a deletion plan WITHOUT deleting,
+ *  - a real delete removes the organization,
+ *  - the offboarded user's access to the org is invalidated afterwards.
+ *
+ * Runs in the live-e2e suite (real backend required); skips cleanly otherwise.
+ */
+test.describe("organization deletion / offboarding", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const email = testEmail("offboard");
+  const password = "TestPass123!";
+  let userToken = "";
+  let superToken = "";
+  let orgId = "";
+
+  test.beforeAll(async ({ request }) => {
+    const regRes = await request.post(`${liveBackendUrl}/api/v1/auth/register`, {
+      data: { email, password, full_name: "Offboard User" },
+      headers: { Origin: liveBackendUrl },
+    });
+    if (!regRes.ok()) return;
+
+    const regData = (await regRes.json()) as Record<string, unknown>;
+    const userId = (regData.user_id ?? regData.id ?? "") as string;
+    superToken = (await getSuperuserToken(request)) ?? "";
+    if (superToken && userId) await verifyUser(request, userId, superToken);
+
+    const login = (await loginUser(request, email, password)) as {
+      access_token?: string;
+    };
+    userToken = login.access_token ?? "";
+
+    if (userToken) {
+      const onboard = await request.post(`${liveBackendUrl}/api/v1/auth/onboard`, {
+        headers: authHeaders(userToken),
+        data: { action: "create_org", org_name: "Offboard Corp" },
+      });
+      if (onboard.ok()) {
+        const data = (await onboard.json()) as Record<string, unknown>;
+        orgId = ((data.org_id ?? data.organization_id) as string) ?? "";
+      }
+    }
+  });
+
+  test("dry-run returns a deletion plan without deleting", async ({ request }) => {
+    if (!superToken || !orgId) {
+      test.skip(true, "Backend unavailable or org not provisioned");
+      return;
+    }
+
+    const res = await request.delete(`${liveBackendUrl}/api/v1/admin/orgs/${orgId}?dry_run=true`, {
+      headers: authHeaders(superToken),
+    });
+    expect(res.status()).toBe(200);
+
+    const plan = (await res.json()) as {
+      organization_id: string;
+      dry_run: boolean;
+      postgres: { total: number; tables: Record<string, number> };
+      disabled_jobs: number;
+    };
+    expect(plan.organization_id).toBe(orgId);
+    expect(plan.dry_run).toBe(true);
+    expect(plan.postgres.tables.organizations).toBe(1);
+
+    // Dry-run must NOT delete: a second dry-run still sees the organization.
+    const again = await request.delete(
+      `${liveBackendUrl}/api/v1/admin/orgs/${orgId}?dry_run=true`,
+      { headers: authHeaders(superToken) },
+    );
+    const againPlan = (await again.json()) as {
+      postgres: { tables: Record<string, number> };
+    };
+    expect(againPlan.postgres.tables.organizations).toBe(1);
+  });
+
+  test("real delete removes the organization", async ({ request }) => {
+    if (!superToken || !orgId) {
+      test.skip(true, "Backend unavailable or org not provisioned");
+      return;
+    }
+
+    const res = await request.delete(`${liveBackendUrl}/api/v1/admin/orgs/${orgId}`, {
+      headers: authHeaders(superToken),
+    });
+    expect(res.status()).toBe(200);
+    const result = (await res.json()) as { dry_run: boolean };
+    expect(result.dry_run).toBe(false);
+
+    // The organization is gone from active systems.
+    const after = await request.delete(
+      `${liveBackendUrl}/api/v1/admin/orgs/${orgId}?dry_run=true`,
+      { headers: authHeaders(superToken) },
+    );
+    const afterPlan = (await after.json()) as {
+      postgres: { tables: Record<string, number> };
+    };
+    expect(afterPlan.postgres.tables.organizations).toBe(0);
+  });
+
+  test("offboarded user's org access is invalidated", async ({ request }) => {
+    if (!userToken || !orgId) {
+      test.skip(true, "Backend unavailable or org not provisioned");
+      return;
+    }
+
+    // The user's membership was removed; org-scoped access must no longer resolve.
+    const me = await request.get(`${liveBackendUrl}/api/v1/orgs/me`, {
+      headers: { ...authHeaders(userToken), "X-Org-Id": orgId },
+    });
+    expect(me.ok()).toBe(false);
+
+    // Re-login: the user no longer belongs to any org → needs onboarding again.
+    const relogin = (await loginUser(request, email, password)) as {
+      needs_onboarding?: boolean;
+    };
+    expect(relogin.needs_onboarding).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the offboarding UX on top of the new centralized backend deletion service (ops MR: full.chaos/dev-health-ops!4).

- `DeletionPlanPreview`: shows per-category record counts, disabled scheduled jobs, and credential count **before** a confirmed delete; confirm is gated on typing the org name/slug.
- Wired into both the org **Danger Zone** (`/admin/settings`) and the **superadmin** org delete section (`/superadmin/orgs/[id]`).
- Routes deletion through the centralized backend service and normalizes its `DeletionResult` (snake_case, `postgres`/`clickhouse` scopes) into the UI plan shape via `normalizeDeletionResult` (zero-count tables omitted; analytics name collisions disambiguated).
- Post-delete: current-org delete signs the user out; offboarded users lose org access (backend removes memberships + refresh tokens).

## Tests
- Unit: `normalizeDeletionResult` mapping (3 cases).
- Component: `DeletionPlanPreview` rendering + confirm gating (3 cases).
- Live e2e (`tests/live/org-deletion.spec.ts`): dry-run returns plan without deleting → real delete removes org → offboarded user's org access is invalidated.

`tsc` 0 errors, eslint clean, vitest 6/6.

SCREENSHOT-WAIVER: UI captured via component test; live screenshots require the full dev stack (backend + seeded fixtures + auth) which is not available in this automation environment. Recommend attaching dry-run preview screenshots for both delete flows before merge.

Closes CHAOS-2019, CHAOS-2020
Part of CHAOS-2010