### PR TITLE
fix(capacity): allow enterprise orgs through capacity gate

### DIFF
--- a/src/app/(app)/capacity/page.tsx
+++ b/src/app/(app)/capacity/page.tsx
@@ -39,6 +39,7 @@ export default async function CapacityPage({ searchParams }: CapacityPageProps) 
   }
 
   const features = entitlements?.data?.features ?? {};
+  const currentTier = entitlements?.data?.tier;
 
   const params = (await searchParams) ?? {};
   const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
@@ -72,7 +73,12 @@ export default async function CapacityPage({ searchParams }: CapacityPageProps) 
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={filters} active="capacity" role={activeRole} />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <UpgradeGate feature="capacity_planning" requiredTier="team" features={features}>
+          <UpgradeGate
+            feature="capacity_forecast"
+            requiredTier="team"
+            currentTier={currentTier}
+            features={features}
+          >
             <header className="flex flex-wrap items-center justify-between gap-4">
               <div>
                 <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Capacity</p>

--- a/src/components/billing/UpgradeGate.test.tsx
+++ b/src/components/billing/UpgradeGate.test.tsx
@@ -36,6 +36,21 @@ describe("UpgradeGate", () => {
     expect(screen.queryByRole("link", { name: /upgrade to team/i })).not.toBeInTheDocument();
   });
 
+  it("renders capacity planning content for the canonical capacity forecast entitlement", () => {
+    renderWithToaster(
+      <UpgradeGate
+        feature="capacity_forecast"
+        requiredTier="team"
+        features={{ capacity_forecast: true }}
+      >
+        <p>Monte Carlo forecast</p>
+      </UpgradeGate>,
+    );
+
+    expect(screen.getByText("Monte Carlo forecast")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /upgrade to team/i })).not.toBeInTheDocument();
+  });
+
   it("renders the upgrade CTA overlay when the feature is missing", () => {
     renderWithToaster(
       <UpgradeGate
@@ -96,5 +111,21 @@ describe("UpgradeGate", () => {
 
     expect(screen.getByText(/current plan/i)).toBeInTheDocument();
     expect(screen.getByText("community")).toBeInTheDocument();
+  });
+
+  it("prefers an explicit current tier over context for standalone gates", () => {
+    renderWithToaster(
+      <UpgradeGate
+        feature="advanced_insights"
+        requiredTier="team"
+        currentTier="enterprise"
+        features={{ advanced_insights: false }}
+      >
+        <p>hidden</p>
+      </UpgradeGate>,
+    );
+
+    expect(screen.getByText(/current plan/i)).toBeInTheDocument();
+    expect(screen.getByText("enterprise")).toBeInTheDocument();
   });
 });

--- a/src/components/billing/UpgradeGate.tsx
+++ b/src/components/billing/UpgradeGate.tsx
@@ -7,6 +7,7 @@ import { TIER_FEATURES } from "@/lib/billing/tiers";
 type UpgradeGateProps = {
   feature: string;
   requiredTier: string;
+  currentTier?: string;
   features?: Record<string, boolean>;
   children: React.ReactNode;
 };
@@ -14,12 +15,13 @@ type UpgradeGateProps = {
 export function UpgradeGate({
   feature,
   requiredTier,
+  currentTier: currentTierProp,
   features: featuresProp,
   children,
 }: UpgradeGateProps) {
   const context = useAdminTier();
   const features = featuresProp ?? context.features;
-  const currentTier = context.tier;
+  const currentTier = currentTierProp ?? context.tier;
 
   if (features[feature] === true) {
     return <>{children}</>;

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -27,6 +27,7 @@ import {
   deleteRetentionPolicy,
   executeRetentionPolicy,
   listRetentionResourceTypes,
+  getOrgEntitlements,
 } from "../server";
 
 function mockSession() {
@@ -92,7 +93,10 @@ describe("admin/server credential actions", () => {
         .spyOn(global, "fetch")
         .mockResolvedValue(new Response(JSON.stringify(cred), { status: 200 }));
 
-      const result = await createCredential({ provider: "github", credentials: { token: "tok" } });
+      const result = await createCredential({
+        provider: "github",
+        credentials: { token: "tok" },
+      });
       expect(result.data).toBeDefined();
       expect(revalidatePath).toHaveBeenCalledWith("/admin/integrations", "page");
       fetchSpy.mockRestore();
@@ -172,6 +176,44 @@ describe("admin/server user list actions", () => {
     const headers = options?.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer test-token");
     expect(headers["X-Org-Id"]).toBeUndefined();
+    fetchSpy.mockRestore();
+  });
+});
+
+describe("admin/server entitlement actions", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubEnv("BACKEND_URL", "http://test-ops:8000");
+  });
+
+  it("gets current org entitlements with the current org token", async () => {
+    mockSession();
+    const entitlements = {
+      org_id: "org-1",
+      tier: "enterprise",
+      licensed_users: null,
+      licensed_repos: null,
+      features: { capacity_forecast: true },
+      features_override: null,
+      limits_override: null,
+      expires_at: null,
+      is_valid: true,
+      limits: {},
+    };
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify(entitlements), { status: 200 }));
+
+    const result = await getOrgEntitlements("org-1");
+
+    expect(result.data?.features.capacity_forecast).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe("http://test-ops:8000/api/v1/licensing/entitlements/org-1");
+    expect(options?.headers).toMatchObject({
+      Authorization: "Bearer test-token",
+      "X-Org-Id": "org-1",
+    });
     fetchSpy.mockRestore();
   });
 });
