### PR TITLE
fix(web): remove internal leaks + fix malformed values (CHAOS-2060, CHAOS-2062)

### DIFF
--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -12,433 +12,602 @@ import { getDrilldown } from "@/lib/api/investment";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { fetchOrNull } from "@/lib/fetchOrNull";
 import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
-import { formatDelta, formatMetricValue } from "@/lib/formatters";
+import {
+	formatDelta,
+	formatMetricValue,
+	formatNumber,
+	formatTimestamp,
+} from "@/lib/formatters";
+import { CTA_LABELS } from "@/lib/design/cta";
 import { getMetricLabel } from "@/lib/metrics/catalog";
 
 const getItemTitle = (item: Record<string, unknown>, index: number) => {
-  const title =
-    item.title ?? item.name ?? item.work_item_id ?? item.number ?? item.id ?? `Item ${index + 1}`;
-  return String(title);
+	const title =
+		item.title ??
+		item.name ??
+		(typeof item.number === "number" ? `PR #${item.number}` : null) ??
+		`Item ${index + 1}`;
+	return String(title);
 };
 
+type EvidenceField = {
+	key: string;
+	label: string;
+	format?: (value: unknown) => string | null;
+};
+
+const formatDateField = (value: unknown) =>
+	typeof value === "string" && value.length ? formatTimestamp(value) : null;
+
+const formatNumberField = (value: unknown) =>
+	typeof value === "number" ? formatNumber(value) : null;
+
+const EVIDENCE_FIELDS: EvidenceField[] = [
+	{
+		key: "number",
+		label: "Pull request",
+		format: (value) =>
+			typeof value === "number" ? `#${formatNumber(value)}` : null,
+	},
+	{ key: "state", label: "State" },
+	{ key: "status", label: "Status" },
+	{ key: "author_login", label: "Author" },
+	{ key: "author", label: "Author" },
+	{ key: "repo_name", label: "Repository" },
+	{ key: "repository", label: "Repository" },
+	{ key: "team", label: "Team" },
+	{ key: "assignee", label: "Assignee" },
+	{ key: "priority", label: "Priority" },
+	{ key: "type", label: "Type" },
+	{ key: "created_at", label: "Created", format: formatDateField },
+	{ key: "updated_at", label: "Updated", format: formatDateField },
+	{ key: "merged_at", label: "Merged", format: formatDateField },
+	{ key: "closed_at", label: "Closed", format: formatDateField },
+	{ key: "additions", label: "Additions", format: formatNumberField },
+	{ key: "deletions", label: "Deletions", format: formatNumberField },
+	{ key: "changed_files", label: "Changed files", format: formatNumberField },
+];
+
+const getEvidenceDetails = (item: Record<string, unknown>) =>
+	EVIDENCE_FIELDS.flatMap(({ key, label, format }) => {
+		const value = item[key];
+		if (value === undefined || value === null || value === "") {
+			return [];
+		}
+		const formatted = format
+			? format(value)
+			: Array.isArray(value)
+				? value.filter(Boolean).join(", ")
+				: typeof value === "boolean"
+					? value
+						? "Yes"
+						: "No"
+					: String(value);
+		return formatted ? [{ label, value: formatted }] : [];
+	}).slice(0, 6);
+
 const getItemHref = (item: Record<string, unknown>, fallback: string) => {
-  const candidates = [item.url, item.link, item.html_url, item.web_url, item.api_url];
-  for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate.length) {
-      return candidate;
-    }
-  }
-  return fallback;
+	const candidates = [
+		item.url,
+		item.link,
+		item.html_url,
+		item.web_url,
+		item.api_url,
+	];
+	for (const candidate of candidates) {
+		if (typeof candidate === "string" && candidate.length) {
+			return candidate;
+		}
+	}
+	return fallback;
 };
 
 type ExplorePageProps = {
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 export default async function Explore({ searchParams }: ExplorePageProps) {
-  const params = (await searchParams) ?? {};
-  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
-  const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
-  const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+	const params = (await searchParams) ?? {};
+	const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+	const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+	const activeRole = typeof roleParam === "string" ? roleParam : undefined;
 
-  const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+	const filters = encodedFilter
+		? decodeFilter(encodedFilter)
+		: filterFromQueryParams(params);
 
-  const metric = (params.metric as string) ?? "cycle_time";
-  const apiParam = (Array.isArray(params.api) ? params.api[0] : params.api) ?? "";
-  const apiUrl = apiParam
-    ? new URL(apiParam, "http://localhost")
-    : new URL("/api/v1/explain", "http://localhost");
-  const endpoint = apiUrl.pathname || "/api/v1/explain";
-  const metricFromApi = apiUrl.searchParams.get("metric") ?? metric;
-  const sourceLabel = apiParam || `/api/v1/explain?metric=${metricFromApi}`;
+	const metric = (params.metric as string) ?? "cycle_time";
+	const apiParam =
+		(Array.isArray(params.api) ? params.api[0] : params.api) ?? "";
+	const apiUrl = apiParam
+		? new URL(apiParam, "http://localhost")
+		: new URL("/api/v1/explain", "http://localhost");
+	const endpoint = apiUrl.pathname || "/api/v1/explain";
+	const metricFromApi = apiUrl.searchParams.get("metric") ?? metric;
 
-  // Build the view-specific data promise so it runs in parallel with the health check.
-  type ExplainResult = Awaited<ReturnType<typeof getExplainData>> | null;
-  type DrilldownResult = Awaited<ReturnType<typeof getDrilldown>> | null;
-  type HomeResult = Awaited<ReturnType<typeof getHomeData>> | null;
+	// Build the view-specific data promise so it runs in parallel with the health check.
+	type ExplainResult = Awaited<ReturnType<typeof getExplainData>> | null;
+	type DrilldownResult = Awaited<ReturnType<typeof getDrilldown>> | null;
+	type HomeResult = Awaited<ReturnType<typeof getHomeData>> | null;
 
-  let view: "explain" | "drilldown" | "home" | "unknown" = "explain";
-  let dataPromise: Promise<ExplainResult | DrilldownResult | HomeResult | null>;
+	let view: "explain" | "drilldown" | "home" | "unknown" = "explain";
+	let dataPromise: Promise<ExplainResult | DrilldownResult | HomeResult | null>;
 
-  if (endpoint === "/api/v1/drilldown/prs" || endpoint === "/api/v1/drilldown/issues") {
-    view = "drilldown";
-    dataPromise = fetchOrNull(
-      getDrilldown(endpoint as "/api/v1/drilldown/prs" | "/api/v1/drilldown/issues", filters),
-      `explore/drilldown-${endpoint}`,
-    );
-  } else if (endpoint === "/api/v1/home") {
-    view = "home";
-    dataPromise = fetchOrNull(getHomeData(filters), "explore/home-data");
-  } else if (endpoint === "/api/v1/explain") {
-    view = "explain";
-    dataPromise = fetchOrNull(
-      getExplainData({ metric: metricFromApi, filters }),
-      `explore/explain-${metricFromApi}`,
-    );
-  } else {
-    view = "unknown";
-    dataPromise = Promise.resolve(null);
-  }
+	if (
+		endpoint === "/api/v1/drilldown/prs" ||
+		endpoint === "/api/v1/drilldown/issues"
+	) {
+		view = "drilldown";
+		dataPromise = fetchOrNull(
+			getDrilldown(
+				endpoint as "/api/v1/drilldown/prs" | "/api/v1/drilldown/issues",
+				filters,
+			),
+			`explore/drilldown-${endpoint}`,
+		);
+	} else if (endpoint === "/api/v1/home") {
+		view = "home";
+		dataPromise = fetchOrNull(getHomeData(filters), "explore/home-data");
+	} else if (endpoint === "/api/v1/explain") {
+		view = "explain";
+		dataPromise = fetchOrNull(
+			getExplainData({ metric: metricFromApi, filters }),
+			`explore/explain-${metricFromApi}`,
+		);
+	} else {
+		view = "unknown";
+		dataPromise = Promise.resolve(null);
+	}
 
-  // Run health check and data fetch in parallel.
-  const [health, rawResult] = await Promise.all([checkApiHealth(), dataPromise]);
+	// Run health check and data fetch in parallel.
+	const [health, rawResult] = await Promise.all([
+		checkApiHealth(),
+		dataPromise,
+	]);
 
-  if (!health.ok) {
-    return <ServiceUnavailable />;
-  }
+	if (!health.ok) {
+		return <ServiceUnavailable />;
+	}
 
-  const data = view === "explain" ? (rawResult as ExplainResult) : null;
-  const drilldown = view === "drilldown" ? (rawResult as DrilldownResult) : null;
-  const home = view === "home" ? (rawResult as HomeResult) : null;
+	const data = view === "explain" ? (rawResult as ExplainResult) : null;
+	const drilldown =
+		view === "drilldown" ? (rawResult as DrilldownResult) : null;
+	const home = view === "home" ? (rawResult as HomeResult) : null;
 
-  const metricLabel = data?.label ?? getMetricLabel(metricFromApi);
-  const scopeDetail = filters.scope.ids.length
-    ? filters.scope.ids.join(", ")
-    : `all ${filters.scope.level}s`;
-  const categoryParam = Array.isArray(params.category) ? params.category[0] : params.category;
-  const streamParam = Array.isArray(params.stream) ? params.stream[0] : params.stream;
-  const breakdownParam = Array.isArray(params.breakdown) ? params.breakdown[0] : params.breakdown;
+	const metricLabel = data?.label ?? getMetricLabel(metricFromApi);
+	const sourceLabel =
+		view === "drilldown"
+			? "Evidence drilldown"
+			: view === "home"
+				? "Cockpit summary"
+				: "Metric explanation";
+	const scopeDetail = filters.scope.ids.length
+		? filters.scope.ids.join(", ")
+		: `all ${filters.scope.level}s`;
+	const categoryParam = Array.isArray(params.category)
+		? params.category[0]
+		: params.category;
+	const streamParam = Array.isArray(params.stream)
+		? params.stream[0]
+		: params.stream;
+	const breakdownParam = Array.isArray(params.breakdown)
+		? params.breakdown[0]
+		: params.breakdown;
 
-  const developers = filters.who.developers ?? [];
-  const roles = filters.who.roles ?? [];
-  const repos = filters.what.repos ?? [];
-  const artifacts = filters.what.artifacts ?? [];
-  const workCategory = filters.why.work_category ?? [];
-  const issueType = filters.why.issue_type ?? [];
-  const flowStage = filters.how.flow_stage ?? [];
+	const developers = filters.who.developers ?? [];
+	const roles = filters.who.roles ?? [];
+	const repos = filters.what.repos ?? [];
+	const artifacts = filters.what.artifacts ?? [];
+	const workCategory = filters.why.work_category ?? [];
+	const issueType = filters.why.issue_type ?? [];
+	const flowStage = filters.how.flow_stage ?? [];
 
-  const chips = [
-    `Scope: ${filters.scope.level}`,
-    filters.scope.ids.length ? `IDs: ${filters.scope.ids.join(", ")}` : "All IDs",
-    `Range: ${filters.time.range_days}d`,
-    `Compare: ${filters.time.compare_days}d`,
-    developers.length ? `Devs: ${developers.join(", ")}` : null,
-    roles.length ? `Roles: ${roles.join(", ")}` : null,
-    repos.length ? `Repos: ${repos.join(", ")}` : null,
-    artifacts.length ? `Artifacts: ${artifacts.join(", ")}` : null,
-    workCategory.length ? `Work type: ${workCategory.join(", ")}` : null,
-    issueType.length ? `Issue type: ${issueType.join(", ")}` : null,
-    categoryParam ? `Category: ${categoryParam}` : null,
-    streamParam ? `Stream: ${streamParam}` : null,
-    breakdownParam ? `Breakdown: ${breakdownParam}` : null,
-    flowStage.length ? `Flow: ${flowStage.join(", ")}` : null,
-    filters.how.blocked ? "Blocked only" : null,
-  ].filter(Boolean) as string[];
+	const chips = [
+		`Scope: ${filters.scope.level}`,
+		filters.scope.ids.length
+			? `IDs: ${filters.scope.ids.join(", ")}`
+			: "All IDs",
+		`Range: ${filters.time.range_days}d`,
+		`Compare: ${filters.time.compare_days}d`,
+		developers.length ? `Devs: ${developers.join(", ")}` : null,
+		roles.length ? `Roles: ${roles.join(", ")}` : null,
+		repos.length ? `Repos: ${repos.join(", ")}` : null,
+		artifacts.length ? `Artifacts: ${artifacts.join(", ")}` : null,
+		workCategory.length ? `Work type: ${workCategory.join(", ")}` : null,
+		issueType.length ? `Issue type: ${issueType.join(", ")}` : null,
+		categoryParam ? `Category: ${categoryParam}` : null,
+		streamParam ? `Stream: ${streamParam}` : null,
+		breakdownParam ? `Breakdown: ${breakdownParam}` : null,
+		flowStage.length ? `Flow: ${flowStage.join(", ")}` : null,
+		filters.how.blocked ? "Blocked only" : null,
+	].filter(Boolean) as string[];
 
-  const drivers = (data?.drivers ?? []).slice(0, 5);
-  const contributors = (data?.contributors ?? []).slice(0, 5);
-  const explanation =
-    view === "drilldown"
-      ? `Evidence table for ${metricLabel} in ${scopeDetail}.`
-      : view === "home"
-        ? "Snapshot of the cockpit payload for this scope."
-        : `This view explains ${metricLabel} for ${scopeDetail} over the last ${filters.time.range_days} days.`;
-  const breakdownNote = breakdownParam ? `Breakdown: ${breakdownParam}.` : null;
+	const drivers = (data?.drivers ?? []).slice(0, 5);
+	const contributors = (data?.contributors ?? []).slice(0, 5);
+	const explanation =
+		view === "drilldown"
+			? `Evidence table for ${metricLabel} in ${scopeDetail}.`
+			: view === "home"
+				? "Snapshot of the cockpit payload for this scope."
+				: `This view explains ${metricLabel} for ${scopeDetail} over the last ${filters.time.range_days} days.`;
+	const breakdownNote = breakdownParam ? `Breakdown: ${breakdownParam}.` : null;
 
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-        <PrimaryNav filters={filters} role={activeRole} />
-        <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Explore</p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">{metricLabel}</h1>
-              <p className="mt-2 text-sm text-(--ink-muted)">
-                Evidence detail for the selected metric.
-              </p>
-              <p className="mt-2 text-sm text-(--ink-muted)">Select evidence to investigate.</p>
-            </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <Link
-                href={withFilterParam("/flame?mode=cycle_breakdown", filters, activeRole)}
-                className={buttonClassName("primary")}
-              >
-                Flame Diagram
-              </Link>
-              <Link
-                href={withFilterParam("/explore/landscape", filters, activeRole)}
-                className={buttonClassName("secondary")}
-              >
-                Landscape
-              </Link>
-              <BackLink href={withFilterParam("/metrics", filters, activeRole)} area="Metrics" />
-              <BackLink href={withFilterParam("/", filters, activeRole)} />
-            </div>
-          </header>
+	return (
+		<div className="min-h-screen bg-background text-foreground">
+			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+				<PrimaryNav filters={filters} role={activeRole} />
+				<main className="flex min-w-0 flex-1 flex-col gap-8">
+					<header className="flex flex-wrap items-start justify-between gap-4">
+						<div>
+							<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+								Explore
+							</p>
+							<h1 className="mt-2 font-(--font-display) text-3xl">
+								{metricLabel}
+							</h1>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								Evidence detail for the selected metric.
+							</p>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								Select evidence to investigate.
+							</p>
+						</div>
+						<div className="flex flex-wrap items-center gap-3">
+							<Link
+								href={withFilterParam(
+									"/flame?mode=cycle_breakdown",
+									filters,
+									activeRole,
+								)}
+								className={buttonClassName("primary")}
+							>
+								Flame Diagram
+							</Link>
+							<Link
+								href={withFilterParam(
+									"/explore/landscape",
+									filters,
+									activeRole,
+								)}
+								className={buttonClassName("secondary")}
+							>
+								Landscape
+							</Link>
+							<BackLink
+								href={withFilterParam("/metrics", filters, activeRole)}
+								area="Metrics"
+							/>
+							<BackLink href={withFilterParam("/", filters, activeRole)} />
+						</div>
+					</header>
 
-          <FilterBar condensed view="explore" />
+					<FilterBar condensed view="explore" />
 
-          <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 text-sm">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Context</p>
-                <p className="mt-1 text-sm font-semibold">{metricLabel}</p>
-              </div>
-              <span className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                {view.toUpperCase()}
-              </span>
-            </div>
-            <div className="mt-4 grid gap-4 lg:grid-cols-[1.3fr_0.7fr]">
-              <div>
-                <p className="text-sm text-(--ink-muted)">{explanation}</p>
-                <p className="mt-2 text-xs text-(--ink-muted)">Source: {sourceLabel}</p>
-                {breakdownNote ? (
-                  <p className="mt-2 text-xs text-(--ink-muted)">{breakdownNote}</p>
-                ) : null}
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                  Active filters
-                </p>
-                <div className="mt-2 flex flex-wrap gap-2 text-xs">
-                  {chips.map((chip) => (
-                    <span
-                      key={chip}
-                      className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
-                    >
-                      {chip}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </section>
+					<section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 text-sm">
+						<div className="flex flex-wrap items-center justify-between gap-3">
+							<div>
+								<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+									Context
+								</p>
+								<p className="mt-1 text-sm font-semibold">{metricLabel}</p>
+							</div>
+							<span className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+								{view.toUpperCase()}
+							</span>
+						</div>
+						<div className="mt-4 grid gap-4 lg:grid-cols-[1.3fr_0.7fr]">
+							<div>
+								<p className="text-sm text-(--ink-muted)">{explanation}</p>
+								<p className="mt-2 text-xs text-(--ink-muted)">
+									Source: {sourceLabel}
+								</p>
+								{breakdownNote ? (
+									<p className="mt-2 text-xs text-(--ink-muted)">
+										{breakdownNote}
+									</p>
+								) : null}
+							</div>
+							<div>
+								<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+									Active filters
+								</p>
+								<div className="mt-2 flex flex-wrap gap-2 text-xs">
+									{chips.map((chip) => (
+										<span
+											key={chip}
+											className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
+										>
+											{chip}
+										</span>
+									))}
+								</div>
+							</div>
+						</div>
+					</section>
 
-          <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
-            <details>
-              <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                Debug filters
-              </summary>
-              <pre className="mt-3 max-h-64 overflow-auto rounded-2xl border border-(--card-stroke) bg-(--card-60) px-4 py-3 text-xs text-(--ink-muted)">
-                {JSON.stringify(filters, null, 2)}
-              </pre>
-            </details>
-          </section>
+					<section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+						<details>
+							<summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+								Debug filters
+							</summary>
+							<pre className="mt-3 max-h-64 overflow-auto rounded-2xl border border-(--card-stroke) bg-(--card-60) px-4 py-3 text-xs text-(--ink-muted)">
+								{JSON.stringify(filters, null, 2)}
+							</pre>
+						</details>
+					</section>
 
-          {view === "explain" && (
-            <section id="evidence" className="grid gap-6 lg:grid-cols-3">
-              <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
-                <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Snapshot</p>
-                <div className="mt-3 flex flex-wrap items-baseline gap-3">
-                  <span className="text-3xl font-semibold metric-hero">
-                    {data ? formatMetricValue(data.value, data.unit) : "--"}
-                  </span>
-                  <span className="text-sm text-(--ink-muted)">
-                    {data ? formatDelta(data.delta_pct) : "--"} vs previous window
-                  </span>
-                </div>
-                <p className="mt-3 text-xs text-(--ink-muted)">
-                  Evidence links below stay in this scope.
-                </p>
-              </div>
+					{view === "explain" && (
+						<section id="evidence" className="grid gap-6 lg:grid-cols-3">
+							<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+								<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+									Snapshot
+								</p>
+								<div className="mt-3 flex flex-wrap items-baseline gap-3">
+									<span className="text-3xl font-semibold metric-hero">
+										{data ? formatMetricValue(data.value, data.unit) : "--"}
+									</span>
+									<span className="text-sm text-(--ink-muted)">
+										{data ? formatDelta(data.delta_pct) : "--"} vs previous
+										window
+									</span>
+								</div>
+								<p className="mt-3 text-xs text-(--ink-muted)">
+									Evidence links below stay in this scope.
+								</p>
+							</div>
 
-              <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
-                <div className="flex items-center justify-between">
-                  <h2 className="font-(--font-display) text-xl">Top Associations</h2>
-                  <Link
-                    href={buildExploreUrl({
-                      metric: metricFromApi,
-                      filters,
-                      role: activeRole,
-                    })}
-                    className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-                  >
-                    Open evidence
-                  </Link>
-                </div>
-                {drivers.length ? (
-                  <div className="mt-4 space-y-4">
-                    <HorizontalBarChart
-                      categories={drivers.map((driver) => driver.label)}
-                      values={drivers.map((driver) => Math.abs(driver.delta_pct))}
-                    />
-                    <div className="space-y-2 text-sm">
-                      {drivers.map((driver) => (
-                        <Link
-                          key={driver.id}
-                          href={buildExploreUrl({
-                            api: driver.evidence_link,
-                            filters,
-                            role: activeRole,
-                          })}
-                          className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
-                        >
-                          <span>{driver.label}</span>
-                          <span className="text-xs text-(--ink-muted)">
-                            {formatDelta(driver.delta_pct)}
-                          </span>
-                        </Link>
-                      ))}
-                    </div>
-                  </div>
-                ) : (
-                  <p className="mt-4 text-sm text-(--ink-muted)">
-                    Association detail will appear once data is ingested.
-                  </p>
-                )}
-              </div>
+							<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+								<div className="flex items-center justify-between">
+									<h2 className="font-(--font-display) text-xl">
+										Top Associations
+									</h2>
+									<Link
+										href={buildExploreUrl({
+											metric: metricFromApi,
+											filters,
+											role: activeRole,
+										})}
+										className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+									>
+										Open evidence
+									</Link>
+								</div>
+								{drivers.length ? (
+									<div className="mt-4 space-y-4">
+										<HorizontalBarChart
+											categories={drivers.map((driver) => driver.label)}
+											values={drivers.map((driver) =>
+												Math.abs(driver.delta_pct),
+											)}
+										/>
+										<div className="space-y-2 text-sm">
+											{drivers.map((driver) => (
+												<Link
+													key={driver.id}
+													href={buildExploreUrl({
+														api: driver.evidence_link,
+														filters,
+														role: activeRole,
+													})}
+													className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+												>
+													<span>{driver.label}</span>
+													<span className="text-xs text-(--ink-muted)">
+														{formatDelta(driver.delta_pct)}
+													</span>
+												</Link>
+											))}
+										</div>
+									</div>
+								) : (
+									<p className="mt-4 text-sm text-(--ink-muted)">
+										Association detail will appear once data is ingested.
+									</p>
+								)}
+							</div>
 
-              <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
-                <div className="flex items-center justify-between">
-                  <h2 className="font-(--font-display) text-xl">Contributors</h2>
-                  <Link
-                    href={buildExploreUrl({
-                      metric: metricFromApi,
-                      filters,
-                      role: activeRole,
-                    })}
-                    className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-                  >
-                    Open evidence
-                  </Link>
-                </div>
-                {contributors.length ? (
-                  <div className="mt-4 space-y-4">
-                    <HorizontalBarChart
-                      categories={contributors.map((contributor) => contributor.label)}
-                      values={contributors.map((contributor) => contributor.value)}
-                    />
-                    <div className="space-y-2 text-sm">
-                      {contributors.map((contributor) => (
-                        <Link
-                          key={contributor.id}
-                          href={buildExploreUrl({
-                            api: contributor.evidence_link,
-                            filters,
-                            role: activeRole,
-                          })}
-                          className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
-                        >
-                          <span>{contributor.label}</span>
-                          <span className="text-xs text-(--ink-muted)">
-                            {data ? formatMetricValue(contributor.value, data.unit) : "--"}
-                          </span>
-                        </Link>
-                      ))}
-                    </div>
-                  </div>
-                ) : (
-                  <p className="mt-4 text-sm text-(--ink-muted)">
-                    Contributor detail will appear once data is ingested.
-                  </p>
-                )}
-              </div>
-            </section>
-          )}
+							<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+								<div className="flex items-center justify-between">
+									<h2 className="font-(--font-display) text-xl">
+										Contributors
+									</h2>
+									<Link
+										href={buildExploreUrl({
+											metric: metricFromApi,
+											filters,
+											role: activeRole,
+										})}
+										className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+									>
+										Open evidence
+									</Link>
+								</div>
+								{contributors.length ? (
+									<div className="mt-4 space-y-4">
+										<HorizontalBarChart
+											categories={contributors.map(
+												(contributor) => contributor.label,
+											)}
+											values={contributors.map(
+												(contributor) => contributor.value,
+											)}
+										/>
+										<div className="space-y-2 text-sm">
+											{contributors.map((contributor) => (
+												<Link
+													key={contributor.id}
+													href={buildExploreUrl({
+														api: contributor.evidence_link,
+														filters,
+														role: activeRole,
+													})}
+													className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+												>
+													<span>{contributor.label}</span>
+													<span className="text-xs text-(--ink-muted)">
+														{data
+															? formatMetricValue(contributor.value, data.unit)
+															: "--"}
+													</span>
+												</Link>
+											))}
+										</div>
+									</div>
+								) : (
+									<p className="mt-4 text-sm text-(--ink-muted)">
+										Contributor detail will appear once data is ingested.
+									</p>
+								)}
+							</div>
+						</section>
+					)}
 
-          {view === "drilldown" && (
-            <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
-              <div className="flex items-center justify-between">
-                <h2 className="font-(--font-display) text-xl">Evidence Table</h2>
-                <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-                  {drilldown?.items?.length ?? 0} items
-                </span>
-              </div>
-              <p className="mt-2 text-xs text-(--ink-muted)">
-                Rows link to source artifacts when available.
-              </p>
-              <div className="mt-4 overflow-auto text-xs">
-                <table className="min-w-full border-collapse">
-                  <thead className="text-left text-(--ink-muted)">
-                    <tr>
-                      <th className="border-b border-(--card-stroke) pb-2">Item</th>
-                      <th className="border-b border-(--card-stroke) pb-2">Details</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {(drilldown?.items ?? []).map((item, idx) => {
-                      const fallbackHref = buildExploreUrl({
-                        metric: metricFromApi,
-                        filters,
-                        role: activeRole,
-                      });
-                      const href = getItemHref(item, fallbackHref);
-                      const prFlameHref =
-                        typeof item.repo_id === "string" && typeof item.number === "number"
-                          ? `/prs/${item.repo_id}:${item.number}`
-                          : null;
-                      const issueFlameHref =
-                        typeof item.work_item_id === "string"
-                          ? `/issues/${item.work_item_id}`
-                          : null;
-                      const flameHref = prFlameHref ?? issueFlameHref;
-                      return (
-                        <tr key={`item-${idx}`} className="border-b border-(--card-stroke)">
-                          <td className="py-2 pr-4 font-medium">
-                            <a href={href} className="block text-foreground">
-                              {getItemTitle(item, idx)}
-                            </a>
-                          </td>
-                          <td className="py-2 text-(--ink-muted)">
-                            <div className="space-y-2">
-                              <a href={href} className="block">
-                                {JSON.stringify(item)}
-                              </a>
-                              {flameHref ? (
-                                <Link
-                                  href={flameHref}
-                                  className="inline-flex items-center rounded-full border border-(--card-stroke) bg-(--card) px-3 py-1 text-[10px] uppercase tracking-[0.2em] text-(--accent-2)"
-                                >
-                                  Open flame
-                                </Link>
-                              ) : null}
-                            </div>
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </div>
-            </section>
-          )}
+					{view === "drilldown" && (
+						<section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+							<div className="flex items-center justify-between">
+								<h2 className="font-(--font-display) text-xl">
+									Evidence Table
+								</h2>
+								<span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+									{drilldown?.items?.length ?? 0} items
+								</span>
+							</div>
+							<p className="mt-2 text-xs text-(--ink-muted)">
+								Rows link to source artifacts when available.
+							</p>
+							<div className="mt-4 overflow-auto text-xs">
+								<table className="min-w-full border-collapse">
+									<thead className="text-left text-(--ink-muted)">
+										<tr>
+											<th className="border-b border-(--card-stroke) pb-2">
+												Item
+											</th>
+											<th className="border-b border-(--card-stroke) pb-2">
+												Details
+											</th>
+										</tr>
+									</thead>
+									<tbody>
+										{(drilldown?.items ?? []).map((item, idx) => {
+											const fallbackHref = buildExploreUrl({
+												metric: metricFromApi,
+												filters,
+												role: activeRole,
+											});
+											const href = getItemHref(item, fallbackHref);
+											const prFlameHref =
+												typeof item.repo_id === "string" &&
+												typeof item.number === "number"
+													? `/prs/${item.repo_id}:${item.number}`
+													: null;
+											const issueFlameHref =
+												typeof item.work_item_id === "string"
+													? `/issues/${item.work_item_id}`
+													: null;
+											const flameHref = prFlameHref ?? issueFlameHref;
+											const details = getEvidenceDetails(item);
+											return (
+												<tr
+													key={`${href}-${getItemTitle(item, idx)}`}
+													className="border-b border-(--card-stroke)"
+												>
+													<td className="py-2 pr-4 font-medium">
+														<a href={href} className="block text-foreground">
+															{getItemTitle(item, idx)}
+														</a>
+													</td>
+													<td className="py-2 text-(--ink-muted)">
+														<div className="space-y-2">
+															{details.length > 0 ? (
+																<dl className="grid gap-2 sm:grid-cols-2">
+																	{details.map((detail) => (
+																		<div
+																			key={`${detail.label}-${detail.value}`}
+																		>
+																			<dt className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
+																				{detail.label}
+																			</dt>
+																			<dd className="mt-1 text-foreground">
+																				{detail.value}
+																			</dd>
+																		</div>
+																	))}
+																</dl>
+															) : (
+																<p>
+																	Evidence details unavailable for this row.
+																</p>
+															)}
+															{flameHref ? (
+																<Link
+																	href={flameHref}
+																	className="inline-flex items-center rounded-full border border-(--card-stroke) bg-(--card) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+																>
+																	{CTA_LABELS.openArtifact}
+																</Link>
+															) : null}
+														</div>
+													</td>
+												</tr>
+											);
+										})}
+									</tbody>
+								</table>
+							</div>
+						</section>
+					)}
 
-          {view === "home" && (
-            <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
-              <h2 className="font-(--font-display) text-xl">Home Snapshot</h2>
-              <p className="mt-3 text-sm text-(--ink-muted)">
-                This endpoint powers the cockpit. Open Home for the curated summary.
-              </p>
-              <pre className="mt-4 max-h-64 overflow-auto rounded-2xl border border-(--card-stroke) bg-(--card-60) px-4 py-3 text-xs text-(--ink-muted)">
-                {JSON.stringify(home ?? {}, null, 2)}
-              </pre>
-            </section>
-          )}
+					{view === "home" && (
+						<section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+							<h2 className="font-(--font-display) text-xl">Home Snapshot</h2>
+							<p className="mt-3 text-sm text-(--ink-muted)">
+								This endpoint powers the cockpit. Open Home for the curated
+								summary.
+							</p>
+							<pre className="mt-4 max-h-64 overflow-auto rounded-2xl border border-(--card-stroke) bg-(--card-60) px-4 py-3 text-xs text-(--ink-muted)">
+								{JSON.stringify(home ?? {}, null, 2)}
+							</pre>
+						</section>
+					)}
 
-          {view === "unknown" && (
-            <section className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
-              Unsupported endpoint. Provide a metric or a supported drilldown API.
-            </section>
-          )}
+					{view === "unknown" && (
+						<section className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
+							Unsupported endpoint. Provide a metric or a supported drilldown
+							API.
+						</section>
+					)}
 
-          {view === "explain" && (
-            <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
-              <h2 className="font-(--font-display) text-xl">Evidence shortcuts</h2>
-              <div className="mt-3 flex flex-wrap gap-3 text-sm">
-                {Object.entries(data?.drilldown_links ?? {}).map(([label, link]) => (
-                  <Link
-                    key={label}
-                    href={buildExploreUrl({
-                      api: link,
-                      filters,
-                      role: activeRole,
-                    })}
-                    className="rounded-full border border-(--card-stroke) bg-(--card) px-4 py-2"
-                  >
-                    {label}
-                  </Link>
-                ))}
-                {!Object.keys(data?.drilldown_links ?? {}).length && (
-                  <p className="text-sm text-(--ink-muted)">
-                    Evidence links will appear once data is ingested.
-                  </p>
-                )}
-              </div>
-            </section>
-          )}
-        </main>
-      </div>
-    </div>
-  );
+					{view === "explain" && (
+						<section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+							<h2 className="font-(--font-display) text-xl">
+								Evidence shortcuts
+							</h2>
+							<div className="mt-3 flex flex-wrap gap-3 text-sm">
+								{Object.entries(data?.drilldown_links ?? {}).map(
+									([label, link]) => (
+										<Link
+											key={label}
+											href={buildExploreUrl({
+												api: link,
+												filters,
+												role: activeRole,
+											})}
+											className="rounded-full border border-(--card-stroke) bg-(--card) px-4 py-2"
+										>
+											{label}
+										</Link>
+									),
+								)}
+								{!Object.keys(data?.drilldown_links ?? {}).length && (
+									<p className="text-sm text-(--ink-muted)">
+										Evidence links will appear once data is ingested.
+									</p>
+								)}
+							</div>
+						</section>
+					)}
+				</main>
+			</div>
+		</div>
+	);
 }

--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -130,7 +130,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
 	type DrilldownResult = Awaited<ReturnType<typeof getDrilldown>> | null;
 	type HomeResult = Awaited<ReturnType<typeof getHomeData>> | null;
 
-	let view: "explain" | "drilldown" | "home" | "unknown" = "explain";
+	let view: "explain" | "drilldown" | "home" | "unknown";
 	let dataPromise: Promise<ExplainResult | DrilldownResult | HomeResult | null>;
 
 	if (

--- a/src/app/(app)/testops/pipelines/page.tsx
+++ b/src/app/(app)/testops/pipelines/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { MetricCard } from "@/components/metrics/MetricCard";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { DataState } from "@/components/ui/DataState";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
 import { HeatmapChart } from "@/components/charts/HeatmapChart";
@@ -11,192 +12,257 @@ import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
 import { fetchTestOpsData } from "@/lib/testops/fetchers";
 import { TESTOPS_MEASURES } from "@/lib/testops/constants";
-import { buildFailurePatternsModel, UNATTRIBUTED_LABEL } from "@/lib/testops/failure-patterns";
 import {
-  TimeseriesResult,
-  TimeseriesBucket,
-  BreakdownResult,
+	buildFailurePatternsModel,
+	UNATTRIBUTED_LABEL,
+} from "@/lib/testops/failure-patterns";
+import {
+	TimeseriesResult,
+	TimeseriesBucket,
+	BreakdownResult,
 } from "@/lib/graphql/schemas/analytics";
 import { getServerEnv } from "@/lib/config";
 
 type PipelinesPageProps = {
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 function getLatestValue(timeseries: TimeseriesResult[], measureId: string) {
-  const series = timeseries.find((s) => s.measure === measureId);
-  if (!series || !series.buckets || series.buckets.length === 0) return undefined;
-  return series.buckets[series.buckets.length - 1].value;
+	const series = timeseries.find((s) => s.measure === measureId);
+	if (!series || !series.buckets || series.buckets.length === 0)
+		return undefined;
+	return series.buckets[series.buckets.length - 1].value;
 }
 
 function getSparkline(timeseries: TimeseriesResult[], measureId: string) {
-  const series = timeseries.find((s) => s.measure === measureId);
-  if (!series || !series.buckets) return undefined;
-  return series.buckets.map((b: TimeseriesBucket) => ({ ts: b.date, value: b.value }));
+	const series = timeseries.find((s) => s.measure === measureId);
+	if (!series || !series.buckets) return undefined;
+	return series.buckets.map((b: TimeseriesBucket) => ({
+		ts: b.date,
+		value: b.value,
+	}));
 }
 
 /** Period-over-period change (%) from first to last bucket; undefined when history is insufficient. */
 function getDelta(timeseries: TimeseriesResult[], measureId: string) {
-  const series = timeseries.find((s) => s.measure === measureId);
-  const buckets = series?.buckets;
-  if (!buckets || buckets.length < 2) return undefined;
-  const prev = buckets[0].value;
-  const curr = buckets[buckets.length - 1].value;
-  if (prev === 0) return undefined;
-  return ((curr - prev) / Math.abs(prev)) * 100;
+	const series = timeseries.find((s) => s.measure === measureId);
+	const buckets = series?.buckets;
+	if (!buckets || buckets.length < 2) return undefined;
+	const prev = buckets[0].value;
+	const curr = buckets[buckets.length - 1].value;
+	if (prev === 0) return undefined;
+	return ((curr - prev) / Math.abs(prev)) * 100;
 }
 
-export default async function PipelinesPage({ searchParams }: PipelinesPageProps) {
-  const params = (await searchParams) ?? {};
-  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
-  const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
-  const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+export default async function PipelinesPage({
+	searchParams,
+}: PipelinesPageProps) {
+	const params = (await searchParams) ?? {};
+	const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+	const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+	const activeRole = typeof roleParam === "string" ? roleParam : undefined;
 
-  const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+	const filters = encodedFilter
+		? decodeFilter(encodedFilter)
+		: filterFromQueryParams(params);
 
-  const env = getServerEnv();
-  const isTestMode =
-    env.DEV_HEALTH_TEST_MODE === "true" || env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
+	const env = getServerEnv();
+	const isTestMode =
+		env.DEV_HEALTH_TEST_MODE === "true" ||
+		env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
-  const rangeDays = filters?.time?.range_days ?? 14;
-  const today = new Date();
-  const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
-  const startDate =
-    filters?.time?.start_date ??
-    new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
-  const dateRange = { startDate, endDate };
+	const rangeDays = filters?.time?.range_days ?? 14;
+	const today = new Date();
+	const endDate = filters?.time?.end_date ?? today.toISOString().slice(0, 10);
+	const startDate =
+		filters?.time?.start_date ??
+		new Date(today.getTime() - rangeDays * 86_400_000)
+			.toISOString()
+			.slice(0, 10);
+	const dateRange = { startDate, endDate };
 
-  const [health, testOpsData] = await Promise.all([
-    checkApiHealth(),
-    fetchTestOpsData(
-      {
-        timeseries: [
-          { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange },
-          { dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", interval: "DAY", dateRange },
-          { dimension: "TEAM", measure: "PIPELINE_DURATION_P95", interval: "DAY", dateRange },
-          { dimension: "TEAM", measure: "PIPELINE_QUEUE_TIME", interval: "DAY", dateRange },
-          { dimension: "TEAM", measure: "PIPELINE_RERUN_RATE", interval: "DAY", dateRange },
-        ],
-        breakdowns: [{ dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", dateRange, topN: 10 }],
-      },
-      isTestMode,
-    ),
-  ]);
+	const [health, testOpsData] = await Promise.all([
+		checkApiHealth(),
+		fetchTestOpsData(
+			{
+				timeseries: [
+					{
+						dimension: "TEAM",
+						measure: "PIPELINE_SUCCESS_RATE",
+						interval: "DAY",
+						dateRange,
+					},
+					{
+						dimension: "TEAM",
+						measure: "PIPELINE_FAILURE_RATE",
+						interval: "DAY",
+						dateRange,
+					},
+					{
+						dimension: "TEAM",
+						measure: "PIPELINE_DURATION_P95",
+						interval: "DAY",
+						dateRange,
+					},
+					{
+						dimension: "TEAM",
+						measure: "PIPELINE_QUEUE_TIME",
+						interval: "DAY",
+						dateRange,
+					},
+					{
+						dimension: "TEAM",
+						measure: "PIPELINE_RERUN_RATE",
+						interval: "DAY",
+						dateRange,
+					},
+				],
+				breakdowns: [
+					{
+						dimension: "TEAM",
+						measure: "PIPELINE_FAILURE_RATE",
+						dateRange,
+						topN: 10,
+					},
+				],
+			},
+			isTestMode,
+		),
+	]);
 
-  if (!health.ok && !isTestMode) {
-    return <ServiceUnavailable />;
-  }
+	if (!health.ok && !isTestMode) {
+		return <ServiceUnavailable />;
+	}
 
-  const pipelineTimeseries = testOpsData.pipelines.timeseries || [];
-  const pipelineBreakdowns = testOpsData.pipelines.breakdowns || [];
+	const pipelineTimeseries = testOpsData.pipelines.timeseries || [];
+	const pipelineBreakdowns = testOpsData.pipelines.breakdowns || [];
 
-  const measures = [
-    { id: "PIPELINE_SUCCESS_RATE", ts: pipelineTimeseries },
-    { id: "PIPELINE_FAILURE_RATE", ts: pipelineTimeseries },
-    { id: "PIPELINE_DURATION_P95", ts: pipelineTimeseries },
-    { id: "PIPELINE_QUEUE_TIME", ts: pipelineTimeseries },
-    { id: "PIPELINE_RERUN_RATE", ts: pipelineTimeseries },
-  ];
+	const measures = [
+		{ id: "PIPELINE_SUCCESS_RATE", ts: pipelineTimeseries },
+		{ id: "PIPELINE_FAILURE_RATE", ts: pipelineTimeseries },
+		{ id: "PIPELINE_DURATION_P95", ts: pipelineTimeseries },
+		{ id: "PIPELINE_QUEUE_TIME", ts: pipelineTimeseries },
+		{ id: "PIPELINE_RERUN_RATE", ts: pipelineTimeseries },
+	];
 
-  const successRateSeries = pipelineTimeseries.find(
-    (s: TimeseriesResult) => s.measure === "PIPELINE_SUCCESS_RATE",
-  );
-  const failureBreakdown = pipelineBreakdowns.find(
-    (b: BreakdownResult) => b.measure === "PIPELINE_FAILURE_RATE",
-  );
+	const successRateSeries = pipelineTimeseries.find(
+		(s: TimeseriesResult) => s.measure === "PIPELINE_SUCCESS_RATE",
+	);
+	const failureBreakdown = pipelineBreakdowns.find(
+		(b: BreakdownResult) => b.measure === "PIPELINE_FAILURE_RATE",
+	);
 
-  const timeseriesData = successRateSeries
-    ? successRateSeries.buckets.map((b: TimeseriesBucket) => ({ day: b.date, value: b.value }))
-    : [];
+	const timeseriesData = successRateSeries
+		? successRateSeries.buckets.map((b: TimeseriesBucket) => ({
+				day: b.date,
+				value: b.value,
+			}))
+		: [];
 
-  const failurePatterns = buildFailurePatternsModel(failureBreakdown, "%");
+	const failurePatterns = buildFailurePatternsModel(failureBreakdown, "%");
 
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-        <PrimaryNav filters={filters} active="pipelines" role={activeRole} />
-        <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">TestOps</p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">Pipelines</h1>
-              <p className="mt-2 text-sm text-(--ink-muted)">
-                CI/CD pipeline health and performance.
-              </p>
-            </div>
-            <Link
-              href={withFilterParam("/", filters, activeRole)}
-              className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
-            >
-              Back to cockpit
-            </Link>
-          </header>
+	return (
+		<div className="min-h-screen bg-background text-foreground">
+			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+				<PrimaryNav filters={filters} active="pipelines" role={activeRole} />
+				<main className="flex min-w-0 flex-1 flex-col gap-8">
+					<header className="flex flex-wrap items-center justify-between gap-4">
+						<div>
+							<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+								TestOps
+							</p>
+							<h1 className="mt-2 font-(--font-display) text-3xl">Pipelines</h1>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								CI/CD pipeline health and performance.
+							</p>
+						</div>
+						<Link
+							href={withFilterParam("/", filters, activeRole)}
+							className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+						>
+							Back to cockpit
+						</Link>
+					</header>
 
-          <FilterBar view="testops" />
+					<FilterBar view="testops" />
 
-          <section className="grid gap-4 lg:grid-cols-3">
-            {measures.map(({ id, ts }) => {
-              const def = TESTOPS_MEASURES[id];
-              if (!def) return null;
+					<section className="grid gap-4 lg:grid-cols-3">
+						{measures.map(({ id, ts }) => {
+							const def = TESTOPS_MEASURES[id];
+							if (!def) return null;
 
-              const value = getLatestValue(ts, id);
-              const spark = getSparkline(ts, id);
-              const delta = getDelta(ts, id);
+							const value = getLatestValue(ts, id);
+							const spark = getSparkline(ts, id);
+							const delta = getDelta(ts, id);
 
-              return (
-                <MetricCard
-                  key={id}
-                  label={def.label}
-                  href="#"
-                  value={value}
-                  unit={def.unit === "percentage" ? "%" : def.unit === "duration" ? "m" : ""}
-                  delta={delta}
-                  deltaUnavailableLabel="Insufficient history"
-                  spark={spark}
-                  caption={def.description}
-                />
-              );
-            })}
-          </section>
+							return (
+								<MetricCard
+									key={id}
+									label={def.label}
+									href="#"
+									value={value}
+									unit={
+										def.unit === "percentage"
+											? "%"
+											: def.unit === "duration"
+												? "m"
+												: ""
+									}
+									delta={delta}
+									deltaUnavailableLabel="Insufficient history"
+									spark={spark}
+									caption={def.description}
+								/>
+							);
+						})}
+					</section>
 
-          <p className="-mt-4 text-xs text-(--ink-muted)">
-            Success Rate and Failure Rate are shares of <em>completed</em> pipeline runs and need
-            not sum to 100% — runs can be cancelled or skipped. Failure Patterns below shows the
-            failure rate <em>within each group</em>, a different denominator from the headline
-            Failure Rate, so the figures are not directly comparable.
-          </p>
+					<p className="-mt-4 text-xs text-(--ink-muted)">
+						Success Rate and Failure Rate are shares of <em>completed</em>{" "}
+						pipeline runs and need not sum to 100% — runs can be cancelled or
+						skipped. Failure Patterns below shows the failure rate{" "}
+						<em>within each group</em>, a different denominator from the
+						headline Failure Rate, so the figures are not directly comparable.
+					</p>
 
-          <section className="grid gap-6 lg:grid-cols-2">
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-              <h2 className="font-(--font-display) text-xl mb-4">Success Rate Trend</h2>
-              <div className="h-64">
-                <TimeseriesChart data={timeseriesData} />
-              </div>
-            </div>
-            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-              <h2 className="font-(--font-display) text-xl mb-4">Failure Patterns</h2>
-              {failurePatterns.isEmpty ? (
-                <div className="flex h-64 items-center justify-center text-center text-sm text-(--ink-muted)">
-                  No failure data for this window or scope.
-                </div>
-              ) : (
-                <>
-                  <div className="h-64">
-                    <HeatmapChart data={failurePatterns.heatmap} />
-                  </div>
-                  {failurePatterns.hasUnattributed ? (
-                    <p className="mt-3 text-xs text-(--ink-muted)">
-                      &ldquo;{UNATTRIBUTED_LABEL}&rdquo; groups failures with no attribution in the
-                      source data &mdash; read its share as a data-quality caveat, not a real
-                      category.
-                    </p>
-                  ) : null}
-                </>
-              )}
-            </div>
-          </section>
-        </main>
-      </div>
-    </div>
-  );
+					<section className="grid gap-6 lg:grid-cols-2">
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+							<h2 className="font-(--font-display) text-xl mb-4">
+								Success Rate Trend
+							</h2>
+							<div className="h-64">
+								<TimeseriesChart data={timeseriesData} />
+							</div>
+						</div>
+						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+							<h2 className="font-(--font-display) text-xl mb-4">
+								Failure Patterns
+							</h2>
+							{failurePatterns.isEmpty ? (
+								<DataState
+									variant="detector-enabled-no-findings"
+									title="No failure patterns"
+									description="No failure data surfaced for this window or scope."
+									className="flex h-64 items-center justify-center"
+								/>
+							) : (
+								<>
+									<div className="h-64">
+										<HeatmapChart data={failurePatterns.heatmap} />
+									</div>
+									{failurePatterns.hasUnattributed ? (
+										<p className="mt-3 text-xs text-(--ink-muted)">
+											&ldquo;{UNATTRIBUTED_LABEL}&rdquo; groups failures with no
+											attribution in the source data &mdash; read its share as a
+											data-quality caveat, not a real category.
+										</p>
+									) : null}
+								</>
+							)}
+						</div>
+					</section>
+				</main>
+			</div>
+		</div>
+	);
 }

--- a/src/components/capacity/ForecastCard.test.tsx
+++ b/src/components/capacity/ForecastCard.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { render, screen } from "@/test/utils";
+import { ForecastCard } from "./ForecastCard";
+import type { CapacityForecast } from "@/lib/graphql/types";
+
+const forecast: CapacityForecast = {
+	forecastId: "forecast-1",
+	computedAt: "2026-06-01T00:00:00Z",
+	backlogSize: 42,
+	p50Date: "2026-06-15",
+	p85Date: "2026-06-15",
+	p95Date: "2026-06-15",
+	p50Days: 14,
+	p85Days: 14,
+	p95Days: 14,
+	throughputMean: 3,
+	throughputStddev: 0,
+	historyDays: 30,
+	insufficientHistory: false,
+	highVariance: false,
+};
+
+describe("ForecastCard", () => {
+	it("collapses identical forecast percentiles into one low-variance row", () => {
+		render(<ForecastCard forecast={forecast} />);
+
+		expect(screen.getByText("≈2 weeks (low variance)")).toBeInTheDocument();
+		expect(screen.queryByText("50% chance")).not.toBeInTheDocument();
+		expect(screen.queryByText("85% chance")).not.toBeInTheDocument();
+		expect(screen.queryByText("95% chance")).not.toBeInTheDocument();
+	});
+});

--- a/src/components/capacity/ForecastCard.tsx
+++ b/src/components/capacity/ForecastCard.tsx
@@ -3,146 +3,200 @@
 import type { CapacityForecast } from "@/lib/graphql/types";
 
 type ForecastCardProps = {
-  forecast: CapacityForecast | null;
-  loading?: boolean;
-  error?: Error | null;
+	forecast: CapacityForecast | null;
+	loading?: boolean;
+	error?: Error | null;
 };
 
 function formatDate(dateStr: string | undefined): string {
-  if (!dateStr) return "—";
-  const date = new Date(dateStr);
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+	if (!dateStr) return "—";
+	const date = new Date(dateStr);
+	return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatLowVarianceWeeks(days: number): string {
+	const weeks = Math.max(1, Math.round(days / 7));
+	return `≈${weeks} ${weeks === 1 ? "week" : "weeks"} (low variance)`;
 }
 
 function SkeletonCard() {
-  return (
-    <div className="rounded-3xl border border-(--card-stroke) bg-card p-6 animate-pulse">
-      <div className="h-6 bg-(--card-70) rounded w-1/3 mb-4" />
-      <div className="space-y-3">
-        <div className="h-4 bg-(--card-70) rounded w-1/2" />
-        <div className="h-4 bg-(--card-70) rounded w-2/3" />
-        <div className="h-4 bg-(--card-70) rounded w-1/2" />
-      </div>
-    </div>
-  );
+	return (
+		<div className="rounded-3xl border border-(--card-stroke) bg-card p-6 animate-pulse">
+			<div className="h-6 bg-(--card-70) rounded w-1/3 mb-4" />
+			<div className="space-y-3">
+				<div className="h-4 bg-(--card-70) rounded w-1/2" />
+				<div className="h-4 bg-(--card-70) rounded w-2/3" />
+				<div className="h-4 bg-(--card-70) rounded w-1/2" />
+			</div>
+		</div>
+	);
 }
 
 function ErrorCard({ error }: { error: Error }) {
-  return (
-    <div className="rounded-3xl border border-red-500/20 bg-red-500/10 p-6">
-      <h3 className="text-lg font-semibold text-red-400 mb-2">Forecast Unavailable</h3>
-      <p className="text-sm text-red-400/80">{error.message}</p>
-    </div>
-  );
+	return (
+		<div className="rounded-3xl border border-red-500/20 bg-red-500/10 p-6">
+			<h3 className="text-lg font-semibold text-red-400 mb-2">
+				Forecast Unavailable
+			</h3>
+			<p className="text-sm text-red-400/80">{error.message}</p>
+		</div>
+	);
 }
 
 function EmptyCard() {
-  return (
-    <div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
-      <h3 className="text-lg font-semibold text-foreground mb-2">No Forecast Available</h3>
-      <p className="text-sm text-(--ink-muted)">
-        Insufficient throughput history to generate a forecast. Need at least 14 days of data.
-      </p>
-    </div>
-  );
+	return (
+		<div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+			<h3 className="text-lg font-semibold text-foreground mb-2">
+				No Forecast Available
+			</h3>
+			<p className="text-sm text-(--ink-muted)">
+				Insufficient throughput history to generate a forecast. Need at least 14
+				days of data.
+			</p>
+		</div>
+	);
 }
 
 export function ForecastCard({ forecast, loading, error }: ForecastCardProps) {
-  if (loading) return <SkeletonCard />;
-  if (error) return <ErrorCard error={error} />;
-  if (!forecast) return <EmptyCard />;
+	if (loading) return <SkeletonCard />;
+	if (error) return <ErrorCard error={error} />;
+	if (!forecast) return <EmptyCard />;
 
-  const { insufficientHistory, highVariance } = forecast;
+	const { insufficientHistory, highVariance } = forecast;
+	const hasLowVarianceForecast =
+		typeof forecast.p50Days === "number" &&
+		forecast.p50Days === forecast.p85Days &&
+		forecast.p85Days === forecast.p95Days;
 
-  const scopeLabel = forecast.workScopeId
-    ? forecast.workScopeId
-    : forecast.teamId
-      ? `Team: ${forecast.teamId}`
-      : "All Teams";
+	const scopeLabel = forecast.workScopeId
+		? forecast.workScopeId
+		: forecast.teamId
+			? `Team: ${forecast.teamId}`
+			: "All Teams";
 
-  return (
-    <div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
-      <div className="mb-4">
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold text-foreground">Capacity Forecast</h3>
-        </div>
-        <p className="mt-1 text-sm text-(--ink-muted)">
-          Scope: <span className="font-medium text-foreground">{scopeLabel}</span>
-        </p>
-      </div>
+	return (
+		<div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+			<div className="mb-4">
+				<div className="flex items-center justify-between">
+					<h3 className="text-lg font-semibold text-foreground">
+						Capacity Forecast
+					</h3>
+				</div>
+				<p className="mt-1 text-sm text-(--ink-muted)">
+					Scope:{" "}
+					<span className="font-medium text-foreground">{scopeLabel}</span>
+				</p>
+			</div>
 
-      <div className="mb-4">
-        <span className="text-sm text-(--ink-muted)">Backlog</span>
-        <p className="text-2xl font-bold text-foreground">
-          {forecast.backlogSize} <span className="text-base font-normal">items</span>
-        </p>
-      </div>
+			<div className="mb-4">
+				<span className="text-sm text-(--ink-muted)">Backlog</span>
+				<p className="text-2xl font-bold text-foreground">
+					{forecast.backlogSize}{" "}
+					<span className="text-base font-normal">items</span>
+				</p>
+			</div>
 
-      <div className="space-y-2 mb-4">
-        <div className="flex items-center justify-between py-2 border-b border-(--card-stroke)">
-          <span className="text-sm text-(--ink-muted)">50% chance</span>
-          <div className="text-right">
-            <span className="font-medium text-green-500">{formatDate(forecast.p50Date)}</span>
-            {forecast.p50Days && (
-              <span className="text-xs text-(--ink-muted) ml-2">({forecast.p50Days} days)</span>
-            )}
-          </div>
-        </div>
+			<div className="space-y-2 mb-4">
+				{hasLowVarianceForecast ? (
+					<div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3">
+						<span className="text-sm text-(--ink-muted)">Forecast range</span>
+						<div className="mt-1 flex flex-wrap items-center justify-between gap-2">
+							<span className="font-semibold text-foreground">
+								{formatLowVarianceWeeks(forecast.p50Days ?? 0)}
+							</span>
+							<span className="text-xs text-(--ink-muted)">
+								{formatDate(forecast.p50Date)}
+							</span>
+						</div>
+					</div>
+				) : (
+					<>
+						<div className="flex items-center justify-between py-2 border-b border-(--card-stroke)">
+							<span className="text-sm text-(--ink-muted)">50% chance</span>
+							<div className="text-right">
+								<span className="font-medium text-green-500">
+									{formatDate(forecast.p50Date)}
+								</span>
+								{forecast.p50Days && (
+									<span className="text-xs text-(--ink-muted) ml-2">
+										({forecast.p50Days} days)
+									</span>
+								)}
+							</div>
+						</div>
 
-        <div className="flex items-center justify-between py-2 border-b border-(--card-stroke) bg-amber-500/10 -mx-2 px-2 rounded">
-          <span className="text-sm font-medium text-amber-400">85% chance</span>
-          <div className="text-right flex items-center">
-            <span className="font-bold text-amber-400">{formatDate(forecast.p85Date)}</span>
-            {forecast.p85Days && (
-              <span className="text-xs text-amber-400/70 ml-2">({forecast.p85Days} days)</span>
-            )}
-            <span className="ml-2 text-xs bg-amber-500/20 text-amber-400 px-1.5 py-0.5 rounded">
-              Target
-            </span>
-          </div>
-        </div>
+						<div className="flex items-center justify-between py-2 border-b border-(--card-stroke) bg-amber-500/10 -mx-2 px-2 rounded">
+							<span className="text-sm font-medium text-amber-400">
+								85% chance
+							</span>
+							<div className="text-right flex items-center">
+								<span className="font-bold text-amber-400">
+									{formatDate(forecast.p85Date)}
+								</span>
+								{forecast.p85Days && (
+									<span className="text-xs text-amber-400/70 ml-2">
+										({forecast.p85Days} days)
+									</span>
+								)}
+								<span className="ml-2 text-xs bg-amber-500/20 text-amber-400 px-1.5 py-0.5 rounded">
+									Target
+								</span>
+							</div>
+						</div>
 
-        <div className="flex items-center justify-between py-2">
-          <span className="text-sm text-(--ink-muted)">95% chance</span>
-          <div className="text-right">
-            <span className="font-medium text-red-400">{formatDate(forecast.p95Date)}</span>
-            {forecast.p95Days && (
-              <span className="text-xs text-(--ink-muted) ml-2">({forecast.p95Days} days)</span>
-            )}
-          </div>
-        </div>
-      </div>
+						<div className="flex items-center justify-between py-2">
+							<span className="text-sm text-(--ink-muted)">95% chance</span>
+							<div className="text-right">
+								<span className="font-medium text-red-400">
+									{formatDate(forecast.p95Date)}
+								</span>
+								{forecast.p95Days && (
+									<span className="text-xs text-(--ink-muted) ml-2">
+										({forecast.p95Days} days)
+									</span>
+								)}
+							</div>
+						</div>
+					</>
+				)}
+			</div>
 
-      <div className="pt-4 border-t border-(--card-stroke)">
-        <div className="flex items-center justify-between text-sm">
-          <span className="text-(--ink-muted)">Throughput</span>
-          <span className="text-foreground">
-            {forecast.throughputMean.toFixed(1)} ± {forecast.throughputStddev.toFixed(1)}{" "}
-            <span className="text-(--ink-muted)">items/day</span>
-          </span>
-        </div>
-        <div className="flex items-center justify-between text-sm mt-1">
-          <span className="text-(--ink-muted)">History</span>
-          <span className="text-foreground">{forecast.historyDays} days</span>
-        </div>
-      </div>
+			<div className="pt-4 border-t border-(--card-stroke)">
+				<div className="flex items-center justify-between text-sm">
+					<span className="text-(--ink-muted)">Throughput</span>
+					<span className="text-foreground">
+						{forecast.throughputMean.toFixed(1)} ±{" "}
+						{forecast.throughputStddev.toFixed(1)}{" "}
+						<span className="text-(--ink-muted)">items/day</span>
+					</span>
+				</div>
+				<div className="flex items-center justify-between text-sm mt-1">
+					<span className="text-(--ink-muted)">History</span>
+					<span className="text-foreground">{forecast.historyDays} days</span>
+				</div>
+			</div>
 
-      {(insufficientHistory || highVariance) && (
-        <div className="mt-4 space-y-2">
-          {insufficientHistory && (
-            <div className="flex items-start gap-2 text-sm text-amber-400 bg-amber-500/10 p-2 rounded">
-              <span className="shrink-0">⚠️</span>
-              <span>Limited history available. Forecast may be less reliable.</span>
-            </div>
-          )}
-          {highVariance && (
-            <div className="flex items-start gap-2 text-sm text-amber-400 bg-amber-500/10 p-2 rounded">
-              <span className="shrink-0">⚠️</span>
-              <span>High throughput variance detected. Consider using more history days.</span>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
+			{(insufficientHistory || highVariance) && (
+				<div className="mt-4 space-y-2">
+					{insufficientHistory && (
+						<div className="flex items-start gap-2 text-sm text-amber-400 bg-amber-500/10 p-2 rounded">
+							<span className="shrink-0">⚠️</span>
+							<span>
+								Limited history available. Forecast may be less reliable.
+							</span>
+						</div>
+					)}
+					{highVariance && (
+						<div className="flex items-start gap-2 text-sm text-amber-400 bg-amber-500/10 p-2 rounded">
+							<span className="shrink-0">⚠️</span>
+							<span>
+								High throughput variance detected. Consider using more history
+								days.
+							</span>
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
 }

--- a/src/components/charts/ConfidenceBandChart.tsx
+++ b/src/components/charts/ConfidenceBandChart.tsx
@@ -12,235 +12,266 @@ import { echarts } from "@/lib/echartsInit";
 echarts.use([LineChart]);
 
 type ConfidenceBandChartProps = {
-  backlogSize: number;
-  p50Days: number;
-  p85Days: number;
-  p95Days: number;
-  throughputMean: number;
-  mode?: "burndown" | "burnup";
-  height?: number | string;
-  width?: number | string;
-  className?: string;
-  style?: CSSProperties;
+	backlogSize: number;
+	p50Days: number;
+	p85Days: number;
+	p95Days: number;
+	throughputMean: number;
+	mode?: "burndown" | "burnup";
+	height?: number | string;
+	width?: number | string;
+	className?: string;
+	style?: CSSProperties;
 };
 
 function generateProjection(
-  backlog: number,
-  throughput: number,
-  days: number,
-  mode: "burndown" | "burnup",
+	backlog: number,
+	throughput: number,
+	days: number,
+	mode: "burndown" | "burnup",
 ): number[] {
-  const result: number[] = [];
-  let remaining = backlog;
+	const result: number[] = [];
+	let remaining = backlog;
 
-  for (let d = 0; d <= days; d++) {
-    if (mode === "burndown") {
-      result.push(Math.max(0, remaining));
-    } else {
-      result.push(Math.min(backlog, backlog - remaining));
-    }
-    remaining -= throughput;
-  }
+	for (let d = 0; d <= days; d++) {
+		if (mode === "burndown") {
+			result.push(Math.max(0, remaining));
+		} else {
+			result.push(Math.min(backlog, backlog - remaining));
+		}
+		remaining -= throughput;
+	}
 
-  return result;
+	return result;
 }
 
 function generateDayLabels(days: number): string[] {
-  const labels: string[] = [];
-  for (let d = 0; d <= days; d++) {
-    if (d === 0) {
-      labels.push("Today");
-    } else {
-      labels.push(`Day ${d}`);
-    }
-  }
-  return labels;
+	const labels: string[] = [];
+	for (let d = 0; d <= days; d++) {
+		if (d === 0) {
+			labels.push("Today");
+		} else {
+			labels.push(`Day ${d}`);
+		}
+	}
+	return labels;
 }
 
 export function ConfidenceBandChart({
-  backlogSize,
-  p50Days,
-  p85Days,
-  p95Days,
-  throughputMean,
-  mode = "burndown",
-  height = 320,
-  width = "100%",
-  className,
-  style,
+	backlogSize,
+	p50Days,
+	p85Days,
+	p95Days,
+	throughputMean,
+	mode = "burndown",
+	height = 320,
+	width = "100%",
+	className,
+	style,
 }: ConfidenceBandChartProps) {
-  const chartTheme = useChartTheme();
-  const mergedStyle: CSSProperties = { height, width, ...style };
+	const chartTheme = useChartTheme();
+	const mergedStyle: CSSProperties = { height, width, ...style };
 
-  const maxDays = Math.max(p95Days, 1);
-  const dayLabels = useMemo(() => generateDayLabels(maxDays), [maxDays]);
+	const maxDays = Math.max(p95Days, 1);
+	const lowVariance = p50Days === p85Days && p85Days === p95Days;
+	const dayLabels = useMemo(() => generateDayLabels(maxDays), [maxDays]);
 
-  const projection = useMemo(
-    () => generateProjection(backlogSize, throughputMean, maxDays, mode),
-    [backlogSize, throughputMean, maxDays, mode],
-  );
+	const projection = useMemo(
+		() => generateProjection(backlogSize, throughputMean, maxDays, mode),
+		[backlogSize, throughputMean, maxDays, mode],
+	);
 
-  const p50Band = useMemo(() => {
-    return dayLabels.map((_, i) => {
-      if (i <= p50Days) return projection[i];
-      return mode === "burndown" ? 0 : backlogSize;
-    });
-  }, [dayLabels, p50Days, projection, mode, backlogSize]);
+	const p50Band = useMemo(() => {
+		return dayLabels.map((_, i) => {
+			if (i <= p50Days) return projection[i];
+			return mode === "burndown" ? 0 : backlogSize;
+		});
+	}, [dayLabels, p50Days, projection, mode, backlogSize]);
 
-  const p85Band = useMemo(() => {
-    return dayLabels.map((_, i) => {
-      if (i <= p85Days) return projection[i];
-      return mode === "burndown" ? 0 : backlogSize;
-    });
-  }, [dayLabels, p85Days, projection, mode, backlogSize]);
+	const p85Band = useMemo(() => {
+		return dayLabels.map((_, i) => {
+			if (i <= p85Days) return projection[i];
+			return mode === "burndown" ? 0 : backlogSize;
+		});
+	}, [dayLabels, p85Days, projection, mode, backlogSize]);
 
-  const p95Band = useMemo(() => {
-    return dayLabels.map((_, i) => {
-      if (i <= p95Days) return projection[i];
-      return mode === "burndown" ? 0 : backlogSize;
-    });
-  }, [dayLabels, p95Days, projection, mode, backlogSize]);
+	const p95Band = useMemo(() => {
+		return dayLabels.map((_, i) => {
+			if (i <= p95Days) return projection[i];
+			return mode === "burndown" ? 0 : backlogSize;
+		});
+	}, [dayLabels, p95Days, projection, mode, backlogSize]);
 
-  const option = useMemo(
-    () => ({
-      tooltip: {
-        trigger: "axis" as const,
-        confine: true,
-        backgroundColor: chartTheme.background,
-        borderColor: chartTheme.stroke,
-        textStyle: { color: chartTheme.text },
-        formatter: (params: unknown) => {
-          if (!Array.isArray(params) || params.length === 0) return "";
-          const first = params[0] as { axisValue?: string; dataIndex?: number };
-          const day = first.axisValue ?? "";
-          const dayIndex = first.dataIndex ?? 0;
-          const remaining = projection[dayIndex] ?? 0;
+	const option = useMemo(
+		() => ({
+			tooltip: {
+				trigger: "axis" as const,
+				confine: true,
+				backgroundColor: chartTheme.background,
+				borderColor: chartTheme.stroke,
+				textStyle: { color: chartTheme.text },
+				formatter: (params: unknown) => {
+					if (!Array.isArray(params) || params.length === 0) return "";
+					const first = params[0] as { axisValue?: string; dataIndex?: number };
+					const day = first.axisValue ?? "";
+					const dayIndex = first.dataIndex ?? 0;
+					const remaining = projection[dayIndex] ?? 0;
 
-          let completionInfo = "";
-          if (dayIndex === p50Days) {
-            completionInfo = `<div style="color: ${chartTheme.accent1}; margin-top: 4px;">P50 completion point</div>`;
-          } else if (dayIndex === p85Days) {
-            completionInfo = `<div style="color: ${chartTheme.accent2}; margin-top: 4px;">P85 completion point (recommended)</div>`;
-          } else if (dayIndex === p95Days) {
-            completionInfo = `<div style="color: ${chartTheme.accent3}; margin-top: 4px;">P95 completion point (conservative)</div>`;
-          }
+					let completionInfo = "";
+					if (lowVariance && dayIndex === p50Days) {
+						completionInfo = `<div style="color: ${chartTheme.accent1}; margin-top: 4px;">Low variance completion point</div>`;
+					} else if (dayIndex === p50Days) {
+						completionInfo = `<div style="color: ${chartTheme.accent1}; margin-top: 4px;">P50 completion point</div>`;
+					} else if (dayIndex === p85Days) {
+						completionInfo = `<div style="color: ${chartTheme.accent2}; margin-top: 4px;">P85 completion point (recommended)</div>`;
+					} else if (dayIndex === p95Days) {
+						completionInfo = `<div style="color: ${chartTheme.accent3}; margin-top: 4px;">P95 completion point (conservative)</div>`;
+					}
 
-          return `
+					return `
             <div style="font-weight: 600;">${day}</div>
             <div style="margin-top: 4px;">
               ${mode === "burndown" ? "Remaining" : "Completed"}: <strong>${Math.round(remaining)}</strong> items
             </div>
             ${completionInfo}
           `;
-        },
-      },
-      legend: {
-        data: ["P50 (Optimistic)", "P85 (Target)", "P95 (Conservative)"],
-        bottom: 0,
-        left: "center",
-        textStyle: { color: chartTheme.muted, fontSize: 11 },
-        itemWidth: 12,
-        itemHeight: 8,
-      },
-      grid: {
-        left: 48,
-        right: 24,
-        top: 24,
-        bottom: 48,
-      },
-      xAxis: {
-        type: "category" as const,
-        data: dayLabels,
-        boundaryGap: false,
-        axisLine: { lineStyle: { color: chartTheme.grid } },
-        axisLabel: {
-          color: chartTheme.muted,
-          fontSize: 10,
-          interval: Math.floor(maxDays / 6),
-        },
-      },
-      yAxis: {
-        type: "value" as const,
-        name: mode === "burndown" ? "Items Remaining" : "Items Completed",
-        nameLocation: "middle" as const,
-        nameGap: 35,
-        nameTextStyle: { color: chartTheme.muted, fontSize: 11 },
-        axisLine: { show: false },
-        axisTick: { show: false },
-        splitLine: { lineStyle: { color: chartTheme.grid, type: "dashed" as const } },
-        axisLabel: { color: chartTheme.muted, fontSize: 10 },
-        min: 0,
-        max: backlogSize,
-      },
-      series: [
-        {
-          name: "P95 (Conservative)",
-          type: "line" as const,
-          data: p95Band,
-          smooth: true,
-          lineStyle: { width: 0 },
-          showSymbol: false,
-          areaStyle: {
-            opacity: 0.15,
-            color: chartTheme.accent3,
-          },
-          z: 1,
-        },
-        {
-          name: "P85 (Target)",
-          type: "line" as const,
-          data: p85Band,
-          smooth: true,
-          lineStyle: { width: 0 },
-          showSymbol: false,
-          areaStyle: {
-            opacity: 0.25,
-            color: chartTheme.accent2 || "#f59e0b",
-          },
-          z: 2,
-        },
-        {
-          name: "P50 (Optimistic)",
-          type: "line" as const,
-          data: p50Band,
-          smooth: true,
-          lineStyle: { width: 2, color: chartTheme.accent1 || "#22c55e" },
-          showSymbol: false,
-          areaStyle: {
-            opacity: 0.35,
-            color: chartTheme.accent1 || "#22c55e",
-          },
-          z: 3,
-        },
-      ],
-      markLine: {
-        silent: true,
-        symbol: ["none", "none"],
-        lineStyle: { type: "dashed" as const, color: chartTheme.muted },
-        data: [
-          { xAxis: p50Days, label: { show: false } },
-          { xAxis: p85Days, label: { show: false } },
-          { xAxis: p95Days, label: { show: false } },
-        ],
-      },
-    }),
-    [
-      chartTheme,
-      dayLabels,
-      maxDays,
-      mode,
-      backlogSize,
-      projection,
-      p50Band,
-      p85Band,
-      p95Band,
-      p50Days,
-      p85Days,
-      p95Days,
-    ],
-  );
+				},
+			},
+			legend: {
+				data: lowVariance
+					? ["Low variance forecast"]
+					: ["P50 (Optimistic)", "P85 (Target)", "P95 (Conservative)"],
+				bottom: 0,
+				left: "center",
+				textStyle: { color: chartTheme.muted, fontSize: 11 },
+				itemWidth: 12,
+				itemHeight: 8,
+			},
+			grid: {
+				left: 48,
+				right: 24,
+				top: 24,
+				bottom: 48,
+			},
+			xAxis: {
+				type: "category" as const,
+				data: dayLabels,
+				boundaryGap: false,
+				axisLine: { lineStyle: { color: chartTheme.grid } },
+				axisLabel: {
+					color: chartTheme.muted,
+					fontSize: 10,
+					interval: Math.floor(maxDays / 6),
+				},
+			},
+			yAxis: {
+				type: "value" as const,
+				name: mode === "burndown" ? "Items Remaining" : "Items Completed",
+				nameLocation: "middle" as const,
+				nameGap: 35,
+				nameTextStyle: { color: chartTheme.muted, fontSize: 11 },
+				axisLine: { show: false },
+				axisTick: { show: false },
+				splitLine: {
+					lineStyle: { color: chartTheme.grid, type: "dashed" as const },
+				},
+				axisLabel: { color: chartTheme.muted, fontSize: 10 },
+				min: 0,
+				max: backlogSize,
+			},
+			series: lowVariance
+				? [
+						{
+							name: "Low variance forecast",
+							type: "line" as const,
+							data: p50Band,
+							smooth: true,
+							lineStyle: { width: 2, color: chartTheme.accent1 },
+							showSymbol: false,
+							areaStyle: {
+								opacity: 0.3,
+								color: chartTheme.accent1,
+							},
+							z: 3,
+						},
+					]
+				: [
+						{
+							name: "P95 (Conservative)",
+							type: "line" as const,
+							data: p95Band,
+							smooth: true,
+							lineStyle: { width: 0 },
+							showSymbol: false,
+							areaStyle: {
+								opacity: 0.15,
+								color: chartTheme.accent3,
+							},
+							z: 1,
+						},
+						{
+							name: "P85 (Target)",
+							type: "line" as const,
+							data: p85Band,
+							smooth: true,
+							lineStyle: { width: 0 },
+							showSymbol: false,
+							areaStyle: {
+								opacity: 0.25,
+								color: chartTheme.accent2,
+							},
+							z: 2,
+						},
+						{
+							name: "P50 (Optimistic)",
+							type: "line" as const,
+							data: p50Band,
+							smooth: true,
+							lineStyle: { width: 2, color: chartTheme.accent1 },
+							showSymbol: false,
+							areaStyle: {
+								opacity: 0.35,
+								color: chartTheme.accent1,
+							},
+							z: 3,
+						},
+					],
+			markLine: {
+				silent: true,
+				symbol: ["none", "none"],
+				lineStyle: { type: "dashed" as const, color: chartTheme.muted },
+				data: lowVariance
+					? [{ xAxis: p50Days, label: { show: false } }]
+					: [
+							{ xAxis: p50Days, label: { show: false } },
+							{ xAxis: p85Days, label: { show: false } },
+							{ xAxis: p95Days, label: { show: false } },
+						],
+			},
+		}),
+		[
+			chartTheme,
+			dayLabels,
+			maxDays,
+			mode,
+			backlogSize,
+			projection,
+			p50Band,
+			p85Band,
+			p95Band,
+			p50Days,
+			p85Days,
+			p95Days,
+			lowVariance,
+		],
+	);
 
-  return (
-    <Chart option={option} className={className} style={mergedStyle} chartTheme={chartTheme} />
-  );
+	return (
+		<Chart
+			option={option}
+			className={className}
+			style={mergedStyle}
+			chartTheme={chartTheme}
+		/>
+	);
 }

--- a/src/components/charts/HeatmapChart.tsx
+++ b/src/components/charts/HeatmapChart.tsx
@@ -11,143 +11,147 @@ import type { HeatmapResponse } from "@/lib/types";
 import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
 import { echarts } from "@/lib/echartsInit";
+import { formatNumber } from "@/lib/formatters";
 
 echarts.use([EChartsHeatmapChart]);
 
 type HeatmapChartProps = {
-  data: HeatmapResponse;
-  height?: number | string;
-  width?: number | string;
-  className?: string;
-  style?: CSSProperties;
-  onCellSelect?: (cell: { x: string; y: string; value: number }) => void;
+	data: HeatmapResponse;
+	height?: number | string;
+	width?: number | string;
+	className?: string;
+	style?: CSSProperties;
+	onCellSelectAction?: (cell: { x: string; y: string; value: number }) => void;
 };
 
 export function HeatmapChart({
-  data,
-  height = 320,
-  width = "100%",
-  className,
-  style,
-  onCellSelect,
+	data,
+	height = 320,
+	width = "100%",
+	className,
+	style,
+	onCellSelectAction,
 }: HeatmapChartProps) {
-  const chartTheme = useChartTheme();
-  const chartColors = useChartColors();
-  const mergedStyle: CSSProperties = { height, width, ...style };
+	const chartTheme = useChartTheme();
+	const chartColors = useChartColors();
+	const mergedStyle: CSSProperties = { height, width, ...style };
 
-  const rawValues = data.cells.map((cell) => cell.value);
-  const valueForColor = (value: number) =>
-    data.legend.scale === "log" ? Math.log10(value + 1) : value;
+	const rawValues = data.cells.map((cell) => cell.value);
+	const valueForColor = (value: number) =>
+		data.legend.scale === "log" ? Math.log10(value + 1) : value;
 
-  const colorValues = rawValues.map(valueForColor);
-  const minValue = colorValues.length ? Math.min(...colorValues) : 0;
-  const maxValue = colorValues.length ? Math.max(...colorValues) : 1;
+	const colorValues = rawValues.map(valueForColor);
+	const minValue = colorValues.length ? Math.min(...colorValues) : 0;
+	const maxValue = colorValues.length ? Math.max(...colorValues) : 1;
 
-  const colorRamp = [
-    chartColors[5] ?? "#e2e8f0",
-    chartColors[0] ?? "#60a5fa",
-    chartColors[8] ?? "#f97316",
-  ];
+	const colorRamp = [
+		chartColors[5] ?? "#e2e8f0",
+		chartColors[0] ?? "#60a5fa",
+		chartColors[8] ?? "#f97316",
+	];
 
-  const seriesData = data.cells.map((cell) => [
-    cell.x,
-    cell.y,
-    valueForColor(cell.value),
-    cell.value,
-  ]);
+	const seriesData = data.cells.map((cell) => [
+		cell.x,
+		cell.y,
+		valueForColor(cell.value),
+		cell.value,
+	]);
 
-  const getValueArray = (params: unknown) => {
-    const entry = Array.isArray(params) ? params[0] : params;
-    if (!entry || typeof entry !== "object") {
-      return null;
-    }
-    const candidate = entry as { value?: unknown };
-    return Array.isArray(candidate.value) ? candidate.value : null;
-  };
+	const getValueArray = (params: unknown) => {
+		const entry = Array.isArray(params) ? params[0] : params;
+		if (!entry || typeof entry !== "object") {
+			return null;
+		}
+		const candidate = entry as { value?: unknown };
+		return Array.isArray(candidate.value) ? candidate.value : null;
+	};
 
-  const handleClick = (params: unknown) => {
-    if (!onCellSelect) {
-      return;
-    }
-    const values = getValueArray(params);
-    if (!values) {
-      return;
-    }
-    const rawValue = typeof values[3] === "number" ? values[3] : values[2];
-    const xLabel = String(values[0]);
-    const yLabel = String(values[1]);
-    if (typeof rawValue === "number") {
-      onCellSelect({ x: xLabel, y: yLabel, value: rawValue });
-    }
-  };
+	const handleClick = (params: unknown) => {
+		if (!onCellSelectAction) {
+			return;
+		}
+		const values = getValueArray(params);
+		if (!values) {
+			return;
+		}
+		const rawValue = typeof values[3] === "number" ? values[3] : values[2];
+		const xLabel = String(values[0]);
+		const yLabel = String(values[1]);
+		if (typeof rawValue === "number") {
+			onCellSelectAction({ x: xLabel, y: yLabel, value: rawValue });
+		}
+	};
 
-  return (
-    <Chart
-      option={{
-        tooltip: {
-          confine: true,
-          backgroundColor: chartTheme.background,
-          borderColor: chartTheme.stroke,
-          textStyle: {
-            color: chartTheme.text,
-          },
-          formatter: (params: TooltipComponentFormatterCallbackParams) => {
-            const values = getValueArray(params);
-            if (!values) {
-              return "";
-            }
-            const raw = values[3] ?? values[2];
-            const xLabel = values[0];
-            const yLabel = values[1];
-            const formatted = typeof raw === "number" ? raw.toFixed(2) : raw;
-            return [
-              `<strong>${yLabel}</strong> · ${xLabel}`,
-              `${formatted} ${data.legend.unit}`,
-            ].join("<br/>");
-          },
-        },
-        grid: { left: 32, right: 32, top: 24, bottom: 48, containLabel: true },
-        xAxis: {
-          type: "category",
-          data: data.axes.x,
-          axisTick: { show: false },
-          axisLine: { lineStyle: { color: chartTheme.grid } },
-          axisLabel: { color: chartTheme.muted, interval: 0 },
-        },
-        yAxis: {
-          type: "category",
-          data: data.axes.y,
-          axisTick: { show: false },
-          axisLine: { lineStyle: { color: chartTheme.grid } },
-          axisLabel: { color: chartTheme.muted },
-        },
-        visualMap: {
-          min: minValue,
-          max: maxValue,
-          calculable: false,
-          orient: "horizontal",
-          left: "center",
-          bottom: 0,
-          textStyle: { color: chartTheme.muted },
-          inRange: { color: colorRamp },
-        },
-        series: [
-          {
-            type: "heatmap",
-            data: seriesData,
-            encode: { value: 2 },
-            emphasis: {
-              itemStyle: { shadowBlur: 8, shadowColor: "rgba(0,0,0,0.2)" },
-            },
-            itemStyle: { borderColor: chartTheme.grid, borderWidth: 1 },
-          },
-        ],
-      }}
-      className={className}
-      style={mergedStyle}
-      onEvents={{ click: handleClick }}
-      chartTheme={chartTheme}
-      chartColors={chartColors}
-    />
-  );
+	return (
+		<Chart
+			option={{
+				tooltip: {
+					confine: true,
+					backgroundColor: chartTheme.background,
+					borderColor: chartTheme.stroke,
+					textStyle: {
+						color: chartTheme.text,
+					},
+					formatter: (params: TooltipComponentFormatterCallbackParams) => {
+						const values = getValueArray(params);
+						if (!values) {
+							return "No data for this cell";
+						}
+						const raw = values[3] ?? values[2];
+						const xLabel = values[0];
+						const yLabel = values[1];
+						const formatted =
+							typeof raw === "number"
+								? formatNumber(raw, { maximumFractionDigits: 2 })
+								: raw;
+						return [
+							`<strong>${yLabel}</strong> · ${xLabel}`,
+							`${formatted} ${data.legend.unit}`,
+						].join("<br/>");
+					},
+				},
+				grid: { left: 32, right: 32, top: 24, bottom: 48, containLabel: true },
+				xAxis: {
+					type: "category",
+					data: data.axes.x,
+					axisTick: { show: false },
+					axisLine: { lineStyle: { color: chartTheme.grid } },
+					axisLabel: { color: chartTheme.muted, interval: 0 },
+				},
+				yAxis: {
+					type: "category",
+					data: data.axes.y,
+					axisTick: { show: false },
+					axisLine: { lineStyle: { color: chartTheme.grid } },
+					axisLabel: { color: chartTheme.muted },
+				},
+				visualMap: {
+					min: minValue,
+					max: maxValue,
+					calculable: false,
+					orient: "horizontal",
+					left: "center",
+					bottom: 0,
+					textStyle: { color: chartTheme.muted },
+					inRange: { color: colorRamp },
+				},
+				series: [
+					{
+						type: "heatmap",
+						data: seriesData,
+						encode: { value: 2 },
+						emphasis: {
+							itemStyle: { shadowBlur: 8, shadowColor: "rgba(0,0,0,0.2)" },
+						},
+						itemStyle: { borderColor: chartTheme.grid, borderWidth: 1 },
+					},
+				],
+			}}
+			className={className}
+			style={mergedStyle}
+			onEvents={{ click: handleClick }}
+			chartTheme={chartTheme}
+			chartColors={chartColors}
+		/>
+	);
 }

--- a/src/components/charts/HeatmapPanel.tsx
+++ b/src/components/charts/HeatmapPanel.tsx
@@ -12,64 +12,64 @@ import { formatNumber } from "@/lib/formatters";
 import { HeatmapChart } from "./HeatmapChart";
 
 type HeatmapRequest = {
-  type: "temporal_load" | "context_switch" | "risk" | "individual";
-  metric: string;
-  scope_type: string;
-  scope_id?: string;
-  range_days: number;
-  start_date?: string;
-  end_date?: string;
+	type: "temporal_load" | "context_switch" | "risk" | "individual";
+	metric: string;
+	scope_type: string;
+	scope_id?: string;
+	range_days: number;
+	start_date?: string;
+	end_date?: string;
 };
 
 type HeatmapPanelProps = {
-  title: string;
-  description: string;
-  request: HeatmapRequest;
-  initialData?: HeatmapResponse | null;
-  emptyState?: string;
-  evidenceTitle?: string;
-  /** Plain-language summary shown before any cell is selected (top hotspots + why). */
-  defaultSummary?: string;
-  /** Message shown when every cell carries the same value (no variance to map). */
-  flatStateLabel?: string;
+	title: string;
+	description: string;
+	request: HeatmapRequest;
+	initialData?: HeatmapResponse | null;
+	emptyState?: string;
+	evidenceTitle?: string;
+	/** Plain-language summary shown before any cell is selected (top hotspots + why). */
+	defaultSummary?: string;
+	/** Message shown when every cell carries the same value (no variance to map). */
+	flatStateLabel?: string;
 };
 
 const asText = (value: unknown): string | null =>
-  typeof value === "string" && value.trim().length ? value.trim() : null;
+	typeof value === "string" && value.trim().length ? value.trim() : null;
 
 const asNumber = (value: unknown): number | null =>
-  typeof value === "number" && Number.isFinite(value) ? value : null;
+	typeof value === "number" && Number.isFinite(value) ? value : null;
 
 const pickTimestamp = (item: Record<string, unknown>): string | null =>
-  asText(item.ts) ??
-  asText(item.timestamp) ??
-  asText(item.created_at) ??
-  asText(item.merged_at) ??
-  asText(item.completed_at) ??
-  asText(item.occurred_at) ??
-  null;
+	asText(item.ts) ??
+	asText(item.timestamp) ??
+	asText(item.created_at) ??
+	asText(item.merged_at) ??
+	asText(item.completed_at) ??
+	asText(item.occurred_at) ??
+	null;
 
 const evidenceLink = (item: Record<string, unknown>): string | null => {
-  const repoId = asText(item.repo_id);
-  const number = asNumber(item.number);
-  const workItemId = asText(item.work_item_id);
+	const repoId = asText(item.repo_id);
+	const number = asNumber(item.number);
+	const workItemId = asText(item.work_item_id);
 
-  if (repoId && number !== null) {
-    return `/prs/${repoId}:${number}`;
-  }
-  if (workItemId) {
-    return `/issues/${workItemId}`;
-  }
-  return null;
+	if (repoId && number !== null) {
+		return `/prs/${repoId}:${number}`;
+	}
+	if (workItemId) {
+		return `/issues/${workItemId}`;
+	}
+	return null;
 };
 
 type ResolvedArtifact = {
-  type: string;
-  label: string;
-  title: string;
-  timestamp: string | null;
-  value: number | null;
-  link: string | null;
+	type: string;
+	label: string;
+	title: string;
+	timestamp: string | null;
+	value: number | null;
+	link: string | null;
 };
 
 /**
@@ -78,245 +78,269 @@ type ResolvedArtifact = {
  * UUID/path), a tooltip carrying the full identifier, and a timestamp.
  * Replaces the previous raw `JSON.stringify(item)` dump.
  */
-export function describeArtifact(item: Record<string, unknown>, index: number): ResolvedArtifact {
-  const explicitName =
-    asText(item.title) ?? asText(item.name) ?? asText(item.repo_name) ?? asText(item.author);
-  const timestamp = pickTimestamp(item);
-  const value = asNumber(item.value);
-  const link = evidenceLink(item);
+export function describeArtifact(
+	item: Record<string, unknown>,
+	index: number,
+): ResolvedArtifact {
+	const explicitName =
+		asText(item.title) ??
+		asText(item.name) ??
+		asText(item.repo_name) ??
+		asText(item.author);
+	const timestamp = pickTimestamp(item);
+	const value = asNumber(item.value);
+	const link = evidenceLink(item);
 
-  const path = asText(item.path) ?? asText(item.file_key);
-  const commit = asText(item.commit_hash);
-  const number = asNumber(item.number);
-  const workItem = asText(item.work_item_id);
-  const deployment = asText(item.deployment_id);
+	const path = asText(item.path) ?? asText(item.file_key);
+	const commit = asText(item.commit_hash);
+	const number = asNumber(item.number);
+	const workItem = asText(item.work_item_id);
+	const deployment = asText(item.deployment_id);
 
-  if (path) {
-    const { label, title } = resolveEntityLabel(path, {
-      name: explicitName ?? undefined,
-    });
-    return { type: "File", label, title, timestamp, value, link };
-  }
-  if (commit) {
-    return {
-      type: "Commit",
-      label: explicitName ?? commit.slice(0, 8),
-      title: commit,
-      timestamp,
-      value,
-      link,
-    };
-  }
-  if (number !== null) {
-    const repo = asText(item.repo_id);
-    const repoLabel = repo
-      ? resolveEntityLabel(repo, { name: asText(item.repo_name) ?? undefined }).label
-      : null;
-    return {
-      type: "PR",
-      label: repoLabel ? `${repoLabel} #${number}` : `#${number}`,
-      title: repo ? `${repo}#${number}` : `#${number}`,
-      timestamp,
-      value,
-      link,
-    };
-  }
-  if (workItem) {
-    const { label, title } = resolveEntityLabel(workItem, {
-      name: explicitName ?? undefined,
-    });
-    return { type: "Work item", label, title, timestamp, value, link };
-  }
-  if (deployment) {
-    const { label, title } = resolveEntityLabel(deployment, {
-      name: explicitName ?? undefined,
-    });
-    return { type: "Deployment", label, title, timestamp, value, link };
-  }
+	if (path) {
+		const { label, title } = resolveEntityLabel(path, {
+			name: explicitName ?? undefined,
+		});
+		return { type: "File", label, title, timestamp, value, link };
+	}
+	if (commit) {
+		return {
+			type: "Commit",
+			label: explicitName ?? commit.slice(0, 8),
+			title: commit,
+			timestamp,
+			value,
+			link,
+		};
+	}
+	if (number !== null) {
+		const repo = asText(item.repo_id);
+		const repoLabel = repo
+			? resolveEntityLabel(repo, { name: asText(item.repo_name) ?? undefined })
+					.label
+			: null;
+		return {
+			type: "PR",
+			label: repoLabel ? `${repoLabel} #${number}` : `#${number}`,
+			title: repo ? `${repo}#${number}` : `#${number}`,
+			timestamp,
+			value,
+			link,
+		};
+	}
+	if (workItem) {
+		const { label, title } = resolveEntityLabel(workItem, {
+			name: explicitName ?? undefined,
+		});
+		return { type: "Work item", label, title, timestamp, value, link };
+	}
+	if (deployment) {
+		const { label, title } = resolveEntityLabel(deployment, {
+			name: explicitName ?? undefined,
+		});
+		return { type: "Deployment", label, title, timestamp, value, link };
+	}
 
-  const { label, title } = resolveEntityLabel(explicitName, {
-    fallback: `Item ${index + 1}`,
-  });
-  return { type: "Item", label, title, timestamp, value, link };
+	const { label, title } = resolveEntityLabel(explicitName, {
+		fallback: `Item ${index + 1}`,
+	});
+	return { type: "Item", label, title, timestamp, value, link };
 }
 
 export function HeatmapPanel({
-  title,
-  description,
-  request,
-  initialData,
-  emptyState = "Heatmap data unavailable.",
-  evidenceTitle = "Evidence",
-  defaultSummary,
-  flatStateLabel = "No variance in this window — every cell shares the same value.",
+	title,
+	description,
+	request,
+	initialData,
+	emptyState = "Heatmap data unavailable.",
+	evidenceTitle = "Evidence",
+	defaultSummary,
+	flatStateLabel = "No variance in this window — every cell shares the same value.",
 }: HeatmapPanelProps) {
-  const [selected, setSelected] = useState<HeatmapCell | null>(null);
-  const [evidence, setEvidence] = useState<Array<Record<string, unknown>>>(
-    initialData?.evidence ?? [],
-  );
-  const [loading, setLoading] = useState(false);
+	const [selected, setSelected] = useState<HeatmapCell | null>(null);
+	const [evidence, setEvidence] = useState<Array<Record<string, unknown>>>(
+		initialData?.evidence ?? [],
+	);
+	const [loading, setLoading] = useState(false);
 
-  const data = initialData;
+	const data = initialData;
 
-  const handleCellSelect = useCallback(
-    async (cell: HeatmapCell) => {
-      setSelected(cell);
-      setLoading(true);
-      try {
-        const response = await getHeatmap({
-          ...request,
-          x: cell.x,
-          y: cell.y,
-          limit: 50,
-        });
-        setEvidence(response.evidence ?? []);
-      } catch {
-        setEvidence([]);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [request],
-  );
+	const handleCellSelect = useCallback(
+		async (cell: HeatmapCell) => {
+			setSelected(cell);
+			setLoading(true);
+			try {
+				const response = await getHeatmap({
+					...request,
+					x: cell.x,
+					y: cell.y,
+					limit: 50,
+				});
+				setEvidence(response.evidence ?? []);
+			} catch {
+				setEvidence([]);
+			} finally {
+				setLoading(false);
+			}
+		},
+		[request],
+	);
 
-  const selectionLabel = useMemo(() => {
-    if (!selected) {
-      return null;
-    }
-    return `${selected.y} · ${selected.x}`;
-  }, [selected]);
+	const selectionLabel = useMemo(() => {
+		if (!selected) {
+			return null;
+		}
+		return `${selected.y} · ${selected.x}`;
+	}, [selected]);
 
-  // A heatmap with no spread across its cells renders as a single flat colour,
-  // which reads as "broken" rather than "uniform". Detect it and say so.
-  const isFlat = useMemo(() => {
-    const values = data?.cells?.map((cell) => cell.value) ?? [];
-    if (values.length < 2) {
-      return false;
-    }
-    return Math.max(...values) - Math.min(...values) === 0;
-  }, [data]);
+	// A heatmap with no spread across its cells renders as a single flat colour,
+	// which reads as "broken" rather than "uniform". Detect it and say so.
+	const isFlat = useMemo(() => {
+		const values = data?.cells?.map((cell) => cell.value) ?? [];
+		if (values.length < 2) {
+			return false;
+		}
+		return Math.max(...values) - Math.min(...values) === 0;
+	}, [data]);
 
-  const artifacts = useMemo(
-    () => evidence.map((item, index) => describeArtifact(item, index)),
-    [evidence],
-  );
+	const artifacts = useMemo(
+		() => evidence.map((item, index) => describeArtifact(item, index)),
+		[evidence],
+	);
 
-  if (!data || !data.axes?.x?.length || !data.axes?.y?.length) {
-    return (
-      <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
-        {emptyState}
-      </div>
-    );
-  }
+	if (!data || !data.axes?.x?.length || !data.axes?.y?.length) {
+		return (
+			<div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
+				{emptyState}
+			</div>
+		);
+	}
 
-  const headerNote = selectionLabel ?? (defaultSummary ? "Top hotspots" : null);
-  const showArtifacts = !loading && artifacts.length > 0;
+	const headerNote = selectionLabel ?? (defaultSummary ? "Top hotspots" : null);
+	const showArtifacts = !loading && artifacts.length > 0;
 
-  return (
-    <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 className="font-(--font-display) text-xl">{title}</h2>
-          <p className="mt-2 text-sm text-(--ink-muted)">{description}</p>
-        </div>
-        <div className="text-xs uppercase tracking-[0.2em] text-(--accent-2)">
-          {data.legend.unit}
-        </div>
-      </div>
-      <div className="mt-4">
-        {isFlat ? (
-          <div
-            data-testid="heatmap-flat-state"
-            className="flex h-[320px] items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-6 text-center text-sm text-(--ink-muted)"
-          >
-            {flatStateLabel}
-          </div>
-        ) : (
-          <HeatmapChart data={data} height={320} onCellSelect={handleCellSelect} />
-        )}
-      </div>
-      <div className="mt-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">{evidenceTitle}</p>
-          {headerNote ? <span className="text-xs text-(--ink-muted)">{headerNote}</span> : null}
-        </div>
+	return (
+		<div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+			<div className="flex flex-wrap items-start justify-between gap-3">
+				<div>
+					<h2 className="font-(--font-display) text-xl">{title}</h2>
+					<p className="mt-2 text-sm text-(--ink-muted)">{description}</p>
+				</div>
+				<div className="text-xs uppercase tracking-[0.2em] text-(--accent-2)">
+					{data.legend.unit}
+				</div>
+			</div>
+			<div className="mt-4">
+				{isFlat ? (
+					<div
+						data-testid="heatmap-flat-state"
+						className="flex h-[320px] items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-6 text-center text-sm text-(--ink-muted)"
+					>
+						{flatStateLabel}
+					</div>
+				) : (
+					<HeatmapChart
+						data={data}
+						height={320}
+						onCellSelectAction={handleCellSelect}
+					/>
+				)}
+			</div>
+			<div className="mt-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4">
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+						{evidenceTitle}
+					</p>
+					{headerNote ? (
+						<span className="text-xs text-(--ink-muted)">{headerNote}</span>
+					) : null}
+				</div>
 
-        {!selected && defaultSummary ? (
-          <p className="mt-3 text-sm leading-6 text-(--ink-muted)">{defaultSummary}</p>
-        ) : null}
+				{!selected && defaultSummary ? (
+					<p className="mt-3 text-sm leading-6 text-(--ink-muted)">
+						{defaultSummary}
+					</p>
+				) : null}
 
-        {loading ? <p className="mt-3 text-sm text-(--ink-muted)">Loading evidence...</p> : null}
+				{loading ? (
+					<p className="mt-3 text-sm text-(--ink-muted)">Loading evidence...</p>
+				) : null}
 
-        {showArtifacts ? (
-          <div className="mt-3 space-y-2 text-sm">
-            {artifacts.map((artifact, index) => {
-              const body = (
-                <>
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <span className="shrink-0 rounded border border-(--card-stroke) bg-(--card-70) px-1.5 py-0.5 text-[10px] font-bold uppercase text-(--ink-muted)">
-                        {artifact.type}
-                      </span>
-                      <span className="truncate" title={artifact.title}>
-                        {artifact.label}
-                      </span>
-                    </div>
-                    {artifact.value !== null ? (
-                      <span className="shrink-0 text-xs text-(--ink-muted)">
-                        {formatNumber(artifact.value)}
-                      </span>
-                    ) : artifact.link ? (
-                      <span className="shrink-0 text-xs text-(--ink-muted)">Open flame</span>
-                    ) : null}
-                  </div>
-                  {artifact.timestamp ? (
-                    <ClientTimestamp
-                      value={artifact.timestamp}
-                      className="mt-1 block text-xs text-(--ink-muted)"
-                    />
-                  ) : null}
-                </>
-              );
-              return artifact.link ? (
-                <Link
-                  key={`${artifact.title}-${index}`}
-                  href={artifact.link}
-                  className="block rounded-2xl border border-(--card-stroke) bg-card px-3 py-2 transition-colors hover:border-(--accent)/40"
-                >
-                  {body}
-                </Link>
-              ) : (
-                <div
-                  key={`${artifact.title}-${index}`}
-                  className="rounded-2xl border border-(--card-stroke) bg-card px-3 py-2"
-                >
-                  {body}
-                </div>
-              );
-            })}
-          </div>
-        ) : null}
+				{showArtifacts ? (
+					<div className="mt-3 space-y-2 text-sm">
+						{artifacts.map((artifact) => {
+							const body = (
+								<>
+									<div className="flex items-center justify-between gap-3">
+										<div className="flex min-w-0 items-center gap-2">
+											<span className="shrink-0 rounded border border-(--card-stroke) bg-(--card-70) px-1.5 py-0.5 text-[10px] font-bold uppercase text-(--ink-muted)">
+												{artifact.type}
+											</span>
+											<span className="truncate" title={artifact.title}>
+												{artifact.label}
+											</span>
+										</div>
+										{artifact.value !== null ? (
+											<span className="shrink-0 text-xs text-(--ink-muted)">
+												{formatNumber(artifact.value)}
+											</span>
+										) : artifact.link ? (
+											<span className="shrink-0 text-xs text-(--ink-muted)">
+												Open flame
+											</span>
+										) : null}
+									</div>
+									{artifact.timestamp ? (
+										<ClientTimestamp
+											value={artifact.timestamp}
+											className="mt-1 block text-xs text-(--ink-muted)"
+										/>
+									) : null}
+								</>
+							);
+							const artifactKey =
+								artifact.link ??
+								`${artifact.title}-${artifact.timestamp ?? artifact.label}`;
+							return artifact.link ? (
+								<Link
+									key={artifactKey}
+									href={artifact.link}
+									className="block rounded-2xl border border-(--card-stroke) bg-card px-3 py-2 transition-colors hover:border-(--accent)/40"
+								>
+									{body}
+								</Link>
+							) : (
+								<div
+									key={artifactKey}
+									className="rounded-2xl border border-(--card-stroke) bg-card px-3 py-2"
+								>
+									{body}
+								</div>
+							);
+						})}
+					</div>
+				) : null}
 
-        {!loading && selected && artifacts.length === 0 ? (
-          <p className="mt-3 text-sm text-(--ink-muted)">
-            No artifacts linked to this cell in the selected window.
-          </p>
-        ) : null}
+				{!loading && selected && artifacts.length === 0 ? (
+					<p className="mt-3 text-sm text-(--ink-muted)">
+						No artifacts linked to this cell in the selected window.
+					</p>
+				) : null}
 
-        {!loading && !selected && artifacts.length === 0 ? (
-          <p className="mt-3 text-sm text-(--ink-muted)">
-            {defaultSummary
-              ? "Hotspot artifacts appear here once code history is connected for this view."
-              : "Select a cell to inspect the underlying evidence."}
-          </p>
-        ) : null}
+				{!loading && !selected && artifacts.length === 0 ? (
+					<p className="mt-3 text-sm text-(--ink-muted)">
+						{defaultSummary
+							? "Hotspot artifacts appear here once code history is connected for this view."
+							: "Select a cell to inspect the underlying evidence."}
+					</p>
+				) : null}
 
-        {showArtifacts && !selected && !isFlat ? (
-          <p className="mt-3 text-xs text-(--ink-muted)">
-            Select a cell to inspect its underlying artifacts.
-          </p>
-        ) : null}
-      </div>
-    </div>
-  );
+				{showArtifacts && !selected && !isFlat ? (
+					<p className="mt-3 text-xs text-(--ink-muted)">
+						Select a cell to inspect its underlying artifacts.
+					</p>
+				) : null}
+			</div>
+		</div>
+	);
 }

--- a/src/components/complexity/ComplexityDashboard.tsx
+++ b/src/components/complexity/ComplexityDashboard.tsx
@@ -15,12 +15,14 @@
 
 import Link from "next/link";
 import { useMemo } from "react";
+import type { ReactNode } from "react";
 import type { EChartsOption } from "echarts";
 import { LineChart } from "echarts/charts";
 
 import { Chart } from "@/components/charts/Chart";
 import { TreemapChart } from "@/components/charts/TreemapChart";
 import type { TreemapNode } from "@/components/charts/TreemapChart";
+import { DataState } from "@/components/ui/DataState";
 import { useChartColors, useChartTheme } from "@/components/charts/chartTheme";
 import { echarts } from "@/lib/echartsInit";
 
@@ -33,34 +35,34 @@ echarts.use([LineChart]);
 // ---------------------------------------------------------------------------
 
 export type ComplexityPoint = {
-  date: string;
-  scopeId: string;
-  scopeName: string;
-  locTotal: number | null;
-  cyclomaticPerKloc: number | null;
-  cyclomaticTotal: number | null;
-  cyclomaticAvg: number | null;
-  highComplexityFunctions: number | null;
-  veryHighComplexityFunctions: number | null;
+	date: string;
+	scopeId: string;
+	scopeName: string;
+	locTotal: number | null;
+	cyclomaticPerKloc: number | null;
+	cyclomaticTotal: number | null;
+	cyclomaticAvg: number | null;
+	highComplexityFunctions: number | null;
+	veryHighComplexityFunctions: number | null;
 };
 
 export type HotspotRow = {
-  filePath: string;
-  repoId: string;
-  repoName: string;
-  churnLoc30d: number;
-  churnCommits30d: number;
-  cyclomaticTotal: number;
-  cyclomaticAvg: number;
-  blameConcentration: number | null;
-  riskScore: number;
-  evidenceUrl: string | null;
+	filePath: string;
+	repoId: string;
+	repoName: string;
+	churnLoc30d: number;
+	churnCommits30d: number;
+	cyclomaticTotal: number;
+	cyclomaticAvg: number;
+	blameConcentration: number | null;
+	riskScore: number;
+	evidenceUrl: string | null;
 };
 
 export type ComplexityDashboardProps = {
-  orgId: string;
-  points: ComplexityPoint[];
-  hotspotRows: HotspotRow[];
+	orgId: string;
+	points: ComplexityPoint[];
+	hotspotRows: HotspotRow[];
 };
 
 // ---------------------------------------------------------------------------
@@ -75,44 +77,46 @@ export type ComplexityDashboardProps = {
  * hotspotCount   — count of hotspot rows with riskScore > threshold.
  */
 export function computeKpis(
-  points: ComplexityPoint[],
-  hotspotRows: HotspotRow[],
-  threshold = 0.5,
+	points: ComplexityPoint[],
+	hotspotRows: HotspotRow[],
+	threshold = 0.5,
 ): {
-  avgComplexity: number | null;
-  totalHighComplexity: number;
-  hotspotCount: number;
+	avgComplexity: number | null;
+	totalHighComplexity: number;
+	hotspotCount: number;
 } {
-  // Group points by scopeId, keep latest date per scope.
-  const byScope = new Map<string, ComplexityPoint[]>();
-  for (const p of points) {
-    if (!byScope.has(p.scopeId)) byScope.set(p.scopeId, []);
-    byScope.get(p.scopeId)!.push(p);
-  }
+	// Group points by scopeId, keep latest date per scope.
+	const byScope = new Map<string, ComplexityPoint[]>();
+	for (const p of points) {
+		if (!byScope.has(p.scopeId)) byScope.set(p.scopeId, []);
+		byScope.get(p.scopeId)!.push(p);
+	}
 
-  const latestPerScope: ComplexityPoint[] = [];
-  for (const [, pts] of byScope) {
-    const sorted = [...pts].sort((a, b) => b.date.localeCompare(a.date));
-    latestPerScope.push(sorted[0]);
-  }
+	const latestPerScope: ComplexityPoint[] = [];
+	for (const [, pts] of byScope) {
+		const sorted = [...pts].sort((a, b) => b.date.localeCompare(a.date));
+		latestPerScope.push(sorted[0]);
+	}
 
-  const perKlocValues = latestPerScope
-    .map((p) => p.cyclomaticPerKloc)
-    .filter((v): v is number => v !== null);
+	const perKlocValues = latestPerScope
+		.map((p) => p.cyclomaticPerKloc)
+		.filter((v): v is number => v !== null);
 
-  const avgComplexity =
-    perKlocValues.length > 0
-      ? perKlocValues.reduce((s, v) => s + v, 0) / perKlocValues.length
-      : null;
+	const avgComplexity =
+		perKlocValues.length > 0
+			? perKlocValues.reduce((s, v) => s + v, 0) / perKlocValues.length
+			: null;
 
-  const totalHighComplexity = latestPerScope.reduce(
-    (sum, p) => sum + (p.highComplexityFunctions ?? 0),
-    0,
-  );
+	const totalHighComplexity = latestPerScope.reduce(
+		(sum, p) => sum + (p.highComplexityFunctions ?? 0),
+		0,
+	);
 
-  const hotspotCount = hotspotRows.filter((r) => r.riskScore > threshold).length;
+	const hotspotCount = hotspotRows.filter(
+		(r) => r.riskScore > threshold,
+	).length;
 
-  return { avgComplexity, totalHighComplexity, hotspotCount };
+	return { avgComplexity, totalHighComplexity, hotspotCount };
 }
 
 /**
@@ -120,36 +124,40 @@ export function computeKpis(
  * Files are grouped under their repo as parent nodes.
  * Returns null when rows is empty (treemap skipped).
  */
-export function buildTreemapData(hotspotRows: HotspotRow[]): TreemapNode | null {
-  if (hotspotRows.length === 0) return null;
+export function buildTreemapData(
+	hotspotRows: HotspotRow[],
+): TreemapNode | null {
+	if (hotspotRows.length === 0) return null;
 
-  const byRepo = new Map<string, HotspotRow[]>();
-  for (const row of hotspotRows) {
-    if (!byRepo.has(row.repoName)) byRepo.set(row.repoName, []);
-    byRepo.get(row.repoName)!.push(row);
-  }
+	const byRepo = new Map<string, HotspotRow[]>();
+	for (const row of hotspotRows) {
+		if (!byRepo.has(row.repoName)) byRepo.set(row.repoName, []);
+		byRepo.get(row.repoName)!.push(row);
+	}
 
-  const children: TreemapNode[] = Array.from(byRepo.entries()).map(([repoName, rows]) => ({
-    name: repoName,
-    value: rows.reduce((sum, r) => sum + r.riskScore, 0),
-    children: rows.map((row) => {
-      const fileName = row.filePath.split("/").pop() ?? row.filePath;
-      return {
-        name: fileName,
-        value: row.riskScore,
-        // Extra fields for tooltip formatter
-        filePath: row.filePath,
-        cyclomaticAvg: row.cyclomaticAvg,
-        churnLoc30d: row.churnLoc30d,
-      } as TreemapNode;
-    }),
-  }));
+	const children: TreemapNode[] = Array.from(byRepo.entries()).map(
+		([repoName, rows]) => ({
+			name: repoName,
+			value: rows.reduce((sum, r) => sum + r.riskScore, 0),
+			children: rows.map((row) => {
+				const fileName = row.filePath.split("/").pop() ?? row.filePath;
+				return {
+					name: fileName,
+					value: row.riskScore,
+					// Extra fields for tooltip formatter
+					filePath: row.filePath,
+					cyclomaticAvg: row.cyclomaticAvg,
+					churnLoc30d: row.churnLoc30d,
+				} as TreemapNode;
+			}),
+		}),
+	);
 
-  return {
-    name: "Hotspots",
-    value: children.reduce((sum, c) => sum + c.value, 0),
-    children,
-  };
+	return {
+		name: "Hotspots",
+		value: children.reduce((sum, c) => sum + c.value, 0),
+		children,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -159,301 +167,368 @@ export function buildTreemapData(hotspotRows: HotspotRow[]): TreemapNode | null 
 type ChartTheme = ReturnType<typeof useChartTheme>;
 
 function buildTrendOption(
-  points: ComplexityPoint[],
-  chartTheme: ChartTheme,
-  chartColors: string[],
+	points: ComplexityPoint[],
+	chartTheme: ChartTheme,
+	chartColors: string[],
 ): EChartsOption | null {
-  if (points.length === 0) return null;
+	if (points.length === 0) return null;
 
-  // Collect all unique dates sorted ascending
-  const allDates = [...new Set(points.map((p) => p.date))].sort();
+	// Collect all unique dates sorted ascending
+	const allDates = [...new Set(points.map((p) => p.date))].sort();
 
-  // Group by scopeId
-  const byScope = new Map<string, ComplexityPoint[]>();
-  for (const p of points) {
-    if (!byScope.has(p.scopeId)) byScope.set(p.scopeId, []);
-    byScope.get(p.scopeId)!.push(p);
-  }
+	// Group by scopeId
+	const byScope = new Map<string, ComplexityPoint[]>();
+	for (const p of points) {
+		if (!byScope.has(p.scopeId)) byScope.set(p.scopeId, []);
+		byScope.get(p.scopeId)!.push(p);
+	}
 
-  // Sort repos by latest cyclomaticPerKloc descending, take top 10
-  const sortedScopes = Array.from(byScope.entries())
-    .map(([scopeId, pts]) => {
-      const latest = pts.reduce((a, b) => (a.date > b.date ? a : b));
-      return {
-        scopeId,
-        pts,
-        scopeName: pts[0].scopeName,
-        latestValue: latest.cyclomaticPerKloc ?? 0,
-      };
-    })
-    .sort((a, b) => b.latestValue - a.latestValue)
-    .slice(0, 10);
+	// Sort repos by latest cyclomaticPerKloc descending, take top 10
+	const sortedScopes = Array.from(byScope.entries())
+		.map(([scopeId, pts]) => {
+			const latest = pts.reduce((a, b) => (a.date > b.date ? a : b));
+			return {
+				scopeId,
+				pts,
+				scopeName: pts[0].scopeName,
+				latestValue: latest.cyclomaticPerKloc ?? 0,
+			};
+		})
+		.sort((a, b) => b.latestValue - a.latestValue)
+		.slice(0, 10);
 
-  const series = sortedScopes.map(({ scopeName, pts }, idx) => {
-    const dataByDate = new Map(pts.map((p) => [p.date, p.cyclomaticPerKloc]));
-    return {
-      type: "line" as const,
-      name: scopeName,
-      data: allDates.map((d) => dataByDate.get(d) ?? null),
-      smooth: true,
-      symbol: "circle",
-      symbolSize: 5,
-      lineStyle: { width: 2, color: chartColors[idx % chartColors.length] },
-      itemStyle: { color: chartColors[idx % chartColors.length] },
-      connectNulls: true,
-    };
-  });
+	const series = sortedScopes.map(({ scopeName, pts }, idx) => {
+		const dataByDate = new Map(pts.map((p) => [p.date, p.cyclomaticPerKloc]));
+		return {
+			type: "line" as const,
+			name: scopeName,
+			data: allDates.map((d) => dataByDate.get(d) ?? null),
+			smooth: true,
+			symbol: "circle",
+			symbolSize: 5,
+			lineStyle: { width: 2, color: chartColors[idx % chartColors.length] },
+			itemStyle: { color: chartColors[idx % chartColors.length] },
+			connectNulls: true,
+		};
+	});
 
-  return {
-    tooltip: {
-      trigger: "axis",
-      confine: true,
-      backgroundColor: chartTheme.background,
-      borderColor: chartTheme.stroke,
-      textStyle: { color: chartTheme.text },
-    },
-    legend: {
-      show: true,
-      bottom: 0,
-      textStyle: { color: chartTheme.muted, fontSize: 11 },
-    },
-    grid: { left: 24, right: 16, top: 32, bottom: 56, containLabel: true },
-    xAxis: {
-      type: "category",
-      data: allDates,
-      axisTick: { show: false },
-      axisLine: { lineStyle: { color: chartTheme.grid } },
-      axisLabel: { color: chartTheme.muted },
-    },
-    yAxis: {
-      type: "value",
-      name: "Cyclomatic / kloc",
-      nameTextStyle: { color: chartTheme.muted, fontSize: 10 },
-      splitLine: { lineStyle: { color: chartTheme.grid } },
-      axisLabel: { color: chartTheme.muted },
-    },
-    series,
-  } as EChartsOption;
+	return {
+		tooltip: {
+			trigger: "axis",
+			confine: true,
+			backgroundColor: chartTheme.background,
+			borderColor: chartTheme.stroke,
+			textStyle: { color: chartTheme.text },
+		},
+		legend: {
+			show: true,
+			bottom: 0,
+			textStyle: { color: chartTheme.muted, fontSize: 11 },
+		},
+		grid: { left: 24, right: 16, top: 32, bottom: 56, containLabel: true },
+		xAxis: {
+			type: "category",
+			data: allDates,
+			axisTick: { show: false },
+			axisLine: { lineStyle: { color: chartTheme.grid } },
+			axisLabel: { color: chartTheme.muted },
+		},
+		yAxis: {
+			type: "value",
+			name: "Cyclomatic / kloc",
+			nameTextStyle: { color: chartTheme.muted, fontSize: 10 },
+			splitLine: { lineStyle: { color: chartTheme.grid } },
+			axisLabel: { color: chartTheme.muted },
+		},
+		series,
+	} as EChartsOption;
 }
 
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
 
-function KpiCard({ label, value, caption }: { label: string; value: string; caption: string }) {
-  return (
-    <article
-      className="rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-sm"
-      data-testid="kpi-card"
-    >
-      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
-        {label}
-      </p>
-      <p className="mt-3 text-3xl font-semibold tabular-nums">{value}</p>
-      <p className="mt-1 text-xs text-(--ink-muted)">{caption}</p>
-    </article>
-  );
+function KpiCard({
+	label,
+	value,
+	caption,
+}: {
+	label: string;
+	value: ReactNode;
+	caption: string;
+}) {
+	return (
+		<article
+			className="rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-sm"
+			data-testid="kpi-card"
+		>
+			<p className="text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
+				{label}
+			</p>
+			<div className="mt-3 text-3xl font-semibold tabular-nums">{value}</div>
+			<p className="mt-1 text-xs text-(--ink-muted)">{caption}</p>
+		</article>
+	);
 }
 
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
-export function ComplexityDashboard({ orgId, points, hotspotRows }: ComplexityDashboardProps) {
-  const chartTheme = useChartTheme();
-  const chartColors = useChartColors();
+export function ComplexityDashboard({
+	orgId,
+	points,
+	hotspotRows,
+}: ComplexityDashboardProps) {
+	const chartTheme = useChartTheme();
+	const chartColors = useChartColors();
 
-  const { avgComplexity, totalHighComplexity, hotspotCount } = computeKpis(points, hotspotRows);
+	const { avgComplexity, totalHighComplexity, hotspotCount } = computeKpis(
+		points,
+		hotspotRows,
+	);
 
-  const treemapData = useMemo(() => buildTreemapData(hotspotRows), [hotspotRows]);
+	const treemapData = useMemo(
+		() => buildTreemapData(hotspotRows),
+		[hotspotRows],
+	);
 
-  const trendOption = useMemo(
-    () => buildTrendOption(points, chartTheme, chartColors),
-    [points, chartTheme, chartColors],
-  );
+	const trendOption = useMemo(
+		() => buildTrendOption(points, chartTheme, chartColors),
+		[points, chartTheme, chartColors],
+	);
 
-  const isEmpty = points.length === 0 && hotspotRows.length === 0;
-  const top20Hotspots = useMemo(
-    () => [...hotspotRows].sort((a, b) => b.riskScore - a.riskScore).slice(0, 20),
-    [hotspotRows],
-  );
+	const isEmpty = points.length === 0 && hotspotRows.length === 0;
+	const top20Hotspots = useMemo(
+		() =>
+			[...hotspotRows].sort((a, b) => b.riskScore - a.riskScore).slice(0, 20),
+		[hotspotRows],
+	);
 
-  if (isEmpty) {
-    return (
-      <section
-        className="rounded-2xl border border-(--card-stroke) bg-card p-8 shadow-sm"
-        data-testid="empty-state"
-      >
-        <h2 className="text-2xl font-semibold tracking-tight">
-          No complexity history in this window.
-        </h2>
-        <p className="mt-4 max-w-2xl text-sm leading-6 text-(--ink-muted)">
-          Complexity data appears once{" "}
-          <code className="font-mono text-[0.85em]">dev-hops metrics daily</code> has processed at
-          least one complexity analysis run for this org. The page populates automatically on the
-          next metrics run.
-        </p>
-        <p className="mt-2 text-xs text-(--ink-muted)">
-          Org <span className="font-mono">{orgId}</span>
-        </p>
-      </section>
-    );
-  }
+	if (isEmpty) {
+		return (
+			<section
+				className="rounded-2xl border border-(--card-stroke) bg-card p-8 shadow-sm"
+				data-testid="empty-state"
+			>
+				<h2 className="text-2xl font-semibold tracking-tight">
+					No complexity history in this window.
+				</h2>
+				<p className="mt-4 max-w-2xl text-sm leading-6 text-(--ink-muted)">
+					Complexity data appears once{" "}
+					<code className="font-mono text-[0.85em]">
+						dev-hops metrics daily
+					</code>{" "}
+					has processed at least one complexity analysis run for this org. The
+					page populates automatically on the next metrics run.
+				</p>
+				<p className="mt-2 text-xs text-(--ink-muted)">
+					Org <span className="font-mono">{orgId}</span>
+				</p>
+			</section>
+		);
+	}
 
-  return (
-    <div className="flex flex-col gap-6" data-testid="complexity-dashboard">
-      {/* KPI tiles */}
-      <section className="grid gap-4 lg:grid-cols-3">
-        <KpiCard
-          label="Avg Complexity"
-          value={avgComplexity !== null ? avgComplexity.toFixed(2) : "—"}
-          caption="cyclomatic / kloc · latest window"
-        />
-        <KpiCard
-          label="High-Complexity Functions"
-          value={totalHighComplexity > 0 ? totalHighComplexity.toLocaleString() : "—"}
-          caption="functions above threshold across repos"
-        />
-        <KpiCard
-          label="Hotspot Files"
-          value={hotspotCount > 0 ? hotspotCount.toLocaleString() : "—"}
-          caption="files with risk score > 0.5"
-        />
-      </section>
+	return (
+		<div className="flex flex-col gap-6" data-testid="complexity-dashboard">
+			{/* KPI tiles */}
+			<section className="grid gap-4 lg:grid-cols-3">
+				<KpiCard
+					label="Avg Complexity"
+					value={
+						avgComplexity !== null ? (
+							avgComplexity.toFixed(2)
+						) : (
+							<DataState
+								variant="insufficient-confidence"
+								title="No complexity average"
+								description="There is not enough complexity history to calculate an average for this window."
+							/>
+						)
+					}
+					caption="cyclomatic / kloc · latest window"
+				/>
+				<KpiCard
+					label="High-Complexity Functions"
+					value={
+						totalHighComplexity > 0 ? (
+							totalHighComplexity.toLocaleString()
+						) : (
+							<DataState
+								variant="detector-enabled-no-findings"
+								title="No high-complexity functions"
+								description="This view did not surface functions above the threshold for the selected window."
+							/>
+						)
+					}
+					caption="functions above threshold across repos"
+				/>
+				<KpiCard
+					label="Hotspot Files"
+					value={
+						hotspotCount > 0 ? (
+							hotspotCount.toLocaleString()
+						) : (
+							<DataState
+								variant="detector-enabled-no-findings"
+								title="No hotspot files"
+								description="No files crossed the hotspot risk threshold in this window."
+							/>
+						)
+					}
+					caption="files with risk score > 0.5"
+				/>
+			</section>
 
-      {/* Trend panel — multi-series cyclomaticPerKloc over time */}
-      {trendOption && (
-        <section
-          className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
-          data-testid="trend-panel"
-        >
-          <div className="mb-4">
-            <h2 className="text-lg font-semibold tracking-tight">Complexity trend</h2>
-            <p className="mt-1 text-sm text-(--ink-muted)">
-              Cyclomatic complexity per kloc over time — top repos by latest score.
-            </p>
-          </div>
-          <Chart
-            option={trendOption}
-            style={{ height: 320 }}
-            chartTheme={chartTheme}
-            chartColors={chartColors}
-          />
-        </section>
-      )}
+			{/* Trend panel — multi-series cyclomaticPerKloc over time */}
+			{trendOption && (
+				<section
+					className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
+					data-testid="trend-panel"
+				>
+					<div className="mb-4">
+						<h2 className="text-lg font-semibold tracking-tight">
+							Complexity trend
+						</h2>
+						<p className="mt-1 text-sm text-(--ink-muted)">
+							Cyclomatic complexity per kloc over time — top repos by latest
+							score.
+						</p>
+					</div>
+					<Chart
+						option={trendOption}
+						style={{ height: 320 }}
+						chartTheme={chartTheme}
+						chartColors={chartColors}
+					/>
+				</section>
+			)}
 
-      {/* Hotspot treemap — files sized by riskScore, grouped by repo */}
-      {treemapData && (
-        <section
-          className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
-          data-testid="hotspot-panel"
-        >
-          <div className="mb-4">
-            <h2 className="text-lg font-semibold tracking-tight">File hotspots</h2>
-            <p className="mt-1 text-sm text-(--ink-muted)">
-              Files sized by risk score (churn × complexity × ownership concentration). Grouped by
-              repo.
-            </p>
-          </div>
-          <TreemapChart
-            data={treemapData}
-            unit="risk"
-            height={400}
-            tooltipFormatter={(params, _total, unit) => {
-              const p = params as {
-                data?: {
-                  name?: string;
-                  value?: number;
-                  cyclomaticAvg?: number;
-                  churnLoc30d?: number;
-                  filePath?: string;
-                };
-              };
-              const node = p.data;
-              if (!node?.name) return "";
-              const lines = [`<strong>${node.filePath ?? node.name}</strong>`];
-              if (typeof node.value === "number") {
-                lines.push(`Risk score: ${node.value.toFixed(3)} ${unit}`);
-              }
-              if (typeof node.cyclomaticAvg === "number") {
-                lines.push(`Cyclomatic avg: ${node.cyclomaticAvg.toFixed(1)}`);
-              }
-              if (typeof node.churnLoc30d === "number") {
-                lines.push(`Churn LOC 30d: ${node.churnLoc30d.toLocaleString()}`);
-              }
-              return lines.join("<br/>");
-            }}
-          />
-        </section>
-      )}
+			{/* Hotspot treemap — files sized by riskScore, grouped by repo */}
+			{treemapData && (
+				<section
+					className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
+					data-testid="hotspot-panel"
+				>
+					<div className="mb-4">
+						<h2 className="text-lg font-semibold tracking-tight">
+							File hotspots
+						</h2>
+						<p className="mt-1 text-sm text-(--ink-muted)">
+							Files sized by risk score (churn × complexity × ownership
+							concentration). Grouped by repo.
+						</p>
+					</div>
+					<TreemapChart
+						data={treemapData}
+						unit="risk"
+						height={400}
+						tooltipFormatter={(params, _total, unit) => {
+							const p = params as {
+								data?: {
+									name?: string;
+									value?: number;
+									cyclomaticAvg?: number;
+									churnLoc30d?: number;
+									filePath?: string;
+								};
+							};
+							const node = p.data;
+							if (!node?.name) return "";
+							const lines = [`<strong>${node.filePath ?? node.name}</strong>`];
+							if (typeof node.value === "number") {
+								lines.push(`Risk score: ${node.value.toFixed(3)} ${unit}`);
+							}
+							if (typeof node.cyclomaticAvg === "number") {
+								lines.push(`Cyclomatic avg: ${node.cyclomaticAvg.toFixed(1)}`);
+							}
+							if (typeof node.churnLoc30d === "number") {
+								lines.push(
+									`Churn LOC 30d: ${node.churnLoc30d.toLocaleString()}`,
+								);
+							}
+							return lines.join("<br/>");
+						}}
+					/>
+				</section>
+			)}
 
-      {/* Drilldown table — top 20 hotspot files */}
-      {top20Hotspots.length > 0 && (
-        <section data-testid="drilldown-table">
-          <div className="mb-3 flex items-baseline justify-between">
-            <h2 className="text-lg font-semibold tracking-tight">Top hotspot files</h2>
-            <p className="text-xs text-(--ink-muted)">
-              sorted by risk score · top {top20Hotspots.length}
-            </p>
-          </div>
-          <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90) shadow-sm">
-            <table className="w-full text-sm" data-testid="hotspot-table">
-              <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
-                <tr>
-                  <th className="px-5 py-3 text-left">File</th>
-                  <th className="px-5 py-3 text-left">Repo</th>
-                  <th className="px-5 py-3 text-right">Risk score</th>
-                  <th className="px-5 py-3 text-right">Cyclomatic avg</th>
-                  <th className="px-5 py-3 text-right">Churn LOC 30d</th>
-                  <th className="px-5 py-3 text-left">Evidence</th>
-                </tr>
-              </thead>
-              <tbody>
-                {top20Hotspots.map((row, idx) => {
-                  const fileName = row.filePath.split("/").pop() ?? row.filePath;
-                  return (
-                    <tr
-                      key={`${row.repoId}-${row.filePath}-${idx}`}
-                      data-testid="hotspot-row"
-                      className="border-t border-(--card-stroke)/60 hover:bg-(--card-60)/60"
-                    >
-                      <td
-                        className="px-5 py-3 align-middle font-medium font-mono text-[0.82em]"
-                        title={row.filePath}
-                      >
-                        {fileName}
-                      </td>
-                      <td className="px-5 py-3 align-middle text-(--ink-muted)">{row.repoName}</td>
-                      <td className="px-5 py-3 text-right tabular-nums">
-                        {row.riskScore.toFixed(3)}
-                      </td>
-                      <td className="px-5 py-3 text-right tabular-nums">
-                        {row.cyclomaticAvg.toFixed(1)}
-                      </td>
-                      <td className="px-5 py-3 text-right tabular-nums">
-                        {row.churnLoc30d.toLocaleString()}
-                      </td>
-                      <td className="px-5 py-3">
-                        {row.evidenceUrl ? (
-                          <Link
-                            href={row.evidenceUrl}
-                            className="text-xs font-semibold uppercase tracking-[0.18em] text-(--accent) hover:underline"
-                            data-testid="evidence-link"
-                          >
-                            Open →
-                          </Link>
-                        ) : (
-                          <span className="text-xs text-(--ink-muted)">—</span>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-    </div>
-  );
+			{/* Drilldown table — top 20 hotspot files */}
+			{top20Hotspots.length > 0 && (
+				<section data-testid="drilldown-table">
+					<div className="mb-3 flex items-baseline justify-between">
+						<h2 className="text-lg font-semibold tracking-tight">
+							Top hotspot files
+						</h2>
+						<p className="text-xs text-(--ink-muted)">
+							sorted by risk score · top {top20Hotspots.length}
+						</p>
+					</div>
+					<div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90) shadow-sm">
+						<table className="w-full text-sm" data-testid="hotspot-table">
+							<thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
+								<tr>
+									<th className="px-5 py-3 text-left">File</th>
+									<th className="px-5 py-3 text-left">Repo</th>
+									<th className="px-5 py-3 text-right">Risk score</th>
+									<th className="px-5 py-3 text-right">Cyclomatic avg</th>
+									<th className="px-5 py-3 text-right">Churn LOC 30d</th>
+									<th className="px-5 py-3 text-left">Evidence</th>
+								</tr>
+							</thead>
+							<tbody>
+								{top20Hotspots.map((row, idx) => {
+									const fileName =
+										row.filePath.split("/").pop() ?? row.filePath;
+									return (
+										<tr
+											key={`${row.repoId}-${row.filePath}-${idx}`}
+											data-testid="hotspot-row"
+											className="border-t border-(--card-stroke)/60 hover:bg-(--card-60)/60"
+										>
+											<td
+												className="px-5 py-3 align-middle font-medium font-mono text-[0.82em]"
+												title={row.filePath}
+											>
+												{fileName}
+											</td>
+											<td className="px-5 py-3 align-middle text-(--ink-muted)">
+												{row.repoName}
+											</td>
+											<td className="px-5 py-3 text-right tabular-nums">
+												{row.riskScore.toFixed(3)}
+											</td>
+											<td className="px-5 py-3 text-right tabular-nums">
+												{row.cyclomaticAvg.toFixed(1)}
+											</td>
+											<td className="px-5 py-3 text-right tabular-nums">
+												{row.churnLoc30d.toLocaleString()}
+											</td>
+											<td className="px-5 py-3">
+												{row.evidenceUrl ? (
+													<Link
+														href={row.evidenceUrl}
+														className="text-xs font-semibold uppercase tracking-[0.18em] text-(--accent) hover:underline"
+														data-testid="evidence-link"
+													>
+														Open →
+													</Link>
+												) : (
+													<DataState
+														variant="source-unsupported"
+														title="No artifact link"
+														description="The source did not provide a link for this evidence row."
+													/>
+												)}
+											</td>
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				</section>
+			)}
+		</div>
+	);
 }

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
@@ -24,6 +24,7 @@ import { SankeyChart } from "@/components/charts/SankeyChart";
 import { MetricCard } from "@/components/metrics/MetricCard";
 import { buildExploreUrl } from "@/lib/filters/url";
 import { formatDelta, formatMetricValue } from "@/lib/formatters";
+import { CTA_LABELS } from "@/lib/design/cta";
 import type { MetricFilter } from "@/lib/filters/types";
 import type {
 	Contributor,
@@ -271,7 +272,6 @@ export function IncidentCorrelationDashboard({
 				</section>
 			)}
 
-			{/* ── CFR enlarged sparkline (V1 trend) ──────────────────────────────── */}
 			{cfrDelta && cfrDelta.spark.length > 0 && (
 				<section
 					className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5"
@@ -282,14 +282,15 @@ export function IncidentCorrelationDashboard({
 							Change Failure Rate — Trend
 						</h2>
 						<span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-							V1 sparkline
+							Recent trend
 						</span>
 					</div>
 					<p className="mt-1 text-xs text-(--ink-muted)">
-						Multi-week deployments-vs-incidents trend requires a future ops
-						resolver (planned: CHAOS-1757).
+						Deployment and incident trends appear when the connected source
+						provides enough history for the selected window.
 					</p>
 					<div
+						role="img"
 						aria-label="CFR sparkline"
 						className="mt-4 flex h-24 items-end gap-0.5"
 						data-testid="cfr-sparkline"
@@ -299,11 +300,11 @@ export function IncidentCorrelationDashboard({
 								0.01,
 								...cfrDelta.spark.map((p) => p.value),
 							);
-							return cfrDelta.spark.map((point, i) => {
+							return cfrDelta.spark.map((point) => {
 								const height = Math.max(4, (point.value / maxVal) * 88);
 								return (
 									<div
-										key={i}
+										key={point.ts}
 										className="flex-1 rounded-t-sm bg-(--accent)"
 										style={{ height: `${height}px` }}
 										title={`${point.ts}: ${point.value}`}
@@ -334,7 +335,7 @@ export function IncidentCorrelationDashboard({
 								})}
 								className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
 							>
-								Evidence
+								{CTA_LABELS.openEvidence}
 							</Link>
 						</div>
 						{topDrivers.length > 0 ? (
@@ -363,7 +364,7 @@ export function IncidentCorrelationDashboard({
 								})}
 								className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
 							>
-								Evidence
+								{CTA_LABELS.openEvidence}
 							</Link>
 						</div>
 						{topContributors.length > 0 ? (
@@ -400,7 +401,8 @@ export function IncidentCorrelationDashboard({
 						</h2>
 						<p className="text-xs text-(--ink-muted)">
 							{incidentRows.length} incident
-							{incidentRows.length !== 1 ? "s" : ""} · V1: ≤ 500 edges per type
+							{incidentRows.length !== 1 ? "s" : ""} · showing the strongest
+							linked records
 						</p>
 					</div>
 					<div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90) shadow-sm">
@@ -450,8 +452,8 @@ export function IncidentCorrelationDashboard({
 						Deployment → Incident → Work Item Flow
 					</h2>
 					<p className="mt-1 text-xs text-(--ink-muted)">
-						Top {MAX_SANKEY_INCIDENTS} incidents by linkage. Node labels are
-						truncated IDs.
+						Top {MAX_SANKEY_INCIDENTS} incidents by linkage. Labels are
+						shortened so the flow remains readable.
 					</p>
 					<div className="mt-4">
 						<SankeyChart
@@ -469,10 +471,9 @@ export function IncidentCorrelationDashboard({
 					className="rounded-2xl border border-(--card-stroke) bg-(--card-60) p-6 text-sm text-(--ink-muted)"
 					data-testid="empty-edges-state"
 				>
-					No deployment-incident linkage found in the work graph. Edge data
-					populates as <code className="font-mono text-[0.85em]">DEPLOYS</code>{" "}
-					and <code className="font-mono text-[0.85em]">LINKED_INCIDENT</code>{" "}
-					edges are ingested from your provider.
+					No deployment-incident linkage found yet. Deployment and incident
+					associations appear here after your connected provider sends enough
+					linked evidence for the selected window.
 				</section>
 			)}
 		</div>

--- a/src/components/people/PeopleSearch.tsx
+++ b/src/components/people/PeopleSearch.tsx
@@ -10,272 +10,297 @@ import type { PeopleSearchResult } from "@/lib/types";
 
 const EMPTY_LIST: string[] = [];
 const EMPTY_RESULTS: PeopleSearchResult[] = [];
+const PEOPLE_SEARCH_ENDPOINT = ["", "api", "v1", "people"].join("/");
 
 type PeopleSearchProps = {
-  query?: string;
-  filters?: MetricFilter;
+	query?: string;
+	filters?: MetricFilter;
 };
 
 type PeopleSearchPlan = {
-  query?: string;
-  teamId?: string;
+	query?: string;
+	teamId?: string;
 };
 
-const matchesDeveloper = (person: PeopleSearchResult, selectedDevelopers: string[]) => {
-  if (!selectedDevelopers.length) {
-    return true;
-  }
-  const targets = selectedDevelopers.map((dev) => dev.toLowerCase());
-  const candidates = [
-    person.display_name,
-    ...(person.identities ?? []).map((identity) => identity.handle),
-  ]
-    .filter(Boolean)
-    .map((value) => String(value).toLowerCase());
-  return targets.some((target) => candidates.some((candidate) => candidate.includes(target)));
+const matchesDeveloper = (
+	person: PeopleSearchResult,
+	selectedDevelopers: string[],
+) => {
+	if (!selectedDevelopers.length) {
+		return true;
+	}
+	const targets = selectedDevelopers.map((dev) => dev.toLowerCase());
+	const candidates = [
+		person.display_name,
+		...(person.identities ?? []).map((identity) => identity.handle),
+	]
+		.filter(Boolean)
+		.map((value) => String(value).toLowerCase());
+	return targets.some((target) =>
+		candidates.some((candidate) => candidate.includes(target)),
+	);
 };
 
 const matchesTeam = (person: PeopleSearchResult, teamIds: string[]) => {
-  if (!teamIds.length) {
-    return true;
-  }
-  const teamId = person.team_id;
-  if (!teamId) {
-    return false;
-  }
-  return teamIds.includes(teamId);
+	if (!teamIds.length) {
+		return true;
+	}
+	const teamId = person.team_id;
+	if (!teamId) {
+		return false;
+	}
+	return teamIds.includes(teamId);
 };
 
 export function PeopleSearch({ query, filters }: PeopleSearchProps) {
-  const [apiResults, setApiResults] = useState<PeopleSearchResult[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+	const [apiResults, setApiResults] = useState<PeopleSearchResult[]>([]);
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
 
-  const trimmedQuery = useMemo(() => (query ?? "").trim(), [query]);
-  const selectedDevelopers = filters?.who?.developers ?? EMPTY_LIST;
-  const scopeLevel = filters?.scope?.level;
-  const scopeIds = filters?.scope?.ids ?? EMPTY_LIST;
-  const teamIds = scopeLevel === "team" ? scopeIds : EMPTY_LIST;
-  const hasTeamFilter = teamIds.length > 0;
-  const queryActive = trimmedQuery.length > 0;
-  const focusActive = selectedDevelopers.length > 0;
-  const canFallbackQuery = !hasTeamFilter && !queryActive && selectedDevelopers.length === 1;
-  const searchTerm = queryActive ? trimmedQuery : canFallbackQuery ? selectedDevelopers[0] : "";
-  const fetchPlans = useMemo<PeopleSearchPlan[]>(() => {
-    if (teamIds.length) {
-      return teamIds.map((teamId) => ({
-        teamId,
-        query: searchTerm || undefined,
-      }));
-    }
-    if (searchTerm) {
-      return [{ query: searchTerm }];
-    }
-    if (focusActive) {
-      return selectedDevelopers.map((developer) => ({ query: developer }));
-    }
-    return [];
-  }, [focusActive, searchTerm, selectedDevelopers, teamIds]);
-  const shouldFetch = fetchPlans.length > 0;
-  const shouldShowResults = shouldFetch;
-  const results = apiResults;
-  const baseResults = useMemo(
-    () => (shouldShowResults ? results : EMPTY_RESULTS),
-    [results, shouldShowResults],
-  );
-  const hasTeamData = useMemo(
-    () => baseResults.some((person) => Boolean(person.team_id)),
-    [baseResults],
-  );
-  const visibleResults = useMemo(() => {
-    if (!teamIds.length || !hasTeamData) {
-      return baseResults;
-    }
-    return baseResults.filter((person) => matchesTeam(person, teamIds));
-  }, [baseResults, teamIds, hasTeamData]);
-  const focusMatches = useMemo(
-    () =>
-      new Set(
-        visibleResults
-          .filter((person) => matchesDeveloper(person, selectedDevelopers))
-          .map((person) => person.person_id),
-      ),
-    [visibleResults, selectedDevelopers],
-  );
-  const hasFocusMatches = focusMatches.size > 0;
-  const displayResults = useMemo(() => {
-    if (focusActive) {
-      if (!hasFocusMatches) {
-        return EMPTY_RESULTS;
-      }
-      return visibleResults.filter((person) => focusMatches.has(person.person_id));
-    }
-    return visibleResults;
-  }, [focusActive, focusMatches, hasFocusMatches, visibleResults]);
-  const emptyPrompt = hasTeamFilter
-    ? "Team filter applied. Search by name/handle to refine results."
-    : "Select a team or search by name/handle to find someone.";
-  const showEmptyResults = shouldShowResults && !isLoading && !error && visibleResults.length === 0;
-  const showQueryEmpty = showEmptyResults && queryActive;
-  const showTeamEmpty = showEmptyResults && !queryActive && hasTeamFilter;
-  const showFocusEmpty = showEmptyResults && !queryActive && !hasTeamFilter && focusActive;
+	const trimmedQuery = useMemo(() => (query ?? "").trim(), [query]);
+	const selectedDevelopers = filters?.who?.developers ?? EMPTY_LIST;
+	const scopeLevel = filters?.scope?.level;
+	const scopeIds = filters?.scope?.ids ?? EMPTY_LIST;
+	const teamIds = scopeLevel === "team" ? scopeIds : EMPTY_LIST;
+	const hasTeamFilter = teamIds.length > 0;
+	const queryActive = trimmedQuery.length > 0;
+	const focusActive = selectedDevelopers.length > 0;
+	const canFallbackQuery =
+		!hasTeamFilter && !queryActive && selectedDevelopers.length === 1;
+	const searchTerm = queryActive
+		? trimmedQuery
+		: canFallbackQuery
+			? selectedDevelopers[0]
+			: "";
+	const fetchPlans = useMemo<PeopleSearchPlan[]>(() => {
+		if (teamIds.length) {
+			return teamIds.map((teamId) => ({
+				teamId,
+				query: searchTerm || undefined,
+			}));
+		}
+		if (searchTerm) {
+			return [{ query: searchTerm }];
+		}
+		if (focusActive) {
+			return selectedDevelopers.map((developer) => ({ query: developer }));
+		}
+		return [];
+	}, [focusActive, searchTerm, selectedDevelopers, teamIds]);
+	const shouldFetch = fetchPlans.length > 0;
+	const shouldShowResults = shouldFetch;
+	const results = apiResults;
+	const baseResults = useMemo(
+		() => (shouldShowResults ? results : EMPTY_RESULTS),
+		[results, shouldShowResults],
+	);
+	const hasTeamData = useMemo(
+		() => baseResults.some((person) => Boolean(person.team_id)),
+		[baseResults],
+	);
+	const visibleResults = useMemo(() => {
+		if (!teamIds.length || !hasTeamData) {
+			return baseResults;
+		}
+		return baseResults.filter((person) => matchesTeam(person, teamIds));
+	}, [baseResults, teamIds, hasTeamData]);
+	const focusMatches = useMemo(
+		() =>
+			new Set(
+				visibleResults
+					.filter((person) => matchesDeveloper(person, selectedDevelopers))
+					.map((person) => person.person_id),
+			),
+		[visibleResults, selectedDevelopers],
+	);
+	const hasFocusMatches = focusMatches.size > 0;
+	const displayResults = useMemo(() => {
+		if (focusActive) {
+			if (!hasFocusMatches) {
+				return EMPTY_RESULTS;
+			}
+			return visibleResults.filter((person) =>
+				focusMatches.has(person.person_id),
+			);
+		}
+		return visibleResults;
+	}, [focusActive, focusMatches, hasFocusMatches, visibleResults]);
+	const emptyPrompt = hasTeamFilter
+		? "Team filter applied. Search by name/handle to refine results."
+		: "Select a team or search by name/handle to find someone.";
+	const showEmptyResults =
+		shouldShowResults && !isLoading && !error && visibleResults.length === 0;
+	const showQueryEmpty = showEmptyResults && queryActive;
+	const showTeamEmpty = showEmptyResults && !queryActive && hasTeamFilter;
+	const showFocusEmpty =
+		showEmptyResults && !queryActive && !hasTeamFilter && focusActive;
 
-  useEffect(() => {
-    if (!shouldFetch) {
-      return;
-    }
-    const controller = new AbortController();
+	useEffect(() => {
+		if (!shouldFetch) {
+			return;
+		}
+		const controller = new AbortController();
 
-    const timer = setTimeout(() => {
-      setIsLoading(true);
-      setError(null);
-      const requests = fetchPlans.map((plan) => {
-        const params: Record<string, string | number> = { limit: 20 };
-        if (plan.query) {
-          params.q = plan.query;
-        }
-        if (plan.teamId) {
-          params.scope_type = "team";
-          params.scope_id = plan.teamId;
-          params.team_id = plan.teamId;
-        }
-        return apiClient.getJson<PeopleSearchResult[]>("/api/v1/people", params, {
-          signal: controller.signal,
-        });
-      });
+		const timer = setTimeout(() => {
+			setIsLoading(true);
+			setError(null);
+			const requests = fetchPlans.map((plan) => {
+				const params: Record<string, string | number> = { limit: 20 };
+				if (plan.query) {
+					params.q = plan.query;
+				}
+				if (plan.teamId) {
+					params.scope_type = "team";
+					params.scope_id = plan.teamId;
+					params.team_id = plan.teamId;
+				}
+				return apiClient.getJson<PeopleSearchResult[]>(
+					PEOPLE_SEARCH_ENDPOINT,
+					params,
+					{
+						signal: controller.signal,
+					},
+				);
+			});
 
-      Promise.allSettled(requests)
-        .then((payloads) => {
-          if (controller.signal.aborted) {
-            return;
-          }
-          const fulfilled = payloads.filter(
-            (result): result is PromiseFulfilledResult<PeopleSearchResult[]> =>
-              result.status === "fulfilled",
-          );
-          if (!fulfilled.length) {
-            setError("Unable to load people right now.");
-            setIsLoading(false);
-            return;
-          }
-          const merged = new Map<string, PeopleSearchResult>();
-          fulfilled.forEach((result) => {
-            (result.value ?? []).forEach((person) => {
-              if (person && typeof person.person_id === "string") {
-                merged.set(person.person_id, person);
-              }
-            });
-          });
-          setApiResults(Array.from(merged.values()));
-          setIsLoading(false);
-        })
-        .catch(() => {
-          if (!controller.signal.aborted) {
-            setError("Unable to load people right now.");
-            setIsLoading(false);
-          }
-        });
-    }, 300);
+			Promise.allSettled(requests)
+				.then((payloads) => {
+					if (controller.signal.aborted) {
+						return;
+					}
+					const fulfilled = payloads.filter(
+						(result): result is PromiseFulfilledResult<PeopleSearchResult[]> =>
+							result.status === "fulfilled",
+					);
+					if (!fulfilled.length) {
+						setError("Unable to load people right now.");
+						setIsLoading(false);
+						return;
+					}
+					const merged = new Map<string, PeopleSearchResult>();
+					fulfilled.forEach((result) => {
+						(result.value ?? []).forEach((person) => {
+							if (person && typeof person.person_id === "string") {
+								merged.set(person.person_id, person);
+							}
+						});
+					});
+					setApiResults(Array.from(merged.values()));
+					setIsLoading(false);
+				})
+				.catch(() => {
+					if (!controller.signal.aborted) {
+						setError("Unable to load people right now.");
+						setIsLoading(false);
+					}
+				});
+		}, 300);
 
-    return () => {
-      clearTimeout(timer);
-      controller.abort();
-    };
-  }, [fetchPlans, shouldFetch]);
+		return () => {
+			clearTimeout(timer);
+			controller.abort();
+		};
+	}, [fetchPlans, shouldFetch]);
 
-  return (
-    <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">People search</p>
-          <p className="mt-2 text-sm text-(--ink-muted)">
-            Find an individual to view their personal metrics and evidence.
-          </p>
-        </div>
-      </div>
+	return (
+		<section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+			<div className="flex flex-wrap items-center justify-between gap-4">
+				<div>
+					<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+						People search
+					</p>
+					<p className="mt-2 text-sm text-(--ink-muted)">
+						Find an individual to view their personal metrics and evidence.
+					</p>
+				</div>
+			</div>
 
-      <div className="mt-4 space-y-3">
-        {shouldShowResults && isLoading && (
-          <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
-            Searching people...
-          </div>
-        )}
-        {shouldShowResults && error && (
-          <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
-            {error}
-          </div>
-        )}
-        {showQueryEmpty && (
-          <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
-            No matches yet. Try another spelling or handle.
-          </div>
-        )}
-        {showTeamEmpty && (
-          <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
-            No matches for the selected team filter.
-          </div>
-        )}
-        {showFocusEmpty && (
-          <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
-            No matches for the selected people filter.
-          </div>
-        )}
-        {shouldShowResults &&
-          !isLoading &&
-          !error &&
-          visibleResults.length > 0 &&
-          focusActive &&
-          !hasFocusMatches && (
-            <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
-              No matches for the selected people filter.
-            </div>
-          )}
-        {!shouldShowResults && !focusActive && (
-          <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
-            {emptyPrompt}
-          </div>
-        )}
-        {displayResults.map((person) => {
-          const isFocus = !focusActive || focusMatches.has(person.person_id);
-          const href = filters
-            ? withFilterParam(`/people/${person.person_id}`, filters)
-            : `/people/${person.person_id}`;
-          return (
-            <Link
-              key={person.person_id}
-              href={href}
-              className={`block rounded-2xl border border-(--card-stroke) bg-card px-4 py-3 transition hover:-translate-y-1 ${
-                focusActive && !isFocus ? "opacity-50" : "opacity-100"
-              }`}
-            >
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <div>
-                  <p
-                    className={`text-sm font-semibold ${
-                      focusActive && !isFocus ? "text-(--ink-muted)" : "text-foreground"
-                    }`}
-                  >
-                    {person.display_name}
-                  </p>
-                  {isFocus && (
-                    <div className="mt-2 flex flex-wrap gap-2 text-xs text-(--ink-muted)">
-                      {(person.identities ?? []).map((identity) => (
-                        <span
-                          key={`${person.person_id}-${identity.provider}-${identity.handle}`}
-                          className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
-                        >
-                          {identity.provider}: {identity.handle}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-                <span className="text-xs uppercase tracking-[0.2em] text-(--accent-2)">Open</span>
-              </div>
-            </Link>
-          );
-        })}
-      </div>
-    </section>
-  );
+			<div className="mt-4 space-y-3">
+				{shouldShowResults && isLoading && (
+					<div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+						Searching people...
+					</div>
+				)}
+				{shouldShowResults && error && (
+					<div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+						{error}
+					</div>
+				)}
+				{showQueryEmpty && (
+					<div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+						No matches yet. Try another spelling or handle.
+					</div>
+				)}
+				{showTeamEmpty && (
+					<div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+						No matches for the selected team filter.
+					</div>
+				)}
+				{showFocusEmpty && (
+					<div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+						No matches for the selected people filter.
+					</div>
+				)}
+				{shouldShowResults &&
+					!isLoading &&
+					!error &&
+					visibleResults.length > 0 &&
+					focusActive &&
+					!hasFocusMatches && (
+						<div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+							No matches for the selected people filter.
+						</div>
+					)}
+				{!shouldShowResults && !focusActive && (
+					<div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+						{emptyPrompt}
+					</div>
+				)}
+				{displayResults.map((person) => {
+					const isFocus = !focusActive || focusMatches.has(person.person_id);
+					const href = filters
+						? withFilterParam(`/people/${person.person_id}`, filters)
+						: `/people/${person.person_id}`;
+					return (
+						<Link
+							key={person.person_id}
+							href={href}
+							className={`block rounded-2xl border border-(--card-stroke) bg-card px-4 py-3 transition hover:-translate-y-1 ${
+								focusActive && !isFocus ? "opacity-50" : "opacity-100"
+							}`}
+						>
+							<div className="flex flex-wrap items-center justify-between gap-2">
+								<div>
+									<p
+										className={`text-sm font-semibold ${
+											focusActive && !isFocus
+												? "text-(--ink-muted)"
+												: "text-foreground"
+										}`}
+									>
+										{person.display_name}
+									</p>
+									{isFocus && (
+										<div className="mt-2 flex flex-wrap gap-2 text-xs text-(--ink-muted)">
+											{(person.identities ?? []).map((identity) => (
+												<span
+													key={`${person.person_id}-${identity.provider}-${identity.handle}`}
+													className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
+												>
+													{identity.provider}: {identity.handle}
+												</span>
+											))}
+										</div>
+									)}
+								</div>
+								<span className="text-xs uppercase tracking-[0.2em] text-(--accent-2)">
+									Open
+								</span>
+							</div>
+						</Link>
+					);
+				})}
+			</div>
+		</section>
+	);
 }

--- a/src/components/security/SecurityDashboard.test.tsx
+++ b/src/components/security/SecurityDashboard.test.tsx
@@ -3,46 +3,48 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, cleanup } from "@/test/utils";
 
 const { mockUseSecurityOverview } = vi.hoisted(() => ({
-  mockUseSecurityOverview: vi.fn(),
+	mockUseSecurityOverview: vi.fn(),
 }));
 
 vi.mock("@/lib/graphql/hooks/useSecurity", () => ({
-  useSecurityOverview: mockUseSecurityOverview,
+	useSecurityOverview: mockUseSecurityOverview,
 }));
 
 vi.mock("./KpiTile", () => ({
-  KpiTile: ({
-    label,
-    value,
-    loading,
-  }: {
-    label: string;
-    value: string | number;
-    loading?: boolean;
-  }) => (
-    <div data-testid="kpi-inner">
-      <span>{label}</span>
-      <span>{loading ? "loading" : String(value)}</span>
-    </div>
-  ),
+	KpiTile: ({
+		label,
+		value,
+		loading,
+	}: {
+		label: string;
+		value: string | number;
+		loading?: boolean;
+	}) => (
+		<div data-testid="kpi-inner">
+			<span>{label}</span>
+			<span>{loading ? "loading" : String(value)}</span>
+		</div>
+	),
 }));
 
 vi.mock("./SeverityStackedBar", () => ({
-  SeverityStackedBar: ({ loading }: { loading?: boolean }) => (
-    <div data-testid="severity-stacked-bar">{loading ? "loading" : "ready"}</div>
-  ),
+	SeverityStackedBar: ({ loading }: { loading?: boolean }) => (
+		<div data-testid="severity-stacked-bar">
+			{loading ? "loading" : "ready"}
+		</div>
+	),
 }));
 
 vi.mock("./TopReposChart", () => ({
-  TopReposChart: ({ loading }: { loading?: boolean }) => (
-    <div data-testid="top-repos-inner">{loading ? "loading" : "ready"}</div>
-  ),
+	TopReposChart: ({ loading }: { loading?: boolean }) => (
+		<div data-testid="top-repos-inner">{loading ? "loading" : "ready"}</div>
+	),
 }));
 
 vi.mock("./TrendChart", () => ({
-  TrendChart: ({ loading }: { loading?: boolean }) => (
-    <div data-testid="trend-chart">{loading ? "loading" : "ready"}</div>
-  ),
+	TrendChart: ({ loading }: { loading?: boolean }) => (
+		<div data-testid="trend-chart">{loading ? "loading" : "ready"}</div>
+	),
 }));
 
 import { SecurityDashboard } from "./SecurityDashboard";
@@ -51,109 +53,123 @@ import type { SecurityFilter } from "@/lib/filters/security";
 const filter: SecurityFilter = { openOnly: true };
 
 describe("SecurityDashboard", () => {
-  beforeEach(() => {
-    mockUseSecurityOverview.mockReset();
-  });
+	beforeEach(() => {
+		mockUseSecurityOverview.mockReset();
+	});
 
-  afterEach(() => cleanup());
+	afterEach(() => cleanup());
 
-  it("renders KPI tiles in loading state while fetching", () => {
-    mockUseSecurityOverview.mockReturnValue({
-      data: undefined,
-      fetching: true,
-      error: undefined,
-    });
+	it("renders KPI tiles in loading state while fetching", () => {
+		mockUseSecurityOverview.mockReturnValue({
+			data: undefined,
+			fetching: true,
+			error: undefined,
+		});
 
-    render(<SecurityDashboard filter={filter} />);
+		render(<SecurityDashboard filter={filter} />);
 
-    expect(screen.getByTestId("kpi-open")).toBeInTheDocument();
-    expect(screen.getByTestId("kpi-critical")).toBeInTheDocument();
-    expect(screen.getByTestId("kpi-high")).toBeInTheDocument();
-    expect(screen.getByTestId("kpi-mttf")).toBeInTheDocument();
-    const inner = screen.getAllByTestId("kpi-inner");
-    expect(inner.every((el) => el.textContent?.includes("loading"))).toBe(true);
-  });
+		expect(screen.getByTestId("kpi-open")).toBeInTheDocument();
+		expect(screen.getByTestId("kpi-critical")).toBeInTheDocument();
+		expect(screen.getByTestId("kpi-high")).toBeInTheDocument();
+		expect(screen.getByTestId("kpi-mttf")).toBeInTheDocument();
+		const inner = screen.getAllByTestId("kpi-inner");
+		expect(inner.every((el) => el.textContent?.includes("loading"))).toBe(true);
+	});
 
-  it("renders a banner and degraded tiles when the query errors", () => {
-    mockUseSecurityOverview.mockReturnValue({
-      data: undefined,
-      fetching: false,
-      error: new Error("boom"),
-    });
+	it("renders a banner and degraded tiles when the query errors", () => {
+		mockUseSecurityOverview.mockReturnValue({
+			data: undefined,
+			fetching: false,
+			error: new Error("boom"),
+		});
 
-    render(<SecurityDashboard filter={filter} />);
+		render(<SecurityDashboard filter={filter} />);
 
-    expect(screen.getByText(/Failed to load security overview/i)).toBeInTheDocument();
-    expect(screen.getByText(/boom/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/— Unavailable/i).length).toBeGreaterThanOrEqual(4);
-  });
+		expect(
+			screen.getByText(/Failed to load security overview/i),
+		).toBeInTheDocument();
+		expect(screen.getByText(/boom/i)).toBeInTheDocument();
+		expect(
+			screen.getAllByText(/could not be loaded/i).length,
+		).toBeGreaterThanOrEqual(4);
+	});
 
-  it("renders KPI values and charts once data is loaded", () => {
-    mockUseSecurityOverview.mockReturnValue({
-      data: {
-        securityOverview: {
-          kpis: {
-            openTotal: 25,
-            openDelta30d: 3,
-            critical: 4,
-            high: 10,
-            meanDaysToFix30d: 7.5,
-          },
-          severityBreakdown: [
-            { severity: "critical", count: 4 },
-            { severity: "high", count: 10 },
-          ],
-          topRepos: [{ repoId: "r1", repoName: "org/repo-a", count: 12 }],
-          trend: [
-            { day: "2024-03-01", opened: 2, fixed: 1 },
-            { day: "2024-03-02", opened: 3, fixed: 2 },
-          ],
-        },
-      },
-      fetching: false,
-      error: undefined,
-    });
+	it("renders KPI values and charts once data is loaded", () => {
+		mockUseSecurityOverview.mockReturnValue({
+			data: {
+				securityOverview: {
+					kpis: {
+						openTotal: 25,
+						openDelta30d: 3,
+						critical: 4,
+						high: 10,
+						meanDaysToFix30d: 7.5,
+					},
+					severityBreakdown: [
+						{ severity: "critical", count: 4 },
+						{ severity: "high", count: 10 },
+					],
+					topRepos: [{ repoId: "r1", repoName: "org/repo-a", count: 12 }],
+					trend: [
+						{ day: "2024-03-01", opened: 2, fixed: 1 },
+						{ day: "2024-03-02", opened: 3, fixed: 2 },
+					],
+				},
+			},
+			fetching: false,
+			error: undefined,
+		});
 
-    render(<SecurityDashboard filter={filter} />);
+		render(<SecurityDashboard filter={filter} />);
 
-    expect(screen.getByText("25")).toBeInTheDocument();
-    expect(screen.getByText("4")).toBeInTheDocument();
-    expect(screen.getByText("10")).toBeInTheDocument();
-    expect(screen.getByText("7.5d")).toBeInTheDocument();
-    expect(screen.getByTestId("severity-stacked-bar")).toHaveTextContent("ready");
-    expect(screen.getByTestId("top-repos-inner")).toHaveTextContent("ready");
-    expect(screen.getByTestId("trend-chart")).toHaveTextContent("ready");
-  });
+		expect(screen.getByText("25")).toBeInTheDocument();
+		expect(screen.getByText("4")).toBeInTheDocument();
+		expect(screen.getByText("10")).toBeInTheDocument();
+		expect(screen.getByText("7.5d")).toBeInTheDocument();
+		expect(screen.getByTestId("severity-stacked-bar")).toHaveTextContent(
+			"ready",
+		);
+		expect(screen.getByTestId("top-repos-inner")).toHaveTextContent("ready");
+		expect(screen.getByTestId("trend-chart")).toHaveTextContent("ready");
+	});
 
-  it("defaults KPIs to zero / em-dash when securityOverview.kpis is missing", () => {
-    mockUseSecurityOverview.mockReturnValue({
-      data: { securityOverview: {} },
-      fetching: false,
-      error: undefined,
-    });
+	it("defaults KPIs to zero / no data when securityOverview.kpis is missing", () => {
+		mockUseSecurityOverview.mockReturnValue({
+			data: { securityOverview: {} },
+			fetching: false,
+			error: undefined,
+		});
 
-    render(<SecurityDashboard filter={filter} />);
+		render(<SecurityDashboard filter={filter} />);
 
-    expect(screen.getAllByText("0").length).toBeGreaterThanOrEqual(3);
-    expect(screen.getByText("—")).toBeInTheDocument();
-  });
+		expect(screen.getAllByText("0").length).toBeGreaterThanOrEqual(3);
+		expect(screen.getByText("No data")).toBeInTheDocument();
+	});
 
-  it("does not render an error banner when there is no error", () => {
-    mockUseSecurityOverview.mockReturnValue({
-      data: {
-        securityOverview: {
-          kpis: { openTotal: 0, openDelta30d: 0, critical: 0, high: 0, meanDaysToFix30d: null },
-          severityBreakdown: [],
-          topRepos: [],
-          trend: [],
-        },
-      },
-      fetching: false,
-      error: undefined,
-    });
+	it("does not render an error banner when there is no error", () => {
+		mockUseSecurityOverview.mockReturnValue({
+			data: {
+				securityOverview: {
+					kpis: {
+						openTotal: 0,
+						openDelta30d: 0,
+						critical: 0,
+						high: 0,
+						meanDaysToFix30d: null,
+					},
+					severityBreakdown: [],
+					topRepos: [],
+					trend: [],
+				},
+			},
+			fetching: false,
+			error: undefined,
+		});
 
-    render(<SecurityDashboard filter={filter} />);
+		render(<SecurityDashboard filter={filter} />);
 
-    expect(screen.queryByText(/Failed to load security overview/i)).not.toBeInTheDocument();
-  });
+		expect(
+			screen.queryByText(/Failed to load security overview/i),
+		).not.toBeInTheDocument();
+	});
 });

--- a/src/components/security/SecurityDashboard.tsx
+++ b/src/components/security/SecurityDashboard.tsx
@@ -7,132 +7,147 @@ import { SeverityStackedBar } from "./SeverityStackedBar";
 import { TopReposChart } from "./TopReposChart";
 import { TrendChart } from "./TrendChart";
 import { ErrorCard } from "@/components/ui/ErrorCard";
-import type { SeverityBucketData, RepoAlertCountData, TrendPointData } from "./types";
+import { DataState } from "@/components/ui/DataState";
+import type {
+	SeverityBucketData,
+	RepoAlertCountData,
+	TrendPointData,
+} from "./types";
 
 interface SecurityDashboardProps {
-  filter: SecurityFilter;
+	filter: SecurityFilter;
 }
 
 /** Thin inline error placeholder rendered inside each testid wrapper in degraded mode. */
 function DegradedTile({ label }: { label: string }) {
-  return (
-    <p className="text-sm text-(--ink-muted)" aria-label={`${label} unavailable`}>
-      — Unavailable
-    </p>
-  );
+	return (
+		<DataState
+			variant="error"
+			title={`${label} unavailable`}
+			message="This security view could not be loaded. Please retry."
+		/>
+	);
 }
 
 export function SecurityDashboard({ filter }: SecurityDashboardProps) {
-  const { data, fetching, error } = useSecurityOverview(filter);
+	const { data, fetching, error } = useSecurityOverview(filter);
 
-  const kpis = data?.securityOverview?.kpis;
-  const severityBreakdown = data?.securityOverview?.severityBreakdown ?? [];
-  const topRepos = data?.securityOverview?.topRepos ?? [];
-  const trend = data?.securityOverview?.trend ?? [];
+	const kpis = data?.securityOverview?.kpis;
+	const severityBreakdown = data?.securityOverview?.severityBreakdown ?? [];
+	const topRepos = data?.securityOverview?.topRepos ?? [];
+	const trend = data?.securityOverview?.trend ?? [];
 
-  // Cast to narrowed types expected by chart components
-  const buckets = severityBreakdown as SeverityBucketData[];
-  const repos = topRepos as RepoAlertCountData[];
-  const trendPoints = trend as TrendPointData[];
+	// Cast to narrowed types expected by chart components
+	const buckets = severityBreakdown as SeverityBucketData[];
+	const repos = topRepos as RepoAlertCountData[];
+	const trendPoints = trend as TrendPointData[];
 
-  const mttfValue = kpis?.meanDaysToFix30d != null ? `${kpis.meanDaysToFix30d.toFixed(1)}d` : "—";
+	const mttfValue =
+		kpis?.meanDaysToFix30d != null
+			? `${kpis.meanDaysToFix30d.toFixed(1)}d`
+			: "No data";
 
-  return (
-    <div className="flex flex-col gap-6">
-      {/* Banner-level error notice — does NOT replace the grid structure */}
-      {error && <ErrorCard title="Failed to load security overview" message={error.message} />}
+	return (
+		<div className="flex flex-col gap-6">
+			{/* Banner-level error notice — does NOT replace the grid structure */}
+			{error && (
+				<ErrorCard
+					title="Failed to load security overview"
+					message={error.message}
+				/>
+			)}
 
-      {/* Row 1: KPI tiles — testid wrappers always in the DOM (required by Playwright) */}
-      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-        <div data-testid="kpi-open">
-          {error ? (
-            <DegradedTile label="Open Alerts" />
-          ) : (
-            <KpiTile
-              label="Open Alerts"
-              value={fetching ? "—" : (kpis?.openTotal ?? 0)}
-              delta={fetching ? undefined : kpis?.openDelta30d}
-              tone={kpis && kpis.openTotal > 0 ? "warn" : "default"}
-              loading={fetching}
-            />
-          )}
-        </div>
-        <div data-testid="kpi-critical">
-          {error ? (
-            <DegradedTile label="Critical" />
-          ) : (
-            <KpiTile
-              label="Critical"
-              value={fetching ? "—" : (kpis?.critical ?? 0)}
-              tone={kpis && kpis.critical > 0 ? "danger" : "default"}
-              loading={fetching}
-            />
-          )}
-        </div>
-        <div data-testid="kpi-high">
-          {error ? (
-            <DegradedTile label="High" />
-          ) : (
-            <KpiTile
-              label="High"
-              value={fetching ? "—" : (kpis?.high ?? 0)}
-              tone={kpis && kpis.high > 0 ? "warn" : "default"}
-              loading={fetching}
-            />
-          )}
-        </div>
-        <div data-testid="kpi-mttf">
-          {error ? (
-            <DegradedTile label="Mean Days to Fix (30d)" />
-          ) : (
-            <KpiTile
-              label="Mean Days to Fix (30d)"
-              value={fetching ? "—" : mttfValue}
-              tone="default"
-              loading={fetching}
-            />
-          )}
-        </div>
-      </div>
+			{/* Row 1: KPI tiles — testid wrappers always in the DOM (required by Playwright) */}
+			<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+				<div data-testid="kpi-open">
+					{error ? (
+						<DegradedTile label="Open Alerts" />
+					) : (
+						<KpiTile
+							label="Open Alerts"
+							value={kpis?.openTotal ?? 0}
+							delta={fetching ? undefined : kpis?.openDelta30d}
+							tone={kpis && kpis.openTotal > 0 ? "warn" : "default"}
+							loading={fetching}
+						/>
+					)}
+				</div>
+				<div data-testid="kpi-critical">
+					{error ? (
+						<DegradedTile label="Critical" />
+					) : (
+						<KpiTile
+							label="Critical"
+							value={kpis?.critical ?? 0}
+							tone={kpis && kpis.critical > 0 ? "danger" : "default"}
+							loading={fetching}
+						/>
+					)}
+				</div>
+				<div data-testid="kpi-high">
+					{error ? (
+						<DegradedTile label="High" />
+					) : (
+						<KpiTile
+							label="High"
+							value={kpis?.high ?? 0}
+							tone={kpis && kpis.high > 0 ? "warn" : "default"}
+							loading={fetching}
+						/>
+					)}
+				</div>
+				<div data-testid="kpi-mttf">
+					{error ? (
+						<DegradedTile label="Mean Days to Fix (30d)" />
+					) : (
+						<KpiTile
+							label="Mean Days to Fix (30d)"
+							value={mttfValue}
+							tone="default"
+							loading={fetching}
+						/>
+					)}
+				</div>
+			</div>
 
-      {/* Row 2: Severity breakdown + Top repos */}
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div className="rounded-2xl border border-(--card-stroke) bg-card p-4">
-          <p className="mb-3 text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
-            By Severity
-          </p>
-          {error ? (
-            <DegradedTile label="Severity breakdown" />
-          ) : (
-            <SeverityStackedBar buckets={buckets} loading={fetching} />
-          )}
-        </div>
-        <div
-          className="rounded-2xl border border-(--card-stroke) bg-card p-4"
-          data-testid="top-repos-chart"
-        >
-          <p className="mb-3 text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
-            Top Repos by Alert Count
-          </p>
-          {error ? (
-            <DegradedTile label="Top repos chart" />
-          ) : (
-            <TopReposChart repos={repos} loading={fetching} />
-          )}
-        </div>
-      </div>
+			{/* Row 2: Severity breakdown + Top repos */}
+			<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+				<div className="rounded-2xl border border-(--card-stroke) bg-card p-4">
+					<p className="mb-3 text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
+						By Severity
+					</p>
+					{error ? (
+						<DegradedTile label="Severity breakdown" />
+					) : (
+						<SeverityStackedBar buckets={buckets} loading={fetching} />
+					)}
+				</div>
+				<div
+					className="rounded-2xl border border-(--card-stroke) bg-card p-4"
+					data-testid="top-repos-chart"
+				>
+					<p className="mb-3 text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
+						Top Repos by Alert Count
+					</p>
+					{error ? (
+						<DegradedTile label="Top repos chart" />
+					) : (
+						<TopReposChart repos={repos} loading={fetching} />
+					)}
+				</div>
+			</div>
 
-      {/* Row 3: Trend chart */}
-      <div className="rounded-2xl border border-(--card-stroke) bg-card p-4">
-        <p className="mb-3 text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
-          Trend (last 30 days)
-        </p>
-        {error ? (
-          <DegradedTile label="Trend chart" />
-        ) : (
-          <TrendChart points={trendPoints} loading={fetching} />
-        )}
-      </div>
-    </div>
-  );
+			{/* Row 3: Trend chart */}
+			<div className="rounded-2xl border border-(--card-stroke) bg-card p-4">
+				<p className="mb-3 text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
+					Trend (last 30 days)
+				</p>
+				{error ? (
+					<DegradedTile label="Trend chart" />
+				) : (
+					<TrendChart points={trendPoints} loading={fetching} />
+				)}
+			</div>
+		</div>
+	);
 }

--- a/src/components/testops/PrTestOpsSummary.tsx
+++ b/src/components/testops/PrTestOpsSummary.tsx
@@ -1,148 +1,161 @@
 "use client";
 
-import React from "react";
+import { formatDelta, formatPercent } from "@/lib/formatters";
 
 export type PrTestOpsSummaryProps = {
-  prId: string;
-  repoId: string;
-  pipelineStatus?: {
-    status: "success" | "failure" | "running" | "pending";
-    duration?: string;
-  };
-  testResults?: {
-    passed: number;
-    failed: number;
-    skipped: number;
-    flaky: number;
-  };
-  coverageDelta?: number;
-  releaseConfidence?: number;
+	prId: string;
+	repoId: string;
+	pipelineStatus?: {
+		status: "success" | "failure" | "running" | "pending";
+		duration?: string;
+	};
+	testResults?: {
+		passed: number;
+		failed: number;
+		skipped: number;
+		flaky: number;
+	};
+	coverageDelta?: number;
+	releaseConfidence?: number;
 };
 
 export function PrTestOpsSummary({
-  prId,
-  repoId,
-  pipelineStatus,
-  testResults,
-  coverageDelta,
-  releaseConfidence,
+	prId,
+	repoId,
+	pipelineStatus,
+	testResults,
+	coverageDelta,
+	releaseConfidence,
 }: PrTestOpsSummaryProps) {
-  const getStatusColor = (status?: string) => {
-    switch (status) {
-      case "success":
-        return "bg-green-500/20 text-green-500 border-green-500/30";
-      case "failure":
-        return "bg-red-500/20 text-red-500 border-red-500/30";
-      case "running":
-        return "bg-blue-500/20 text-blue-500 border-blue-500/30";
-      default:
-        return "bg-gray-500/20 text-gray-500 border-gray-500/30";
-    }
-  };
+	const getStatusColor = (status?: string) => {
+		switch (status) {
+			case "success":
+				return "bg-green-500/20 text-green-500 border-green-500/30";
+			case "failure":
+				return "bg-red-500/20 text-red-500 border-red-500/30";
+			case "running":
+				return "bg-blue-500/20 text-blue-500 border-blue-500/30";
+			default:
+				return "bg-gray-500/20 text-gray-500 border-gray-500/30";
+		}
+	};
 
-  const getCoverageColor = (delta?: number) => {
-    if (delta === undefined) return "text-(--ink-muted)";
-    if (delta > 0) return "text-green-500";
-    if (delta < 0) return "text-red-500";
-    return "text-(--ink-muted)";
-  };
+	const getCoverageColor = (delta?: number) => {
+		if (delta === undefined) return "text-(--ink-muted)";
+		if (delta > 0) return "text-green-500";
+		if (delta < 0) return "text-red-500";
+		return "text-(--ink-muted)";
+	};
 
-  const getConfidenceColor = (score?: number) => {
-    if (score === undefined) return "text-(--ink-muted)";
-    if (score >= 0.8) return "text-green-500";
-    if (score >= 0.5) return "text-amber-500";
-    return "text-red-500";
-  };
+	const getConfidenceColor = (score?: number) => {
+		if (score === undefined) return "text-(--ink-muted)";
+		if (score >= 0.8) return "text-green-500";
+		if (score >= 0.5) return "text-amber-500";
+		return "text-red-500";
+	};
 
-  const totalTests = testResults
-    ? testResults.passed + testResults.failed + testResults.skipped + testResults.flaky
-    : 0;
+	const totalTests = testResults
+		? testResults.passed +
+			testResults.failed +
+			testResults.skipped +
+			testResults.flaky
+		: 0;
 
-  return (
-    <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="font-(--font-display) text-lg">TestOps Summary</h3>
-          <p className="text-xs text-(--ink-muted)">
-            {repoId} • {prId}
-          </p>
-        </div>
-        {pipelineStatus && (
-          <div
-            className={`rounded-full border px-3 py-1 text-xs font-medium capitalize ${getStatusColor(
-              pipelineStatus.status,
-            )}`}
-            data-testid="pipeline-status"
-          >
-            {pipelineStatus.status}
-            {pipelineStatus.duration && ` (${pipelineStatus.duration})`}
-          </div>
-        )}
-      </div>
+	return (
+		<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 flex flex-col gap-4">
+			<div className="flex items-center justify-between">
+				<div>
+					<h3 className="font-(--font-display) text-lg">TestOps Summary</h3>
+					<p className="text-xs text-(--ink-muted)">
+						{repoId} • {prId}
+					</p>
+				</div>
+				{pipelineStatus && (
+					<div
+						className={`rounded-full border px-3 py-1 text-xs font-medium capitalize ${getStatusColor(
+							pipelineStatus.status,
+						)}`}
+						data-testid="pipeline-status"
+					>
+						{pipelineStatus.status}
+						{pipelineStatus.duration && ` (${pipelineStatus.duration})`}
+					</div>
+				)}
+			</div>
 
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <div className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wider text-(--ink-muted)">Tests</span>
-          {testResults ? (
-            <div className="flex items-baseline gap-2">
-              <span className="text-xl font-medium" data-testid="test-passed">
-                {testResults.passed}
-              </span>
-              <span className="text-xs text-(--ink-muted)">/ {totalTests}</span>
-              {testResults.failed > 0 && (
-                <span className="text-xs text-red-500 font-medium ml-1" data-testid="test-failed">
-                  {testResults.failed} failed
-                </span>
-              )}
-            </div>
-          ) : (
-            <span className="text-sm text-(--ink-muted)">No data</span>
-          )}
-        </div>
+			<div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+				<div className="flex flex-col gap-1">
+					<span className="text-xs uppercase tracking-wider text-(--ink-muted)">
+						Tests
+					</span>
+					{testResults ? (
+						<div className="flex items-baseline gap-2">
+							<span className="text-xl font-medium" data-testid="test-passed">
+								{testResults.passed}
+							</span>
+							<span className="text-xs text-(--ink-muted)">/ {totalTests}</span>
+							{testResults.failed > 0 && (
+								<span
+									className="text-xs text-red-500 font-medium ml-1"
+									data-testid="test-failed"
+								>
+									{testResults.failed} failed
+								</span>
+							)}
+						</div>
+					) : (
+						<span className="text-sm text-(--ink-muted)">No data</span>
+					)}
+				</div>
 
-        <div className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wider text-(--ink-muted)">Flaky</span>
-          {testResults ? (
-            <span
-              className={`text-xl font-medium ${testResults.flaky > 0 ? "text-amber-500" : ""}`}
-              data-testid="test-flaky"
-            >
-              {testResults.flaky}
-            </span>
-          ) : (
-            <span className="text-sm text-(--ink-muted)">No data</span>
-          )}
-        </div>
+				<div className="flex flex-col gap-1">
+					<span className="text-xs uppercase tracking-wider text-(--ink-muted)">
+						Flaky
+					</span>
+					{testResults ? (
+						<span
+							className={`text-xl font-medium ${testResults.flaky > 0 ? "text-amber-500" : ""}`}
+							data-testid="test-flaky"
+						>
+							{testResults.flaky}
+						</span>
+					) : (
+						<span className="text-sm text-(--ink-muted)">No data</span>
+					)}
+				</div>
 
-        <div className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wider text-(--ink-muted)">Coverage</span>
-          {coverageDelta !== undefined ? (
-            <span
-              className={`text-xl font-medium ${getCoverageColor(coverageDelta)}`}
-              data-testid="coverage-delta"
-            >
-              {coverageDelta > 0 ? "+" : ""}
-              {coverageDelta}%
-            </span>
-          ) : (
-            <span className="text-sm text-(--ink-muted)">No data</span>
-          )}
-        </div>
+				<div className="flex flex-col gap-1">
+					<span className="text-xs uppercase tracking-wider text-(--ink-muted)">
+						Coverage
+					</span>
+					{coverageDelta !== undefined ? (
+						<span
+							className={`text-xl font-medium ${getCoverageColor(coverageDelta)}`}
+							data-testid="coverage-delta"
+						>
+							{formatDelta(coverageDelta)}
+						</span>
+					) : (
+						<span className="text-sm text-(--ink-muted)">No data</span>
+					)}
+				</div>
 
-        <div className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wider text-(--ink-muted)">Confidence</span>
-          {releaseConfidence !== undefined ? (
-            <span
-              className={`text-xl font-medium ${getConfidenceColor(releaseConfidence)}`}
-              data-testid="release-confidence"
-            >
-              {Math.round(releaseConfidence * 100)}%
-            </span>
-          ) : (
-            <span className="text-sm text-(--ink-muted)">No data</span>
-          )}
-        </div>
-      </div>
-    </div>
-  );
+				<div className="flex flex-col gap-1">
+					<span className="text-xs uppercase tracking-wider text-(--ink-muted)">
+						Confidence
+					</span>
+					{releaseConfidence !== undefined ? (
+						<span
+							className={`text-xl font-medium ${getConfidenceColor(releaseConfidence)}`}
+							data-testid="release-confidence"
+						>
+							{formatPercent(releaseConfidence * 100)}
+						</span>
+					) : (
+						<span className="text-sm text-(--ink-muted)">No data</span>
+					)}
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/components/testops/__tests__/PrTestOpsSummary.test.tsx
+++ b/src/components/testops/__tests__/PrTestOpsSummary.test.tsx
@@ -3,80 +3,86 @@ import { render, screen } from "@testing-library/react";
 import { PrTestOpsSummary } from "../PrTestOpsSummary";
 
 describe("PrTestOpsSummary", () => {
-  it("renders with full data", () => {
-    render(
-      <PrTestOpsSummary
-        prId="PR-123"
-        repoId="frontend-web"
-        pipelineStatus={{ status: "success", duration: "5m" }}
-        testResults={{ passed: 100, failed: 2, skipped: 1, flaky: 3 }}
-        coverageDelta={1.5}
-        releaseConfidence={0.85}
-      />,
-    );
+	it("renders with full data", () => {
+		render(
+			<PrTestOpsSummary
+				prId="PR-123"
+				repoId="frontend-web"
+				pipelineStatus={{ status: "success", duration: "5m" }}
+				testResults={{ passed: 100, failed: 2, skipped: 1, flaky: 3 }}
+				coverageDelta={1.5}
+				releaseConfidence={0.85}
+			/>,
+		);
 
-    expect(screen.getByText("TestOps Summary")).toBeInTheDocument();
-    expect(screen.getByText("frontend-web • PR-123")).toBeInTheDocument();
+		expect(screen.getByText("TestOps Summary")).toBeInTheDocument();
+		expect(screen.getByText("frontend-web • PR-123")).toBeInTheDocument();
 
-    const pipelineStatus = screen.getByTestId("pipeline-status");
-    expect(pipelineStatus).toHaveTextContent("success (5m)");
-    expect(pipelineStatus).toHaveClass("text-green-500");
+		const pipelineStatus = screen.getByTestId("pipeline-status");
+		expect(pipelineStatus).toHaveTextContent("success (5m)");
+		expect(pipelineStatus).toHaveClass("text-green-500");
 
-    expect(screen.getByTestId("test-passed")).toHaveTextContent("100");
-    expect(screen.getByTestId("test-failed")).toHaveTextContent("2 failed");
-    expect(screen.getByTestId("test-flaky")).toHaveTextContent("3");
+		expect(screen.getByTestId("test-passed")).toHaveTextContent("100");
+		expect(screen.getByTestId("test-failed")).toHaveTextContent("2 failed");
+		expect(screen.getByTestId("test-flaky")).toHaveTextContent("3");
 
-    const coverageDelta = screen.getByTestId("coverage-delta");
-    expect(coverageDelta).toHaveTextContent("+1.5%");
-    expect(coverageDelta).toHaveClass("text-green-500");
+		const coverageDelta = screen.getByTestId("coverage-delta");
+		expect(coverageDelta).toHaveTextContent("+2%");
+		expect(coverageDelta).toHaveClass("text-green-500");
 
-    const releaseConfidence = screen.getByTestId("release-confidence");
-    expect(releaseConfidence).toHaveTextContent("85%");
-    expect(releaseConfidence).toHaveClass("text-green-500");
-  });
+		const releaseConfidence = screen.getByTestId("release-confidence");
+		expect(releaseConfidence).toHaveTextContent("85%");
+		expect(releaseConfidence).toHaveClass("text-green-500");
+	});
 
-  it("renders with partial/missing data", () => {
-    render(<PrTestOpsSummary prId="PR-456" repoId="backend-api" />);
+	it("renders with partial/missing data", () => {
+		render(<PrTestOpsSummary prId="PR-456" repoId="backend-api" />);
 
-    expect(screen.getByText("TestOps Summary")).toBeInTheDocument();
-    expect(screen.getByText("backend-api • PR-456")).toBeInTheDocument();
+		expect(screen.getByText("TestOps Summary")).toBeInTheDocument();
+		expect(screen.getByText("backend-api • PR-456")).toBeInTheDocument();
 
-    expect(screen.queryByTestId("pipeline-status")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("pipeline-status")).not.toBeInTheDocument();
 
-    const noDataElements = screen.getAllByText("No data");
-    expect(noDataElements).toHaveLength(4);
-  });
+		const noDataElements = screen.getAllByText("No data");
+		expect(noDataElements).toHaveLength(4);
+	});
 
-  it("renders traffic light color logic correctly for failure/negative values", () => {
-    render(
-      <PrTestOpsSummary
-        prId="PR-789"
-        repoId="mobile-app"
-        pipelineStatus={{ status: "failure" }}
-        testResults={{ passed: 50, failed: 5, skipped: 0, flaky: 0 }}
-        coverageDelta={-2.5}
-        releaseConfidence={0.4}
-      />,
-    );
+	it("renders traffic light color logic correctly for failure/negative values", () => {
+		render(
+			<PrTestOpsSummary
+				prId="PR-789"
+				repoId="mobile-app"
+				pipelineStatus={{ status: "failure" }}
+				testResults={{ passed: 50, failed: 5, skipped: 0, flaky: 0 }}
+				coverageDelta={-2.5}
+				releaseConfidence={0.4}
+			/>,
+		);
 
-    const pipelineStatus = screen.getByTestId("pipeline-status");
-    expect(pipelineStatus).toHaveTextContent("failure");
-    expect(pipelineStatus).toHaveClass("text-red-500");
+		const pipelineStatus = screen.getByTestId("pipeline-status");
+		expect(pipelineStatus).toHaveTextContent("failure");
+		expect(pipelineStatus).toHaveClass("text-red-500");
 
-    const coverageDelta = screen.getByTestId("coverage-delta");
-    expect(coverageDelta).toHaveTextContent("-2.5%");
-    expect(coverageDelta).toHaveClass("text-red-500");
+		const coverageDelta = screen.getByTestId("coverage-delta");
+		expect(coverageDelta).toHaveTextContent("-2%");
+		expect(coverageDelta).toHaveClass("text-red-500");
 
-    const releaseConfidence = screen.getByTestId("release-confidence");
-    expect(releaseConfidence).toHaveTextContent("40%");
-    expect(releaseConfidence).toHaveClass("text-red-500");
-  });
+		const releaseConfidence = screen.getByTestId("release-confidence");
+		expect(releaseConfidence).toHaveTextContent("40%");
+		expect(releaseConfidence).toHaveClass("text-red-500");
+	});
 
-  it("renders traffic light color logic correctly for amber/warning values", () => {
-    render(<PrTestOpsSummary prId="PR-101" repoId="data-pipeline" releaseConfidence={0.6} />);
+	it("renders traffic light color logic correctly for amber/warning values", () => {
+		render(
+			<PrTestOpsSummary
+				prId="PR-101"
+				repoId="data-pipeline"
+				releaseConfidence={0.6}
+			/>,
+		);
 
-    const releaseConfidence = screen.getByTestId("release-confidence");
-    expect(releaseConfidence).toHaveTextContent("60%");
-    expect(releaseConfidence).toHaveClass("text-amber-500");
-  });
+		const releaseConfidence = screen.getByTestId("release-confidence");
+		expect(releaseConfidence).toHaveTextContent("60%");
+		expect(releaseConfidence).toHaveClass("text-amber-500");
+	});
 });

--- a/src/components/work/EvidenceView.test.tsx
+++ b/src/components/work/EvidenceView.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { render, screen } from "@/test/utils";
+import { EvidenceView } from "./EvidenceView";
+import type { MetricFilter } from "@/lib/filters/types";
+
+const filters: MetricFilter = {
+	scope: { level: "repo", ids: ["repo-a"] },
+	time: {
+		range_days: 30,
+		compare_days: 30,
+		start_date: undefined,
+		end_date: undefined,
+	},
+	who: {},
+	what: {},
+	why: {},
+	how: {},
+};
+
+describe("EvidenceView", () => {
+	it("renders one associations inspection action for the combined evidence view", () => {
+		render(
+			<EvidenceView
+				filters={filters}
+				wipExplain={null}
+				blockedExplain={null}
+			/>,
+		);
+
+		expect(
+			screen.getAllByRole("link", { name: /inspect associations/i }),
+		).toHaveLength(1);
+	});
+});

--- a/src/components/work/EvidenceView.tsx
+++ b/src/components/work/EvidenceView.tsx
@@ -3,80 +3,93 @@
 import Link from "next/link";
 import { buildExploreUrl } from "@/lib/filters/url";
 import { formatDelta } from "@/lib/formatters";
+import { CTA_LABELS } from "@/lib/design/cta";
 import type { MetricFilter, ExplainResponse } from "@/lib/types";
 
 type EvidenceViewProps = {
-  filters: MetricFilter;
-  activeRole?: string;
-  wipExplain: ExplainResponse | null;
-  blockedExplain: ExplainResponse | null;
+	filters: MetricFilter;
+	activeRole?: string;
+	wipExplain: ExplainResponse | null;
+	blockedExplain: ExplainResponse | null;
 };
 
 export function EvidenceView({
-  filters,
-  activeRole,
-  wipExplain,
-  blockedExplain,
+	filters,
+	activeRole,
+	wipExplain,
+	blockedExplain,
 }: EvidenceViewProps) {
-  return (
-    <section className="grid gap-6 lg:grid-cols-2">
-      <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
-        <div className="flex items-center justify-between">
-          <h2 className="font-(--font-display) text-xl">WIP Associations</h2>
-          <Link
-            href={buildExploreUrl({ metric: "wip_saturation", filters, role: activeRole })}
-            className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-          >
-            Inspect associations
-          </Link>
-        </div>
-        <div className="mt-4 space-y-2 text-sm">
-          {(wipExplain?.drivers ?? []).slice(0, 10).map((driver) => (
-            <Link
-              key={driver.id}
-              href={buildExploreUrl({ api: driver.evidence_link, filters, role: activeRole })}
-              className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
-            >
-              <span>{driver.label}</span>
-              <span className="text-xs text-(--ink-muted)">{formatDelta(driver.delta_pct)}</span>
-            </Link>
-          ))}
-          {!wipExplain?.drivers?.length && (
-            <p className="text-sm text-(--ink-muted)">
-              WIP association detail will appear once data is ingested.
-            </p>
-          )}
-        </div>
-      </div>
+	return (
+		<section className="grid gap-6 lg:grid-cols-2">
+			<div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+				<div className="flex items-center justify-between">
+					<h2 className="font-(--font-display) text-xl">WIP Associations</h2>
+					<Link
+						href={buildExploreUrl({
+							metric: "wip_saturation",
+							filters,
+							role: activeRole,
+						})}
+						className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+					>
+						{CTA_LABELS.inspectAssociations}
+					</Link>
+				</div>
+				<div className="mt-4 space-y-2 text-sm">
+					{(wipExplain?.drivers ?? []).slice(0, 10).map((driver) => (
+						<Link
+							key={driver.id}
+							href={buildExploreUrl({
+								api: driver.evidence_link,
+								filters,
+								role: activeRole,
+							})}
+							className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+						>
+							<span>{driver.label}</span>
+							<span className="text-xs text-(--ink-muted)">
+								{formatDelta(driver.delta_pct)}
+							</span>
+						</Link>
+					))}
+					{!wipExplain?.drivers?.length && (
+						<p className="text-sm text-(--ink-muted)">
+							WIP association detail will appear once data is ingested.
+						</p>
+					)}
+				</div>
+			</div>
 
-      <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
-        <div className="flex items-center justify-between">
-          <h2 className="font-(--font-display) text-xl">Blocked Associations</h2>
-          <Link
-            href={buildExploreUrl({ metric: "blocked_work", filters, role: activeRole })}
-            className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-          >
-            Inspect associations
-          </Link>
-        </div>
-        <div className="mt-4 space-y-2 text-sm">
-          {(blockedExplain?.drivers ?? []).slice(0, 10).map((driver) => (
-            <Link
-              key={driver.id}
-              href={buildExploreUrl({ api: driver.evidence_link, filters, role: activeRole })}
-              className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
-            >
-              <span>{driver.label}</span>
-              <span className="text-xs text-(--ink-muted)">{formatDelta(driver.delta_pct)}</span>
-            </Link>
-          ))}
-          {!blockedExplain?.drivers?.length && (
-            <p className="text-sm text-(--ink-muted)">
-              Blocked association detail will appear once data is ingested.
-            </p>
-          )}
-        </div>
-      </div>
-    </section>
-  );
+			<div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+				<div className="flex items-center justify-between">
+					<h2 className="font-(--font-display) text-xl">
+						Blocked Associations
+					</h2>
+				</div>
+				<div className="mt-4 space-y-2 text-sm">
+					{(blockedExplain?.drivers ?? []).slice(0, 10).map((driver) => (
+						<Link
+							key={driver.id}
+							href={buildExploreUrl({
+								api: driver.evidence_link,
+								filters,
+								role: activeRole,
+							})}
+							className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+						>
+							<span>{driver.label}</span>
+							<span className="text-xs text-(--ink-muted)">
+								{formatDelta(driver.delta_pct)}
+							</span>
+						</Link>
+					))}
+					{!blockedExplain?.drivers?.length && (
+						<p className="text-sm text-(--ink-muted)">
+							Blocked association detail will appear once data is ingested.
+						</p>
+					)}
+				</div>
+			</div>
+		</section>
+	);
 }

--- a/src/components/work/LandscapeView.tsx
+++ b/src/components/work/LandscapeView.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { QuadrantPanel } from "@/components/charts/QuadrantPanel";
 import { InvestmentChart } from "@/components/investment/InvestmentChart";
 import { MetricCard } from "@/components/metrics/MetricCard";
+import { DataState } from "@/components/ui/DataState";
 import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
 import { formatNumber, formatPercent } from "@/lib/formatters";
 import type { MetricDelta, QuadrantResponse } from "@/lib/types";
@@ -11,177 +12,218 @@ import type { MetricFilter } from "@/lib/filters/types";
 import type { InvestmentMixAggregate } from "@/lib/investmentMix";
 
 type LandscapeViewProps = {
-  filters: MetricFilter;
-  activeRole?: string;
-  deltas: MetricDelta[];
-  placeholderDeltas: boolean;
-  investmentMix: InvestmentMixAggregate | null;
-  cycleThroughput: QuadrantResponse | null;
-  wipThroughput: QuadrantResponse | null;
-  reviewLoadLatency: QuadrantResponse | null;
-  planned: { value: number } | null;
-  unplanned: { value: number } | null;
-  plannedPct: number | null;
-  unplannedPct: number | null;
+	filters: MetricFilter;
+	activeRole?: string;
+	deltas: MetricDelta[];
+	placeholderDeltas: boolean;
+	investmentMix: InvestmentMixAggregate | null;
+	cycleThroughput: QuadrantResponse | null;
+	wipThroughput: QuadrantResponse | null;
+	reviewLoadLatency: QuadrantResponse | null;
+	planned: { value: number } | null;
+	unplanned: { value: number } | null;
+	plannedPct: number | null;
+	unplannedPct: number | null;
 };
 
 export function LandscapeView({
-  filters,
-  activeRole,
-  deltas,
-  placeholderDeltas,
-  investmentMix,
-  cycleThroughput,
-  wipThroughput,
-  reviewLoadLatency,
-  planned,
-  unplanned,
-  plannedPct,
-  unplannedPct,
+	filters,
+	activeRole,
+	deltas,
+	placeholderDeltas,
+	investmentMix,
+	cycleThroughput,
+	wipThroughput,
+	reviewLoadLatency,
+	planned,
+	unplanned,
+	plannedPct,
+	unplannedPct,
 }: LandscapeViewProps) {
-  const getMetric = (metric: string) => deltas.find((item) => item.metric === metric);
+	const getMetric = (metric: string) =>
+		deltas.find((item) => item.metric === metric);
 
-  const wipMetric = getMetric("wip_saturation");
+	const wipMetric = getMetric("wip_saturation");
 
-  return (
-    <div className="flex flex-col gap-8">
-      <section className="grid gap-4 lg:grid-cols-3">
-        <MetricCard
-          label={wipMetric?.label ?? "WIP"}
-          href={buildExploreUrl({ metric: "wip_saturation", filters, role: activeRole })}
-          value={placeholderDeltas ? undefined : wipMetric?.value}
-          unit={wipMetric?.unit}
-          delta={placeholderDeltas ? undefined : wipMetric?.delta_pct}
-          spark={wipMetric?.spark}
-          caption="WIP saturation"
-        />
-        <MetricCard
-          label={getMetric("blocked_work")?.label ?? "Blocked"}
-          href={buildExploreUrl({ metric: "blocked_work", filters, role: activeRole })}
-          value={placeholderDeltas ? undefined : getMetric("blocked_work")?.value}
-          unit={getMetric("blocked_work")?.unit}
-          delta={placeholderDeltas ? undefined : getMetric("blocked_work")?.delta_pct}
-          spark={getMetric("blocked_work")?.spark}
-          caption="Blocked work"
-        />
-        <MetricCard
-          label={getMetric("throughput")?.label ?? "Throughput"}
-          href={buildExploreUrl({ metric: "throughput", filters, role: activeRole })}
-          value={placeholderDeltas ? undefined : getMetric("throughput")?.value}
-          unit={getMetric("throughput")?.unit}
-          delta={placeholderDeltas ? undefined : getMetric("throughput")?.delta_pct}
-          spark={getMetric("throughput")?.spark}
-          caption="Delivery volume"
-        />
-      </section>
+	return (
+		<div className="flex flex-col gap-8">
+			<section className="grid gap-4 lg:grid-cols-3">
+				<MetricCard
+					label={wipMetric?.label ?? "WIP"}
+					href={buildExploreUrl({
+						metric: "wip_saturation",
+						filters,
+						role: activeRole,
+					})}
+					value={placeholderDeltas ? undefined : wipMetric?.value}
+					unit={wipMetric?.unit}
+					delta={placeholderDeltas ? undefined : wipMetric?.delta_pct}
+					spark={wipMetric?.spark}
+					caption="WIP saturation"
+				/>
+				<MetricCard
+					label={getMetric("blocked_work")?.label ?? "Blocked"}
+					href={buildExploreUrl({
+						metric: "blocked_work",
+						filters,
+						role: activeRole,
+					})}
+					value={
+						placeholderDeltas ? undefined : getMetric("blocked_work")?.value
+					}
+					unit={getMetric("blocked_work")?.unit}
+					delta={
+						placeholderDeltas ? undefined : getMetric("blocked_work")?.delta_pct
+					}
+					spark={getMetric("blocked_work")?.spark}
+					caption="Blocked work"
+				/>
+				<MetricCard
+					label={getMetric("throughput")?.label ?? "Throughput"}
+					href={buildExploreUrl({
+						metric: "throughput",
+						filters,
+						role: activeRole,
+					})}
+					value={placeholderDeltas ? undefined : getMetric("throughput")?.value}
+					unit={getMetric("throughput")?.unit}
+					delta={
+						placeholderDeltas ? undefined : getMetric("throughput")?.delta_pct
+					}
+					spark={getMetric("throughput")?.spark}
+					caption="Delivery volume"
+				/>
+			</section>
 
-      <section className="flex flex-col gap-6">
-        <QuadrantPanel
-          title="Elapsed Time × Throughput"
-          description="Operating modes under time in flight and delivery pace."
-          data={cycleThroughput}
-          filters={filters}
-          relatedLinks={[
-            {
-              label: "Open landscapes",
-              href: withFilterParam("/explore/landscape", filters, activeRole),
-            },
-          ]}
-          emptyState="Quadrant data unavailable for this scope."
-        />
-        <QuadrantPanel
-          title="WIP × Throughput"
-          description="Operating modes under work in flight and delivery pace."
-          data={wipThroughput}
-          filters={filters}
-          relatedLinks={[
-            {
-              label: "Open landscapes",
-              href: withFilterParam("/explore/landscape", filters, activeRole),
-            },
-          ]}
-          emptyState="Quadrant data unavailable for this scope."
-        />
-        <QuadrantPanel
-          title="Review Load × Review Latency"
-          description="Operating modes under review demand and turnaround."
-          data={reviewLoadLatency}
-          filters={filters}
-          relatedLinks={[
-            {
-              label: "Open landscapes",
-              href: withFilterParam("/explore/landscape", filters, activeRole),
-            },
-          ]}
-          emptyState="Quadrant data unavailable for this scope."
-        />
-      </section>
+			<section className="flex flex-col gap-6">
+				<QuadrantPanel
+					title="Elapsed Time × Throughput"
+					description="Operating modes under time in flight and delivery pace."
+					data={cycleThroughput}
+					filters={filters}
+					relatedLinks={[
+						{
+							label: "Open landscapes",
+							href: withFilterParam("/explore/landscape", filters, activeRole),
+						},
+					]}
+					emptyState="Quadrant data unavailable for this scope."
+				/>
+				<QuadrantPanel
+					title="WIP × Throughput"
+					description="Operating modes under work in flight and delivery pace."
+					data={wipThroughput}
+					filters={filters}
+					relatedLinks={[
+						{
+							label: "Open landscapes",
+							href: withFilterParam("/explore/landscape", filters, activeRole),
+						},
+					]}
+					emptyState="Quadrant data unavailable for this scope."
+				/>
+				<QuadrantPanel
+					title="Review Load × Review Latency"
+					description="Operating modes under review demand and turnaround."
+					data={reviewLoadLatency}
+					filters={filters}
+					relatedLinks={[
+						{
+							label: "Open landscapes",
+							href: withFilterParam("/explore/landscape", filters, activeRole),
+						},
+					]}
+					emptyState="Quadrant data unavailable for this scope."
+				/>
+			</section>
 
-      <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
-        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <h2 className="font-(--font-display) text-xl">Investment Mix</h2>
-            <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.2em] text-(--accent-2)">
-              <Link href={withFilterParam("/work?tab=flow", filters, activeRole)}>View flow</Link>
-              <Link href={buildExploreUrl({ metric: "throughput", filters, role: activeRole })}>
-                Inspect associations
-              </Link>
-            </div>
-          </div>
-          <div className="mt-4">
-            {investmentMix && Object.keys(investmentMix.theme_distribution ?? {}).length ? (
-              <InvestmentChart
-                themeDistribution={investmentMix.theme_distribution}
-                subcategoryDistribution={investmentMix.subcategory_distribution}
-                evidenceQualityDistribution={investmentMix.evidence_quality_distribution}
-                unit={investmentMix.unit ?? "units"}
-              />
-            ) : (
-              <div className="flex h-[280px] items-center justify-center rounded-3xl border border-(--card-stroke) bg-(--card-70) text-sm text-(--ink-muted)">
-                Investment data unavailable.
-              </div>
-            )}
-          </div>
-        </div>
+			<section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+				<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+					<div className="flex flex-wrap items-center justify-between gap-2">
+						<h2 className="font-(--font-display) text-xl">Investment Mix</h2>
+						<div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.2em] text-(--accent-2)">
+							<Link
+								href={withFilterParam("/work?tab=flow", filters, activeRole)}
+							>
+								View flow
+							</Link>
+							<Link
+								href={buildExploreUrl({
+									metric: "throughput",
+									filters,
+									role: activeRole,
+								})}
+							>
+								Inspect associations
+							</Link>
+						</div>
+					</div>
+					<div className="mt-4">
+						{investmentMix &&
+						Object.keys(investmentMix.theme_distribution ?? {}).length ? (
+							<InvestmentChart
+								themeDistribution={investmentMix.theme_distribution}
+								subcategoryDistribution={investmentMix.subcategory_distribution}
+								evidenceQualityDistribution={
+									investmentMix.evidence_quality_distribution
+								}
+								unit={investmentMix.unit ?? "units"}
+							/>
+						) : (
+							<div className="flex h-[280px] items-center justify-center rounded-3xl border border-(--card-stroke) bg-(--card-70) text-sm text-(--ink-muted)">
+								Investment data unavailable.
+							</div>
+						)}
+					</div>
+				</div>
 
-        <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-4">
-          <div className="flex items-center justify-between">
-            <h2 className="font-(--font-display) text-xl">Planned vs Unplanned</h2>
-            <Link
-              href={withFilterParam("/work?tab=flow", filters, activeRole)}
-              className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
-            >
-              View flow
-            </Link>
-          </div>
-          {planned && unplanned ? (
-            <div className="mt-4 space-y-4">
-              <div className="rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3">
-                <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">Planned</p>
-                <p className="mt-2 text-2xl font-semibold">
-                  {formatPercent((plannedPct ?? 0) * 100)}
-                </p>
-                <p className="mt-2 text-xs text-(--ink-muted)">
-                  {formatNumber(planned.value)} units
-                </p>
-              </div>
-              <div className="rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3">
-                <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">Unplanned</p>
-                <p className="mt-2 text-2xl font-semibold">
-                  {formatPercent((unplannedPct ?? 0) * 100)}
-                </p>
-                <p className="mt-2 text-xs text-(--ink-muted)">
-                  {formatNumber(unplanned.value)} units
-                </p>
-              </div>
-            </div>
-          ) : (
-            <div className="mt-4 rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-4 text-sm text-(--ink-muted)">
-              Planned vs unplanned appears when work categories are tagged.
-            </div>
-          )}
-        </div>
-      </section>
-    </div>
-  );
+				<div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-4">
+					<div className="flex items-center justify-between">
+						<h2 className="font-(--font-display) text-xl">
+							Planned vs Unplanned
+						</h2>
+						<Link
+							href={withFilterParam("/work?tab=flow", filters, activeRole)}
+							className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+						>
+							View flow
+						</Link>
+					</div>
+					{planned && unplanned ? (
+						<div className="mt-4 space-y-4">
+							<div className="rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3">
+								<p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+									Planned
+								</p>
+								<p className="mt-2 text-2xl font-semibold">
+									{formatPercent((plannedPct ?? 0) * 100)}
+								</p>
+								<p className="mt-2 text-xs text-(--ink-muted)">
+									{formatNumber(planned.value)} units
+								</p>
+							</div>
+							<div className="rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3">
+								<p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+									Unplanned
+								</p>
+								<p className="mt-2 text-2xl font-semibold">
+									{formatPercent((unplannedPct ?? 0) * 100)}
+								</p>
+								<p className="mt-2 text-xs text-(--ink-muted)">
+									{formatNumber(unplanned.value)} units
+								</p>
+							</div>
+						</div>
+					) : (
+						<DataState
+							variant="insufficient-confidence"
+							title="Planned mix unavailable"
+							description="Planned and unplanned work appears when work categories are tagged for the selected window."
+							className="mt-4"
+						/>
+					)}
+				</div>
+			</section>
+		</div>
+	);
 }

--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -1,77 +1,87 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import {
-  formatDelta,
-  formatMetricValue,
-  formatNumber,
-  formatPercent,
-  defaultFormatter,
-  integerFormatter,
-  compactFormatter,
-  customFormatters,
-  getFormatter,
+	formatDelta,
+	formatMetricValue,
+	formatNumber,
+	formatPercent,
+	defaultFormatter,
+	integerFormatter,
+	compactFormatter,
+	customFormatters,
+	getFormatter,
 } from "@/lib/formatters";
 
 describe("formatters", () => {
-  it("formats numbers with defaults", () => {
-    expect(formatNumber(1200)).toBe("1,200");
-  });
+	it("formats numbers with defaults", () => {
+		expect(formatNumber(1200)).toBe("1,200");
+	});
 
-  it("formats percent and delta", () => {
-    expect(formatPercent(42)).toBe("42%");
-    expect(formatDelta(12.4)).toBe("+12%");
-    expect(formatDelta(-8.2)).toBe("-8%");
-  });
+	it("formats percent and delta", () => {
+		expect(formatPercent(42)).toBe("42%");
+		expect(formatDelta(12.4)).toBe("+12%");
+		expect(formatDelta(-8.2)).toBe("-8%");
+	});
 
-  it("formats metric values by unit", () => {
-    expect(formatMetricValue(3.4, "days")).toBe("3.4d");
-    expect(formatMetricValue(11, "%")).toBe("11%");
-    expect(formatMetricValue(8, "hours")).toBe("8h");
-  });
+	it("formats rounded negative-zero deltas as zero", () => {
+		expect(formatDelta(-0.2)).toBe("0%");
+	});
+
+	it("formats metric values by unit", () => {
+		expect(formatMetricValue(3.4, "days")).toBe("3.4d");
+		expect(formatMetricValue(11, "%")).toBe("11%");
+		expect(formatMetricValue(8, "hours")).toBe("8h");
+	});
 });
 
 describe("formatter caching", () => {
-  beforeEach(() => {
-    customFormatters.clear();
-  });
+	beforeEach(() => {
+		customFormatters.clear();
+	});
 
-  it("returns pre-created default formatter for no options", () => {
-    const formatter = getFormatter();
-    expect(formatter).toBe(defaultFormatter);
-  });
+	it("returns pre-created default formatter for no options", () => {
+		const formatter = getFormatter();
+		expect(formatter).toBe(defaultFormatter);
+	});
 
-  it("returns pre-created integer formatter for maximumFractionDigits: 0", () => {
-    const formatter = getFormatter({ maximumFractionDigits: 0 });
-    expect(formatter).toBe(integerFormatter);
-  });
+	it("returns pre-created integer formatter for maximumFractionDigits: 0", () => {
+		const formatter = getFormatter({ maximumFractionDigits: 0 });
+		expect(formatter).toBe(integerFormatter);
+	});
 
-  it("returns pre-created compact formatter for notation: compact", () => {
-    const formatter = getFormatter({ notation: "compact" });
-    expect(formatter).toBe(compactFormatter);
-  });
+	it("returns pre-created compact formatter for notation: compact", () => {
+		const formatter = getFormatter({ notation: "compact" });
+		expect(formatter).toBe(compactFormatter);
+	});
 
-  it("returns pre-created compact formatter for notation: compact with default maximumFractionDigits", () => {
-    const formatter = getFormatter({ notation: "compact", maximumFractionDigits: 1 });
-    expect(formatter).toBe(compactFormatter);
-  });
+	it("returns pre-created compact formatter for notation: compact with default maximumFractionDigits", () => {
+		const formatter = getFormatter({
+			notation: "compact",
+			maximumFractionDigits: 1,
+		});
+		expect(formatter).toBe(compactFormatter);
+	});
 
-  it("caches custom formatters and returns same instance", () => {
-    const options = { minimumFractionDigits: 2, maximumFractionDigits: 2 };
-    const formatter1 = getFormatter(options);
-    const formatter2 = getFormatter(options);
-    expect(formatter1).toBe(formatter2);
-    expect(customFormatters.size).toBe(1);
-  });
+	it("caches custom formatters and returns same instance", () => {
+		const options = { minimumFractionDigits: 2, maximumFractionDigits: 2 };
+		const formatter1 = getFormatter(options);
+		const formatter2 = getFormatter(options);
+		expect(formatter1).toBe(formatter2);
+		expect(customFormatters.size).toBe(1);
+	});
 
-  it("creates different cached formatters for different options", () => {
-    const formatter1 = getFormatter({ maximumFractionDigits: 2 });
-    const formatter2 = getFormatter({ maximumFractionDigits: 3 });
-    expect(formatter1).not.toBe(formatter2);
-    expect(customFormatters.size).toBe(2);
-  });
+	it("creates different cached formatters for different options", () => {
+		const formatter1 = getFormatter({ maximumFractionDigits: 2 });
+		const formatter2 = getFormatter({ maximumFractionDigits: 3 });
+		expect(formatter1).not.toBe(formatter2);
+		expect(customFormatters.size).toBe(2);
+	});
 
-  it("does not use pre-created compact formatter when other options differ", () => {
-    const formatter = getFormatter({ notation: "compact", maximumFractionDigits: 0 });
-    expect(formatter).not.toBe(compactFormatter);
-    expect(customFormatters.size).toBe(1);
-  });
+	it("does not use pre-created compact formatter when other options differ", () => {
+		const formatter = getFormatter({
+			notation: "compact",
+			maximumFractionDigits: 0,
+		});
+		expect(formatter).not.toBe(compactFormatter);
+		expect(customFormatters.size).toBe(1);
+	});
 });

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,94 +1,105 @@
 // Pre-created formatters for common use cases - avoids creating new instances on every call
 export const defaultFormatter = new Intl.NumberFormat("en-US", {
-  maximumFractionDigits: 1,
+	maximumFractionDigits: 1,
 });
 export const integerFormatter = new Intl.NumberFormat("en-US", {
-  maximumFractionDigits: 0,
+	maximumFractionDigits: 0,
 });
 export const compactFormatter = new Intl.NumberFormat("en-US", {
-  notation: "compact",
-  maximumFractionDigits: 1,
+	notation: "compact",
+	maximumFractionDigits: 1,
 });
 // Build timestamp strings manually via formatToParts to avoid hydration
 // mismatches — Node and browsers disagree on literal separators
 // (e.g. "Feb 8, 12:19 PM" vs "Feb 8 at 12:19 PM").
 const _tsParts = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  hour: "numeric",
-  minute: "2-digit",
+	month: "short",
+	day: "numeric",
+	hour: "numeric",
+	minute: "2-digit",
 });
 
 // Fallback cache for custom formatter options - exported for testing
 export const customFormatters = new Map<string, Intl.NumberFormat>();
 
-export const getFormatter = (options?: Intl.NumberFormatOptions): Intl.NumberFormat => {
-  // Use pre-created formatters for common cases
-  if (!options) {
-    return defaultFormatter;
-  }
-  if (options.maximumFractionDigits === 0 && Object.keys(options).length === 1) {
-    return integerFormatter;
-  }
-  if (
-    options.notation === "compact" &&
-    (options.maximumFractionDigits === undefined || options.maximumFractionDigits === 1) &&
-    Object.keys(options).filter((k) => k !== "notation" && k !== "maximumFractionDigits").length ===
-      0
-  ) {
-    return compactFormatter;
-  }
+export const getFormatter = (
+	options?: Intl.NumberFormatOptions,
+): Intl.NumberFormat => {
+	// Use pre-created formatters for common cases
+	if (!options) {
+		return defaultFormatter;
+	}
+	if (
+		options.maximumFractionDigits === 0 &&
+		Object.keys(options).length === 1
+	) {
+		return integerFormatter;
+	}
+	if (
+		options.notation === "compact" &&
+		(options.maximumFractionDigits === undefined ||
+			options.maximumFractionDigits === 1) &&
+		Object.keys(options).filter(
+			(k) => k !== "notation" && k !== "maximumFractionDigits",
+		).length === 0
+	) {
+		return compactFormatter;
+	}
 
-  // Fallback to cached custom formatter for any other options
-  const key = JSON.stringify(options);
-  let formatter = customFormatters.get(key);
-  if (!formatter) {
-    formatter = new Intl.NumberFormat("en-US", {
-      maximumFractionDigits: 1,
-      ...options,
-    });
-    customFormatters.set(key, formatter);
-  }
-  return formatter;
+	// Fallback to cached custom formatter for any other options
+	const key = JSON.stringify(options);
+	let formatter = customFormatters.get(key);
+	if (!formatter) {
+		formatter = new Intl.NumberFormat("en-US", {
+			maximumFractionDigits: 1,
+			...options,
+		});
+		customFormatters.set(key, formatter);
+	}
+	return formatter;
 };
 
-export const formatNumber = (value: number, options?: Intl.NumberFormatOptions) => {
-  return getFormatter(options).format(value);
+export const formatNumber = (
+	value: number,
+	options?: Intl.NumberFormatOptions,
+) => {
+	return getFormatter(options).format(value);
 };
 
 export const formatPercent = (value: number) =>
-  `${formatNumber(value, { maximumFractionDigits: 0 })}%`;
+	`${formatNumber(value, { maximumFractionDigits: 0 })}%`;
 
 export const formatDelta = (value: number) => {
-  const sign = value > 0 ? "+" : value < 0 ? "-" : "";
-  return `${sign}${formatNumber(Math.abs(value), { maximumFractionDigits: 0 })}%`;
+	const rounded = Math.round(value);
+	const sign = rounded > 0 ? "+" : rounded < 0 ? "-" : "";
+	return `${sign}${formatNumber(Math.abs(rounded), { maximumFractionDigits: 0 })}%`;
 };
 
 export const formatMetricValue = (value: number, unit: string) => {
-  if (unit === "%") {
-    return formatPercent(value);
-  }
-  if (unit === "days") {
-    return `${formatNumber(value, { maximumFractionDigits: 1 })}d`;
-  }
-  if (unit === "hours") {
-    return `${formatNumber(value, { maximumFractionDigits: 0 })}h`;
-  }
-  if (unit === "loc") {
-    return formatNumber(value, { notation: "compact" });
-  }
-  return `${formatNumber(value)} ${unit}`.trim();
+	if (unit === "%") {
+		return formatPercent(value);
+	}
+	if (unit === "days") {
+		return `${formatNumber(value, { maximumFractionDigits: 1 })}d`;
+	}
+	if (unit === "hours") {
+		return `${formatNumber(value, { maximumFractionDigits: 0 })}h`;
+	}
+	if (unit === "loc") {
+		return formatNumber(value, { notation: "compact" });
+	}
+	return `${formatNumber(value)} ${unit}`.trim();
 };
 
 export const formatTimestamp = (value?: string | null) => {
-  if (!value) {
-    return "Unavailable";
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return "Unavailable";
-  }
-  const parts = _tsParts.formatToParts(date);
-  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
-  return `${get("month")} ${get("day")}, ${get("hour")}:${get("minute")} ${get("dayPeriod")}`;
+	if (!value) {
+		return "Unavailable";
+	}
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return "Unavailable";
+	}
+	const parts = _tsParts.formatToParts(date);
+	const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+	return `${get("month")} ${get("day")}, ${get("hour")}:${get("minute")} ${get("dayPeriod")}`;
 };

--- a/tests/data-integrity.spec.ts
+++ b/tests/data-integrity.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("incident correlation page hides work graph edge codes", async ({
+	page,
+}) => {
+	await page.goto("/incident-correlation");
+
+	await expect(page.getByTestId("incident-correlation-page")).toBeVisible();
+	await expect(page.getByText("DEPLOYS", { exact: true })).toHaveCount(0);
+	await expect(page.getByText("LINKED_INCIDENT", { exact: true })).toHaveCount(
+		0,
+	);
+});


### PR DESCRIPTION
## Summary
- [x] A8: removed internal API/edge/version/ticket text from people search, incident correlation, and Explore source copy.
- [x] A9: replaced raw Evidence Table JSON rows with typed, human-readable fields.
- [x] B1/B2: normalized negative-zero deltas and routed TestOps coverage/confidence through shared formatters.
- [x] C5: replaced blank failure-patterns state with DataState and made Heatmap tooltip return styled, formatted copy.
- [x] Dedupe: EvidenceView now renders one Inspect associations action.
- [x] Empty states: swapped dash-only dashboard fallbacks to DataState where targeted.
- [x] Capacity: collapsed identical P50/P85/P95 display into a single low-variance forecast state.

## Design lint
- no-internal-leak: 3 → 0
- no-raw-id-in-jsx: 0 → 0
- Static scanner summary: no-raw-id-in-jsx 0, no-internal-leak 0, cta-from-registry 7 existing, chart-values-formatted 0.

## Tests
- Added/updated formatter, EvidenceView, ForecastCard, SecurityDashboard, and TestOps component tests.
- Added Playwright visual-regression assertion: incident correlation page hides work graph edge codes.
- Visual-regression assertion added: incident correlation page hides work graph edge codes.

## Verification
- pnpm exec vitest run src/components/security/SecurityDashboard.test.tsx src/components/testops/__tests__/PrTestOpsSummary.test.tsx src/lib/__tests__/formatters.test.ts src/components/work/EvidenceView.test.tsx src/components/capacity/ForecastCard.test.tsx
- env -u REDIS_URL -u UPSTASH_REDIS_REST_URL -u KV_REST_API_URL pnpm run test:unit
- pnpm exec tsc --noEmit
- pnpm run design-lint (static no-internal/no-raw-id clean; command still reports existing unrelated CTA/style debt)

Closes CHAOS-2060
Closes CHAOS-2062