### PR TITLE
test(operating-review): drop stale lowercase AI kicker assertion (CHAOS-2071)

### DIFF
--- a/tests/operating-review.spec.ts
+++ b/tests/operating-review.spec.ts
@@ -33,7 +33,6 @@ test.describe("Operating Review", () => {
     await expect(
       aiSection.getByRole("heading", { name: "AI Workflow Intelligence" }),
     ).toBeVisible();
-    await expect(aiSection).toContainText("AI workflow intelligence");
     await expect(aiSection).toContainText(/operating patterns, not individual performance/i);
     await expect(aiSection).toContainText("AI-assisted PR ratio");
     await expect(aiSection).toContainText("Review amplification");


### PR DESCRIPTION
## Summary

`tests/operating-review.spec.ts:36` asserted `toContainText("AI workflow intelligence")` (lowercase). PR #582 ("Remove section titles") deleted that lowercase kicker from `src/app/(app)/operating-review/page.tsx`, leaving only the title-case `<h1>` heading **"AI Workflow Intelligence"**. The stale assertion fails on `origin/main`, which **fails the full E2E suite for every web PR**.

This removes the redundant assertion. The branded AI Workflow Intelligence section is still fully verified by:
- the heading `AI Workflow Intelligence` (line 34)
- the `operating patterns, not individual performance` copy (line 37)
- the three metric rows: AI-assisted PR ratio / Review amplification / AI test gap rate (38-40)
- the four follow-up links: Impact → `/ai`, Review Load → `/ai/review-load`, Risk → `/ai/risk`, Automations → `/ai/automations` (41-50)

## Verification

`pnpm exec playwright test tests/operating-review.spec.ts` → **5 passed (8.6s)** locally.

SCREENSHOT-WAIVER: test-only change, no `src/` or rendered-UI changes.

Closes CHAOS-2071