### PR TITLE
feat(web): preview-gate AI Automations, add breadcrumbs, fix AI hub anchor (CHAOS-2045)

### DIFF
--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -11,6 +11,7 @@ export default async function AdminDashboardPage() {
       <AdminHeader
         title="Admin Dashboard"
         description={`Welcome back, ${user?.name || user?.email}.`}
+        breadcrumbs={[{ label: "Home", href: "/dashboard" }, { label: "Admin" }]}
       />
 
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/src/app/(app)/ai/automations/page.tsx
+++ b/src/app/(app)/ai/automations/page.tsx
@@ -20,9 +20,18 @@ export default async function AIAutomationsPage({ searchParams }: AIAutomationsP
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={filters} active="ai-opportunities" />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <AIPageHeader eyebrow="AI workflows" title="AI Automations">
-            Candidate patterns for responsible automation, separated from Impact diagnostics so
-            teams can triage opportunities directly.
+          <AIPageHeader
+            eyebrow="AI workflows"
+            title="AI Automations"
+            preview
+            breadcrumbs={[
+              { label: "Home", href: "/dashboard" },
+              { label: "AI Workflow", href: "/ai/impact" },
+              { label: "AI Automations" },
+            ]}
+          >
+            Repeatable work patterns surfaced as candidate opportunities for responsible automation,
+            kept separate from Impact diagnostics so teams can triage them directly.
           </AIPageHeader>
           <FilterBar view="ai" />
           <AIAutomationsDashboard filter={aiFilter} />

--- a/src/app/(app)/ai/impact/page.tsx
+++ b/src/app/(app)/ai/impact/page.tsx
@@ -27,7 +27,15 @@ export default async function AIImpactPage({ searchParams }: AIImpactPageProps) 
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={filters} active="ai-impact" />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <AIPageHeader eyebrow="AI" title="AI Impact">
+          <AIPageHeader
+            eyebrow="AI"
+            title="AI Impact"
+            breadcrumbs={[
+              { label: "Home", href: "/dashboard" },
+              { label: "AI Workflow", href: "/ai/impact" },
+              { label: "AI Impact" },
+            ]}
+          >
             Org-wide view of how AI-assisted workflows appear to influence delivery, review load,
             quality gaps, and operational drag.
           </AIPageHeader>

--- a/src/app/(app)/ai/review-load/page.tsx
+++ b/src/app/(app)/ai/review-load/page.tsx
@@ -20,7 +20,15 @@ export default async function AIReviewLoadPage({ searchParams }: AIReviewLoadPag
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={filters} active="ai-review-load" />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <AIPageHeader eyebrow="AI workflows" title="AI Review Load">
+          <AIPageHeader
+            eyebrow="AI workflows"
+            title="AI Review Load"
+            breadcrumbs={[
+              { label: "Home", href: "/dashboard" },
+              { label: "AI Workflow", href: "/ai/impact" },
+              { label: "AI Review Load" },
+            ]}
+          >
             Diagnostic view for AI-generated review pressure, comparing AI-attributed work against
             the human baseline without person-level rankings.
           </AIPageHeader>

--- a/src/app/(app)/ai/risk/page.tsx
+++ b/src/app/(app)/ai/risk/page.tsx
@@ -20,7 +20,15 @@ export default async function AIRiskPage({ searchParams }: AIRiskPageProps) {
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={filters} active="ai-risk" />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <AIPageHeader eyebrow="AI workflows" title="AI Risk">
+          <AIPageHeader
+            eyebrow="AI workflows"
+            title="AI Risk"
+            breadcrumbs={[
+              { label: "Home", href: "/dashboard" },
+              { label: "AI Workflow", href: "/ai/impact" },
+              { label: "AI Risk" },
+            ]}
+          >
             Quality-risk diagnostics for AI-associated work, including baseline deltas, explicit
             missing-data states, and governance findings.
           </AIPageHeader>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -66,7 +66,7 @@ const AI_WORKFLOW_STEPS = [
   {
     label: "Evidence + intervention",
     description: "Move from recommendations into evidence and weekly review.",
-    href: "/operating-review#ai-workflow-intelligence",
+    href: "/operating-review#ai_workflow_intelligence",
   },
 ];
 
@@ -186,11 +186,10 @@ export default async function Home({ searchParams }: HomePageProps) {
                 <p className="text-xs uppercase tracking-[0.2em] text-(--accent-2)">
                   Starting point
                 </p>
-                <h2 className="mt-3 text-xl leading-tight">
-                  AI Workflow Intelligence
-                </h2>
+                <h2 className="mt-3 text-xl leading-tight">AI Workflow Intelligence</h2>
                 <p className="mt-3 text-sm leading-6 text-(--ink-muted)">
-                  See whether AI-assisted work is improving delivery or shifting cost into review, rework, and risk.
+                  See whether AI-assisted work is improving delivery or shifting cost into review,
+                  rework, and risk.
                 </p>
                 <div className="mt-5 flex flex-wrap gap-3 text-xs uppercase tracking-[0.18em]">
                   <Link
@@ -201,7 +200,7 @@ export default async function Home({ searchParams }: HomePageProps) {
                   </Link>
                   <Link
                     href={withFilterParam(
-                      "/operating-review#ai-workflow-intelligence",
+                      "/operating-review#ai_workflow_intelligence",
                       filters,
                       activeRole,
                     )}
@@ -285,7 +284,11 @@ export default async function Home({ searchParams }: HomePageProps) {
                   Open Work view
                 </Link>
                 <Link
-                  href={buildExploreUrl({ metric: "throughput", filters, role: activeRole })}
+                  href={buildExploreUrl({
+                    metric: "throughput",
+                    filters,
+                    role: activeRole,
+                  })}
                   className="text-(--accent-2)"
                 >
                   Open in Explore

--- a/src/app/(app)/operating-review/page.tsx
+++ b/src/app/(app)/operating-review/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { FilterBar } from "@/components/filters/FilterBar";
+import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { ContextStrip } from "@/components/navigation/ContextStrip";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
@@ -73,6 +74,11 @@ export default async function OperatingReviewPage({ searchParams }: OperatingRev
         <main className="flex min-w-0 flex-1 flex-col gap-8">
           <header className="flex flex-wrap items-center justify-between gap-4">
             <div>
+              <div className="mb-3">
+                <Breadcrumbs
+                  items={[{ label: "Home", href: "/dashboard" }, { label: "Operating Review" }]}
+                />
+              </div>
               <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Weekly mode</p>
               <h1 className="mt-2 font-(--font-display) text-3xl">Engineering Operating Review</h1>
               <p className="mt-2 text-sm text-(--ink-muted)">

--- a/src/components/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/utils";
+import { Breadcrumbs } from "./Breadcrumbs";
+
+describe("Breadcrumbs", () => {
+  it("renders nothing when given no items", () => {
+    const { container } = render(<Breadcrumbs items={[]} />);
+    expect(container.querySelector("[data-testid='breadcrumbs']")).toBeNull();
+  });
+
+  it("renders crumbs with the last as the current page (non-link, aria-current)", () => {
+    render(
+      <Breadcrumbs
+        items={[
+          { label: "Home", href: "/dashboard" },
+          { label: "AI Workflow", href: "/ai/impact" },
+          { label: "AI Automations" },
+        ]}
+      />,
+    );
+
+    const home = screen.getByRole("link", { name: "Home" });
+    expect(home).toHaveAttribute("href", "/dashboard");
+
+    const current = screen.getByText("AI Automations");
+    expect(current.tagName).toBe("SPAN");
+    expect(current).toHaveAttribute("aria-current", "page");
+    // The current page must never be a link.
+    expect(screen.queryByRole("link", { name: "AI Automations" })).toBeNull();
+  });
+
+  it("exposes an accessible Breadcrumb landmark", () => {
+    render(<Breadcrumbs items={[{ label: "Home", href: "/dashboard" }, { label: "Admin" }]} />);
+    expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toBeInTheDocument();
+  });
+});

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { Fragment } from "react";
+
+export type Crumb = {
+  label: string;
+  /** Omit `href` for the current page (rendered as plain, non-link text). */
+  href?: string;
+};
+
+/**
+ * Reusable location trail (section → page → tab) so users always know where
+ * they are inside the authenticated app. Shared across (app) routes via the
+ * page-header components (AIPageHeader, AdminHeader) rather than re-invented
+ * per page.
+ *
+ * Rendering rules:
+ * - The last crumb is the current page: rendered as text with aria-current.
+ * - Earlier crumbs with an `href` are links; without one they are plain text.
+ */
+export function Breadcrumbs({ items }: { items: Crumb[] }) {
+  if (items.length === 0) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" data-testid="breadcrumbs">
+      <ol className="flex flex-wrap items-center gap-1.5 text-xs text-(--ink-muted)">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+          return (
+            <Fragment key={`${item.label}-${index}`}>
+              <li className="flex items-center">
+                {item.href && !isLast ? (
+                  <Link href={item.href} className="transition-colors hover:text-foreground">
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span
+                    className={isLast ? "font-medium text-foreground" : undefined}
+                    aria-current={isLast ? "page" : undefined}
+                  >
+                    {item.label}
+                  </span>
+                )}
+              </li>
+              {!isLast && (
+                <li aria-hidden="true" className="select-none text-(--ink-muted)/60">
+                  /
+                </li>
+              )}
+            </Fragment>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/PreviewBadge.test.tsx
+++ b/src/components/PreviewBadge.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/utils";
+import { PreviewBadge } from "./PreviewBadge";
+
+describe("PreviewBadge", () => {
+  it("renders a span with 'Preview' text", () => {
+    render(<PreviewBadge />);
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+  });
+
+  it("renders with the expected badge styles", () => {
+    render(<PreviewBadge />);
+    const badge = screen.getByText("Preview");
+    expect(badge.tagName).toBe("SPAN");
+    expect(badge).toHaveClass("uppercase");
+  });
+
+  it("applies a title attribute when provided", () => {
+    render(<PreviewBadge title="This feature is in preview." />);
+    expect(screen.getByText("Preview")).toHaveAttribute("title", "This feature is in preview.");
+  });
+});

--- a/src/components/PreviewBadge.tsx
+++ b/src/components/PreviewBadge.tsx
@@ -1,0 +1,18 @@
+/**
+ * Small, reusable "Preview" marker for destinations whose underlying signal is
+ * not yet generally available. Distinct from {@link BetaBadge} (amber, app-wide
+ * beta state): Preview is sky-toned and scoped to a single feature so users can
+ * tell a preview surface apart from a finished one at a glance.
+ *
+ * Decorative by default; pass a `title` when the badge needs a tooltip.
+ */
+export function PreviewBadge({ title }: { title?: string }) {
+  return (
+    <span
+      title={title}
+      className="rounded-full border border-sky-500/30 bg-sky-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-sky-400"
+    >
+      Preview
+    </span>
+  );
+}

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,15 +1,23 @@
 import React from "react";
+import { Breadcrumbs, type Crumb } from "@/components/Breadcrumbs";
 
 type AdminHeaderProps = {
   title: string;
   description?: string;
   children?: React.ReactNode;
+  /** Location trail (section → page). Rendered above the title. */
+  breadcrumbs?: Crumb[];
 };
 
-export function AdminHeader({ title, description, children }: AdminHeaderProps) {
+export function AdminHeader({ title, description, children, breadcrumbs }: AdminHeaderProps) {
   return (
     <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
       <div>
+        {breadcrumbs && breadcrumbs.length > 0 ? (
+          <div className="mb-3">
+            <Breadcrumbs items={breadcrumbs} />
+          </div>
+        ) : null}
         <h1 className="font-(--font-display) text-2xl font-bold">{title}</h1>
         {description && <p className="mt-1 text-sm text-(--ink-muted)">{description}</p>}
       </div>

--- a/src/components/ai/AIAutomationsDashboard.tsx
+++ b/src/components/ai/AIAutomationsDashboard.tsx
@@ -31,7 +31,7 @@ export function AIAutomationsDashboard({ filter }: AIAutomationsDashboardProps) 
     <div className="flex flex-col gap-6" data-testid="ai-automations-dashboard">
       <AIPanelCard
         title="Best-fit automation opportunities"
-        description="Candidate patterns for responsible automation once the recommendation engine becomes ready."
+        description="Repeatable work patterns that may be good candidates for responsible automation, scoped to your current selection."
       >
         <AIOpportunityList
           detectorReady={opportunities?.detectorReady}

--- a/src/components/ai/AIImpactDashboard.tsx
+++ b/src/components/ai/AIImpactDashboard.tsx
@@ -204,11 +204,11 @@ export function AIImpactDashboard({ filter }: AIImpactDashboardProps) {
 
         <AIPanelCard
           title="Top affected repos and teams"
-          description="Scoped rollups will appear after repo/team AI summary coverage lands."
+          description="Scoped repo and team rollups appear here once enough AI summary coverage exists for the selected scope."
         >
-          <AIEmptyState title="Coming after detector lands">
-            Org-scoped AI impact data populates now. Repo and team ranking placeholders remain empty
-            to avoid fabricating scoped values.
+          <AIEmptyState title="No scoped rollups in this scope yet">
+            Org-wide AI impact is shown above. Repo- and team-level rankings stay empty until there
+            is enough scoped coverage to show them without estimating values.
           </AIEmptyState>
         </AIPanelCard>
 

--- a/src/components/ai/AIOpportunityList.tsx
+++ b/src/components/ai/AIOpportunityList.tsx
@@ -69,10 +69,10 @@ export function AIOpportunityList({
   if (!detectorReady) {
     return (
       <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-80) p-5 text-sm text-(--ink-muted)">
-        <p className="font-medium text-foreground">Opportunity engine pending</p>
+        <p className="font-medium text-foreground">No automation candidates in this scope yet</p>
         <p className="mt-2">
-          Best-fit automation candidates land with CHAOS-1586. This space will suggest repeatable
-          work patterns once that signal becomes available.
+          As more repeatable work patterns accumulate for the selected scope, best-fit automation
+          candidates will appear here.
         </p>
       </div>
     );
@@ -80,9 +80,7 @@ export function AIOpportunityList({
 
   if (!recommendations?.length) {
     return (
-      <p className="text-sm text-(--ink-muted)">
-        No automation candidates appear in the current scope.
-      </p>
+      <p className="text-sm text-(--ink-muted)">No automation candidates in this scope yet.</p>
     );
   }
 

--- a/src/components/ai/AIPageHeader.tsx
+++ b/src/components/ai/AIPageHeader.tsx
@@ -1,9 +1,15 @@
 import type { ReactNode } from "react";
+import { Breadcrumbs, type Crumb } from "@/components/Breadcrumbs";
+import { PreviewBadge } from "@/components/PreviewBadge";
 
 type AIPageHeaderProps = {
   eyebrow: string;
   title: string;
   children: ReactNode;
+  /** Location trail (section → page → tab). Rendered above the eyebrow. */
+  breadcrumbs?: Crumb[];
+  /** When true, marks the page as a preview surface next to the title. */
+  preview?: boolean;
 };
 
 /**
@@ -11,11 +17,25 @@ type AIPageHeaderProps = {
  * (Impact, Review Load, Risk). Keeps eyebrow + title + lede consistent
  * across the cluster so copy tone doesn't drift between pages.
  */
-export function AIPageHeader({ eyebrow, title, children }: AIPageHeaderProps) {
+export function AIPageHeader({
+  eyebrow,
+  title,
+  children,
+  breadcrumbs,
+  preview,
+}: AIPageHeaderProps) {
   return (
     <header>
+      {breadcrumbs && breadcrumbs.length > 0 ? (
+        <div className="mb-3">
+          <Breadcrumbs items={breadcrumbs} />
+        </div>
+      ) : null}
       <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">{eyebrow}</p>
-      <h1 className="mt-2 font-(--font-display) text-3xl">{title}</h1>
+      <div className="mt-2 flex items-center gap-3">
+        <h1 className="font-(--font-display) text-3xl">{title}</h1>
+        {preview ? <PreviewBadge title="This feature is in preview." /> : null}
+      </div>
       <p className="mt-2 max-w-3xl text-sm text-(--ink-muted)">{children}</p>
     </header>
   );

--- a/src/lib/__tests__/preview.test.ts
+++ b/src/lib/__tests__/preview.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { PREVIEW_FEATURES, isPreviewFeature } from "@/lib/preview";
+
+describe("preview feature registry", () => {
+  it("marks ai-opportunities (AI Automations) as a preview feature", () => {
+    expect(isPreviewFeature("ai-opportunities")).toBe(true);
+    expect(PREVIEW_FEATURES["ai-opportunities"].label).toBeTruthy();
+  });
+
+  it("returns false for features that are generally available", () => {
+    expect(isPreviewFeature("ai-impact")).toBe(false);
+    expect(isPreviewFeature("home")).toBe(false);
+    expect(isPreviewFeature("unknown-id")).toBe(false);
+  });
+});

--- a/src/lib/preview.ts
+++ b/src/lib/preview.ts
@@ -1,0 +1,31 @@
+/**
+ * Single source of truth for "is this feature a preview / not-yet-general
+ * destination". Centralizing this lets navigation (PrimaryNav), page headers
+ * (AIPageHeader / AdminHeader), and feature surfaces agree on one answer
+ * instead of each re-deciding via scattered copy or ad-hoc flags.
+ *
+ * A preview feature is one whose underlying signal is not yet generally
+ * available (e.g. detector-gated AI surfaces). It is NOT deleted — it stays
+ * reachable but is clearly marked so it never looks like a plain, broken
+ * destination.
+ *
+ * Keys are stable nav-item ids (see `PrimaryNav` `navGroups[].items[].id`) so a
+ * consumer can ask `isPreviewFeature(item.id)` while rendering the nav.
+ */
+
+export type PreviewFeatureId = "ai-opportunities";
+
+/**
+ * Registry of features currently in preview. Add an entry here (and only here)
+ * to mark a destination as preview across nav + headers.
+ */
+export const PREVIEW_FEATURES: Record<PreviewFeatureId, { label: string }> = {
+  // /ai/automations — best-fit automation candidates depend on the
+  // recommendation detector, which is not yet generally available.
+  "ai-opportunities": { label: "Automation candidates" },
+};
+
+/** True when `id` names a feature that should be marked as preview. */
+export function isPreviewFeature(id: string): id is PreviewFeatureId {
+  return Object.prototype.hasOwnProperty.call(PREVIEW_FEATURES, id);
+}


### PR DESCRIPTION
## Summary

Three "location & honesty" fixes from CHAOS-2045 so navigation is trustworthy:

### 1. Preview-gate the unfinished detector-based page
- New reusable `PreviewBadge` (`src/components/PreviewBadge.tsx`) — sky-toned, distinct from the amber app-wide `BetaBadge`.
- New single source of truth `src/lib/preview.ts` (`PREVIEW_FEATURES` / `isPreviewFeature(id)`), keyed by **nav-item id** so `PrimaryNav` can consume it (`ai-opportunities` → AI Automations). This is the contract nav-ia can read to hide/mark the slot.
- `/ai/automations` now renders a **Preview** marker via `AIPageHeader`.
- Detector routes are **gated/marked, not deleted**.

### 2. User-safe data-state copy (removed implementation language)
- `AIOpportunityList`: "Opportunity engine pending" + `CHAOS-1586` reference → "No automation candidates in this scope yet" + scope-based explanation.
- `AIImpactDashboard`: "Coming after detector lands" / "placeholders remain empty…" → "No scoped rollups in this scope yet".
- `AIAutomationsDashboard`: "…once the recommendation engine becomes ready" → scope-based wording.
- No invented data; empty states stay honest.

### 3. Breadcrumbs / page titles (section → page → tab)
- New reusable `Breadcrumbs` (`src/components/Breadcrumbs.tsx`) with accessible `nav[aria-label="Breadcrumb"]` and `aria-current="page"` on the leaf.
- Integrated into the **shared** headers (`AIPageHeader`, `AdminHeader`) rather than per-page headers.
- Wired across the AI cluster (Impact / Risk / Review Load / Automations), the Admin landing, and Operating Review.

### 4. Fix broken AI hub anchor
- `/dashboard` linked `#ai-workflow-intelligence` but the **data-driven** operating-review section id is `ai_workflow_intelligence`. The id comes from backend `section.key`, so the dashboard links were aligned to the underscore slug. Verified the anchor element resolves at runtime.

## Coordination
- I did **not** touch `PrimaryNav.tsx` — nav slot decision (hide vs Preview marker) is owned by nav-ia (CHAOS-2043/2044). `src/lib/preview.ts` is the ready-to-consume flag for that wiring.

## Testing
- New unit tests: `PreviewBadge.test.tsx`, `Breadcrumbs.test.tsx`, `src/lib/__tests__/preview.test.ts` (8 passing).
- `tsc --noEmit` clean; `eslint` clean on changed files.

## Screenshots
Captured against a worktree dev server (port 3100) on the live local stack with the canonical `admin@devhealth.example` account. Attached to CHAOS-2045 (Linear):
- `chaos-2045-ai-automations-preview-after.png` — Preview badge + breadcrumbs + safe copy
- `chaos-2045-ai-impact-breadcrumbs-after.png` — breadcrumbs + "No scoped rollups in this scope yet"
- `chaos-2045-ai-risk-breadcrumbs-after.png`
- `chaos-2045-operating-review-breadcrumbs-after.png`
- `chaos-2045-dashboard-after.png` — AI Workflow Intelligence section (anchor target verified)

Closes CHAOS-2045