### PR TITLE
fix(ci): align test job to Node 22 LTS to stop dev-server wedge (CHAOS-2041)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
         if: needs.changes.outputs.code == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 25
+          node-version: 22
           cache: pnpm
       - name: Install dependencies
         if: needs.changes.outputs.code == 'true'


### PR DESCRIPTION
## Summary
Aligns the `test` job in `.github/workflows/tests.yml` from `node-version: 25` to `node-version: 22`.

## Root cause
The `test` job (`ci` tier = `next build` + the full Playwright suite against one shared `next dev` server) intermittently wedges after ~146 tests, cascading later specs to `net::ERR_ABORTED` (surfaced on #555; full RCA in CHAOS-2041). The **identical** standalone `E2E Tests` job runs the same `ci/run_tests.sh e2e` and is reliably green — and it runs on **Node 22 LTS**, while this job runs on **Node 25** (non-LTS "current"). The build memory is reclaimed when `next build` exits, so the persistent differentiator between the wedging job and the passing one is the Node runtime version. Node 22 LTS is also the platform standard.

## Why minimal
Surgical, **gating-preserving** (e2e stays in the `test` contract — unlike moving it to a separate job). A speculative dev-server heap bump was considered but dropped to keep the change to the single most-likely, lowest-risk variable.

## Verification caveat (important)
The `changes` filter that gates this job does **not** include `.github/workflows/**`, so this workflow-only PR will **not** run the suite on its own CI — it's validated on the next PR that touches `src/`/`tests/`/`ci/` (e.g. #561). If the wedge recurs on Node 22, the documented fallback in CHAOS-2041 is to move the e2e tier out of the `ci` job (the dedicated `E2E Tests` job already covers it) and/or shard the suite.

CI/config-only change — no `src/` change (governance gate N/A), no rendered UI (no screenshots).

Closes CHAOS-2041