### PR TITLE
feat(home): ranked signal cards + evidence/recommended-action (CHAOS-2050)

### DIFF
--- a/src/components/home/CockpitEmptyState.tsx
+++ b/src/components/home/CockpitEmptyState.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from "react";
+
+import { EmptyState } from "@/components/ui/EmptyState";
+
+/**
+ * Phase-1 customer-safe sparse/empty states for the cockpit (CHAOS-2052).
+ *
+ * VENDORED for branch isolation: the canonical owner of this file is
+ * trust-states (CHAOS-2052). signal-cards (CHAOS-2050) consumes it so the
+ * feat/chaos-2050-ranked-signals branch compiles and tests standalone. On
+ * integration KEEP trust-states' copy and drop this one (content is identical).
+ *
+ * These variants are the ONLY approved vocabulary for distinguishing *why* a
+ * cockpit panel has nothing to show. They are trust-preserving: they never
+ * imply a finding ("healthy", "all clear") and never leak internal detector
+ * names. Exported so signal-cards (and any other cockpit panel) reuse the exact
+ * same wording rather than inventing per-panel copy.
+ *
+ * | variant                  | meaning                                          |
+ * | ------------------------ | ------------------------------------------------ |
+ * | no-data-connected        | No source feeds this panel yet.                  |
+ * | detector-unavailable     | Sources connected, but the detector can't run.   |
+ * | no-findings              | Detector ran and surfaced nothing for the window.|
+ * | insufficient-confidence  | Some evidence, but not enough to show a result.  |
+ */
+export type CockpitEmptyStateVariant =
+  | "no-data-connected"
+  | "detector-unavailable"
+  | "no-findings"
+  | "insufficient-confidence";
+
+type VariantCopy = {
+  title: string;
+  description: string;
+};
+
+const VARIANT_COPY: Record<CockpitEmptyStateVariant, VariantCopy> = {
+  "no-data-connected": {
+    title: "No data connected",
+    description:
+      "Connect a source to start populating this view. Until then there is nothing to summarize.",
+  },
+  "detector-unavailable": {
+    title: "Connected but detector unavailable",
+    description:
+      "Sources are connected, but this signal could not be computed for the selected window.",
+  },
+  "no-findings": {
+    title: "Enabled but no findings",
+    description: "This signal ran and surfaced nothing notable in the selected window.",
+  },
+  "insufficient-confidence": {
+    title: "Insufficient confidence",
+    description:
+      "There is some evidence, but not enough to show a reliable result for this window.",
+  },
+};
+
+type CockpitEmptyStateProps = {
+  variant: CockpitEmptyStateVariant;
+  /** Optional override for the default variant title. */
+  title?: string;
+  /** Optional override for the default variant description. */
+  description?: string;
+  /** Optional leading icon, forwarded to the base EmptyState. */
+  icon?: ReactNode;
+  /** Optional call-to-action (e.g. a "Connect a source" link). */
+  action?: ReactNode;
+  /** Test hook; defaults to a stable per-variant id. */
+  "data-testid"?: string;
+};
+
+export function CockpitEmptyState({
+  variant,
+  title,
+  description,
+  icon,
+  action,
+  "data-testid": testId,
+}: CockpitEmptyStateProps) {
+  const copy = VARIANT_COPY[variant];
+  return (
+    <div data-testid={testId ?? `cockpit-empty-${variant}`} data-variant={variant}>
+      <EmptyState
+        icon={icon}
+        title={title ?? copy.title}
+        description={description ?? copy.description}
+        action={action}
+      />
+    </div>
+  );
+}

