### PR TITLE
fix(operating-review): remove scaffolding eyebrow/kicker labels (CHAOS-2068)

### DIFF
--- a/src/app/(app)/operating-review/page.tsx
+++ b/src/app/(app)/operating-review/page.tsx
@@ -188,10 +188,7 @@ function OperatingReviewAgenda({ review }: { review: OperatingReview }) {
             href={`#${section.key}`}
             className={`rounded-2xl border bg-card p-4 transition hover:border-primary/50 ${section.key === AI_WORKFLOW_SECTION_KEY ? "border-sky-400/40 shadow-sm shadow-sky-500/10" : "border-border"}`}
           >
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-              {section.key === AI_WORKFLOW_SECTION_KEY ? "AI section" : "Section"}
-            </p>
-            <h2 className="mt-2 text-base font-semibold">{section.title}</h2>
+            <h2 className="text-base font-semibold">{section.title}</h2>
             <p className="mt-2 text-xs text-muted-foreground">
               {section.improved.length} improved · {section.worsened.length} worsened ·{" "}
               {section.changed.length} changed
@@ -237,10 +234,7 @@ function OperatingReviewAgenda({ review }: { review: OperatingReview }) {
       ))}
 
       <section className="rounded-[1.75rem] border border-border bg-card/90 p-6 shadow-sm">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-          Rule engine
-        </p>
-        <h2 className="mt-2 text-2xl font-semibold tracking-tight">Recommendations</h2>
+        <h2 className="text-2xl font-semibold tracking-tight">Recommendations</h2>
         {review.recommendations.length ? (
           <ul className="mt-4 space-y-3">
             {review.recommendations.map((recommendation) => (

--- a/tests/operating-review.spec.ts
+++ b/tests/operating-review.spec.ts
@@ -33,6 +33,8 @@ test.describe("Operating Review", () => {
     await expect(
       aiSection.getByRole("heading", { name: "AI Workflow Intelligence" }),
     ).toBeVisible();
+    await expect(aiSection).not.toContainText(/\bAI section\b/i);
+    await expect(aiSection).not.toContainText(/\bSection\b/);
     await expect(aiSection).toContainText(/operating patterns, not individual performance/i);
     await expect(aiSection).toContainText("AI-assisted PR ratio");
     await expect(aiSection).toContainText("Review amplification");
@@ -47,6 +49,11 @@ test.describe("Operating Review", () => {
       "href",
       "/ai/automations",
     );
+
+    const recommendationsBlock = page
+      .getByRole("heading", { name: "Recommendations" })
+      .locator("..");
+    await expect(recommendationsBlock).not.toContainText(/\bRule engine\b/i);
   });
 
   test("pinned team in URL switches off the All Teams aggregate", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Removed the Operating Review agenda-card eyebrow labels `Section` and `AI section` because A8 bans page-scaffolding kicker nouns.
- Removed the Recommendations eyebrow label `Rule engine` because A8 explicitly bans that copy.
- Kept `Weekly mode` because it provides cadence/mode context and does not repeat the adjacent `Engineering Operating Review` title.

## Tests
- Updated `tests/operating-review.spec.ts` to assert the AI Workflow Intelligence section no longer contains `AI section`/`Section` and the Recommendations block no longer contains `Rule engine`.
- Visual-regression assertion added: kicker-removal test

Closes CHAOS-2068