### PR TITLE
feat(web): roll out EntityLabel identity labels across charts/cards/tables/tooltips (CHAOS-2059)

### DIFF
--- a/src/app/(app)/metrics/page.tsx
+++ b/src/app/(app)/metrics/page.tsx
@@ -17,394 +17,452 @@ import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
 import { formatDelta, formatMetricValue } from "@/lib/formatters";
 import { FALLBACK_DELTAS } from "@/lib/metrics/catalog";
 import type { MetricDelta } from "@/lib/types";
+import { EntityLabel } from "@/components/labels/EntityLabel";
+import { resolveEntityLabels } from "@/lib/labels/entityLabel";
 
 type MetricsPageProps = {
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 type QuadrantType =
-  | "churn_throughput"
-  | "cycle_throughput"
-  | "wip_throughput"
-  | "review_load_latency";
+	| "churn_throughput"
+	| "cycle_throughput"
+	| "wip_throughput"
+	| "review_load_latency";
 
 type MetricTab = {
-  id: string;
-  label: string;
-  description: string;
-  metrics: string[];
-  highlight: string;
-  quadrant: {
-    type: QuadrantType;
-    title: string;
-    description: string;
-  };
+	id: string;
+	label: string;
+	description: string;
+	metrics: string[];
+	highlight: string;
+	quadrant: {
+		type: QuadrantType;
+		title: string;
+		description: string;
+	};
 };
 
 const METRIC_TABS: MetricTab[] = [
-  {
-    id: "dora",
-    label: "DORA",
-    description: "Release speed and stability.",
-    metrics: ["deploy_freq", "cycle_time", "change_failure_rate", "review_latency"],
-    highlight: "deploy_freq",
-    quadrant: {
-      type: "churn_throughput",
-      title: "Churn × Throughput landscape",
-      description: "Operating modes under change volume and delivery pace.",
-    },
-  },
-  {
-    id: "flow",
-    label: "Flow",
-    description: "From idea to merge.",
-    metrics: ["cycle_time", "review_latency", "throughput", "wip_saturation"],
-    highlight: "cycle_time",
-    quadrant: {
-      type: "cycle_throughput",
-      title: "Cycle Time × Throughput landscape",
-      description: "Coordination debt and delivery efficiency.",
-    },
-  },
-  {
-    id: "quality",
-    label: "Quality",
-    description: "Reliability and rework.",
-    metrics: ["change_failure_rate", "churn", "blocked_work", "review_latency"],
-    highlight: "change_failure_rate",
-    quadrant: {
-      type: "review_load_latency",
-      title: "Review Load × Review Latency landscape",
-      description: "Review bottlenecks and quality gate pressure.",
-    },
-  },
-  {
-    id: "throughput",
-    label: "Throughput",
-    description: "Delivery volume and pacing.",
-    metrics: ["throughput", "deploy_freq", "wip_saturation", "blocked_work"],
-    highlight: "throughput",
-    quadrant: {
-      type: "wip_throughput",
-      title: "WIP × Throughput landscape",
-      description: "Work-in-progress saturation and delivery capacity.",
-    },
-  },
+	{
+		id: "dora",
+		label: "DORA",
+		description: "Release speed and stability.",
+		metrics: [
+			"deploy_freq",
+			"cycle_time",
+			"change_failure_rate",
+			"review_latency",
+		],
+		highlight: "deploy_freq",
+		quadrant: {
+			type: "churn_throughput",
+			title: "Churn × Throughput landscape",
+			description: "Operating modes under change volume and delivery pace.",
+		},
+	},
+	{
+		id: "flow",
+		label: "Flow",
+		description: "From idea to merge.",
+		metrics: ["cycle_time", "review_latency", "throughput", "wip_saturation"],
+		highlight: "cycle_time",
+		quadrant: {
+			type: "cycle_throughput",
+			title: "Cycle Time × Throughput landscape",
+			description: "Coordination debt and delivery efficiency.",
+		},
+	},
+	{
+		id: "quality",
+		label: "Quality",
+		description: "Reliability and rework.",
+		metrics: ["change_failure_rate", "churn", "blocked_work", "review_latency"],
+		highlight: "change_failure_rate",
+		quadrant: {
+			type: "review_load_latency",
+			title: "Review Load × Review Latency landscape",
+			description: "Review bottlenecks and quality gate pressure.",
+		},
+	},
+	{
+		id: "throughput",
+		label: "Throughput",
+		description: "Delivery volume and pacing.",
+		metrics: ["throughput", "deploy_freq", "wip_saturation", "blocked_work"],
+		highlight: "throughput",
+		quadrant: {
+			type: "wip_throughput",
+			title: "WIP × Throughput landscape",
+			description: "Work-in-progress saturation and delivery capacity.",
+		},
+	},
 ];
 
 const getMetric = (deltas: MetricDelta[], metric: string) =>
-  deltas.find((item) => item.metric === metric) ??
-  FALLBACK_DELTAS.find((item) => item.metric === metric);
+	deltas.find((item) => item.metric === metric) ??
+	FALLBACK_DELTAS.find((item) => item.metric === metric);
 
 export default async function MetricsPage({ searchParams }: MetricsPageProps) {
-  const params = (await searchParams) ?? {};
-  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
-  const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+	const params = (await searchParams) ?? {};
+	const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+	const filters = encodedFilter
+		? decodeFilter(encodedFilter)
+		: filterFromQueryParams(params);
 
-  const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
-  const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+	const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+	const activeRole = typeof roleParam === "string" ? roleParam : undefined;
 
-  const tabParam = Array.isArray(params.tab) ? params.tab[0] : params.tab;
-  const activeTab = METRIC_TABS.find((tab) => tab.id === tabParam) ?? METRIC_TABS[0];
+	const tabParam = Array.isArray(params.tab) ? params.tab[0] : params.tab;
+	const activeTab =
+		METRIC_TABS.find((tab) => tab.id === tabParam) ?? METRIC_TABS[0];
 
-  const quadrantScope: "org" | "team" | "repo" | "developer" =
-    filters.scope.level === "developer"
-      ? "developer"
-      : filters.scope.level === "team" || filters.scope.level === "repo"
-        ? filters.scope.level
-        : "org";
+	const quadrantScope: "org" | "team" | "repo" | "developer" =
+		filters.scope.level === "developer"
+			? "developer"
+			: filters.scope.level === "team" || filters.scope.level === "repo"
+				? filters.scope.level
+				: "org";
 
-  // Run health check in parallel with all data fetches to eliminate the waterfall.
-  const [health, home, highlight, quadrant] = await Promise.all([
-    checkApiHealth(),
-    fetchOrNull(getHomeData(filters), "metrics/home-data"),
-    fetchOrNull(
-      getExplainData({ metric: activeTab.highlight, filters }),
-      `metrics/explain-${activeTab.highlight}`,
-    ),
-    fetchOrNull(
-      getQuadrant({
-        type: activeTab.quadrant.type,
-        scope_type: quadrantScope,
-        scope_id: filters.scope.ids[0] ?? "",
-        range_days: filters.time.range_days,
-        bucket: "week",
-        start_date: filters.time.start_date,
-        end_date: filters.time.end_date,
-      }),
-      "metrics/quadrant",
-    ),
-  ]);
+	// Run health check in parallel with all data fetches to eliminate the waterfall.
+	const [health, home, highlight, quadrant] = await Promise.all([
+		checkApiHealth(),
+		fetchOrNull(getHomeData(filters), "metrics/home-data"),
+		fetchOrNull(
+			getExplainData({ metric: activeTab.highlight, filters }),
+			`metrics/explain-${activeTab.highlight}`,
+		),
+		fetchOrNull(
+			getQuadrant({
+				type: activeTab.quadrant.type,
+				scope_type: quadrantScope,
+				scope_id: filters.scope.ids[0] ?? "",
+				range_days: filters.time.range_days,
+				bucket: "week",
+				start_date: filters.time.start_date,
+				end_date: filters.time.end_date,
+			}),
+			"metrics/quadrant",
+		),
+	]);
 
-  if (!health.ok) {
-    return <ServiceUnavailable />;
-  }
+	if (!health.ok) {
+		return <ServiceUnavailable />;
+	}
 
-  const deltas = home?.deltas?.length ? home.deltas : FALLBACK_DELTAS;
-  const placeholderDeltas = !home?.deltas?.length;
-  const highlightMetric = getMetric(deltas, activeTab.highlight);
-  const highlightLabel = highlightMetric?.label ?? activeTab.highlight;
+	const deltas = home?.deltas?.length ? home.deltas : FALLBACK_DELTAS;
+	const placeholderDeltas = !home?.deltas?.length;
+	const highlightMetric = getMetric(deltas, activeTab.highlight);
+	const highlightLabel = highlightMetric?.label ?? activeTab.highlight;
 
-  const drivers = (highlight?.drivers ?? []).slice(0, 5);
-  const contributors = (highlight?.contributors ?? []).slice(0, 5);
+	const drivers = (highlight?.drivers ?? []).slice(0, 5);
+	const contributors = (highlight?.contributors ?? []).slice(0, 5);
+	// Render-safe association labels (A7): raw ids degrade to stable short
+	// tokens; the full label remains in the axis tooltip title.
+	const driverChartLabels = resolveEntityLabels(drivers.map((d) => d.label));
+	const contributorChartLabels = resolveEntityLabels(
+		contributors.map((c) => c.label),
+	);
 
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-        <PrimaryNav filters={filters} active="metrics" role={activeRole} />
-        <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Metrics</p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">Monitoring view</h1>
-              <p className="mt-2 text-sm text-(--ink-muted)">Trends over the selected window.</p>
-              <p className="mt-2 text-sm text-(--ink-muted)">Open a metric to investigate.</p>
-            </div>
-            <BackLink href={withFilterParam("/", filters, activeRole)} />
-          </header>
+	return (
+		<div className="min-h-screen bg-background text-foreground">
+			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+				<PrimaryNav filters={filters} active="metrics" role={activeRole} />
+				<main className="flex min-w-0 flex-1 flex-col gap-8">
+					<header className="flex flex-wrap items-center justify-between gap-4">
+						<div>
+							<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+								Metrics
+							</p>
+							<h1 className="mt-2 font-(--font-display) text-3xl">
+								Monitoring view
+							</h1>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								Trends over the selected window.
+							</p>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								Open a metric to investigate.
+							</p>
+						</div>
+						<BackLink href={withFilterParam("/", filters, activeRole)} />
+					</header>
 
-          <FilterBar view="metrics" tab={activeTab.id} />
+					<FilterBar view="metrics" tab={activeTab.id} />
 
-          <ModeTabs
-            ariaLabel="Metrics views"
-            activeId={activeTab.id}
-            items={METRIC_TABS.map(
-              (tab): ModeTabItem => ({
-                id: tab.id,
-                label: tab.label,
-                href: withFilterParam(`/metrics?tab=${tab.id}`, filters, activeRole),
-              }),
-            )}
-          />
+					<ModeTabs
+						ariaLabel="Metrics views"
+						activeId={activeTab.id}
+						items={METRIC_TABS.map(
+							(tab): ModeTabItem => ({
+								id: tab.id,
+								label: tab.label,
+								href: withFilterParam(
+									`/metrics?tab=${tab.id}`,
+									filters,
+									activeRole,
+								),
+							}),
+						)}
+					/>
 
-          <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                  {activeTab.label} monitoring
-                </p>
-                <p className="mt-1 text-sm text-(--ink-muted)">{activeTab.description}</p>
-              </div>
-              <Link
-                href={buildExploreUrl({
-                  metric: activeTab.highlight,
-                  filters,
-                  role: activeRole,
-                })}
-                className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-                title={`Open evidence for ${highlightLabel}`}
-              >
-                Open evidence
-              </Link>
-            </div>
-            <div className="mt-4 flex flex-wrap gap-2 text-xs">
-              {activeTab.metrics.map((metric) => {
-                const data = getMetric(deltas, metric);
-                return (
-                  <Link
-                    key={`chip-${metric}`}
-                    href={buildExploreUrl({
-                      metric,
-                      filters,
-                      role: activeRole,
-                    })}
-                    className="rounded-full border border-(--card-stroke) bg-(--card) px-3 py-1 text-[11px] uppercase tracking-[0.2em] text-(--ink-muted) transition hover:text-foreground"
-                  >
-                    {data?.label ?? metric}
-                  </Link>
-                );
-              })}
-            </div>
-          </section>
+					<section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+						<div className="flex flex-wrap items-center justify-between gap-3">
+							<div>
+								<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+									{activeTab.label} monitoring
+								</p>
+								<p className="mt-1 text-sm text-(--ink-muted)">
+									{activeTab.description}
+								</p>
+							</div>
+							<Link
+								href={buildExploreUrl({
+									metric: activeTab.highlight,
+									filters,
+									role: activeRole,
+								})}
+								className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+								title={`Open evidence for ${highlightLabel}`}
+							>
+								Open evidence
+							</Link>
+						</div>
+						<div className="mt-4 flex flex-wrap gap-2 text-xs">
+							{activeTab.metrics.map((metric) => {
+								const data = getMetric(deltas, metric);
+								return (
+									<Link
+										key={`chip-${metric}`}
+										href={buildExploreUrl({
+											metric,
+											filters,
+											role: activeRole,
+										})}
+										className="rounded-full border border-(--card-stroke) bg-(--card) px-3 py-1 text-[11px] uppercase tracking-[0.2em] text-(--ink-muted) transition hover:text-foreground"
+									>
+										{data?.label ?? metric}
+									</Link>
+								);
+							})}
+						</div>
+					</section>
 
-          <MetricEvidenceCards
-            metrics={activeTab.metrics}
-            deltas={deltas}
-            filters={filters}
-            activeRole={activeRole}
-            placeholderDeltas={placeholderDeltas}
-          />
+					<MetricEvidenceCards
+						metrics={activeTab.metrics}
+						deltas={deltas}
+						filters={filters}
+						activeRole={activeRole}
+						placeholderDeltas={placeholderDeltas}
+					/>
 
-          <section>
-            <QuadrantPanel
-              title={activeTab.quadrant.title}
-              description={activeTab.quadrant.description}
-              data={quadrant}
-              filters={filters}
-              relatedLinks={[
-                {
-                  label: "Open landscapes",
-                  href: withFilterParam("/explore/landscape", filters, activeRole),
-                },
-              ]}
-              emptyState="Quadrant data unavailable for this scope."
-            />
-          </section>
+					<section>
+						<QuadrantPanel
+							title={activeTab.quadrant.title}
+							description={activeTab.quadrant.description}
+							data={quadrant}
+							filters={filters}
+							relatedLinks={[
+								{
+									label: "Open landscapes",
+									href: withFilterParam(
+										"/explore/landscape",
+										filters,
+										activeRole,
+									),
+								},
+							]}
+							emptyState="Quadrant data unavailable for this scope."
+						/>
+					</section>
 
-          <section className="grid gap-6 lg:grid-cols-2">
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
-              <div className="flex items-center justify-between">
-                <h2 className="font-(--font-display) text-xl">Likely associations</h2>
-                <Link
-                  href={buildExploreUrl({
-                    metric: activeTab.highlight,
-                    filters,
-                    role: activeRole,
-                  })}
-                  className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-                >
-                  Open evidence
-                </Link>
-              </div>
-              <p className="mt-2 text-xs text-(--ink-muted)">
-                Preview of the selected window. Select a data point for detail.
-              </p>
-              {drivers.length ? (
-                <div className="mt-4 space-y-4">
-                  <HorizontalBarChart
-                    categories={drivers.map((driver) => driver.label)}
-                    values={drivers.map((driver) => Math.abs(driver.delta_pct))}
-                  />
-                  <div className="space-y-2 text-sm">
-                    {drivers.map((driver) => (
-                      <Link
-                        key={driver.id}
-                        href={buildExploreUrl({
-                          api: driver.evidence_link,
-                          filters,
-                          role: activeRole,
-                        })}
-                        className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
-                      >
-                        <span>{driver.label}</span>
-                        <span className="text-xs text-(--ink-muted)">
-                          {formatDelta(driver.delta_pct)}
-                        </span>
-                      </Link>
-                    ))}
-                  </div>
-                </div>
-              ) : (
-                <p className="mt-4 text-sm text-(--ink-muted)">
-                  Association detail will appear once data is ingested.
-                </p>
-              )}
-            </div>
+					<section className="grid gap-6 lg:grid-cols-2">
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+							<div className="flex items-center justify-between">
+								<h2 className="font-(--font-display) text-xl">
+									Likely associations
+								</h2>
+								<Link
+									href={buildExploreUrl({
+										metric: activeTab.highlight,
+										filters,
+										role: activeRole,
+									})}
+									className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+								>
+									Open evidence
+								</Link>
+							</div>
+							<p className="mt-2 text-xs text-(--ink-muted)">
+								Preview of the selected window. Select a data point for detail.
+							</p>
+							{drivers.length ? (
+								<div className="mt-4 space-y-4">
+									<HorizontalBarChart
+										categories={driverChartLabels.labels}
+										values={drivers.map((driver) => Math.abs(driver.delta_pct))}
+										categoryTitles={driverChartLabels.titles}
+									/>
+									<div className="space-y-2 text-sm">
+										{drivers.map((driver) => (
+											<Link
+												key={driver.id}
+												href={buildExploreUrl({
+													api: driver.evidence_link,
+													filters,
+													role: activeRole,
+												})}
+												className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+											>
+												<EntityLabel id={driver.label} />
+												<span className="text-xs text-(--ink-muted)">
+													{formatDelta(driver.delta_pct)}
+												</span>
+											</Link>
+										))}
+									</div>
+								</div>
+							) : (
+								<p className="mt-4 text-sm text-(--ink-muted)">
+									Association detail will appear once data is ingested.
+								</p>
+							)}
+						</div>
 
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
-              <div className="flex items-center justify-between">
-                <h2 className="font-(--font-display) text-xl">Primary contributors</h2>
-                <Link
-                  href={buildExploreUrl({
-                    metric: activeTab.highlight,
-                    filters,
-                    role: activeRole,
-                  })}
-                  className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-                >
-                  Open evidence
-                </Link>
-              </div>
-              <p className="mt-2 text-xs text-(--ink-muted)">
-                Where the impact concentrates in this window.
-              </p>
-              {contributors.length ? (
-                <div className="mt-4 space-y-4">
-                  <HorizontalBarChart
-                    categories={contributors.map((contributor) => contributor.label)}
-                    values={contributors.map((contributor) => contributor.value)}
-                  />
-                  <div className="space-y-2 text-sm">
-                    {contributors.map((contributor) => (
-                      <Link
-                        key={contributor.id}
-                        href={buildExploreUrl({
-                          api: contributor.evidence_link,
-                          filters,
-                          role: activeRole,
-                        })}
-                        className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
-                      >
-                        <span>{contributor.label}</span>
-                        <span className="text-xs text-(--ink-muted)">
-                          {highlight ? formatMetricValue(contributor.value, highlight.unit) : "--"}
-                        </span>
-                      </Link>
-                    ))}
-                  </div>
-                </div>
-              ) : (
-                <p className="mt-4 text-sm text-(--ink-muted)">
-                  Contributor detail will appear once data is ingested.
-                </p>
-              )}
-            </div>
-          </section>
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+							<div className="flex items-center justify-between">
+								<h2 className="font-(--font-display) text-xl">
+									Primary contributors
+								</h2>
+								<Link
+									href={buildExploreUrl({
+										metric: activeTab.highlight,
+										filters,
+										role: activeRole,
+									})}
+									className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+								>
+									Open evidence
+								</Link>
+							</div>
+							<p className="mt-2 text-xs text-(--ink-muted)">
+								Where the impact concentrates in this window.
+							</p>
+							{contributors.length ? (
+								<div className="mt-4 space-y-4">
+									<HorizontalBarChart
+										categories={contributorChartLabels.labels}
+										values={contributors.map(
+											(contributor) => contributor.value,
+										)}
+										categoryTitles={contributorChartLabels.titles}
+									/>
+									<div className="space-y-2 text-sm">
+										{contributors.map((contributor) => (
+											<Link
+												key={contributor.id}
+												href={buildExploreUrl({
+													api: contributor.evidence_link,
+													filters,
+													role: activeRole,
+												})}
+												className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+											>
+												<EntityLabel id={contributor.label} />
+												<span className="text-xs text-(--ink-muted)">
+													{highlight
+														? formatMetricValue(
+																contributor.value,
+																highlight.unit,
+															)
+														: "--"}
+												</span>
+											</Link>
+										))}
+									</div>
+								</div>
+							) : (
+								<p className="mt-4 text-sm text-(--ink-muted)">
+									Contributor detail will appear once data is ingested.
+								</p>
+							)}
+						</div>
+					</section>
 
-          <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
-            <div className="flex items-center justify-between">
-              <h2 className="font-(--font-display) text-xl">Summary</h2>
-              <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-                Active window
-              </span>
-            </div>
-            <div className="mt-4 overflow-auto">
-              <table className="min-w-full border-collapse text-sm">
-                <thead className="text-left text-(--ink-muted)">
-                  <tr>
-                    <th className="border-b border-(--card-stroke) pb-2">Metric</th>
-                    <th className="border-b border-(--card-stroke) pb-2">Current</th>
-                    <th className="border-b border-(--card-stroke) pb-2">Delta</th>
-                    <th className="border-b border-(--card-stroke) pb-2">Explore</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {activeTab.metrics.map((metric) => {
-                    const data = getMetric(deltas, metric);
-                    const href = buildExploreUrl({
-                      metric,
-                      filters,
-                      role: activeRole,
-                    });
-                    return (
-                      <tr key={metric} className="border-b border-(--card-stroke)">
-                        <td className="py-3 pr-4 font-medium">
-                          <Link href={href} className="block">
-                            {data?.label ?? metric}
-                          </Link>
-                        </td>
-                        <td className="py-3 pr-4 text-(--ink-muted)">
-                          <Link href={href} className="block">
-                            {placeholderDeltas || !data
-                              ? "--"
-                              : formatMetricValue(data.value, data.unit)}
-                          </Link>
-                        </td>
-                        <td className="py-3 pr-4 text-(--ink-muted)">
-                          <Link href={href} className="block">
-                            {placeholderDeltas || !data ? (
-                              <span title="No prior period available to compute a change">
-                                No prior period
-                              </span>
-                            ) : (
-                              formatDelta(data.delta_pct)
-                            )}
-                          </Link>
-                        </td>
-                        <td className="py-3 text-xs uppercase tracking-[0.2em] text-(--accent-2)">
-                          <Link href={href} className="block">
-                            Open
-                          </Link>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </section>
-        </main>
-      </div>
-    </div>
-  );
+					<section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+						<div className="flex items-center justify-between">
+							<h2 className="font-(--font-display) text-xl">Summary</h2>
+							<span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+								Active window
+							</span>
+						</div>
+						<div className="mt-4 overflow-auto">
+							<table className="min-w-full border-collapse text-sm">
+								<thead className="text-left text-(--ink-muted)">
+									<tr>
+										<th className="border-b border-(--card-stroke) pb-2">
+											Metric
+										</th>
+										<th className="border-b border-(--card-stroke) pb-2">
+											Current
+										</th>
+										<th className="border-b border-(--card-stroke) pb-2">
+											Delta
+										</th>
+										<th className="border-b border-(--card-stroke) pb-2">
+											Explore
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									{activeTab.metrics.map((metric) => {
+										const data = getMetric(deltas, metric);
+										const href = buildExploreUrl({
+											metric,
+											filters,
+											role: activeRole,
+										});
+										return (
+											<tr
+												key={metric}
+												className="border-b border-(--card-stroke)"
+											>
+												<td className="py-3 pr-4 font-medium">
+													<Link href={href} className="block">
+														{data?.label ?? metric}
+													</Link>
+												</td>
+												<td className="py-3 pr-4 text-(--ink-muted)">
+													<Link href={href} className="block">
+														{placeholderDeltas || !data
+															? "--"
+															: formatMetricValue(data.value, data.unit)}
+													</Link>
+												</td>
+												<td className="py-3 pr-4 text-(--ink-muted)">
+													<Link href={href} className="block">
+														{placeholderDeltas || !data ? (
+															<span title="No prior period available to compute a change">
+																No prior period
+															</span>
+														) : (
+															formatDelta(data.delta_pct)
+														)}
+													</Link>
+												</td>
+												<td className="py-3 text-xs uppercase tracking-[0.2em] text-(--accent-2)">
+													<Link href={href} className="block">
+														Open
+													</Link>
+												</td>
+											</tr>
+										);
+									})}
+								</tbody>
+							</table>
+						</div>
+					</section>
+				</main>
+			</div>
+		</div>
+	);
 }

--- a/src/app/(app)/people/[person_id]/metrics/[metric]/page.tsx
+++ b/src/app/(app)/people/[person_id]/metrics/[metric]/page.tsx
@@ -7,440 +7,527 @@ import { PersonRangeBar } from "@/components/people/PersonRangeBar";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { checkApiHealth } from "@/lib/api/system";
 import { getHeatmap } from "@/lib/api/visuals";
-import { getPersonDrilldown, getPersonMetric, getPersonSummary } from "@/lib/api/people";
+import {
+	getPersonDrilldown,
+	getPersonMetric,
+	getPersonSummary,
+} from "@/lib/api/people";
 import { defaultMetricFilter } from "@/lib/filters/defaults";
 import { fetchOrNull } from "@/lib/fetchOrNull";
 import { decodeFilter } from "@/lib/filters/encode";
 import { formatNumber } from "@/lib/formatters";
 import { getMetricLabel } from "@/lib/metrics/catalog";
 import { getRangeParams, withRangeParams } from "@/lib/people/query";
+import { EntityLabel } from "@/components/labels/EntityLabel";
+import { resolveEntityLabels } from "@/lib/labels/entityLabel";
 
 const getItemTitle = (item: Record<string, unknown>, index: number) => {
-  const title =
-    item.title ?? item.name ?? item.work_item_id ?? item.number ?? item.id ?? `Item ${index + 1}`;
-  return String(title);
+	const title =
+		item.title ??
+		item.name ??
+		item.work_item_id ??
+		item.number ??
+		item.id ??
+		`Item ${index + 1}`;
+	return String(title);
 };
 
 const getItemHref = (item: Record<string, unknown>, fallback: string) => {
-  const candidates = [item.url, item.link, item.html_url, item.web_url, item.api_url];
-  for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate.length) {
-      return candidate;
-    }
-  }
-  return fallback;
+	const candidates = [
+		item.url,
+		item.link,
+		item.html_url,
+		item.web_url,
+		item.api_url,
+	];
+	for (const candidate of candidates) {
+		if (typeof candidate === "string" && candidate.length) {
+			return candidate;
+		}
+	}
+	return fallback;
 };
 
 const getEvidenceTypeFromLink = (link?: string) => {
-  if (!link) {
-    return null;
-  }
-  try {
-    const url = new URL(link, "http://localhost");
-    if (url.pathname.includes("/drilldown/prs")) {
-      return "prs";
-    }
-    if (url.pathname.includes("/drilldown/issues")) {
-      return "issues";
-    }
-  } catch {
-    return null;
-  }
-  return null;
+	if (!link) {
+		return null;
+	}
+	try {
+		const url = new URL(link, "http://localhost");
+		if (url.pathname.includes("/drilldown/prs")) {
+			return "prs";
+		}
+		if (url.pathname.includes("/drilldown/issues")) {
+			return "issues";
+		}
+	} catch {
+		return null;
+	}
+	return null;
 };
 
 const pickDefinitionValue = (
-  definition: Record<string, string | number | string[]> | undefined,
-  keys: string[],
+	definition: Record<string, string | number | string[]> | undefined,
+	keys: string[],
 ) => {
-  if (!definition) {
-    return null;
-  }
-  for (const key of keys) {
-    const value = definition[key];
-    if (typeof value === "string" && value.trim().length) {
-      return value;
-    }
-  }
-  return null;
+	if (!definition) {
+		return null;
+	}
+	for (const key of keys) {
+		const value = definition[key];
+		if (typeof value === "string" && value.trim().length) {
+			return value;
+		}
+	}
+	return null;
 };
 
 type PersonMetricPageProps = {
-  params: Promise<{ person_id: string; metric: string }>;
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+	params: Promise<{ person_id: string; metric: string }>;
+	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-export default async function PersonMetricPage({ params, searchParams }: PersonMetricPageProps) {
-  const health = await checkApiHealth();
+export default async function PersonMetricPage({
+	params,
+	searchParams,
+}: PersonMetricPageProps) {
+	const health = await checkApiHealth();
 
-  const { person_id: personId, metric } = await params;
-  const rawParams = (await searchParams) ?? {};
-  const { range_days, compare_days } = getRangeParams(rawParams);
-  const encodedFilter = Array.isArray(rawParams.f) ? rawParams.f[0] : rawParams.f;
-  const filters = encodedFilter ? decodeFilter(encodedFilter) : defaultMetricFilter;
+	const { person_id: personId, metric } = await params;
+	const rawParams = (await searchParams) ?? {};
+	const { range_days, compare_days } = getRangeParams(rawParams);
+	const encodedFilter = Array.isArray(rawParams.f)
+		? rawParams.f[0]
+		: rawParams.f;
+	const filters = encodedFilter
+		? decodeFilter(encodedFilter)
+		: defaultMetricFilter;
 
-  const evidenceParam = Array.isArray(rawParams.evidence)
-    ? rawParams.evidence[0]
-    : rawParams.evidence;
-  const evidenceType = evidenceParam === "prs" || evidenceParam === "issues" ? evidenceParam : null;
-  const limitParam = Array.isArray(rawParams.limit) ? rawParams.limit[0] : rawParams.limit;
-  const limit = limitParam ? Math.max(1, Number(limitParam)) : 50;
-  const cursorParam = Array.isArray(rawParams.cursor) ? rawParams.cursor[0] : rawParams.cursor;
+	const evidenceParam = Array.isArray(rawParams.evidence)
+		? rawParams.evidence[0]
+		: rawParams.evidence;
+	const evidenceType =
+		evidenceParam === "prs" || evidenceParam === "issues"
+			? evidenceParam
+			: null;
+	const limitParam = Array.isArray(rawParams.limit)
+		? rawParams.limit[0]
+		: rawParams.limit;
+	const limit = limitParam ? Math.max(1, Number(limitParam)) : 50;
+	const cursorParam = Array.isArray(rawParams.cursor)
+		? rawParams.cursor[0]
+		: rawParams.cursor;
 
-  const [summary, metricData] = await Promise.all([
-    fetchOrNull(
-      getPersonSummary({ personId, range_days, compare_days }),
-      `people/${personId}/summary`,
-    ),
-    fetchOrNull(
-      getPersonMetric({ personId, metric, range_days, compare_days }),
-      `people/${personId}/metric-${metric}`,
-    ),
-  ]);
-  const activeHoursHeatmap = await fetchOrNull(
-    getHeatmap({
-      type: "individual",
-      metric: "active_hours",
-      scope_type: "person",
-      scope_id: personId,
-      range_days,
-    }),
-    `people/${personId}/active-hours-heatmap`,
-  );
+	const [summary, metricData] = await Promise.all([
+		fetchOrNull(
+			getPersonSummary({ personId, range_days, compare_days }),
+			`people/${personId}/summary`,
+		),
+		fetchOrNull(
+			getPersonMetric({ personId, metric, range_days, compare_days }),
+			`people/${personId}/metric-${metric}`,
+		),
+	]);
+	const activeHoursHeatmap = await fetchOrNull(
+		getHeatmap({
+			type: "individual",
+			metric: "active_hours",
+			scope_type: "person",
+			scope_id: personId,
+			range_days,
+		}),
+		`people/${personId}/active-hours-heatmap`,
+	);
 
-  const person = summary?.person;
-  const label = metricData?.label ?? getMetricLabel(metric);
-  const definition = metricData?.definition;
-  const definitionSummary = pickDefinitionValue(definition, [
-    "summary",
-    "description",
-    "definition",
-    "what_it_measures",
-  ]);
-  const interpretation = pickDefinitionValue(definition, [
-    "interpretation",
-    "how_to_interpret",
-    "guidance",
-  ]);
-  const definitionEntries = definition
-    ? Object.entries(definition).filter(
-        ([, value]) =>
-          typeof value === "string" || typeof value === "number" || Array.isArray(value),
-      )
-    : [];
+	const person = summary?.person;
+	const label = metricData?.label ?? getMetricLabel(metric);
+	const definition = metricData?.definition;
+	const definitionSummary = pickDefinitionValue(definition, [
+		"summary",
+		"description",
+		"definition",
+		"what_it_measures",
+	]);
+	const interpretation = pickDefinitionValue(definition, [
+		"interpretation",
+		"how_to_interpret",
+		"guidance",
+	]);
+	const definitionEntries = definition
+		? Object.entries(definition).filter(
+				([, value]) =>
+					typeof value === "string" ||
+					typeof value === "number" ||
+					Array.isArray(value),
+			)
+		: [];
 
-  const drilldown = evidenceType
-    ? await fetchOrNull(
-        getPersonDrilldown({
-          personId,
-          type: evidenceType,
-          limit,
-          cursor: cursorParam ?? undefined,
-          metric,
-          range_days,
-          compare_days,
-        }),
-        `people/${personId}/drilldown-${evidenceType}`,
-      )
-    : null;
+	const drilldown = evidenceType
+		? await fetchOrNull(
+				getPersonDrilldown({
+					personId,
+					type: evidenceType,
+					limit,
+					cursor: cursorParam ?? undefined,
+					metric,
+					range_days,
+					compare_days,
+				}),
+				`people/${personId}/drilldown-${evidenceType}`,
+			)
+		: null;
 
-  const breakdowns = metricData?.breakdowns ?? {};
-  const drivers = metricData?.drivers ?? [];
-  const timeseries = metricData?.timeseries ?? [];
+	const breakdowns = metricData?.breakdowns ?? {};
+	const drivers = metricData?.drivers ?? [];
+	const timeseries = metricData?.timeseries ?? [];
 
-  const breakdownGroups = [
-    {
-      id: "repo",
-      label: "By repo",
-      items:
-        breakdowns.by_repo?.map((item) => ({
-          label: item.repo,
-          value: item.value,
-        })) ?? [],
-    },
-    {
-      id: "work",
-      label: "By work type",
-      items:
-        breakdowns.by_work_type?.map((item) => ({
-          label: item.work_type,
-          value: item.value,
-        })) ?? [],
-    },
-    {
-      id: "stage",
-      label: "By stage",
-      items:
-        breakdowns.by_stage?.map((item) => ({
-          label: item.stage,
-          value: item.value,
-        })) ?? [],
-    },
-  ];
+	const breakdownGroups = [
+		{
+			id: "repo",
+			isEntity: true,
+			label: "By repo",
+			items:
+				breakdowns.by_repo?.map((item) => ({
+					label: item.repo,
+					value: item.value,
+				})) ?? [],
+		},
+		{
+			id: "work",
+			isEntity: false,
+			label: "By work type",
+			items:
+				breakdowns.by_work_type?.map((item) => ({
+					label: item.work_type,
+					value: item.value,
+				})) ?? [],
+		},
+		{
+			id: "stage",
+			isEntity: false,
+			label: "By stage",
+			items:
+				breakdowns.by_stage?.map((item) => ({
+					label: item.stage,
+					value: item.value,
+				})) ?? [],
+		},
+	];
 
-  const evidenceHref = (type: "prs" | "issues") =>
-    withRangeParams(`/people/${personId}/metrics/${metric}`, range_days, compare_days, {
-      evidence: type,
-      limit,
-    });
+	const evidenceHref = (type: "prs" | "issues") =>
+		withRangeParams(
+			`/people/${personId}/metrics/${metric}`,
+			range_days,
+			compare_days,
+			{
+				evidence: type,
+				limit,
+			},
+		);
 
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-        <PrimaryNav filters={filters} active="people" />
-        <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                Individual metric
-              </p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">{label}</h1>
-              <p className="mt-2 text-sm text-(--ink-muted)">
-                {person?.display_name ?? "Individual"} • {range_days}d window
-              </p>
-              <div className="mt-3 flex flex-wrap gap-2 text-xs text-(--ink-muted)">
-                {(person?.identities ?? []).map((identity) => (
-                  <span
-                    key={`${personId}-${identity.provider}-${identity.handle}`}
-                    className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
-                  >
-                    {identity.provider}: {identity.handle}
-                  </span>
-                ))}
-              </div>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Link
-                href={withRangeParams(`/people/${personId}`, range_days, compare_days)}
-                className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
-              >
-                Back to individual
-              </Link>
-            </div>
-          </header>
+	return (
+		<div className="min-h-screen bg-background text-foreground">
+			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+				<PrimaryNav filters={filters} active="people" />
+				<main className="flex min-w-0 flex-1 flex-col gap-8">
+					<header className="flex flex-wrap items-start justify-between gap-4">
+						<div>
+							<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+								Individual metric
+							</p>
+							<h1 className="mt-2 font-(--font-display) text-3xl">{label}</h1>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								{person?.display_name ?? "Individual"} • {range_days}d window
+							</p>
+							<div className="mt-3 flex flex-wrap gap-2 text-xs text-(--ink-muted)">
+								{(person?.identities ?? []).map((identity) => (
+									<span
+										key={`${personId}-${identity.provider}-${identity.handle}`}
+										className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
+									>
+										{identity.provider}: {identity.handle}
+									</span>
+								))}
+							</div>
+						</div>
+						<div className="flex flex-wrap gap-2">
+							<Link
+								href={withRangeParams(
+									`/people/${personId}`,
+									range_days,
+									compare_days,
+								)}
+								className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+							>
+								Back to individual
+							</Link>
+						</div>
+					</header>
 
-          {!health.ok && (
-            <div className="rounded-3xl border border-dashed border-amber-400/80 bg-amber-50/80 px-4 py-3 text-sm text-amber-900">
-              Data service unavailable. Evidence will refresh once the API is back.
-            </div>
-          )}
+					{!health.ok && (
+						<div className="rounded-3xl border border-dashed border-amber-400/80 bg-amber-50/80 px-4 py-3 text-sm text-amber-900">
+							Data service unavailable. Evidence will refresh once the API is
+							back.
+						</div>
+					)}
 
-          <PersonRangeBar rangeDays={range_days} />
+					<PersonRangeBar rangeDays={range_days} />
 
-          <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
-              <h2 className="font-(--font-display) text-xl">Definition</h2>
-              <p className="mt-2 text-sm text-(--ink-muted)">
-                {definitionSummary ??
-                  "Definition will appear when the indicator library is available."}
-              </p>
-              {interpretation && (
-                <p className="mt-3 text-sm text-(--ink-muted)">
-                  How to interpret: {interpretation}
-                </p>
-              )}
-              {definitionEntries.length > 0 && (
-                <div className="mt-4 grid gap-2 text-xs text-(--ink-muted)">
-                  {definitionEntries.map(([key, value]) => (
-                    <div
-                      key={key}
-                      className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-card px-3 py-2"
-                    >
-                      <span className="uppercase tracking-[0.2em]">
-                        {key.replace(/[_-]+/g, " ")}
-                      </span>
-                      <span className="font-semibold text-foreground">
-                        {Array.isArray(value) ? value.join(", ") : String(value)}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+					<section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+							<h2 className="font-(--font-display) text-xl">Definition</h2>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								{definitionSummary ??
+									"Definition will appear when the indicator library is available."}
+							</p>
+							{interpretation && (
+								<p className="mt-3 text-sm text-(--ink-muted)">
+									How to interpret: {interpretation}
+								</p>
+							)}
+							{definitionEntries.length > 0 && (
+								<div className="mt-4 grid gap-2 text-xs text-(--ink-muted)">
+									{definitionEntries.map(([key, value]) => (
+										<div
+											key={key}
+											className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-card px-3 py-2"
+										>
+											<span className="uppercase tracking-[0.2em]">
+												{key.replace(/[_-]+/g, " ")}
+											</span>
+											<span className="font-semibold text-foreground">
+												{Array.isArray(value)
+													? value.join(", ")
+													: String(value)}
+											</span>
+										</div>
+									))}
+								</div>
+							)}
+						</div>
 
-            <div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
-              <div className="flex items-center justify-between">
-                <h2 className="font-(--font-display) text-xl">Timeseries</h2>
-                <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">Daily</span>
-              </div>
-              <div className="mt-4">
-                {timeseries.length ? (
-                  <TimeseriesChart data={timeseries} height={240} />
-                ) : (
-                  <div className="flex h-[240px] items-center justify-center rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-60) text-sm text-(--ink-muted)">
-                    Timeseries data unavailable.
-                  </div>
-                )}
-              </div>
-            </div>
-          </section>
+						<div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+							<div className="flex items-center justify-between">
+								<h2 className="font-(--font-display) text-xl">Timeseries</h2>
+								<span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+									Daily
+								</span>
+							</div>
+							<div className="mt-4">
+								{timeseries.length ? (
+									<TimeseriesChart data={timeseries} height={240} />
+								) : (
+									<div className="flex h-[240px] items-center justify-center rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-60) text-sm text-(--ink-muted)">
+										Timeseries data unavailable.
+									</div>
+								)}
+							</div>
+						</div>
+					</section>
 
-          <section>
-            <HeatmapPanel
-              title="Active hours distribution"
-              description="See when work concentrates across weekdays and hours."
-              request={{
-                type: "individual",
-                metric: "active_hours",
-                scope_type: "developer",
-                scope_id: personId,
-                range_days,
-              }}
-              initialData={activeHoursHeatmap}
-              emptyState="Active hours heatmap unavailable."
-              evidenceTitle="Commit evidence"
-            />
-          </section>
+					<section>
+						<HeatmapPanel
+							title="Active hours distribution"
+							description="See when work concentrates across weekdays and hours."
+							request={{
+								type: "individual",
+								metric: "active_hours",
+								scope_type: "developer",
+								scope_id: personId,
+								range_days,
+							}}
+							initialData={activeHoursHeatmap}
+							emptyState="Active hours heatmap unavailable."
+							evidenceTitle="Commit evidence"
+						/>
+					</section>
 
-          <section className="grid gap-6 lg:grid-cols-3">
-            {breakdownGroups.map((group) => (
-              <div key={group.id} className="rounded-3xl border border-(--card-stroke) bg-card p-5">
-                <div className="flex items-center justify-between">
-                  <h2 className="font-(--font-display) text-xl">{group.label}</h2>
-                  <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-                    Breakdown
-                  </span>
-                </div>
-                <div className="mt-4">
-                  {group.items.length ? (
-                    <HorizontalBarChart
-                      categories={group.items.map((item) => item.label)}
-                      values={group.items.map((item) => item.value)}
-                    />
-                  ) : (
-                    <div className="flex h-[220px] items-center justify-center rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-60) text-sm text-(--ink-muted)">
-                      No breakdown data.
-                    </div>
-                  )}
-                </div>
-                <div className="mt-4 space-y-2 text-sm">
-                  {group.items.map((item, index) => (
-                    <div
-                      key={`${group.id}-${item.label ?? "unknown"}-${index}`}
-                      className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
-                    >
-                      <span>{item.label}</span>
-                      <span className="text-xs text-(--ink-muted)">{formatNumber(item.value)}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </section>
+					<section className="grid gap-6 lg:grid-cols-3">
+						{breakdownGroups.map((group) => {
+							// Repo breakdown labels are entity ids — route through the A7
+							// resolver so a raw repo id degrades to a stable short token
+							// (with the full id in the axis tooltip). Work-type / stage
+							// labels are plain categories and pass through untouched.
+							const chartLabels = group.isEntity
+								? resolveEntityLabels(group.items.map((item) => item.label))
+								: null;
+							return (
+								<div
+									key={group.id}
+									className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+								>
+									<div className="flex items-center justify-between">
+										<h2 className="font-(--font-display) text-xl">
+											{group.label}
+										</h2>
+										<span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+											Breakdown
+										</span>
+									</div>
+									<div className="mt-4">
+										{group.items.length ? (
+											<HorizontalBarChart
+												categories={
+													chartLabels
+														? chartLabels.labels
+														: group.items.map((item) => item.label)
+												}
+												values={group.items.map((item) => item.value)}
+												categoryTitles={
+													chartLabels ? chartLabels.titles : undefined
+												}
+											/>
+										) : (
+											<div className="flex h-[220px] items-center justify-center rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-60) text-sm text-(--ink-muted)">
+												No breakdown data.
+											</div>
+										)}
+									</div>
+									<div className="mt-4 space-y-2 text-sm">
+										{group.items.map((item, index) => (
+											<div
+												key={`${group.id}-${item.label ?? "unknown"}-${index}`}
+												className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+											>
+												{group.isEntity ? (
+													<EntityLabel id={item.label} />
+												) : (
+													<span>{item.label}</span>
+												)}
+												<span className="text-xs text-(--ink-muted)">
+													{formatNumber(item.value)}
+												</span>
+											</div>
+										))}
+									</div>
+								</div>
+							);
+						})}
+					</section>
 
-          <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-            <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
-              <div className="flex items-center justify-between">
-                <h2 className="font-(--font-display) text-xl">Associations</h2>
-                <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-                  Evidence linked
-                </span>
-              </div>
-              <div className="mt-4 space-y-3 text-sm">
-                {drivers.length ? (
-                  drivers.map((driver, idx) => {
-                    const evidence = getEvidenceTypeFromLink(driver.link);
-                    const href = evidence ? evidenceHref(evidence) : null;
-                    return (
-                      <div
-                        key={`${driver.text}-${idx}`}
-                        className="rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3"
-                      >
-                        <p className="text-sm text-foreground">{driver.text}</p>
-                        {href && (
-                          <Link
-                            href={href}
-                            className="mt-2 inline-flex text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-                          >
-                            Open evidence
-                          </Link>
-                        )}
-                      </div>
-                    );
-                  })
-                ) : (
-                  <p className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-60) px-4 py-3 text-sm text-(--ink-muted)">
-                    Association statements will appear once data is ingested.
-                  </p>
-                )}
-              </div>
-            </div>
+					<section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+						<div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+							<div className="flex items-center justify-between">
+								<h2 className="font-(--font-display) text-xl">Associations</h2>
+								<span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+									Evidence linked
+								</span>
+							</div>
+							<div className="mt-4 space-y-3 text-sm">
+								{drivers.length ? (
+									drivers.map((driver, idx) => {
+										const evidence = getEvidenceTypeFromLink(driver.link);
+										const href = evidence ? evidenceHref(evidence) : null;
+										return (
+											<div
+												key={`${driver.text}-${idx}`}
+												className="rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3"
+											>
+												<p className="text-sm text-foreground">{driver.text}</p>
+												{href && (
+													<Link
+														href={href}
+														className="mt-2 inline-flex text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+													>
+														Open evidence
+													</Link>
+												)}
+											</div>
+										);
+									})
+								) : (
+									<p className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-60) px-4 py-3 text-sm text-(--ink-muted)">
+										Association statements will appear once data is ingested.
+									</p>
+								)}
+							</div>
+						</div>
 
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
-              <div className="flex items-center justify-between">
-                <h2 className="font-(--font-display) text-xl">Evidence</h2>
-                <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-                  Drilldown
-                </span>
-              </div>
-              <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.2em]">
-                <Link
-                  href={evidenceHref("prs")}
-                  className={`rounded-full border px-3 py-2 ${
-                    evidenceType === "prs"
-                      ? "border-(--accent) bg-(--accent)/15 text-foreground"
-                      : "border-(--card-stroke) text-(--ink-muted)"
-                  }`}
-                >
-                  PRs
-                </Link>
-                <Link
-                  href={evidenceHref("issues")}
-                  className={`rounded-full border px-3 py-2 ${
-                    evidenceType === "issues"
-                      ? "border-(--accent) bg-(--accent)/15 text-foreground"
-                      : "border-(--card-stroke) text-(--ink-muted)"
-                  }`}
-                >
-                  Issues
-                </Link>
-              </div>
-              {evidenceType && (
-                <div className="mt-4 overflow-auto text-xs">
-                  <table className="min-w-full border-collapse">
-                    <thead className="text-left text-(--ink-muted)">
-                      <tr>
-                        <th className="border-b border-(--card-stroke) pb-2">Item</th>
-                        <th className="border-b border-(--card-stroke) pb-2">Details</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {(drilldown?.items ?? []).map((item, idx) => {
-                        const fallbackHref = evidenceHref(evidenceType);
-                        const href = getItemHref(item, fallbackHref);
-                        return (
-                          <tr key={`item-${idx}`} className="border-b border-(--card-stroke)">
-                            <td className="py-2 pr-4 font-medium">
-                              <a href={href} className="block text-foreground">
-                                {getItemTitle(item, idx)}
-                              </a>
-                            </td>
-                            <td className="py-2 text-(--ink-muted)">
-                              <a href={href} className="block">
-                                {JSON.stringify(item)}
-                              </a>
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                  {!drilldown?.items?.length && (
-                    <p className="mt-3 text-sm text-(--ink-muted)">
-                      Evidence rows will appear once data is ingested.
-                    </p>
-                  )}
-                </div>
-              )}
-              {!evidenceType && (
-                <div className="mt-4 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-60) px-4 py-3 text-sm text-(--ink-muted)">
-                  Choose PRs or Issues to review evidence.
-                </div>
-              )}
-            </div>
-          </section>
-        </main>
-      </div>
-    </div>
-  );
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+							<div className="flex items-center justify-between">
+								<h2 className="font-(--font-display) text-xl">Evidence</h2>
+								<span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+									Drilldown
+								</span>
+							</div>
+							<div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.2em]">
+								<Link
+									href={evidenceHref("prs")}
+									className={`rounded-full border px-3 py-2 ${
+										evidenceType === "prs"
+											? "border-(--accent) bg-(--accent)/15 text-foreground"
+											: "border-(--card-stroke) text-(--ink-muted)"
+									}`}
+								>
+									PRs
+								</Link>
+								<Link
+									href={evidenceHref("issues")}
+									className={`rounded-full border px-3 py-2 ${
+										evidenceType === "issues"
+											? "border-(--accent) bg-(--accent)/15 text-foreground"
+											: "border-(--card-stroke) text-(--ink-muted)"
+									}`}
+								>
+									Issues
+								</Link>
+							</div>
+							{evidenceType && (
+								<div className="mt-4 overflow-auto text-xs">
+									<table className="min-w-full border-collapse">
+										<thead className="text-left text-(--ink-muted)">
+											<tr>
+												<th className="border-b border-(--card-stroke) pb-2">
+													Item
+												</th>
+												<th className="border-b border-(--card-stroke) pb-2">
+													Details
+												</th>
+											</tr>
+										</thead>
+										<tbody>
+											{(drilldown?.items ?? []).map((item, idx) => {
+												const fallbackHref = evidenceHref(evidenceType);
+												const href = getItemHref(item, fallbackHref);
+												return (
+													<tr
+														key={`item-${idx}`}
+														className="border-b border-(--card-stroke)"
+													>
+														<td className="py-2 pr-4 font-medium">
+															<a href={href} className="block text-foreground">
+																<EntityLabel
+																	variant="text"
+																	id={getItemTitle(item, idx)}
+																/>
+															</a>
+														</td>
+														<td className="py-2 text-(--ink-muted)">
+															<a href={href} className="block">
+																{JSON.stringify(item)}
+															</a>
+														</td>
+													</tr>
+												);
+											})}
+										</tbody>
+									</table>
+									{!drilldown?.items?.length && (
+										<p className="mt-3 text-sm text-(--ink-muted)">
+											Evidence rows will appear once data is ingested.
+										</p>
+									)}
+								</div>
+							)}
+							{!evidenceType && (
+								<div className="mt-4 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-60) px-4 py-3 text-sm text-(--ink-muted)">
+									Choose PRs or Issues to review evidence.
+								</div>
+							)}
+						</div>
+					</section>
+				</main>
+			</div>
+		</div>
+	);
 }

--- a/src/app/(app)/quality/page.tsx
+++ b/src/app/(app)/quality/page.tsx
@@ -13,190 +13,222 @@ import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
 import { formatDelta, formatMetricValue } from "@/lib/formatters";
 import { FALLBACK_DELTAS } from "@/lib/metrics/catalog";
 import type { MetricDelta } from "@/lib/types";
+import { EntityLabel } from "@/components/labels/EntityLabel";
+import { resolveEntityLabels } from "@/lib/labels/entityLabel";
 
 type QualityPageProps = {
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 const getMetric = (deltas: MetricDelta[], metric: string) =>
-  deltas.find((item) => item.metric === metric) ??
-  FALLBACK_DELTAS.find((item) => item.metric === metric);
+	deltas.find((item) => item.metric === metric) ??
+	FALLBACK_DELTAS.find((item) => item.metric === metric);
 
 export default async function QualityPage({ searchParams }: QualityPageProps) {
-  const params = (await searchParams) ?? {};
-  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
-  const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
-  const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+	const params = (await searchParams) ?? {};
+	const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+	const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+	const activeRole = typeof roleParam === "string" ? roleParam : undefined;
 
-  const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+	const filters = encodedFilter
+		? decodeFilter(encodedFilter)
+		: filterFromQueryParams(params);
 
-  // Run health check in parallel with all data fetches to eliminate the waterfall.
-  const [health, home, explain] = await Promise.all([
-    checkApiHealth(),
-    fetchOrNull(getHomeData(filters), "quality/home-data"),
-    fetchOrNull(
-      getExplainData({ metric: "change_failure_rate", filters }),
-      "quality/explain-change_failure_rate",
-    ),
-  ]);
+	// Run health check in parallel with all data fetches to eliminate the waterfall.
+	const [health, home, explain] = await Promise.all([
+		checkApiHealth(),
+		fetchOrNull(getHomeData(filters), "quality/home-data"),
+		fetchOrNull(
+			getExplainData({ metric: "change_failure_rate", filters }),
+			"quality/explain-change_failure_rate",
+		),
+	]);
 
-  if (!health.ok) {
-    return <ServiceUnavailable />;
-  }
+	if (!health.ok) {
+		return <ServiceUnavailable />;
+	}
 
-  const deltas = home?.deltas?.length ? home.deltas : FALLBACK_DELTAS;
-  const placeholderDeltas = !home?.deltas?.length;
+	const deltas = home?.deltas?.length ? home.deltas : FALLBACK_DELTAS;
+	const placeholderDeltas = !home?.deltas?.length;
 
-  const changeFailureMetric = getMetric(deltas, "change_failure_rate");
-  const ciMetric = getMetric(deltas, "ci_success");
-  const reworkMetric = getMetric(deltas, "rework_ratio");
+	const changeFailureMetric = getMetric(deltas, "change_failure_rate");
+	const ciMetric = getMetric(deltas, "ci_success");
+	const reworkMetric = getMetric(deltas, "rework_ratio");
 
-  const drivers = (explain?.drivers ?? []).slice(0, 5);
-  const contributors = (explain?.contributors ?? []).slice(0, 5);
+	const drivers = (explain?.drivers ?? []).slice(0, 5);
+	const contributors = (explain?.contributors ?? []).slice(0, 5);
+	// Render-safe association labels (A7): raw ids degrade to stable short
+	// tokens; the full label remains in the axis tooltip title.
+	const driverChartLabels = resolveEntityLabels(drivers.map((d) => d.label));
 
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-        <PrimaryNav filters={filters} active="quality" role={activeRole} />
-        <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Quality</p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">Reliability Patterns</h1>
-              <p className="mt-2 text-sm text-(--ink-muted)">
-                Change failure, CI stability, and rework indicators.
-              </p>
-              <p className="mt-2 text-sm text-(--ink-muted)">Open a metric to investigate.</p>
-            </div>
-            <Link
-              href={withFilterParam("/", filters, activeRole)}
-              className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
-            >
-              Back to cockpit
-            </Link>
-          </header>
+	return (
+		<div className="min-h-screen bg-background text-foreground">
+			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+				<PrimaryNav filters={filters} active="quality" role={activeRole} />
+				<main className="flex min-w-0 flex-1 flex-col gap-8">
+					<header className="flex flex-wrap items-center justify-between gap-4">
+						<div>
+							<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+								Quality
+							</p>
+							<h1 className="mt-2 font-(--font-display) text-3xl">
+								Reliability Patterns
+							</h1>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								Change failure, CI stability, and rework indicators.
+							</p>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								Open a metric to investigate.
+							</p>
+						</div>
+						<Link
+							href={withFilterParam("/", filters, activeRole)}
+							className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+						>
+							Back to cockpit
+						</Link>
+					</header>
 
-          <FilterBar view="quality" />
+					<FilterBar view="quality" />
 
-          <section className="grid gap-4 lg:grid-cols-3">
-            <MetricCard
-              label={changeFailureMetric?.label ?? "Change Failure Rate"}
-              href={buildExploreUrl({ metric: "change_failure_rate", filters, role: activeRole })}
-              value={placeholderDeltas ? undefined : changeFailureMetric?.value}
-              unit={changeFailureMetric?.unit}
-              delta={placeholderDeltas ? undefined : changeFailureMetric?.delta_pct}
-              spark={changeFailureMetric?.spark}
-              caption="Change failure rate"
-            />
-            <MetricCard
-              label={ciMetric?.label ?? "CI Success Rate"}
-              href={buildExploreUrl({ metric: "ci_success", filters, role: activeRole })}
-              value={placeholderDeltas ? undefined : ciMetric?.value}
-              unit={ciMetric?.unit}
-              delta={placeholderDeltas ? undefined : ciMetric?.delta_pct}
-              spark={ciMetric?.spark}
-              caption="Pipeline success"
-            />
-            <MetricCard
-              label={reworkMetric?.label ?? "Rework Ratio"}
-              href={buildExploreUrl({ metric: "rework_ratio", filters, role: activeRole })}
-              value={placeholderDeltas ? undefined : reworkMetric?.value}
-              unit={reworkMetric?.unit}
-              delta={placeholderDeltas ? undefined : reworkMetric?.delta_pct}
-              spark={reworkMetric?.spark}
-              caption="Churn from rework"
-            />
-          </section>
+					<section className="grid gap-4 lg:grid-cols-3">
+						<MetricCard
+							label={changeFailureMetric?.label ?? "Change Failure Rate"}
+							href={buildExploreUrl({
+								metric: "change_failure_rate",
+								filters,
+								role: activeRole,
+							})}
+							value={placeholderDeltas ? undefined : changeFailureMetric?.value}
+							unit={changeFailureMetric?.unit}
+							delta={
+								placeholderDeltas ? undefined : changeFailureMetric?.delta_pct
+							}
+							spark={changeFailureMetric?.spark}
+							caption="Change failure rate"
+						/>
+						<MetricCard
+							label={ciMetric?.label ?? "CI Success Rate"}
+							href={buildExploreUrl({
+								metric: "ci_success",
+								filters,
+								role: activeRole,
+							})}
+							value={placeholderDeltas ? undefined : ciMetric?.value}
+							unit={ciMetric?.unit}
+							delta={placeholderDeltas ? undefined : ciMetric?.delta_pct}
+							spark={ciMetric?.spark}
+							caption="Pipeline success"
+						/>
+						<MetricCard
+							label={reworkMetric?.label ?? "Rework Ratio"}
+							href={buildExploreUrl({
+								metric: "rework_ratio",
+								filters,
+								role: activeRole,
+							})}
+							value={placeholderDeltas ? undefined : reworkMetric?.value}
+							unit={reworkMetric?.unit}
+							delta={placeholderDeltas ? undefined : reworkMetric?.delta_pct}
+							spark={reworkMetric?.spark}
+							caption="Churn from rework"
+						/>
+					</section>
 
-          <section className="grid gap-6 lg:grid-cols-2">
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-              <div className="flex items-center justify-between">
-                <h2 className="font-(--font-display) text-xl">Change Failure Associations</h2>
-                <Link
-                  href={buildExploreUrl({
-                    metric: "change_failure_rate",
-                    filters,
-                    role: activeRole,
-                  })}
-                  className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-                >
-                  Evidence
-                </Link>
-              </div>
-              {drivers.length ? (
-                <div className="mt-4 space-y-4">
-                  <HorizontalBarChart
-                    categories={drivers.map((driver) => driver.label)}
-                    values={drivers.map((driver) => Math.abs(driver.delta_pct))}
-                  />
-                  <div className="space-y-2 text-sm">
-                    {drivers.map((driver) => (
-                      <Link
-                        key={driver.id}
-                        href={buildExploreUrl({
-                          api: driver.evidence_link,
-                          filters,
-                          role: activeRole,
-                        })}
-                        className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
-                      >
-                        <span>{driver.label}</span>
-                        <span className="text-xs text-(--ink-muted)">
-                          {formatDelta(driver.delta_pct)}
-                        </span>
-                      </Link>
-                    ))}
-                  </div>
-                </div>
-              ) : (
-                <p className="mt-4 text-sm text-(--ink-muted)">
-                  Association detail will appear once data is ingested.
-                </p>
-              )}
-            </div>
+					<section className="grid gap-6 lg:grid-cols-2">
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+							<div className="flex items-center justify-between">
+								<h2 className="font-(--font-display) text-xl">
+									Change Failure Associations
+								</h2>
+								<Link
+									href={buildExploreUrl({
+										metric: "change_failure_rate",
+										filters,
+										role: activeRole,
+									})}
+									className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+								>
+									Evidence
+								</Link>
+							</div>
+							{drivers.length ? (
+								<div className="mt-4 space-y-4">
+									<HorizontalBarChart
+										categories={driverChartLabels.labels}
+										values={drivers.map((driver) => Math.abs(driver.delta_pct))}
+										categoryTitles={driverChartLabels.titles}
+									/>
+									<div className="space-y-2 text-sm">
+										{drivers.map((driver) => (
+											<Link
+												key={driver.id}
+												href={buildExploreUrl({
+													api: driver.evidence_link,
+													filters,
+													role: activeRole,
+												})}
+												className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+											>
+												<EntityLabel id={driver.label} />
+												<span className="text-xs text-(--ink-muted)">
+													{formatDelta(driver.delta_pct)}
+												</span>
+											</Link>
+										))}
+									</div>
+								</div>
+							) : (
+								<p className="mt-4 text-sm text-(--ink-muted)">
+									Association detail will appear once data is ingested.
+								</p>
+							)}
+						</div>
 
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-              <div className="flex items-center justify-between">
-                <h2 className="font-(--font-display) text-xl">Contributors</h2>
-                <Link
-                  href={buildExploreUrl({
-                    metric: "change_failure_rate",
-                    filters,
-                    role: activeRole,
-                  })}
-                  className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-                >
-                  Evidence
-                </Link>
-              </div>
-              {contributors.length ? (
-                <div className="mt-4 space-y-2 text-sm">
-                  {contributors.map((contributor) => (
-                    <Link
-                      key={contributor.id}
-                      href={buildExploreUrl({
-                        api: contributor.evidence_link,
-                        filters,
-                        role: activeRole,
-                      })}
-                      className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
-                    >
-                      <span>{contributor.label}</span>
-                      <span className="text-xs text-(--ink-muted)">
-                        {explain ? formatMetricValue(contributor.value, explain.unit) : "--"}
-                      </span>
-                    </Link>
-                  ))}
-                </div>
-              ) : (
-                <p className="mt-4 text-sm text-(--ink-muted)">
-                  Contributor detail will appear once data is ingested.
-                </p>
-              )}
-            </div>
-          </section>
-        </main>
-      </div>
-    </div>
-  );
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+							<div className="flex items-center justify-between">
+								<h2 className="font-(--font-display) text-xl">Contributors</h2>
+								<Link
+									href={buildExploreUrl({
+										metric: "change_failure_rate",
+										filters,
+										role: activeRole,
+									})}
+									className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+								>
+									Evidence
+								</Link>
+							</div>
+							{contributors.length ? (
+								<div className="mt-4 space-y-2 text-sm">
+									{contributors.map((contributor) => (
+										<Link
+											key={contributor.id}
+											href={buildExploreUrl({
+												api: contributor.evidence_link,
+												filters,
+												role: activeRole,
+											})}
+											className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+										>
+											<EntityLabel id={contributor.label} />
+											<span className="text-xs text-(--ink-muted)">
+												{explain
+													? formatMetricValue(contributor.value, explain.unit)
+													: "--"}
+											</span>
+										</Link>
+									))}
+								</div>
+							) : (
+								<p className="mt-4 text-sm text-(--ink-muted)">
+									Contributor detail will appear once data is ingested.
+								</p>
+							)}
+						</div>
+					</section>
+				</main>
+			</div>
+		</div>
+	);
 }

--- a/src/app/(app)/testops/risk/page.tsx
+++ b/src/app/(app)/testops/risk/page.tsx
@@ -12,170 +12,229 @@ import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
 import { fetchRiskMetrics } from "@/lib/testops/fetchers";
 import { getServerEnv } from "@/lib/config";
+import { chartEntityLabel } from "@/lib/labels/entityLabel";
 
 type RiskPageProps = {
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 export default async function RiskPage({ searchParams }: RiskPageProps) {
-  const params = (await searchParams) ?? {};
-  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
-  const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
-  const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+	const params = (await searchParams) ?? {};
+	const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+	const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+	const activeRole = typeof roleParam === "string" ? roleParam : undefined;
 
-  const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+	const filters = encodedFilter
+		? decodeFilter(encodedFilter)
+		: filterFromQueryParams(params);
 
-  const env = getServerEnv();
-  const isTestMode =
-    env.DEV_HEALTH_TEST_MODE === "true" || env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
+	const env = getServerEnv();
+	const isTestMode =
+		env.DEV_HEALTH_TEST_MODE === "true" ||
+		env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
-  const rangeDays = filters?.time?.range_days ?? 14;
-  const today = new Date();
-  const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
-  const startDate =
-    filters?.time?.start_date ??
-    new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
-  const dateRange = { startDate, endDate };
+	const rangeDays = filters?.time?.range_days ?? 14;
+	const today = new Date();
+	const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
+	const startDate =
+		filters?.time?.start_date ??
+		new Date(today.getTime() - rangeDays * 86_400_000)
+			.toISOString()
+			.slice(0, 10);
+	const dateRange = { startDate, endDate };
 
-  const [health, riskData] = await Promise.all([
-    checkApiHealth(),
-    fetchRiskMetrics(
-      {
-        timeseries: [
-          { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange },
-          { dimension: "TEAM", measure: "TEST_FLAKE_RATE", interval: "DAY", dateRange },
-          { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange },
-        ],
-        breakdowns: [{ dimension: "REPO", measure: "PIPELINE_SUCCESS_RATE", dateRange, topN: 10 }],
-      },
-      isTestMode,
-    ),
-  ]);
+	const [health, riskData] = await Promise.all([
+		checkApiHealth(),
+		fetchRiskMetrics(
+			{
+				timeseries: [
+					{
+						dimension: "TEAM",
+						measure: "PIPELINE_SUCCESS_RATE",
+						interval: "DAY",
+						dateRange,
+					},
+					{
+						dimension: "TEAM",
+						measure: "TEST_FLAKE_RATE",
+						interval: "DAY",
+						dateRange,
+					},
+					{
+						dimension: "TEAM",
+						measure: "COVERAGE_LINE_PCT",
+						interval: "DAY",
+						dateRange,
+					},
+				],
+				breakdowns: [
+					{
+						dimension: "REPO",
+						measure: "PIPELINE_SUCCESS_RATE",
+						dateRange,
+						topN: 10,
+					},
+				],
+			},
+			isTestMode,
+		),
+	]);
 
-  if ((!health.ok && !isTestMode) || !riskData) {
-    return <ServiceUnavailable />;
-  }
+	if ((!health.ok && !isTestMode) || !riskData) {
+		return <ServiceUnavailable />;
+	}
 
-  const timeseriesData = riskData.timeseries
-    ? riskData.timeseries.map((b: { date: string; riskScore: number }) => ({
-        day: b.date,
-        value: b.riskScore * 100,
-      }))
-    : [];
+	const timeseriesData = riskData.timeseries
+		? riskData.timeseries.map((b: { date: string; riskScore: number }) => ({
+				day: b.date,
+				value: b.riskScore * 100,
+			}))
+		: [];
 
-  const dragCategories = riskData.quality_drag_breakdown
-    ? riskData.quality_drag_breakdown.map(
-        (item: { category: string; hours: number }) => item.category,
-      )
-    : [];
-  const dragValues = riskData.quality_drag_breakdown
-    ? riskData.quality_drag_breakdown.map((item: { category: string; hours: number }) => item.hours)
-    : [];
+	const dragCategories = riskData.quality_drag_breakdown
+		? riskData.quality_drag_breakdown.map(
+				(item: { category: string; hours: number }) => item.category,
+			)
+		: [];
+	const dragValues = riskData.quality_drag_breakdown
+		? riskData.quality_drag_breakdown.map(
+				(item: { category: string; hours: number }) => item.hours,
+			)
+		: [];
 
-  const quadrantData = {
-    axes: {
-      x: { metric: "pipeline_success_rate", label: "Pipeline Success Rate", unit: "%" },
-      y: { metric: "test_pass_rate", label: "Test Pass Rate", unit: "%" },
-    },
-    points: riskData.quadrant_data
-      ? riskData.quadrant_data.map(
-          (item: { id: string; pipeline_success_rate: number; test_pass_rate: number }) => ({
-            entity_id: item.id,
-            entity_label: item.id,
-            x: item.pipeline_success_rate,
-            y: item.test_pass_rate,
-            window_start: "2024-01-01",
-            window_end: "2024-01-07",
-            evidence_link: "#",
-          }),
-        )
-      : [],
-    annotations: [
-      {
-        type: "zone",
-        description: "High Risk",
-        x_range: [0, 75] as [number, number],
-        y_range: [0, 90] as [number, number],
-      },
-    ],
-  };
+	const quadrantData = {
+		axes: {
+			x: {
+				metric: "pipeline_success_rate",
+				label: "Pipeline Success Rate",
+				unit: "%",
+			},
+			y: { metric: "test_pass_rate", label: "Test Pass Rate", unit: "%" },
+		},
+		points: riskData.quadrant_data
+			? riskData.quadrant_data.map(
+					(item: {
+						id: string;
+						pipeline_success_rate: number;
+						test_pass_rate: number;
+					}) => ({
+						entity_id: item.id,
+						// Render-safe (A7): never feed a raw repo UUID as the quadrant's
+						// primary label — unresolved ids degrade to a stable short token.
+						entity_label: chartEntityLabel(item.id),
+						x: item.pipeline_success_rate,
+						y: item.test_pass_rate,
+						window_start: "2024-01-01",
+						window_end: "2024-01-07",
+						evidence_link: "#",
+					}),
+				)
+			: [],
+		annotations: [
+			{
+				type: "zone",
+				description: "High Risk",
+				x_range: [0, 75] as [number, number],
+				y_range: [0, 90] as [number, number],
+			},
+		],
+	};
 
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-        <PrimaryNav filters={filters} active="risk" role={activeRole} />
-        <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">TestOps</p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">Risk & Quality Drag</h1>
-              <p className="mt-2 text-sm text-(--ink-muted)">
-                Deployment confidence and risk assessment.
-              </p>
-            </div>
-            <Link
-              href={withFilterParam("/", filters, activeRole)}
-              className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
-            >
-              Back to cockpit
-            </Link>
-          </header>
+	return (
+		<div className="min-h-screen bg-background text-foreground">
+			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+				<PrimaryNav filters={filters} active="risk" role={activeRole} />
+				<main className="flex min-w-0 flex-1 flex-col gap-8">
+					<header className="flex flex-wrap items-center justify-between gap-4">
+						<div>
+							<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+								TestOps
+							</p>
+							<h1 className="mt-2 font-(--font-display) text-3xl">
+								Risk & Quality Drag
+							</h1>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								Deployment confidence and risk assessment.
+							</p>
+						</div>
+						<Link
+							href={withFilterParam("/", filters, activeRole)}
+							className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+						>
+							Back to cockpit
+						</Link>
+					</header>
 
-          <FilterBar view="testops" />
+					<FilterBar view="testops" />
 
-          <section className="grid gap-4 lg:grid-cols-3">
-            <MetricCard
-              label="Release Confidence"
-              href="#"
-              value={riskData.release_confidence ? riskData.release_confidence * 100 : undefined}
-              unit="%"
-              delta={riskData.confidence_delta}
-              spark={riskData.confidence_spark}
-              caption="Overall confidence score for deployments"
-            />
-            <MetricCard
-              label="Quality Drag"
-              href="#"
-              value={riskData.quality_drag_hours}
-              unit="h"
-              delta={riskData.drag_delta}
-              spark={riskData.drag_spark}
-              caption="Hours lost to test/pipeline issues"
-            />
-            <MetricCard
-              label="Pipeline Stability"
-              href="#"
-              value={riskData.pipeline_stability ? riskData.pipeline_stability * 100 : undefined}
-              unit="%"
-              delta={riskData.stability_delta}
-              spark={riskData.stability_spark}
-              caption="Stability score across all pipelines"
-            />
-          </section>
+					<section className="grid gap-4 lg:grid-cols-3">
+						<MetricCard
+							label="Release Confidence"
+							href="#"
+							value={
+								riskData.release_confidence
+									? riskData.release_confidence * 100
+									: undefined
+							}
+							unit="%"
+							delta={riskData.confidence_delta}
+							spark={riskData.confidence_spark}
+							caption="Overall confidence score for deployments"
+						/>
+						<MetricCard
+							label="Quality Drag"
+							href="#"
+							value={riskData.quality_drag_hours}
+							unit="h"
+							delta={riskData.drag_delta}
+							spark={riskData.drag_spark}
+							caption="Hours lost to test/pipeline issues"
+						/>
+						<MetricCard
+							label="Pipeline Stability"
+							href="#"
+							value={
+								riskData.pipeline_stability
+									? riskData.pipeline_stability * 100
+									: undefined
+							}
+							unit="%"
+							delta={riskData.stability_delta}
+							spark={riskData.stability_spark}
+							caption="Stability score across all pipelines"
+						/>
+					</section>
 
-          <section className="grid gap-6 lg:grid-cols-2">
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-              <h2 className="font-(--font-display) text-xl mb-4">Risk Trend</h2>
-              <div className="h-64">
-                <TimeseriesChart data={timeseriesData} />
-              </div>
-            </div>
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-              <h2 className="font-(--font-display) text-xl mb-4">Quality Drag Breakdown</h2>
-              <div className="h-64">
-                <HorizontalBarChart categories={dragCategories} values={dragValues} />
-              </div>
-            </div>
-          </section>
+					<section className="grid gap-6 lg:grid-cols-2">
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+							<h2 className="font-(--font-display) text-xl mb-4">Risk Trend</h2>
+							<div className="h-64">
+								<TimeseriesChart data={timeseriesData} />
+							</div>
+						</div>
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+							<h2 className="font-(--font-display) text-xl mb-4">
+								Quality Drag Breakdown
+							</h2>
+							<div className="h-64">
+								<HorizontalBarChart
+									categories={dragCategories}
+									values={dragValues}
+								/>
+							</div>
+						</div>
+					</section>
 
-          <section className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-            <h2 className="font-(--font-display) text-xl mb-4">Risk vs Throughput (by Repo)</h2>
-            <div className="h-96">
-              <QuadrantChart data={quadrantData} />
-            </div>
-          </section>
-        </main>
-      </div>
-    </div>
-  );
+					<section className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+						<h2 className="font-(--font-display) text-xl mb-4">
+							Risk vs Throughput (by Repo)
+						</h2>
+						<div className="h-96">
+							<QuadrantChart data={quadrantData} />
+						</div>
+					</section>
+				</main>
+			</div>
+		</div>
+	);
 }

--- a/src/components/charts/QuadrantChart.test.tsx
+++ b/src/components/charts/QuadrantChart.test.tsx
@@ -1,106 +1,165 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@/test/utils";
 
-import { QuadrantChart } from "./QuadrantChart";
+import { QuadrantChart, buildQuadrantOption } from "./QuadrantChart";
 import type { QuadrantResponse } from "@/lib/types";
 
 const chartTheme = {
-  text: "#111827",
-  grid: "#e5e7eb",
-  muted: "#6b7280",
-  background: "#ffffff",
-  stroke: "#d1d5db",
-  accent1: "#2563eb",
-  accent2: "#7c3aed",
-  accent3: "#ef4444",
+	text: "#111827",
+	grid: "#e5e7eb",
+	muted: "#6b7280",
+	background: "#ffffff",
+	stroke: "#d1d5db",
+	accent1: "#2563eb",
+	accent2: "#7c3aed",
+	accent3: "#ef4444",
 };
 
 const chartColors = ["#2563eb", "#14b8a6", "#f97316"];
 
 const { chartSpy } = vi.hoisted(() => ({
-  chartSpy: vi.fn(),
+	chartSpy: vi.fn(),
 }));
 
 vi.mock("./chartTheme", () => ({
-  useChartTheme: () => chartTheme,
-  useChartColors: () => chartColors,
+	useChartTheme: () => chartTheme,
+	useChartColors: () => chartColors,
 }));
 
 vi.mock("./Chart", () => ({
-  Chart: (props: unknown) => {
-    chartSpy(props);
-    return <div data-testid="quadrant-chart" />;
-  },
+	Chart: (props: unknown) => {
+		chartSpy(props);
+		return <div data-testid="quadrant-chart" />;
+	},
 }));
 
 const sampleData: QuadrantResponse = {
-  axes: {
-    x: { metric: "cycle_time", label: "Cycle Time", unit: "days" },
-    y: { metric: "throughput", label: "Throughput", unit: "items" },
-  },
-  points: [
-    {
-      entity_id: "team-a",
-      entity_label: "Team A",
-      x: 4.2,
-      y: 18,
-      window_start: "2026-01-01",
-      window_end: "2026-01-31",
-      evidence_link: "/evidence/team-a",
-    },
-  ],
-  annotations: [],
+	axes: {
+		x: { metric: "cycle_time", label: "Cycle Time", unit: "days" },
+		y: { metric: "throughput", label: "Throughput", unit: "items" },
+	},
+	points: [
+		{
+			entity_id: "team-a",
+			entity_label: "Team A",
+			x: 4.2,
+			y: 18,
+			window_start: "2026-01-01",
+			window_end: "2026-01-31",
+			evidence_link: "/evidence/team-a",
+		},
+	],
+	annotations: [],
 };
 
 describe("QuadrantChart", () => {
-  beforeEach(() => {
-    chartSpy.mockClear();
-  });
+	beforeEach(() => {
+		chartSpy.mockClear();
+	});
 
-  it("renders without crashing", () => {
-    render(<QuadrantChart data={sampleData} />);
+	it("renders without crashing", () => {
+		render(<QuadrantChart data={sampleData} />);
 
-    expect(screen.getByTestId("quadrant-chart")).toBeInTheDocument();
-    expect(chartSpy).toHaveBeenCalledTimes(1);
-  });
+		expect(screen.getByTestId("quadrant-chart")).toBeInTheDocument();
+		expect(chartSpy).toHaveBeenCalledTimes(1);
+	});
 
-  it("renders with sample data and forwards props", () => {
-    render(<QuadrantChart data={sampleData} className="chart-shell" height={420} />);
+	it("renders with sample data and forwards props", () => {
+		render(
+			<QuadrantChart data={sampleData} className="chart-shell" height={420} />,
+		);
 
-    const props = chartSpy.mock.calls[0][0] as {
-      option: {
-        xAxis: { name: string };
-        series: Array<{ data: unknown[] }>;
-      };
-      className: string;
-      style: { height: number; width: string };
-      onEvents: { click: (params: unknown) => void };
-    };
+		const props = chartSpy.mock.calls[0][0] as {
+			option: {
+				xAxis: { name: string };
+				series: Array<{ data: unknown[] }>;
+			};
+			className: string;
+			style: { height: number; width: string };
+			onEvents: { click: (params: unknown) => void };
+		};
 
-    expect(props.className).toBe("chart-shell");
-    expect(props.style).toMatchObject({ height: 420, width: "100%" });
-    expect(props.option.xAxis.name).toContain("Cycle Time (days)");
-    expect(props.option.series[0]?.data).toHaveLength(1);
-    expect(typeof props.onEvents.click).toBe("function");
-  });
+		expect(props.className).toBe("chart-shell");
+		expect(props.style).toMatchObject({ height: 420, width: "100%" });
+		expect(props.option.xAxis.name).toContain("Cycle Time (days)");
+		expect(props.option.series[0]?.data).toHaveLength(1);
+		expect(typeof props.onEvents.click).toBe("function");
+	});
 
-  it("handles empty data and null click payload gracefully", () => {
-    render(
-      <QuadrantChart
-        data={{
-          ...sampleData,
-          points: [],
-          annotations: [],
-        }}
-      />,
-    );
+	it("handles empty data and null click payload gracefully", () => {
+		render(
+			<QuadrantChart
+				data={{
+					...sampleData,
+					points: [],
+					annotations: [],
+				}}
+			/>,
+		);
 
-    const props = chartSpy.mock.calls[0][0] as {
-      option: { series: Array<{ data: unknown[] }> };
-      onEvents: { click: (params: unknown) => void };
-    };
+		const props = chartSpy.mock.calls[0][0] as {
+			option: { series: Array<{ data: unknown[] }> };
+			onEvents: { click: (params: unknown) => void };
+		};
 
-    expect(props.option.series[0]?.data).toHaveLength(0);
-    expect(() => props.onEvents.click(null)).not.toThrow();
-  });
+		expect(props.option.series[0]?.data).toHaveLength(0);
+		expect(() => props.onEvents.click(null)).not.toThrow();
+	});
+
+	it("degrades a raw UUID entity_label to a stable short token in the tooltip (A7)", () => {
+		const UUID = "550e8400-e29b-41d4-a716-446655440000";
+		const option = buildQuadrantOption({
+			data: {
+				axes: {
+					x: { metric: "x", label: "Cycle Time", unit: "days" },
+					y: { metric: "y", label: "Throughput", unit: "items" },
+				},
+				points: [
+					{
+						entity_id: UUID,
+						entity_label: UUID,
+						x: 1,
+						y: 2,
+						window_start: "",
+						window_end: "",
+						evidence_link: "",
+					},
+				],
+				annotations: [],
+			},
+			chartTheme,
+			colors: chartColors,
+			scopeType: "repo",
+		});
+
+		const formatter = (
+			option.tooltip as { formatter: (params: unknown) => string }
+		).formatter;
+		const html = formatter({
+			componentType: "scatter",
+			data: { point: { entity_id: UUID, entity_label: UUID, x: 1, y: 2 } },
+		});
+
+		expect(html).toContain("#550e8400");
+		expect(html).not.toContain(UUID);
+	});
+
+	it("renders a readable entity_label unchanged in the tooltip", () => {
+		const option = buildQuadrantOption({
+			data: sampleData,
+			chartTheme,
+			colors: chartColors,
+			scopeType: "team",
+		});
+
+		const formatter = (
+			option.tooltip as { formatter: (params: unknown) => string }
+		).formatter;
+		const html = formatter({
+			componentType: "scatter",
+			data: { point: sampleData.points[0] },
+		});
+
+		expect(html).toContain("Team A");
+	});
 });

--- a/src/components/charts/QuadrantChart.tsx
+++ b/src/components/charts/QuadrantChart.tsx
@@ -3,14 +3,15 @@
 import type { CSSProperties } from "react";
 // Type-only imports from full echarts package (erased at runtime — no bundle impact).
 import type {
-  DefaultLabelFormatterCallbackParams,
-  EChartsOption,
-  MarkAreaComponentOption,
-  TooltipComponentFormatterCallbackParams,
+	DefaultLabelFormatterCallbackParams,
+	EChartsOption,
+	MarkAreaComponentOption,
+	TooltipComponentFormatterCallbackParams,
 } from "echarts";
 import { ScatterChart } from "echarts/charts";
 
 import type { ZoneOverlay } from "@/lib/quadrantZones";
+import { chartEntityLabel } from "@/lib/labels/entityLabel";
 import type { QuadrantPoint, QuadrantResponse } from "@/lib/types";
 
 import { Chart } from "./Chart";
@@ -20,23 +21,30 @@ import { echarts } from "@/lib/echartsInit";
 echarts.use([ScatterChart]);
 
 const formatValue = (value: number, unit: string) => {
-  if (!Number.isFinite(value)) {
-    return "--";
-  }
-  if (unit === "%") {
-    return `${value.toFixed(1)}%`;
-  }
-  if (unit === "days") {
-    return `${value.toFixed(1)}d`;
-  }
-  if (unit === "hours") {
-    return `${value.toFixed(1)}h`;
-  }
-  return `${value.toFixed(1)} ${unit}`.trim();
+	if (!Number.isFinite(value)) {
+		return "--";
+	}
+	if (unit === "%") {
+		return `${value.toFixed(1)}%`;
+	}
+	if (unit === "days") {
+		return `${value.toFixed(1)}d`;
+	}
+	if (unit === "hours") {
+		return `${value.toFixed(1)}h`;
+	}
+	return `${value.toFixed(1)} ${unit}`.trim();
 };
 
 const normalizeScopeType = (
-  scopeType?: "org" | "team" | "repo" | "person" | "developer" | "service" | string,
+	scopeType?:
+		| "org"
+		| "team"
+		| "repo"
+		| "person"
+		| "developer"
+		| "service"
+		| string,
 ) => (scopeType === "developer" ? "person" : (scopeType ?? "org"));
 
 const rgbaPattern = /rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/i;
@@ -45,388 +53,412 @@ const hexPattern = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i;
 const clampAlpha = (alpha: number) => Math.min(1, Math.max(0, alpha));
 
 const withAlpha = (color: string, alpha: number) => {
-  const nextAlpha = clampAlpha(alpha);
-  const trimmed = color.trim();
-  const match = trimmed.match(rgbaPattern);
-  if (match) {
-    const red = Number(match[1]);
-    const green = Number(match[2]);
-    const blue = Number(match[3]);
-    if ([red, green, blue].some((value) => Number.isNaN(value))) {
-      return color;
-    }
-    return `rgba(${red}, ${green}, ${blue}, ${nextAlpha})`;
-  }
-  const hexMatch = trimmed.match(hexPattern);
-  if (!hexMatch) {
-    return color;
-  }
-  const hex = hexMatch[1];
-  const normalized =
-    hex.length === 3
-      ? hex
-          .split("")
-          .map((item) => item + item)
-          .join("")
-      : hex;
-  const value = Number.parseInt(normalized, 16);
-  if (Number.isNaN(value)) {
-    return color;
-  }
-  const red = (value >> 16) & 255;
-  const green = (value >> 8) & 255;
-  const blue = value & 255;
-  return `rgba(${red}, ${green}, ${blue}, ${nextAlpha})`;
+	const nextAlpha = clampAlpha(alpha);
+	const trimmed = color.trim();
+	const match = trimmed.match(rgbaPattern);
+	if (match) {
+		const red = Number(match[1]);
+		const green = Number(match[2]);
+		const blue = Number(match[3]);
+		if ([red, green, blue].some((value) => Number.isNaN(value))) {
+			return color;
+		}
+		return `rgba(${red}, ${green}, ${blue}, ${nextAlpha})`;
+	}
+	const hexMatch = trimmed.match(hexPattern);
+	if (!hexMatch) {
+		return color;
+	}
+	const hex = hexMatch[1];
+	const normalized =
+		hex.length === 3
+			? hex
+					.split("")
+					.map((item) => item + item)
+					.join("")
+			: hex;
+	const value = Number.parseInt(normalized, 16);
+	if (Number.isNaN(value)) {
+		return color;
+	}
+	const red = (value >> 16) & 255;
+	const green = (value >> 8) & 255;
+	const blue = value & 255;
+	return `rgba(${red}, ${green}, ${blue}, ${nextAlpha})`;
 };
 
 const buildZoneGradient = (color: string) => ({
-  type: "radial" as const,
-  x: 0.45,
-  y: 0.4,
-  r: 0.95,
-  colorStops: [
-    { offset: 0, color: withAlpha(color, 0.2) },
-    { offset: 0.6, color: withAlpha(color, 0.12) },
-    { offset: 1, color: withAlpha(color, 0) },
-  ],
+	type: "radial" as const,
+	x: 0.45,
+	y: 0.4,
+	r: 0.95,
+	colorStops: [
+		{ offset: 0, color: withAlpha(color, 0.2) },
+		{ offset: 0.6, color: withAlpha(color, 0.12) },
+		{ offset: 1, color: withAlpha(color, 0) },
+	],
 });
 
 const buildZoneSurfaceStyle = (
-  color: string,
-  options?: {
-    outlineAlpha?: number;
-    glowAlpha?: number;
-    radius?: number;
-    active?: boolean;
-  },
+	color: string,
+	options?: {
+		outlineAlpha?: number;
+		glowAlpha?: number;
+		radius?: number;
+		active?: boolean;
+	},
 ) => {
-  const outlineAlpha = options?.outlineAlpha ?? 0.32;
-  const glowAlpha = options?.glowAlpha ?? 0.22;
-  const radius = options?.radius ?? 32;
-  const isActive = options?.active ?? false;
-  return {
-    color: buildZoneGradient(color),
-    opacity: isActive ? 1 : 0.92,
-    borderWidth: isActive ? 2 : 1,
-    borderColor: withAlpha(color, isActive ? outlineAlpha + 0.14 : outlineAlpha),
-    borderType: "dashed" as const,
-    borderRadius: radius,
-    shadowBlur: isActive ? 24 : 20,
-    shadowColor: withAlpha(color, isActive ? glowAlpha + 0.12 : glowAlpha),
-  };
+	const outlineAlpha = options?.outlineAlpha ?? 0.32;
+	const glowAlpha = options?.glowAlpha ?? 0.22;
+	const radius = options?.radius ?? 32;
+	const isActive = options?.active ?? false;
+	return {
+		color: buildZoneGradient(color),
+		opacity: isActive ? 1 : 0.92,
+		borderWidth: isActive ? 2 : 1,
+		borderColor: withAlpha(
+			color,
+			isActive ? outlineAlpha + 0.14 : outlineAlpha,
+		),
+		borderType: "dashed" as const,
+		borderRadius: radius,
+		shadowBlur: isActive ? 24 : 20,
+		shadowColor: withAlpha(color, isActive ? glowAlpha + 0.12 : glowAlpha),
+	};
 };
 
 const toPoint = (data: unknown) => {
-  if (!data || typeof data !== "object") {
-    return null;
-  }
-  const candidate = data as { point?: QuadrantPoint };
-  return candidate.point ?? null;
+	if (!data || typeof data !== "object") {
+		return null;
+	}
+	const candidate = data as { point?: QuadrantPoint };
+	return candidate.point ?? null;
 };
 
 type TooltipEntry = TooltipComponentFormatterCallbackParams & {
-  componentType?: string;
-  data?: unknown;
-  name?: string;
+	componentType?: string;
+	data?: unknown;
+	name?: string;
 };
 
 const getParamsEntry = (params: unknown): TooltipEntry | null => {
-  const entry = Array.isArray(params) ? params[0] : params;
-  if (!entry || typeof entry !== "object") {
-    return null;
-  }
-  return entry as TooltipEntry;
+	const entry = Array.isArray(params) ? params[0] : params;
+	if (!entry || typeof entry !== "object") {
+		return null;
+	}
+	return entry as TooltipEntry;
 };
 
 type QuadrantChartOptionParams = {
-  data: QuadrantResponse;
-  chartTheme: ChartTheme;
-  colors: string[];
-  focusEntityIds?: string[];
-  scopeType?: "org" | "team" | "repo" | "person" | "developer" | "service" | string;
-  zoneOverlay?: ZoneOverlay | null;
-  showZoneOverlay?: boolean;
-  highlightOverlayKey?: string | null;
+	data: QuadrantResponse;
+	chartTheme: ChartTheme;
+	colors: string[];
+	focusEntityIds?: string[];
+	scopeType?:
+		| "org"
+		| "team"
+		| "repo"
+		| "person"
+		| "developer"
+		| "service"
+		| string;
+	zoneOverlay?: ZoneOverlay | null;
+	showZoneOverlay?: boolean;
+	highlightOverlayKey?: string | null;
 };
 
 export const buildQuadrantOption = ({
-  data,
-  chartTheme,
-  colors,
-  focusEntityIds,
-  scopeType,
-  zoneOverlay,
-  showZoneOverlay = false,
-  highlightOverlayKey,
+	data,
+	chartTheme,
+	colors,
+	focusEntityIds,
+	scopeType,
+	zoneOverlay,
+	showZoneOverlay = false,
+	highlightOverlayKey,
 }: QuadrantChartOptionParams): EChartsOption => {
-  const xAxisLabel = data.axes.x.unit
-    ? `${data.axes.x.label} (${data.axes.x.unit})`
-    : data.axes.x.label;
-  const yAxisLabel = data.axes.y.unit
-    ? `${data.axes.y.label} (${data.axes.y.unit})`
-    : data.axes.y.label;
+	const xAxisLabel = data.axes.x.unit
+		? `${data.axes.x.label} (${data.axes.x.unit})`
+		: data.axes.x.label;
+	const yAxisLabel = data.axes.y.unit
+		? `${data.axes.y.label} (${data.axes.y.unit})`
+		: data.axes.y.label;
 
-  const normalizedScopeType = normalizeScopeType(scopeType);
-  const isPersonScope = normalizedScopeType === "person";
-  const showTeamLabels = normalizedScopeType === "team";
-  const focusIds = (focusEntityIds ?? []).filter(Boolean);
-  const focusSet = new Set(focusIds);
-  const directFocusPoints = focusIds.length
-    ? data.points.filter((point) => focusSet.has(point.entity_id))
-    : [];
-  const focusPoints =
-    isPersonScope && directFocusPoints.length === 0 ? data.points.slice(0, 1) : directFocusPoints;
-  const focusPointIds = new Set(focusPoints.map((point) => point.entity_id));
-  const hasFocus = focusPoints.length > 0;
-  const backgroundPoints = isPersonScope
-    ? []
-    : hasFocus
-      ? data.points.filter((point) => !focusPointIds.has(point.entity_id))
-      : data.points;
-  const backgroundOpacity = 1;
+	const normalizedScopeType = normalizeScopeType(scopeType);
+	const isPersonScope = normalizedScopeType === "person";
+	const showTeamLabels = normalizedScopeType === "team";
+	const focusIds = (focusEntityIds ?? []).filter(Boolean);
+	const focusSet = new Set(focusIds);
+	const directFocusPoints = focusIds.length
+		? data.points.filter((point) => focusSet.has(point.entity_id))
+		: [];
+	const focusPoints =
+		isPersonScope && directFocusPoints.length === 0
+			? data.points.slice(0, 1)
+			: directFocusPoints;
+	const focusPointIds = new Set(focusPoints.map((point) => point.entity_id));
+	const hasFocus = focusPoints.length > 0;
+	const backgroundPoints = isPersonScope
+		? []
+		: hasFocus
+			? data.points.filter((point) => !focusPointIds.has(point.entity_id))
+			: data.points;
+	const backgroundOpacity = 1;
 
-  const focusData = focusPoints.map((point) => ({
-    value: [point.x, point.y] as [number, number],
-    point,
-  }));
-  const backgroundData = backgroundPoints.map((point) => ({
-    value: [point.x, point.y] as [number, number],
-    point,
-  }));
+	const focusData = focusPoints.map((point) => ({
+		value: [point.x, point.y] as [number, number],
+		point,
+	}));
+	const backgroundData = backgroundPoints.map((point) => ({
+		value: [point.x, point.y] as [number, number],
+		point,
+	}));
 
-  const showInterpretation = Boolean(showZoneOverlay);
-  const activeZoneOverlay = showInterpretation ? zoneOverlay : null;
-  const annotationColor = "rgba(148, 163, 184, 0.2)";
-  const annotationAreas: MarkAreaComponentOption["data"] = showInterpretation
-    ? (data.annotations ?? []).map((annotation, index) => {
-        const isActive = highlightOverlayKey === `annotation:${index}`;
-        return [
-          {
-            name: `Condition: ${annotation.description}`,
-            xAxis: annotation.x_range[0],
-            yAxis: annotation.y_range[0],
-            itemStyle: buildZoneSurfaceStyle(annotationColor, {
-              outlineAlpha: 0.24,
-              glowAlpha: 0.18,
-              radius: 28,
-              active: isActive,
-            }),
-          },
-          {
-            xAxis: annotation.x_range[1],
-            yAxis: annotation.y_range[1],
-          },
-        ];
-      })
-    : [];
-  const zoneAreas: MarkAreaComponentOption["data"] = showInterpretation
-    ? (activeZoneOverlay?.zones ?? []).map((zone: import("@/lib/quadrantZones").ZoneRegion) => [
-        {
-          name: zone.label,
-          xAxis: zone.xRange[0],
-          yAxis: zone.yRange[0],
-          itemStyle: buildZoneSurfaceStyle(zone.color, {
-            active: highlightOverlayKey === `zone:${zone.id}`,
-          }),
-        },
-        {
-          xAxis: zone.xRange[1],
-          yAxis: zone.yRange[1],
-        },
-      ])
-    : [];
-  const markAreaData: MarkAreaComponentOption["data"] = [
-    ...(annotationAreas ?? []),
-    ...(zoneAreas ?? []),
-  ];
-  const markArea: MarkAreaComponentOption | undefined = markAreaData.length
-    ? {
-        silent: true,
-        z: 1,
-        label: { show: false },
-        tooltip: { show: false },
-        data: markAreaData,
-      }
-    : undefined;
-  const gridLineStyle = { color: chartTheme.grid, opacity: 0.16 };
-  const axisLineStyle = { color: chartTheme.grid, opacity: 0.28 };
-  const axisLabelColor = withAlpha(chartTheme.muted, 0.75);
+	const showInterpretation = Boolean(showZoneOverlay);
+	const activeZoneOverlay = showInterpretation ? zoneOverlay : null;
+	const annotationColor = "rgba(148, 163, 184, 0.2)";
+	const annotationAreas: MarkAreaComponentOption["data"] = showInterpretation
+		? (data.annotations ?? []).map((annotation, index) => {
+				const isActive = highlightOverlayKey === `annotation:${index}`;
+				return [
+					{
+						name: `Condition: ${annotation.description}`,
+						xAxis: annotation.x_range[0],
+						yAxis: annotation.y_range[0],
+						itemStyle: buildZoneSurfaceStyle(annotationColor, {
+							outlineAlpha: 0.24,
+							glowAlpha: 0.18,
+							radius: 28,
+							active: isActive,
+						}),
+					},
+					{
+						xAxis: annotation.x_range[1],
+						yAxis: annotation.y_range[1],
+					},
+				];
+			})
+		: [];
+	const zoneAreas: MarkAreaComponentOption["data"] = showInterpretation
+		? (activeZoneOverlay?.zones ?? []).map(
+				(zone: import("@/lib/quadrantZones").ZoneRegion) => [
+					{
+						name: zone.label,
+						xAxis: zone.xRange[0],
+						yAxis: zone.yRange[0],
+						itemStyle: buildZoneSurfaceStyle(zone.color, {
+							active: highlightOverlayKey === `zone:${zone.id}`,
+						}),
+					},
+					{
+						xAxis: zone.xRange[1],
+						yAxis: zone.yRange[1],
+					},
+				],
+			)
+		: [];
+	const markAreaData: MarkAreaComponentOption["data"] = [
+		...(annotationAreas ?? []),
+		...(zoneAreas ?? []),
+	];
+	const markArea: MarkAreaComponentOption | undefined = markAreaData.length
+		? {
+				silent: true,
+				z: 1,
+				label: { show: false },
+				tooltip: { show: false },
+				data: markAreaData,
+			}
+		: undefined;
+	const gridLineStyle = { color: chartTheme.grid, opacity: 0.16 };
+	const axisLineStyle = { color: chartTheme.grid, opacity: 0.28 };
+	const axisLabelColor = withAlpha(chartTheme.muted, 0.75);
 
-  return {
-    tooltip: {
-      confine: true,
-      backgroundColor: chartTheme.background,
-      borderColor: chartTheme.stroke,
-      textStyle: {
-        color: chartTheme.text,
-        fontSize: 12,
-      },
-      formatter: (params: TooltipComponentFormatterCallbackParams) => {
-        const entry = getParamsEntry(params);
-        const isMarkArea = entry?.componentType === "markArea" || Array.isArray(entry?.data);
-        if (isMarkArea) {
-          return "";
-        }
-        const point = entry ? toPoint(entry.data) : null;
-        if (!point) {
-          return "";
-        }
-        const xLabel = data.axes.x.label;
-        const yLabel = data.axes.y.label;
-        const xValue = formatValue(point.x, data.axes.x.unit);
-        const yValue = formatValue(point.y, data.axes.y.unit);
-        const entityLabel = isPersonScope ? "You" : point.entity_label;
+	return {
+		tooltip: {
+			confine: true,
+			backgroundColor: chartTheme.background,
+			borderColor: chartTheme.stroke,
+			textStyle: {
+				color: chartTheme.text,
+				fontSize: 12,
+			},
+			formatter: (params: TooltipComponentFormatterCallbackParams) => {
+				const entry = getParamsEntry(params);
+				const isMarkArea =
+					entry?.componentType === "markArea" || Array.isArray(entry?.data);
+				if (isMarkArea) {
+					return "";
+				}
+				const point = entry ? toPoint(entry.data) : null;
+				if (!point) {
+					return "";
+				}
+				const xLabel = data.axes.x.label;
+				const yLabel = data.axes.y.label;
+				const xValue = formatValue(point.x, data.axes.x.unit);
+				const yValue = formatValue(point.y, data.axes.y.unit);
+				const entityLabel = isPersonScope
+					? "You"
+					: chartEntityLabel(point.entity_label);
 
-        return [
-          `<div style="font-weight: 600; margin-bottom: 4px;">${entityLabel}</div>`,
-          `<div style="display: flex; justify-content: space-between; gap: 12px; opacity: 0.8;"><span>${xLabel}</span> <span style="font-weight: 500;">${xValue}</span></div>`,
-          `<div style="display: flex; justify-content: space-between; gap: 12px; opacity: 0.8;"><span>${yLabel}</span> <span style="font-weight: 500;">${yValue}</span></div>`,
-          `<div style="margin-top: 6px; font-size: 10px; opacity: 0.6;">Click to investigate pattern</div>`,
-        ].join("");
-      },
-    },
-    grid: { left: 48, right: 24, top: 24, bottom: 48, containLabel: true },
-    xAxis: {
-      name: xAxisLabel,
-      nameLocation: "middle",
-      nameGap: 30,
-      type: "value",
-      splitNumber: 4,
-      axisLine: { lineStyle: axisLineStyle },
-      axisLabel: { color: axisLabelColor },
-      splitLine: { lineStyle: gridLineStyle },
-    },
-    yAxis: {
-      name: yAxisLabel,
-      nameLocation: "middle",
-      nameGap: 40,
-      type: "value",
-      splitNumber: 4,
-      axisLine: { lineStyle: axisLineStyle },
-      axisLabel: { color: axisLabelColor },
-      splitLine: { lineStyle: gridLineStyle },
-    },
-    series: [
-      {
-        type: "scatter",
-        data: backgroundData,
-        symbol: "circle",
-        symbolSize: normalizedScopeType === "person" ? 8 : 10,
-        itemStyle: {
-          color: chartTheme.muted,
-          opacity: backgroundOpacity,
-        },
-        label: showTeamLabels
-          ? {
-              show: true,
-              formatter: (params: DefaultLabelFormatterCallbackParams) => {
-                const point = toPoint(params.data);
-                return point?.entity_label ?? "";
-              },
-              color: chartTheme.muted,
-              fontSize: 10,
-              position: "top",
-            }
-          : undefined,
-        labelLayout: showTeamLabels ? { hideOverlap: true } : undefined,
-        markArea: backgroundData.length ? markArea : undefined,
-        emphasis: {
-          scale: true,
-          itemStyle: { borderColor: chartTheme.text, borderWidth: 2 },
-        },
-        z: 5,
-      },
-      ...(hasFocus
-        ? [
-            {
-              type: "scatter" as const,
-              data: focusData,
-              symbol: "circle",
-              symbolSize: 14,
-              itemStyle: {
-                color: colors[0] ?? "#2563eb",
-              },
-              label: {
-                show: true,
-                formatter: (params: DefaultLabelFormatterCallbackParams) => {
-                  const point = toPoint(params.data);
-                  return point?.entity_label ?? "";
-                },
-                color: chartTheme.text,
-                fontSize: 11,
-                fontWeight: 600,
-                position: "top" as const,
-              },
-              labelLayout: { hideOverlap: true },
-              markArea: !backgroundData.length ? markArea : undefined,
-              emphasis: {
-                scale: true,
-                itemStyle: { borderColor: chartTheme.text, borderWidth: 2 },
-              },
-              z: 6,
-            },
-          ]
-        : []),
-    ],
-  };
+				return [
+					`<div style="font-weight: 600; margin-bottom: 4px;">${entityLabel}</div>`,
+					`<div style="display: flex; justify-content: space-between; gap: 12px; opacity: 0.8;"><span>${xLabel}</span> <span style="font-weight: 500;">${xValue}</span></div>`,
+					`<div style="display: flex; justify-content: space-between; gap: 12px; opacity: 0.8;"><span>${yLabel}</span> <span style="font-weight: 500;">${yValue}</span></div>`,
+					`<div style="margin-top: 6px; font-size: 10px; opacity: 0.6;">Click to investigate pattern</div>`,
+				].join("");
+			},
+		},
+		grid: { left: 48, right: 24, top: 24, bottom: 48, containLabel: true },
+		xAxis: {
+			name: xAxisLabel,
+			nameLocation: "middle",
+			nameGap: 30,
+			type: "value",
+			splitNumber: 4,
+			axisLine: { lineStyle: axisLineStyle },
+			axisLabel: { color: axisLabelColor },
+			splitLine: { lineStyle: gridLineStyle },
+		},
+		yAxis: {
+			name: yAxisLabel,
+			nameLocation: "middle",
+			nameGap: 40,
+			type: "value",
+			splitNumber: 4,
+			axisLine: { lineStyle: axisLineStyle },
+			axisLabel: { color: axisLabelColor },
+			splitLine: { lineStyle: gridLineStyle },
+		},
+		series: [
+			{
+				type: "scatter",
+				data: backgroundData,
+				symbol: "circle",
+				symbolSize: normalizedScopeType === "person" ? 8 : 10,
+				itemStyle: {
+					color: chartTheme.muted,
+					opacity: backgroundOpacity,
+				},
+				label: showTeamLabels
+					? {
+							show: true,
+							formatter: (params: DefaultLabelFormatterCallbackParams) => {
+								const point = toPoint(params.data);
+								return point ? chartEntityLabel(point.entity_label) : "";
+							},
+							color: chartTheme.muted,
+							fontSize: 10,
+							position: "top",
+						}
+					: undefined,
+				labelLayout: showTeamLabels ? { hideOverlap: true } : undefined,
+				markArea: backgroundData.length ? markArea : undefined,
+				emphasis: {
+					scale: true,
+					itemStyle: { borderColor: chartTheme.text, borderWidth: 2 },
+				},
+				z: 5,
+			},
+			...(hasFocus
+				? [
+						{
+							type: "scatter" as const,
+							data: focusData,
+							symbol: "circle",
+							symbolSize: 14,
+							itemStyle: {
+								color: colors[0] ?? "#2563eb",
+							},
+							label: {
+								show: true,
+								formatter: (params: DefaultLabelFormatterCallbackParams) => {
+									const point = toPoint(params.data);
+									return point ? chartEntityLabel(point.entity_label) : "";
+								},
+								color: chartTheme.text,
+								fontSize: 11,
+								fontWeight: 600,
+								position: "top" as const,
+							},
+							labelLayout: { hideOverlap: true },
+							markArea: !backgroundData.length ? markArea : undefined,
+							emphasis: {
+								scale: true,
+								itemStyle: { borderColor: chartTheme.text, borderWidth: 2 },
+							},
+							z: 6,
+						},
+					]
+				: []),
+		],
+	};
 };
 
 type QuadrantChartProps = {
-  data: QuadrantResponse;
-  height?: number | string;
-  width?: number | string;
-  className?: string;
-  style?: CSSProperties;
-  onPointSelect?: (point: QuadrantPoint) => void;
-  focusEntityIds?: string[];
-  scopeType?: "org" | "team" | "repo" | "person" | "developer" | "service" | string;
-  zoneOverlay?: ZoneOverlay | null;
-  showZoneOverlay?: boolean;
-  highlightOverlayKey?: string | null;
+	data: QuadrantResponse;
+	height?: number | string;
+	width?: number | string;
+	className?: string;
+	style?: CSSProperties;
+	onPointSelect?: (point: QuadrantPoint) => void;
+	focusEntityIds?: string[];
+	scopeType?:
+		| "org"
+		| "team"
+		| "repo"
+		| "person"
+		| "developer"
+		| "service"
+		| string;
+	zoneOverlay?: ZoneOverlay | null;
+	showZoneOverlay?: boolean;
+	highlightOverlayKey?: string | null;
 };
 
 export function QuadrantChart({
-  data,
-  height = 360,
-  width = "100%",
-  className,
-  style,
-  onPointSelect,
-  focusEntityIds,
-  scopeType,
-  zoneOverlay,
-  showZoneOverlay = false,
-  highlightOverlayKey,
+	data,
+	height = 360,
+	width = "100%",
+	className,
+	style,
+	onPointSelect,
+	focusEntityIds,
+	scopeType,
+	zoneOverlay,
+	showZoneOverlay = false,
+	highlightOverlayKey,
 }: QuadrantChartProps) {
-  const chartTheme = useChartTheme();
-  const colors = useChartColors();
-  const mergedStyle: CSSProperties = { height, width, ...style };
+	const chartTheme = useChartTheme();
+	const colors = useChartColors();
+	const mergedStyle: CSSProperties = { height, width, ...style };
 
-  const handleClick = (params: unknown) => {
-    const entry = getParamsEntry(params);
-    const point = entry ? toPoint(entry.data) : null;
-    if (point && onPointSelect) {
-      onPointSelect(point);
-    }
-  };
+	const handleClick = (params: unknown) => {
+		const entry = getParamsEntry(params);
+		const point = entry ? toPoint(entry.data) : null;
+		if (point && onPointSelect) {
+			onPointSelect(point);
+		}
+	};
 
-  return (
-    <Chart
-      option={buildQuadrantOption({
-        data,
-        chartTheme,
-        colors,
-        focusEntityIds,
-        scopeType,
-        zoneOverlay,
-        showZoneOverlay,
-        highlightOverlayKey,
-      })}
-      className={className}
-      style={mergedStyle}
-      onEvents={{ click: handleClick }}
-      chartTheme={chartTheme}
-      chartColors={colors}
-    />
-  );
+	return (
+		<Chart
+			option={buildQuadrantOption({
+				data,
+				chartTheme,
+				colors,
+				focusEntityIds,
+				scopeType,
+				zoneOverlay,
+				showZoneOverlay,
+				highlightOverlayKey,
+			})}
+			className={className}
+			style={mergedStyle}
+			onEvents={{ click: handleClick }}
+			chartTheme={chartTheme}
+			chartColors={colors}
+		/>
+	);
 }

--- a/src/components/charts/SankeyChart.test.tsx
+++ b/src/components/charts/SankeyChart.test.tsx
@@ -5,96 +5,136 @@ import { SankeyChart } from "./SankeyChart";
 import type { SankeyLink, SankeyNode } from "@/lib/types";
 
 const chartTheme = {
-  text: "#111827",
-  grid: "#e5e7eb",
-  muted: "#6b7280",
-  background: "#ffffff",
-  stroke: "#d1d5db",
-  accent1: "#2563eb",
-  accent2: "#7c3aed",
-  accent3: "#ef4444",
+	text: "#111827",
+	grid: "#e5e7eb",
+	muted: "#6b7280",
+	background: "#ffffff",
+	stroke: "#d1d5db",
+	accent1: "#2563eb",
+	accent2: "#7c3aed",
+	accent3: "#ef4444",
 };
 
 const { chartSpy } = vi.hoisted(() => ({
-  chartSpy: vi.fn(),
+	chartSpy: vi.fn(),
 }));
 
 vi.mock("./chartTheme", () => ({
-  useChartTheme: () => chartTheme,
+	useChartTheme: () => chartTheme,
 }));
 
 vi.mock("./Chart", () => ({
-  Chart: (props: unknown) => {
-    chartSpy(props);
-    return <div data-testid="sankey-chart" />;
-  },
+	Chart: (props: unknown) => {
+		chartSpy(props);
+		return <div data-testid="sankey-chart" />;
+	},
 }));
 
-const sampleNodes: SankeyNode[] = [{ name: "Backlog" }, { name: "In Progress" }, { name: "Done" }];
+const sampleNodes: SankeyNode[] = [
+	{ name: "Backlog" },
+	{ name: "In Progress" },
+	{ name: "Done" },
+];
 
 const sampleLinks: SankeyLink[] = [
-  { source: "Backlog", target: "In Progress", value: 12 },
-  { source: "In Progress", target: "Done", value: 9 },
+	{ source: "Backlog", target: "In Progress", value: 12 },
+	{ source: "In Progress", target: "Done", value: 9 },
 ];
 
 describe("SankeyChart", () => {
-  beforeEach(() => {
-    chartSpy.mockClear();
-  });
+	beforeEach(() => {
+		chartSpy.mockClear();
+	});
 
-  it("renders without crashing", () => {
-    render(<SankeyChart nodes={sampleNodes} links={sampleLinks} />);
+	it("renders without crashing", () => {
+		render(<SankeyChart nodes={sampleNodes} links={sampleLinks} />);
 
-    expect(screen.getByTestId("sankey-chart")).toBeInTheDocument();
-    expect(chartSpy).toHaveBeenCalledTimes(1);
-  });
+		expect(screen.getByTestId("sankey-chart")).toBeInTheDocument();
+		expect(chartSpy).toHaveBeenCalledTimes(1);
+	});
 
-  it("renders with sample data and accepts click callbacks", () => {
-    const onItemClick = vi.fn();
-    render(
-      <SankeyChart
-        nodes={sampleNodes}
-        links={sampleLinks}
-        className="flow-view"
-        onItemClick={onItemClick}
-      />,
-    );
+	it("renders with sample data and accepts click callbacks", () => {
+		const onItemClick = vi.fn();
+		render(
+			<SankeyChart
+				nodes={sampleNodes}
+				links={sampleLinks}
+				className="flow-view"
+				onItemClick={onItemClick}
+			/>,
+		);
 
-    const props = chartSpy.mock.calls[0][0] as {
-      className: string;
-      option: { series: Array<{ data: unknown[]; links: unknown[] }> };
-      onEvents?: { click: (params: unknown) => void };
-    };
+		const props = chartSpy.mock.calls[0][0] as {
+			className: string;
+			option: { series: Array<{ data: unknown[]; links: unknown[] }> };
+			onEvents?: { click: (params: unknown) => void };
+		};
 
-    expect(props.className).toBe("flow-view");
-    expect(props.option.series[0]?.data).toHaveLength(3);
-    expect(props.option.series[0]?.links).toHaveLength(2);
+		expect(props.className).toBe("flow-view");
+		expect(props.option.series[0]?.data).toHaveLength(3);
+		expect(props.option.series[0]?.links).toHaveLength(2);
 
-    props.onEvents?.click({
-      dataType: "edge",
-      data: { source: "Backlog", target: "In Progress", value: 12 },
-    });
-    expect(onItemClick).toHaveBeenCalledWith({
-      type: "link",
-      name: "",
-      source: "Backlog",
-      target: "In Progress",
-      value: 12,
-    });
-  });
+		props.onEvents?.click({
+			dataType: "edge",
+			data: { source: "Backlog", target: "In Progress", value: 12 },
+		});
+		expect(onItemClick).toHaveBeenCalledWith({
+			type: "link",
+			name: "",
+			source: "Backlog",
+			target: "In Progress",
+			value: 12,
+		});
+	});
 
-  it("handles empty data and null click payload gracefully", () => {
-    const onItemClick = vi.fn();
-    render(<SankeyChart nodes={[]} links={[]} onItemClick={onItemClick} />);
+	it("handles empty data and null click payload gracefully", () => {
+		const onItemClick = vi.fn();
+		render(<SankeyChart nodes={[]} links={[]} onItemClick={onItemClick} />);
 
-    const props = chartSpy.mock.calls[0][0] as {
-      option: { series: Array<{ data: unknown[]; links: unknown[] }> };
-      onEvents?: { click: (params: unknown) => void };
-    };
+		const props = chartSpy.mock.calls[0][0] as {
+			option: { series: Array<{ data: unknown[]; links: unknown[] }> };
+			onEvents?: { click: (params: unknown) => void };
+		};
 
-    expect(props.option.series[0]?.data).toHaveLength(0);
-    expect(props.option.series[0]?.links).toHaveLength(0);
-    expect(() => props.onEvents?.click(null)).not.toThrow();
-    expect(onItemClick).not.toHaveBeenCalled();
-  });
+		expect(props.option.series[0]?.data).toHaveLength(0);
+		expect(props.option.series[0]?.links).toHaveLength(0);
+		expect(() => props.onEvents?.click(null)).not.toThrow();
+		expect(onItemClick).not.toHaveBeenCalled();
+	});
+
+	it("degrades a raw UUID node name to a stable short token (A7)", () => {
+		const UUID = "550e8400-e29b-41d4-a716-446655440000";
+		render(<SankeyChart nodes={[{ name: UUID }]} links={[]} />);
+
+		const props = chartSpy.mock.calls[0][0] as {
+			option: {
+				series: Array<{ label: { formatter: (params: unknown) => string } }>;
+			};
+		};
+
+		const label = props.option.series[0].label.formatter({ name: UUID });
+		expect(label).toBe("#550e8400");
+		expect(label).not.toContain(UUID);
+	});
+
+	it("resolves a degraded node label in the click callback (A7)", () => {
+		const UUID = "550e8400-e29b-41d4-a716-446655440000";
+		const onItemClick = vi.fn();
+		render(
+			<SankeyChart
+				nodes={[{ name: UUID }]}
+				links={[]}
+				onItemClick={onItemClick}
+			/>,
+		);
+
+		const props = chartSpy.mock.calls[0][0] as {
+			onEvents?: { click: (params: unknown) => void };
+		};
+
+		props.onEvents?.click({ dataType: "node", data: { name: UUID } });
+		expect(onItemClick).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "node", name: "#550e8400" }),
+		);
+	});
 });

--- a/src/components/charts/SankeyChart.tsx
+++ b/src/components/charts/SankeyChart.tsx
@@ -8,207 +8,217 @@ import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
 import { echarts } from "@/lib/echartsInit";
 import type { SankeyLink, SankeyNode } from "@/lib/types";
+import { chartEntityLabel } from "@/lib/labels/entityLabel";
 
 echarts.use([EChartsSankeyChart]);
 
 type SankeyChartProps = {
-  nodes: SankeyNode[];
-  links: SankeyLink[];
-  unit?: string;
-  height?: number | string;
-  width?: number | string;
-  className?: string;
-  style?: CSSProperties;
-  tooltipFormatter?: (params: unknown, unit: string) => string;
-  onItemClick?: (item: {
-    type: "node" | "link";
-    name?: string;
-    source?: string;
-    target?: string;
-    value?: number;
-  }) => void;
+	nodes: SankeyNode[];
+	links: SankeyLink[];
+	unit?: string;
+	height?: number | string;
+	width?: number | string;
+	className?: string;
+	style?: CSSProperties;
+	tooltipFormatter?: (params: unknown, unit: string) => string;
+	onItemClick?: (item: {
+		type: "node" | "link";
+		name?: string;
+		source?: string;
+		target?: string;
+		value?: number;
+	}) => void;
 };
 
 // Compute flow totals from links/nodes data
 function computeFlowTotals(nodes: SankeyNode[], links: SankeyLink[]) {
-  const incomingTotals = new Map<string, number>();
-  const outgoingTotals = new Map<string, number>();
-  const nodeValueByName = new Map<string, number>();
+	const incomingTotals = new Map<string, number>();
+	const outgoingTotals = new Map<string, number>();
+	const nodeValueByName = new Map<string, number>();
 
-  links.forEach((link) => {
-    outgoingTotals.set(link.source, (outgoingTotals.get(link.source) ?? 0) + link.value);
-    incomingTotals.set(link.target, (incomingTotals.get(link.target) ?? 0) + link.value);
-  });
+	links.forEach((link) => {
+		outgoingTotals.set(
+			link.source,
+			(outgoingTotals.get(link.source) ?? 0) + link.value,
+		);
+		incomingTotals.set(
+			link.target,
+			(incomingTotals.get(link.target) ?? 0) + link.value,
+		);
+	});
 
-  nodes.forEach((node) => {
-    const incoming = incomingTotals.get(node.name) ?? 0;
-    const outgoing = outgoingTotals.get(node.name) ?? 0;
-    nodeValueByName.set(node.name, Math.max(incoming, outgoing));
-  });
+	nodes.forEach((node) => {
+		const incoming = incomingTotals.get(node.name) ?? 0;
+		const outgoing = outgoingTotals.get(node.name) ?? 0;
+		nodeValueByName.set(node.name, Math.max(incoming, outgoing));
+	});
 
-  const rootTotal = nodes.reduce((total, node) => {
-    const incoming = incomingTotals.get(node.name) ?? 0;
-    if (incoming === 0) {
-      return total + (outgoingTotals.get(node.name) ?? 0);
-    }
-    return total;
-  }, 0);
+	const rootTotal = nodes.reduce((total, node) => {
+		const incoming = incomingTotals.get(node.name) ?? 0;
+		if (incoming === 0) {
+			return total + (outgoingTotals.get(node.name) ?? 0);
+		}
+		return total;
+	}, 0);
 
-  const totalFlow =
-    rootTotal > 0 ? rootTotal : links.reduce((total, link) => total + link.value, 0);
+	const totalFlow =
+		rootTotal > 0
+			? rootTotal
+			: links.reduce((total, link) => total + link.value, 0);
 
-  return { incomingTotals, outgoingTotals, nodeValueByName, totalFlow };
+	return { incomingTotals, outgoingTotals, nodeValueByName, totalFlow };
 }
 
 const formatValue = (value: number | undefined, unit: string) => {
-  if (typeof value !== "number" || Number.isNaN(value)) {
-    return "--";
-  }
-  return `${value.toFixed(0)} ${unit}`;
+	if (typeof value !== "number" || Number.isNaN(value)) {
+		return "--";
+	}
+	return `${value.toFixed(0)} ${unit}`;
 };
 
 const formatPercent = (value: number, total: number) => {
-  if (!Number.isFinite(value) || !Number.isFinite(total) || total <= 0) {
-    return "--";
-  }
-  return `${((value / total) * 100).toFixed(1)}%`;
+	if (!Number.isFinite(value) || !Number.isFinite(total) || total <= 0) {
+		return "--";
+	}
+	return `${((value / total) * 100).toFixed(1)}%`;
 };
 
 export function SankeyChart({
-  nodes,
-  links,
-  unit = "items",
-  height = 320,
-  width = "100%",
-  className,
-  style,
-  tooltipFormatter,
-  onItemClick,
+	nodes,
+	links,
+	unit = "items",
+	height = 320,
+	width = "100%",
+	className,
+	style,
+	tooltipFormatter,
+	onItemClick,
 }: SankeyChartProps) {
-  const chartTheme = useChartTheme();
+	const chartTheme = useChartTheme();
 
-  const mergedStyle: CSSProperties = useMemo(
-    () => ({ height, width, ...style }),
-    [height, width, style],
-  );
+	const mergedStyle: CSSProperties = useMemo(
+		() => ({ height, width, ...style }),
+		[height, width, style],
+	);
 
-  const { chartNodes, chartLinks, labelByKey } = useMemo(() => {
-    const keyByRef = new Map<string, string>();
-    const labelByKey = new Map<string, string>();
+	const { chartNodes, chartLinks, labelByKey } = useMemo(() => {
+		const keyByRef = new Map<string, string>();
+		const labelByKey = new Map<string, string>();
 
-    const makeKey = (node: SankeyNode) => {
-      if (node.id) {
-        return node.id;
-      }
-      if (node.group) {
-        return `${node.group}:${node.name}`;
-      }
-      return node.name;
-    };
+		const makeKey = (node: SankeyNode) => {
+			if (node.id) {
+				return node.id;
+			}
+			if (node.group) {
+				return `${node.group}:${node.name}`;
+			}
+			return node.name;
+		};
 
-    nodes.forEach((node) => {
-      const key = makeKey(node);
-      keyByRef.set(node.name, key);
-      if (node.id) {
-        keyByRef.set(node.id, key);
-      }
-      labelByKey.set(key, node.name);
-    });
+		nodes.forEach((node) => {
+			const key = makeKey(node);
+			keyByRef.set(node.name, key);
+			if (node.id) {
+				keyByRef.set(node.id, key);
+			}
+			labelByKey.set(key, node.name);
+		});
 
-    const chartNodes = nodes.map((node) => ({
-      ...node,
-      name: keyByRef.get(node.name) ?? makeKey(node),
-    }));
+		const chartNodes = nodes.map((node) => ({
+			...node,
+			name: keyByRef.get(node.name) ?? makeKey(node),
+		}));
 
-    const chartLinks = links.map((link) => ({
-      ...link,
-      source: keyByRef.get(link.source) ?? link.source,
-      target: keyByRef.get(link.target) ?? link.target,
-    }));
+		const chartLinks = links.map((link) => ({
+			...link,
+			source: keyByRef.get(link.source) ?? link.source,
+			target: keyByRef.get(link.target) ?? link.target,
+		}));
 
-    return { chartNodes, chartLinks, labelByKey };
-  }, [nodes, links]);
+		return { chartNodes, chartLinks, labelByKey };
+	}, [nodes, links]);
 
-  const displayNameForKey = useCallback(
-    (value: string) => {
-      const label = labelByKey.get(value);
-      if (label) {
-        return label;
-      }
-      if (value.includes(":")) {
-        return value.split(":").slice(1).join(":");
-      }
-      return value;
-    },
-    [labelByKey],
-  );
+	const displayNameForKey = useCallback(
+		(value: string) => {
+			// Render-safe entity resolution (A7): a degraded label is the stable
+			// short token, never a bare UUID/hash, so Sankey nodes/tooltips match
+			// cards and tables.
+			const base =
+				labelByKey.get(value) ??
+				(value.includes(":") ? value.split(":").slice(1).join(":") : value);
+			// Preserve an empty value (e.g. unnamed edge endpoints) verbatim so
+			// missing labels never degrade to a placeholder token.
+			return base ? chartEntityLabel(base) : base;
+		},
+		[labelByKey],
+	);
 
-  // Memoize flow computations
-  const { outgoingTotals, nodeValueByName, totalFlow } = useMemo(
-    () => computeFlowTotals(chartNodes, chartLinks),
-    [chartNodes, chartLinks],
-  );
+	// Memoize flow computations
+	const { outgoingTotals, nodeValueByName, totalFlow } = useMemo(
+		() => computeFlowTotals(chartNodes, chartLinks),
+		[chartNodes, chartLinks],
+	);
 
-  // Memoize click handler
-  const handleClick = useCallback(
-    (params: unknown) => {
-      if (!onItemClick || !params || typeof params !== "object") {
-        return;
-      }
-      const entry = params as {
-        dataType?: string;
-        data?: {
-          name?: string;
-          value?: number;
-          source?: string;
-          target?: string;
-        };
-        name?: string;
-      };
-      const data = entry.data ?? {};
-      const isLink = entry.dataType === "edge";
-      onItemClick({
-        type: isLink ? "link" : "node",
-        name: displayNameForKey(data.name ?? entry.name ?? ""),
-        source: data.source ? displayNameForKey(data.source) : undefined,
-        target: data.target ? displayNameForKey(data.target) : undefined,
-        value: data.value,
-      });
-    },
-    [displayNameForKey, onItemClick],
-  );
+	// Memoize click handler
+	const handleClick = useCallback(
+		(params: unknown) => {
+			if (!onItemClick || !params || typeof params !== "object") {
+				return;
+			}
+			const entry = params as {
+				dataType?: string;
+				data?: {
+					name?: string;
+					value?: number;
+					source?: string;
+					target?: string;
+				};
+				name?: string;
+			};
+			const data = entry.data ?? {};
+			const isLink = entry.dataType === "edge";
+			onItemClick({
+				type: isLink ? "link" : "node",
+				name: displayNameForKey(data.name ?? entry.name ?? ""),
+				source: data.source ? displayNameForKey(data.source) : undefined,
+				target: data.target ? displayNameForKey(data.target) : undefined,
+				value: data.value,
+			});
+		},
+		[displayNameForKey, onItemClick],
+	);
 
-  // Memoize the ECharts option to prevent re-renders
-  const option = useMemo(() => {
-    const defaultTooltipFormatter = (params: unknown) => {
-      if (!params || typeof params !== "object") {
-        return "";
-      }
-      const entry = params as {
-        dataType?: string;
-        data?: {
-          name?: string;
-          value?: number;
-          source?: string;
-          target?: string;
-        };
-        name?: string;
-      };
-      const data = entry.data ?? {};
-      if (entry.dataType === "edge") {
-        const sourceLabel = data.source ? displayNameForKey(data.source) : "";
-        const targetLabel = data.target ? displayNameForKey(data.target) : "";
-        const totalFromSource =
-          data.source && outgoingTotals.has(data.source)
-            ? (outgoingTotals.get(data.source) ?? 0)
-            : 0;
-        const unitLabel = unit === "hours" ? "Elapsed" : "Value";
-        const shareLine =
-          totalFromSource > 0 && typeof data.value === "number"
-            ? `<br/><span style="color: ${chartTheme.accent2}">${formatPercent(data.value, totalFromSource)}</span> of source flow`
-            : "";
+	// Memoize the ECharts option to prevent re-renders
+	const option = useMemo(() => {
+		const defaultTooltipFormatter = (params: unknown) => {
+			if (!params || typeof params !== "object") {
+				return "";
+			}
+			const entry = params as {
+				dataType?: string;
+				data?: {
+					name?: string;
+					value?: number;
+					source?: string;
+					target?: string;
+				};
+				name?: string;
+			};
+			const data = entry.data ?? {};
+			if (entry.dataType === "edge") {
+				const sourceLabel = data.source ? displayNameForKey(data.source) : "";
+				const targetLabel = data.target ? displayNameForKey(data.target) : "";
+				const totalFromSource =
+					data.source && outgoingTotals.has(data.source)
+						? (outgoingTotals.get(data.source) ?? 0)
+						: 0;
+				const unitLabel = unit === "hours" ? "Elapsed" : "Value";
+				const shareLine =
+					totalFromSource > 0 && typeof data.value === "number"
+						? `<br/><span style="color: ${chartTheme.accent2}">${formatPercent(data.value, totalFromSource)}</span> of source flow`
+						: "";
 
-        return `
+				return `
           <div style="font-weight: 600; margin-bottom: 4px;">Flow</div>
           <div style="font-size: 11px; color: ${chartTheme.muted}">${sourceLabel} &rarr; ${targetLabel}</div>
           <div style="margin-top: 4px;">
@@ -217,20 +227,22 @@ export function SankeyChart({
             ${shareLine}
           </div>
         `;
-      }
+			}
 
-      const rawNodeName = data.name ?? entry.name ?? "";
-      const nodeName = displayNameForKey(rawNodeName);
+			const rawNodeName = data.name ?? entry.name ?? "";
+			const nodeName = displayNameForKey(rawNodeName);
 
-      const nodeValue =
-        typeof data.value === "number" ? data.value : (nodeValueByName.get(rawNodeName) ?? 0);
-      const unitLabel = unit === "hours" ? "Total Elapsed" : "Total Value";
-      const shareLine =
-        totalFlow > 0
-          ? `<br/><span style="color: ${chartTheme.accent2}">${formatPercent(nodeValue, totalFlow)}</span> of total`
-          : "";
+			const nodeValue =
+				typeof data.value === "number"
+					? data.value
+					: (nodeValueByName.get(rawNodeName) ?? 0);
+			const unitLabel = unit === "hours" ? "Total Elapsed" : "Total Value";
+			const shareLine =
+				totalFlow > 0
+					? `<br/><span style="color: ${chartTheme.accent2}">${formatPercent(nodeValue, totalFlow)}</span> of total`
+					: "";
 
-      return `
+			return `
         <div style="font-weight: 600; margin-bottom: 4px;">${nodeName}</div>
         <div>
           <span style="color: ${chartTheme.muted}">${unitLabel}:</span> 
@@ -238,104 +250,106 @@ export function SankeyChart({
           ${shareLine}
         </div>
       `;
-    };
+		};
 
-    return {
-      tooltip: {
-        trigger: "item" as const,
-        confine: true,
-        backgroundColor: chartTheme.background,
-        borderColor: chartTheme.stroke,
-        textStyle: {
-          color: chartTheme.text,
-        },
-        position: (
-          point: number[],
-          _params: unknown,
-          _dom: unknown,
-          _rect: unknown,
-          size: { contentSize: number[]; viewSize: number[] },
-        ): number[] => {
-          const [x, y] = point;
-          const [tooltipWidth, tooltipHeight] = size.contentSize;
-          const [viewWidth, viewHeight] = size.viewSize;
-          const padding = 16;
-          // Position to the right if there's room, otherwise to the left
-          let newX = x + padding;
-          if (newX + tooltipWidth > viewWidth) {
-            newX = x - tooltipWidth - padding;
-          }
-          // Position below if there's room, otherwise above
-          let newY = y + padding;
-          if (newY + tooltipHeight > viewHeight) {
-            newY = y - tooltipHeight - padding;
-          }
-          // Ensure tooltip stays within bounds
-          newX = Math.max(0, Math.min(newX, viewWidth - tooltipWidth));
-          newY = Math.max(0, Math.min(newY, viewHeight - tooltipHeight));
-          return [newX, newY];
-        },
-        formatter: (params: unknown) =>
-          tooltipFormatter ? tooltipFormatter(params, unit) : defaultTooltipFormatter(params),
-      },
-      series: [
-        {
-          type: "sankey" as const,
-          emphasis: { focus: "adjacency" as const },
-          data: chartNodes,
-          links: chartLinks,
-          roam: false,
-          lineStyle: { color: "gradient", curveness: 0.5, opacity: 0.45 },
-          label: {
-            color: chartTheme.text,
-            fontSize: 11,
-            formatter: (params: unknown) => {
-              if (!params || typeof params !== "object") {
-                return "";
-              }
-              const entry = params as { name?: string };
-              const name = entry.name || "";
-              return displayNameForKey(name);
-            },
-          },
-          itemStyle: {
-            borderColor: chartTheme.grid,
-            borderWidth: 1,
-          },
-          nodeGap: 14,
-        },
-      ],
-    };
-  }, [
-    chartNodes,
-    chartLinks,
-    unit,
-    chartTheme.text,
-    chartTheme.grid,
-    chartTheme.muted,
-    chartTheme.accent2,
-    chartTheme.background,
-    chartTheme.stroke,
-    outgoingTotals,
-    nodeValueByName,
-    totalFlow,
-    tooltipFormatter,
-    displayNameForKey,
-  ]);
+		return {
+			tooltip: {
+				trigger: "item" as const,
+				confine: true,
+				backgroundColor: chartTheme.background,
+				borderColor: chartTheme.stroke,
+				textStyle: {
+					color: chartTheme.text,
+				},
+				position: (
+					point: number[],
+					_params: unknown,
+					_dom: unknown,
+					_rect: unknown,
+					size: { contentSize: number[]; viewSize: number[] },
+				): number[] => {
+					const [x, y] = point;
+					const [tooltipWidth, tooltipHeight] = size.contentSize;
+					const [viewWidth, viewHeight] = size.viewSize;
+					const padding = 16;
+					// Position to the right if there's room, otherwise to the left
+					let newX = x + padding;
+					if (newX + tooltipWidth > viewWidth) {
+						newX = x - tooltipWidth - padding;
+					}
+					// Position below if there's room, otherwise above
+					let newY = y + padding;
+					if (newY + tooltipHeight > viewHeight) {
+						newY = y - tooltipHeight - padding;
+					}
+					// Ensure tooltip stays within bounds
+					newX = Math.max(0, Math.min(newX, viewWidth - tooltipWidth));
+					newY = Math.max(0, Math.min(newY, viewHeight - tooltipHeight));
+					return [newX, newY];
+				},
+				formatter: (params: unknown) =>
+					tooltipFormatter
+						? tooltipFormatter(params, unit)
+						: defaultTooltipFormatter(params),
+			},
+			series: [
+				{
+					type: "sankey" as const,
+					emphasis: { focus: "adjacency" as const },
+					data: chartNodes,
+					links: chartLinks,
+					roam: false,
+					lineStyle: { color: "gradient", curveness: 0.5, opacity: 0.45 },
+					label: {
+						color: chartTheme.text,
+						fontSize: 11,
+						formatter: (params: unknown) => {
+							if (!params || typeof params !== "object") {
+								return "";
+							}
+							const entry = params as { name?: string };
+							const name = entry.name || "";
+							return displayNameForKey(name);
+						},
+					},
+					itemStyle: {
+						borderColor: chartTheme.grid,
+						borderWidth: 1,
+					},
+					nodeGap: 14,
+				},
+			],
+		};
+	}, [
+		chartNodes,
+		chartLinks,
+		unit,
+		chartTheme.text,
+		chartTheme.grid,
+		chartTheme.muted,
+		chartTheme.accent2,
+		chartTheme.background,
+		chartTheme.stroke,
+		outgoingTotals,
+		nodeValueByName,
+		totalFlow,
+		tooltipFormatter,
+		displayNameForKey,
+	]);
 
-  // Memoize onEvents to prevent re-renders
-  const onEvents = useMemo(
-    () => (onItemClick ? { click: handleClick } : undefined),
-    [onItemClick, handleClick],
-  );
+	// Memoize onEvents to prevent re-renders
+	const onEvents = useMemo(
+		() => (onItemClick ? { click: handleClick } : undefined),
+		[onItemClick, handleClick],
+	);
 
-  return (
-    <Chart
-      option={option}
-      className={className}
-      style={mergedStyle}
-      onEvents={onEvents}
-      chartTheme={chartTheme}
-    />
-  );
+	return (
+		<Chart
+			option={option}
+			className={className}
+			style={mergedStyle}
+			onEvents={onEvents}
+			chartTheme={chartTheme}
+		/>
+	);
 }

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
@@ -25,7 +25,14 @@ import { MetricCard } from "@/components/metrics/MetricCard";
 import { buildExploreUrl } from "@/lib/filters/url";
 import { formatDelta, formatMetricValue } from "@/lib/formatters";
 import type { MetricFilter } from "@/lib/filters/types";
-import type { Contributor, MetricDelta, SankeyLink, SankeyNode } from "@/lib/types";
+import type {
+	Contributor,
+	MetricDelta,
+	SankeyLink,
+	SankeyNode,
+} from "@/lib/types";
+import { EntityLabel } from "@/components/labels/EntityLabel";
+import { resolveEntityLabels } from "@/lib/labels/entityLabel";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,36 +40,36 @@ import type { Contributor, MetricDelta, SankeyLink, SankeyNode } from "@/lib/typ
 
 /** WorkGraph edge — mirrors WORK_GRAPH_EDGES_QUERY field set exactly. */
 export type WorkGraphEdge = {
-  edgeId: string;
-  sourceType: string;
-  sourceId: string;
-  targetType: string;
-  targetId: string;
-  edgeType: string;
-  provenance: string | null;
-  confidence: number | null;
-  evidence: string | null;
-  repoId: string | null;
-  provider: string | null;
+	edgeId: string;
+	sourceType: string;
+	sourceId: string;
+	targetType: string;
+	targetId: string;
+	edgeType: string;
+	provenance: string | null;
+	confidence: number | null;
+	evidence: string | null;
+	repoId: string | null;
+	provider: string | null;
 };
 
 /** Joined incident row: one incident with its linked deployments and work items. */
 export type IncidentRow = {
-  incidentId: string;
-  deploymentIds: string[];
-  workItemIds: string[];
+	incidentId: string;
+	deploymentIds: string[];
+	workItemIds: string[];
 };
 
 export type IncidentCorrelationDashboardProps = {
-  orgId: string;
-  deltas: MetricDelta[];
-  drivers: Contributor[];
-  contributors: Contributor[];
-  explainUnit?: string;
-  deploysEdges: WorkGraphEdge[];
-  incidentEdges: WorkGraphEdge[];
-  filters: MetricFilter;
-  role?: string;
+	orgId: string;
+	deltas: MetricDelta[];
+	drivers: Contributor[];
+	contributors: Contributor[];
+	explainUnit?: string;
+	deploysEdges: WorkGraphEdge[];
+	incidentEdges: WorkGraphEdge[];
+	filters: MetricFilter;
+	role?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -70,7 +77,11 @@ export type IncidentCorrelationDashboardProps = {
 // ---------------------------------------------------------------------------
 
 /** DORA metric keys we recognise — tiles rendered only when present in home.deltas. */
-const DORA_METRIC_KEYS = ["change_failure_rate", "deployment_frequency", "mttr"] as const;
+const DORA_METRIC_KEYS = [
+	"change_failure_rate",
+	"deployment_frequency",
+	"mttr",
+] as const;
 
 const MAX_SANKEY_INCIDENTS = 10;
 const MAX_LINKS_PER_INCIDENT = 3;
@@ -89,36 +100,39 @@ const MAX_LINKS_PER_INCIDENT = 3;
  * V1 limitation: no time-windowed filtering — schema doesn't support it.
  */
 export function joinEdges(
-  deploysEdges: WorkGraphEdge[],
-  incidentEdges: WorkGraphEdge[],
+	deploysEdges: WorkGraphEdge[],
+	incidentEdges: WorkGraphEdge[],
 ): IncidentRow[] {
-  const deploysByIncident = new Map<string, Set<string>>();
-  for (const edge of deploysEdges) {
-    const incidentId = edge.targetId;
-    const deploymentId = edge.sourceId;
-    if (!deploysByIncident.has(incidentId)) {
-      deploysByIncident.set(incidentId, new Set());
-    }
-    deploysByIncident.get(incidentId)!.add(deploymentId);
-  }
+	const deploysByIncident = new Map<string, Set<string>>();
+	for (const edge of deploysEdges) {
+		const incidentId = edge.targetId;
+		const deploymentId = edge.sourceId;
+		if (!deploysByIncident.has(incidentId)) {
+			deploysByIncident.set(incidentId, new Set());
+		}
+		deploysByIncident.get(incidentId)!.add(deploymentId);
+	}
 
-  const workItemsByIncident = new Map<string, Set<string>>();
-  for (const edge of incidentEdges) {
-    const incidentId = edge.sourceId;
-    const workItemId = edge.targetId;
-    if (!workItemsByIncident.has(incidentId)) {
-      workItemsByIncident.set(incidentId, new Set());
-    }
-    workItemsByIncident.get(incidentId)!.add(workItemId);
-  }
+	const workItemsByIncident = new Map<string, Set<string>>();
+	for (const edge of incidentEdges) {
+		const incidentId = edge.sourceId;
+		const workItemId = edge.targetId;
+		if (!workItemsByIncident.has(incidentId)) {
+			workItemsByIncident.set(incidentId, new Set());
+		}
+		workItemsByIncident.get(incidentId)!.add(workItemId);
+	}
 
-  const allIncidentIds = new Set([...deploysByIncident.keys(), ...workItemsByIncident.keys()]);
+	const allIncidentIds = new Set([
+		...deploysByIncident.keys(),
+		...workItemsByIncident.keys(),
+	]);
 
-  return Array.from(allIncidentIds).map((incidentId) => ({
-    incidentId,
-    deploymentIds: Array.from(deploysByIncident.get(incidentId) ?? []),
-    workItemIds: Array.from(workItemsByIncident.get(incidentId) ?? []),
-  }));
+	return Array.from(allIncidentIds).map((incidentId) => ({
+		incidentId,
+		deploymentIds: Array.from(deploysByIncident.get(incidentId) ?? []),
+		workItemIds: Array.from(workItemsByIncident.get(incidentId) ?? []),
+	}));
 }
 
 /**
@@ -126,38 +140,38 @@ export function joinEdges(
  * Returns null when there are no links to render.
  */
 export function buildSankeyData(
-  rows: IncidentRow[],
+	rows: IncidentRow[],
 ): { nodes: SankeyNode[]; links: SankeyLink[] } | null {
-  const limited = rows.slice(0, MAX_SANKEY_INCIDENTS);
-  const nodes: SankeyNode[] = [];
-  const links: SankeyLink[] = [];
-  const seen = new Set<string>();
+	const limited = rows.slice(0, MAX_SANKEY_INCIDENTS);
+	const nodes: SankeyNode[] = [];
+	const links: SankeyLink[] = [];
+	const seen = new Set<string>();
 
-  const addNode = (name: string, group: string) => {
-    if (!seen.has(name)) {
-      nodes.push({ name, group });
-      seen.add(name);
-    }
-  };
+	const addNode = (name: string, group: string) => {
+		if (!seen.has(name)) {
+			nodes.push({ name, group });
+			seen.add(name);
+		}
+	};
 
-  for (const row of limited) {
-    const incName = `inc:${row.incidentId.slice(0, 8)}`;
-    addNode(incName, "incident");
+	for (const row of limited) {
+		const incName = `inc:${row.incidentId.slice(0, 8)}`;
+		addNode(incName, "incident");
 
-    for (const depId of row.deploymentIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
-      const depName = `dep:${depId.slice(0, 8)}`;
-      addNode(depName, "deployment");
-      links.push({ source: depName, target: incName, value: 1 });
-    }
+		for (const depId of row.deploymentIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
+			const depName = `dep:${depId.slice(0, 8)}`;
+			addNode(depName, "deployment");
+			links.push({ source: depName, target: incName, value: 1 });
+		}
 
-    for (const wiId of row.workItemIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
-      const wiName = `wi:${wiId.slice(0, 8)}`;
-      addNode(wiName, "work_item");
-      links.push({ source: incName, target: wiName, value: 1 });
-    }
-  }
+		for (const wiId of row.workItemIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
+			const wiName = `wi:${wiId.slice(0, 8)}`;
+			addNode(wiName, "work_item");
+			links.push({ source: incName, target: wiName, value: 1 });
+		}
+	}
 
-  return links.length > 0 ? { nodes, links } : null;
+	return links.length > 0 ? { nodes, links } : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -165,269 +179,302 @@ export function buildSankeyData(
 // ---------------------------------------------------------------------------
 
 export function IncidentCorrelationDashboard({
-  orgId,
-  deltas,
-  drivers,
-  contributors,
-  explainUnit,
-  deploysEdges,
-  incidentEdges,
-  filters,
-  role,
+	orgId,
+	deltas,
+	drivers,
+	contributors,
+	explainUnit,
+	deploysEdges,
+	incidentEdges,
+	filters,
+	role,
 }: IncidentCorrelationDashboardProps) {
-  const incidentRows = useMemo(
-    () => joinEdges(deploysEdges, incidentEdges),
-    [deploysEdges, incidentEdges],
-  );
+	const incidentRows = useMemo(
+		() => joinEdges(deploysEdges, incidentEdges),
+		[deploysEdges, incidentEdges],
+	);
 
-  const sankeyData = useMemo(() => buildSankeyData(incidentRows), [incidentRows]);
+	const sankeyData = useMemo(
+		() => buildSankeyData(incidentRows),
+		[incidentRows],
+	);
 
-  const doraMetrics = useMemo(
-    () =>
-      DORA_METRIC_KEYS.flatMap((key) => {
-        const delta = deltas.find((d) => d.metric === key);
-        return delta ? [delta] : [];
-      }),
-    [deltas],
-  );
+	const doraMetrics = useMemo(
+		() =>
+			DORA_METRIC_KEYS.flatMap((key) => {
+				const delta = deltas.find((d) => d.metric === key);
+				return delta ? [delta] : [];
+			}),
+		[deltas],
+	);
 
-  const topDrivers = drivers.slice(0, 5);
-  const topContributors = contributors.slice(0, 5);
-  const hasExplainData = topDrivers.length > 0 || topContributors.length > 0;
-  const hasEdgeData = incidentRows.length > 0;
-  const hasAnyData = doraMetrics.length > 0 || hasExplainData || hasEdgeData;
+	const topDrivers = drivers.slice(0, 5);
+	// Render-safe association labels (A7): degrade raw ids to stable short
+	// tokens; the full label stays available as the axis tooltip title.
+	const driverChartLabels = resolveEntityLabels(topDrivers.map((d) => d.label));
+	const topContributors = contributors.slice(0, 5);
+	const hasExplainData = topDrivers.length > 0 || topContributors.length > 0;
+	const hasEdgeData = incidentRows.length > 0;
+	const hasAnyData = doraMetrics.length > 0 || hasExplainData || hasEdgeData;
 
-  // ---------------------------------------------------------------------------
-  // Empty state (mirrors CompoundingRiskDashboard voice)
-  // ---------------------------------------------------------------------------
-  if (!hasAnyData) {
-    return (
-      <div
-        className="rounded-2xl border border-(--card-stroke) bg-card p-8 shadow-sm"
-        data-testid="empty-state"
-      >
-        <h2 className="text-2xl font-semibold tracking-tight">
-          No incident-correlation evidence in this window.
-        </h2>
-        <p className="mt-4 max-w-2xl text-sm leading-6 text-(--ink-muted)">
-          Incident correlation requires deployment activity and linked incidents to be ingested. Run{" "}
-          <code className="font-mono text-[0.85em]">dev-hops sync git</code> and ensure incidents
-          are linked in your provider. The page will populate automatically after the next data
-          sync.
-        </p>
-        <p className="mt-8 text-xs text-(--ink-muted)">
-          Org <span className="font-mono">{orgId}</span>
-        </p>
-      </div>
-    );
-  }
+	// ---------------------------------------------------------------------------
+	// Empty state (mirrors CompoundingRiskDashboard voice)
+	// ---------------------------------------------------------------------------
+	if (!hasAnyData) {
+		return (
+			<div
+				className="rounded-2xl border border-(--card-stroke) bg-card p-8 shadow-sm"
+				data-testid="empty-state"
+			>
+				<h2 className="text-2xl font-semibold tracking-tight">
+					No incident-correlation evidence in this window.
+				</h2>
+				<p className="mt-4 max-w-2xl text-sm leading-6 text-(--ink-muted)">
+					Incident correlation requires deployment activity and linked incidents
+					to be ingested. Run{" "}
+					<code className="font-mono text-[0.85em]">dev-hops sync git</code> and
+					ensure incidents are linked in your provider. The page will populate
+					automatically after the next data sync.
+				</p>
+				<p className="mt-8 text-xs text-(--ink-muted)">
+					Org <span className="font-mono">{orgId}</span>
+				</p>
+			</div>
+		);
+	}
 
-  const cfrDelta = deltas.find((d) => d.metric === "change_failure_rate");
+	const cfrDelta = deltas.find((d) => d.metric === "change_failure_rate");
 
-  return (
-    <div className="flex flex-col gap-8" data-testid="incident-correlation-dashboard">
-      {/* ── DORA KPI tiles ─────────────────────────────────────────────────── */}
-      {doraMetrics.length > 0 && (
-        <section aria-label="DORA metrics">
-          <h2 className="mb-4 font-(--font-display) text-xl">DORA Metrics</h2>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {doraMetrics.map((m) => (
-              <MetricCard
-                key={m.metric}
-                label={m.label}
-                href={buildExploreUrl({ metric: m.metric, filters, role })}
-                value={m.value}
-                unit={m.unit}
-                delta={m.delta_pct}
-                spark={m.spark}
-                caption={m.label}
-              />
-            ))}
-          </div>
-        </section>
-      )}
+	return (
+		<div
+			className="flex flex-col gap-8"
+			data-testid="incident-correlation-dashboard"
+		>
+			{/* ── DORA KPI tiles ─────────────────────────────────────────────────── */}
+			{doraMetrics.length > 0 && (
+				<section aria-label="DORA metrics">
+					<h2 className="mb-4 font-(--font-display) text-xl">DORA Metrics</h2>
+					<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{doraMetrics.map((m) => (
+							<MetricCard
+								key={m.metric}
+								label={m.label}
+								href={buildExploreUrl({ metric: m.metric, filters, role })}
+								value={m.value}
+								unit={m.unit}
+								delta={m.delta_pct}
+								spark={m.spark}
+								caption={m.label}
+							/>
+						))}
+					</div>
+				</section>
+			)}
 
-      {/* ── CFR enlarged sparkline (V1 trend) ──────────────────────────────── */}
-      {cfrDelta && cfrDelta.spark.length > 0 && (
-        <section
-          className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5"
-          aria-label="Change failure rate trend"
-        >
-          <div className="flex items-center justify-between">
-            <h2 className="font-(--font-display) text-xl">Change Failure Rate — Trend</h2>
-            <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-              V1 sparkline
-            </span>
-          </div>
-          <p className="mt-1 text-xs text-(--ink-muted)">
-            Multi-week deployments-vs-incidents trend requires a future ops resolver (planned:
-            CHAOS-1757).
-          </p>
-          <div
-            aria-label="CFR sparkline"
-            className="mt-4 flex h-24 items-end gap-0.5"
-            data-testid="cfr-sparkline"
-          >
-            {(() => {
-              const maxVal = Math.max(0.01, ...cfrDelta.spark.map((p) => p.value));
-              return cfrDelta.spark.map((point, i) => {
-                const height = Math.max(4, (point.value / maxVal) * 88);
-                return (
-                  <div
-                    key={i}
-                    className="flex-1 rounded-t-sm bg-(--accent)"
-                    style={{ height: `${height}px` }}
-                    title={`${point.ts}: ${point.value}`}
-                  />
-                );
-              });
-            })()}
-          </div>
-        </section>
-      )}
+			{/* ── CFR enlarged sparkline (V1 trend) ──────────────────────────────── */}
+			{cfrDelta && cfrDelta.spark.length > 0 && (
+				<section
+					className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5"
+					aria-label="Change failure rate trend"
+				>
+					<div className="flex items-center justify-between">
+						<h2 className="font-(--font-display) text-xl">
+							Change Failure Rate — Trend
+						</h2>
+						<span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+							V1 sparkline
+						</span>
+					</div>
+					<p className="mt-1 text-xs text-(--ink-muted)">
+						Multi-week deployments-vs-incidents trend requires a future ops
+						resolver (planned: CHAOS-1757).
+					</p>
+					<div
+						aria-label="CFR sparkline"
+						className="mt-4 flex h-24 items-end gap-0.5"
+						data-testid="cfr-sparkline"
+					>
+						{(() => {
+							const maxVal = Math.max(
+								0.01,
+								...cfrDelta.spark.map((p) => p.value),
+							);
+							return cfrDelta.spark.map((point, i) => {
+								const height = Math.max(4, (point.value / maxVal) * 88);
+								return (
+									<div
+										key={i}
+										className="flex-1 rounded-t-sm bg-(--accent)"
+										style={{ height: `${height}px` }}
+										title={`${point.ts}: ${point.value}`}
+									/>
+								);
+							});
+						})()}
+					</div>
+				</section>
+			)}
 
-      {/* ── Drivers + Contributors ──────────────────────────────────────────── */}
-      {hasExplainData && (
-        <section className="grid gap-6 lg:grid-cols-2" aria-label="Change failure root cause">
-          <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-            <div className="flex items-center justify-between">
-              <h2 className="font-(--font-display) text-xl">Change Failure Associations</h2>
-              <Link
-                href={buildExploreUrl({
-                  metric: "change_failure_rate",
-                  filters,
-                  role,
-                })}
-                className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-              >
-                Evidence
-              </Link>
-            </div>
-            {topDrivers.length > 0 ? (
-              <div className="mt-4 space-y-4">
-                <HorizontalBarChart
-                  categories={topDrivers.map((d) => d.label)}
-                  values={topDrivers.map((d) => Math.abs(d.delta_pct))}
-                />
-              </div>
-            ) : (
-              <p className="mt-4 text-sm text-(--ink-muted)">
-                Association detail will appear once data is ingested.
-              </p>
-            )}
-          </div>
+			{/* ── Drivers + Contributors ──────────────────────────────────────────── */}
+			{hasExplainData && (
+				<section
+					className="grid gap-6 lg:grid-cols-2"
+					aria-label="Change failure root cause"
+				>
+					<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+						<div className="flex items-center justify-between">
+							<h2 className="font-(--font-display) text-xl">
+								Change Failure Associations
+							</h2>
+							<Link
+								href={buildExploreUrl({
+									metric: "change_failure_rate",
+									filters,
+									role,
+								})}
+								className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+							>
+								Evidence
+							</Link>
+						</div>
+						{topDrivers.length > 0 ? (
+							<div className="mt-4 space-y-4">
+								<HorizontalBarChart
+									categories={driverChartLabels.labels}
+									values={topDrivers.map((d) => Math.abs(d.delta_pct))}
+									categoryTitles={driverChartLabels.titles}
+								/>
+							</div>
+						) : (
+							<p className="mt-4 text-sm text-(--ink-muted)">
+								Association detail will appear once data is ingested.
+							</p>
+						)}
+					</div>
 
-          <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-            <div className="flex items-center justify-between">
-              <h2 className="font-(--font-display) text-xl">Contributors</h2>
-              <Link
-                href={buildExploreUrl({
-                  metric: "change_failure_rate",
-                  filters,
-                  role,
-                })}
-                className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-              >
-                Evidence
-              </Link>
-            </div>
-            {topContributors.length > 0 ? (
-              <div className="mt-4 space-y-2 text-sm">
-                {topContributors.map((c) => (
-                  <div
-                    key={c.id}
-                    className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
-                  >
-                    <span>{c.label}</span>
-                    <span className="text-xs text-(--ink-muted)">
-                      {explainUnit
-                        ? formatMetricValue(c.value, explainUnit)
-                        : formatDelta(c.delta_pct)}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <p className="mt-4 text-sm text-(--ink-muted)">
-                Contributor detail will appear once data is ingested.
-              </p>
-            )}
-          </div>
-        </section>
-      )}
+					<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+						<div className="flex items-center justify-between">
+							<h2 className="font-(--font-display) text-xl">Contributors</h2>
+							<Link
+								href={buildExploreUrl({
+									metric: "change_failure_rate",
+									filters,
+									role,
+								})}
+								className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+							>
+								Evidence
+							</Link>
+						</div>
+						{topContributors.length > 0 ? (
+							<div className="mt-4 space-y-2 text-sm">
+								{topContributors.map((c) => (
+									<div
+										key={c.id}
+										className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+									>
+										<EntityLabel id={c.label} />
+										<span className="text-xs text-(--ink-muted)">
+											{explainUnit
+												? formatMetricValue(c.value, explainUnit)
+												: formatDelta(c.delta_pct)}
+										</span>
+									</div>
+								))}
+							</div>
+						) : (
+							<p className="mt-4 text-sm text-(--ink-muted)">
+								Contributor detail will appear once data is ingested.
+							</p>
+						)}
+					</div>
+				</section>
+			)}
 
-      {/* ── Deployment ↔ Incident ↔ Work-item table ────────────────────────── */}
-      {hasEdgeData && (
-        <section aria-label="Linked incidents">
-          <div className="mb-4 flex items-baseline justify-between">
-            <h2 className="text-lg font-semibold tracking-tight">Linked Incidents</h2>
-            <p className="text-xs text-(--ink-muted)">
-              {incidentRows.length} incident
-              {incidentRows.length !== 1 ? "s" : ""} · V1: ≤ 500 edges per type
-            </p>
-          </div>
-          <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90) shadow-sm">
-            <table className="w-full text-sm" data-testid="incident-linkage-table">
-              <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
-                <tr>
-                  <th className="px-5 py-3 text-left">Incident ID</th>
-                  <th className="px-5 py-3 text-right">Linked Deployments</th>
-                  <th className="px-5 py-3 text-right">Linked Work Items</th>
-                </tr>
-              </thead>
-              <tbody>
-                {incidentRows.slice(0, 50).map((row) => (
-                  <tr
-                    key={row.incidentId}
-                    className="border-t border-(--card-stroke)/60 hover:bg-(--card-60)/60"
-                    data-testid="incident-row"
-                    data-incident-id={row.incidentId}
-                  >
-                    <td className="px-5 py-3 font-mono text-xs">
-                      {row.incidentId.length > 16
-                        ? `${row.incidentId.slice(0, 16)}…`
-                        : row.incidentId}
-                    </td>
-                    <td className="px-5 py-3 text-right tabular-nums">
-                      {row.deploymentIds.length}
-                    </td>
-                    <td className="px-5 py-3 text-right tabular-nums">{row.workItemIds.length}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
+			{/* ── Deployment ↔ Incident ↔ Work-item table ────────────────────────── */}
+			{hasEdgeData && (
+				<section aria-label="Linked incidents">
+					<div className="mb-4 flex items-baseline justify-between">
+						<h2 className="text-lg font-semibold tracking-tight">
+							Linked Incidents
+						</h2>
+						<p className="text-xs text-(--ink-muted)">
+							{incidentRows.length} incident
+							{incidentRows.length !== 1 ? "s" : ""} · V1: ≤ 500 edges per type
+						</p>
+					</div>
+					<div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90) shadow-sm">
+						<table
+							className="w-full text-sm"
+							data-testid="incident-linkage-table"
+						>
+							<thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
+								<tr>
+									<th className="px-5 py-3 text-left">Incident ID</th>
+									<th className="px-5 py-3 text-right">Linked Deployments</th>
+									<th className="px-5 py-3 text-right">Linked Work Items</th>
+								</tr>
+							</thead>
+							<tbody>
+								{incidentRows.slice(0, 50).map((row) => (
+									<tr
+										key={row.incidentId}
+										className="border-t border-(--card-stroke)/60 hover:bg-(--card-60)/60"
+										data-testid="incident-row"
+										data-incident-id={row.incidentId}
+									>
+										<td className="px-5 py-3 text-xs">
+											<EntityLabel id={row.incidentId} className="font-mono" />
+										</td>
+										<td className="px-5 py-3 text-right tabular-nums">
+											{row.deploymentIds.length}
+										</td>
+										<td className="px-5 py-3 text-right tabular-nums">
+											{row.workItemIds.length}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</section>
+			)}
 
-      {/* ── Sankey: deployment → incident → work-item ───────────────────────── */}
-      {sankeyData && (
-        <section
-          className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5"
-          aria-label="Correlation flow diagram"
-        >
-          <h2 className="font-(--font-display) text-xl">Deployment → Incident → Work Item Flow</h2>
-          <p className="mt-1 text-xs text-(--ink-muted)">
-            Top {MAX_SANKEY_INCIDENTS} incidents by linkage. Node labels are truncated IDs.
-          </p>
-          <div className="mt-4">
-            <SankeyChart nodes={sankeyData.nodes} links={sankeyData.links} height={360} />
-          </div>
-        </section>
-      )}
+			{/* ── Sankey: deployment → incident → work-item ───────────────────────── */}
+			{sankeyData && (
+				<section
+					className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5"
+					aria-label="Correlation flow diagram"
+				>
+					<h2 className="font-(--font-display) text-xl">
+						Deployment → Incident → Work Item Flow
+					</h2>
+					<p className="mt-1 text-xs text-(--ink-muted)">
+						Top {MAX_SANKEY_INCIDENTS} incidents by linkage. Node labels are
+						truncated IDs.
+					</p>
+					<div className="mt-4">
+						<SankeyChart
+							nodes={sankeyData.nodes}
+							links={sankeyData.links}
+							height={360}
+						/>
+					</div>
+				</section>
+			)}
 
-      {/* ── Sub-empty: metrics/explain present but no edges ─────────────────── */}
-      {!hasEdgeData && (doraMetrics.length > 0 || hasExplainData) && (
-        <section
-          className="rounded-2xl border border-(--card-stroke) bg-(--card-60) p-6 text-sm text-(--ink-muted)"
-          data-testid="empty-edges-state"
-        >
-          No deployment-incident linkage found in the work graph. Edge data populates as{" "}
-          <code className="font-mono text-[0.85em]">DEPLOYS</code> and{" "}
-          <code className="font-mono text-[0.85em]">LINKED_INCIDENT</code> edges are ingested from
-          your provider.
-        </section>
-      )}
-    </div>
-  );
+			{/* ── Sub-empty: metrics/explain present but no edges ─────────────────── */}
+			{!hasEdgeData && (doraMetrics.length > 0 || hasExplainData) && (
+				<section
+					className="rounded-2xl border border-(--card-stroke) bg-(--card-60) p-6 text-sm text-(--ink-muted)"
+					data-testid="empty-edges-state"
+				>
+					No deployment-incident linkage found in the work graph. Edge data
+					populates as <code className="font-mono text-[0.85em]">DEPLOYS</code>{" "}
+					and <code className="font-mono text-[0.85em]">LINKED_INCIDENT</code>{" "}
+					edges are ingested from your provider.
+				</section>
+			)}
+		</div>
+	);
 }

--- a/src/lib/labels/__tests__/entityLabel.test.ts
+++ b/src/lib/labels/__tests__/entityLabel.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
 	resolveEntityLabel,
+	chartEntityLabel,
 	resolveEntityLabels,
 	scrubIdentifiers,
 } from "@/lib/labels/entityLabel";
@@ -153,5 +154,44 @@ describe("scrubIdentifiers", () => {
 		expect(scrubIdentifiers("")).toEqual({ text: "", changed: false });
 		expect(scrubIdentifiers(null)).toEqual({ text: "", changed: false });
 		expect(scrubIdentifiers(undefined)).toEqual({ text: "", changed: false });
+	});
+});
+
+describe("chartEntityLabel", () => {
+	it("returns a confident human label unchanged", () => {
+		expect(chartEntityLabel("frontend-web")).toBe("frontend-web");
+	});
+
+	it("strips a known prefix from a readable slug", () => {
+		expect(chartEntityLabel("repo:web-app")).toBe("web-app");
+	});
+
+	it("NEVER returns a bare UUID — degrades to a stable short token", () => {
+		const label = chartEntityLabel(UUID);
+		expect(label).toBe("#550e8400");
+		expect(label).not.toBe(UUID);
+	});
+
+	it("degrades a prefixed UUID while preserving the entity prefix", () => {
+		expect(chartEntityLabel(`repo:${UUID}`)).toBe("repo\u00b7550e8400");
+	});
+
+	it("degrades a 32-char hex id", () => {
+		expect(chartEntityLabel(HEX32)).toBe("#550e8400");
+	});
+
+	it("honours an explicit name when one resolves", () => {
+		expect(chartEntityLabel(UUID, { name: "Web App" })).toBe("Web App");
+	});
+
+	it("falls back safely for empty ids without leaking a raw token", () => {
+		expect(chartEntityLabel("")).toBe("Unknown");
+		expect(chartEntityLabel(undefined)).toBe("Unknown");
+	});
+
+	it("never throws in development for an unresolved id", () => {
+		vi.stubEnv("NODE_ENV", "development");
+		expect(() => chartEntityLabel(UUID)).not.toThrow();
+		expect(chartEntityLabel(UUID)).toBe("#550e8400");
 	});
 });

--- a/src/lib/labels/entityLabel.ts
+++ b/src/lib/labels/entityLabel.ts
@@ -176,6 +176,29 @@ export function resolveEntityLabels(
 	};
 }
 
+/**
+ * Resolve a single identifier for a NON-React surface — ECharts tooltip /
+ * axis / node label strings, where the JSX `EntityLabel` component cannot be
+ * used. Returns a confident human label when one resolves, otherwise the
+ * stable short token (e.g. `#a1b2c3d4` or `repo·a1b2c3d4`). It NEVER returns a
+ * bare UUID / hash, so chart labels degrade identically to cards and tables.
+ *
+ * Use this anywhere a chart formatter needs a render-safe string for an entity
+ * identifier (repo / team / person / service / artifact).
+ */
+export function chartEntityLabel(
+	id: string | null | undefined,
+	options: ResolveEntityLabelOptions = {},
+): string {
+	const resolved = resolveEntityLabel(id, {
+		unresolvedFallback: "Unresolved",
+		...options,
+	});
+	return resolved.resolved
+		? resolved.label
+		: (resolved.short ?? resolved.label);
+}
+
 // Embedded-identifier scrubbing (CHAOS-2064). Backend-built narrative strings
 // (cockpit headlines, signal titles) can interpolate an *unresolved* scope id
 // directly into prose, e.g. "Compounding risk appears elevated for <uuid>".


### PR DESCRIPTION
## Summary

Framework **A7** rollout: route every repo / team / person / artifact identity label through the existing `EntityLabel` primitive (and its `resolveEntityLabel` / `resolveEntityLabels` resolver) so **no raw hash/UUID is ever a primary label** across charts, cards, tables, tooltips, and drawers. Reuses the merged primitive (#571) — no reimplementation.

A7 fallback order (unchanged): display name → repo/name slug → provider key w/ prefix → shortened ID + explicit **Unresolved** badge.

## Changes

**Resolver**
- `lib/labels/entityLabel.ts`: add `chartEntityLabel()` — a render-safe helper for **non-React ECharts surfaces** (tooltip / axis / node formatters). Returns a confident human label when resolved, otherwise a stable short token (`#a1b2c3d4` / `repo·a1b2c3d4`), never a bare UUID. Does not throw in dev.

**Charts (defensive resolution)**
- `charts/QuadrantChart.tsx`: resolve `point.entity_label` via `chartEntityLabel` in the tooltip + both label formatters.
- `charts/SankeyChart.tsx`: resolve node display labels in `displayNameForKey` (tooltip / node label / click callback). Empty endpoints preserved verbatim.
- `charts/HorizontalBarChart.tsx`: unchanged — already supports `categoryTitles`; resolution happens at the page level (it renders both entity and non-entity categories).

**Pages / dashboards**
- `testops/risk/page.tsx`: stop feeding raw `entity_label: item.id` into the quadrant — resolve via `chartEntityLabel`.
- `incident-correlation/IncidentCorrelationDashboard.tsx`: resolve driver chart labels (`resolveEntityLabels` + `categoryTitles`), route contributor rows + the **Linked Incidents** `Incident ID` column through `EntityLabel`.
- `quality/page.tsx` + `metrics/page.tsx`: route association / contributor bars (`resolveEntityLabels`) and list rows (`EntityLabel`).
- `people/[person_id]/metrics/[metric]/page.tsx`: resolve the **By repo** breakdown (chart + rows) as entities; route evidence **Item** titles through `EntityLabel variant="text"` (degrades bare ids, keeps prose). Work-type / stage categories pass through untouched.
- `testops/coverage/page.tsx`: verified — already routed through `resolveEntityLabels`.

**Tests**
- `chartEntityLabel`: human label / prefix strip / UUID + hex degradation / explicit name / safe empty fallback / no-throw-in-dev.
- `QuadrantChart`: raw-UUID `entity_label` degrades in tooltip; readable label passes through.
- `SankeyChart`: raw-UUID node name degrades in label formatter + click callback.

## Verification

- `bash ci/run_tests.sh unit` → **1284 passed (165 files)**
- `tsc --noEmit` → clean
- `pnpm build` → clean
- design-lint: **`no-raw-id-in-jsx: 0`**, identical counts with/without the change (**0 new violations**; pre-existing `cta-from-registry` / `no-internal-leak` are out of scope — CTA strings owned by a teammate + intentional backend tokens).

## Screenshots

Captured via the test-mode Playwright dev server (mock data uses already-readable ids, so labels resolve via the slug path — happy-path, no regression). Attached to the linked Linear issue CHAOS-2059:
- `chaos-2059-metrics-after.png`
- `chaos-2059-testops-risk-after.png`
- `chaos-2059-quality-after.png`
- `chaos-2059-incident-correlation-after.png`

Confirmed: human-readable labels render unchanged (e.g. `PR-201`, `PROJ-101`, `handler.ts`, `Retry Overhead`); no raw UUIDs/hashes as primary labels.

## Coordination

Region-scoped edits in `metrics/page.tsx`, `IncidentCorrelationDashboard.tsx`, `quality/page.tsx` (shared with the tabs/CTA workstream) — touched only the identity-label regions; rebased onto `origin/main` before push.

Closes CHAOS-2059