--- a/src/components/home/RankedSignals.test.tsx
+++ b/src/components/home/RankedSignals.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, userEvent, waitFor } from "@/test/utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { MetricFilter } from "@/lib/filters/types";
+
+import { RankedSignals } from "./RankedSignals";
+import type { CockpitSignal } from "./SignalCard";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const filters = {
+  scope: { level: "org", ids: ["org-1"] },
+  time: { range_days: 30 },
+  who: {},
+  what: {},
+  why: {},
+  how: {},
+} as MetricFilter;
+
+const makeSignal = (overrides: Partial<CockpitSignal> = {}): CockpitSignal => ({
+  id: "sig-1",
+  title: "Review latency is climbing",
+  metric: "review_latency",
+  severity: "high",
+  confidence: "medium",
+  affected_scope: "3 repos · payments",
+  evidence_count: 7,
+  current: 2.4,
+  prior: 1.6,
+  delta_pct: 50,
+  unit: "days",
+  direction: "up",
+  why_it_matters: "Longer reviews delay delivery.",
+  recommended_action: "Rebalance reviewers.",
+  evidence_ref: "/api/home/explain/review_latency",
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("RankedSignals", () => {
+  it("renders a trust-preserving empty state for empty signals", () => {
+    render(<RankedSignals signals={[]} filters={filters} />);
+
+    expect(screen.getByTestId("ranked-signals-empty")).toBeInTheDocument();
+    // never implies a clean bill of health
+    expect(screen.getByText(/surfaced nothing notable/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("signal-card")).not.toBeInTheDocument();
+  });
+
+  it("renders signals in rank order with the top signal emphasized", () => {
+    const signals = [
+      makeSignal({
+        id: "sig-1",
+        title: "Top signal claim",
+        severity: "critical",
+      }),
+      makeSignal({
+        id: "sig-2",
+        title: "Second signal claim",
+        severity: "medium",
+      }),
+    ];
+
+    render(<RankedSignals signals={signals} filters={filters} />);
+
+    const cards = screen.getAllByTestId("signal-card");
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toHaveAttribute("data-emphasized", "true");
+    expect(cards[0]).toHaveTextContent("Top signal claim");
+    expect(cards[1]).toHaveAttribute("data-emphasized", "false");
+    expect(cards[1]).toHaveTextContent("Second signal claim");
+  });
+
+  it("opens a populated EvidencePanel via evidence_ref", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            metric: "review_latency",
+            label: "Review latency",
+            value: 2.4,
+            unit: "days",
+            delta_pct: 50,
+            summary: "Review latency appears higher in this window.",
+            evidence: [
+              {
+                id: "PR-1",
+                title: "Shorten review queue",
+                url: "/prs/PR-1",
+                type: "pr",
+                meta: "merged in 2d",
+              },
+            ],
+            actions: [],
+            provenance: {
+              source: "workGraphEdges",
+              quality: "high",
+              last_sync: "2026-05-20T00:00:00Z",
+              identity_confidence: 0.92,
+            },
+          }),
+      }),
+    );
+
+    render(<RankedSignals signals={[makeSignal()]} filters={filters} />);
+
+    await userEvent.click(screen.getByTestId("signal-open-evidence"));
+
+    await waitFor(() => expect(screen.getByText("Quality + provenance")).toBeInTheDocument());
+    // Panel is populated with a real artifact — not an empty / recommendation-only drawer.
+    expect(screen.getByText("Shorten review queue")).toBeInTheDocument();
+    expect(screen.getByText(/Source: workGraphEdges/i)).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith("/api/home/explain/review_latency");
+  });
+});