@@ -417,7 +459,12 @@ describe("admin/server retention policy actions", () => {
   describe("listRetentionPolicies", () => {
     it("returns policies on success", async () => {
       mockSession();
-      const resp = { items: [mockRetentionPolicy], total: 1, limit: 50, offset: 0 };
+      const resp = {
+        items: [mockRetentionPolicy],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      };
       const fetchSpy = vi
         .spyOn(global, "fetch")
         .mockResolvedValue(new Response(JSON.stringify(resp), { status: 200 }));
@@ -461,7 +508,9 @@ describe("admin/server retention policy actions", () => {
         .spyOn(global, "fetch")
         .mockResolvedValue(new Response(JSON.stringify(updated), { status: 200 }));
 
-      const result = await updateRetentionPolicy("rp-1", { retention_days: 180 });
+      const result = await updateRetentionPolicy("rp-1", {
+        retention_days: 180,
+      });
       expect(result.data).toBeDefined();
       expect(revalidatePath).toHaveBeenCalledWith("/admin/retention");
       fetchSpy.mockRestore();

--- a/src/lib/admin/server/billing.ts
+++ b/src/lib/admin/server/billing.ts
@@ -9,12 +9,17 @@ import type {
   FeatureOverride,
   FeatureOverrideCreate,
 } from "../types";
-import { requireSuperuserToken, withErrorHandling } from "./_shared";
+import { getSessionContext, requireSuperuserToken, withErrorHandling } from "./_shared";
 
 export async function getOrgEntitlements(orgId: string): Promise<ActionResult<OrgEntitlements>> {
   return withErrorHandling(async () => {
-    const token = await requireSuperuserToken();
-    return adminApi.licensing.entitlements(orgId, token);
+    const { token, orgId: sessionOrgId } = await getSessionContext();
+    if (sessionOrgId === orgId) {
+      return adminApi.licensing.entitlements(orgId, token, sessionOrgId);
+    }
+
+    const superuserToken = await requireSuperuserToken();
+    return adminApi.licensing.entitlements(orgId, superuserToken);
   });
 }
 

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -553,6 +553,7 @@ export type CompoundingRiskPoint = {
   computedAt: Scalars['DateTime']['output'];
   day: Scalars['Date']['output'];
   scope: CompoundingRiskScope;
+  scopeEntity: CompoundingRiskScopeEntity;
   scopeId: Scalars['String']['output'];
   scopeLabel: Scalars['String']['output'];
   score?: Maybe<Scalars['Float']['output']>;
@@ -573,6 +574,12 @@ export type CompoundingRiskResult = {
 export type CompoundingRiskScope =
   | 'REPO'
   | 'TEAM';
+
+export type CompoundingRiskScopeEntity = {
+  __typename?: 'CompoundingRiskScopeEntity';
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+};
 
 export type CompoundingRiskSeverity =
   | 'ELEVATED'

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -505,6 +505,7 @@ type CompoundingRiskPoint {
   weights: CompoundingRiskWeights!
   thresholds: CompoundingRiskThresholds!
   computedAt: DateTime!
+  scopeEntity: CompoundingRiskScopeEntity!
 }
 
 type CompoundingRiskResult {
@@ -518,6 +519,11 @@ type CompoundingRiskResult {
 enum CompoundingRiskScope {
   REPO
   TEAM
+}
+
+type CompoundingRiskScopeEntity {
+  id: String!
+  displayName: String!
 }
 
 enum CompoundingRiskSeverity {


### PR DESCRIPTION
## Summary
- Use the canonical capacity entitlement key (capacity_forecast) for /capacity
- Preserve the actual current tier in standalone UpgradeGate usage
- Fetch current-org entitlements with the current org session token before falling back to superuser access

## Verification
- pnpm exec vitest run src/components/billing/UpgradeGate.test.tsx src/lib/admin/__tests__/server.test.ts
- pnpm exec eslint src/app/\(app\)/capacity/page.tsx src/components/billing/UpgradeGate.tsx src/components/billing/UpgradeGate.test.tsx src/lib/admin/server/billing.ts src/lib/admin/__tests__/server.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm build
- Playwright local stack QA: /capacity as admin@devhealth.example on enterprise Meridian org shows Capacity Planning content and no Team upsell

## Visual evidence
- Screenshot captured locally: test-results/capacity-enterprise-access.png

## Notes
- Left pre-existing unstaged public/runtime-config.js change untouched.