### PR TITLE
feat(nav): area landing pages → severity-sorted signal cards (CHAOS-2074)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -12,6 +12,7 @@
 
 - **A1 Sidebar**, major product areas only. No one-off metric pages without product approval.
 - **A2 Tabs**, sibling views within one area only (Work: Investment/Flow/Landscape/Heatmap/Capacity/Evidence; AI Workflows: Impact/Attribution/Review Load/Test Gaps/Governance Risk/Evidence). Never style a navigation exit as a tab.
+- **A2a Area landings**, the area header names the area; sub-areas surface as severity-sorted signal cards (metric + state), never passive links; bubble the top sub-area signal(s) up to the area level. Dense areas may sub-group (e.g. Govern → Quality / Risk); light areas degrade gracefully; unavailable metrics use DataState, never fabricated values. ([CHAOS-2074](https://linear.app/fullchaos/issue/CHAOS-2074/area-landing-pages-severity-sorted-signal-cards).)
 - **A3 Pills**, filters, scope, status, and segmented view controls only. Never for navigation, back, or primary CTAs.
 - **A4 Buttons**, actions only, from the CTA registry (Part D). Don't invent verbs.
 - **A5 Back links**, one pattern: `Back to Cockpit` or `Back to {parent area}`. Never styled as pills/filters. One return path per screen, remove redundant ones (e.g. `Back to Metrics View` **and** `Back to Cockpit` together).

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { AreaHub } from "@/components/navigation/AreaHub";
+import { getAreaSignals } from "@/lib/areaSignals";
 import { RoleSelectorWithSuspense, RoleFraming } from "@/components/RoleSelectorWrapper";
 import { checkApiHealth, getApiMeta } from "@/lib/api/system";
 import { getHomeData } from "@/lib/api/home";
@@ -188,6 +189,7 @@ export default async function Home({ searchParams }: HomePageProps) {
 
           <AreaHub
             areaId="cockpit"
+            signals={await getAreaSignals("cockpit", filters)}
             filters={filters}
             role={activeRole}
             title="Cockpit area"

--- a/src/app/(app)/opportunities/page.tsx
+++ b/src/app/(app)/opportunities/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { AreaHub } from "@/components/navigation/AreaHub";
+import { getAreaSignals } from "@/lib/areaSignals";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { FocusCard } from "./FocusCard";
 import { checkApiHealth } from "@/lib/api/system";
@@ -71,6 +72,7 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
           </section>
           <AreaHub
             areaId="improve"
+            signals={await getAreaSignals("improve", filters)}
             filters={filters}
             role={activeRole}
             title="Improve area"

--- a/src/app/(app)/opportunities/page.tsx
+++ b/src/app/(app)/opportunities/page.tsx
@@ -1,83 +1,134 @@
-import Link from "next/link";
-
 import { FilterBar } from "@/components/filters/FilterBar";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { AreaHub } from "@/components/navigation/AreaHub";
-import { getAreaSignals } from "@/lib/areaSignals";
+import { AreaSignalCard } from "@/components/navigation/AreaSignalCard";
+import { BackLink } from "@/components/shared/BackLink";
+import { ModeTabs, type ModeTabItem } from "@/components/shared/ModeTabs";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { FocusCard } from "./FocusCard";
 import { checkApiHealth } from "@/lib/api/system";
 import { getOpportunities } from "@/lib/api/home";
+import { getAreaSignals } from "@/lib/areaSignals";
+import { topSignals } from "@/lib/areaSignals/sort";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { fetchOrNull } from "@/lib/fetchOrNull";
 import { withFilterParam } from "@/lib/filters/url";
+import { getServerEnv } from "@/lib/config";
 
 type OpportunitiesPageProps = {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
+
+// Improve landing sub-views (Framework A2). "Overview" is the area summary +
+// signal grid; "Focus Cards" preserves the existing opportunity cards view.
+// (CHAOS-2076: "RECOMMENDED NEXT STEP" text is a known backend bug — not fixed here.)
+type ImproveView = "overview" | "focus-cards";
+const IMPROVE_VIEWS: ImproveView[] = ["overview", "focus-cards"];
 
 export default async function OpportunitiesPage({ searchParams }: OpportunitiesPageProps) {
   const params = (await searchParams) ?? {};
   const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
   const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
   const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+  const viewParam = Array.isArray(params.view) ? params.view[0] : params.view;
+  const activeView: ImproveView = IMPROVE_VIEWS.includes(viewParam as ImproveView)
+    ? (viewParam as ImproveView)
+    : "overview";
 
   const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
 
-  // Run health check and data fetch in parallel to eliminate the waterfall.
-  const [health, data] = await Promise.all([
+  const env = getServerEnv();
+  const isTestMode =
+    env.DEV_HEALTH_TEST_MODE === "true" || env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
+
+  // Resolve area signals, health, and opportunity data in parallel — no waterfall.
+  const [health, data, improveSignals] = await Promise.all([
     checkApiHealth(),
     fetchOrNull(getOpportunities(filters), "opportunities/data"),
+    getAreaSignals("improve", filters, isTestMode),
   ]);
 
-  if (!health.ok) {
+  if (!health.ok && !isTestMode) {
     return <ServiceUnavailable />;
   }
+
+  // Top sub-area signals bubbled up to the area overview (Framework A2a).
+  const leadSignals = topSignals(improveSignals, 2);
+
+  const tabs: ReadonlyArray<ModeTabItem<ImproveView>> = [
+    {
+      id: "overview",
+      label: "Overview",
+      href: withFilterParam("/opportunities", filters, activeRole),
+    },
+    {
+      id: "focus-cards",
+      label: "Focus Cards",
+      href: withFilterParam("/opportunities?view=focus-cards", filters, activeRole),
+    },
+  ];
 
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={filters} active="opportunities" role={activeRole} />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-wrap items-center justify-between gap-4">
+          <header className="flex flex-col gap-4">
+            <BackLink href={withFilterParam("/", filters, activeRole)} />
             <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                Opportunities
-              </p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">Focus Cards</h1>
+              {/* A6: the area is named by the AREA ("Improve"), not a borrowed leaf. */}
+              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Improve</p>
+              <h1 className="mt-2 font-(--font-display) text-3xl">Improve</h1>
               <p className="mt-2 text-sm text-(--ink-muted)">
-                Evidence-linked threads with candidate experiments.
+                Capacity planning, AI workflows, and evidence-linked improvement opportunities.
               </p>
-              <p className="mt-2 text-sm text-(--ink-muted)">Open a card to review evidence.</p>
             </div>
-            <Link
-              href={withFilterParam("/", filters, activeRole)}
-              className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
-            >
-              Back to cockpit
-            </Link>
+
+            {/* Overview: bubble the top sub-area signals up to the area level. */}
+            {leadSignals.length > 0 ? (
+              <div
+                data-testid="improve-overview"
+                className="grid gap-3 md:grid-cols-2"
+              >
+                {leadSignals.map((signal, index) => (
+                  <AreaSignalCard
+                    key={signal.id}
+                    signal={signal}
+                    filters={filters}
+                    role={activeRole}
+                    emphasized={index === 0}
+                  />
+                ))}
+              </div>
+            ) : null}
           </header>
 
-          <FilterBar view="opportunities" />
+          <ModeTabs items={tabs} activeId={activeView} ariaLabel="Improve views" />
 
-          <section className="grid gap-6 md:grid-cols-2">
-            {(data?.items ?? []).map((card) => (
-              <FocusCard key={card.id} card={card} filters={filters} activeRole={activeRole} />
-            ))}
-            {!data?.items?.length && (
-              <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
-                Opportunity data unavailable.
-              </div>
-            )}
-          </section>
-          <AreaHub
-            areaId="improve"
-            signals={await getAreaSignals("improve", filters)}
-            filters={filters}
-            role={activeRole}
-            title="Improve area"
-            description="Other improvement surfaces."
-          />
+          {activeView === "focus-cards" ? (
+            <>
+              <FilterBar view="opportunities" />
+              <section className="grid gap-6 md:grid-cols-2">
+                {(data?.items ?? []).map((card) => (
+                  <FocusCard key={card.id} card={card} filters={filters} activeRole={activeRole} />
+                ))}
+                {!data?.items?.length && (
+                  <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
+                    Opportunity data unavailable.
+                  </div>
+                )}
+              </section>
+            </>
+          ) : (
+            <AreaHub
+              areaId="improve"
+              signals={improveSignals}
+              filters={filters}
+              role={activeRole}
+              title="Improve signals"
+              description="Capacity and AI workflow sub-areas."
+            />
+          )}
         </main>
       </div>
     </div>

--- a/src/app/(app)/testops/page.tsx
+++ b/src/app/(app)/testops/page.tsx
@@ -67,7 +67,10 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
 
   // Resolve the area's sub-area signals (Govern reference resolver) and the
   // borrowed TestOps metric grid in parallel — no waterfall.
-  const [health, testOpsData, governSignals] = await Promise.all([
+  // testOpsData is fetched once here; getGovernSignals reuses it via `prefetched`
+  // to avoid a duplicate analytics POST (PIPELINE_SUCCESS_RATE / TEST_FLAKE_RATE /
+  // COVERAGE_LINE_PCT are all present in the batch below).
+  const [health, testOpsData] = await Promise.all([
     checkApiHealth(),
     fetchTestOpsData(
       {
@@ -84,8 +87,8 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
       },
       isTestMode,
     ),
-    getGovernSignals(filters, isTestMode),
   ]);
+  const governSignals = await getGovernSignals(filters, isTestMode, { testOpsData });
 
   if (!health.ok && !isTestMode) {
     return <ServiceUnavailable />;

--- a/src/app/(app)/testops/page.tsx
+++ b/src/app/(app)/testops/page.tsx
@@ -1,14 +1,17 @@
-import Link from "next/link";
-
 import { FilterBar } from "@/components/filters/FilterBar";
 import { MetricCard } from "@/components/metrics/MetricCard";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { AreaHub } from "@/components/navigation/AreaHub";
+import { AreaSignalCard } from "@/components/navigation/AreaSignalCard";
+import { BackLink } from "@/components/shared/BackLink";
+import { ModeTabs, type ModeTabItem } from "@/components/shared/ModeTabs";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { checkApiHealth } from "@/lib/api/system";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
 import { fetchTestOpsData } from "@/lib/testops/fetchers";
+import { getGovernSignals } from "@/lib/areaSignals";
+import { topSignals } from "@/lib/areaSignals/sort";
 import { TESTOPS_MEASURES } from "@/lib/testops/constants";
 import { TimeseriesResult, TimeseriesBucket } from "@/lib/graphql/schemas/analytics";
 import { getServerEnv } from "@/lib/config";
@@ -16,6 +19,12 @@ import { getServerEnv } from "@/lib/config";
 type TestOpsPageProps = {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
+
+// Govern landing sub-views (Framework A2). "Overview" is the area summary +
+// signal grid; "TestOps" preserves the borrowed pipeline/test/coverage metric
+// grid (A6: the area is named "Govern", not its borrowed leaf).
+type GovernView = "overview" | "testops";
+const GOVERN_VIEWS: GovernView[] = ["overview", "testops"];
 
 function getLatestValue(timeseries: TimeseriesResult[], measureId: string) {
   const series = timeseries.find((s) => s.measure === measureId);
@@ -37,6 +46,10 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
   const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
   const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
   const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+  const viewParam = Array.isArray(params.view) ? params.view[0] : params.view;
+  const activeView: GovernView = GOVERN_VIEWS.includes(viewParam as GovernView)
+    ? (viewParam as GovernView)
+    : "overview";
 
   const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
 
@@ -52,58 +65,26 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
     new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
   const dateRange = { startDate, endDate };
 
-  const [health, testOpsData] = await Promise.all([
+  // Resolve the area's sub-area signals (Govern reference resolver) and the
+  // borrowed TestOps metric grid in parallel — no waterfall.
+  const [health, testOpsData, governSignals] = await Promise.all([
     checkApiHealth(),
     fetchTestOpsData(
       {
         timeseries: [
-          {
-            dimension: "TEAM",
-            measure: "PIPELINE_SUCCESS_RATE",
-            interval: "DAY",
-            dateRange,
-          },
-          {
-            dimension: "TEAM",
-            measure: "PIPELINE_FAILURE_RATE",
-            interval: "DAY",
-            dateRange,
-          },
-          {
-            dimension: "TEAM",
-            measure: "PIPELINE_DURATION_P95",
-            interval: "DAY",
-            dateRange,
-          },
-          {
-            dimension: "TEAM",
-            measure: "PIPELINE_QUEUE_TIME",
-            interval: "DAY",
-            dateRange,
-          },
-          {
-            dimension: "TEAM",
-            measure: "PIPELINE_RERUN_RATE",
-            interval: "DAY",
-            dateRange,
-          },
-          {
-            dimension: "TEAM",
-            measure: "TEST_FLAKE_RATE",
-            interval: "DAY",
-            dateRange,
-          },
-          {
-            dimension: "TEAM",
-            measure: "COVERAGE_LINE_PCT",
-            interval: "DAY",
-            dateRange,
-          },
+          { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange },
+          { dimension: "TEAM", measure: "PIPELINE_FAILURE_RATE", interval: "DAY", dateRange },
+          { dimension: "TEAM", measure: "PIPELINE_DURATION_P95", interval: "DAY", dateRange },
+          { dimension: "TEAM", measure: "PIPELINE_QUEUE_TIME", interval: "DAY", dateRange },
+          { dimension: "TEAM", measure: "PIPELINE_RERUN_RATE", interval: "DAY", dateRange },
+          { dimension: "TEAM", measure: "TEST_FLAKE_RATE", interval: "DAY", dateRange },
+          { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange },
         ],
         breakdowns: [],
       },
       isTestMode,
     ),
+    getGovernSignals(filters, isTestMode),
   ]);
 
   if (!health.ok && !isTestMode) {
@@ -124,57 +105,90 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
     { id: "COVERAGE_LINE_PCT", ts: coverageTimeseries },
   ];
 
+  // Top sub-area signals bubbled up to the area overview (Framework A2a).
+  const leadSignals = topSignals(governSignals, 3);
+
+  const tabs: ReadonlyArray<ModeTabItem<GovernView>> = [
+    { id: "overview", label: "Overview", href: withFilterParam("/testops", filters, activeRole) },
+    {
+      id: "testops",
+      label: "TestOps",
+      href: withFilterParam("/testops?view=testops", filters, activeRole),
+    },
+  ];
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={filters} active="testops" role={activeRole} />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-wrap items-center justify-between gap-4">
+          <header className="flex flex-col gap-4">
+            <BackLink href={withFilterParam("/", filters, activeRole)} />
             <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">TestOps</p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">Health Overview</h1>
+              {/* A6: the area is named by the AREA ("Govern"), not a borrowed leaf. */}
+              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Govern</p>
+              <h1 className="mt-2 font-(--font-display) text-3xl">Govern</h1>
               <p className="mt-2 text-sm text-(--ink-muted)">
-                Pipeline stability, test reliability, and coverage.
+                Quality and risk across pipelines, tests, coverage, security, and delivery.
               </p>
             </div>
-            <Link
-              href={withFilterParam("/", filters, activeRole)}
-              className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
-            >
-              Back to cockpit
-            </Link>
+
+            {/* Overview: bubble the top sub-area signals up to the area level. */}
+            {leadSignals.length > 0 ? (
+              <div
+                data-testid="govern-overview"
+                className="grid gap-3 md:grid-cols-2 lg:grid-cols-3"
+              >
+                {leadSignals.map((signal, index) => (
+                  <AreaSignalCard
+                    key={signal.id}
+                    signal={signal}
+                    filters={filters}
+                    role={activeRole}
+                    emphasized={index === 0}
+                  />
+                ))}
+              </div>
+            ) : null}
           </header>
 
-          <FilterBar view="testops" />
+          <ModeTabs items={tabs} activeId={activeView} ariaLabel="Govern views" />
 
-          <section className="grid gap-4 lg:grid-cols-3">
-            {measures.map(({ id, ts }) => {
-              const def = TESTOPS_MEASURES[id];
-              if (!def) return null;
+          {activeView === "testops" ? (
+            <>
+              <FilterBar view="testops" />
+              <section className="grid gap-4 lg:grid-cols-3">
+                {measures.map(({ id, ts }) => {
+                  const def = TESTOPS_MEASURES[id];
+                  if (!def) return null;
 
-              const value = getLatestValue(ts, id);
-              const spark = getSparkline(ts, id);
+                  const value = getLatestValue(ts, id);
+                  const spark = getSparkline(ts, id);
 
-              return (
-                <MetricCard
-                  key={id}
-                  label={def.label}
-                  href="#"
-                  value={value}
-                  unit={def.unit === "percentage" ? "%" : def.unit === "duration" ? "m" : ""}
-                  spark={spark}
-                  caption={def.description}
-                />
-              );
-            })}
-          </section>
-          <AreaHub
-            areaId="govern"
-            filters={filters}
-            role={activeRole}
-            title="Govern area"
-            description="Pipelines, tests, quality, security, and risk surfaces."
-          />
+                  return (
+                    <MetricCard
+                      key={id}
+                      label={def.label}
+                      href="#"
+                      value={value}
+                      unit={def.unit === "percentage" ? "%" : def.unit === "duration" ? "m" : ""}
+                      spark={spark}
+                      caption={def.description}
+                    />
+                  );
+                })}
+              </section>
+            </>
+          ) : (
+            <AreaHub
+              areaId="govern"
+              signals={governSignals}
+              filters={filters}
+              role={activeRole}
+              title="Govern signals"
+              description="Quality and risk sub-areas, ordered by severity."
+            />
+          )}
         </main>
       </div>
     </div>

--- a/src/app/(app)/work/page.tsx
+++ b/src/app/(app)/work/page.tsx
@@ -1,7 +1,9 @@
 import { FilterBar } from "@/components/filters/FilterBar";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { AreaHub } from "@/components/navigation/AreaHub";
-import { getAreaSignals } from "@/lib/areaSignals";
+import { AreaSignalCard } from "@/components/navigation/AreaSignalCard";
+import { BackLink } from "@/components/shared/BackLink";
+import { ModeTabs, type ModeTabItem } from "@/components/shared/ModeTabs";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { checkApiHealth } from "@/lib/api/system";
 import { getExplainData, getHomeData } from "@/lib/api/home";
@@ -24,12 +26,20 @@ import { FlameView } from "@/components/work/FlameView";
 import { EvidenceView } from "@/components/work/EvidenceView";
 import { GraphView } from "@/components/work/GraphView";
 import { ContextStrip } from "@/components/navigation/ContextStrip";
-import { BackLink } from "@/components/shared/BackLink";
 import { WorkTabNav, type WorkTab } from "@/components/navigation/WorkTabNav";
+import { getDiagnoseSignals } from "@/lib/areaSignals/diagnose";
+import { topSignals } from "@/lib/areaSignals/sort";
+import { getServerEnv } from "@/lib/config";
 
 type WorkPageProps = {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
+
+// Diagnose landing sub-views (Framework A2). "Overview" is the area summary +
+// signal grid; "Work" preserves the borrowed Work Investment and Flow leaf
+// content (A6: the area is named "Diagnose", not its borrowed leaf).
+type DiagnoseView = "overview" | "work";
+const DIAGNOSE_VIEWS: DiagnoseView[] = ["overview", "work"];
 
 const findCategory = (
   categories: Array<{ key: string; name: string; value: number }>,
@@ -46,6 +56,11 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
   const originParam = Array.isArray(params.origin) ? params.origin[0] : params.origin;
   const activeRole = typeof roleParam === "string" ? roleParam : undefined;
   const activeOrigin = typeof originParam === "string" ? originParam : undefined;
+
+  const viewParam = Array.isArray(params.view) ? params.view[0] : params.view;
+  const activeView: DiagnoseView = DIAGNOSE_VIEWS.includes(viewParam as DiagnoseView)
+    ? (viewParam as DiagnoseView)
+    : "overview";
 
   const tabParam = Array.isArray(params.tab) ? params.tab[0] : params.tab;
   const activeTab: WorkTab =
@@ -71,6 +86,10 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
       : filters.scope.level === "team" || filters.scope.level === "repo"
         ? filters.scope.level
         : "org";
+
+  const env = getServerEnv();
+  const isTestMode =
+    env.DEV_HEALTH_TEST_MODE === "true" || env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
   // When GraphQL transport is enabled we use the hydration-aware fetcher so
   // the client-side <InvestmentView> useQuery resolves from cache instead of
@@ -98,6 +117,8 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
           "work/investment",
         );
 
+  // Resolve the area's sub-area signals and the borrowed Work metric content
+  // in parallel — no waterfall.
   const [
     health,
     home,
@@ -108,6 +129,7 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
     cycleThroughput,
     wipThroughput,
     reviewLoadLatency,
+    diagnoseSignals,
   ] = await Promise.all([
     checkApiHealth(),
     fetchOrNull(getHomeData(filters), "work/home-data"),
@@ -165,9 +187,10 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
       }),
       "work/review-load-latency-quadrant",
     ),
+    getDiagnoseSignals(filters, isTestMode),
   ]);
 
-  if (!health.ok) {
+  if (!health.ok && !isTestMode) {
     return <ServiceUnavailable />;
   }
 
@@ -202,81 +225,118 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
   const plannedPct = plannedTotal ? (planned?.value ?? 0) / plannedTotal : null;
   const unplannedPct = plannedTotal ? (unplanned?.value ?? 0) / plannedTotal : null;
 
+  // Top sub-area signals bubbled up to the area overview (Framework A2a).
+  const leadSignals = topSignals(diagnoseSignals, 3);
+
+  const tabs: ReadonlyArray<ModeTabItem<DiagnoseView>> = [
+    { id: "overview", label: "Overview", href: withFilterParam("/work", filters, activeRole) },
+    {
+      id: "work",
+      label: "Work",
+      href: withFilterParam("/work?view=work", filters, activeRole),
+    },
+  ];
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
         <PrimaryNav filters={filters} active="work" role={activeRole} />
         <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Work</p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">Work Investment and Flow</h1>
-              <p className="mt-2 text-sm text-(--ink-muted)">
-                Work allocation, WIP pressure, and blocked effort.
-              </p>
-              <p className="mt-2 text-sm text-(--ink-muted)">Select a tab to investigate.</p>
-            </div>
+          <header className="flex flex-col gap-4">
             <BackLink href={withFilterParam("/", filters, activeRole)} />
+            <div>
+              {/* A6: the area is named by the AREA ("Diagnose"), not a borrowed leaf. */}
+              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Diagnose</p>
+              <h1 className="mt-2 font-(--font-display) text-3xl">Diagnose</h1>
+              <p className="mt-2 text-sm text-(--ink-muted)">
+                Metrics, code health, complexity, and flow bottlenecks across the system.
+              </p>
+            </div>
+
+            {/* Overview: bubble the top sub-area signals up to the area level. */}
+            {leadSignals.length > 0 ? (
+              <div
+                data-testid="diagnose-overview"
+                className="grid gap-3 md:grid-cols-2 lg:grid-cols-3"
+              >
+                {leadSignals.map((signal, index) => (
+                  <AreaSignalCard
+                    key={signal.id}
+                    signal={signal}
+                    filters={filters}
+                    role={activeRole}
+                    emphasized={index === 0}
+                  />
+                ))}
+              </div>
+            ) : null}
           </header>
 
-          <FilterBar view="work" />
+          <ModeTabs items={tabs} activeId={activeView} ariaLabel="Diagnose views" />
 
-          <WorkTabNav activeTab={activeTab} filters={filters} role={activeRole} />
-
-          <ContextStrip filters={filters} origin={activeOrigin} />
-
-          {activeTab === "landscape" && (
-            <LandscapeView
-              filters={filters}
-              activeRole={activeRole}
-              deltas={deltas}
-              placeholderDeltas={placeholderDeltas}
-              investmentMix={investmentMix}
-              cycleThroughput={cycleThroughput}
-              wipThroughput={wipThroughput}
-              reviewLoadLatency={reviewLoadLatency}
-              planned={planned}
-              unplanned={unplanned}
-              plannedPct={plannedPct}
-              unplannedPct={unplannedPct}
-            />
-          )}
-
-          {activeTab === "heatmap" && (
-            <HeatmapView filters={filters} scopeId={scopeId} reviewHeatmap={reviewHeatmap} />
-          )}
-
-          {activeTab === "flow" && <FlowView filters={filters} activeRole={activeRole} />}
-
-          {activeTab === "investment" && (
+          {activeView === "work" ? (
             <>
-              <HydrateUrqlResults payload={investmentHydrationPayload} />
-              <InvestmentView filters={filters} activeRole={activeRole} />
+              <FilterBar view="work" />
+
+              <WorkTabNav activeTab={activeTab} filters={filters} role={activeRole} />
+
+              <ContextStrip filters={filters} origin={activeOrigin} />
+
+              {activeTab === "landscape" && (
+                <LandscapeView
+                  filters={filters}
+                  activeRole={activeRole}
+                  deltas={deltas}
+                  placeholderDeltas={placeholderDeltas}
+                  investmentMix={investmentMix}
+                  cycleThroughput={cycleThroughput}
+                  wipThroughput={wipThroughput}
+                  reviewLoadLatency={reviewLoadLatency}
+                  planned={planned}
+                  unplanned={unplanned}
+                  plannedPct={plannedPct}
+                  unplannedPct={unplannedPct}
+                />
+              )}
+
+              {activeTab === "heatmap" && (
+                <HeatmapView filters={filters} scopeId={scopeId} reviewHeatmap={reviewHeatmap} />
+              )}
+
+              {activeTab === "flow" && <FlowView filters={filters} activeRole={activeRole} />}
+
+              {activeTab === "investment" && (
+                <>
+                  <HydrateUrqlResults payload={investmentHydrationPayload} />
+                  <InvestmentView filters={filters} activeRole={activeRole} />
+                </>
+              )}
+
+              {activeTab === "capacity" && <CapacityView filters={filters} />}
+
+              {activeTab === "flame" && <FlameView filters={filters} />}
+
+              {activeTab === "evidence" && (
+                <EvidenceView
+                  filters={filters}
+                  activeRole={activeRole}
+                  wipExplain={wipExplain}
+                  blockedExplain={blockedExplain}
+                />
+              )}
+
+              {activeTab === "graph" && <GraphView filters={filters} activeRole={activeRole} />}
             </>
-          )}
-
-          {activeTab === "capacity" && <CapacityView filters={filters} />}
-
-          {activeTab === "flame" && <FlameView filters={filters} />}
-
-          {activeTab === "evidence" && (
-            <EvidenceView
+          ) : (
+            <AreaHub
+              areaId="diagnose"
+              signals={diagnoseSignals}
               filters={filters}
-              activeRole={activeRole}
-              wipExplain={wipExplain}
-              blockedExplain={blockedExplain}
+              role={activeRole}
+              title="Diagnose signals"
+              description="Diagnostic sub-areas, ordered by severity."
             />
           )}
-
-          {activeTab === "graph" && <GraphView filters={filters} activeRole={activeRole} />}
-          <AreaHub
-            areaId="diagnose"
-            signals={await getAreaSignals("diagnose", filters)}
-            filters={filters}
-            role={activeRole}
-            title="Diagnose area"
-            description="Other diagnostic surfaces."
-          />
         </main>
       </div>
     </div>

--- a/src/app/(app)/work/page.tsx
+++ b/src/app/(app)/work/page.tsx
@@ -1,6 +1,7 @@
 import { FilterBar } from "@/components/filters/FilterBar";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { AreaHub } from "@/components/navigation/AreaHub";
+import { getAreaSignals } from "@/lib/areaSignals";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { checkApiHealth } from "@/lib/api/system";
 import { getExplainData, getHomeData } from "@/lib/api/home";
@@ -270,6 +271,7 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
           {activeTab === "graph" && <GraphView filters={filters} activeRole={activeRole} />}
           <AreaHub
             areaId="diagnose"
+            signals={await getAreaSignals("diagnose", filters)}
             filters={filters}
             role={activeRole}
             title="Diagnose area"

--- a/src/components/home/SignalCard.tsx
+++ b/src/components/home/SignalCard.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import type {
-	CockpitSignal,
-	ConfidenceLevel,
-	SignalDirection,
-	SignalSeverity,
-} from "@/lib/types";
+import type { CockpitSignal } from "@/lib/types";
+
+import {
+	CONFIDENCE_DOT,
+	CONFIDENCE_TEXT,
+	DIRECTION_GLYPH,
+	SEVERITY_BADGE,
+	SEVERITY_LABEL,
+	directionAccent,
+} from "./severityTokens";
 
 /**
  * Cockpit signal card (CHAOS-2050).
@@ -33,45 +37,6 @@ export type SignalCardProps = {
 	emphasized?: boolean;
 	onOpenEvidence: OpenEvidence;
 };
-
-const SEVERITY_BADGE: Record<SignalSeverity, string> = {
-	critical: "border-red-500/30 bg-red-500/15 text-red-300",
-	high: "border-amber-500/30 bg-amber-500/15 text-amber-300",
-	medium: "border-(--accent-2)/30 bg-(--accent-2)/12 text-(--accent-2)",
-	low: "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)",
-};
-
-const SEVERITY_LABEL: Record<SignalSeverity, string> = {
-	critical: "Critical",
-	high: "High",
-	medium: "Medium",
-	low: "Low",
-};
-
-const CONFIDENCE_DOT: Record<ConfidenceLevel, string> = {
-	high: "bg-(--accent-3)",
-	medium: "bg-amber-400",
-	low: "bg-(--ink-muted)",
-};
-
-const CONFIDENCE_TEXT: Record<ConfidenceLevel, string> = {
-	high: "text-(--accent-3)",
-	medium: "text-amber-300",
-	low: "text-(--ink-muted)",
-};
-
-const DIRECTION_GLYPH: Record<SignalDirection, string> = {
-	up: "↑",
-	down: "↓",
-	flat: "→",
-};
-
-const directionAccent = (direction: SignalDirection) =>
-	direction === "up"
-		? "text-(--accent-3)"
-		: direction === "down"
-			? "text-(--accent-negative)"
-			: "text-(--ink-muted)";
 
 export function SignalCard({
 	signal,

--- a/src/components/home/severityTokens.ts
+++ b/src/components/home/severityTokens.ts
@@ -1,0 +1,71 @@
+// ── Shared signal severity tokens (CHAOS-2074) ────────────────────────────────
+//
+// The canonical severity → token maps, extracted from {@link SignalCard} so the
+// cockpit cards and the area-landing signal cards ({@link AreaHub}) share ONE
+// visual language. Token-only (design tokens / Tailwind utilities — no new hex
+// or px), so this module is import-safe from both client and server components.
+
+import type { ConfidenceLevel, SignalDirection, SignalSeverity } from "@/lib/types";
+import type { AreaSignalState } from "@/lib/areaSignals/types";
+
+/** Severity badge chip classes (border + bg + text). */
+export const SEVERITY_BADGE: Record<SignalSeverity, string> = {
+  critical: "border-red-500/30 bg-red-500/15 text-red-300",
+  high: "border-amber-500/30 bg-amber-500/15 text-amber-300",
+  medium: "border-(--accent-2)/30 bg-(--accent-2)/12 text-(--accent-2)",
+  low: "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)",
+};
+
+/** Severity badge labels. */
+export const SEVERITY_LABEL: Record<SignalSeverity, string> = {
+  critical: "Critical",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+export const CONFIDENCE_DOT: Record<ConfidenceLevel, string> = {
+  high: "bg-(--accent-3)",
+  medium: "bg-amber-400",
+  low: "bg-(--ink-muted)",
+};
+
+export const CONFIDENCE_TEXT: Record<ConfidenceLevel, string> = {
+  high: "text-(--accent-3)",
+  medium: "text-amber-300",
+  low: "text-(--ink-muted)",
+};
+
+export const DIRECTION_GLYPH: Record<SignalDirection, string> = {
+  up: "↑",
+  down: "↓",
+  flat: "→",
+};
+
+export const directionAccent = (direction: SignalDirection): string =>
+  direction === "up"
+    ? "text-(--accent-3)"
+    : direction === "down"
+      ? "text-(--accent-negative)"
+      : "text-(--ink-muted)";
+
+// ── Area-signal state extensions (CHAOS-2074) ─────────────────────────────────
+// Area signals widen `SignalSeverity` with "neutral" (informational, non-severity
+// — e.g. AI adoption %) and "unavailable" (honest-empty, rendered via DataState
+// rather than a badge). The badge map below covers only the badge-bearing states.
+
+/** Neutral / informational chip — calm, non-alarming. */
+export const NEUTRAL_BADGE = "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)";
+export const NEUTRAL_LABEL = "Info";
+
+/** Badge classes for any badge-bearing area-signal state ("unavailable" excluded). */
+export const AREA_STATE_BADGE: Record<Exclude<AreaSignalState, "unavailable">, string> = {
+  ...SEVERITY_BADGE,
+  neutral: NEUTRAL_BADGE,
+};
+
+/** Badge label for any badge-bearing area-signal state ("unavailable" excluded). */
+export const AREA_STATE_LABEL: Record<Exclude<AreaSignalState, "unavailable">, string> = {
+  ...SEVERITY_LABEL,
+  neutral: NEUTRAL_LABEL,
+};

--- a/src/components/navigation/AreaHub.test.tsx
+++ b/src/components/navigation/AreaHub.test.tsx
@@ -1,0 +1,145 @@
+/** AreaHub component tests (CHAOS-2074). */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@/test/utils";
+
+import { AreaHub } from "./AreaHub";
+import type { AreaSignal, AreaSignalState } from "@/lib/areaSignals/types";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function signal(
+  id: string,
+  state: AreaSignalState,
+  cluster?: string,
+  extra: Partial<AreaSignal> = {},
+): AreaSignal {
+  return {
+    id,
+    label: id,
+    href: `/${id}`,
+    cluster,
+    metricLabel: `${id} metric`,
+    value: state === "unavailable" ? "" : "42%",
+    state,
+    ...extra,
+  };
+}
+
+afterEach(cleanup);
+
+function renderHub(signals: AreaSignal[]) {
+  return render(<AreaHub areaId="govern" signals={signals} filters={defaultMetricFilter} />);
+}
+
+describe("AreaHub — severity-sorted signal cards", () => {
+  it("renders nothing when there are no signals", () => {
+    const { container } = renderHub([]);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("orders cards by severity within a cluster (critical → low → unavailable last)", () => {
+    renderHub([
+      signal("a", "low", "Quality"),
+      signal("u", "unavailable", "Quality"),
+      signal("c", "critical", "Quality"),
+      signal("m", "medium", "Quality"),
+    ]);
+    const cards = screen.getAllByTestId("area-signal-card");
+    expect(cards.map((c) => c.getAttribute("data-signal-id"))).toEqual(["c", "m", "a", "u"]);
+  });
+
+  it("groups by cluster with headers, each cluster severity-sorted (Govern: Quality then Risk)", () => {
+    renderHub([
+      signal("flake", "medium", "Quality"),
+      signal("sec", "critical", "Risk"),
+      signal("cov", "low", "Quality"),
+      signal("flags", "high", "Risk"),
+    ]);
+
+    // Cluster headers present and ordered.
+    expect(screen.getByText("Quality")).toBeInTheDocument();
+    expect(screen.getByText("Risk")).toBeInTheDocument();
+
+    const clusters = screen.getAllByTestId("area-hub-cluster");
+    expect(clusters.map((c) => c.getAttribute("data-cluster"))).toEqual(["Quality", "Risk"]);
+
+    // Within Quality: medium before low.
+    const quality = clusters[0];
+    expect(
+      within(quality)
+        .getAllByTestId("area-signal-card")
+        .map((c) => c.getAttribute("data-signal-id")),
+    ).toEqual(["flake", "cov"]);
+    // Within Risk: critical before high.
+    const risk = clusters[1];
+    expect(
+      within(risk)
+        .getAllByTestId("area-signal-card")
+        .map((c) => c.getAttribute("data-signal-id")),
+    ).toEqual(["sec", "flags"]);
+  });
+
+  it("renders a flat single bucket (no headers) when nothing is clustered", () => {
+    renderHub([signal("a", "low"), signal("b", "critical")]);
+    const clusters = screen.getAllByTestId("area-hub-cluster");
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].getAttribute("data-cluster")).toBe("");
+  });
+
+  it("renders an unavailable signal as an inline DataState (no fabricated value), sunk last", () => {
+    renderHub([signal("ok", "high", "Quality"), signal("gap", "unavailable", "Quality")]);
+
+    const gap = screen
+      .getAllByTestId("area-signal-card")
+      .find((c) => c.getAttribute("data-signal-id") === "gap")!;
+    expect(gap.getAttribute("data-state")).toBe("unavailable");
+    expect(within(gap).getByTestId("area-signal-unavailable")).toBeInTheDocument();
+    // No metric value node rendered for the unavailable card.
+    expect(within(gap).queryByTestId("area-signal-value")).toBeNull();
+
+    // It is the last card overall.
+    const order = screen
+      .getAllByTestId("area-signal-card")
+      .map((c) => c.getAttribute("data-signal-id"));
+    expect(order[order.length - 1]).toBe("gap");
+  });
+
+  it("emphasizes the single most-severe severity-bearing signal exactly once", () => {
+    renderHub([
+      signal("low", "low", "Quality"),
+      signal("crit", "critical", "Risk"),
+      signal("high", "high", "Quality"),
+    ]);
+    const emphasized = screen
+      .getAllByTestId("area-signal-card")
+      .filter((c) => c.getAttribute("data-emphasized") === "true");
+    expect(emphasized).toHaveLength(1);
+    expect(emphasized[0].getAttribute("data-signal-id")).toBe("crit");
+  });
+
+  it("marks a demoted signal secondary via the data attribute", () => {
+    renderHub([
+      signal("sec", "high", "Risk"),
+      signal("flags", "medium", "Risk", { demoted: true }),
+    ]);
+    const flags = screen
+      .getAllByTestId("area-signal-card")
+      .find((c) => c.getAttribute("data-signal-id") === "flags")!;
+    expect(flags.getAttribute("data-demoted")).toBe("true");
+  });
+});

--- a/src/components/navigation/AreaHub.tsx
+++ b/src/components/navigation/AreaHub.tsx
@@ -1,18 +1,38 @@
-import Link from "next/link";
-
-import { withFilterParam } from "@/lib/filters/url";
 import type { MetricFilter } from "@/lib/filters/types";
 import { getAreaById, type NavAreaId } from "@/lib/navigation/areas";
+import type { AreaSignal } from "@/lib/areaSignals/types";
+import { groupByCluster, sortBySeverity } from "@/lib/areaSignals/sort";
+
+import { AreaSignalCard } from "./AreaSignalCard";
 
 // ── AreaHub ──────────────────────────────────────────────────────────────────
 //
-// Renders an area's leaf destinations as a drill-down card grid on the area's
-// landing page (Framework A2: leaves live in area tabs/drill-down, not the
-// sidebar). Reads its items from the central nav config so the sidebar, active
-// state, and landing drill-downs can never drift apart (CHAOS-2073).
+// Renders an area's sub-areas as severity-sorted SIGNAL CARDS on the area's
+// landing page (Framework A2a: sub-areas surface as cards — metric + state —
+// never passive links). Reads card metadata from the central nav config so the
+// sidebar, active state, and landing cards can never drift apart (CHAOS-2073),
+// and the resolved per-signal state/value from the `signals` prop.
+//
+// RSC pattern (CHAOS-2074): AreaHub is PRESENTATIONAL. The area landing RSC
+// resolves the `AreaSignal[]` (via `getAreaSignals(areaId, filters)`) and passes
+// it in. This keeps AreaHub free of data-fetching / test-mode concerns and
+// trivially unit-testable, while the landing owns the one fetch. Phase 2 wires
+// Diagnose / Improve resolvers behind the same `getAreaSignals` dispatcher; this
+// component does not change.
+//
+// Rendering rules:
+//   - Severity-sorted: critical > high > medium > low > neutral > unavailable
+//     (unavailable always last), applied per cluster by `groupByCluster`.
+//   - Grouped by cluster when any signal carries one (Govern: Quality / Risk
+//     headers); flat grid otherwise (light areas degrade gracefully).
+//   - The single top signal across the area is emphasized like RankedSignals.
+//   - Unavailable signals render an inline DataState; demoted ones render
+//     visually secondary — both handled inside AreaSignalCard.
 
 type AreaHubProps = {
   areaId: NavAreaId;
+  /** Resolved signals for this area (from the landing RSC via getAreaSignals). */
+  signals: AreaSignal[];
   filters: MetricFilter;
   role?: string;
   /** Eyebrow label above the grid. Defaults to "<Area> area". */
@@ -21,13 +41,26 @@ type AreaHubProps = {
   description?: string;
 };
 
-export function AreaHub({ areaId, filters, role, title, description }: AreaHubProps) {
+export function AreaHub({ areaId, signals, filters, role, title, description }: AreaHubProps) {
   const area = getAreaById(areaId);
-  if (!area || area.hubItems.length === 0) return null;
+  if (!area || signals.length === 0) return null;
+
+  const clusters = groupByCluster(signals);
+  const isClustered = clusters.some((group) => group.cluster != null);
+
+  // The single most-severe *severity-bearing* signal across the WHOLE area gets
+  // the emphasized treatment — sorted globally so a critical in a later cluster
+  // still wins over a high in an earlier one. Identified by id so it renders
+  // emphasized exactly once wherever it falls. Neutral (navigational) and
+  // unavailable cards never claim the emphasized "top signal" slot.
+  const SEVERITY_STATES = new Set(["critical", "high", "medium", "low"]);
+  const [topSignal] = sortBySeverity(signals.filter((signal) => SEVERITY_STATES.has(signal.state)));
+  const topSignalId = topSignal?.id;
 
   return (
     <section
-      aria-label={`${area.label} destinations`}
+      aria-label={`${area.label} signals`}
+      data-testid="area-hub"
       className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5"
     >
       <div>
@@ -36,21 +69,31 @@ export function AreaHub({ areaId, filters, role, title, description }: AreaHubPr
         </p>
         {description ? <p className="mt-1 text-sm text-(--ink-muted)">{description}</p> : null}
       </div>
-      <div className="mt-4 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-        {area.hubItems.map((item) => (
-          <Link
-            key={item.id}
-            href={withFilterParam(item.href, filters, role)}
-            className="group rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3 transition hover:-translate-y-1 hover:border-(--accent)"
+
+      <div className="mt-4 space-y-6">
+        {clusters.map((group) => (
+          <div
+            key={group.cluster ?? "_flat"}
+            data-testid="area-hub-cluster"
+            data-cluster={group.cluster ?? ""}
           >
-            <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-              <span>{item.label}</span>
-              <span className="text-(--accent-2)">Open</span>
-            </div>
-            {item.description ? (
-              <p className="mt-2 text-sm text-(--ink-muted)">{item.description}</p>
+            {isClustered && group.cluster ? (
+              <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
+                {group.cluster}
+              </p>
             ) : null}
-          </Link>
+            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+              {group.signals.map((signal) => (
+                <AreaSignalCard
+                  key={signal.id}
+                  signal={signal}
+                  filters={filters}
+                  role={role}
+                  emphasized={signal.id === topSignalId}
+                />
+              ))}
+            </div>
+          </div>
         ))}
       </div>
     </section>

--- a/src/components/navigation/AreaSignalCard.tsx
+++ b/src/components/navigation/AreaSignalCard.tsx
@@ -1,0 +1,133 @@
+import Link from "next/link";
+
+import { DataState } from "@/components/ui/DataState";
+import {
+  AREA_STATE_BADGE,
+  AREA_STATE_LABEL,
+  DIRECTION_GLYPH,
+} from "@/components/home/severityTokens";
+import type { AreaSignal } from "@/lib/areaSignals/types";
+import { withFilterParam } from "@/lib/filters/url";
+import type { MetricFilter } from "@/lib/filters/types";
+
+// ── AreaSignalCard (CHAOS-2074) ───────────────────────────────────────────────
+//
+// One sub-area rendered as a signal card on its area's landing page (Framework
+// A2a): a severity badge + metric label + state value + drill-in affordance,
+// matching {@link SignalCard}'s visual language via the shared severity tokens.
+// An RSC (no client state) — the whole card is a link into the sub-area.
+//
+// Honest states (owner decision 1): a signal whose value is genuinely
+// unavailable renders an inline {@link DataState} instead of a fabricated
+// number. Demoted signals (R4 low-value single surfaces) render visually
+// secondary — tighter padding, no emphasis — within their cluster.
+
+type AreaSignalCardProps = {
+  signal: AreaSignal;
+  filters: MetricFilter;
+  role?: string;
+  /** Top-signal emphasis (mirrors RankedSignals' lead card). */
+  emphasized?: boolean;
+};
+
+export function AreaSignalCard({ signal, filters, role, emphasized = false }: AreaSignalCardProps) {
+  const href = withFilterParam(signal.href, filters, role);
+  const demoted = signal.demoted === true;
+
+  // Unavailable → inline DataState (never a fabricated value). Still a link so
+  // the sub-area stays reachable from the card.
+  if (signal.state === "unavailable") {
+    return (
+      <Link
+        href={href}
+        data-testid="area-signal-card"
+        data-signal-id={signal.id}
+        data-state="unavailable"
+        className="group block rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4 transition hover:border-(--accent)"
+      >
+        <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">{signal.label}</p>
+        <DataState
+          variant="detector-unavailable"
+          title={`${signal.metricLabel} unavailable`}
+          description="No source feeds this metric for the selected window yet."
+          className="mt-3"
+          data-testid="area-signal-unavailable"
+        />
+      </Link>
+    );
+  }
+
+  const badge = AREA_STATE_BADGE[signal.state];
+  const stateLabel = AREA_STATE_LABEL[signal.state];
+
+  return (
+    <Link
+      href={href}
+      data-testid="area-signal-card"
+      data-signal-id={signal.id}
+      data-state={signal.state}
+      data-demoted={demoted ? "true" : "false"}
+      data-emphasized={emphasized ? "true" : "false"}
+      className={
+        emphasized
+          ? "group relative block overflow-hidden rounded-3xl border border-(--accent)/30 bg-gradient-to-br from-(--card) to-(--card-80) p-6 shadow-lg ring-1 ring-(--accent)/10 transition hover:-translate-y-1 hover:border-(--accent)"
+          : demoted
+            ? "group block rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3 transition hover:border-(--accent)"
+            : "group block overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card) p-4 transition hover:-translate-y-1 hover:border-(--accent)"
+      }
+    >
+      {emphasized ? (
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-(--accent)">
+          Top signal
+        </p>
+      ) : null}
+
+      <header className="mt-1 flex items-start justify-between gap-3">
+        <h3
+          className={
+            emphasized
+              ? "font-(--font-display) text-xl leading-tight text-foreground"
+              : demoted
+                ? "text-sm font-medium text-foreground"
+                : "font-(--font-display) text-base leading-tight text-foreground"
+          }
+        >
+          {signal.label}
+        </h3>
+        <span
+          data-testid="area-signal-badge"
+          className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-bold uppercase tracking-[0.18em] ${badge}`}
+        >
+          {stateLabel}
+        </span>
+      </header>
+
+      {/* Metric label + formatted value (+ optional trend glyph). A value-less
+          neutral card (navigational sub-area) shows just its descriptor copy. */}
+      {signal.value ? (
+        <div className="mt-3 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          <span
+            data-testid="area-signal-value"
+            className={
+              demoted
+                ? "metric-hero text-lg font-semibold text-foreground"
+                : "metric-hero text-2xl font-semibold text-foreground"
+            }
+          >
+            {signal.value}
+          </span>
+          {signal.direction ? (
+            <span aria-hidden className="text-xs text-(--ink-muted)">
+              {DIRECTION_GLYPH[signal.direction]}
+            </span>
+          ) : null}
+          <span className="text-xs uppercase tracking-[0.12em] text-(--ink-muted)">
+            {signal.metricLabel}
+          </span>
+        </div>
+      ) : (
+        <p className="mt-2 text-sm text-(--ink-muted)">{signal.metricLabel}</p>
+      )}
+    </Link>
+  );
+}

--- a/src/lib/api/home.ts
+++ b/src/lib/api/home.ts
@@ -1,14 +1,20 @@
+import { cache } from "react";
 import type { ExplainResponse, HomeResponse, OpportunitiesResponse } from "@/lib/types";
 import type { MetricFilter } from "@/lib/filters/types";
 import { encodeFilterParam } from "@/lib/filters/encode";
 import { normalizeFilters, postJson } from "./_shared";
 
-export async function getHomeData(filters: MetricFilter) {
+/**
+ * Per-request memoized home data fetch. React.cache() deduplicates calls
+ * within a single RSC render tree so the Work/page and getDiagnoseSignals
+ * resolver share one POST instead of issuing two identical requests per render.
+ */
+export const getHomeData = cache(async function getHomeData(filters: MetricFilter) {
   const normalized = normalizeFilters(filters);
   return postJson<HomeResponse>("/api/v1/home", { filters: normalized }, 60, {
     f: encodeFilterParam(normalized),
   });
-}
+});
 
 export async function getExplainData(params: { metric: string; filters: MetricFilter }) {
   const normalized = normalizeFilters(params.filters);

--- a/src/lib/areaSignals/__tests__/deriveState.test.ts
+++ b/src/lib/areaSignals/__tests__/deriveState.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COVERAGE_THRESHOLDS,
+  DELIVERY_RISK_THRESHOLDS,
+  FLAKE_THRESHOLDS,
+  PIPELINE_SHORTFALL_THRESHOLDS,
+  deriveState,
+} from "../deriveState";
+
+describe("deriveState — direction-parameterized severity ladder", () => {
+  describe("lowerIsBetter (value >= cut is worse)", () => {
+    // Flake thresholds: >=15 crit, >=8 high, >=3 med, else low.
+    it.each([
+      { value: 20, expected: "critical" },
+      { value: 15, expected: "critical" }, // boundary is inclusive
+      { value: 14.9, expected: "high" },
+      { value: 8, expected: "high" },
+      { value: 7, expected: "medium" },
+      { value: 3, expected: "medium" },
+      { value: 2.9, expected: "low" },
+      { value: 0, expected: "low" },
+    ])("flake $value → $expected", ({ value, expected }) => {
+      expect(deriveState(value, { thresholds: FLAKE_THRESHOLDS, direction: "lowerIsBetter" })).toBe(
+        expected,
+      );
+    });
+
+    it("applies the pipeline ladder to the shortfall (100 - successRate)", () => {
+      // success 55 → shortfall 45 → >=40 critical
+      expect(
+        deriveState(100 - 55, {
+          thresholds: PIPELINE_SHORTFALL_THRESHOLDS,
+          direction: "lowerIsBetter",
+        }),
+      ).toBe("critical");
+      // success 80 → shortfall 20 → >=10 medium (not high, which needs >=25)
+      expect(
+        deriveState(100 - 80, {
+          thresholds: PIPELINE_SHORTFALL_THRESHOLDS,
+          direction: "lowerIsBetter",
+        }),
+      ).toBe("medium");
+      // success 95 → shortfall 5 → low
+      expect(
+        deriveState(100 - 95, {
+          thresholds: PIPELINE_SHORTFALL_THRESHOLDS,
+          direction: "lowerIsBetter",
+        }),
+      ).toBe("low");
+    });
+  });
+
+  describe("higherIsBetter (value < cut is worse)", () => {
+    // Coverage thresholds (target 80): <50 crit, <65 high, <80 med, else low.
+    it.each([
+      { value: 30, expected: "critical" },
+      { value: 49.9, expected: "critical" },
+      { value: 50, expected: "high" }, // boundary: not < 50
+      { value: 64.9, expected: "high" },
+      { value: 65, expected: "medium" },
+      { value: 79.9, expected: "medium" },
+      { value: 80, expected: "low" },
+      { value: 95, expected: "low" },
+    ])("coverage $value% → $expected", ({ value, expected }) => {
+      expect(
+        deriveState(value, { thresholds: COVERAGE_THRESHOLDS, direction: "higherIsBetter" }),
+      ).toBe(expected);
+    });
+
+    // Delivery confidence thresholds: <40 crit, <55 high, <70 med, else low.
+    it.each([
+      { value: 35, expected: "critical" },
+      { value: 50, expected: "high" },
+      { value: 68, expected: "medium" },
+      { value: 70, expected: "low" },
+      { value: 90, expected: "low" },
+    ])("release confidence $value% → $expected", ({ value, expected }) => {
+      expect(
+        deriveState(value, { thresholds: DELIVERY_RISK_THRESHOLDS, direction: "higherIsBetter" }),
+      ).toBe(expected);
+    });
+  });
+
+  it("the SAME raw value lands opposite severities under opposite directions", () => {
+    // value 10 on a 0-100 scale: tiny under lowerIsBetter, dire under higherIsBetter.
+    const lower = deriveState(10, { thresholds: COVERAGE_THRESHOLDS, direction: "lowerIsBetter" });
+    const higher = deriveState(10, {
+      thresholds: COVERAGE_THRESHOLDS,
+      direction: "higherIsBetter",
+    });
+    expect(lower).toBe("low");
+    expect(higher).toBe("critical");
+  });
+});

--- a/src/lib/areaSignals/__tests__/diagnose.test.ts
+++ b/src/lib/areaSignals/__tests__/diagnose.test.ts
@@ -1,0 +1,296 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock every Diagnose source at the module boundary ─────────────────────────
+// The resolver fans out to these; we drive each independently to assert the
+// source → AreaSignal mapping (DERIVE vs RETURNED) without any network.
+
+vi.mock("@/lib/api/home", () => ({ getHomeData: vi.fn() }));
+vi.mock("@/lib/graphql/server", () => ({ graphqlFetch: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ user: { org_id: "org-test" } }),
+}));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+
+import { getHomeData } from "@/lib/api/home";
+import { graphqlFetch } from "@/lib/graphql/server";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+
+import { getDiagnoseSignals } from "../diagnose";
+import type { AreaSignal } from "../types";
+
+const mockGetHomeData = vi.mocked(getHomeData);
+const mockGraphql = vi.mocked(graphqlFetch);
+
+function byId(signals: AreaSignal[]): Record<string, AreaSignal> {
+  return Object.fromEntries(signals.map((s) => [s.id, s]));
+}
+
+// Helper: build a complexity timeseries response with a given cyclomaticPerKloc.
+function complexityResponse(cyclomaticPerKloc: number) {
+  return {
+    complexityTimeseries: {
+      points: [
+        {
+          date: "2026-06-01",
+          scopeId: "repo-1",
+          scopeName: "my-repo",
+          cyclomaticPerKloc,
+          cyclomaticAvg: cyclomaticPerKloc * 0.5,
+          cyclomaticTotal: 100,
+          locTotal: 10000,
+          highComplexityFunctions: 5,
+          veryHighComplexityFunctions: 1,
+        },
+      ],
+      totalScope: 1,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Default home response: all three RETURNED metrics present.
+  mockGetHomeData.mockResolvedValue({
+    deltas: [
+      { metric: "deploy_freq", label: "Deploy Frequency", value: 8, unit: "deploys", delta_pct: 0, spark: [] },
+      { metric: "churn", label: "Code Churn", value: 3200, unit: "loc", delta_pct: 0, spark: [] },
+      { metric: "wip_saturation", label: "WIP Saturation", value: 72, unit: "%", delta_pct: 0, spark: [] },
+    ],
+    signals: [
+      {
+        id: "df",
+        title: "Deploy frequency",
+        metric: "deploy_freq",
+        current_value: "8",
+        direction: "up",
+        severity: "low",
+        confidence: "medium",
+        affected_scope: "org",
+        evidence_count: 1,
+        why_it_matters: "",
+        recommended_action: "",
+        category: "delivery",
+      },
+      {
+        id: "churn",
+        title: "Code churn",
+        metric: "churn",
+        current_value: "3200",
+        direction: "up",
+        severity: "high",
+        confidence: "medium",
+        affected_scope: "org",
+        evidence_count: 2,
+        why_it_matters: "",
+        recommended_action: "",
+        category: "dynamics",
+      },
+      {
+        id: "wip",
+        title: "WIP saturation",
+        metric: "wip_saturation",
+        current_value: "72%",
+        direction: "up",
+        severity: "critical",
+        confidence: "high",
+        affected_scope: "org",
+        evidence_count: 3,
+        why_it_matters: "",
+        recommended_action: "",
+        category: "delivery",
+      },
+    ],
+  } as never);
+
+  // Default complexity: avg cyclomaticPerKloc = 18 → medium (>=15).
+  mockGraphql.mockResolvedValue(complexityResponse(18) as never);
+});
+
+describe("getDiagnoseSignals — source → AreaSignal mapping", () => {
+  it("returns all seven Diagnose sub-areas exactly once, flat (no cluster)", async () => {
+    const signals = await getDiagnoseSignals(defaultMetricFilter);
+    const ids = signals.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "metrics",
+        "people",
+        "code",
+        "landscape",
+        "complexity",
+        "cognitive-load",
+        "bottleneck",
+      ]),
+    );
+    // Diagnose is FLAT — no clusters.
+    for (const s of signals) expect(s.cluster).toBeUndefined();
+  });
+
+  describe("RETURNED signals (home REST severity reused)", () => {
+    it("Metrics: reuses deploy_freq signal severity and formats delta value", async () => {
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.metrics).toMatchObject({ state: "low", value: "8" });
+    });
+
+    it("Code: reuses churn signal severity and formats delta value", async () => {
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.code).toMatchObject({ state: "high", value: "3,200" });
+    });
+
+    it("Bottlenecks: reuses wip_saturation signal severity and formats delta value", async () => {
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.bottleneck).toMatchObject({ state: "critical", value: "72%" });
+    });
+  });
+
+  describe("DERIVE signals (Complexity)", () => {
+    it("derives Complexity from mean cyclomaticPerKloc (>=15 medium)", async () => {
+      // cyclomaticPerKloc = 18 → medium (>=15, <25).
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.complexity).toMatchObject({ state: "medium" });
+      expect(signals.complexity.value).not.toBe("");
+    });
+
+    it("derives Complexity critical when cyclomaticPerKloc >= 40", async () => {
+      mockGraphql.mockResolvedValue(complexityResponse(45) as never);
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.complexity).toMatchObject({ state: "critical" });
+    });
+
+    it("derives Complexity high when cyclomaticPerKloc >= 25 and < 40", async () => {
+      mockGraphql.mockResolvedValue(complexityResponse(30) as never);
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.complexity).toMatchObject({ state: "high" });
+    });
+
+    it("derives Complexity low when cyclomaticPerKloc < 15", async () => {
+      mockGraphql.mockResolvedValue(complexityResponse(10) as never);
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.complexity).toMatchObject({ state: "low" });
+    });
+
+    it("emits unavailable for Complexity when no timeseries points are returned", async () => {
+      mockGraphql.mockResolvedValue({
+        complexityTimeseries: { points: [], totalScope: 0 },
+      } as never);
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.complexity).toMatchObject({ state: "unavailable", value: "" });
+    });
+
+    it("computes mean across multiple complexity points", async () => {
+      // Two points: 20 + 40 → mean 30 → high (>=25, <40).
+      mockGraphql.mockResolvedValue({
+        complexityTimeseries: {
+          points: [
+            {
+              date: "2026-05-25",
+              scopeId: "repo-1",
+              scopeName: "repo-one",
+              cyclomaticPerKloc: 20,
+              cyclomaticAvg: 10,
+              cyclomaticTotal: 50,
+              locTotal: 5000,
+              highComplexityFunctions: 2,
+              veryHighComplexityFunctions: 0,
+            },
+            {
+              date: "2026-06-01",
+              scopeId: "repo-1",
+              scopeName: "repo-one",
+              cyclomaticPerKloc: 40,
+              cyclomaticAvg: 20,
+              cyclomaticTotal: 100,
+              locTotal: 5000,
+              highComplexityFunctions: 4,
+              veryHighComplexityFunctions: 1,
+            },
+          ],
+          totalScope: 1,
+        },
+      } as never);
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.complexity).toMatchObject({ state: "high" });
+    });
+  });
+
+  describe("unavailable signals (backend gaps)", () => {
+    it("People is always unavailable (no area-level aggregate metric)", async () => {
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.people).toMatchObject({ state: "unavailable", value: "" });
+    });
+
+    it("Landscape is always unavailable (CHAOS-2077 backend gap)", async () => {
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.landscape).toMatchObject({ state: "unavailable", value: "" });
+    });
+
+    it("Cognitive Load is always unavailable (CHAOS-2077 backend gap)", async () => {
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals["cognitive-load"]).toMatchObject({ state: "unavailable", value: "" });
+    });
+  });
+
+  describe("honest empty when source data is absent", () => {
+    it("Metrics/Code/Bottlenecks emit unavailable when signals array is missing", async () => {
+      mockGetHomeData.mockResolvedValue({
+        deltas: [],
+        signals: [],
+      } as never);
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.metrics).toMatchObject({ state: "unavailable", value: "" });
+      expect(signals.code).toMatchObject({ state: "unavailable", value: "" });
+      expect(signals.bottleneck).toMatchObject({ state: "unavailable", value: "" });
+    });
+  });
+
+  describe("source-failure degradation", () => {
+    it("degrades home-backed signals to unavailable when home fetch fails", async () => {
+      mockGetHomeData.mockRejectedValue(new Error("home down"));
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.metrics).toMatchObject({ state: "unavailable", value: "" });
+      expect(signals.code).toMatchObject({ state: "unavailable", value: "" });
+      expect(signals.bottleneck).toMatchObject({ state: "unavailable", value: "" });
+      // Complexity is independent — still resolves if graphql is up.
+      expect(signals.complexity.state).toBe("medium");
+    });
+
+    it("degrades Complexity to unavailable when graphql fetch fails", async () => {
+      mockGraphql.mockRejectedValue(new Error("graphql down"));
+      const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+      expect(signals.complexity).toMatchObject({ state: "unavailable", value: "" });
+      // Home-backed signals still resolve.
+      expect(signals.metrics.state).toBe("low");
+      expect(signals.code.state).toBe("high");
+      expect(signals.bottleneck.state).toBe("critical");
+    });
+
+    it("does not throw when both sources fail simultaneously", async () => {
+      mockGetHomeData.mockRejectedValue(new Error("home down"));
+      mockGraphql.mockRejectedValue(new Error("graphql down"));
+      const signals = await getDiagnoseSignals(defaultMetricFilter);
+      expect(signals).toHaveLength(7);
+      for (const s of signals) {
+        if (!["people", "landscape", "cognitive-load"].includes(s.id)) {
+          expect(s.state).toBe("unavailable");
+        }
+      }
+    });
+  });
+
+  it("test-mode skips graphql and resolves complexity as unavailable", async () => {
+    // In test mode, graphqlFetch is never called for complexity.
+    const signals = byId(await getDiagnoseSignals(defaultMetricFilter, true));
+    expect(mockGraphql).not.toHaveBeenCalled();
+    expect(signals.complexity).toMatchObject({ state: "unavailable", value: "" });
+  });
+
+  it("each signal has a non-empty label, href, and metricLabel", async () => {
+    const signals = await getDiagnoseSignals(defaultMetricFilter);
+    for (const s of signals) {
+      expect(s.label).toBeTruthy();
+      expect(s.href).toBeTruthy();
+      expect(s.metricLabel).toBeTruthy();
+    }
+  });
+});

--- a/src/lib/areaSignals/__tests__/govern.test.ts
+++ b/src/lib/areaSignals/__tests__/govern.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock every Govern source at the module boundary ───────────────────────────
+// The resolver fans out to these; we drive each independently to assert the
+// source → AreaSignal mapping (DERIVE vs RETURNED) without any network.
+
+vi.mock("@/lib/api/home", () => ({ getHomeData: vi.fn() }));
+vi.mock("@/lib/feature-flags/fetchers", () => ({ fetchFeatureFlagsData: vi.fn() }));
+vi.mock("@/lib/testops/fetchers", () => ({
+  fetchTestOpsData: vi.fn(),
+  fetchCoverageMetrics: vi.fn(),
+  fetchRiskMetrics: vi.fn(),
+}));
+vi.mock("@/lib/graphql/server", () => ({ graphqlFetch: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ user: { org_id: "org-test" } }),
+}));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+
+import { getHomeData } from "@/lib/api/home";
+import { fetchFeatureFlagsData } from "@/lib/feature-flags/fetchers";
+import { graphqlFetch } from "@/lib/graphql/server";
+import { fetchCoverageMetrics, fetchRiskMetrics, fetchTestOpsData } from "@/lib/testops/fetchers";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+
+import { getGovernSignals } from "../govern";
+import type { AreaSignal } from "../types";
+
+const mockGetHomeData = vi.mocked(getHomeData);
+const mockFetchFlags = vi.mocked(fetchFeatureFlagsData);
+const mockGraphql = vi.mocked(graphqlFetch);
+const mockTestOps = vi.mocked(fetchTestOpsData);
+const mockCoverage = vi.mocked(fetchCoverageMetrics);
+const mockRisk = vi.mocked(fetchRiskMetrics);
+
+const ts = (measure: string, value: number) => ({
+  dimension: "TEAM",
+  dimensionValue: "all",
+  measure,
+  buckets: [{ date: "2026-06-01", value }],
+});
+
+const emptyAnalytics = { timeseries: [], breakdowns: [] };
+
+function byId(signals: AreaSignal[]): Record<string, AreaSignal> {
+  return Object.fromEntries(signals.map((s) => [s.id, s]));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Sensible "all available" defaults; individual tests override.
+  mockTestOps.mockResolvedValue({
+    pipelines: { timeseries: [ts("PIPELINE_SUCCESS_RATE", 92)], breakdowns: [] },
+    tests: { timeseries: [ts("TEST_FLAKE_RATE", 4)], breakdowns: [] },
+    coverage: { timeseries: [ts("COVERAGE_LINE_PCT", 83)], breakdowns: [] },
+  });
+  mockCoverage.mockResolvedValue({ timeseries: [ts("COVERAGE_LINE_PCT", 83)], breakdowns: [] });
+  mockRisk.mockResolvedValue({ release_confidence: 0.62 } as never);
+  mockGetHomeData.mockResolvedValue({
+    deltas: [
+      {
+        metric: "change_failure_rate",
+        label: "CFR",
+        value: 12,
+        unit: "%",
+        delta_pct: 0,
+        spark: [],
+      },
+    ],
+    signals: [
+      {
+        id: "cfr",
+        title: "Change failure rate",
+        metric: "change_failure_rate",
+        current_value: "12%",
+        direction: "up",
+        severity: "high",
+        confidence: "medium",
+        affected_scope: "org",
+        evidence_count: 3,
+        why_it_matters: "",
+        recommended_action: "",
+        category: "delivery",
+      },
+    ],
+  } as never);
+  mockFetchFlags.mockResolvedValue({
+    summary: {
+      activeFlags: 7,
+      activeFlagsDelta: 0,
+      activeFlagsSpark: [],
+      releaseFrictionDelta: 0,
+      releaseFrictionSeverity: "moderate",
+      releaseFrictionSpark: [],
+      releaseErrorRateDelta: 0,
+      releaseErrorRateSpark: [],
+      coverageRatio: 0,
+      coverageRatioDelta: 0,
+      coverageRatioSpark: [],
+    },
+  } as never);
+  // graphqlFetch is used for securityOverview AND compoundingRisk — branch on query text.
+  mockGraphql.mockImplementation((query: unknown) => {
+    const q = String(query);
+    if (q.includes("securityOverview")) {
+      return Promise.resolve({
+        securityOverview: { kpis: { critical: 2, high: 5, openTotal: 11 } },
+      } as never);
+    }
+    if (q.includes("compoundingRisk")) {
+      return Promise.resolve({
+        compoundingRisk: {
+          rows: [
+            { severity: "ELEVATED", score: 0.4 },
+            { severity: "HIGH", score: 0.8 },
+          ],
+        },
+      } as never);
+    }
+    return Promise.resolve({} as never);
+  });
+});
+
+describe("getGovernSignals — source → AreaSignal mapping", () => {
+  it("derives Quality cluster states from analytics values", async () => {
+    const signals = byId(await getGovernSignals(defaultMetricFilter));
+
+    // Coverage 83% (higher-is-better, >=80 target) → low; formatted percent.
+    expect(signals.coverage).toMatchObject({ state: "low", value: "83%", cluster: "Quality" });
+    // Flake 4% (lower-is-better, >=3 medium) → medium.
+    expect(signals.tests).toMatchObject({ state: "medium", value: "4%", cluster: "Quality" });
+    // Success 92 → shortfall 8 → low.
+    expect(signals.pipelines).toMatchObject({ state: "low", value: "92%", cluster: "Quality" });
+  });
+
+  it("reuses the server-returned severity for home-REST signals (Quality + Incident)", async () => {
+    const signals = byId(await getGovernSignals(defaultMetricFilter));
+    expect(signals.quality).toMatchObject({ state: "high", value: "12%" });
+    // Incident Correlation reuses the same change_failure_rate signal.
+    expect(signals["incident-correlation"]).toMatchObject({ state: "high", value: "12%" });
+  });
+
+  it("derives Security severity by count ladder (critical>=1 → critical)", async () => {
+    const signals = byId(await getGovernSignals(defaultMetricFilter));
+    expect(signals.security).toMatchObject({ state: "critical", value: "2", cluster: "Risk" });
+  });
+
+  it("falls back to openTotal for Security when there are no criticals", async () => {
+    mockGraphql.mockImplementation((query: unknown) =>
+      String(query).includes("securityOverview")
+        ? (Promise.resolve({
+            securityOverview: { kpis: { critical: 0, high: 0, openTotal: 4 } },
+          }) as never)
+        : (Promise.resolve({ compoundingRisk: { rows: [] } }) as never),
+    );
+    const signals = byId(await getGovernSignals(defaultMetricFilter));
+    expect(signals.security).toMatchObject({ state: "medium", value: "4" });
+  });
+
+  it("derives Delivery Risk from release_confidence (×100, higher-is-better)", async () => {
+    const signals = byId(await getGovernSignals(defaultMetricFilter));
+    // 0.62 → 62% → <70 medium.
+    expect(signals.risk).toMatchObject({ state: "medium", value: "62%" });
+  });
+
+  it("maps the WORST compounding-risk row severity (HIGH → critical)", async () => {
+    const signals = byId(await getGovernSignals(defaultMetricFilter));
+    expect(signals["risk-compounding"]).toMatchObject({ state: "critical" });
+  });
+
+  it("maps feature-flag friction severity and flags it demoted (R4)", async () => {
+    const signals = byId(await getGovernSignals(defaultMetricFilter));
+    // "moderate" → "medium"; activeFlags count as value; demoted secondary.
+    expect(signals["feature-flags"]).toMatchObject({
+      state: "medium",
+      value: "7",
+      demoted: true,
+    });
+  });
+
+  it("emits an honest 'unavailable' signal (no fabricated value) when a source is empty", async () => {
+    mockTestOps.mockResolvedValue({
+      pipelines: emptyAnalytics,
+      tests: emptyAnalytics,
+      coverage: emptyAnalytics,
+    });
+    mockCoverage.mockResolvedValue(emptyAnalytics);
+    const signals = byId(await getGovernSignals(defaultMetricFilter));
+    expect(signals.coverage).toMatchObject({ state: "unavailable", value: "" });
+    expect(signals.tests).toMatchObject({ state: "unavailable", value: "" });
+    expect(signals.pipelines).toMatchObject({ state: "unavailable", value: "" });
+  });
+
+  it("degrades a failed source to unavailable instead of throwing", async () => {
+    mockGetHomeData.mockRejectedValue(new Error("home down"));
+    const signals = byId(await getGovernSignals(defaultMetricFilter));
+    expect(signals.quality).toMatchObject({ state: "unavailable" });
+    expect(signals["incident-correlation"]).toMatchObject({ state: "unavailable" });
+    // other sources still resolve
+    expect(signals.security.state).toBe("critical");
+  });
+
+  it("returns every Govern sub-area exactly once with its cluster", async () => {
+    const signals = await getGovernSignals(defaultMetricFilter);
+    const ids = signals.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "coverage",
+        "tests",
+        "pipelines",
+        "quality",
+        "security",
+        "risk",
+        "incident-correlation",
+        "risk-compounding",
+        "feature-flags",
+      ]),
+    );
+    for (const s of signals) expect(["Quality", "Risk"]).toContain(s.cluster);
+  });
+});

--- a/src/lib/areaSignals/__tests__/govern.test.ts
+++ b/src/lib/areaSignals/__tests__/govern.test.ts
@@ -219,4 +219,24 @@ describe("getGovernSignals — source → AreaSignal mapping", () => {
     );
     for (const s of signals) expect(["Quality", "Risk"]).toContain(s.cluster);
   });
+
+  it("skips fetchTestOpsData when prefetched.testOpsData is provided", async () => {
+    // Simulate the page passing its already-fetched testOpsData — the resolver
+    // must reuse it without issuing a second analytics POST.
+    const prefetchedData = {
+      pipelines: { timeseries: [ts("PIPELINE_SUCCESS_RATE", 95)], breakdowns: [] },
+      tests: { timeseries: [ts("TEST_FLAKE_RATE", 1)], breakdowns: [] },
+      coverage: { timeseries: [ts("COVERAGE_LINE_PCT", 90)], breakdowns: [] },
+    };
+    const signals = byId(
+      await getGovernSignals(defaultMetricFilter, false, { testOpsData: prefetchedData }),
+    );
+    // fetchTestOpsData must NOT have been called — the prefetched data was reused.
+    expect(mockTestOps).not.toHaveBeenCalled();
+    // Signals derived from the prefetched data reflect the prefetched values.
+    // Success 95 → shortfall 5 → low.
+    expect(signals.pipelines).toMatchObject({ state: "low", value: "95%" });
+    // Flake 1% → low (< 3 medium threshold).
+    expect(signals.tests).toMatchObject({ state: "low", value: "1%" });
+  });
 });

--- a/src/lib/areaSignals/__tests__/improve.test.ts
+++ b/src/lib/areaSignals/__tests__/improve.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock every Improve source at the module boundary ──────────────────────────
+// The resolver fans out to these; we drive each independently to assert the
+// source → AreaSignal mapping (RETURNED vs "neutral" vs "unavailable").
+
+vi.mock("@/lib/graphql/server", () => ({ graphqlFetch: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ user: { org_id: "org-test" } }),
+}));
+vi.mock("@/lib/logger", () => ({ logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+
+import { graphqlFetch } from "@/lib/graphql/server";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+
+import { getImproveSignals } from "../improve";
+import type { AreaSignal } from "../types";
+
+const mockGraphql = vi.mocked(graphqlFetch);
+
+function byId(signals: AreaSignal[]): Record<string, AreaSignal> {
+  return Object.fromEntries(signals.map((s) => [s.id, s]));
+}
+
+/** Minimal ThroughputForecast stub — primaryRisk.active=false → "low". */
+function mockThroughput(overrides: {
+  insufficientHistory?: boolean;
+  primaryRiskActive?: boolean;
+  p50Weeks?: number | null;
+}) {
+  return {
+    throughputForecast: {
+      forecastId: "f1",
+      computedAt: "2026-06-03T00:00:00Z",
+      teamId: null,
+      workScopeId: null,
+      backlogSize: 50,
+      historyWeeks: 12,
+      p50Weeks: overrides.p50Weeks ?? 6,
+      p75Weeks: 8,
+      p90Weeks: 10,
+      insufficientHistory: overrides.insufficientHistory ?? false,
+      rollingWindows: [],
+      primaryRisk: {
+        kind: "WIP",
+        score: 0.3,
+        label: "WIP pressure",
+        value: 0.3,
+        threshold: 0.5,
+        active: overrides.primaryRiskActive ?? false,
+      },
+      wipCongestion: { kind: "WIP", score: 0, label: "", value: 0, threshold: 0, active: false },
+      reviewBottleneck: {
+        kind: "REVIEW",
+        score: 0,
+        label: "",
+        value: 0,
+        threshold: 0,
+        active: false,
+      },
+      incidentLoad: {
+        kind: "INCIDENT",
+        score: 0,
+        label: "",
+        value: 0,
+        threshold: 0,
+        active: false,
+      },
+    },
+  };
+}
+
+/** Minimal AIImpactSummary stub — dataAvailable=true, ratio=0.42 → "42%" neutral. */
+function mockAIImpact(overrides: { dataAvailable?: boolean; aiAssistedPrRatio?: number | null }) {
+  return {
+    aiImpactSummary: {
+      orgId: "org-test",
+      startDate: "2026-05-20",
+      endDate: "2026-06-03",
+      totalPrs: 100,
+      aiAssistedPrs: 42,
+      agentCreatedPrs: 10,
+      humanPrs: 58,
+      unknownPrs: 0,
+      aiAssistedPrRatio: overrides.aiAssistedPrRatio ?? 0.42,
+      dataAvailable: overrides.dataAvailable ?? true,
+      computedAt: null,
+      byBucket: [],
+      daily: [],
+      missingStates: [],
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: both sources healthy.
+  mockGraphql.mockImplementation((query: unknown) => {
+    const q = String(query);
+    if (q.includes("throughputForecast")) {
+      return Promise.resolve(mockThroughput({})) as never;
+    }
+    if (q.includes("aiImpactSummary")) {
+      return Promise.resolve(mockAIImpact({})) as never;
+    }
+    return Promise.resolve({}) as never;
+  });
+});
+
+describe("getImproveSignals — source → AreaSignal mapping", () => {
+  it("returns exactly the two Improve hub items (capacity-planning + ai-workflows)", async () => {
+    const signals = await getImproveSignals(defaultMetricFilter);
+    const ids = signals.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(expect.arrayContaining(["capacity-planning", "ai-workflows"]));
+    expect(ids).toHaveLength(2);
+  });
+
+  it("Capacity Planning: RETURNED state low when primaryRisk.active is false", async () => {
+    const signals = byId(await getImproveSignals(defaultMetricFilter));
+    expect(signals["capacity-planning"]).toMatchObject({
+      state: "low",
+      value: "6w",
+      id: "capacity-planning",
+    });
+  });
+
+  it("Capacity Planning: RETURNED state medium when primaryRisk.active is true", async () => {
+    mockGraphql.mockImplementation((query: unknown) => {
+      const q = String(query);
+      if (q.includes("throughputForecast")) {
+        return Promise.resolve(mockThroughput({ primaryRiskActive: true })) as never;
+      }
+      return Promise.resolve(mockAIImpact({})) as never;
+    });
+    const signals = byId(await getImproveSignals(defaultMetricFilter));
+    expect(signals["capacity-planning"]).toMatchObject({ state: "medium" });
+  });
+
+  it("Capacity Planning: unavailable when insufficientHistory is true", async () => {
+    mockGraphql.mockImplementation((query: unknown) => {
+      const q = String(query);
+      if (q.includes("throughputForecast")) {
+        return Promise.resolve(mockThroughput({ insufficientHistory: true })) as never;
+      }
+      return Promise.resolve(mockAIImpact({})) as never;
+    });
+    const signals = byId(await getImproveSignals(defaultMetricFilter));
+    expect(signals["capacity-planning"]).toMatchObject({ state: "unavailable", value: "" });
+  });
+
+  it("Capacity Planning: unavailable when throughputForecast is null", async () => {
+    mockGraphql.mockImplementation((query: unknown) => {
+      const q = String(query);
+      if (q.includes("throughputForecast")) {
+        return Promise.resolve({ throughputForecast: null }) as never;
+      }
+      return Promise.resolve(mockAIImpact({})) as never;
+    });
+    const signals = byId(await getImproveSignals(defaultMetricFilter));
+    expect(signals["capacity-planning"]).toMatchObject({ state: "unavailable", value: "" });
+  });
+
+  it("AI Workflows: always 'neutral' (adoption metric, never a severity)", async () => {
+    const signals = byId(await getImproveSignals(defaultMetricFilter));
+    const ai = signals["ai-workflows"];
+    expect(ai.state).toBe("neutral");
+    // 0.42 × 100 → formatPercent → "42%"
+    expect(ai.value).toBe("42%");
+  });
+
+  it("AI Workflows: unavailable when dataAvailable is false", async () => {
+    mockGraphql.mockImplementation((query: unknown) => {
+      const q = String(query);
+      if (q.includes("aiImpactSummary")) {
+        return Promise.resolve(mockAIImpact({ dataAvailable: false })) as never;
+      }
+      return Promise.resolve(mockThroughput({})) as never;
+    });
+    const signals = byId(await getImproveSignals(defaultMetricFilter));
+    expect(signals["ai-workflows"]).toMatchObject({ state: "unavailable", value: "" });
+  });
+
+  it("AI Workflows: unavailable when aiImpactSummary is missing", async () => {
+    mockGraphql.mockImplementation((query: unknown) => {
+      const q = String(query);
+      if (q.includes("aiImpactSummary")) {
+        // Simulate graphqlFetch throwing (query fails entirely).
+        return Promise.reject(new Error("ai down")) as never;
+      }
+      return Promise.resolve(mockThroughput({})) as never;
+    });
+    const signals = byId(await getImproveSignals(defaultMetricFilter));
+    expect(signals["ai-workflows"]).toMatchObject({ state: "unavailable", value: "" });
+  });
+
+  it("degrades a failed Capacity Planning source to unavailable without throwing", async () => {
+    mockGraphql.mockImplementation((query: unknown) => {
+      const q = String(query);
+      if (q.includes("throughputForecast")) {
+        return Promise.reject(new Error("throughput down")) as never;
+      }
+      return Promise.resolve(mockAIImpact({})) as never;
+    });
+    const signals = byId(await getImproveSignals(defaultMetricFilter));
+    expect(signals["capacity-planning"]).toMatchObject({ state: "unavailable" });
+    // Other source still resolves.
+    expect(signals["ai-workflows"].state).toBe("neutral");
+  });
+
+  it("degrades both sources independently — full degradation still returns two cards", async () => {
+    mockGraphql.mockRejectedValue(new Error("all sources down"));
+    const signals = await getImproveSignals(defaultMetricFilter);
+    expect(signals).toHaveLength(2);
+    for (const s of signals) {
+      expect(s.state).toBe("unavailable");
+      expect(s.value).toBe("");
+    }
+  });
+
+  it("no signal carries a cluster (Improve is flat per the nav descriptor)", async () => {
+    const signals = await getImproveSignals(defaultMetricFilter);
+    for (const s of signals) {
+      expect(s.cluster).toBeUndefined();
+    }
+  });
+
+  it("isTestMode: returns both signals as unavailable without calling GraphQL", async () => {
+    const signals = byId(await getImproveSignals(defaultMetricFilter, true));
+    // In test mode, fetchers are skipped (Promise.resolve(undefined)) → both unavailable.
+    expect(signals["capacity-planning"]).toMatchObject({ state: "unavailable" });
+    expect(signals["ai-workflows"]).toMatchObject({ state: "unavailable" });
+    // graphqlFetch was never called (mocks not invoked).
+    expect(mockGraphql).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/areaSignals/__tests__/sort.test.ts
+++ b/src/lib/areaSignals/__tests__/sort.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { groupByCluster, isAvailable, sortBySeverity, topSignals } from "../sort";
+import type { AreaSignal, AreaSignalState } from "../types";
+
+function signal(id: string, state: AreaSignalState, cluster?: string): AreaSignal {
+  return {
+    id,
+    label: id,
+    href: `/${id}`,
+    cluster,
+    metricLabel: `${id} metric`,
+    value: state === "unavailable" ? "" : "1",
+    state,
+  };
+}
+
+describe("sortBySeverity", () => {
+  it("orders critical > high > medium > low > neutral > unavailable", () => {
+    const input = [
+      signal("a", "low"),
+      signal("b", "unavailable"),
+      signal("c", "critical"),
+      signal("d", "neutral"),
+      signal("e", "high"),
+      signal("f", "medium"),
+    ];
+    expect(sortBySeverity(input).map((s) => s.id)).toEqual(["c", "e", "f", "a", "d", "b"]);
+  });
+
+  it("sinks every unavailable signal to the bottom regardless of input order", () => {
+    const input = [
+      signal("u1", "unavailable"),
+      signal("hi", "high"),
+      signal("u2", "unavailable"),
+      signal("crit", "critical"),
+    ];
+    const ordered = sortBySeverity(input);
+    expect(ordered.map((s) => s.id)).toEqual(["crit", "hi", "u1", "u2"]);
+    // both unavailable cards are last
+    expect(ordered.slice(-2).every((s) => !isAvailable(s))).toBe(true);
+  });
+
+  it("is stable within a severity band (preserves input order on ties)", () => {
+    const input = [signal("first", "high"), signal("second", "high"), signal("third", "high")];
+    expect(sortBySeverity(input).map((s) => s.id)).toEqual(["first", "second", "third"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [signal("a", "low"), signal("b", "critical")];
+    const copy = [...input];
+    sortBySeverity(input);
+    expect(input).toEqual(copy);
+  });
+});
+
+describe("groupByCluster", () => {
+  it("groups by cluster, preserving first-seen cluster order, each severity-sorted", () => {
+    const input = [
+      signal("cov", "low", "Quality"),
+      signal("sec", "critical", "Risk"),
+      signal("flake", "high", "Quality"),
+      signal("flags", "medium", "Risk"),
+    ];
+    const groups = groupByCluster(input);
+    expect(groups.map((g) => g.cluster)).toEqual(["Quality", "Risk"]);
+    expect(groups[0].signals.map((s) => s.id)).toEqual(["flake", "cov"]); // high before low
+    expect(groups[1].signals.map((s) => s.id)).toEqual(["sec", "flags"]); // crit before med
+  });
+
+  it("returns a single undefined-cluster bucket when nothing is clustered (flat areas)", () => {
+    const input = [signal("a", "low"), signal("b", "critical")];
+    const groups = groupByCluster(input);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].cluster).toBeUndefined();
+    expect(groups[0].signals.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+
+  it("sinks unavailable signals to the bottom within their cluster", () => {
+    const input = [signal("u", "unavailable", "Quality"), signal("ok", "medium", "Quality")];
+    expect(groupByCluster(input)[0].signals.map((s) => s.id)).toEqual(["ok", "u"]);
+  });
+});
+
+describe("topSignals", () => {
+  it("returns the top N available signals by severity, excluding unavailable", () => {
+    const input = [
+      signal("u", "unavailable"),
+      signal("low", "low"),
+      signal("crit", "critical"),
+      signal("high", "high"),
+      signal("med", "medium"),
+    ];
+    expect(topSignals(input, 3).map((s) => s.id)).toEqual(["crit", "high", "med"]);
+  });
+
+  it("never bubbles an unavailable metric even when it is the only signal", () => {
+    expect(topSignals([signal("u", "unavailable")], 3)).toEqual([]);
+  });
+});

--- a/src/lib/areaSignals/deriveState.ts
+++ b/src/lib/areaSignals/deriveState.ts
@@ -1,0 +1,103 @@
+// ── deriveState: value → severity ladder (CHAOS-2074) ─────────────────────────
+//
+// Maps a raw metric value to a {@link SignalSeverity}, mirroring the backend
+// severity ladder but PARAMETERIZED by metric direction so a single helper
+// serves both metric polarities:
+//
+//   - lower-is-better (`direction: "lowerIsBetter"`, e.g. flake %, pipeline
+//     shortfall): a BIGGER value is worse, so the ladder is `value >= cut`.
+//   - higher-is-better (`direction: "higherIsBetter"`, e.g. coverage %, release
+//     confidence %): a SMALLER value is worse, so the ladder is `value < cut`.
+//
+// The backend ladder (>=60 critical, >=35 high, >=15 medium, else low) is the
+// canonical lower-is-better shape; for higher-is-better metrics the issue gives
+// per-family cut points applied to the value with `<` (e.g. coverage target 80:
+// <50 crit, <65 high, <80 med, else low). Both idioms live here so callers never
+// hand-roll a ladder. Thresholds are exported named constants so product can
+// calibrate them in ONE place.
+
+import type { SignalSeverity } from "@/lib/types";
+
+export type SeverityThresholds = {
+  readonly critical: number;
+  readonly high: number;
+  readonly medium: number;
+};
+
+// CHAOS-2074: provisional thresholds — pending product calibration.
+
+/**
+ * Canonical lower-is-better backend ladder (shortfall / count style):
+ * value >= 60 critical, >= 35 high, >= 15 medium, else low.
+ */
+export const BACKEND_LADDER: SeverityThresholds = { critical: 60, high: 35, medium: 15 };
+
+/**
+ * Pipeline success-rate ladder, applied to the SHORTFALL s = 100 − successRate
+ * (lower-is-better on the shortfall): s >= 40 crit, >= 25 high, >= 10 med.
+ */
+export const PIPELINE_SHORTFALL_THRESHOLDS: SeverityThresholds = {
+  critical: 40,
+  high: 25,
+  medium: 10,
+};
+
+/**
+ * Coverage ladder, applied to the coverage % directly (higher-is-better, `<`):
+ * target 80 → < 50 crit, < 65 high, < 80 med, else low.
+ */
+export const COVERAGE_TARGET = 80 as const;
+export const COVERAGE_THRESHOLDS: SeverityThresholds = { critical: 50, high: 65, medium: 80 };
+
+/**
+ * Test flake-rate ladder, applied to the flake % directly (lower-is-better):
+ * >= 15 crit, >= 8 high, >= 3 med, else low.
+ */
+export const FLAKE_THRESHOLDS: SeverityThresholds = { critical: 15, high: 8, medium: 3 };
+
+/**
+ * Delivery / release-confidence ladder, applied to the confidence % directly
+ * (higher-is-better, `<`): < 40 crit, < 55 high, < 70 med, else low.
+ */
+export const DELIVERY_RISK_THRESHOLDS: SeverityThresholds = {
+  critical: 40,
+  high: 55,
+  medium: 70,
+};
+
+export type DeriveDirection = "lowerIsBetter" | "higherIsBetter";
+
+export type DeriveStateOptions = {
+  /** Severity cut points (see the exported constants). */
+  thresholds: SeverityThresholds;
+  /**
+   * Metric polarity.
+   *  - "lowerIsBetter": ladder is `value >= cut` (bigger = worse).
+   *  - "higherIsBetter": ladder is `value < cut` (smaller = worse).
+   */
+  direction: DeriveDirection;
+};
+
+/**
+ * Resolve a {@link SignalSeverity} for a metric value.
+ *
+ * Lower-is-better metrics compare with `>=` (a larger value is worse);
+ * higher-is-better metrics compare with `<` (a smaller value is worse). Cut
+ * points are checked from most to least severe so the worst matching band wins.
+ */
+export function deriveState(value: number, opts: DeriveStateOptions): SignalSeverity {
+  const { thresholds, direction } = opts;
+
+  if (direction === "higherIsBetter") {
+    if (value < thresholds.critical) return "critical";
+    if (value < thresholds.high) return "high";
+    if (value < thresholds.medium) return "medium";
+    return "low";
+  }
+
+  // lowerIsBetter
+  if (value >= thresholds.critical) return "critical";
+  if (value >= thresholds.high) return "high";
+  if (value >= thresholds.medium) return "medium";
+  return "low";
+}

--- a/src/lib/areaSignals/diagnose.ts
+++ b/src/lib/areaSignals/diagnose.ts
@@ -1,0 +1,271 @@
+// ── Diagnose area signal resolver (CHAOS-2074) ────────────────────────────────
+//
+// Resolves the Diagnose landing's sub-area signal cards. Mirrors the Govern
+// reference resolver (`govern.ts`) exactly: fetches every backing source IN
+// PARALLEL (`Promise.all`, no serial N+1), then maps each source onto an
+// `AreaSignal` whose static metadata (label, href, demoted) comes from the
+// single nav source of truth (`navAreas` → Diagnose → hubItems).
+//
+// Diagnose is FLAT (no clusters). Descriptors carry no `cluster` field.
+//
+// Honest-state contract (owner decision 1): a sub-area whose value cannot be
+// resolved is emitted with `state: "unavailable"` and an empty `value` — never a
+// fabricated number — and sinks to the bottom of the sort.
+//
+// Severity policy per the confirmed data contract:
+//   - "Derive": run `deriveState` on the headline value with the metric's
+//     polarity + family thresholds.
+//   - "Returned": reuse the server-resolved severity (home REST `signals[]`,
+//     deltas severity).
+//
+// Backend gaps (CHAOS-2077): People / Landscape / Cognitive Load have no
+// area-level aggregate metric yet. They surface as honest "unavailable" cards
+// until CHAOS-2077 lands the resolver-backed metrics.
+
+import { auth } from "@/lib/auth";
+import { getHomeData } from "@/lib/api/home";
+import { graphqlFetch } from "@/lib/graphql/server";
+import { COMPLEXITY_TIMESERIES_QUERY } from "@/lib/graphql/queries";
+import type { ComplexityTimeseriesResult } from "@/lib/graphql/__generated__/types";
+import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
+import type { MetricFilter } from "@/lib/filters/types";
+import { formatNumber } from "@/lib/formatters";
+import { logger } from "@/lib/logger";
+
+import { deriveState } from "./deriveState";
+import type { SeverityThresholds } from "./deriveState";
+import type { AreaSignal, AreaSignalState } from "./types";
+
+// ── Provisional Complexity thresholds (CHAOS-2074) ────────────────────────────
+//
+// CHAOS-2074: provisional Complexity thresholds — pending calibration.
+// Applied to avgComplexity (mean cyclomaticPerKloc across all repo points; higher=WORSE).
+// This is NOT a 0–100 scale; cut points are raw cyclomatic-per-Kloc values.
+// Flag for owner: these need empirical calibration before the card goes stable.
+const COMPLEXITY_THRESHOLDS: SeverityThresholds = {
+  critical: 40, // cyclomaticPerKloc >= 40 → critical
+  high: 25, // cyclomaticPerKloc >= 25 → high
+  medium: 15, // cyclomaticPerKloc >= 15 → medium
+  // else → low
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build an `AreaSignal` from its nav descriptor + resolved state/value. Pulls
+ * label / href / demoted from the descriptor so the card metadata stays
+ * anchored to the single nav source of truth.
+ */
+function buildSignal(
+  descriptor: NavAreaHubItem,
+  resolved: { state: AreaSignalState; value: string },
+): AreaSignal {
+  return {
+    id: descriptor.id,
+    label: descriptor.label,
+    href: descriptor.href,
+    cluster: descriptor.cluster,
+    metricLabel: descriptor.metricLabel ?? descriptor.label,
+    value: resolved.value,
+    state: resolved.state,
+    demoted: descriptor.demoted,
+  };
+}
+
+/** The unavailable (honest-empty) resolution — no fabricated value. */
+const UNAVAILABLE = { state: "unavailable" as const, value: "" };
+
+/** Find a home `deltas[]` entry by its backend metric key. */
+function homeDeltaValue(
+  deltas: { metric: string; value: number; unit: string }[] | undefined,
+  metric: string,
+): { value: number; unit: string } | undefined {
+  const delta = deltas?.find((d) => d.metric === metric);
+  return delta ? { value: delta.value, unit: delta.unit } : undefined;
+}
+
+/** Find a home `signals[]` entry by its backend metric key. */
+function homeSignalByMetric(
+  signals: { metric: string; severity: string }[] | undefined,
+  metric: string,
+): { metric: string; severity: AreaSignalState } | undefined {
+  const match = signals?.find((s) => s.metric === metric);
+  return match ? (match as { metric: string; severity: AreaSignalState }) : undefined;
+}
+
+/** Compute mean cyclomaticPerKloc across all points in a complexity result. */
+function meanCyclomaticPerKloc(result: ComplexityTimeseriesResult | undefined): number | undefined {
+  const points = result?.points ?? [];
+  if (points.length === 0) return undefined;
+  const values = points
+    .map((p) => p.cyclomaticPerKloc)
+    .filter((v): v is number => typeof v === "number" && !isNaN(v));
+  if (values.length === 0) return undefined;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/** Resolve the org scope from the auth session (mirrors the area fetchers). */
+async function resolveOrgId(): Promise<string> {
+  const session = await auth();
+  return (session?.user?.org_id as string | undefined) ?? "default-org";
+}
+
+/**
+ * Run a source fetch, swallowing failures to `undefined` so one dead source
+ * degrades to a single honest-empty card instead of failing the whole area.
+ */
+async function safe<T>(fn: () => Promise<T>, source: string): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (error) {
+    logger.error({ err: error, source }, "Diagnose signal source failed");
+    return undefined;
+  }
+}
+
+// ── Resolver ──────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the Diagnose area's signal cards.
+ *
+ * Diagnose is FLAT (no clusters). Metrics, Code, and Bottlenecks all share a
+ * single `getHomeData` call (fetched once, reused across all three). Complexity
+ * uses the `complexityTimeseries` GraphQL query. People / Landscape / Cognitive
+ * Load have no resolver-backed metric yet (CHAOS-2077) and surface as honest
+ * "unavailable" cards.
+ *
+ * @param filters  Active metric filter (drives the REST date range).
+ * @param isTestMode  Render deterministic sample data without hitting the API.
+ */
+export async function getDiagnoseSignals(
+  filters: MetricFilter,
+  isTestMode = false,
+): Promise<AreaSignal[]> {
+  const diagnose = getAreaById("diagnose");
+  if (!diagnose) return [];
+
+  // Descriptor lookup by id — card metadata is owned by `navAreas`.
+  const byId = new Map(diagnose.hubItems.map((item) => [item.id, item]));
+  const descriptor = (id: string): NavAreaHubItem | undefined => byId.get(id);
+
+  // Shared date range for the complexity GraphQL call.
+  const rangeDays = filters.time?.range_days ?? 14;
+  const today = new Date();
+  const endDate = filters.time?.end_date ?? today.toISOString().slice(0, 10);
+  const startDate =
+    filters.time?.start_date ??
+    new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
+
+  // Resolve the org scope server-side (the complexity GraphQL call needs it
+  // threaded in as a variable AND as the `X-Org-Id` header).
+  const orgId = isTestMode ? "default-org" : await resolveOrgId();
+
+  // ── Fetch every source in parallel (no serial N+1) ───────────────────────
+  // Metrics + Code + Bottlenecks all come from a single getHomeData call.
+  const [homeData, complexityData] = await Promise.all([
+    safe(() => getHomeData(filters), "home"),
+    safe(
+      () =>
+        isTestMode
+          ? Promise.resolve(undefined)
+          : graphqlFetch<{ complexityTimeseries: ComplexityTimeseriesResult }>(
+              COMPLEXITY_TIMESERIES_QUERY,
+              {
+                input: {
+                  orgId,
+                  sinceUtc: startDate + "T00:00:00Z",
+                  untilUtc: endDate + "T23:59:59Z",
+                  granularity: "WEEK",
+                  scope: "REPO",
+                  limit: 50,
+                },
+              },
+              { orgId },
+            ).then((r) => r.complexityTimeseries),
+      "complexity",
+    ),
+  ]);
+
+  const signals: AreaSignal[] = [];
+  const push = (id: string, resolved: { state: AreaSignalState; value: string }) => {
+    const d = descriptor(id);
+    if (d) signals.push(buildSignal(d, resolved));
+  };
+
+  // ── Metrics (/metrics) ────────────────────────────────────────────────────
+  // Home REST deltas[metric=deploy_freq] value; RETURNED severity from
+  // signals[metric=deploy_freq].severity.
+  const deploySignal = homeSignalByMetric(homeData?.signals, "deploy_freq");
+  const deployDelta = homeDeltaValue(homeData?.deltas, "deploy_freq");
+  push(
+    "metrics",
+    deploySignal
+      ? {
+          state: deploySignal.severity,
+          value: deployDelta ? formatNumber(deployDelta.value) : "",
+        }
+      : UNAVAILABLE,
+  );
+
+  // ── People (/people) ─────────────────────────────────────────────────────
+  // No area-level aggregate metric exists → honest "unavailable" (CHAOS-2077).
+  push("people", UNAVAILABLE);
+
+  // ── Code (/code) ──────────────────────────────────────────────────────────
+  // Home REST deltas[metric=churn] value; RETURNED severity from
+  // signals[metric=churn].severity.
+  const churnSignal = homeSignalByMetric(homeData?.signals, "churn");
+  const churnDelta = homeDeltaValue(homeData?.deltas, "churn");
+  push(
+    "code",
+    churnSignal
+      ? {
+          state: churnSignal.severity,
+          value: churnDelta ? formatNumber(churnDelta.value) : "",
+        }
+      : UNAVAILABLE,
+  );
+
+  // ── Landscape (/explore/landscape) ───────────────────────────────────────
+  // Backend gap (CHAOS-2077) → honest "unavailable".
+  push("landscape", UNAVAILABLE);
+
+  // ── Complexity (/complexity) ──────────────────────────────────────────────
+  // GraphQL complexityTimeseries; headline = mean cyclomaticPerKloc across all
+  // repo points. Higher = WORSE (lowerIsBetter polarity). DERIVE.
+  // CHAOS-2074: provisional thresholds — see COMPLEXITY_THRESHOLDS above.
+  const avgComplexity = meanCyclomaticPerKloc(complexityData);
+  push(
+    "complexity",
+    avgComplexity != null
+      ? {
+          state: deriveState(avgComplexity, {
+            thresholds: COMPLEXITY_THRESHOLDS,
+            direction: "lowerIsBetter",
+          }),
+          value: formatNumber(avgComplexity, { maximumFractionDigits: 1 }),
+        }
+      : UNAVAILABLE,
+  );
+
+  // ── Cognitive Load (/cognitive-load) ──────────────────────────────────────
+  // Backend gap (CHAOS-2077) → honest "unavailable".
+  push("cognitive-load", UNAVAILABLE);
+
+  // ── Bottlenecks (/bottleneck) ─────────────────────────────────────────────
+  // Home REST deltas[metric=wip_saturation] value; RETURNED severity from
+  // signals[metric=wip_saturation].severity.
+  const wipSignal = homeSignalByMetric(homeData?.signals, "wip_saturation");
+  const wipDelta = homeDeltaValue(homeData?.deltas, "wip_saturation");
+  push(
+    "bottleneck",
+    wipSignal
+      ? {
+          state: wipSignal.severity,
+          value: wipDelta ? `${formatNumber(wipDelta.value)}%` : "",
+        }
+      : UNAVAILABLE,
+  );
+
+  return signals;
+}

--- a/src/lib/areaSignals/govern.ts
+++ b/src/lib/areaSignals/govern.ts
@@ -34,6 +34,7 @@ import type { MetricFilter } from "@/lib/filters/types";
 import { formatNumber, formatPercent } from "@/lib/formatters";
 import { logger } from "@/lib/logger";
 import type { CockpitSignal, SignalSeverity } from "@/lib/types";
+import type { TestOpsData } from "@/lib/testops/types";
 
 import {
   COVERAGE_THRESHOLDS,
@@ -120,10 +121,15 @@ const UNAVAILABLE = { state: "unavailable" as const, value: "" };
  *
  * @param filters  Active metric filter (drives the analytics date range).
  * @param isTestMode  Render deterministic sample data without hitting the API.
+ * @param prefetched  Optional prefetched data from the calling page. When the
+ *   page has already called fetchTestOpsData with a batch that covers
+ *   PIPELINE_SUCCESS_RATE, TEST_FLAKE_RATE, and COVERAGE_LINE_PCT, pass it
+ *   here to avoid a duplicate analytics POST per render.
  */
 export async function getGovernSignals(
   filters: MetricFilter,
   isTestMode = false,
+  prefetched?: { testOpsData?: TestOpsData },
 ): Promise<AreaSignal[]> {
   const govern = getAreaById("govern");
   if (!govern) return [];
@@ -156,10 +162,15 @@ export async function getGovernSignals(
   const orgId = isTestMode ? "default-org" : await resolveOrgId();
 
   // ── Fetch every source in parallel (no serial N+1) ──────────────────────────
+  // When the calling page has already fetched testOpsData with a batch that
+  // covers PIPELINE_SUCCESS_RATE, TEST_FLAKE_RATE, and COVERAGE_LINE_PCT (all
+  // three measures this resolver needs), reuse it to avoid a duplicate POST.
   const [homeData, testOps, coverage, risk, security, compounding, featureFlags] =
     await Promise.all([
       safe(() => getHomeData(filters), "home"),
-      safe(() => fetchTestOpsData(analyticsBatch, isTestMode), "testops"),
+      prefetched?.testOpsData
+        ? Promise.resolve(prefetched.testOpsData)
+        : safe(() => fetchTestOpsData(analyticsBatch, isTestMode), "testops"),
       safe(() => fetchCoverageMetrics(analyticsBatch, isTestMode), "coverage"),
       safe(() => fetchRiskMetrics(analyticsBatch, isTestMode), "risk"),
       safe(

--- a/src/lib/areaSignals/govern.ts
+++ b/src/lib/areaSignals/govern.ts
@@ -1,0 +1,361 @@
+// ── Govern area signal resolver (CHAOS-2074) ──────────────────────────────────
+//
+// Resolves the Govern landing's sub-area signal cards. This is the REFERENCE
+// resolver for the shared area-signal pattern (Phase 2 mirrors it for Diagnose /
+// Improve): it fetches every backing source IN PARALLEL (`Promise.all`, no
+// serial N+1), then maps each source onto an `AreaSignal` whose static metadata
+// (label, href, cluster, demoted) comes from the single nav source of truth
+// (`navAreas` → Govern → hubItems).
+//
+// Honest-state contract (owner decision 1): a sub-area whose value cannot be
+// resolved is emitted with `state: "unavailable"` and an empty `value` — never a
+// fabricated number — and sinks to the bottom of the sort.
+//
+// Severity policy per the confirmed data contract:
+//   - "Derive": run `deriveState` on the headline value with the metric's
+//     polarity + family thresholds.
+//   - "Returned": reuse the server-resolved severity (home REST `signals[]`,
+//     compoundingRisk rows, feature-flag friction severity).
+
+import { auth } from "@/lib/auth";
+import { getHomeData } from "@/lib/api/home";
+import { fetchFeatureFlagsData } from "@/lib/feature-flags/fetchers";
+import { graphqlFetch } from "@/lib/graphql/server";
+import { COMPOUNDING_RISK_QUERY, SECURITY_OVERVIEW_QUERY } from "@/lib/graphql/queries";
+import type {
+  CompoundingRiskResult,
+  CompoundingRiskSeverity,
+  SecurityOverview,
+} from "@/lib/graphql/__generated__/types";
+import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
+import { fetchCoverageMetrics, fetchRiskMetrics, fetchTestOpsData } from "@/lib/testops/fetchers";
+import type { AnalyticsRequestInput, TimeseriesResult } from "@/lib/graphql/schemas/analytics";
+import type { MetricFilter } from "@/lib/filters/types";
+import { formatNumber, formatPercent } from "@/lib/formatters";
+import { logger } from "@/lib/logger";
+import type { CockpitSignal, SignalSeverity } from "@/lib/types";
+
+import {
+  COVERAGE_THRESHOLDS,
+  DELIVERY_RISK_THRESHOLDS,
+  FLAKE_THRESHOLDS,
+  PIPELINE_SHORTFALL_THRESHOLDS,
+  deriveState,
+} from "./deriveState";
+import type { AreaSignal, AreaSignalState } from "./types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Latest bucket value for a measure in an analytics timeseries result. */
+function latestMeasure(timeseries: TimeseriesResult[], measure: string): number | undefined {
+  const series = timeseries.find((t) => t.measure === measure);
+  if (!series || series.buckets.length === 0) return undefined;
+  return series.buckets[series.buckets.length - 1].value;
+}
+
+/** Map a backend compounding-risk severity onto the cockpit severity ladder. */
+function mapCompoundingSeverity(severity: CompoundingRiskSeverity): AreaSignalState {
+  switch (severity) {
+    case "HIGH":
+      return "critical";
+    case "ELEVATED":
+      return "medium";
+    case "LOW":
+      return "low";
+    default:
+      return "unavailable"; // UNKNOWN
+  }
+}
+
+/** Map a feature-flag friction severity onto the cockpit severity ladder. */
+function mapFrictionSeverity(severity: "low" | "moderate" | "high" | "critical"): SignalSeverity {
+  return severity === "moderate" ? "medium" : severity;
+}
+
+/** Find a home `signals[]` entry by its backend metric key. */
+function homeSignalByMetric(
+  signals: CockpitSignal[] | undefined,
+  metric: string,
+): CockpitSignal | undefined {
+  return signals?.find((s) => s.metric === metric);
+}
+
+/** Find a home `deltas[]` value by its backend metric key. */
+function homeDeltaValue(
+  deltas: { metric: string; value: number; unit: string }[] | undefined,
+  metric: string,
+): { value: number; unit: string } | undefined {
+  const delta = deltas?.find((d) => d.metric === metric);
+  return delta ? { value: delta.value, unit: delta.unit } : undefined;
+}
+
+/**
+ * Build an `AreaSignal` from its nav descriptor + resolved state/value. Pulls
+ * label / href / cluster / demoted from the descriptor so the card metadata
+ * stays anchored to the single nav source of truth.
+ */
+function buildSignal(
+  descriptor: NavAreaHubItem,
+  resolved: { state: AreaSignalState; value: string },
+): AreaSignal {
+  return {
+    id: descriptor.id,
+    label: descriptor.label,
+    href: descriptor.href,
+    cluster: descriptor.cluster,
+    metricLabel: descriptor.metricLabel ?? descriptor.label,
+    value: resolved.value,
+    state: resolved.state,
+    demoted: descriptor.demoted,
+  };
+}
+
+/** The unavailable (honest-empty) resolution — no fabricated value. */
+const UNAVAILABLE = { state: "unavailable" as const, value: "" };
+
+// ── Resolver ──────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the Govern area's signal cards.
+ *
+ * @param filters  Active metric filter (drives the analytics date range).
+ * @param isTestMode  Render deterministic sample data without hitting the API.
+ */
+export async function getGovernSignals(
+  filters: MetricFilter,
+  isTestMode = false,
+): Promise<AreaSignal[]> {
+  const govern = getAreaById("govern");
+  if (!govern) return [];
+
+  // Descriptor lookup by id — card metadata is owned by `navAreas`.
+  const byId = new Map(govern.hubItems.map((item) => [item.id, item]));
+  const descriptor = (id: string): NavAreaHubItem | undefined => byId.get(id);
+
+  // Shared analytics date range (mirrors the TestOps landing's own derivation).
+  const rangeDays = filters.time?.range_days ?? 14;
+  const today = new Date();
+  const endDate = filters.time?.end_date ?? today.toISOString().slice(0, 10);
+  const startDate =
+    filters.time?.start_date ??
+    new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
+  const dateRange = { startDate, endDate };
+
+  const analyticsBatch: AnalyticsRequestInput = {
+    timeseries: [
+      { dimension: "TEAM", measure: "PIPELINE_SUCCESS_RATE", interval: "DAY", dateRange },
+      { dimension: "TEAM", measure: "TEST_FLAKE_RATE", interval: "DAY", dateRange },
+      { dimension: "TEAM", measure: "COVERAGE_LINE_PCT", interval: "DAY", dateRange },
+    ],
+    breakdowns: [],
+  };
+
+  // Resolve the org scope server-side (the client hooks rely on a provider; the
+  // analytics/feature-flag fetchers resolve it internally, but the direct
+  // GraphQL calls below need it threaded in as a variable AND `X-Org-Id`).
+  const orgId = isTestMode ? "default-org" : await resolveOrgId();
+
+  // ── Fetch every source in parallel (no serial N+1) ──────────────────────────
+  const [homeData, testOps, coverage, risk, security, compounding, featureFlags] =
+    await Promise.all([
+      safe(() => getHomeData(filters), "home"),
+      safe(() => fetchTestOpsData(analyticsBatch, isTestMode), "testops"),
+      safe(() => fetchCoverageMetrics(analyticsBatch, isTestMode), "coverage"),
+      safe(() => fetchRiskMetrics(analyticsBatch, isTestMode), "risk"),
+      safe(
+        () =>
+          isTestMode
+            ? Promise.resolve(undefined)
+            : graphqlFetch<{ securityOverview: SecurityOverview }>(
+                SECURITY_OVERVIEW_QUERY,
+                { orgId, filters: { openOnly: true } },
+                { orgId },
+              ).then((r) => r.securityOverview),
+        "security",
+      ),
+      safe(
+        () =>
+          isTestMode
+            ? Promise.resolve(undefined)
+            : graphqlFetch<{ compoundingRisk: CompoundingRiskResult }>(
+                COMPOUNDING_RISK_QUERY,
+                { orgId, filter: null },
+                { orgId },
+              ).then((r) => r.compoundingRisk),
+        "compounding",
+      ),
+      safe(() => fetchFeatureFlagsData(dateRange, isTestMode), "feature-flags"),
+    ]);
+
+  const signals: AreaSignal[] = [];
+  const push = (id: string, resolved: { state: AreaSignalState; value: string }) => {
+    const d = descriptor(id);
+    if (d) signals.push(buildSignal(d, resolved));
+  };
+
+  // ── Cluster: Quality ────────────────────────────────────────────────────────
+
+  // Coverage — analytics COVERAGE_LINE_PCT, DERIVE (higher-is-better).
+  const coveragePct =
+    latestMeasure(coverage?.timeseries ?? [], "COVERAGE_LINE_PCT") ??
+    latestMeasure(testOps?.coverage.timeseries ?? [], "COVERAGE_LINE_PCT");
+  push(
+    "coverage",
+    coveragePct != null
+      ? {
+          state: deriveState(coveragePct, {
+            thresholds: COVERAGE_THRESHOLDS,
+            direction: "higherIsBetter",
+          }),
+          value: formatPercent(coveragePct),
+        }
+      : UNAVAILABLE,
+  );
+
+  // Tests — analytics TEST_FLAKE_RATE, DERIVE (lower-is-better).
+  const flakePct = latestMeasure(testOps?.tests.timeseries ?? [], "TEST_FLAKE_RATE");
+  push(
+    "tests",
+    flakePct != null
+      ? {
+          state: deriveState(flakePct, {
+            thresholds: FLAKE_THRESHOLDS,
+            direction: "lowerIsBetter",
+          }),
+          value: formatPercent(flakePct),
+        }
+      : UNAVAILABLE,
+  );
+
+  // Pipelines — analytics PIPELINE_SUCCESS_RATE, DERIVE on shortfall (100 − rate).
+  const successPct = latestMeasure(testOps?.pipelines.timeseries ?? [], "PIPELINE_SUCCESS_RATE");
+  push(
+    "pipelines",
+    successPct != null
+      ? {
+          state: deriveState(Math.max(0, 100 - successPct), {
+            thresholds: PIPELINE_SHORTFALL_THRESHOLDS,
+            direction: "lowerIsBetter",
+          }),
+          value: formatPercent(successPct),
+        }
+      : UNAVAILABLE,
+  );
+
+  // Quality — home REST signals[change_failure_rate].severity (RETURNED).
+  const qualitySignal = homeSignalByMetric(homeData?.signals, "change_failure_rate");
+  const qualityDelta = homeDeltaValue(homeData?.deltas, "change_failure_rate");
+  push(
+    "quality",
+    qualitySignal
+      ? {
+          state: qualitySignal.severity,
+          value: qualityDelta ? formatPercent(qualityDelta.value) : qualitySignal.current_value,
+        }
+      : UNAVAILABLE,
+  );
+
+  // ── Cluster: Risk ─────────────────────────────────────────────────────────────
+
+  // Security — GraphQL securityOverview kpis, DERIVE by counts.
+  if (security) {
+    const { critical, high, openTotal } = security.kpis;
+    const state: AreaSignalState =
+      critical >= 1 ? "critical" : high >= 1 ? "high" : openTotal > 0 ? "medium" : "low";
+    const value = critical >= 1 ? formatNumber(critical) : formatNumber(openTotal);
+    push("security", { state, value });
+  } else {
+    push("security", UNAVAILABLE);
+  }
+
+  // Delivery Risk — fetchRiskMetrics release_confidence (0–1 ×100), DERIVE (higher=better).
+  const releaseConfidence = risk?.release_confidence;
+  push(
+    "risk",
+    releaseConfidence != null
+      ? {
+          state: deriveState(releaseConfidence * 100, {
+            thresholds: DELIVERY_RISK_THRESHOLDS,
+            direction: "higherIsBetter",
+          }),
+          value: formatPercent(releaseConfidence * 100),
+        }
+      : UNAVAILABLE,
+  );
+
+  // Incident Correlation — home REST signals[change_failure_rate].severity (RETURNED).
+  // Same backend metric as Quality; the two surfaces frame it differently.
+  push(
+    "incident-correlation",
+    qualitySignal
+      ? {
+          state: qualitySignal.severity,
+          value: qualityDelta ? formatPercent(qualityDelta.value) : qualitySignal.current_value,
+        }
+      : UNAVAILABLE,
+  );
+
+  // Compounding Risk — GraphQL compoundingRisk rows[].severity (RETURNED, worst).
+  const worstRow = pickWorstCompoundingRow(compounding);
+  push(
+    "risk-compounding",
+    worstRow
+      ? {
+          state: mapCompoundingSeverity(worstRow.severity),
+          value: worstRow.score != null ? formatNumber(worstRow.score) : "",
+        }
+      : UNAVAILABLE,
+  );
+
+  // Feature Flags — fetchFeatureFlagsData summary (RETURNED severity, demoted).
+  const ffSummary = featureFlags?.summary;
+  push(
+    "feature-flags",
+    ffSummary
+      ? {
+          state: mapFrictionSeverity(ffSummary.releaseFrictionSeverity),
+          value: formatNumber(ffSummary.activeFlags),
+        }
+      : UNAVAILABLE,
+  );
+
+  return signals;
+}
+
+/** Pick the worst compounding-risk row by severity rank then score. */
+function pickWorstCompoundingRow(
+  result: CompoundingRiskResult | undefined,
+): { severity: CompoundingRiskSeverity; score?: number | null } | undefined {
+  const rows = result?.rows ?? [];
+  if (rows.length === 0) return undefined;
+  const rank: Record<CompoundingRiskSeverity, number> = {
+    HIGH: 0,
+    ELEVATED: 1,
+    LOW: 2,
+    UNKNOWN: 3,
+  };
+  return [...rows].sort((a, b) => {
+    const bySev = rank[a.severity] - rank[b.severity];
+    if (bySev !== 0) return bySev;
+    return (b.score ?? 0) - (a.score ?? 0);
+  })[0];
+}
+
+/** Resolve the org scope from the auth session (mirrors the area fetchers). */
+async function resolveOrgId(): Promise<string> {
+  const session = await auth();
+  return (session?.user?.org_id as string | undefined) ?? "default-org";
+}
+
+/**
+ * Run a source fetch, swallowing failures to `undefined` so one dead source
+ * degrades to a single honest-empty card instead of failing the whole area.
+ */
+async function safe<T>(fn: () => Promise<T>, source: string): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (error) {
+    logger.error({ err: error, source }, "Govern signal source failed");
+    return undefined;
+  }
+}

--- a/src/lib/areaSignals/improve.ts
+++ b/src/lib/areaSignals/improve.ts
@@ -1,0 +1,167 @@
+// ── Improve area signal resolver (CHAOS-2074) ─────────────────────────────────
+//
+// Resolves the Improve landing's sub-area signal cards. Mirrors govern.ts:
+// parallel fetch → AreaSignal[]; server-side orgId-from-session. Improve is
+// FLAT (no clusters) and LIGHT (two cards), degrading gracefully per rule R3.
+//
+// Sub-areas:
+//   - Capacity Planning (/capacity-planning) — GraphQL throughputForecast.
+//       headline: p50Weeks formatted (e.g. "6 weeks").
+//       state: RETURNED from primaryRisk.active (true → "medium"; false → "low").
+//       unavailable when insufficientHistory === true.
+//
+//   - AI Workflows (/ai) — GraphQL aiImpactSummary.
+//       headline: aiAssistedPrRatio as %.
+//       state: "neutral" always (adoption metric, NOT a severity).
+//       unavailable when dataAvailable === false.
+//
+// Honest-state contract: a source that fails or lacks data degrades to
+// state "unavailable" with an empty value — never a fabricated number.
+
+import { auth } from "@/lib/auth";
+import { graphqlFetch } from "@/lib/graphql/server";
+import { THROUGHPUT_FORECAST_QUERY, AI_IMPACT_SUMMARY_QUERY } from "@/lib/graphql/queries";
+import type { ThroughputForecast } from "@/lib/graphql/__generated__/types";
+import type { AiImpactSummary, AiDateRangeInput } from "@/lib/graphql/__generated__/types";
+import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
+import type { MetricFilter } from "@/lib/filters/types";
+import { formatPercent } from "@/lib/formatters";
+import { logger } from "@/lib/logger";
+
+import type { AreaSignal, AreaSignalState } from "./types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build an `AreaSignal` from its nav descriptor + resolved state/value. Pulls
+ * label / href / cluster / demoted from the descriptor so the card metadata
+ * stays anchored to the single nav source of truth.
+ */
+function buildSignal(
+  descriptor: NavAreaHubItem,
+  resolved: { state: AreaSignalState; value: string },
+): AreaSignal {
+  return {
+    id: descriptor.id,
+    label: descriptor.label,
+    href: descriptor.href,
+    cluster: descriptor.cluster,
+    metricLabel: descriptor.metricLabel ?? descriptor.label,
+    value: resolved.value,
+    state: resolved.state,
+    demoted: descriptor.demoted,
+  };
+}
+
+/** The unavailable (honest-empty) resolution — no fabricated value. */
+const UNAVAILABLE = { state: "unavailable" as const, value: "" };
+
+// ── Resolver ──────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the Improve area's signal cards.
+ *
+ * @param filters  Active metric filter (drives the analytics date range).
+ * @param isTestMode  Render deterministic sample data without hitting the API.
+ */
+export async function getImproveSignals(
+  filters: MetricFilter,
+  isTestMode = false,
+): Promise<AreaSignal[]> {
+  const improve = getAreaById("improve");
+  if (!improve) return [];
+
+  // Descriptor lookup by id — card metadata is owned by `navAreas`.
+  const byId = new Map(improve.hubItems.map((item) => [item.id, item]));
+  const descriptor = (id: string): NavAreaHubItem | undefined => byId.get(id);
+
+  // Resolve the org scope server-side (mirrors govern.ts).
+  const orgId = isTestMode ? "default-org" : await resolveOrgId();
+
+  // Date range for AI query (mirrors how govern.ts computes analytics date range).
+  const rangeDays = filters.time?.range_days ?? 14;
+  const today = new Date();
+  const endDate = filters.time?.end_date ?? today.toISOString().slice(0, 10);
+  const startDate =
+    filters.time?.start_date ??
+    new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
+  const dateRange: AiDateRangeInput = { startDate, endDate };
+
+  // ── Fetch every source in parallel (no serial N+1) ──────────────────────────
+  const [throughput, aiImpact] = await Promise.all([
+    safe(
+      () =>
+        isTestMode
+          ? Promise.resolve(undefined)
+          : graphqlFetch<{ throughputForecast: ThroughputForecast | null }>(
+              THROUGHPUT_FORECAST_QUERY,
+              { orgId, input: {} },
+              { orgId },
+            ).then((r) => r.throughputForecast ?? undefined),
+      "throughput-forecast",
+    ),
+    safe(
+      () =>
+        isTestMode
+          ? Promise.resolve(undefined)
+          : graphqlFetch<{ aiImpactSummary: AiImpactSummary }>(
+              AI_IMPACT_SUMMARY_QUERY,
+              { orgId, dateRange, scope: null },
+              { orgId },
+            ).then((r) => r.aiImpactSummary),
+      "ai-impact-summary",
+    ),
+  ]);
+
+  const signals: AreaSignal[] = [];
+  const push = (id: string, resolved: { state: AreaSignalState; value: string }) => {
+    const d = descriptor(id);
+    if (d) signals.push(buildSignal(d, resolved));
+  };
+
+  // ── Capacity Planning ────────────────────────────────────────────────────────
+  //
+  // State RETURNED from primaryRisk.active (true → watch/"medium"; false → "low").
+  // Unavailable when insufficientHistory === true (no data to forecast from).
+  if (throughput == null || throughput.insufficientHistory) {
+    push("capacity-planning", UNAVAILABLE);
+  } else {
+    const p50Weeks = throughput.p50Weeks;
+    const state: AreaSignalState = throughput.primaryRisk?.active ? "medium" : "low";
+    const value = p50Weeks != null ? `${p50Weeks}w` : "";
+    push("capacity-planning", { state, value });
+  }
+
+  // ── AI Workflows ─────────────────────────────────────────────────────────────
+  //
+  // State is always "neutral" — adoption %, NOT a severity.
+  // Unavailable when dataAvailable === false.
+  if (aiImpact == null || !aiImpact.dataAvailable) {
+    push("ai-workflows", UNAVAILABLE);
+  } else {
+    const ratio = aiImpact.aiAssistedPrRatio;
+    const value = ratio != null ? formatPercent(ratio * 100) : "";
+    push("ai-workflows", { state: "neutral", value });
+  }
+
+  return signals;
+}
+
+/** Resolve the org scope from the auth session (mirrors govern.ts). */
+async function resolveOrgId(): Promise<string> {
+  const session = await auth();
+  return (session?.user?.org_id as string | undefined) ?? "default-org";
+}
+
+/**
+ * Run a source fetch, swallowing failures to `undefined` so one dead source
+ * degrades to a single honest-empty card instead of failing the whole area.
+ */
+async function safe<T>(fn: () => Promise<T>, source: string): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (error) {
+    logger.error({ err: error, source }, "Improve signal source failed");
+    return undefined;
+  }
+}

--- a/src/lib/areaSignals/index.ts
+++ b/src/lib/areaSignals/index.ts
@@ -1,29 +1,29 @@
 // ── Area signals: shared dispatcher (CHAOS-2074) ──────────────────────────────
 //
 // `getAreaSignals(areaId, filters)` is the single RSC entry point an area
-// landing calls to resolve its sub-area signal cards. Govern is wired to its
-// real resolver now; Diagnose / Improve are Phase-2 stubs that currently return
-// the static descriptors as honest-empty ("unavailable") cards so the landing
-// renders the right SHAPE before the resolver fetching lands. Cockpit / utility
-// areas have no signal grid.
-//
-// Phase 2 only has to replace the `diagnose` / `improve` cases with real
-// resolvers mirroring `getGovernSignals` — the type, the AreaHub rendering, and
-// the descriptors are already in place.
+// landing calls to resolve its sub-area signal cards. Govern, Diagnose, and
+// Improve are wired to their real resolvers. Cockpit renders its single
+// navigational sub-area as a calm "neutral" card; reports / admin have no
+// signal grid. No sub-area ever renders a fabricated value — a missing or
+// failed source degrades to an honest "unavailable" (DataState) card.
 
 import { getAreaById, type NavAreaId } from "@/lib/navigation/areas";
 import type { MetricFilter } from "@/lib/filters/types";
 
+import { getDiagnoseSignals } from "./diagnose";
 import { getGovernSignals } from "./govern";
+import { getImproveSignals } from "./improve";
 import type { AreaSignal } from "./types";
 
 export type { AreaSignal, AreaSignalState } from "./types";
+export { getDiagnoseSignals } from "./diagnose";
 export { getGovernSignals } from "./govern";
+export { getImproveSignals } from "./improve";
 
 /**
- * Resolve an area's signal cards. Returns `[]` for areas with no signal grid
- * (cockpit, reports, admin) and honest-empty descriptor cards for areas whose
- * resolver is not yet wired (Phase 2).
+ * Resolve an area's signal cards. Govern/Diagnose/Improve fetch real signals;
+ * Cockpit returns its single sub-area as a calm "neutral" card; reports / admin
+ * return `[]` (no signal grid).
  */
 export async function getAreaSignals(
   areaId: NavAreaId,
@@ -34,10 +34,9 @@ export async function getAreaSignals(
     case "govern":
       return getGovernSignals(filters, isTestMode);
     case "diagnose":
+      return getDiagnoseSignals(filters, isTestMode);
     case "improve":
-      // Phase 2 wires these resolvers. Until then, surface the descriptors as
-      // honest-empty cards (never fabricated values) so the grid shape is right.
-      return descriptorStubs(areaId, "unavailable");
+      return getImproveSignals(filters, isTestMode);
     case "cockpit":
       // Cockpit's single sub-area (Operating Review) has no severity metric; it
       // is a navigational surface. Render it as a calm "neutral" card rather
@@ -51,7 +50,6 @@ export async function getAreaSignals(
 
 /**
  * Map an area's nav descriptors to placeholder `AreaSignal`s in a given state.
- * "unavailable" → honest-empty (DataState) for not-yet-wired metric areas;
  * "neutral" → calm navigational card for areas without severity metrics.
  */
 function descriptorStubs(areaId: NavAreaId, state: "unavailable" | "neutral"): AreaSignal[] {

--- a/src/lib/areaSignals/index.ts
+++ b/src/lib/areaSignals/index.ts
@@ -1,0 +1,70 @@
+// ── Area signals: shared dispatcher (CHAOS-2074) ──────────────────────────────
+//
+// `getAreaSignals(areaId, filters)` is the single RSC entry point an area
+// landing calls to resolve its sub-area signal cards. Govern is wired to its
+// real resolver now; Diagnose / Improve are Phase-2 stubs that currently return
+// the static descriptors as honest-empty ("unavailable") cards so the landing
+// renders the right SHAPE before the resolver fetching lands. Cockpit / utility
+// areas have no signal grid.
+//
+// Phase 2 only has to replace the `diagnose` / `improve` cases with real
+// resolvers mirroring `getGovernSignals` — the type, the AreaHub rendering, and
+// the descriptors are already in place.
+
+import { getAreaById, type NavAreaId } from "@/lib/navigation/areas";
+import type { MetricFilter } from "@/lib/filters/types";
+
+import { getGovernSignals } from "./govern";
+import type { AreaSignal } from "./types";
+
+export type { AreaSignal, AreaSignalState } from "./types";
+export { getGovernSignals } from "./govern";
+
+/**
+ * Resolve an area's signal cards. Returns `[]` for areas with no signal grid
+ * (cockpit, reports, admin) and honest-empty descriptor cards for areas whose
+ * resolver is not yet wired (Phase 2).
+ */
+export async function getAreaSignals(
+  areaId: NavAreaId,
+  filters: MetricFilter,
+  isTestMode = false,
+): Promise<AreaSignal[]> {
+  switch (areaId) {
+    case "govern":
+      return getGovernSignals(filters, isTestMode);
+    case "diagnose":
+    case "improve":
+      // Phase 2 wires these resolvers. Until then, surface the descriptors as
+      // honest-empty cards (never fabricated values) so the grid shape is right.
+      return descriptorStubs(areaId, "unavailable");
+    case "cockpit":
+      // Cockpit's single sub-area (Operating Review) has no severity metric; it
+      // is a navigational surface. Render it as a calm "neutral" card rather
+      // than implying a finding (leave-as-is per CHAOS-2074).
+      return descriptorStubs(areaId, "neutral");
+    default:
+      // reports / admin — no signal grid.
+      return [];
+  }
+}
+
+/**
+ * Map an area's nav descriptors to placeholder `AreaSignal`s in a given state.
+ * "unavailable" → honest-empty (DataState) for not-yet-wired metric areas;
+ * "neutral" → calm navigational card for areas without severity metrics.
+ */
+function descriptorStubs(areaId: NavAreaId, state: "unavailable" | "neutral"): AreaSignal[] {
+  const area = getAreaById(areaId);
+  if (!area) return [];
+  return area.hubItems.map((item) => ({
+    id: item.id,
+    label: item.label,
+    href: item.href,
+    cluster: item.cluster,
+    metricLabel: item.metricLabel ?? item.description ?? item.label,
+    value: "",
+    state,
+    demoted: item.demoted,
+  }));
+}

--- a/src/lib/areaSignals/sort.ts
+++ b/src/lib/areaSignals/sort.ts
@@ -1,0 +1,79 @@
+// ── Area-signal ordering + grouping (CHAOS-2074) ──────────────────────────────
+//
+// Pure helpers shared by {@link AreaHub} and the area resolvers so the severity
+// order and cluster grouping are defined once and tested in isolation.
+//
+// Ordering (owner decision 1 — honest states):
+//   critical > high > medium > low > neutral > unavailable
+// Real signals sort first; "neutral" (informational, non-severity) sits above
+// the genuinely-unavailable cards, which always sink to the bottom.
+
+import type { AreaSignal, AreaSignalState } from "./types";
+
+/** Lower rank = higher up the list. Unavailable always last. */
+export const STATE_RANK: Record<AreaSignalState, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  neutral: 4,
+  unavailable: 5,
+};
+
+/** True when the signal has a real, surfaced value (not the honest-empty state). */
+export function isAvailable(signal: AreaSignal): boolean {
+  return signal.state !== "unavailable";
+}
+
+/**
+ * Stable severity sort: by {@link STATE_RANK} ascending, ties preserved in input
+ * order (so resolvers control intra-band ordering). Does not mutate the input.
+ */
+export function sortBySeverity(signals: readonly AreaSignal[]): AreaSignal[] {
+  return signals
+    .map((signal, index) => ({ signal, index }))
+    .sort((a, b) => {
+      const byState = STATE_RANK[a.signal.state] - STATE_RANK[b.signal.state];
+      return byState !== 0 ? byState : a.index - b.index;
+    })
+    .map(({ signal }) => signal);
+}
+
+/**
+ * The top N signals across the whole area by severity, used to bubble the
+ * leading sub-area signal(s) up to the area overview (Framework A2a). Only
+ * available signals bubble — an unavailable metric is never "the top signal".
+ */
+export function topSignals(signals: readonly AreaSignal[], count = 3): AreaSignal[] {
+  return sortBySeverity(signals.filter(isAvailable)).slice(0, count);
+}
+
+export type SignalCluster = {
+  /** Cluster header, or `undefined` for the flat (unclustered) bucket. */
+  cluster: string | undefined;
+  signals: AreaSignal[];
+};
+
+/**
+ * Group signals into severity-sorted clusters, preserving first-seen cluster
+ * order. Returns a single `{ cluster: undefined }` bucket when no signal carries
+ * a cluster (light areas degrade to a flat grid).
+ */
+export function groupByCluster(signals: readonly AreaSignal[]): SignalCluster[] {
+  const order: (string | undefined)[] = [];
+  const byCluster = new Map<string | undefined, AreaSignal[]>();
+
+  for (const signal of signals) {
+    const key = signal.cluster;
+    if (!byCluster.has(key)) {
+      byCluster.set(key, []);
+      order.push(key);
+    }
+    byCluster.get(key)!.push(signal);
+  }
+
+  return order.map((cluster) => ({
+    cluster,
+    signals: sortBySeverity(byCluster.get(cluster)!),
+  }));
+}

--- a/src/lib/areaSignals/types.ts
+++ b/src/lib/areaSignals/types.ts
@@ -1,0 +1,55 @@
+// ── Area signals: the cross-area signal-card contract (CHAOS-2074) ────────────
+//
+// An `AreaSignal` is the resolved, render-ready descriptor for one sub-area of a
+// decision area's landing page. The area landing (an RSC) resolves an
+// `AreaSignal[]` for its area and hands it to {@link AreaHub}, which renders each
+// as a severity-sorted signal card (metric + state) instead of a passive link
+// (Framework A2a).
+//
+// Honest-state contract (owner decision 1): a signal whose metric is genuinely
+// unavailable carries `state: "unavailable"` — never a fabricated value. Those
+// cards render the {@link DataState} primitive and sink to the bottom of the
+// sort. Real signals always sort first.
+//
+// This is the SHARED shape every area resolver returns. Govern is wired now;
+// Diagnose / Improve resolvers (Phase 2) return the same shape.
+
+import type { ConfidenceLevel, SignalDirection, SignalSeverity } from "@/lib/types";
+
+/**
+ * A sub-area surfaced as a signal card on its area's landing page.
+ *
+ * `state` reuses the canonical {@link SignalSeverity} ladder, widened with
+ * `"unavailable"` (honest empty — render via DataState) and `"neutral"` (a
+ * value worth surfacing that is NOT a severity, e.g. AI adoption %).
+ */
+export type AreaSignalState = SignalSeverity | "neutral" | "unavailable";
+
+export type AreaSignal = {
+  /** Stable id, mirrors the originating `NavAreaHubItem.id`. */
+  id: string;
+  /** Sub-area label (e.g. "Coverage", "Security"). */
+  label: string;
+  /** Destination route (already filter-decorated by AreaHub at render time). */
+  href: string;
+  /** Optional sub-group header within the area (Govern: "Quality" | "Risk"). */
+  cluster?: string;
+  /** Short metric name shown on the card (e.g. "Line coverage", "Open criticals"). */
+  metricLabel: string;
+  /**
+   * Pre-formatted headline value via `@/lib/formatters` (e.g. "83%", "2").
+   * Empty string when `state === "unavailable"`.
+   */
+  value: string;
+  /** Severity ladder, widened with "neutral" / "unavailable" (honest states). */
+  state: AreaSignalState;
+  /** Optional trend glyph direction for the metric. */
+  direction?: SignalDirection;
+  /** Optional confidence in the resolved value. */
+  confidence?: ConfidenceLevel;
+  /**
+   * R4-style low-value single surface (e.g. Feature Flags): render visually
+   * secondary within its cluster rather than at equal billing.
+   */
+  demoted?: boolean;
+};

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -23,6 +23,24 @@ export type NavAreaHubItem = {
   label: string;
   href: string;
   description?: string;
+  // ── Signal-card descriptors (CHAOS-2074) ───────────────────────────────────
+  // Static metadata the area resolver pairs with a fetched value to build an
+  // `AreaSignal`. Kept here (the single nav source of truth) so the sidebar,
+  // landing hub, and signal resolvers can never drift. The *value* + *state* are
+  // resolved at request time by the area resolver (see `@/lib/areaSignals`);
+  // these fields only describe HOW a sub-area surfaces as a card.
+  /**
+   * Optional sub-group header within a dense area. Govern groups into
+   * "Quality" / "Risk"; flat areas (Diagnose, Improve) leave this undefined.
+   */
+  cluster?: string;
+  /** Short metric name shown on the card (e.g. "Line coverage", "Open criticals"). */
+  metricLabel?: string;
+  /**
+   * R4 low-value single surface (e.g. Feature Flags): render visually secondary
+   * within its cluster rather than at equal billing.
+   */
+  demoted?: boolean;
 };
 
 export type NavArea = {
@@ -94,48 +112,60 @@ export const navAreas: readonly NavArea[] = [
       "bottleneck",
       "diagnose",
     ],
+    // CHAOS-2074: Diagnose is FLAT (no clusters). Descriptors placed here; Phase
+    // 2 wires the resolver fetching (see `@/lib/areaSignals/getAreaSignals`).
     hubItems: [
       {
         id: "metrics",
         label: "Metrics",
         href: "/metrics?tab=dora",
         description: "DORA and flow trends.",
+        metricLabel: "Deploy frequency",
       },
       {
         id: "people",
         label: "People",
         href: "/people",
         description: "Individual reflection surfaces.",
+        // No area-level metric → resolver surfaces "unavailable" (DataState).
+        metricLabel: "No area metric",
       },
       {
         id: "code",
         label: "Code",
         href: "/code",
         description: "Code health and ownership.",
+        metricLabel: "Code churn",
       },
       {
         id: "landscape",
         label: "Landscape",
         href: "/explore/landscape",
         description: "System landscape overview.",
+        // Gap: no resolver-backed metric yet → "unavailable" (DataState).
+        metricLabel: "No area metric",
       },
       {
         id: "complexity",
         label: "Complexity",
         href: "/complexity",
         description: "Complexity trend and hotspots.",
+        metricLabel: "Avg complexity",
       },
       {
         id: "cognitive-load",
         label: "Cognitive Load",
         href: "/cognitive-load",
         description: "Focus and context-switch pressure.",
+        // Gap: no resolver-backed metric yet → "unavailable" (DataState).
+        metricLabel: "No area metric",
       },
       {
         id: "bottleneck",
         label: "Bottlenecks",
         href: "/bottleneck",
         description: "Flow bottleneck detection.",
+        metricLabel: "WIP saturation",
       },
     ],
   },
@@ -146,18 +176,25 @@ export const navAreas: readonly NavArea[] = [
     placement: "main",
     ownedPathPrefixes: ["/opportunities", "/capacity-planning", "/capacity", "/ai"],
     legacyActiveIds: ["opportunities", "capacity-planning", "ai-workflows", "improve"],
+    // CHAOS-2074: Improve is FLAT (no clusters). Opportunities is the area's own
+    // landing route (`href: "/opportunities"`), so it is NOT duplicated as a hub
+    // item — its volume signal bubbles at the area level via the resolver.
+    // Descriptors placed here; Phase 2 wires the resolver fetching.
     hubItems: [
       {
         id: "capacity-planning",
         label: "Capacity Planning",
         href: "/capacity-planning",
         description: "Plan capacity against demand.",
+        metricLabel: "Forecast (p50 weeks)",
       },
       {
         id: "ai-workflows",
         label: "AI Workflows",
         href: "/ai",
         description: "AI impact, attribution, and governance.",
+        // Adoption %, NOT a severity → resolver surfaces a neutral/info state.
+        metricLabel: "AI-assisted PRs",
       },
     ],
   },
@@ -187,60 +224,84 @@ export const navAreas: readonly NavArea[] = [
       "risk-compounding",
       "govern",
     ],
+    // CHAOS-2074: Govern is sub-grouped into "Quality" and "Risk" clusters,
+    // each internally severity-sorted by the resolver (`getGovernSignals`).
     hubItems: [
+      // ── Cluster: Quality ──────────────────────────────────────────────────
       {
-        id: "pipelines",
-        label: "Pipelines",
-        href: "/testops/pipelines",
-        description: "Pipeline stability.",
+        id: "coverage",
+        label: "Coverage",
+        href: "/testops/coverage",
+        description: "Coverage delta.",
+        cluster: "Quality",
+        metricLabel: "Line coverage",
       },
       {
         id: "tests",
         label: "Tests",
         href: "/testops/tests",
         description: "Test reliability and flake.",
+        cluster: "Quality",
+        metricLabel: "Flake rate",
+      },
+      {
+        id: "pipelines",
+        label: "Pipelines",
+        href: "/testops/pipelines",
+        description: "Pipeline stability.",
+        cluster: "Quality",
+        metricLabel: "Success rate",
       },
       {
         id: "quality",
         label: "Quality",
         href: "/quality",
         description: "Reliability and rework.",
+        cluster: "Quality",
+        metricLabel: "Change failure rate",
       },
+      // ── Cluster: Risk ─────────────────────────────────────────────────────
       {
-        id: "coverage",
-        label: "Coverage",
-        href: "/testops/coverage",
-        description: "Coverage delta.",
+        id: "security",
+        label: "Security",
+        href: "/security",
+        description: "Security posture.",
+        cluster: "Risk",
+        metricLabel: "Open criticals",
       },
       {
         id: "risk",
         label: "Delivery Risk",
         href: "/testops/risk",
         description: "Delivery risk drag.",
+        cluster: "Risk",
+        metricLabel: "Release confidence",
       },
       {
         id: "incident-correlation",
         label: "Incident Correlation",
         href: "/incident-correlation",
         description: "Incidents correlated to changes.",
-      },
-      {
-        id: "security",
-        label: "Security",
-        href: "/security",
-        description: "Security posture.",
-      },
-      {
-        id: "feature-flags",
-        label: "Feature Flags",
-        href: "/feature-flags",
-        description: "Flag lifecycle and debt.",
+        cluster: "Risk",
+        metricLabel: "Change failure rate",
       },
       {
         id: "risk-compounding",
         label: "Compounding Risk",
         href: "/risk/compounding",
         description: "Compounding risk signals.",
+        cluster: "Risk",
+        metricLabel: "Worst risk score",
+      },
+      {
+        id: "feature-flags",
+        label: "Feature Flags",
+        href: "/feature-flags",
+        description: "Flag lifecycle and debt.",
+        cluster: "Risk",
+        metricLabel: "Active flags",
+        // R4: low-value single surface — render secondary, not equal billing.
+        demoted: true,
       },
     ],
   },


### PR DESCRIPTION
## Summary
Converts the area landing pages from a flat grid of passive "OPEN" links into **severity-sorted signal cards** (metric + state) so each area surfaces *where the problem is* instead of relocating the old sidebar into the page body. Implements CHAOS-2074's recommended default (R1 + R2 + R3) and codifies framework rule **A2a**.

Stacked on `fix/nav-collapse-areas-chaos-2073` — the preview branch that introduced the area landings (they are not on `main`). Rebase onto `main` when the nav collapse lands.

## What changed
- **Shared model** (`src/lib/areaSignals/`): `AreaSignal` type, direction-aware `deriveState`, per-area resolvers (`govern`/`diagnose`/`improve`) that fetch in parallel and degrade failed sources to honest `DataState`, and a `getAreaSignals` dispatcher.
- **`AreaHub`** rebuilt as presentational: reuses cockpit severity tokens (extracted to `severityTokens.ts`, shared with `SignalCard`), severity-sorts, **sub-groups Govern into Quality / Risk**, emphasizes the top signal, `DataState` for unavailable metrics.
- **Landing restructure** (R1): `testops`→**Govern**, `work`→**Diagnose**, `opportunities`→**Improve** — each titled by the *area* (rule A6), borrowed leaf moved into a `ModeTabs` tab, top 1–3 signals bubbled into an overview.
- **Framework**: rule **A2a** added to `docs/design-system.md`.
- **Perf (review fix)**: deduped page/resolver double-fetch — `getHomeData` wrapped in React `cache()`; `getGovernSignals` reuses the page's prefetched `testOpsData`.

## Data
17 of 19 sub-areas wire to **existing** endpoints (no backend changes), confirmed by a frontend + ops-backend inventory. State is reused where the backend already computes severity (home `signals[].severity`, compounding `rows[].severity`, feature-flag `releaseFrictionSeverity`, capacity `primaryRisk`) and derived from raw values otherwise. The 2 genuine gaps — **Landscape** (ClickHouse data exists but Grafana-view-only) and **Cognitive Load** (no backend metric) — render honest "not yet measured" `DataState`, tracked in **CHAOS-2077**.

## Flagged for reviewer (sensible defaults; tunable)
- `deriveState` thresholds are **provisional** (named constants, `// pending calibration`) — esp. **Complexity** (raw cyclomatic/kloc, not 0–100).
- Compounding-risk **ELEVATED → "medium"** (watch-tier); reviewer suggested "high" — kept, flagging for product.
- **Incident Correlation ≈ Quality** (both map to `change_failure_rate`) → identical chip until a distinct metric is chosen.
- Added a **"neutral"** state for non-severity metrics (AI adoption %).

## Tests
- `pnpm test:unit`: **1495 pass / 181 files**; `tsc --noEmit` clean.
- `pnpm design-lint`: zero new violations (net −1); the repo's ~484 pre-existing advisory backlog is untouched.

## Related
- CHAOS-2074 (this) · pairs with CHAOS-2075 (two-level nav)
- CHAOS-2076 — Focus Cards identical "recommended next step" (backend bug, filed)
- CHAOS-2077 — wire Landscape + Cognitive Load metrics (backend follow-up, filed)

Screenshots (Govern / Diagnose / Improve) attaching shortly.