--- a/src/components/home/RankedSignals.tsx
+++ b/src/components/home/RankedSignals.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+
+import { EvidencePanel } from "@/components/evidence";
+import type { MetricFilter } from "@/lib/filters/types";
+
+import { CockpitEmptyState } from "./CockpitEmptyState";
+import { SignalCard, type CockpitSignal } from "./SignalCard";
+
+export type RankedSignalsProps = {
+  /** Already-ranked signals (top first) from the enriched HomeResponse. */
+  signals: CockpitSignal[];
+  /** Active metric filter, forwarded to the EvidencePanel for Explore links. */
+  filters: MetricFilter;
+};
+
+type PanelState = {
+  isOpen: boolean;
+  title: string;
+  apiUrl?: string;
+  metric?: string;
+};
+
+/**
+ * Ranked cockpit signals (CHAOS-2050).
+ *
+ * Renders the already-ranked `signals[]` in order with the top signal
+ * emphasized. Self-owns its EvidencePanel so the component is independently
+ * testable and trivially integratable — cockpit-lead drops
+ * `<RankedSignals signals={home.signals} filters={filters} />` into the cockpit.
+ * Every card opens a populated EvidencePanel via `signal.evidence_ref` (apiUrl).
+ *
+ * Empty `signals[]` renders the trust-preserving `CockpitEmptyState`
+ * ("no-findings") rather than implying a clean bill of health.
+ */
+export function RankedSignals({ signals, filters }: RankedSignalsProps) {
+  const [panel, setPanel] = useState<PanelState>({ isOpen: false, title: "" });
+
+  const openPanel = (title: string, params: { apiUrl?: string; metric?: string }) =>
+    setPanel({ isOpen: true, title, ...params });
+
+  const closePanel = () => setPanel((prev) => ({ ...prev, isOpen: false }));
+
+  return (
+    <section data-testid="ranked-signals" className="space-y-4">
+      <EvidencePanel
+        isOpen={panel.isOpen}
+        onCloseAction={closePanel}
+        title={panel.title}
+        apiUrl={panel.apiUrl}
+        metric={panel.metric}
+        filters={filters}
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">Ranked signals</p>
+          <p className="mt-1 text-sm text-(--ink-muted)">
+            Ordered by severity and confidence for the selected window.
+          </p>
+        </div>
+      </div>
+
+      {signals.length === 0 ? (
+        <CockpitEmptyState variant="no-findings" data-testid="ranked-signals-empty" />
+      ) : (
+        <div className="space-y-4">
+          <SignalCard signal={signals[0]} emphasized onOpenEvidence={openPanel} />
+          {signals.length > 1 && (
+            <div className="grid gap-4 md:grid-cols-2">
+              {signals.slice(1).map((signal) => (
+                <SignalCard key={signal.id} signal={signal} onOpenEvidence={openPanel} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/home/SignalCard.test.tsx
+++ b/src/components/home/SignalCard.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, userEvent } from "@/test/utils";
+import { describe, expect, it, vi } from "vitest";
+
+import { SignalCard, type CockpitSignal } from "./SignalCard";
+
+const baseSignal: CockpitSignal = {
+  id: "sig-1",
+  title: "Review latency is climbing",
+  metric: "review_latency",
+  severity: "high",
+  confidence: "medium",
+  affected_scope: "3 repos · payments",
+  evidence_count: 7,
+  current: 2.4,
+  prior: 1.6,
+  delta_pct: 50,
+  unit: "days",
+  direction: "up",
+  why_it_matters: "Longer reviews delay delivery and frustrate contributors.",
+  recommended_action: "Rebalance reviewers on the payments repos.",
+  evidence_ref: "/api/home/explain/review_latency",
+};
+
+describe("SignalCard", () => {
+  it("renders all four required encodings plus why + recommended action", () => {
+    render(<SignalCard signal={baseSignal} onOpenEvidence={() => undefined} />);
+
+    // 1) severity, 2) confidence, 3) affected scope, 4) evidence count
+    expect(screen.getByTestId("signal-severity")).toHaveTextContent(/high/i);
+    expect(screen.getByTestId("signal-confidence")).toHaveTextContent(/medium confidence/i);
+    expect(screen.getByTestId("signal-scope")).toHaveTextContent("3 repos · payments");
+    expect(screen.getByTestId("signal-evidence-count")).toHaveTextContent(/7 artifacts/i);
+
+    // why + recommended action
+    expect(screen.getByTestId("signal-why")).toHaveTextContent(/longer reviews delay/i);
+    expect(screen.getByTestId("signal-recommended-action")).toHaveTextContent(
+      /rebalance reviewers/i,
+    );
+  });
+
+  it("shows current/prior/delta with direction", () => {
+    render(<SignalCard signal={baseSignal} onOpenEvidence={() => undefined} />);
+
+    expect(screen.getByTestId("signal-card")).toHaveAttribute("data-direction", "up");
+    expect(screen.getByTestId("signal-current")).toHaveTextContent("2.4d");
+    expect(screen.getByTestId("signal-delta")).toHaveTextContent(/\+50%/);
+    expect(screen.getByText(/from 1\.6d prior/i)).toBeInTheDocument();
+  });
+
+  it("renders a no-prior-period state when prior is null", () => {
+    render(<SignalCard signal={{ ...baseSignal, prior: null }} onOpenEvidence={() => undefined} />);
+    expect(screen.getByText(/no prior period/i)).toBeInTheDocument();
+  });
+
+  it.each(["critical", "high", "medium", "low"] as const)(
+    "encodes %s severity on the card",
+    (severity) => {
+      render(<SignalCard signal={{ ...baseSignal, severity }} onOpenEvidence={() => undefined} />);
+      expect(screen.getByTestId("signal-card")).toHaveAttribute("data-severity", severity);
+      expect(screen.getByTestId("signal-severity")).toHaveTextContent(new RegExp(severity, "i"));
+    },
+  );
+
+  it.each(["high", "medium", "low"] as const)("encodes %s confidence on the card", (confidence) => {
+    render(<SignalCard signal={{ ...baseSignal, confidence }} onOpenEvidence={() => undefined} />);
+    expect(screen.getByTestId("signal-card")).toHaveAttribute("data-confidence", confidence);
+    expect(screen.getByTestId("signal-confidence")).toHaveTextContent(
+      new RegExp(`${confidence} confidence`, "i"),
+    );
+  });
+
+  it("opens evidence via the signal's evidence_ref apiUrl", async () => {
+    const onOpenEvidence = vi.fn();
+    render(<SignalCard signal={baseSignal} onOpenEvidence={onOpenEvidence} />);
+
+    await userEvent.click(screen.getByTestId("signal-open-evidence"));
+
+    expect(onOpenEvidence).toHaveBeenCalledWith(baseSignal.title, {
+      apiUrl: baseSignal.evidence_ref,
+    });
+  });
+
+  it("applies the emphasized treatment for the top signal", () => {
+    render(<SignalCard signal={baseSignal} emphasized onOpenEvidence={() => undefined} />);
+    expect(screen.getByTestId("signal-card")).toHaveAttribute("data-emphasized", "true");
+    expect(screen.getByText(/top signal/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/home/SignalCard.tsx
+++ b/src/components/home/SignalCard.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { formatDelta, formatMetricValue } from "@/lib/formatters";
+
+/**
+ * Cockpit signal contract (CHAOS-2050).
+ *
+ * PROVISIONAL: these types are proposed to cockpit-lead and will move to the
+ * canonical `web/src/lib/types.ts` once published on the enriched HomeResponse
+ * (`signals: CockpitSignal[]`). On integration, swap the local imports for
+ * `import type { CockpitSignal } from "@/lib/types"`. Field names/enum values
+ * are derived directly from the CHAOS-2050 acceptance criteria and aligned with
+ * the EvidenceConfidence band in `@/components/evidence/contract.ts`.
+ */
+export type SignalSeverity = "critical" | "high" | "medium" | "low";
+export type SignalConfidence = "high" | "medium" | "low";
+export type SignalDirection = "up" | "down" | "flat";
+
+export type CockpitSignal = {
+  id: string;
+  /** Human-facing claim/title for the signal. */
+  title: string;
+  /** Metric key the signal is grounded in. */
+  metric: string;
+  severity: SignalSeverity;
+  confidence: SignalConfidence;
+  /** Human label for the affected blast-radius, e.g. "3 repos · payments". */
+  affected_scope: string;
+  /** Count of traceable artifacts backing the signal. */
+  evidence_count: number;
+  /** Current-window metric value. */
+  current: number;
+  /** Prior-window value, or null when no comparable prior period exists. */
+  prior: number | null;
+  /** Percentage change between prior and current. */
+  delta_pct: number;
+  /** Unit for current/prior (drives formatting): "%", "days", "hours", "loc"... */
+  unit: string;
+  direction: SignalDirection;
+  /** Plain-language "so what" — why this signal deserves attention. */
+  why_it_matters: string;
+  /** The single recommended next action (also surfaced as a cockpit CTA). */
+  recommended_action: string;
+  /** apiUrl the EvidencePanel fetches to populate claim/value/evidence/action. */
+  evidence_ref: string;
+};
+
+/** Callback into the panel owner (RankedSignals / cockpit-lead's CockpitClient). */
+export type OpenEvidence = (title: string, params: { apiUrl?: string; metric?: string }) => void;
+
+export type SignalCardProps = {
+  signal: CockpitSignal;
+  /** When true, render the emphasized "top signal" treatment. */
+  emphasized?: boolean;
+  onOpenEvidence: OpenEvidence;
+};
+
+const SEVERITY_BADGE: Record<SignalSeverity, string> = {
+  critical: "border-red-500/30 bg-red-500/15 text-red-300",
+  high: "border-amber-500/30 bg-amber-500/15 text-amber-300",
+  medium: "border-(--accent-2)/30 bg-(--accent-2)/12 text-(--accent-2)",
+  low: "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)",
+};
+
+const SEVERITY_LABEL: Record<SignalSeverity, string> = {
+  critical: "Critical",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+const CONFIDENCE_DOT: Record<SignalConfidence, string> = {
+  high: "bg-(--accent-3)",
+  medium: "bg-amber-400",
+  low: "bg-(--ink-muted)",
+};
+
+const CONFIDENCE_TEXT: Record<SignalConfidence, string> = {
+  high: "text-(--accent-3)",
+  medium: "text-amber-300",
+  low: "text-(--ink-muted)",
+};
+
+const DIRECTION_GLYPH: Record<SignalDirection, string> = {
+  up: "↑",
+  down: "↓",
+  flat: "→",
+};
+
+const directionAccent = (direction: SignalDirection) =>
+  direction === "up"
+    ? "text-(--accent-3)"
+    : direction === "down"
+      ? "text-(--accent-negative)"
+      : "text-(--ink-muted)";
+
+export function SignalCard({ signal, emphasized = false, onOpenEvidence }: SignalCardProps) {
+  const open = () => onOpenEvidence(signal.title, { apiUrl: signal.evidence_ref || undefined });
+
+  const hasPrior = signal.prior !== null;
+
+  return (
+    <article
+      data-testid="signal-card"
+      data-severity={signal.severity}
+      data-confidence={signal.confidence}
+      data-direction={signal.direction}
+      data-emphasized={emphasized ? "true" : "false"}
+      className={
+        emphasized
+          ? "relative overflow-hidden rounded-3xl border border-(--accent)/30 bg-gradient-to-br from-(--card) to-(--card-80) p-6 shadow-lg ring-1 ring-(--accent)/10"
+          : "relative overflow-hidden rounded-3xl border border-(--card-stroke) bg-(--card) p-5"
+      }
+    >
+      {emphasized && (
+        <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-(--accent)">
+          Top signal
+        </p>
+      )}
+
+      {/* Title + severity badge */}
+      <header className="mt-1 flex items-start justify-between gap-3">
+        <h3
+          className={
+            emphasized
+              ? "font-(--font-display) text-2xl leading-tight text-foreground"
+              : "font-(--font-display) text-lg leading-tight text-foreground"
+          }
+        >
+          {signal.title}
+        </h3>
+        <span
+          data-testid="signal-severity"
+          className={`shrink-0 rounded-full border px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.18em] ${SEVERITY_BADGE[signal.severity]}`}
+        >
+          {SEVERITY_LABEL[signal.severity]}
+        </span>
+      </header>
+
+      {/* Current / prior / delta + direction */}
+      <div className="mt-4 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <span
+          data-testid="signal-current"
+          className="metric-hero text-3xl font-semibold text-foreground"
+        >
+          {formatMetricValue(signal.current, signal.unit)}
+        </span>
+        <span
+          data-testid="signal-delta"
+          className={`flex items-center gap-1 text-sm font-medium ${directionAccent(signal.direction)}`}
+        >
+          <span aria-hidden>{DIRECTION_GLYPH[signal.direction]}</span>
+          {formatDelta(signal.delta_pct)}
+        </span>
+        {hasPrior ? (
+          <span className="text-xs text-(--ink-muted)">
+            from {formatMetricValue(signal.prior as number, signal.unit)} prior
+          </span>
+        ) : (
+          <span className="text-xs text-(--ink-muted)">no prior period</span>
+        )}
+      </div>
+
+      {/* The four required encodings: severity (above) + confidence, scope, evidence count */}
+      <div className="mt-4 flex flex-wrap items-center gap-2 text-[11px]">
+        <span
+          data-testid="signal-confidence"
+          className={`inline-flex items-center gap-1.5 rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-1 font-medium uppercase tracking-[0.12em] ${CONFIDENCE_TEXT[signal.confidence]}`}
+        >
+          <span className={`h-1.5 w-1.5 rounded-full ${CONFIDENCE_DOT[signal.confidence]}`} />
+          {signal.confidence} confidence
+        </span>
+        <span
+          data-testid="signal-scope"
+          className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-1 text-(--ink-muted)"
+        >
+          {signal.affected_scope}
+        </span>
+        <span
+          data-testid="signal-evidence-count"
+          className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-1 text-(--ink-muted)"
+        >
+          {signal.evidence_count} {signal.evidence_count === 1 ? "artifact" : "artifacts"}
+        </span>
+      </div>
+
+      {/* Why it matters */}
+      <p data-testid="signal-why" className="mt-4 text-sm leading-6 text-(--ink-muted)">
+        {signal.why_it_matters}
+      </p>
+
+      {/* Recommended action — explicit, not buried in the drawer */}
+      <div
+        data-testid="signal-recommended-action"
+        className="mt-4 rounded-2xl border border-(--accent)/20 bg-(--accent)/8 p-3"
+      >
+        <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-(--accent)">
+          Recommended action
+        </p>
+        <p className="mt-1 text-sm leading-5 text-foreground">{signal.recommended_action}</p>
+      </div>
+
+      {/* Evidence affordance */}
+      <button
+        type="button"
+        data-testid="signal-open-evidence"
+        onClick={open}
+        className="mt-4 flex w-full items-center justify-between rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2.5 text-left text-xs font-medium uppercase tracking-[0.18em] text-(--ink-muted) transition-colors hover:border-(--accent)/40 hover:bg-(--accent)/10 hover:text-(--accent)"
+      >
+        Open evidence
+        <span aria-hidden>↗</span>
+      </button>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary

Implements **CHAOS-2050** (ranked signal cards) and delivers the **CHAOS-2053** wiring snippet for cockpit-lead to apply in their hot files.

New, self-contained components (no edits to cockpit-lead's `CockpitClient.tsx` / `page.tsx` / `CockpitSummary.tsx`):

- **`SignalCard.tsx`** — one signal showing all four required encodings (severity badge, confidence badge, `affected_scope`, `evidence_count`) plus current/prior/delta with direction, `why_it_matters`, and an explicit **Recommended action** CTA (surfaced on the card, not buried in the drawer). Opens the `EvidencePanel` via `signal.evidence_ref`.
- **`RankedSignals.tsx`** — renders the already-ranked `signals[]` top-first with the top signal emphasized; self-owns its `EvidencePanel` so it is independently testable and a trivial drop-in (`<RankedSignals signals={home.signals} filters={filters} />`). Empty `signals[]` renders the trust-preserving `CockpitEmptyState` (`no-findings`), never implying a clean bill of health.

Reuses `EvidencePanel` + `contract.ts` (CHAOS-2036) and `formatters.ts`.

## Coordination notes

- **Provisional contract:** `CockpitSignal` / `SignalSeverity` / `SignalConfidence` / `SignalDirection` are exported locally from `SignalCard.tsx`, derived directly from the CHAOS-2050 acceptance criteria and aligned with `EvidenceConfidence`. Once cockpit-lead publishes them on the enriched `HomeResponse` in `src/lib/types.ts`, the import swaps to `import type { CockpitSignal } from "@/lib/types"` — mechanical.
- **Vendored `CockpitEmptyState.tsx`:** canonical owner is trust-states (CHAOS-2052). Vendored identically here for branch isolation/testability. On integration keep trust-states' copy and drop this one (content identical → trivial add/add resolution).
- **CHAOS-2053:** the exact snippet (replace hardcoded `review_latency` with `limiting_factor.evidence_ref`; surface `recommended_action` as a cockpit CTA) was sent to cockpit-lead to apply in `CockpitClient.tsx`, per the hot-file rule.

## Tests

- `SignalCard.test.tsx` + `RankedSignals.test.tsx` — **15 tests passing**: all-four-encodings render, severity variants (critical/high/medium/low), confidence variants (high/medium/low), no-prior-period state, `evidence_ref` wiring, rank order + top emphasis, empty trust-state, and a **populated `EvidencePanel`** open (mocked fetch → provenance + real artifact, no empty/recommendation-only drawer).
- `lsp_diagnostics` clean; eslint clean; prettier formatted.

## Screenshots

Captured against an isolated preview (uncommitted) and **attached to the linked Linear issues CHAOS-2050 and CHAOS-2053**:

- `signal-card-top.png` — emphasized top signal: CRITICAL badge, HIGH CONFIDENCE, scope, 12 artifacts, 2.4d ↑ +71% from 1.4d prior, why-it-matters, Recommended action CTA, Open evidence.
- `ranked-signals-full.png` — ranked list (top emphasized + secondary grid) and empty state together.
- `ranked-signals-empty.png` — trust-preserving "Enabled but no findings".
- `evidence-panel-open.png` — EvidencePanel opening from a card via `evidence_ref`.

Closes CHAOS-2050

TEST-WAIVER: not required — adds `SignalCard.test.tsx` and `RankedSignals.test.tsx` (15 tests).

## Screenshots (rendered)

**Top signal card** — all four encodings + current/prior/delta + why + Recommended action CTA:

![Top signal card](https://gist.githubusercontent.com/chrisgeo/18f80e17aacd05e8cdb70fa6f9540e4a/raw/signal-card-top.png)

**Ranked list + empty state:**

![Ranked signals full](https://gist.githubusercontent.com/chrisgeo/18f80e17aacd05e8cdb70fa6f9540e4a/raw/ranked-signals-full.png)

**Trust-preserving empty state:**

![Empty state](https://gist.githubusercontent.com/chrisgeo/18f80e17aacd05e8cdb70fa6f9540e4a/raw/ranked-signals-empty.png)

**EvidencePanel opens via evidence_ref:**

![Evidence panel](https://gist.githubusercontent.com/chrisgeo/18f80e17aacd05e8cdb70fa6f9540e4a/raw/evidence-panel-open.png)