### PR TITLE
fix(nav): single sidebar selected-state + consistent page identity (CHAOS-2057)

### DIFF
--- a/src/app/(app)/bottleneck/page.tsx
+++ b/src/app/(app)/bottleneck/page.tsx
@@ -1,5 +1,5 @@
 /**
- * /bottleneck — Delivery Bottleneck Summary (CHAOS-1742).
+ * /bottleneck — Bottlenecks.
  *
  * RSC entry. Pre-fetches WIP saturation + review latency data and renders
  * KPI tiles, WIP × Throughput quadrant, Review Load × Latency quadrant,
@@ -25,6 +25,7 @@ import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
 import { FALLBACK_DELTAS } from "@/lib/metrics/catalog";
 import { fetchOrNull } from "@/lib/fetchOrNull";
+import { CTA_LABELS } from "@/lib/design/cta";
 
 type BottleneckPageProps = {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -120,7 +121,7 @@ export default async function BottleneckPage({ searchParams }: BottleneckPagePro
           <header className="flex flex-wrap items-center justify-between gap-4">
             <div>
               <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Bottlenecks</p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">Delivery Bottleneck Summary</h1>
+              <h1 className="mt-2 font-(--font-display) text-3xl">Bottlenecks</h1>
               <p className="mt-2 text-sm text-(--ink-muted)">
                 WIP saturation, review latency, and blocked work in one view.
               </p>
@@ -132,7 +133,7 @@ export default async function BottleneckPage({ searchParams }: BottleneckPagePro
               href={withFilterParam("/", filters, activeRole)}
               className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
             >
-              Back to cockpit
+              {CTA_LABELS.backToCockpit}
             </Link>
           </header>
 

--- a/src/app/(app)/testops/risk/page.tsx
+++ b/src/app/(app)/testops/risk/page.tsx
@@ -13,6 +13,7 @@ import { withFilterParam } from "@/lib/filters/url";
 import { fetchRiskMetrics } from "@/lib/testops/fetchers";
 import { getServerEnv } from "@/lib/config";
 import { chartEntityLabel } from "@/lib/labels/entityLabel";
+import { CTA_LABELS } from "@/lib/design/cta";
 
 type RiskPageProps = {
 	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -151,7 +152,7 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
 								TestOps
 							</p>
 							<h1 className="mt-2 font-(--font-display) text-3xl">
-								Risk & Quality Drag
+								Delivery Risk
 							</h1>
 							<p className="mt-2 text-sm text-(--ink-muted)">
 								Deployment confidence and risk assessment.
@@ -161,7 +162,7 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
 							href={withFilterParam("/", filters, activeRole)}
 							className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
 						>
-							Back to cockpit
+							{CTA_LABELS.backToCockpit}
 						</Link>
 					</header>
 

--- a/src/components/navigation/PrimaryNav.test.tsx
+++ b/src/components/navigation/PrimaryNav.test.tsx
@@ -1,12 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/react";
 import { render } from "@/test/utils";
 import { PrimaryNav } from "./PrimaryNav";
 import type { MetricFilter } from "@/lib/filters/types";
 
 // Stub usePathname so PrimaryNav (a client component) renders deterministically
+const navigationMock = vi.hoisted(() => ({ pathname: "/dashboard" }));
+
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/dashboard",
+  usePathname: () => navigationMock.pathname,
   useRouter: () => ({ refresh: vi.fn() }),
 }));
 
@@ -31,6 +33,16 @@ function makeFilter(): MetricFilter {
     why: {},
     how: {},
   };
+}
+
+beforeEach(() => {
+  navigationMock.pathname = "/dashboard";
+});
+
+function currentPageLinks() {
+  return screen
+    .getAllByRole("link")
+    .filter((link) => link.getAttribute("aria-current") === "page");
 }
 
 describe("PrimaryNav — section composition", () => {
@@ -119,6 +131,7 @@ it("renders the 'Complexity' nav item under Diagnose (CHAOS-1745)", () => {
 });
 
 it("renders and highlights the 'Quality' nav item for /quality (CHAOS-1763)", () => {
+  navigationMock.pathname = "/quality";
   render(<PrimaryNav filters={makeFilter()} active="quality" />);
 
   const qualityLinks = screen.getAllByRole("link", {
@@ -128,22 +141,50 @@ it("renders and highlights the 'Quality' nav item for /quality (CHAOS-1763)", ()
   expect(qualityLinks).toHaveLength(1);
   expect(qualityLinks[0]).toHaveAttribute("href", expect.stringContaining("/quality"));
   expect(qualityLinks[0]).toHaveAttribute("aria-current", "page");
+  expect(currentPageLinks()).toHaveLength(1);
 });
 
 it.each([
-  { active: "home", label: /^Home$/i, href: "/dashboard" },
-  { active: "work", label: /^Work$/i, href: "/work" },
-  { active: "ai-workflows", label: /^AI Workflows$/i, href: "/ai" },
-  { active: "testops", label: /^TestOps$/i, href: "/testops" },
-  { active: "reports", label: /^Report Center$/i, href: "/reports" },
-  { active: "admin", label: /^Settings$/i, href: "/admin" },
+  { pathname: "/dashboard", active: "home", label: /^Home$/i, href: "/dashboard" },
+  { pathname: "/work", active: "work", label: /^Work$/i, href: "/work" },
+  { pathname: "/metrics", active: "metrics", label: /^Metrics$/i, href: "/metrics" },
+  { pathname: "/ai/impact", active: "ai-workflows", label: /^AI Workflows$/i, href: "/ai" },
+  { pathname: "/testops", active: "testops", label: /^TestOps$/i, href: "/testops" },
+  { pathname: "/reports", active: "reports", label: /^Report Center$/i, href: "/reports" },
+  { pathname: "/admin", active: "admin", label: /^Settings$/i, href: "/admin" },
 ])(
-  "highlights $active as the active nav item for representative routes",
-  ({ active, label, href }) => {
+  "highlights $active from $pathname as the active nav item for representative routes",
+  ({ pathname, active, label, href }) => {
+    navigationMock.pathname = pathname;
     render(<PrimaryNav filters={makeFilter()} active={active} />);
 
     const link = screen.getByRole("link", { name: label });
     expect(link).toHaveAttribute("href", expect.stringContaining(href));
     expect(link).toHaveAttribute("aria-current", "page");
+    expect(currentPageLinks()).toHaveLength(1);
   },
 );
+
+it("uses the longest pathname match and ignores a stale active prop", () => {
+  navigationMock.pathname = "/testops/risk";
+  render(<PrimaryNav filters={makeFilter()} active="coverage" />);
+
+  const deliveryRisk = screen.getByRole("link", { name: /^Delivery Risk$/i });
+  const testOps = screen.getByRole("link", { name: /^TestOps$/i });
+  const coverage = screen.getByRole("link", { name: /^Coverage$/i });
+
+  expect(deliveryRisk).toHaveAttribute("aria-current", "page");
+  expect(testOps).not.toHaveAttribute("aria-current");
+  expect(coverage).not.toHaveAttribute("aria-current");
+  expect(currentPageLinks()).toHaveLength(1);
+});
+
+it("falls back to the active prop only when no nav href matches the pathname", () => {
+  navigationMock.pathname = "/prs/123";
+  render(<PrimaryNav filters={makeFilter()} active="people" />);
+
+  const people = screen.getByRole("link", { name: /^People$/i });
+
+  expect(people).toHaveAttribute("aria-current", "page");
+  expect(currentPageLinks()).toHaveLength(1);
+});

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -61,6 +61,55 @@ function groupContainsPath(group: NavGroup, pathname: string): boolean {
   });
 }
 
+function splitHref(href: string): { path: string; hash: string } {
+  const [withoutHash, hash = ""] = href.split("#", 2);
+  return {
+    path: withoutHash.split("?")[0] || "/",
+    hash: hash ? `#${hash}` : "",
+  };
+}
+
+function pathnameMatchesItem(pathname: string, itemPath: string): boolean {
+  return pathname === itemPath || pathname.startsWith(itemPath + "/");
+}
+
+function selectedItemIdForPathname(
+  groups: NavGroup[],
+  pathname: string,
+  hash: string,
+  fallbackActive?: string,
+): string | undefined {
+  let selectedItemId: string | undefined;
+  let selectedScore = -1;
+  let fallbackItemId: string | undefined;
+
+  for (const group of groups) {
+    for (const item of group.items) {
+      const { path: itemPath, hash: itemHash } = splitHref(item.href);
+
+      if (fallbackActive === item.id) fallbackItemId = item.id;
+
+      if (itemHash) {
+        if (pathname === itemPath && hash === itemHash) {
+          const score = itemPath.length + itemHash.length;
+          if (score > selectedScore) {
+            selectedItemId = item.id;
+            selectedScore = score;
+          }
+        }
+        continue;
+      }
+
+      if (pathnameMatchesItem(pathname, itemPath) && itemPath.length > selectedScore) {
+        selectedItemId = item.id;
+        selectedScore = itemPath.length;
+      }
+    }
+  }
+
+  return selectedItemId ?? fallbackItemId;
+}
+
 // ── Navigation data ──────────────────────────────────────────────────────────
 
 const navGroups: NavGroup[] = [
@@ -210,6 +259,7 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
 
   const mainGroups = navGroups.filter((g) => g.placement === "main");
   const utilityGroups = navGroups.filter((g) => g.placement === "utility");
+  const selectedItemId = selectedItemIdForPathname(navGroups, pathname, hash, active);
 
   const renderGroup = (group: NavGroup) => {
     const groupIsCollapsed = isGroupCollapsed(group);
@@ -244,21 +294,18 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
           }`}
         >
           {group.items.map((item) => {
-            const [itemPath, itemHash] = item.href.split("#", 2);
-            const hashMatchesItem =
-              Boolean(itemHash) && pathname === itemPath && hash === `#${itemHash}`;
-            const pageMatchesItem = active === item.id && !(hash && pathname === itemPath);
-            const isActive = hashMatchesItem || pageMatchesItem;
+            const [, itemHash] = item.href.split("#", 2);
+            const isActive = selectedItemId === item.id;
             return (
               <Link
                 key={item.id}
                 href={withFilterParam(item.href, filters, role)}
                 onClick={itemHash ? () => setHash(`#${itemHash}`) : undefined}
                 aria-current={isActive ? "page" : undefined}
-                className={`group relative flex flex-col gap-0.5 rounded-2xl border px-3 py-2 transition ${
+                className={`group relative flex flex-col gap-0.5 rounded-2xl border px-3 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35 ${
                   isActive
                     ? "border-(--accent) bg-(--accent)/15 text-foreground before:absolute before:left-0 before:top-1/4 before:h-1/2 before:w-[3px] before:rounded-full before:bg-(--accent)"
-                    : "border-transparent bg-(--card-70) text-(--ink-muted) hover:border-(--card-stroke) hover:text-foreground"
+                    : "border-transparent bg-(--card-70) text-(--ink-muted) hover:border-(--card-stroke) hover:bg-(--card-80) hover:text-foreground focus-visible:border-(--card-stroke) focus-visible:bg-(--card-80) focus-visible:text-foreground"
                 }`}
               >
                 <span className="font-medium">{item.label}</span>
@@ -280,7 +327,7 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
   };
 
   return (
-    <aside className="w-full md:max-w-[220px] md:shrink-0">
+    <aside className="w-full md:max-w-56 md:shrink-0">
       <div className="md:sticky md:top-6">
         <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-4">
           <div>

--- a/tests/nav-reachability.spec.ts
+++ b/tests/nav-reachability.spec.ts
@@ -96,6 +96,21 @@ async function expandSection(page: Page, section: string) {
 	await page.getByRole("button", { name: section }).click();
 }
 
+async function expectSingleSelectedNavItem(
+	page: Page,
+	path: string,
+	selectedLabel: string,
+) {
+	await page.goto(path);
+	await page.evaluate(() => localStorage.removeItem("devhealth-nav-collapsed"));
+	await page.goto(path);
+	await waitForHydration(page);
+
+	const selectedLinks = page.locator('aside a[aria-current="page"]');
+	await expect(selectedLinks).toHaveCount(1);
+	await expect(selectedLinks).toHaveText(selectedLabel);
+}
+
 test.describe("primary navigation reachability", () => {
 	test("exposes every primary section and reaches representative nav destinations", async ({
 		page,
@@ -156,6 +171,20 @@ test.describe("primary navigation reachability", () => {
 	}) => {
 		for (const destination of previouslyReachableDestinations) {
 			await expectReachable(request, destination);
+		}
+	});
+
+	test("marks exactly one primary nav item as selected for representative routes", async ({
+		page,
+	}) => {
+		for (const route of [
+			{ path: "/metrics?tab=dora", selectedLabel: "Metrics" },
+			{ path: "/testops/coverage", selectedLabel: "Coverage" },
+			{ path: "/testops/risk", selectedLabel: "Delivery Risk" },
+			{ path: "/bottleneck", selectedLabel: "Bottlenecks" },
+			{ path: "/risk/compounding", selectedLabel: "Compounding Risk" },
+		]) {
+			await expectSingleSelectedNavItem(page, route.path, route.selectedLabel);
 		}
 	});
 });

--- a/tests/nav-reachability.spec.ts
+++ b/tests/nav-reachability.spec.ts
@@ -102,12 +102,12 @@ async function expectSingleSelectedNavItem(
 	selectedLabel: string,
 ) {
 	await page.goto(path);
-	await page.evaluate(() => localStorage.removeItem("devhealth-nav-collapsed"));
-	await page.goto(path);
-	await waitForHydration(page);
 
+	// aria-current is rendered from usePathname() (server + hydration) and does not
+	// depend on the slower ?f= filter-param append, so wait for the selected link
+	// directly to stay robust under CI load.
 	const selectedLinks = page.locator('aside a[aria-current="page"]');
-	await expect(selectedLinks).toHaveCount(1);
+	await expect(selectedLinks).toHaveCount(1, { timeout: 15000 });
 	await expect(selectedLinks).toHaveText(selectedLabel);
 }
 


### PR DESCRIPTION
## Summary
- Derive PrimaryNav selected state from the current pathname using longest matching nav href, with active prop as fallback only.
- Keep hover/focus styling visually distinct from selected state.
- Normalize Delivery Risk and Bottlenecks page identity to match sidebar labels.

## Tests
- Updated PrimaryNav unit tests for pathname-derived exactly-one-selected behavior.
- Added Playwright coverage for exactly one aria-current nav item on representative routes.

Visual-regression assertion added: exactly-one-selected nav test

Closes CHAOS-2057