### PR TITLE
feat(web): curated Meridian demo identity — remove fixture ids from customer surfaces (CHAOS-2037)

### DIFF
--- a/src/components/risk/CompoundingRiskDashboard.test.tsx
+++ b/src/components/risk/CompoundingRiskDashboard.test.tsx
@@ -26,7 +26,7 @@ function makeRow(overrides: Partial<CompoundingRiskRowView> = {}): CompoundingRi
     day: "2026-05-20",
     scope: "repo",
     scopeId: "11111111-1111-1111-1111-111111111111",
-    scopeLabel: "acme/backend",
+    scopeLabel: "meridian/core-api",
     score: 0.72,
     severity: "high",
     components: {
@@ -101,10 +101,14 @@ describe("CompoundingRiskDashboard", () => {
 
   it("renders one table row per scope and links into Work Graph", () => {
     const rows = [
-      makeRow({ scopeId: "repo-a", scopeLabel: "acme/a", score: 0.8 }),
+      makeRow({
+        scopeId: "repo-a",
+        scopeLabel: "meridian/web-app",
+        score: 0.8,
+      }),
       makeRow({
         scopeId: "repo-b",
-        scopeLabel: "acme/b",
+        scopeLabel: "meridian/infra",
         score: 0.35,
         severity: "low",
       }),

--- a/src/data/__tests__/fixtureLeakGuard.test.ts
+++ b/src/data/__tests__/fixtureLeakGuard.test.ts
@@ -38,6 +38,14 @@ const FORBIDDEN_SUBSTRINGS: ReadonlyArray<{ pattern: RegExp; reason: string }> =
     pattern: /\bacme\//i,
     reason: "fixture-flavoured 'acme/' scope label — use curated 'meridian/*'",
   },
+  {
+    pattern: /Default Organization/i,
+    reason: "fixture 'Default Organization' display name — use the curated brand",
+  },
+  {
+    pattern: /\bdefault-org\b/i,
+    reason: "fixture 'default-org' identifier rendered in demo data — use a curated id",
+  },
 ];
 
 /** Bare UUID used as a literal value (acceptable in functional mocks, not in labels). */

--- a/src/data/__tests__/fixtureLeakGuard.test.ts
+++ b/src/data/__tests__/fixtureLeakGuard.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * CHAOS-2037 — fixture-leak guard.
+ *
+ * Customer/demo surfaces must never render fixture-only identifiers. The
+ * synthetic seed and the frontend demo/sample data are the two sources that
+ * feed rendered labels (org switcher, churn paths, repo coverage, delivery
+ * risk). This guard statically scans those rendered-data sources so a fixture
+ * identifier (`Fixture Org`, `acme/demo-app`, an `acme/` scope label, or a bare
+ * UUID used as a display label) can never regress back onto a demo screen.
+ *
+ * Runtime UUID→name resolution (when a real id fails to resolve) is owned by the
+ * shared render-safe entity-label helper (CHAOS-2034); this guard covers the
+ * static data that the demo renders by default.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const webRoot = resolve(here, "../../..");
+
+const read = (relPath: string): string => readFileSync(resolve(webRoot, relPath), "utf8");
+
+/** Fixture-only identifiers that must never appear in rendered demo data. */
+const FORBIDDEN_SUBSTRINGS: ReadonlyArray<{ pattern: RegExp; reason: string }> = [
+  {
+    pattern: /Fixture Org/i,
+    reason: "fixture org display name leaked from the seed",
+  },
+  {
+    pattern: /acme\/demo-app/i,
+    reason: "fixture default repo name 'acme/demo-app' leaked",
+  },
+  {
+    pattern: /\bacme\//i,
+    reason: "fixture-flavoured 'acme/' scope label — use curated 'meridian/*'",
+  },
+];
+
+/** Bare UUID used as a literal value (acceptable in functional mocks, not in labels). */
+const BARE_UUID =
+  /["'`][0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}["'`]/;
+
+/**
+ * Files whose string content becomes a rendered demo/sample label. These carry
+ * curated names only — no functional UUIDs — so they are also scanned for bare
+ * UUID literals.
+ */
+const RENDERED_LABEL_FILES = [
+  "src/data/devHealthOpsSample.ts",
+  "src/lib/workGraph/demo.ts",
+  "src/data/devHealthOpsTranslations.ts",
+];
+
+/**
+ * MSW mock responses that drive demo/e2e screens. These legitimately contain
+ * functional UUIDs (billing audit ids, etc.), so they are scanned for the
+ * fixture-only substrings but not for bare UUID literals.
+ */
+const MOCK_RESPONSE_FILES = ["tests/mocks/handlers.ts", "tests/mocks/aiSample.ts"];
+
+describe("fixture-leak guard (CHAOS-2037)", () => {
+  for (const file of [...RENDERED_LABEL_FILES, ...MOCK_RESPONSE_FILES]) {
+    it(`${file} renders no fixture-only identifiers`, () => {
+      const source = read(file);
+      const offenders = FORBIDDEN_SUBSTRINGS.filter(({ pattern }) => pattern.test(source)).map(
+        ({ reason }) => reason,
+      );
+      expect(offenders, `${file}: ${offenders.join("; ")}`).toEqual([]);
+    });
+  }
+
+  for (const file of RENDERED_LABEL_FILES) {
+    it(`${file} renders no bare UUID labels`, () => {
+      const source = read(file);
+      expect(BARE_UUID.test(source), `${file} contains a bare UUID string literal`).toBe(false);
+    });
+  }
+});

--- a/src/data/devHealthOpsSample.ts
+++ b/src/data/devHealthOpsSample.ts
@@ -731,7 +731,7 @@ export const sampleChordTeamReviewLoad: ChordRecord[] = [
  * at default topN=8. Includes one strongly bilateral pair.
  *
  * Shape:
- * - 6 distinct repos (web-app, core-api, auth-svc, billing-svc, search-svc,
+ * - 6 distinct repos (web-app, core-api, auth-service, billing-service, search-service,
  *   mobile-app).
  * - No self-links: demonstrates clean directional exchange.
  * - Strongest bilateral: web-app <-> core-api (25 + 20 = 45).
@@ -752,27 +752,27 @@ export const sampleChordRepoTransfer: ChordRecord[] = [
   },
   {
     source: "core-api",
-    target: "auth-svc",
+    target: "auth-service",
     value: 18,
     metadata: { repo: "core-api", period: "2025-W08" },
   },
   {
-    source: "auth-svc",
+    source: "auth-service",
     target: "core-api",
     value: 6,
-    metadata: { repo: "auth-svc", period: "2025-W08" },
+    metadata: { repo: "auth-service", period: "2025-W08" },
   },
   {
     source: "core-api",
-    target: "billing-svc",
+    target: "billing-service",
     value: 14,
     metadata: { repo: "core-api", period: "2025-W08" },
   },
   {
-    source: "billing-svc",
+    source: "billing-service",
     target: "core-api",
     value: 10,
-    metadata: { repo: "billing-svc", period: "2025-W08" },
+    metadata: { repo: "billing-service", period: "2025-W08" },
   },
   {
     source: "mobile-app",
@@ -787,20 +787,20 @@ export const sampleChordRepoTransfer: ChordRecord[] = [
     metadata: { repo: "core-api", period: "2025-W08" },
   },
   {
-    source: "search-svc",
+    source: "search-service",
     target: "core-api",
     value: 9,
-    metadata: { repo: "search-svc", period: "2025-W08" },
+    metadata: { repo: "search-service", period: "2025-W08" },
   },
   {
     source: "core-api",
-    target: "search-svc",
+    target: "search-service",
     value: 5,
     metadata: { repo: "core-api", period: "2025-W08" },
   },
   {
     source: "web-app",
-    target: "auth-svc",
+    target: "auth-service",
     value: 7,
     metadata: { repo: "web-app", period: "2025-W08" },
   },
@@ -811,14 +811,14 @@ export const sampleChordRepoTransfer: ChordRecord[] = [
     metadata: { repo: "web-app", period: "2025-W08" },
   },
   {
-    source: "billing-svc",
-    target: "auth-svc",
+    source: "billing-service",
+    target: "auth-service",
     value: 4,
-    metadata: { repo: "billing-svc", period: "2025-W08" },
+    metadata: { repo: "billing-service", period: "2025-W08" },
   },
   {
     source: "mobile-app",
-    target: "search-svc",
+    target: "search-service",
     value: 2,
     metadata: { repo: "mobile-app", period: "2025-W08" },
   },

--- a/src/lib/workGraph/demo.ts
+++ b/src/lib/workGraph/demo.ts
@@ -6,7 +6,11 @@ import type {
 
 const issueInvestment: WorkUnitInvestmentDistribution = {
   workUnitId: "PROJ-101",
-  themeDistribution: { feature_delivery: 0.72, quality: 0.18, maintenance: 0.1 },
+  themeDistribution: {
+    feature_delivery: 0.72,
+    quality: 0.18,
+    maintenance: 0.1,
+  },
   subcategoryDistribution: {
     "feature_delivery.customer": 0.46,
     "feature_delivery.roadmap": 0.26,
@@ -24,7 +28,11 @@ const issueInvestment: WorkUnitInvestmentDistribution = {
 
 const prInvestment: WorkUnitInvestmentDistribution = {
   workUnitId: "PR-201",
-  themeDistribution: { feature_delivery: 0.62, quality: 0.28, operational: 0.1 },
+  themeDistribution: {
+    feature_delivery: 0.62,
+    quality: 0.28,
+    operational: 0.1,
+  },
   subcategoryDistribution: {
     "feature_delivery.customer": 0.42,
     "feature_delivery.enablement": 0.2,
@@ -51,7 +59,7 @@ export function demoInvestmentForRoot(
 export function demoWorkflowDrilldown(
   rootType: AIWorkflowRootTypeInput,
   rootId: string,
-  orgId = "default-org",
+  orgId = "meridian",
 ): AIWorkflowDrilldownResult {
   const isPr = rootType === "PR";
   const issueId = isPr ? "PROJ-101" : rootId;

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -112,7 +112,13 @@ const workUnitInvestmentsSample = [
     },
     evidence_quality: { value: 0.78, band: "moderate" },
     evidence: {
-      textual: [{ type: "text_phrase", phrase: "feature launch", source: "issue_title" }],
+      textual: [
+        {
+          type: "text_phrase",
+          phrase: "feature launch",
+          source: "issue_title",
+        },
+      ],
       structural: [{ type: "work_item_type", work_item_type: "story", count: 3 }],
       contextual: [
         {
@@ -889,7 +895,9 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
 
   // Capacity forecast.
   if (query.includes("capacityForecast") || query.includes("CapacityForecast")) {
-    return HttpResponse.json({ data: { capacityForecast: sampleCapacityForecast } });
+    return HttpResponse.json({
+      data: { capacityForecast: sampleCapacityForecast },
+    });
   }
 
   if (query.includes("OperatingReview") || query.includes("operatingReview")) {
@@ -897,7 +905,11 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
       data: {
         operatingReview: operatingReviewResponse(
           vars.orgId ?? "org-e2e",
-          (variables as { input?: { teamId?: string | null; weekStart?: string } }).input,
+          (
+            variables as {
+              input?: { teamId?: string | null; weekStart?: string };
+            }
+          ).input,
         ),
       },
     });
@@ -929,7 +941,12 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
   if (query.includes("compoundingRisk") || query.includes("CompoundingRisk")) {
     const orgId = vars.orgId ?? "org-e2e";
     const breakout = (variables as { filter?: { breakout?: string } }).filter?.breakout ?? "REPO";
-    const weights = { churn: 0.3, complexity: 0.3, ownership: 0.2, review: 0.2 };
+    const weights = {
+      churn: 0.3,
+      complexity: 0.3,
+      ownership: 0.2,
+      review: 0.2,
+    };
     const thresholds = { elevated: 0.4, high: 0.65 };
 
     // CHAOS-1750 test hook
@@ -944,7 +961,7 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
                 day: "2026-05-20",
                 scope: breakout,
                 scopeId: "scope-1",
-                scopeLabel: "acme/null",
+                scopeLabel: "meridian/data-pipeline",
                 score: null,
                 severity: "UNKNOWN",
                 components: {
@@ -988,7 +1005,7 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
         day: "2026-05-20",
         scope: "REPO",
         scopeId: "repo-a",
-        scopeLabel: "acme/backend",
+        scopeLabel: "meridian/core-api",
         score: 0.71,
         severity: "HIGH",
         components: baseComponents,
@@ -1000,7 +1017,7 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
         day: "2026-05-20",
         scope: "REPO",
         scopeId: "repo-b",
-        scopeLabel: "acme/frontend",
+        scopeLabel: "meridian/web-app",
         score: 0.42,
         severity: "ELEVATED",
         components: {
@@ -1018,7 +1035,7 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
         day: "2026-05-20",
         scope: "REPO",
         scopeId: "repo-c",
-        scopeLabel: "acme/infra",
+        scopeLabel: "meridian/infra",
         score: 0.25,
         severity: "LOW",
         components: {
@@ -1075,7 +1092,9 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
 
   if (query.includes("AIImpactSummary")) {
     return HttpResponse.json({
-      data: { aiImpactSummary: aiImpactSummaryResponse(orgId, startDate, endDate, aiMode) },
+      data: {
+        aiImpactSummary: aiImpactSummaryResponse(orgId, startDate, endDate, aiMode),
+      },
     });
   }
   if (query.includes("AIReviewLoad")) {
@@ -1096,20 +1115,28 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
   }
   if (query.includes("AIComparison")) {
     return HttpResponse.json({
-      data: { aiComparison: aiComparisonResponse(orgId, startDate, endDate, aiMode) },
+      data: {
+        aiComparison: aiComparisonResponse(orgId, startDate, endDate, aiMode),
+      },
     });
   }
   if (query.includes("AIOpportunities")) {
-    return HttpResponse.json({ data: { aiOpportunities: aiOpportunitiesResponse(orgId, aiMode) } });
+    return HttpResponse.json({
+      data: { aiOpportunities: aiOpportunitiesResponse(orgId, aiMode) },
+    });
   }
   if (query.includes("AIGovernanceSummary")) {
     return HttpResponse.json({
-      data: { aiGovernanceSummary: aiGovernanceSummaryResponse(orgId, startDate, endDate, aiMode) },
+      data: {
+        aiGovernanceSummary: aiGovernanceSummaryResponse(orgId, startDate, endDate, aiMode),
+      },
     });
   }
   if (query.includes("AIAttributedPrs")) {
     return HttpResponse.json({
-      data: { aiAttributedPrs: aiAttributedPrsResponse(orgId, startDate, endDate, aiMode) },
+      data: {
+        aiAttributedPrs: aiAttributedPrsResponse(orgId, startDate, endDate, aiMode),
+      },
     });
   }
   if (query.includes("AIWorkflowDrilldown")) {
@@ -1223,7 +1250,10 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
 export const handlers = [
   // ---- Auth (for e2e test authentication) ----
   http.post("*/api/v1/auth/login", async ({ request }) => {
-    const body = (await request.json()) as { email?: string; password?: string } | null;
+    const body = (await request.json()) as {
+      email?: string;
+      password?: string;
+    } | null;
     if (!body?.email || !body?.password) {
       return HttpResponse.json({ detail: "Missing credentials" }, { status: 400 });
     }
@@ -1589,8 +1619,20 @@ export const handlers = [
         coverage: { repos: 10, people: 5 },
       },
       deltas: [
-        { metric: "cycle_time", label: "Cycle Time", unit: "hours", value: 48, delta_pct: -12 },
-        { metric: "throughput", label: "Throughput", unit: "PRs/week", value: 15, delta_pct: 8 },
+        {
+          metric: "cycle_time",
+          label: "Cycle Time",
+          unit: "hours",
+          value: 48,
+          delta_pct: -12,
+        },
+        {
+          metric: "throughput",
+          label: "Throughput",
+          unit: "PRs/week",
+          value: 15,
+          delta_pct: 8,
+        },
         {
           metric: "review_latency",
           label: "Review Latency",
@@ -1793,7 +1835,13 @@ export const handlers = [
       },
       identity_coverage_pct: 100,
       deltas: [
-        { metric: "cycle_time", label: "Cycle Time", unit: "hours", value: 36, delta_pct: -10 },
+        {
+          metric: "cycle_time",
+          label: "Cycle Time",
+          unit: "hours",
+          value: 36,
+          delta_pct: -10,
+        },
         {
           metric: "review_latency",
           label: "Review Latency",
@@ -1801,15 +1849,43 @@ export const handlers = [
           value: 4,
           delta_pct: -15,
         },
-        { metric: "throughput", label: "Throughput", unit: "PRs/week", value: 8, delta_pct: 5 },
-        { metric: "churn", label: "Churn", unit: "%", value: 12, delta_pct: -3 },
-        { metric: "wip_overlap", label: "WIP Overlap", unit: "items", value: 2, delta_pct: 0 },
-        { metric: "blocked_work", label: "Blocked Work", unit: "%", value: 8, delta_pct: -2 },
+        {
+          metric: "throughput",
+          label: "Throughput",
+          unit: "PRs/week",
+          value: 8,
+          delta_pct: 5,
+        },
+        {
+          metric: "churn",
+          label: "Churn",
+          unit: "%",
+          value: 12,
+          delta_pct: -3,
+        },
+        {
+          metric: "wip_overlap",
+          label: "WIP Overlap",
+          unit: "items",
+          value: 2,
+          delta_pct: 0,
+        },
+        {
+          metric: "blocked_work",
+          label: "Blocked Work",
+          unit: "%",
+          value: 8,
+          delta_pct: -2,
+        },
       ],
       narrative: [{ text: "This person appears to maintain a steady delivery pace." }],
       sections: {
         work_mix: {
-          themes: { feature_delivery: 0.6, maintenance: 0.25, operational: 0.15 },
+          themes: {
+            feature_delivery: 0.6,
+            maintenance: 0.25,
+            operational: 0.15,
+          },
           evidence_count: 24,
         },
         flow_breakdown: {
@@ -1819,9 +1895,19 @@ export const handlers = [
           meeting_pct: 0.15,
         },
         collaboration: {
-          reviewers: [{ person_id: "person-456", display_name: "Jordan Lee", review_count: 12 }],
+          reviewers: [
+            {
+              person_id: "person-456",
+              display_name: "Jordan Lee",
+              review_count: 12,
+            },
+          ],
           authors_reviewed: [
-            { person_id: "person-789", display_name: "Sam Rivera", review_count: 8 },
+            {
+              person_id: "person-789",
+              display_name: "Sam Rivera",
+              review_count: 8,
+            },
           ],
         },
       },
@@ -1881,7 +1967,10 @@ export const handlers = [
   http.post("*/graphql", async ({ request }) => {
     let body: { query?: string; variables?: Record<string, unknown> } | null = null;
     try {
-      body = (await request.json()) as { query?: string; variables?: Record<string, unknown> };
+      body = (await request.json()) as {
+        query?: string;
+        variables?: Record<string, unknown>;
+      };
     } catch (error) {
       console.warn("[msw] Failed to parse GraphQL request body", error);
     }
@@ -1912,14 +2001,19 @@ export const handlers = [
   }),
 
   http.post("*/api/v1/auth/forgot-password", () =>
-    HttpResponse.json({ message: "If an account exists, a reset email was sent." }),
+    HttpResponse.json({
+      message: "If an account exists, a reset email was sent.",
+    }),
   ),
 
   http.get("*/api/v1/auth/verify", ({ request }) => {
     const url = new URL(request.url);
     const token = url.searchParams.get("token");
     if (token === "valid-token") {
-      return HttpResponse.json({ message: "Email verified successfully", verified: true });
+      return HttpResponse.json({
+        message: "Email verified successfully",
+        verified: true,
+      });
     }
     return HttpResponse.json(
       { detail: { message: "Invalid or expired verification token" } },
@@ -2048,7 +2142,13 @@ export const handlers = [
 
   http.get("*/api/v1/admin/teams/discover", () =>
     HttpResponse.json({
-      items: [{ team_id: "discovered-team", name: "Auto-discovered", source: "github" }],
+      items: [
+        {
+          team_id: "discovered-team",
+          name: "Auto-discovered",
+          source: "github",
+        },
+      ],
     }),
   ),
 
@@ -2068,7 +2168,14 @@ export const handlers = [
 
   http.get("*/api/v1/admin/users", () =>
     HttpResponse.json({
-      items: [{ id: "e2e-user-1", email: "test@example.com", role: "owner", is_active: true }],
+      items: [
+        {
+          id: "e2e-user-1",
+          email: "test@example.com",
+          role: "owner",
+          is_active: true,
+        },
+      ],
       total: 1,
     }),
   ),


### PR DESCRIPTION
## Summary

Replaces fixture-only identifiers on customer/demo surfaces with a curated, realistic "Meridian" demo identity. Pairs with the backend fixtures PR (ops repo #797) which is the source of `Fixture Org` / `acme/demo-app`.

- Curated org **Meridian** + realistic repo names (`meridian/web-app`, `core-api`, `auth-service`, `billing-service`, `search-service`, `mobile-app`, …), **byte-identical** between frontend sample data and the backend seed.
- Updates `src/data/devHealthOpsSample.ts`, `src/lib/workGraph/demo.ts`, `tests/mocks/handlers.ts` to the curated names.
- New guard `src/data/__tests__/fixtureLeakGuard.test.ts` fails if `Fixture`, `acme/demo-app`, `default-org`/`Default Organization`, or bare-UUID identifiers leak into rendered demo labels.
- Curated risk-scope labels in `CompoundingRiskDashboard.test.tsx`.

## Acceptance criteria (CHAOS-2037)
- [x] Demo-data strategy documented in the PRD (curated synthetic seed) — Linear doc updated.
- [x] No `Fixture` / `acme/demo-app` / bare-UUID identifiers on customer-facing/demo surfaces.
- [x] Coherent names across frontend + backend seed (single Meridian brand).
- [x] Lint/test guard flags fixture-only identifiers leaking into rendered labels.

SCREENSHOT-WAIVER: changes are demo seed/label data + mock handlers + a leak-guard test; rendered impact (org/repo names) is validated by `fixtureLeakGuard.test.ts` and the MSW handler tests. Live visual capture was blocked by a local Docker/dev-server constraint during the run — recommend capturing the org-switcher / churn / coverage screens before merge.

Closes CHAOS-2037