### PR TITLE
fix(web): sync GraphQL schema for compoundingRisk scopeEntity

### DIFF
--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -553,6 +553,7 @@ export type CompoundingRiskPoint = {
   computedAt: Scalars['DateTime']['output'];
   day: Scalars['Date']['output'];
   scope: CompoundingRiskScope;
+  scopeEntity: CompoundingRiskScopeEntity;
   scopeId: Scalars['String']['output'];
   scopeLabel: Scalars['String']['output'];
   score?: Maybe<Scalars['Float']['output']>;
@@ -573,6 +574,12 @@ export type CompoundingRiskResult = {
 export type CompoundingRiskScope =
   | 'REPO'
   | 'TEAM';
+
+export type CompoundingRiskScopeEntity = {
+  __typename?: 'CompoundingRiskScopeEntity';
+  displayName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+};
 
 export type CompoundingRiskSeverity =
   | 'ELEVATED'

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -505,6 +505,7 @@ type CompoundingRiskPoint {
   weights: CompoundingRiskWeights!
   thresholds: CompoundingRiskThresholds!
   computedAt: DateTime!
+  scopeEntity: CompoundingRiskScopeEntity!
 }
 
 type CompoundingRiskResult {
@@ -518,6 +519,11 @@ type CompoundingRiskResult {
 enum CompoundingRiskScope {
   REPO
   TEAM
+}
+
+type CompoundingRiskScopeEntity {
+  id: String!
+  displayName: String!
 }
 
 enum CompoundingRiskSeverity {


### PR DESCRIPTION
## Summary
ops #803 added `scopeEntity: CompoundingRiskScopeEntity!` (with `displayName`) to the `compoundingRisk` GraphQL type, but web's committed `src/lib/graphql/schema.graphql` was never regenerated. This left **web main drifted from ops main**, so the `live-e2e` "GraphQL schema drift" check fails on every open web PR regardless of its content (observed on #575/#576/#577).

## Fix
Regenerated `schema.graphql` from the ops export (`export_schema.py`) and ran `pnpm codegen`. Verified the drift check passes (`diff schema.graphql <fresh export>` is clean).

- `src/lib/graphql/schema.graphql`: +`scopeEntity` + `CompoundingRiskScopeEntity { displayName }`
- `src/lib/graphql/__generated__/types.ts`: regenerated to match

Merging this first unblocks the Wave 1 PRs (they go green on rebase).

TEST-WAIVER: codegen/schema-sync only — generated artifacts, no behavior change.