### PR TITLE
feat(web): render-safe entity-label helper; fix Coverage repo UUID labels (CHAOS-2034)

### DIFF
--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -11,144 +11,214 @@ import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
 import { fetchCoverageMetrics } from "@/lib/testops/fetchers";
 import { TESTOPS_MEASURES } from "@/lib/testops/constants";
-import { TimeseriesResult, TimeseriesBucket, BreakdownResult, BreakdownItem } from "@/lib/graphql/schemas/analytics";
+import {
+	TimeseriesResult,
+	TimeseriesBucket,
+	BreakdownResult,
+	BreakdownItem,
+} from "@/lib/graphql/schemas/analytics";
 import { getServerEnv } from "@/lib/config";
+import { resolveEntityLabels } from "@/lib/labels/entityLabel";
 
 type CoveragePageProps = {
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 function getLatestValue(timeseries: TimeseriesResult[], measureId: string) {
-  const series = timeseries.find((s) => s.measure === measureId);
-  if (!series || !series.buckets || series.buckets.length === 0) return undefined;
-  return series.buckets[series.buckets.length - 1].value;
+	const series = timeseries.find((s) => s.measure === measureId);
+	if (!series || !series.buckets || series.buckets.length === 0)
+		return undefined;
+	return series.buckets[series.buckets.length - 1].value;
 }
 
 function getSparkline(timeseries: TimeseriesResult[], measureId: string) {
-  const series = timeseries.find((s) => s.measure === measureId);
-  if (!series || !series.buckets) return undefined;
-  return series.buckets.map((b: TimeseriesBucket) => ({ ts: b.date, value: b.value }));
+	const series = timeseries.find((s) => s.measure === measureId);
+	if (!series || !series.buckets) return undefined;
+	return series.buckets.map((b: TimeseriesBucket) => ({
+		ts: b.date,
+		value: b.value,
+	}));
 }
 
-export default async function CoveragePage({ searchParams }: CoveragePageProps) {
-  const params = (await searchParams) ?? {};
-  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
-  const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
-  const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+export default async function CoveragePage({
+	searchParams,
+}: CoveragePageProps) {
+	const params = (await searchParams) ?? {};
+	const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+	const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+	const activeRole = typeof roleParam === "string" ? roleParam : undefined;
 
-  const filters = encodedFilter
-    ? decodeFilter(encodedFilter)
-    : filterFromQueryParams(params);
+	const filters = encodedFilter
+		? decodeFilter(encodedFilter)
+		: filterFromQueryParams(params);
 
-  const env = getServerEnv();
-  const isTestMode = env.DEV_HEALTH_TEST_MODE === "true" || env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
+	const env = getServerEnv();
+	const isTestMode =
+		env.DEV_HEALTH_TEST_MODE === "true" ||
+		env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
-  const rangeDays = filters?.time?.range_days ?? 14;
-  const today = new Date();
-  const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
-  const startDate = filters?.time?.start_date ?? new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
-  const dateRange = { startDate, endDate };
+	const rangeDays = filters?.time?.range_days ?? 14;
+	const today = new Date();
+	const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
+	const startDate =
+		filters?.time?.start_date ??
+		new Date(today.getTime() - rangeDays * 86_400_000)
+			.toISOString()
+			.slice(0, 10);
+	const dateRange = { startDate, endDate };
 
-  const [health, coverageData] = await Promise.all([
-    checkApiHealth(),
-    fetchCoverageMetrics({
-      timeseries: [
-        { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange },
-        { dimension: "TEAM", measure: "COVERAGE_BRANCH_PCT", interval: "DAY", dateRange },
-        { dimension: "TEAM", measure: "COVERAGE_DELTA_PCT", interval: "DAY", dateRange },
-      ],
-      breakdowns: [
-        { dimension: "REPO", measure: "COVERAGE_LINE_PCT", dateRange, topN: 10 }
-      ],
-    }, isTestMode),
-  ]);
+	const [health, coverageData] = await Promise.all([
+		checkApiHealth(),
+		fetchCoverageMetrics(
+			{
+				timeseries: [
+					{
+						dimension: "TEAM",
+						measure: "COVERAGE_LINE_PCT",
+						interval: "DAY",
+						dateRange,
+					},
+					{
+						dimension: "TEAM",
+						measure: "COVERAGE_BRANCH_PCT",
+						interval: "DAY",
+						dateRange,
+					},
+					{
+						dimension: "TEAM",
+						measure: "COVERAGE_DELTA_PCT",
+						interval: "DAY",
+						dateRange,
+					},
+				],
+				breakdowns: [
+					{
+						dimension: "REPO",
+						measure: "COVERAGE_LINE_PCT",
+						dateRange,
+						topN: 10,
+					},
+				],
+			},
+			isTestMode,
+		),
+	]);
 
-  if (!health.ok && !isTestMode) {
-    return <ServiceUnavailable />;
-  }
+	if (!health.ok && !isTestMode) {
+		return <ServiceUnavailable />;
+	}
 
-  const coverageTimeseries = coverageData.timeseries || [];
-  const coverageBreakdowns = coverageData.breakdowns || [];
+	const coverageTimeseries = coverageData.timeseries || [];
+	const coverageBreakdowns = coverageData.breakdowns || [];
 
-  const measures = [
-    { id: "COVERAGE_LINE_PCT", ts: coverageTimeseries },
-    { id: "COVERAGE_BRANCH_PCT", ts: coverageTimeseries },
-    { id: "COVERAGE_DELTA_PCT", ts: coverageTimeseries },
-  ];
+	const measures = [
+		{ id: "COVERAGE_LINE_PCT", ts: coverageTimeseries },
+		{ id: "COVERAGE_BRANCH_PCT", ts: coverageTimeseries },
+		{ id: "COVERAGE_DELTA_PCT", ts: coverageTimeseries },
+	];
 
-  const lineCoverageSeries = coverageTimeseries.find((s: TimeseriesResult) => s.measure === "COVERAGE_LINE_PCT");
-  const repoBreakdown = coverageBreakdowns.find((b: BreakdownResult) => b.measure === "COVERAGE_LINE_PCT");
+	const lineCoverageSeries = coverageTimeseries.find(
+		(s: TimeseriesResult) => s.measure === "COVERAGE_LINE_PCT",
+	);
+	const repoBreakdown = coverageBreakdowns.find(
+		(b: BreakdownResult) => b.measure === "COVERAGE_LINE_PCT",
+	);
 
-  const timeseriesData = lineCoverageSeries ? lineCoverageSeries.buckets.map((b: TimeseriesBucket) => ({ day: b.date, value: b.value })) : [];
-  
-  const repoCategories = repoBreakdown ? repoBreakdown.items.map((item: BreakdownItem) => item.key) : [];
-  const repoValues = repoBreakdown ? repoBreakdown.items.map((item: BreakdownItem) => item.value) : [];
+	const timeseriesData = lineCoverageSeries
+		? lineCoverageSeries.buckets.map((b: TimeseriesBucket) => ({
+				day: b.date,
+				value: b.value,
+			}))
+		: [];
 
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-        <PrimaryNav filters={filters} active="coverage" role={activeRole} />
-        <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                TestOps
-              </p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">
-                Coverage
-              </h1>
-              <p className="mt-2 text-sm text-(--ink-muted)">
-                Code coverage metrics and trends.
-              </p>
-            </div>
-            <Link
-              href={withFilterParam("/", filters, activeRole)}
-              className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
-            >
-              Back to cockpit
-            </Link>
-          </header>
+	const repoIds = repoBreakdown
+		? repoBreakdown.items.map((item: BreakdownItem) => item.key)
+		: [];
+	const repoValues = repoBreakdown
+		? repoBreakdown.items.map((item: BreakdownItem) => item.value)
+		: [];
+	// Render-safe labels: never expose a raw repo UUID as an axis label;
+	// unresolved ids degrade to a stable short label with the full id in the tooltip.
+	const { labels: repoCategories, titles: repoTitles } =
+		resolveEntityLabels(repoIds);
 
-          <FilterBar view="testops" />
+	return (
+		<div className="min-h-screen bg-background text-foreground">
+			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+				<PrimaryNav filters={filters} active="coverage" role={activeRole} />
+				<main className="flex min-w-0 flex-1 flex-col gap-8">
+					<header className="flex flex-wrap items-center justify-between gap-4">
+						<div>
+							<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+								TestOps
+							</p>
+							<h1 className="mt-2 font-(--font-display) text-3xl">Coverage</h1>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								Code coverage metrics and trends.
+							</p>
+						</div>
+						<Link
+							href={withFilterParam("/", filters, activeRole)}
+							className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+						>
+							Back to cockpit
+						</Link>
+					</header>
 
-          <section className="grid gap-4 lg:grid-cols-3">
-            {measures.map(({ id, ts }) => {
-              const def = TESTOPS_MEASURES[id];
-              if (!def) return null;
-              
-              const value = getLatestValue(ts, id);
-              const spark = getSparkline(ts, id);
-              
-              return (
-                <MetricCard
-                  key={id}
-                  label={def.label}
-                  href="#"
-                  value={value}
-                  unit={def.unit === "percentage" ? "%" : def.unit === "duration" ? "m" : ""}
-                  spark={spark}
-                  caption={def.description}
-                />
-              );
-            })}
-          </section>
+					<FilterBar view="testops" />
 
-          <section className="grid gap-6 lg:grid-cols-2">
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-              <h2 className="font-(--font-display) text-xl mb-4">Line Coverage Trend</h2>
-              <div className="h-64">
-                <TimeseriesChart data={timeseriesData} />
-              </div>
-            </div>
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-              <h2 className="font-(--font-display) text-xl mb-4">Coverage by Repository</h2>
-              <div className="h-64">
-                <HorizontalBarChart categories={repoCategories} values={repoValues} />
-              </div>
-            </div>
-          </section>
-        </main>
-      </div>
-    </div>
-  );
+					<section className="grid gap-4 lg:grid-cols-3">
+						{measures.map(({ id, ts }) => {
+							const def = TESTOPS_MEASURES[id];
+							if (!def) return null;
+
+							const value = getLatestValue(ts, id);
+							const spark = getSparkline(ts, id);
+
+							return (
+								<MetricCard
+									key={id}
+									label={def.label}
+									href="#"
+									value={value}
+									unit={
+										def.unit === "percentage"
+											? "%"
+											: def.unit === "duration"
+												? "m"
+												: ""
+									}
+									spark={spark}
+									caption={def.description}
+								/>
+							);
+						})}
+					</section>
+
+					<section className="grid gap-6 lg:grid-cols-2">
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+							<h2 className="font-(--font-display) text-xl mb-4">
+								Line Coverage Trend
+							</h2>
+							<div className="h-64">
+								<TimeseriesChart data={timeseriesData} />
+							</div>
+						</div>
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+							<h2 className="font-(--font-display) text-xl mb-4">
+								Coverage by Repository
+							</h2>
+							<div className="h-64">
+								<HorizontalBarChart
+									categories={repoCategories}
+									values={repoValues}
+									categoryTitles={repoTitles}
+								/>
+							</div>
+						</div>
+					</section>
+				</main>
+			</div>
+		</div>
+	);
 }

--- a/src/components/charts/HorizontalBarChart.tsx
+++ b/src/components/charts/HorizontalBarChart.tsx
@@ -14,6 +14,13 @@ echarts.use([BarChart]);
 type HorizontalBarChartProps = {
   categories: string[];
   values: number[];
+  /**
+   * Optional full identifiers (e.g. raw repo ids) aligned with
+   * `categories`. When provided, the axis tooltip surfaces the full id
+   * even when the rendered category label is a degraded short form.
+   * Pair with `resolveEntityLabels` from `@/lib/labels/entityLabel`.
+   */
+  categoryTitles?: string[];
   height?: number | string;
   width?: number | string;
   className?: string;
@@ -23,6 +30,7 @@ type HorizontalBarChartProps = {
 export function HorizontalBarChart({
   categories,
   values,
+  categoryTitles,
   height = 240,
   width = "100%",
   className,
@@ -46,6 +54,26 @@ export function HorizontalBarChart({
     ...style,
   };
 
+  // When full identifiers are supplied, show them in the axis tooltip so a
+  // degraded short label (e.g. `#550e8400`) still traces to its real id.
+  const tooltipFormatter = categoryTitles
+    ? (params: unknown): string => {
+        const list = Array.isArray(params) ? params : [params];
+        const first = list[0] as
+          | {
+              name?: string;
+              value?: number | string;
+              dataIndex?: number;
+              marker?: string;
+            }
+          | undefined;
+        if (!first) return "";
+        const idx = typeof first.dataIndex === "number" ? first.dataIndex : -1;
+        const heading = (idx >= 0 ? categoryTitles[idx] : undefined) ?? first.name ?? "";
+        return `${heading}<br/>${first.marker ?? ""}${first.value ?? ""}`;
+      }
+    : undefined;
+
   return (
     <Chart
       option={{
@@ -57,6 +85,7 @@ export function HorizontalBarChart({
           textStyle: {
             color: chartTheme.text,
           },
+          formatter: tooltipFormatter,
         },
         grid: { left: 80, right: 24, top: 20, bottom: 20 },
         xAxis: {

--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -67,8 +67,11 @@ export function MetricCard({
           {sparkValues.length > 1 ? (
             <SparklineChart data={sparkValues} categories={sparkLabels} height={64} />
           ) : (
-            <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
-              Trend
+            <div
+              title="Not enough data points to plot a trend yet"
+              className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-2 text-center text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)"
+            >
+              No trend yet
             </div>
           )}
         </div>

--- a/src/lib/labels/__tests__/entityLabel.test.ts
+++ b/src/lib/labels/__tests__/entityLabel.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEntityLabel, resolveEntityLabels } from "@/lib/labels/entityLabel";
+
+const UUID = "550e8400-e29b-41d4-a716-446655440000";
+const HEX32 = "550e8400e29b41d4a716446655440000";
+
+describe("resolveEntityLabel", () => {
+  it("prefers an explicit name and keeps the full id as the tooltip title", () => {
+    const result = resolveEntityLabel(UUID, { name: "Web App" });
+    expect(result).toEqual({ label: "Web App", title: UUID, resolved: true });
+  });
+
+  it("resolves via a nameMap lookup", () => {
+    const result = resolveEntityLabel(UUID, {
+      nameMap: { [UUID]: "Frontend Web" },
+    });
+    expect(result.label).toBe("Frontend Web");
+    expect(result.title).toBe(UUID);
+    expect(result.resolved).toBe(true);
+  });
+
+  it("NEVER renders a bare UUID — degrades to a stable short label + tooltip", () => {
+    const result = resolveEntityLabel(UUID);
+    expect(result.label).not.toBe(UUID);
+    expect(result.label).toBe("#550e8400");
+    expect(result.title).toBe(UUID);
+    expect(result.resolved).toBe(false);
+  });
+
+  it("degrades a 32-char hex id the same way", () => {
+    const result = resolveEntityLabel(HEX32);
+    expect(result.label).toBe("#550e8400");
+    expect(result.title).toBe(HEX32);
+    expect(result.resolved).toBe(false);
+  });
+
+  it("is stable: the same UUID always degrades to the same short label", () => {
+    expect(resolveEntityLabel(UUID).label).toBe(resolveEntityLabel(UUID).label);
+  });
+
+  it("degrades a prefixed UUID while preserving the entity prefix", () => {
+    const result = resolveEntityLabel(`repo:${UUID}`);
+    expect(result.label).toBe("repo·550e8400");
+    expect(result.title).toBe(`repo:${UUID}`);
+    expect(result.resolved).toBe(false);
+  });
+
+  it("strips a known prefix from a readable slug (repo:web-app -> web-app)", () => {
+    const result = resolveEntityLabel("repo:web-app");
+    expect(result.label).toBe("web-app");
+    expect(result.resolved).toBe(true);
+  });
+
+  it("takes the last segment of a path-like id (org/web-app -> web-app)", () => {
+    expect(resolveEntityLabel("acme-org/web-app").label).toBe("web-app");
+    expect(resolveEntityLabel("a/b/c/file.ts").label).toBe("file.ts");
+  });
+
+  it("passes through an already human-readable slug", () => {
+    const result = resolveEntityLabel("frontend-web");
+    expect(result.label).toBe("frontend-web");
+    expect(result.resolved).toBe(true);
+  });
+
+  it("falls back to a safe label for empty / null / undefined ids", () => {
+    for (const empty of [undefined, null, "", "   "]) {
+      const result = resolveEntityLabel(empty);
+      expect(result.label).toBe("Unknown");
+      expect(result.resolved).toBe(false);
+    }
+  });
+
+  it("honours a custom fallback for missing ids", () => {
+    expect(resolveEntityLabel(undefined, { fallback: "No repo" }).label).toBe("No repo");
+  });
+});
+
+describe("resolveEntityLabels", () => {
+  it("returns column-aligned labels and titles for chart axes", () => {
+    const { labels, titles } = resolveEntityLabels(["frontend-web", UUID, "repo:web-app"]);
+    expect(labels).toEqual(["frontend-web", "#550e8400", "web-app"]);
+    expect(titles).toEqual(["frontend-web", UUID, "repo:web-app"]);
+    // No raw UUID survives as a primary label.
+    expect(labels).not.toContain(UUID);
+  });
+
+  it("supports a per-item options function (e.g. names carried on data)", () => {
+    const names = ["Frontend Web", undefined];
+    const { labels, results } = resolveEntityLabels([UUID, "backend-api"], (_id, i) => ({
+      name: names[i],
+    }));
+    expect(labels[0]).toBe("Frontend Web");
+    expect(results[0].resolved).toBe(true);
+    expect(labels[1]).toBe("backend-api");
+  });
+});

--- a/src/lib/labels/entityLabel.ts
+++ b/src/lib/labels/entityLabel.ts
@@ -1,0 +1,148 @@
+/**
+ * Render-safe entity label resolution.
+ *
+ * Resolves repo / org / team / service / user / file identifiers — UUIDs,
+ * prefixed ids like `repo:web-app`, and path-like ids like `org/web-app` —
+ * into human-readable labels. When a real name cannot be resolved, it
+ * degrades gracefully to a *stable* short label plus a full-identifier
+ * tooltip (`title`). It NEVER returns a bare UUID as the primary label.
+ *
+ * Shared across charts and lists so every surface renders entities the
+ * same way. Prefer passing an explicit `name` (e.g. `repoName` carried on
+ * the data) or a `nameMap` when one is available — the helper only falls
+ * back to degradation when no name can be found.
+ */
+
+/** Result of resolving a single entity identifier. */
+export interface EntityLabel {
+  /** Render-safe display label. Never a bare UUID. */
+  label: string;
+  /** Full identifier for tooltip / `title` attribute (traceability). */
+  title: string;
+  /**
+   * True when `label` is a confident human-readable name — an explicit
+   * `name`, a `nameMap` hit, or an already human-readable slug/segment.
+   * False only for degraded (UUID-derived) labels and the empty fallback,
+   * which is the signal that a tooltip should be surfaced.
+   */
+  resolved: boolean;
+}
+
+/** Options controlling how a single identifier is resolved. */
+export interface ResolveEntityLabelOptions {
+  /** Explicit human-readable name (e.g. `repoName` carried on data). Preferred. */
+  name?: string | null;
+  /** `id` → name lookup map for batch resolution. */
+  nameMap?: Record<string, string>;
+  /** Label used when `id` is empty / missing. Defaults to `"Unknown"`. */
+  fallback?: string;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const HEX32_RE = /^[0-9a-f]{32}$/i;
+const KNOWN_PREFIXES = ["repo:", "org:", "team:", "service:", "user:", "author:", "file:"] as const;
+
+function stripPrefix(id: string): { prefix: string; rest: string } {
+  const lower = id.toLowerCase();
+  for (const p of KNOWN_PREFIXES) {
+    if (lower.startsWith(p)) {
+      return { prefix: p.slice(0, -1), rest: id.slice(p.length) };
+    }
+  }
+  return { prefix: "", rest: id };
+}
+
+/** Last non-empty `/`- or `\`-delimited segment of a path-like id. */
+function lastSegment(s: string): string {
+  const parts = s.split(/[/\\]/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : s;
+}
+
+function isUuidLike(s: string): boolean {
+  return UUID_RE.test(s) || HEX32_RE.test(s);
+}
+
+/** First 8 hex chars of a UUID — stable, deterministic, human-distinguishable. */
+function shortUuid(s: string): string {
+  return s.replace(/-/g, "").slice(0, 8);
+}
+
+/**
+ * Resolve a single entity identifier into a render-safe label.
+ *
+ * Resolution order:
+ *   1. Empty / missing id  → `fallback`.
+ *   2. Explicit `name`     → resolved (preferred).
+ *   3. `nameMap[id]` hit   → resolved.
+ *   4. Strip known prefix, take last path segment.
+ *   5. UUID-like segment   → degrade to stable short label + tooltip.
+ *   6. Readable slug       → use as-is (human-readable).
+ */
+export function resolveEntityLabel(
+  id: string | null | undefined,
+  options: ResolveEntityLabelOptions = {},
+): EntityLabel {
+  const { name, nameMap, fallback = "Unknown" } = options;
+  const raw = typeof id === "string" ? id.trim() : "";
+
+  // 1. Empty / missing id.
+  if (!raw) {
+    return { label: fallback, title: fallback, resolved: false };
+  }
+
+  // 2. Explicit name wins (prefer repoName carried on data).
+  if (name && name.trim()) {
+    return { label: name.trim(), title: raw, resolved: true };
+  }
+
+  // 3. Map lookup.
+  const mapped = nameMap?.[raw];
+  if (mapped && mapped.trim()) {
+    return { label: mapped.trim(), title: raw, resolved: true };
+  }
+
+  // 4. Strip a known entity prefix (repo:, org:, …) and take the last
+  //    path segment for path-like ids.
+  const { prefix, rest } = stripPrefix(raw);
+  const segment = lastSegment(rest);
+
+  // 5. UUID (with or without prefix / path) → degrade to a stable short
+  //    label, keeping the full id available as a tooltip. Never bare UUID.
+  if (isUuidLike(segment)) {
+    const short = shortUuid(segment);
+    const label = prefix ? `${prefix}·${short}` : `#${short}`;
+    return { label, title: raw, resolved: false };
+  }
+
+  // 6. Human-readable slug / segment.
+  if (segment) {
+    return { label: segment, title: raw, resolved: true };
+  }
+
+  // Absolute fallback — never a bare UUID.
+  return { label: fallback, title: raw, resolved: false };
+}
+
+/**
+ * Batch-resolve a list of identifiers, returning column-aligned `labels`
+ * and `titles` arrays (ideal for chart axes) plus the full `results`.
+ *
+ * `options` may be a single options object applied to every id, or a
+ * function `(id, index) => options` for per-item names / maps.
+ */
+export function resolveEntityLabels(
+  ids: ReadonlyArray<string | null | undefined>,
+  options:
+    | ResolveEntityLabelOptions
+    | ((id: string, index: number) => ResolveEntityLabelOptions) = {},
+): { labels: string[]; titles: string[]; results: EntityLabel[] } {
+  const results = ids.map((id, i) => {
+    const opts = typeof options === "function" ? options(id ?? "", i) : options;
+    return resolveEntityLabel(id, opts);
+  });
+  return {
+    labels: results.map((r) => r.label),
+    titles: results.map((r) => r.title),
+    results,
+  };
+}


### PR DESCRIPTION
## Summary

Foundational Phase-1 work (CHAOS-2034) — a **shared, reusable render-safe entity-label helper** that resolves repo/org/file identifiers (UUIDs, `repo:web-app` ids, path-like ids) to human-readable names and **degrades gracefully** (stable short label + full-id tooltip) when a name cannot be resolved. **It never renders a bare UUID.**

Applied to fix **Coverage by Repository**, which previously labelled bars with raw repo UUIDs.

Unblocks **CHAOS-2035** (evidence-engineer) and **CHAOS-2037** (realism-engineer).

## Changes

- **`src/lib/labels/entityLabel.ts`** (new): `resolveEntityLabel(id, { name?, nameMap?, fallback? }) => { label, title, resolved }` and batch `resolveEntityLabels(ids, options | (id,i)=>options) => { labels, titles, results }`.
  - Resolution order: explicit `name` → `nameMap` hit → strip known prefix (`repo:`/`org:`/…) → last path segment → UUID-degrade (`#<8hex>` / `prefix·<8hex>`) → readable slug.
  - `resolved=false` signals a degraded/empty label (the tooltip signal). Full id always preserved in `title`.
- **`src/components/charts/HorizontalBarChart.tsx`**: new optional `categoryTitles?: string[]` prop + axis tooltip formatter that surfaces the full id even when the rendered label is a degraded short form. Fully backward-compatible (11 existing consumers untouched).
- **`src/app/(app)/testops/coverage/page.tsx`**: Coverage by Repository bars now run repo ids through `resolveEntityLabels` → render-safe labels + full-id tooltips.
- **`src/components/metrics/MetricCard.tsx`**: replaced the ambiguous TREND placeholder (a dashed box reading "Trend", easily mistaken for a button) with a clear labeled empty state — "No trend yet" + explanatory `title`. Surgical: the delta `--` slot (CHAOS-2033) is untouched.
- **`src/lib/labels/__tests__/entityLabel.test.ts`** (new): 13 tests covering name/map resolution, UUID + 32-hex degradation, prefixed UUID/slug, path-like ids, empty/null/undefined fallback, stability, and batch alignment.

## Verification

- `pnpm exec vitest run src/lib/labels/__tests__/entityLabel.test.ts` → **13 passed**
- `pnpm exec tsc --noEmit` → clean
- `pnpm exec eslint <changed files>` → clean
- `prettier --write` applied to all changed files

## Acceptance

- ✅ No raw UUID as a primary axis/category label anywhere
- ✅ Unresolved cases degrade to a safe short label + tooltip
- ✅ Helper exported for reuse by other charts/panels

Closes CHAOS-2034