### PR TITLE
feat(nav): two-level expandable area navigation (CHAOS-2075)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -10,8 +10,8 @@
 
 ## Part A: Interaction and content rules (design inconsistencies)
 
-- **A1 Sidebar**, major product areas only. No one-off metric pages without product approval.
-- **A2 Tabs**, sibling views within one area only (Work: Investment/Flow/Landscape/Heatmap/Capacity/Evidence; AI Workflows: Impact/Attribution/Review Load/Test Gaps/Governance Risk/Evidence). Never style a navigation exit as a tab.
+- **A1 Sidebar**, two levels: the six decision areas, plus the ACTIVE area expanded to its child destinations (inactive areas stay collapsed). Children are real destinations only — never tab subviews, never preview/unbuilt routes, never one-off metric pages without product approval. The route tree is config-driven (`src/lib/navigation/areas.ts` → `navArea.children`), so sidebar = breadcrumb = page title (A6). ([CHAOS-2075](https://linear.app/fullchaos/issue/CHAOS-2075/two-level-expandable-area-navigation).)
+- **A2 Tabs**, sibling views _within_ one destination only (Work: Investment/Flow/Landscape/Heatmap/Capacity/Evidence; AI Workflows: Impact/Attribution/Review Load/Test Gaps/Governance Risk/Evidence). Area children (A1) are destinations, not tabs, and never appear in the sidebar as their tab subviews. Never style a navigation exit as a tab.
 - **A2a Area landings**, the area header names the area; sub-areas surface as severity-sorted signal cards (metric + state), never passive links; bubble the top sub-area signal(s) up to the area level. Dense areas may sub-group (e.g. Govern → Quality / Risk); light areas degrade gracefully; unavailable metrics use DataState, never fabricated values. ([CHAOS-2074](https://linear.app/fullchaos/issue/CHAOS-2074/area-landing-pages-severity-sorted-signal-cards).)
 - **A3 Pills**, filters, scope, status, and segmented view controls only. Never for navigation, back, or primary CTAs.
 - **A4 Buttons**, actions only, from the CTA registry (Part D). Don't invent verbs.

--- a/src/app/(app)/ai/automations/page.tsx
+++ b/src/app/(app)/ai/automations/page.tsx
@@ -3,6 +3,7 @@ import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { metricFilterToAIFilter } from "@/lib/filters/ai";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+import { navTrailForPathname } from "@/lib/navigation/areas";
 
 type AIAutomationsPageProps = {
 	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -25,8 +26,7 @@ export default async function AIAutomationsPage({
 				title="Automations"
 				preview
 				breadcrumbs={[
-					{ label: "Home", href: "/dashboard" },
-					{ label: "AI Workflows", href: "/ai" },
+					...navTrailForPathname("/ai/automations").map((c) => ({ ...c, href: c.href ?? "/ai" })),
 					{ label: "Automations" },
 				]}
 			>

--- a/src/app/(app)/ai/review-load/page.tsx
+++ b/src/app/(app)/ai/review-load/page.tsx
@@ -3,6 +3,7 @@ import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { metricFilterToAIFilter } from "@/lib/filters/ai";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+import { navTrailForPathname } from "@/lib/navigation/areas";
 
 type AIReviewLoadPageProps = {
 	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -24,8 +25,7 @@ export default async function AIReviewLoadPage({
 				eyebrow="AI Workflows"
 				title="Review Load"
 				breadcrumbs={[
-					{ label: "Home", href: "/dashboard" },
-					{ label: "AI Workflows", href: "/ai" },
+					...navTrailForPathname("/ai/review-load").map((c) => ({ ...c, href: c.href ?? "/ai" })),
 					{ label: "Review Load" },
 				]}
 			>

--- a/src/app/(app)/ai/risk/page.tsx
+++ b/src/app/(app)/ai/risk/page.tsx
@@ -3,6 +3,7 @@ import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { metricFilterToAIFilter } from "@/lib/filters/ai";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+import { navTrailForPathname } from "@/lib/navigation/areas";
 
 type AIRiskPageProps = {
 	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -22,8 +23,7 @@ export default async function AIRiskPage({ searchParams }: AIRiskPageProps) {
 				eyebrow="AI Workflows"
 				title="Governance Risk"
 				breadcrumbs={[
-					{ label: "Home", href: "/dashboard" },
-					{ label: "AI Workflows", href: "/ai" },
+					...navTrailForPathname("/ai/risk").map((c) => ({ ...c, href: c.href ?? "/ai" })),
 					{ label: "Governance Risk" },
 				]}
 			>

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -192,7 +192,7 @@ export default async function Home({ searchParams }: HomePageProps) {
             signals={await getAreaSignals("cockpit", filters)}
             filters={filters}
             role={activeRole}
-            title="Cockpit area"
+            title="Related workflows"
             description="Periodic operating review of system health."
           />
 

--- a/src/app/(app)/operating-review/page.tsx
+++ b/src/app/(app)/operating-review/page.tsx
@@ -14,6 +14,7 @@ import { getOperatingReviewViaGraphQL } from "@/lib/graphql/operatingReviewFetch
 import type { OperatingReview, OperatingReviewMetric } from "@/lib/graphql/types";
 import { aggregateOperatingReviews } from "@/lib/operatingReviewAggregate";
 import { selectedOperatingReviewTeamIds } from "@/lib/operatingReviewScope";
+import { navTrailForPathname } from "@/lib/navigation/areas";
 
 type OperatingReviewPageProps = {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -75,9 +76,7 @@ export default async function OperatingReviewPage({ searchParams }: OperatingRev
           <header className="flex flex-wrap items-center justify-between gap-4">
             <div>
               <div className="mb-3">
-                <Breadcrumbs
-                  items={[{ label: "Home", href: "/dashboard" }, { label: "Operating Review" }]}
-                />
+                <Breadcrumbs items={navTrailForPathname("/operating-review")} />
               </div>
               <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Weekly mode</p>
               <h1 className="mt-2 font-(--font-display) text-3xl">Engineering Operating Review</h1>

--- a/src/app/(app)/opportunities/page.tsx
+++ b/src/app/(app)/opportunities/page.tsx
@@ -125,7 +125,7 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
               signals={improveSignals}
               filters={filters}
               role={activeRole}
-              title="Improve signals"
+              title="Related workflows"
               description="Capacity and AI workflow sub-areas."
             />
           )}

--- a/src/app/(app)/quality/page.tsx
+++ b/src/app/(app)/quality/page.tsx
@@ -4,6 +4,7 @@ import { HorizontalBarChart } from "@/components/charts/HorizontalBarChart";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { MetricCard } from "@/components/metrics/MetricCard";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { QualityCoverageTabs } from "@/components/testops/QualityCoverageTabs";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { checkApiHealth } from "@/lib/api/system";
 import { getExplainData, getHomeData } from "@/lib/api/home";
@@ -88,6 +89,8 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
 							Back to cockpit
 						</Link>
 					</header>
+
+					<QualityCoverageTabs />
 
 					<FilterBar view="quality" />
 

--- a/src/app/(app)/quality/page.tsx
+++ b/src/app/(app)/quality/page.tsx
@@ -90,7 +90,7 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
 						</Link>
 					</header>
 
-					<QualityCoverageTabs />
+					<QualityCoverageTabs filters={filters} role={activeRole} />
 
 					<FilterBar view="quality" />
 

--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { MetricCard } from "@/components/metrics/MetricCard";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { QualityCoverageTabs } from "@/components/testops/QualityCoverageTabs";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
 import { HorizontalBarChart } from "@/components/charts/HorizontalBarChart";
@@ -164,6 +165,8 @@ export default async function CoveragePage({
 							Back to cockpit
 						</Link>
 					</header>
+
+					<QualityCoverageTabs />
 
 					<FilterBar view="testops" />
 

--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -166,7 +166,7 @@ export default async function CoveragePage({
 						</Link>
 					</header>
 
-					<QualityCoverageTabs />
+					<QualityCoverageTabs filters={filters} role={activeRole} />
 
 					<FilterBar view="testops" />
 

--- a/src/app/(app)/testops/page.tsx
+++ b/src/app/(app)/testops/page.tsx
@@ -188,7 +188,7 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
               signals={governSignals}
               filters={filters}
               role={activeRole}
-              title="Govern signals"
+              title="Related workflows"
               description="Quality and risk sub-areas, ordered by severity."
             />
           )}

--- a/src/app/(app)/testops/tests/page.tsx
+++ b/src/app/(app)/testops/tests/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { MetricCard } from "@/components/metrics/MetricCard";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { QualityCoverageTabs } from "@/components/testops/QualityCoverageTabs";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
 import { HeatmapChart } from "@/components/charts/HeatmapChart";
@@ -145,6 +146,8 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
               Back to cockpit
             </Link>
           </header>
+
+          <QualityCoverageTabs />
 
           <FilterBar view="testops" />
 

--- a/src/app/(app)/testops/tests/page.tsx
+++ b/src/app/(app)/testops/tests/page.tsx
@@ -147,7 +147,7 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
             </Link>
           </header>
 
-          <QualityCoverageTabs />
+          <QualityCoverageTabs filters={filters} role={activeRole} />
 
           <FilterBar view="testops" />
 

--- a/src/app/(app)/work/page.tsx
+++ b/src/app/(app)/work/page.tsx
@@ -30,16 +30,11 @@ import { WorkTabNav, type WorkTab } from "@/components/navigation/WorkTabNav";
 import { getDiagnoseSignals } from "@/lib/areaSignals/diagnose";
 import { topSignals } from "@/lib/areaSignals/sort";
 import { getServerEnv } from "@/lib/config";
+import { resolveActiveView, type DiagnoseView } from "@/lib/navigation/workPageView";
 
 type WorkPageProps = {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
-
-// Diagnose landing sub-views (Framework A2). "Overview" is the area summary +
-// signal grid; "Work" preserves the borrowed Work Investment and Flow leaf
-// content (A6: the area is named "Diagnose", not its borrowed leaf).
-type DiagnoseView = "overview" | "work";
-const DIAGNOSE_VIEWS: DiagnoseView[] = ["overview", "work"];
 
 const findCategory = (
   categories: Array<{ key: string; name: string; value: number }>,
@@ -57,11 +52,6 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
   const activeRole = typeof roleParam === "string" ? roleParam : undefined;
   const activeOrigin = typeof originParam === "string" ? originParam : undefined;
 
-  const viewParam = Array.isArray(params.view) ? params.view[0] : params.view;
-  const activeView: DiagnoseView = DIAGNOSE_VIEWS.includes(viewParam as DiagnoseView)
-    ? (viewParam as DiagnoseView)
-    : "overview";
-
   const tabParam = Array.isArray(params.tab) ? params.tab[0] : params.tab;
   const activeTab: WorkTab =
     typeof tabParam === "string" &&
@@ -77,6 +67,12 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
     ].includes(tabParam)
       ? (tabParam as WorkTab)
       : "landscape";
+
+  const viewParam = Array.isArray(params.view) ? params.view[0] : params.view;
+  // resolveActiveView preserves legacy /work?tab=<workTab> deep links: when
+  // `view` is absent but a valid `tab` is present it returns "work" so the Work
+  // content branch renders and the existing `tab` logic picks the sub-view.
+  const activeView: DiagnoseView = resolveActiveView(viewParam, tabParam);
 
   const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
   const scopeId = filters.scope.ids[0] ?? "";

--- a/src/app/(app)/work/page.tsx
+++ b/src/app/(app)/work/page.tsx
@@ -333,7 +333,7 @@ export default async function WorkPage({ searchParams }: WorkPageProps) {
               signals={diagnoseSignals}
               filters={filters}
               role={activeRole}
-              title="Diagnose signals"
+              title="Related workflows"
               description="Diagnostic sub-areas, ordered by severity."
             />
           )}

--- a/src/components/navigation/AreaHub.phase2.test.tsx
+++ b/src/components/navigation/AreaHub.phase2.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Phase 2 (CHAOS-2075) — AreaHub title reconciliation.
+ *
+ * The four area landings (dashboard, work, opportunities, testops) now pass
+ * title="Related workflows" instead of "<Area> signals" / "<Area> area" so
+ * the section is not framed as the primary nav directory (the sidebar owns
+ * findability). The signal cards themselves are triage content and stay.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/test/utils";
+
+import { AreaHub } from "./AreaHub";
+import type { AreaSignal } from "@/lib/areaSignals/types";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+afterEach(cleanup);
+
+const stubSignal: AreaSignal = {
+  id: "coverage",
+  label: "Coverage",
+  href: "/testops/coverage",
+  cluster: "Quality",
+  metricLabel: "Line coverage",
+  value: "82%",
+  state: "medium",
+};
+
+describe("AreaHub — title prop (Phase 2: Related workflows framing)", () => {
+  it("renders the explicit title prop instead of the default '<Area> area'", () => {
+    render(
+      <AreaHub
+        areaId="govern"
+        signals={[stubSignal]}
+        filters={defaultMetricFilter}
+        title="Related workflows"
+      />,
+    );
+    expect(screen.getByText("Related workflows")).toBeInTheDocument();
+    // Default title "Govern area" must NOT appear.
+    expect(screen.queryByText("Govern area")).toBeNull();
+  });
+
+  it("falls back to '<Area> area' when no title is provided", () => {
+    render(
+      <AreaHub
+        areaId="govern"
+        signals={[stubSignal]}
+        filters={defaultMetricFilter}
+      />,
+    );
+    expect(screen.getByText("Govern area")).toBeInTheDocument();
+  });
+
+  it("still renders signal cards when title is 'Related workflows'", () => {
+    render(
+      <AreaHub
+        areaId="govern"
+        signals={[stubSignal]}
+        filters={defaultMetricFilter}
+        title="Related workflows"
+      />,
+    );
+    expect(screen.getByTestId("area-hub")).toBeInTheDocument();
+    expect(screen.getAllByTestId("area-signal-card")).toHaveLength(1);
+  });
+});

--- a/src/components/navigation/PrimaryNav.test.tsx
+++ b/src/components/navigation/PrimaryNav.test.tsx
@@ -91,15 +91,21 @@ describe("PrimaryNav — two-level decision-area surface (CHAOS-2075)", () => {
     expect(screen.queryByRole("link", { name: /^Security$/i })).toBeNull();
   });
 
-  it("never renders preview (navVisible:false) children", () => {
-    // Reports active: Report Center shows; the preview rows never do.
-    navigationMock.pathname = "/reports";
-    render(<PrimaryNav filters={makeFilter()} active="reports" />);
+  it("never renders preview (navVisible:false) children — verified via main area", () => {
+    // Use a main-placement area to confirm preview rows are suppressed. Utility
+    // areas (Reports, Admin) no longer expand at all (owner directive), so the
+    // preview guard is now exercised through Govern's navVisible:false rows (none
+    // exist in prod) or indirectly — the utility-area gate tests cover that path.
+    // Here we use Improve: all its children are navVisible, no previews.
+    navigationMock.pathname = "/opportunities";
+    render(<PrimaryNav filters={makeFilter()} active="opportunities" />);
 
-    expect(screen.getByRole("link", { name: /^Report Center$/i })).toBeInTheDocument();
-    for (const preview of [/^Weekly Review$/i, /^Executive Summary$/i, /^Export History$/i]) {
-      expect(screen.queryByRole("link", { name: preview })).toBeNull();
-    }
+    // Improve's children render (main area, active, navVisible).
+    expect(screen.getByRole("link", { name: /^Opportunities$/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^AI Workflows$/i })).toBeInTheDocument();
+    // No phantom/preview rows ever rendered (none exist in Improve).
+    expect(screen.queryByRole("link", { name: /^Weekly Review$/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /^Executive Summary$/i })).toBeNull();
   });
 
   it("never renders tab subviews (AI/Work) as sidebar children", () => {
@@ -159,7 +165,9 @@ describe("PrimaryNav — active child highlight (A10: one selected, distinct hov
     { pathname: "/metrics", active: "metrics", child: /^Metrics$/i },
     { pathname: "/ai/impact", active: "ai-workflows", child: /^AI Workflows$/i },
     { pathname: "/operating-review", active: "operating-review", child: /^Operating Review$/i },
-    { pathname: "/admin/settings", active: "settings", child: /^Settings$/i },
+    // Note: /admin/settings is NOT here — Admin is a utility area and does not
+    // expand children (owner directive). Its behaviour is covered by the
+    // "utility-area gate" describe block below.
     {
       pathname: "/testops/coverage",
       active: "coverage",
@@ -295,6 +303,85 @@ describe("PrimaryNav — active-area resolution (A10: one selected at a time)", 
     render(<PrimaryNav filters={makeFilter()} active="people" />);
 
     expect(screen.getByRole("link", { name: /^Diagnose$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(currentPageLinks()).toHaveLength(1);
+  });
+
+  // REVIEW W1: /testops → Govern row active; Overview child rendered but NOT active.
+  it("pathname /testops → Govern area row active, Overview child rendered but not active (W1)", () => {
+    navigationMock.pathname = "/testops";
+    render(<PrimaryNav filters={makeFilter()} active="testops" />);
+
+    // Govern area row is the current page (area landing).
+    expect(screen.getByRole("link", { name: /^Govern$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    // Overview child is rendered (Govern is a main area and is active).
+    expect(screen.getByRole("link", { name: /^Overview$/i })).toBeInTheDocument();
+    // Overview child is NOT marked current (the area row owns the highlight).
+    expect(screen.getByRole("link", { name: /^Overview$/i })).not.toHaveAttribute("aria-current");
+    // A10: exactly one current-page link.
+    expect(currentPageLinks()).toHaveLength(1);
+  });
+
+  // REVIEW W2: /testops/pipelines → Pipelines child active; cluster + Overview NOT active.
+  it("pathname /testops/pipelines → Pipelines child active, not the cluster or Overview (W2)", () => {
+    navigationMock.pathname = "/testops/pipelines";
+    render(<PrimaryNav filters={makeFilter()} active="pipelines" />);
+
+    // Pipelines child is the current page.
+    expect(screen.getByRole("link", { name: /^Pipelines$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    // Tests · Quality · Coverage cluster is rendered but NOT active.
+    expect(
+      screen.getByRole("link", { name: /Tests · Quality · Coverage/i }),
+    ).not.toHaveAttribute("aria-current");
+    // Overview is rendered but NOT active.
+    expect(screen.getByRole("link", { name: /^Overview$/i })).not.toHaveAttribute("aria-current");
+    // A10: exactly one current-page link.
+    expect(currentPageLinks()).toHaveLength(1);
+  });
+});
+
+describe("PrimaryNav — utility-area gate (owner directive)", () => {
+  // Utility-placement areas (Reports, Admin) must render as plain rows with NO
+  // child expansion even when active. Only main-placement areas expand.
+
+  it("Reports area renders NO child rows when active at /reports", () => {
+    navigationMock.pathname = "/reports";
+    render(<PrimaryNav filters={makeFilter()} active="reports" />);
+
+    // Reports row is rendered and marked current (it's the area landing).
+    expect(screen.getByRole("link", { name: /^Reports$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    // NO child container rendered for Reports.
+    expect(screen.queryByTestId("nav-children-reports")).toBeNull();
+    // Report Center (a navVisible child) must NOT appear in the sidebar.
+    expect(screen.queryByRole("link", { name: /^Report Center$/i })).toBeNull();
+    // Preview rows also absent (they were already suppressed, still absent).
+    expect(screen.queryByRole("link", { name: /^Weekly Review$/i })).toBeNull();
+    // A10: exactly one current-page link.
+    expect(currentPageLinks()).toHaveLength(1);
+  });
+
+  it("Admin area renders NO child rows when active at /admin/settings", () => {
+    navigationMock.pathname = "/admin/settings";
+    render(<PrimaryNav filters={makeFilter()} active="settings" />);
+
+    // Admin row is active (but the child Settings would have been current if expanded).
+    // Under the utility gate, no children render at all.
+    expect(screen.queryByTestId("nav-children-admin")).toBeNull();
+    expect(screen.queryByRole("link", { name: /^Settings$/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /^Connections$/i })).toBeNull();
+    // The Admin area row itself is the sole current-page link (no child selection).
+    expect(screen.getByRole("link", { name: /^Admin$/i })).toHaveAttribute(
       "aria-current",
       "page",
     );

--- a/src/components/navigation/PrimaryNav.test.tsx
+++ b/src/components/navigation/PrimaryNav.test.tsx
@@ -43,8 +43,25 @@ function currentPageLinks() {
   return screen.getAllByRole("link").filter((link) => link.getAttribute("aria-current") === "page");
 }
 
-describe("PrimaryNav — collapsed decision-area surface (CHAOS-2073)", () => {
-  it("renders exactly six decision-area links and nothing else navigable", () => {
+describe("PrimaryNav — two-level decision-area surface (CHAOS-2075)", () => {
+  it("always renders the six area rows", () => {
+    render(<PrimaryNav filters={makeFilter()} active="home" />);
+
+    for (const name of [
+      /^Cockpit$/i,
+      /^Diagnose$/i,
+      /^Improve$/i,
+      /^Govern$/i,
+      /^Reports$/i,
+      /^Admin$/i,
+    ]) {
+      expect(screen.getByRole("link", { name })).toBeInTheDocument();
+    }
+  });
+
+  it("on a childless area (Cockpit) renders only the six area rows", () => {
+    // Cockpit has no expandable children, so the sidebar shows exactly the areas.
+    navigationMock.pathname = "/dashboard";
     render(<PrimaryNav filters={makeFilter()} active="home" />);
 
     const linkNames = screen
@@ -54,45 +71,66 @@ describe("PrimaryNav — collapsed decision-area surface (CHAOS-2073)", () => {
     expect(linkNames).toEqual(["Cockpit", "Diagnose", "Improve", "Govern", "Reports", "Admin"]);
   });
 
-  it("renders no collapsible group buttons (no expand/collapse machinery)", () => {
+  it("renders no expand/collapse buttons — rows are links, not toggles", () => {
     render(<PrimaryNav filters={makeFilter()} active="home" />);
-    // The previous IA rendered six group <button> headers; the collapsed surface
-    // has none — areas are direct links, not toggles.
     expect(screen.queryAllByRole("button")).toHaveLength(0);
   });
 
-  it.each([
-    /^Work$/i,
-    /^Metrics$/i,
-    /^People$/i,
-    /^Code$/i,
-    /^Complexity$/i,
-    /^Cognitive Load$/i,
-    /^Bottlenecks$/i,
-    /^Capacity Planning$/i,
-    /^AI Workflows$/i,
-    /^Operating Review$/i,
-    /^Pipelines$/i,
-    /^Tests$/i,
-    /^Quality$/i,
-    /^Coverage$/i,
-    /^Delivery Risk$/i,
-    /^Incident Correlation$/i,
-    /^Security$/i,
-    /^Feature Flags$/i,
-    /^Compounding Risk$/i,
-    /^Report Center$/i,
-  ])("does not list the leaf destination %s flat in the sidebar", (leaf) => {
-    render(<PrimaryNav filters={makeFilter()} active="home" />);
-    expect(screen.queryByRole("link", { name: leaf })).toBeNull();
-  });
-
-  it("collapses Diagnose and Govern so neither renders 8–10 individual items", () => {
+  it("expands ONLY the active area's children; inactive areas stay collapsed", () => {
     navigationMock.pathname = "/work";
     render(<PrimaryNav filters={makeFilter()} active="work" />);
-    // Exactly one Diagnose row and one Govern row — not the old 8/10 flat lists.
-    expect(screen.getAllByRole("link", { name: /^Diagnose$/i })).toHaveLength(1);
-    expect(screen.getAllByRole("link", { name: /^Govern$/i })).toHaveLength(1);
+
+    // Diagnose is active → its children render as indented rows.
+    expect(screen.getByTestId("nav-children-diagnose")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^Metrics$/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^Bottlenecks$/i })).toBeInTheDocument();
+
+    // Govern is NOT active → none of its children appear.
+    expect(screen.queryByTestId("nav-children-govern")).toBeNull();
+    expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /^Security$/i })).toBeNull();
+  });
+
+  it("never renders preview (navVisible:false) children", () => {
+    // Reports active: Report Center shows; the preview rows never do.
+    navigationMock.pathname = "/reports";
+    render(<PrimaryNav filters={makeFilter()} active="reports" />);
+
+    expect(screen.getByRole("link", { name: /^Report Center$/i })).toBeInTheDocument();
+    for (const preview of [/^Weekly Review$/i, /^Executive Summary$/i, /^Export History$/i]) {
+      expect(screen.queryByRole("link", { name: preview })).toBeNull();
+    }
+  });
+
+  it("never renders tab subviews (AI/Work) as sidebar children", () => {
+    // Improve active on an AI tab: AI Workflows shows as ONE child row; its tab
+    // subviews (Impact/Attribution/…) are NOT sidebar rows (Framework A2).
+    navigationMock.pathname = "/ai/impact";
+    render(<PrimaryNav filters={makeFilter()} active="ai-workflows" />);
+
+    expect(screen.getByRole("link", { name: /^AI Workflows$/i })).toBeInTheDocument();
+    for (const tab of [
+      /^Impact$/i,
+      /^Attribution$/i,
+      /^Review Load$/i,
+      /^Test Gaps$/i,
+      /^Automations$/i,
+    ]) {
+      expect(screen.queryByRole("link", { name: tab })).toBeNull();
+    }
+  });
+
+  it("renders the Govern cluster as a single combined row", () => {
+    navigationMock.pathname = "/testops/coverage";
+    render(<PrimaryNav filters={makeFilter()} active="coverage" />);
+
+    // One clustered row — not separate Tests / Quality / Coverage rows.
+    expect(screen.getByRole("link", { name: /Tests · Quality · Coverage/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /^Tests$/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /^Quality$/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /^Coverage$/i })).toBeNull();
+    // Pipelines stays its own row.
+    expect(screen.getByRole("link", { name: /^Pipelines$/i })).toBeInTheDocument();
   });
 
   it("links each area to its landing route", () => {
@@ -116,57 +154,138 @@ describe("PrimaryNav — collapsed decision-area surface (CHAOS-2073)", () => {
   });
 });
 
-describe("PrimaryNav — active-area resolution (A10: one selected at a time)", () => {
+describe("PrimaryNav — active child highlight (A10: one selected, distinct hover)", () => {
   it.each([
-    { pathname: "/dashboard", active: "home", area: /^Cockpit$/i },
+    { pathname: "/metrics", active: "metrics", child: /^Metrics$/i },
+    { pathname: "/ai/impact", active: "ai-workflows", child: /^AI Workflows$/i },
+    { pathname: "/operating-review", active: "operating-review", child: /^Operating Review$/i },
+    { pathname: "/admin/settings", active: "settings", child: /^Settings$/i },
+    {
+      pathname: "/testops/coverage",
+      active: "coverage",
+      child: /Tests · Quality · Coverage/i,
+    },
+    { pathname: "/quality", active: "quality", child: /Tests · Quality · Coverage/i },
+    { pathname: "/testops/tests", active: "tests", child: /Tests · Quality · Coverage/i },
+  ])("marks exactly the child $child current for $pathname", ({ pathname, active, child }) => {
+    navigationMock.pathname = pathname;
+    render(<PrimaryNav filters={makeFilter()} active={active} />);
+
+    expect(screen.getByRole("link", { name: child })).toHaveAttribute("aria-current", "page");
+    // A10: exactly one selected destination across the whole sidebar.
+    expect(currentPageLinks()).toHaveLength(1);
+  });
+
+  it("highlights the area row (not a child) on the area landing route", () => {
+    // /dashboard → Cockpit (no children); the area row itself is current.
+    navigationMock.pathname = "/dashboard";
+    render(<PrimaryNav filters={makeFilter()} active="home" />);
+
+    expect(screen.getByRole("link", { name: /^Cockpit$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(currentPageLinks()).toHaveLength(1);
+  });
+
+  it("does not mark the area row current when one of its children is active", () => {
+    // On /metrics the active destination is the Metrics CHILD, so the Diagnose
+    // AREA row must NOT also carry aria-current (no double-selection, A10).
+    navigationMock.pathname = "/metrics";
+    render(<PrimaryNav filters={makeFilter()} active="metrics" />);
+
+    expect(screen.getByRole("link", { name: /^Diagnose$/i })).not.toHaveAttribute("aria-current");
+    expect(screen.getByRole("link", { name: /^Metrics$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+});
+
+describe("PrimaryNav — active-area resolution (A10: one selected at a time)", () => {
+  // Each row resolves to its owning area, and exactly one destination is
+  // selected sidebar-wide (A10). On an area-LANDING route the area row is the
+  // selection; on a CHILD route a child row inside that area is. `landing`
+  // flags whether the area row itself should carry aria-current.
+  it.each([
+    { pathname: "/dashboard", active: "home", area: /^Cockpit$/i, landing: true },
+    // Operating Review moved Cockpit → Improve (CHAOS-2075); it is a child route.
     {
       pathname: "/operating-review",
       active: "operating-review",
-      area: /^Cockpit$/i,
+      area: /^Improve$/i,
+      landing: false,
     },
-    { pathname: "/work", active: "work", area: /^Diagnose$/i },
-    { pathname: "/metrics", active: "metrics", area: /^Diagnose$/i },
-    { pathname: "/people", active: "people", area: /^Diagnose$/i },
-    { pathname: "/complexity", active: "complexity", area: /^Diagnose$/i },
-    { pathname: "/bottleneck", active: "bottleneck", area: /^Diagnose$/i },
+    { pathname: "/work", active: "work", area: /^Diagnose$/i, landing: true },
+    { pathname: "/metrics", active: "metrics", area: /^Diagnose$/i, landing: false },
+    { pathname: "/people", active: "people", area: /^Diagnose$/i, landing: false },
+    { pathname: "/complexity", active: "complexity", area: /^Diagnose$/i, landing: false },
+    { pathname: "/bottleneck", active: "bottleneck", area: /^Diagnose$/i, landing: false },
     {
       pathname: "/explore/landscape",
       active: "landscape",
       area: /^Diagnose$/i,
+      landing: false,
     },
-    { pathname: "/opportunities", active: "opportunities", area: /^Improve$/i },
+    {
+      pathname: "/opportunities",
+      active: "opportunities",
+      area: /^Improve$/i,
+      landing: true,
+    },
     {
       pathname: "/capacity-planning",
       active: "capacity-planning",
       area: /^Improve$/i,
+      landing: false,
     },
-    { pathname: "/ai/impact", active: "ai-workflows", area: /^Improve$/i },
-    { pathname: "/testops", active: "testops", area: /^Govern$/i },
-    { pathname: "/testops/risk", active: "risk", area: /^Govern$/i },
-    { pathname: "/quality", active: "quality", area: /^Govern$/i },
-    { pathname: "/security", active: "security", area: /^Govern$/i },
+    { pathname: "/ai/impact", active: "ai-workflows", area: /^Improve$/i, landing: false },
+    { pathname: "/testops", active: "testops", area: /^Govern$/i, landing: true },
+    { pathname: "/testops/risk", active: "risk", area: /^Govern$/i, landing: false },
+    { pathname: "/quality", active: "quality", area: /^Govern$/i, landing: false },
+    { pathname: "/security", active: "security", area: /^Govern$/i, landing: false },
     {
       pathname: "/risk/compounding",
       active: "risk-compounding",
       area: /^Govern$/i,
+      landing: false,
     },
-    { pathname: "/reports", active: "reports", area: /^Reports$/i },
-    { pathname: "/admin", active: "admin", area: /^Admin$/i },
-  ])("highlights the owning area for leaf route $pathname", ({ pathname, active, area }) => {
-    navigationMock.pathname = pathname;
-    render(<PrimaryNav filters={makeFilter()} active={active} />);
+    { pathname: "/reports", active: "reports", area: /^Reports$/i, landing: true },
+    { pathname: "/admin", active: "admin", area: /^Admin$/i, landing: true },
+  ])(
+    "resolves route $pathname to its owning area with exactly one selection",
+    ({ pathname, active, area, landing }) => {
+      navigationMock.pathname = pathname;
+      render(<PrimaryNav filters={makeFilter()} active={active} />);
 
-    expect(screen.getByRole("link", { name: area })).toHaveAttribute("aria-current", "page");
-    expect(currentPageLinks()).toHaveLength(1);
-  });
+      // The owning area row is always rendered.
+      const areaRow = screen.getByRole("link", { name: area });
+      expect(areaRow).toBeInTheDocument();
+      // The area row carries aria-current only on its own landing route.
+      if (landing) {
+        expect(areaRow).toHaveAttribute("aria-current", "page");
+      } else {
+        expect(areaRow).not.toHaveAttribute("aria-current");
+      }
+      // A10: exactly one selected destination across the whole sidebar.
+      expect(currentPageLinks()).toHaveLength(1);
+    },
+  );
 
   it("uses the longest pathname match and ignores a stale active prop", () => {
     // /testops/risk belongs to Govern; the stale active="people" (Diagnose) must lose.
     navigationMock.pathname = "/testops/risk";
     render(<PrimaryNav filters={makeFilter()} active="people" />);
 
-    expect(screen.getByRole("link", { name: /^Govern$/i })).toHaveAttribute("aria-current", "page");
+    // Govern is the active area (its Delivery Risk child is the selection).
+    expect(screen.getByTestId("nav-children-govern")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^Delivery Risk$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    // Diagnose lost: not selected and not expanded.
     expect(screen.getByRole("link", { name: /^Diagnose$/i })).not.toHaveAttribute("aria-current");
+    expect(screen.queryByTestId("nav-children-diagnose")).toBeNull();
     expect(currentPageLinks()).toHaveLength(1);
   });
 

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -7,20 +7,33 @@ import { OrgSwitcher } from "@/components/navigation/OrgSwitcher";
 
 import { withFilterParam } from "@/lib/filters/url";
 import type { MetricFilter } from "@/lib/filters/types";
-import { navAreas, selectedAreaIdForPathname, type NavArea } from "@/lib/navigation/areas";
+import {
+  navAreas,
+  selectedAreaIdForPathname,
+  selectedChildForPathname,
+  type NavArea,
+  type NavChildRoute,
+} from "@/lib/navigation/areas";
 
 // ── Component ────────────────────────────────────────────────────────────────
 //
-// CHAOS-2073: the sidebar surfaces the six decision areas only (Framework A1).
-// Leaf/metric destinations are NOT listed here — they live on each area's
-// landing page via `AreaHub` (Framework A2). The nav config is the single
-// source of truth (`@/lib/navigation/areas`).
+// Two-level sidebar (Framework A1, CHAOS-2075): the six decision areas are
+// always shown; the ACTIVE area expands to its child *destinations* as an
+// indented list, while inactive areas stay collapsed. Tab subviews live on the
+// destination page (Framework A2), never here. The nav config is the single
+// source of truth (`@/lib/navigation/areas`); `children` is the sidebar route
+// tree, distinct from `hubItems` (the landing triage cards).
 
 type PrimaryNavProps = {
   filters: MetricFilter;
   active?: string;
   role?: string;
 };
+
+/** Bare path (no query/hash) for comparing a child route to its area landing. */
+function basePath(href: string): string {
+  return href.split("?")[0].split("#")[0];
+}
 
 export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
   const pathname = usePathname();
@@ -29,21 +42,66 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
   const mainAreas = navAreas.filter((area) => area.placement === "main");
   const utilityAreas = navAreas.filter((area) => area.placement === "utility");
 
-  const renderArea = (area: NavArea) => {
-    const isActive = selectedAreaId === area.id;
+  const renderChild = (child: NavChildRoute, activeChildId: string | undefined) => {
+    const isActive = child.id === activeChildId;
     return (
       <Link
-        key={area.id}
-        href={withFilterParam(area.href, filters, role)}
+        key={child.id}
+        href={withFilterParam(child.path, filters, role)}
         aria-current={isActive ? "page" : undefined}
-        className={`group relative flex items-center rounded-2xl border px-3 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35 ${
+        className={`group relative flex items-center rounded-xl px-3 py-1.5 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35 ${
           isActive
-            ? "border-(--accent) bg-(--accent)/15 text-foreground before:absolute before:left-0 before:top-1/4 before:h-1/2 before:w-[3px] before:rounded-full before:bg-(--accent)"
-            : "border-transparent bg-(--card-70) text-(--ink-muted) hover:border-(--card-stroke) hover:bg-(--card-80) hover:text-foreground focus-visible:border-(--card-stroke) focus-visible:bg-(--card-80) focus-visible:text-foreground"
+            ? "bg-(--accent)/12 font-medium text-foreground before:absolute before:left-0 before:top-1/4 before:h-1/2 before:w-0.5 before:rounded-full before:bg-(--accent)"
+            : `border border-transparent ${
+                child.demoted ? "text-(--ink-muted)/70" : "text-(--ink-muted)"
+              } hover:border-(--card-stroke) hover:bg-(--card-80) hover:text-foreground focus-visible:border-(--card-stroke) focus-visible:bg-(--card-80) focus-visible:text-foreground`
         }`}
       >
-        <span className="font-medium">{area.label}</span>
+        <span>{child.label}</span>
       </Link>
+    );
+  };
+
+  const renderArea = (area: NavArea) => {
+    const isActive = selectedAreaId === area.id;
+    // Only the active area expands; only navVisible children are rendered (no
+    // preview rows, no tab subviews). Exactly one row is highlighted.
+    const visibleChildren = isActive ? area.children.filter((child) => child.navVisible) : [];
+    const activeChild = isActive ? selectedChildForPathname(area, pathname) : undefined;
+    // When the active child IS the area's landing route (the coincident row,
+    // e.g. Diagnose landing `/work` + the "Work" child), the AREA row owns the
+    // highlight — matching the page title (A6: that page is "Diagnose", not
+    // "Work"). Otherwise the matched child row is the single selection.
+    const areaRowIsSelected =
+      isActive && (!activeChild || basePath(activeChild.path) === basePath(area.href));
+    const activeChildId = areaRowIsSelected ? undefined : activeChild?.id;
+
+    return (
+      <div key={area.id}>
+        <Link
+          href={withFilterParam(area.href, filters, role)}
+          aria-current={areaRowIsSelected ? "page" : undefined}
+          className={`group relative flex items-center rounded-2xl border px-3 py-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35 ${
+            isActive
+              ? "border-(--accent) bg-(--accent)/15 text-foreground before:absolute before:left-0 before:top-1/4 before:h-1/2 before:w-[3px] before:rounded-full before:bg-(--accent)"
+              : "border-transparent bg-(--card-70) text-(--ink-muted) hover:border-(--card-stroke) hover:bg-(--card-80) hover:text-foreground focus-visible:border-(--card-stroke) focus-visible:bg-(--card-80) focus-visible:text-foreground"
+          }`}
+        >
+          <span className="font-medium">{area.label}</span>
+        </Link>
+
+        {visibleChildren.length > 0 ? (
+          // C3 4px scale: indent via a hairline rail (--card-stroke), no bright
+          // borders. The active area owns one expanded list; A10 keeps exactly
+          // one child selected with hover/focus visually distinct.
+          <div
+            className="mt-1 ml-3 flex flex-col gap-0.5 border-l border-(--card-stroke) pl-2"
+            data-testid={`nav-children-${area.id}`}
+          >
+            {visibleChildren.map((child) => renderChild(child, activeChildId))}
+          </div>
+        ) : null}
+      </div>
     );
   };
 
@@ -65,7 +123,8 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
 
           <OrgSwitcher />
 
-          {/* Main spine — decision areas only (A1). Leaves live on area landings (A2). */}
+          {/* Main spine — decision areas (A1). The active area expands to its
+              child destinations below its row; tab subviews stay on the page (A2). */}
           <nav className="mt-4 space-y-2 text-sm" aria-label="Primary areas">
             {mainAreas.map((area) => renderArea(area))}
           </nav>
@@ -76,7 +135,7 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
           </div>
 
           <div className="mt-4 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-3 py-2 text-xs text-(--ink-muted)">
-            Each area opens a landing page; drill into metrics from there.
+            The active area expands to its destinations; open one to drill in.
           </div>
         </div>
       </div>

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -11,6 +11,7 @@ import {
   navAreas,
   selectedAreaIdForPathname,
   selectedChildForPathname,
+  basePath,
   type NavArea,
   type NavChildRoute,
 } from "@/lib/navigation/areas";
@@ -18,8 +19,10 @@ import {
 // ── Component ────────────────────────────────────────────────────────────────
 //
 // Two-level sidebar (Framework A1, CHAOS-2075): the six decision areas are
-// always shown; the ACTIVE area expands to its child *destinations* as an
-// indented list, while inactive areas stay collapsed. Tab subviews live on the
+// always shown; the ACTIVE main-placement area expands to its child
+// *destinations* as an indented list, while inactive areas stay collapsed.
+// Utility-placement areas (Reports, Admin) render as plain rows with NO child
+// expansion even when active (owner directive). Tab subviews live on the
 // destination page (Framework A2), never here. The nav config is the single
 // source of truth (`@/lib/navigation/areas`); `children` is the sidebar route
 // tree, distinct from `hubItems` (the landing triage cards).
@@ -29,11 +32,6 @@ type PrimaryNavProps = {
   active?: string;
   role?: string;
 };
-
-/** Bare path (no query/hash) for comparing a child route to its area landing. */
-function basePath(href: string): string {
-  return href.split("?")[0].split("#")[0];
-}
 
 export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
   const pathname = usePathname();
@@ -64,16 +62,25 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
 
   const renderArea = (area: NavArea) => {
     const isActive = selectedAreaId === area.id;
-    // Only the active area expands; only navVisible children are rendered (no
-    // preview rows, no tab subviews). Exactly one row is highlighted.
-    const visibleChildren = isActive ? area.children.filter((child) => child.navVisible) : [];
+    // Only main-placement areas expand; utility areas (Reports, Admin) render as
+    // plain rows with no child expansion even when active (owner directive).
+    // Within main areas, only the active area expands; inactive stay collapsed.
+    // Only navVisible children are rendered (no preview rows, no tab subviews).
+    // Exactly one row is highlighted.
+    const visibleChildren =
+      isActive && area.placement === "main"
+        ? area.children.filter((child) => child.navVisible)
+        : [];
     const activeChild = isActive ? selectedChildForPathname(area, pathname) : undefined;
-    // When the active child IS the area's landing route (the coincident row,
-    // e.g. Diagnose landing `/work` + the "Work" child), the AREA row owns the
-    // highlight — matching the page title (A6: that page is "Diagnose", not
-    // "Work"). Otherwise the matched child row is the single selection.
+    // The area row owns the highlight when:
+    //   a) it IS the current page (no child, or child path === area landing), OR
+    //   b) it's a utility area — children never expand, so the area row is the
+    //      sole visible selection for any path within that utility area.
     const areaRowIsSelected =
-      isActive && (!activeChild || basePath(activeChild.path) === basePath(area.href));
+      isActive &&
+      (area.placement === "utility" ||
+        !activeChild ||
+        basePath(activeChild.path) === basePath(area.href));
     const activeChildId = areaRowIsSelected ? undefined : activeChild?.id;
 
     return (

--- a/src/components/testops/QualityCoverageTabs.tsx
+++ b/src/components/testops/QualityCoverageTabs.tsx
@@ -3,6 +3,8 @@
 import { usePathname } from "next/navigation";
 
 import { ModeTabs, type ModeTabItem } from "@/components/shared/ModeTabs";
+import type { MetricFilter } from "@/lib/filters/types";
+import { withFilterParam } from "@/lib/filters/url";
 
 /**
  * Route-based tab strip for the Tests · Quality · Coverage cluster (CHAOS-2075
@@ -47,21 +49,28 @@ export function activeTabFromPath(pathname: string): QualityCoverageTabId {
   return "coverage";
 }
 
+type QualityCoverageTabsProps = {
+  filters: MetricFilter;
+  role?: string;
+};
+
 /**
  * Renders the Tests · Quality · Coverage cluster tab strip.
  *
  * Drop this near the top of the page `<main>` body on each of the three
  * cluster pages, after the page header and before page-specific content.
- * No props needed — the active tab is resolved from the URL.
+ * Pass `filters` and `role` from the page so that active filter/role query
+ * params are preserved when switching between cluster tabs (matches the
+ * `withFilterParam` convention used by all other ModeTabs in the app).
  */
-export function QualityCoverageTabs() {
+export function QualityCoverageTabs({ filters, role }: QualityCoverageTabsProps) {
   const pathname = usePathname();
   const activeTab = activeTabFromPath(pathname);
 
   const items: ModeTabItem<QualityCoverageTabId>[] = QUALITY_COVERAGE_TABS.map((tab) => ({
     id: tab.id,
     label: tab.label,
-    href: tab.href,
+    href: withFilterParam(tab.href, filters, role),
   }));
 
   return (

--- a/src/components/testops/QualityCoverageTabs.tsx
+++ b/src/components/testops/QualityCoverageTabs.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import { ModeTabs, type ModeTabItem } from "@/components/shared/ModeTabs";
+
+/**
+ * Route-based tab strip for the Tests · Quality · Coverage cluster (CHAOS-2075
+ * Phase 2). These three surfaces live at separate route roots, so a shared
+ * Next.js layout cannot wrap them. This client component resolves the active
+ * tab from `usePathname()` and renders `ModeTabs` — the single underline-idiom
+ * tab primitive (Framework A2) — so the three pages feel like sibling views of
+ * one area.
+ *
+ * Pipelines is deliberately excluded: it is a standalone sidebar row, not part
+ * of this cluster.
+ */
+
+export type QualityCoverageTabId = "tests" | "quality" | "coverage";
+
+type QualityCoverageTab = {
+  id: QualityCoverageTabId;
+  label: string;
+  href: string;
+};
+
+const QUALITY_COVERAGE_TABS: QualityCoverageTab[] = [
+  { id: "tests", label: "Tests", href: "/testops/tests" },
+  { id: "quality", label: "Quality", href: "/quality" },
+  { id: "coverage", label: "Coverage", href: "/testops/coverage" },
+];
+
+/**
+ * Resolve the active tab from the current pathname.
+ *
+ * Longest-prefix match: `/testops/tests` owns anything under `/testops/tests/`;
+ * `/testops/coverage` owns anything under `/testops/coverage/`; `/quality`
+ * owns anything under `/quality/`. Falls back to "coverage" (the cluster's
+ * canonical landing path) when no tab matches.
+ */
+export function activeTabFromPath(pathname: string): QualityCoverageTabId {
+  for (const tab of QUALITY_COVERAGE_TABS) {
+    if (pathname === tab.href || pathname.startsWith(tab.href + "/")) {
+      return tab.id;
+    }
+  }
+  return "coverage";
+}
+
+/**
+ * Renders the Tests · Quality · Coverage cluster tab strip.
+ *
+ * Drop this near the top of the page `<main>` body on each of the three
+ * cluster pages, after the page header and before page-specific content.
+ * No props needed — the active tab is resolved from the URL.
+ */
+export function QualityCoverageTabs() {
+  const pathname = usePathname();
+  const activeTab = activeTabFromPath(pathname);
+
+  const items: ModeTabItem<QualityCoverageTabId>[] = QUALITY_COVERAGE_TABS.map((tab) => ({
+    id: tab.id,
+    label: tab.label,
+    href: tab.href,
+  }));
+
+  return (
+    <ModeTabs items={items} activeId={activeTab} ariaLabel="Tests, Quality, and Coverage" />
+  );
+}

--- a/src/components/testops/__tests__/QualityCoverageTabs.test.tsx
+++ b/src/components/testops/__tests__/QualityCoverageTabs.test.tsx
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@/test/utils";
 import { QualityCoverageTabs, activeTabFromPath } from "../QualityCoverageTabs";
+import { withFilterParam } from "@/lib/filters/url";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+import type { MetricFilter } from "@/lib/filters/types";
 
 const pathnameMock = vi.fn(() => "/testops/coverage");
 
@@ -23,6 +26,8 @@ vi.mock("next/link", () => ({
 		</a>
 	),
 }));
+
+const defaultFilters: MetricFilter = defaultMetricFilter;
 
 describe("activeTabFromPath", () => {
 	it("resolves /testops/tests to 'tests'", () => {
@@ -57,32 +62,57 @@ describe("activeTabFromPath", () => {
 describe("QualityCoverageTabs", () => {
 	it("renders all three tab labels", () => {
 		pathnameMock.mockReturnValue("/testops/coverage");
-		render(<QualityCoverageTabs />);
+		render(<QualityCoverageTabs filters={defaultFilters} />);
 		expect(screen.getByText("Tests")).toBeInTheDocument();
 		expect(screen.getByText("Quality")).toBeInTheDocument();
 		expect(screen.getByText("Coverage")).toBeInTheDocument();
 	});
 
-	it("all tabs are real links with the correct hrefs", () => {
+	it("all tabs are real links with filter params in their hrefs", () => {
 		pathnameMock.mockReturnValue("/testops/coverage");
-		render(<QualityCoverageTabs />);
+		render(<QualityCoverageTabs filters={defaultFilters} />);
 		expect(screen.getByText("Tests").closest("a")).toHaveAttribute(
 			"href",
-			"/testops/tests",
+			withFilterParam("/testops/tests", defaultFilters),
 		);
 		expect(screen.getByText("Quality").closest("a")).toHaveAttribute(
 			"href",
-			"/quality",
+			withFilterParam("/quality", defaultFilters),
 		);
 		expect(screen.getByText("Coverage").closest("a")).toHaveAttribute(
 			"href",
-			"/testops/coverage",
+			withFilterParam("/testops/coverage", defaultFilters),
 		);
+	});
+
+	it("preserves active f and role params on all tab hrefs", () => {
+		pathnameMock.mockReturnValue("/quality");
+		const filters: MetricFilter = {
+			...defaultMetricFilter,
+			scope: { level: "team", ids: ["team-abc"] },
+		};
+		render(<QualityCoverageTabs filters={filters} role="eng-manager" />);
+
+		const testsHref = screen.getByText("Tests").closest("a")?.getAttribute("href") ?? "";
+		const qualityHref = screen.getByText("Quality").closest("a")?.getAttribute("href") ?? "";
+		const coverageHref = screen.getByText("Coverage").closest("a")?.getAttribute("href") ?? "";
+
+		// Every tab href must carry both f= and role=
+		for (const href of [testsHref, qualityHref, coverageHref]) {
+			const url = new URL(href, "http://localhost");
+			expect(url.searchParams.get("f")).toBeTruthy();
+			expect(url.searchParams.get("role")).toBe("eng-manager");
+		}
+
+		// Hrefs must match exactly what withFilterParam produces
+		expect(testsHref).toBe(withFilterParam("/testops/tests", filters, "eng-manager"));
+		expect(qualityHref).toBe(withFilterParam("/quality", filters, "eng-manager"));
+		expect(coverageHref).toBe(withFilterParam("/testops/coverage", filters, "eng-manager"));
 	});
 
 	it("marks Tests as active on /testops/tests", () => {
 		pathnameMock.mockReturnValue("/testops/tests");
-		render(<QualityCoverageTabs />);
+		render(<QualityCoverageTabs filters={defaultFilters} />);
 		expect(screen.getByText("Tests").closest("a")).toHaveAttribute(
 			"aria-current",
 			"page",
@@ -97,7 +127,7 @@ describe("QualityCoverageTabs", () => {
 
 	it("marks Quality as active on /quality", () => {
 		pathnameMock.mockReturnValue("/quality");
-		render(<QualityCoverageTabs />);
+		render(<QualityCoverageTabs filters={defaultFilters} />);
 		expect(screen.getByText("Quality").closest("a")).toHaveAttribute(
 			"aria-current",
 			"page",
@@ -112,7 +142,7 @@ describe("QualityCoverageTabs", () => {
 
 	it("marks Coverage as active on /testops/coverage", () => {
 		pathnameMock.mockReturnValue("/testops/coverage");
-		render(<QualityCoverageTabs />);
+		render(<QualityCoverageTabs filters={defaultFilters} />);
 		expect(screen.getByText("Coverage").closest("a")).toHaveAttribute(
 			"aria-current",
 			"page",
@@ -127,7 +157,7 @@ describe("QualityCoverageTabs", () => {
 
 	it("exposes an accessible nav label", () => {
 		pathnameMock.mockReturnValue("/testops/coverage");
-		render(<QualityCoverageTabs />);
+		render(<QualityCoverageTabs filters={defaultFilters} />);
 		expect(
 			screen.getByRole("navigation", { name: "Tests, Quality, and Coverage" }),
 		).toBeInTheDocument();

--- a/src/components/testops/__tests__/QualityCoverageTabs.test.tsx
+++ b/src/components/testops/__tests__/QualityCoverageTabs.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/utils";
+import { QualityCoverageTabs, activeTabFromPath } from "../QualityCoverageTabs";
+
+const pathnameMock = vi.fn(() => "/testops/coverage");
+
+vi.mock("next/navigation", () => ({
+	usePathname: () => pathnameMock(),
+}));
+
+vi.mock("next/link", () => ({
+	default: ({
+		href,
+		children,
+		...props
+	}: {
+		href: string;
+		children: React.ReactNode;
+		[key: string]: unknown;
+	}) => (
+		<a href={href} {...props}>
+			{children}
+		</a>
+	),
+}));
+
+describe("activeTabFromPath", () => {
+	it("resolves /testops/tests to 'tests'", () => {
+		expect(activeTabFromPath("/testops/tests")).toBe("tests");
+	});
+
+	it("resolves /quality to 'quality'", () => {
+		expect(activeTabFromPath("/quality")).toBe("quality");
+	});
+
+	it("resolves /testops/coverage to 'coverage'", () => {
+		expect(activeTabFromPath("/testops/coverage")).toBe("coverage");
+	});
+
+	it("resolves a subpath of /testops/tests to 'tests'", () => {
+		expect(activeTabFromPath("/testops/tests/detail")).toBe("tests");
+	});
+
+	it("resolves a subpath of /quality to 'quality'", () => {
+		expect(activeTabFromPath("/quality/breakdown")).toBe("quality");
+	});
+
+	it("resolves a subpath of /testops/coverage to 'coverage'", () => {
+		expect(activeTabFromPath("/testops/coverage/summary")).toBe("coverage");
+	});
+
+	it("falls back to 'coverage' for an unrecognised path", () => {
+		expect(activeTabFromPath("/some/unknown/path")).toBe("coverage");
+	});
+});
+
+describe("QualityCoverageTabs", () => {
+	it("renders all three tab labels", () => {
+		pathnameMock.mockReturnValue("/testops/coverage");
+		render(<QualityCoverageTabs />);
+		expect(screen.getByText("Tests")).toBeInTheDocument();
+		expect(screen.getByText("Quality")).toBeInTheDocument();
+		expect(screen.getByText("Coverage")).toBeInTheDocument();
+	});
+
+	it("all tabs are real links with the correct hrefs", () => {
+		pathnameMock.mockReturnValue("/testops/coverage");
+		render(<QualityCoverageTabs />);
+		expect(screen.getByText("Tests").closest("a")).toHaveAttribute(
+			"href",
+			"/testops/tests",
+		);
+		expect(screen.getByText("Quality").closest("a")).toHaveAttribute(
+			"href",
+			"/quality",
+		);
+		expect(screen.getByText("Coverage").closest("a")).toHaveAttribute(
+			"href",
+			"/testops/coverage",
+		);
+	});
+
+	it("marks Tests as active on /testops/tests", () => {
+		pathnameMock.mockReturnValue("/testops/tests");
+		render(<QualityCoverageTabs />);
+		expect(screen.getByText("Tests").closest("a")).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(screen.getByText("Quality").closest("a")).not.toHaveAttribute(
+			"aria-current",
+		);
+		expect(screen.getByText("Coverage").closest("a")).not.toHaveAttribute(
+			"aria-current",
+		);
+	});
+
+	it("marks Quality as active on /quality", () => {
+		pathnameMock.mockReturnValue("/quality");
+		render(<QualityCoverageTabs />);
+		expect(screen.getByText("Quality").closest("a")).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(screen.getByText("Tests").closest("a")).not.toHaveAttribute(
+			"aria-current",
+		);
+		expect(screen.getByText("Coverage").closest("a")).not.toHaveAttribute(
+			"aria-current",
+		);
+	});
+
+	it("marks Coverage as active on /testops/coverage", () => {
+		pathnameMock.mockReturnValue("/testops/coverage");
+		render(<QualityCoverageTabs />);
+		expect(screen.getByText("Coverage").closest("a")).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(screen.getByText("Tests").closest("a")).not.toHaveAttribute(
+			"aria-current",
+		);
+		expect(screen.getByText("Quality").closest("a")).not.toHaveAttribute(
+			"aria-current",
+		);
+	});
+
+	it("exposes an accessible nav label", () => {
+		pathnameMock.mockReturnValue("/testops/coverage");
+		render(<QualityCoverageTabs />);
+		expect(
+			screen.getByRole("navigation", { name: "Tests, Quality, and Coverage" }),
+		).toBeInTheDocument();
+	});
+});

--- a/src/lib/navigation/__tests__/areas.test.ts
+++ b/src/lib/navigation/__tests__/areas.test.ts
@@ -76,12 +76,22 @@ describe("navAreas — leaf reachability (no orphaned routes)", () => {
   const hubItemPaths = new Set(
     navAreas.flatMap((a) => a.hubItems.map((item) => basePath(item.href))),
   );
+  // REVIEW W3: Operating Review moved Cockpit → Improve as a sidebar child (not
+  // a hubItem). Leaf reachability now also checks navVisible children paths so
+  // sidebar-only destinations (like Operating Review) satisfy the guarantee.
+  const childPaths = new Set(
+    navAreas.flatMap((a) =>
+      a.children.filter((c) => c.navVisible).map((c) => basePath(c.path)),
+    ),
+  );
 
   it.each(LEGACY_LEAVES)(
-    "keeps the legacy leaf '$id' reachable via an area landing or hub",
+    "keeps the legacy leaf '$id' reachable via an area landing, hub, or sidebar child",
     ({ href }) => {
       const path = basePath(href);
-      expect(areaLandingPaths.has(path) || hubItemPaths.has(path)).toBe(true);
+      expect(
+        areaLandingPaths.has(path) || hubItemPaths.has(path) || childPaths.has(path),
+      ).toBe(true);
     },
   );
 

--- a/src/lib/navigation/__tests__/areas.test.ts
+++ b/src/lib/navigation/__tests__/areas.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { navAreas, getAreaById, selectedAreaIdForPathname, type NavAreaId } from "../areas";
+import {
+  navAreas,
+  getAreaById,
+  selectedAreaIdForPathname,
+  selectedChildForPathname,
+  navTrailForPathname,
+  navTitleForPathname,
+  type NavAreaId,
+} from "../areas";
 
 /**
  * Snapshot of the pre-collapse PrimaryNav leaf destinations (CHAOS-2043 state).
@@ -92,7 +100,8 @@ describe("navAreas — leaf reachability (no orphaned routes)", () => {
 describe("selectedAreaIdForPathname", () => {
   const cases: Array<{ pathname: string; expected: NavAreaId }> = [
     { pathname: "/dashboard", expected: "cockpit" },
-    { pathname: "/operating-review", expected: "cockpit" },
+    // Operating Review moved Cockpit → Improve (CHAOS-2075).
+    { pathname: "/operating-review", expected: "improve" },
     { pathname: "/work", expected: "diagnose" },
     { pathname: "/metrics", expected: "diagnose" },
     { pathname: "/people/abc", expected: "diagnose" },
@@ -139,5 +148,145 @@ describe("selectedAreaIdForPathname", () => {
 describe("getAreaById", () => {
   it("returns the matching area", () => {
     expect(getAreaById("govern")?.label).toBe("Govern");
+  });
+});
+
+// ── Two-level sidebar route tree (CHAOS-2075) ─────────────────────────────────
+
+const areaById = (id: NavAreaId) => {
+  const area = getAreaById(id);
+  if (!area) throw new Error(`missing area ${id}`);
+  return area;
+};
+
+describe("navArea.children — sidebar route tree", () => {
+  it("Cockpit has no expandable children (single destination)", () => {
+    expect(areaById("cockpit").children).toHaveLength(0);
+  });
+
+  it("every navVisible child path resolves to a real, app-owned route", () => {
+    // navVisible children must point at routes the app actually serves — phantom
+    // routes are `preview` and excluded from this guarantee.
+    for (const area of navAreas) {
+      for (const child of area.children.filter((c) => c.navVisible)) {
+        expect(selectedAreaIdForPathname(navAreas, basePath(child.path))).toBe(area.id);
+      }
+    }
+  });
+
+  it("has unique child ids across all areas", () => {
+    const ids = navAreas.flatMap((a) => a.children.map((c) => c.id));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("keeps the Tests · Quality · Coverage cluster as one row owning three paths", () => {
+    const cluster = areaById("govern").children.find((c) => c.isCluster);
+    expect(cluster?.label).toBe("Tests · Quality · Coverage");
+    expect(cluster?.ownedPaths).toEqual(["/testops/tests", "/quality", "/testops/coverage"]);
+    // Pipelines is a sibling row, never folded into the cluster.
+    expect(areaById("govern").children.some((c) => c.id === "pipelines" && !c.isCluster)).toBe(
+      true,
+    );
+  });
+});
+
+describe("selectedChildForPathname — active child (A10: exactly one)", () => {
+  // The issue's active-state matrix: the destination → which child lights up.
+  const cases: Array<{ areaId: NavAreaId; pathname: string; childId: string | undefined }> = [
+    { areaId: "cockpit", pathname: "/dashboard", childId: undefined },
+    { areaId: "diagnose", pathname: "/work", childId: "work" },
+    { areaId: "diagnose", pathname: "/metrics", childId: "metrics" },
+    { areaId: "improve", pathname: "/ai", childId: "ai-workflows" },
+    { areaId: "improve", pathname: "/ai/impact", childId: "ai-workflows" },
+    { areaId: "improve", pathname: "/operating-review", childId: "operating-review" },
+    { areaId: "govern", pathname: "/testops", childId: "testops" },
+    { areaId: "govern", pathname: "/testops/pipelines", childId: "pipelines" },
+    { areaId: "govern", pathname: "/testops/coverage", childId: "tests-quality-coverage" },
+    { areaId: "govern", pathname: "/quality", childId: "tests-quality-coverage" },
+    { areaId: "govern", pathname: "/testops/tests", childId: "tests-quality-coverage" },
+    { areaId: "govern", pathname: "/testops/risk", childId: "risk" },
+    { areaId: "reports", pathname: "/reports", childId: "report-center" },
+    { areaId: "admin", pathname: "/admin/settings", childId: "settings" },
+    { areaId: "admin", pathname: "/admin/integrations", childId: "connections" },
+    { areaId: "admin", pathname: "/data-health", childId: "data-confidence" },
+  ];
+
+  it.each(cases)("$pathname → child $childId", ({ areaId, pathname, childId }) => {
+    expect(selectedChildForPathname(areaById(areaId), pathname)?.id).toBe(childId);
+  });
+
+  it("lights the cluster child on ALL of its owned paths and nothing else", () => {
+    const govern = areaById("govern");
+    for (const path of ["/testops/coverage", "/quality", "/testops/tests"]) {
+      const child = selectedChildForPathname(govern, path);
+      expect(child?.id).toBe("tests-quality-coverage");
+      expect(child?.isCluster).toBe(true);
+    }
+  });
+
+  it("prefers the more specific sibling over the area Overview", () => {
+    // /testops/pipelines must beat /testops (Overview), not fall through to it.
+    expect(selectedChildForPathname(areaById("govern"), "/testops/pipelines")?.id).toBe(
+      "pipelines",
+    );
+  });
+
+  it("never selects a preview (navVisible:false) child", () => {
+    // A preview child is excluded from resolution entirely: hitting its phantom
+    // path resolves to a navVisible ancestor (Report Center), never the preview
+    // row itself — so a preview destination can never light up in the sidebar.
+    const reports = areaById("reports");
+    const previewIds = new Set(reports.children.filter((c) => !c.navVisible).map((c) => c.id));
+    for (const path of ["/reports/weekly", "/reports/executive", "/reports/exports"]) {
+      const selectedId = selectedChildForPathname(reports, path)?.id;
+      expect(previewIds.has(selectedId ?? "")).toBe(false);
+    }
+  });
+
+  it("returns undefined for an owned area route with no matching child", () => {
+    // /admin/users is Admin-owned but is not one of the navVisible children.
+    expect(selectedChildForPathname(areaById("admin"), "/admin/users")).toBeUndefined();
+  });
+});
+
+describe("navTitleForPathname / navTrailForPathname (A6: labels agree)", () => {
+  it("titles a child page with the child's sidebar label", () => {
+    expect(navTitleForPathname("/metrics")).toBe("Metrics");
+    expect(navTitleForPathname("/admin/settings")).toBe("Settings");
+    expect(navTitleForPathname("/operating-review")).toBe("Operating Review");
+    // Cluster page is titled by the cluster row label across every owned path.
+    expect(navTitleForPathname("/quality")).toBe("Tests · Quality · Coverage");
+    expect(navTitleForPathname("/testops/tests")).toBe("Tests · Quality · Coverage");
+  });
+
+  it("titles an area-landing route (== a child's route) with the AREA name", () => {
+    // /work is the Diagnose landing AND a child route → the area name wins (A6:
+    // the page is "Diagnose", not the borrowed "Work" leaf).
+    expect(navTitleForPathname("/work")).toBe("Diagnose");
+    expect(navTitleForPathname("/testops")).toBe("Govern");
+    // /reports is both the Reports landing and the Report Center child route →
+    // the area name ("Reports") wins, not the child label.
+    expect(navTitleForPathname("/reports")).toBe("Reports");
+  });
+
+  it("builds an Area → Child trail whose last crumb label === the child label", () => {
+    const trail = navTrailForPathname("/admin/settings");
+    expect(trail.map((c) => c.label)).toEqual(["Admin", "Settings"]);
+    // Area crumb links to its landing; the child crumb is the current page (no href).
+    expect(trail[0]?.href).toBe(areaById("admin").href);
+    expect(trail[trail.length - 1]?.href).toBeUndefined();
+    // Crumb label is verbatim the sidebar child label (A6).
+    const settingsChild = areaById("admin").children.find((c) => c.id === "settings");
+    expect(trail[trail.length - 1]?.label).toBe(settingsChild?.label);
+  });
+
+  it("collapses an area-landing route to a single, link-less area crumb", () => {
+    const trail = navTrailForPathname("/work");
+    expect(trail).toEqual([{ label: "Diagnose" }]);
+  });
+
+  it("returns an empty trail/title for routes no area owns", () => {
+    expect(navTrailForPathname("/prs/123")).toEqual([]);
+    expect(navTitleForPathname("/prs/123")).toBe("");
   });
 });

--- a/src/lib/navigation/__tests__/phase2-breadcrumb-areahub.test.ts
+++ b/src/lib/navigation/__tests__/phase2-breadcrumb-areahub.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Phase 2 (CHAOS-2075) — breadcrumb adoption + AreaHub title reconciliation.
+ *
+ * Covers:
+ *   A) navTrailForPathname("/operating-review") resolves to Improve → Operating Review
+ *      (Operating Review moved Cockpit → Improve in Phase 1; the breadcrumb on the
+ *      operating-review page now derives from this trail instead of hardcoding
+ *      "Home → Operating Review").
+ *   B) AI tab page trails (review-load, automations, risk) all start with
+ *      Improve → AI Workflows (not "Home").
+ */
+import { describe, it, expect } from "vitest";
+import {
+  navTrailForPathname,
+  navTitleForPathname,
+  getAreaById,
+} from "../areas";
+
+describe("navTrailForPathname — operating-review (Phase 2: Improve child)", () => {
+  it("returns a two-crumb trail: Improve (linked) → Operating Review (current)", () => {
+    const trail = navTrailForPathname("/operating-review");
+    expect(trail).toHaveLength(2);
+    expect(trail[0]?.label).toBe("Improve");
+    expect(trail[0]?.href).toBe(getAreaById("improve")?.href); // "/opportunities"
+    expect(trail[1]?.label).toBe("Operating Review");
+    expect(trail[1]?.href).toBeUndefined(); // current page — no link
+  });
+
+  it("trail label matches the sidebar child label verbatim (A6)", () => {
+    const trail = navTrailForPathname("/operating-review");
+    const child = getAreaById("improve")?.children.find((c) => c.id === "operating-review");
+    expect(trail[trail.length - 1]?.label).toBe(child?.label);
+  });
+
+  it("area crumb label matches the Improve area label verbatim (A6)", () => {
+    const trail = navTrailForPathname("/operating-review");
+    expect(trail[0]?.label).toBe(getAreaById("improve")?.label);
+  });
+
+  it("title for /operating-review is 'Operating Review' (child label, not area label)", () => {
+    expect(navTitleForPathname("/operating-review")).toBe("Operating Review");
+  });
+});
+
+describe("navTrailForPathname — AI tab pages (Phase 2: start with Improve → AI Workflows)", () => {
+  const tabPaths = ["/ai/review-load", "/ai/automations", "/ai/risk"];
+
+  it.each(tabPaths)("%s trail starts with Improve area crumb", (pathname) => {
+    const trail = navTrailForPathname(pathname);
+    expect(trail.length).toBeGreaterThanOrEqual(1);
+    expect(trail[0]?.label).toBe("Improve");
+    expect(trail[0]?.href).toBe(getAreaById("improve")?.href);
+  });
+
+  it.each(tabPaths)("%s trail second crumb is AI Workflows (sidebar child label)", (pathname) => {
+    const trail = navTrailForPathname(pathname);
+    // All /ai/* paths resolve to the ai-workflows child row.
+    expect(trail[1]?.label).toBe("AI Workflows");
+  });
+
+  it.each(tabPaths)("%s trail does NOT start with 'Home'", (pathname) => {
+    const trail = navTrailForPathname(pathname);
+    expect(trail[0]?.label).not.toBe("Home");
+  });
+});

--- a/src/lib/navigation/__tests__/workPageView.test.ts
+++ b/src/lib/navigation/__tests__/workPageView.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { resolveActiveView, WORK_TABS } from "../workPageView";
+
+// Unit tests for the work/page.tsx activeView resolution logic (CHAOS-2075,
+// Codex review fix): legacy ?tab= deep links must resolve to "work", not
+// silently fall through to "overview".
+
+describe("resolveActiveView", () => {
+  describe("explicit ?view= param", () => {
+    it("returns 'overview' when view=overview", () => {
+      expect(resolveActiveView("overview", undefined)).toBe("overview");
+    });
+
+    it("returns 'work' when view=work", () => {
+      expect(resolveActiveView("work", undefined)).toBe("work");
+    });
+
+    it("?view=work wins even when a tab param is also present", () => {
+      expect(resolveActiveView("work", "flow")).toBe("work");
+    });
+
+    it("?view=overview wins even when a tab param is also present", () => {
+      expect(resolveActiveView("overview", "flow")).toBe("overview");
+    });
+
+    it("ignores an unknown view param and falls through to legacy-tab / default logic", () => {
+      // Unknown view + valid tab → legacy deep-link path → "work"
+      expect(resolveActiveView("unknown", "flow")).toBe("overview");
+    });
+  });
+
+  describe("legacy ?tab= deep links (no view param)", () => {
+    it.each(WORK_TABS)(
+      "resolves to 'work' when view is absent and tab=%s",
+      (tab) => {
+        expect(resolveActiveView(undefined, tab)).toBe("work");
+      },
+    );
+
+    it("resolves /work?tab=flow to 'work' (primary Codex finding)", () => {
+      expect(resolveActiveView(undefined, "flow")).toBe("work");
+    });
+
+    it("resolves /work?tab=investment to 'work'", () => {
+      expect(resolveActiveView(undefined, "investment")).toBe("work");
+    });
+
+    it("resolves /work?tab=flame to 'work'", () => {
+      expect(resolveActiveView(undefined, "flame")).toBe("work");
+    });
+
+    it("ignores an invalid tab value and returns 'overview'", () => {
+      expect(resolveActiveView(undefined, "not-a-tab")).toBe("overview");
+    });
+  });
+
+  describe("bare /work (no params)", () => {
+    it("returns 'overview' when both view and tab are absent", () => {
+      expect(resolveActiveView(undefined, undefined)).toBe("overview");
+    });
+
+    it("returns 'overview' when view is an empty string", () => {
+      expect(resolveActiveView("", undefined)).toBe("overview");
+    });
+  });
+});

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -127,18 +127,12 @@ export const navAreas: readonly NavArea[] = [
     href: "/dashboard",
     placement: "main",
     // Operating Review moved to Improve (CHAOS-2075). `/operating-review` is no
-    // longer area-owned here, so it resolves to Improve. The `hubItems` entry is
-    // intentionally untouched (the 2074 landing cards are demoted in Phase 2).
+    // longer area-owned here, so it resolves to Improve. The hubItems entry is
+    // removed (REVIEW W3): leaving it would make the Cockpit landing's AreaHub
+    // link into Improve, creating a cross-area navigation confusion.
     ownedPathPrefixes: ["/dashboard"],
     legacyActiveIds: ["home", "cockpit"],
-    hubItems: [
-      {
-        id: "operating-review",
-        label: "Operating Review",
-        href: "/operating-review",
-        description: "Periodic operating review of system health.",
-      },
-    ],
+    hubItems: [],
     // Cockpit's only destination is its landing route — no expandable children.
     children: [],
   },
@@ -647,6 +641,6 @@ export function navTitleForPathname(pathname: string): string {
 }
 
 /** Strip query/hash so route comparisons use the bare path. */
-function basePath(href: string): string {
+export function basePath(href: string): string {
   return href.split("?")[0].split("#")[0];
 }

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -1,20 +1,28 @@
 // ── Primary navigation: decision areas ───────────────────────────────────────
 //
-// Design Framework A1 ("sidebar = major product areas only") + A2 ("leaves live
-// in area tabs/drill-down"). The sidebar surfaces exactly six decision areas;
-// individual leaf/metric destinations are NOT enumerated in the sidebar. Each
-// area owns a landing route, and its leaves are reachable from that landing via
-// the `AreaHub` drill-down (see `@/components/navigation/AreaHub`).
+// Design Framework A1 (two-level sidebar) + A2 (tabs are sibling views *within*
+// a destination, never the sidebar). The sidebar surfaces the six decision
+// areas; the ACTIVE area expands to its child destinations (`children`) as an
+// indented list. Inactive areas stay collapsed.
+//
+// Two route models live here, kept deliberately distinct:
+//   - `children`  → the SIDEBAR route tree (CHAOS-2075): real destinations the
+//                   active area expands to. Tab subviews are NOT children.
+//   - `hubItems`  → the landing-page triage cards (CHAOS-2074 signal-card
+//                   descriptors). Untouched by the sidebar work.
 //
 // This is the single source of truth shared by:
-//   - PrimaryNav (renders the six area rows + active state)
-//   - AreaHub (renders each area's leaf drill-down on its landing page)
+//   - PrimaryNav (renders the area rows, expands the active area's children)
+//   - AreaHub (renders each area's signal-card drill-down on its landing page)
+//   - Breadcrumbs / page titles (navTrailForPathname / navTitleForPathname, so
+//     sidebar label === breadcrumb === page title, rule A6)
 //   - PrimaryNav.test / areas.test (contract + reachability guarantees)
 //
-// CHAOS-2073: the prior collapse (CHAOS-2043) only created collapsible group
-// headers while still rendering every leaf link flat. Keeping leaf rows in the
-// DOM — even visually collapsed — repeats that regression, so leaves live here
-// only as `hubItems`, never as sidebar rows.
+// CHAOS-2073 (history): the prior collapse rendered every leaf flat; CHAOS-2075
+// reintroduces leaf rows ONLY as the active area's expanded children, never as a
+// flat always-on list, and only for routes that resolve to a real page.
+
+import type { Crumb } from "@/components/Breadcrumbs";
 
 export type NavAreaId = "cockpit" | "diagnose" | "improve" | "govern" | "reports" | "admin";
 
@@ -43,6 +51,42 @@ export type NavAreaHubItem = {
   demoted?: boolean;
 };
 
+/**
+ * A child *destination* in the two-level sidebar (CHAOS-2075). Distinct from
+ * {@link NavAreaHubItem} (the 2074 signal-card descriptors that drive the
+ * landing triage grid): a `NavChildRoute` is a real route the active area
+ * expands to as an indented sidebar row.
+ *
+ * Children are DESTINATIONS, not tabs — tab subviews (AI: Impact/Attribution/…;
+ * Work: Landscape/Flow/…) are siblings *within* a destination (Framework A2)
+ * and must never appear here. Only routes that resolve to a real page are
+ * `navVisible`; phantom/not-yet-built routes are `preview` and never rendered.
+ */
+export type NavChildRoute = {
+  id: string;
+  label: string;
+  /** The child's canonical route — the sidebar row links here. */
+  path: string;
+  /** Rendered in the sidebar only when true. Preview routes stay false. */
+  navVisible: boolean;
+  /** Phantom/not-yet-built route held for reference; never rendered. */
+  preview?: boolean;
+  /**
+   * Routes whose active state resolves to THIS child (longest match wins among
+   * a single area's navVisible children). Defaults to `[path]`. A cluster child
+   * lists every route it fronts (e.g. `/testops/tests`, `/quality`).
+   */
+  ownedPaths?: string[];
+  /** R4 low-value surface — render visually secondary within the list. */
+  demoted?: boolean;
+  /**
+   * True when this single row fronts several destinations behind one in-page
+   * tab strip (Phase 2). The sidebar shows ONE row; the tab strip lives on the
+   * page, not in the sidebar.
+   */
+  isCluster?: boolean;
+};
+
 export type NavArea = {
   id: NavAreaId;
   label: string;
@@ -66,6 +110,13 @@ export type NavArea = {
    * Empty for areas whose only destination is the landing route itself.
    */
   hubItems: NavAreaHubItem[];
+  /**
+   * The two-level sidebar route tree (CHAOS-2075): the destinations the active
+   * area expands to as indented rows. DISTINCT from `hubItems` — see
+   * {@link NavChildRoute}. Empty when the area's only destination is its landing
+   * route (e.g. Cockpit).
+   */
+  children: NavChildRoute[];
 };
 
 export const navAreas: readonly NavArea[] = [
@@ -75,8 +126,11 @@ export const navAreas: readonly NavArea[] = [
     label: "Cockpit",
     href: "/dashboard",
     placement: "main",
-    ownedPathPrefixes: ["/dashboard", "/operating-review"],
-    legacyActiveIds: ["home", "operating-review", "cockpit"],
+    // Operating Review moved to Improve (CHAOS-2075). `/operating-review` is no
+    // longer area-owned here, so it resolves to Improve. The `hubItems` entry is
+    // intentionally untouched (the 2074 landing cards are demoted in Phase 2).
+    ownedPathPrefixes: ["/dashboard"],
+    legacyActiveIds: ["home", "cockpit"],
     hubItems: [
       {
         id: "operating-review",
@@ -85,6 +139,8 @@ export const navAreas: readonly NavArea[] = [
         description: "Periodic operating review of system health.",
       },
     ],
+    // Cockpit's only destination is its landing route — no expandable children.
+    children: [],
   },
   {
     id: "diagnose",
@@ -168,14 +224,46 @@ export const navAreas: readonly NavArea[] = [
         metricLabel: "WIP saturation",
       },
     ],
+    // Two-level sidebar children (CHAOS-2075): Diagnose's destinations. Each is a
+    // real page; the borrowed Work sub-views (Landscape/Flow/Heatmap/…) are TABS
+    // on /work, not children. Work is the area landing AND a child row so the
+    // expansion is self-consistent.
+    children: [
+      { id: "work", label: "Work", path: "/work", navVisible: true },
+      { id: "metrics", label: "Metrics", path: "/metrics", navVisible: true },
+      { id: "people", label: "People", path: "/people", navVisible: true },
+      { id: "code", label: "Code", path: "/code", navVisible: true },
+      { id: "landscape", label: "Landscape", path: "/explore/landscape", navVisible: true },
+      { id: "complexity", label: "Complexity", path: "/complexity", navVisible: true },
+      {
+        id: "cognitive-load",
+        label: "Cognitive Load",
+        path: "/cognitive-load",
+        navVisible: true,
+      },
+      { id: "bottleneck", label: "Bottlenecks", path: "/bottleneck", navVisible: true },
+    ],
   },
   {
     id: "improve",
     label: "Improve",
     href: "/opportunities",
     placement: "main",
-    ownedPathPrefixes: ["/opportunities", "/capacity-planning", "/capacity", "/ai"],
-    legacyActiveIds: ["opportunities", "capacity-planning", "ai-workflows", "improve"],
+    // `/operating-review` moved here from Cockpit (CHAOS-2075).
+    ownedPathPrefixes: [
+      "/opportunities",
+      "/capacity-planning",
+      "/capacity",
+      "/ai",
+      "/operating-review",
+    ],
+    legacyActiveIds: [
+      "opportunities",
+      "capacity-planning",
+      "ai-workflows",
+      "operating-review",
+      "improve",
+    ],
     // CHAOS-2074: Improve is FLAT (no clusters). Opportunities is the area's own
     // landing route (`href: "/opportunities"`), so it is NOT duplicated as a hub
     // item — its volume signal bubbles at the area level via the resolver.
@@ -195,6 +283,33 @@ export const navAreas: readonly NavArea[] = [
         description: "AI impact, attribution, and governance.",
         // Adoption %, NOT a severity → resolver surfaces a neutral/info state.
         metricLabel: "AI-assisted PRs",
+      },
+    ],
+    // Two-level sidebar children (CHAOS-2075). AI Workflows is ONE child row; its
+    // Impact/Attribution/Review Load/Test Gaps/Risk/Evidence/Automations surfaces
+    // are TABS on /ai (Framework A2), not sidebar children. `/ai` owns its whole
+    // subtree so any AI tab keeps the AI Workflows row active. Operating Review
+    // landed here from Cockpit.
+    children: [
+      { id: "opportunities", label: "Opportunities", path: "/opportunities", navVisible: true },
+      {
+        id: "capacity-planning",
+        label: "Capacity Planning",
+        path: "/capacity-planning",
+        navVisible: true,
+      },
+      {
+        id: "ai-workflows",
+        label: "AI Workflows",
+        path: "/ai",
+        navVisible: true,
+        ownedPaths: ["/ai"],
+      },
+      {
+        id: "operating-review",
+        label: "Operating Review",
+        path: "/operating-review",
+        navVisible: true,
       },
     ],
   },
@@ -304,6 +419,45 @@ export const navAreas: readonly NavArea[] = [
         demoted: true,
       },
     ],
+    // Two-level sidebar children (CHAOS-2075). Tests · Quality · Coverage collapse
+    // into ONE cluster row (owner decision): the row links to /testops/coverage
+    // and stays active on any of its owned paths; the actual tab strip across
+    // those three surfaces is Phase 2 (the sidebar only ever shows one row).
+    // Pipelines stays a standalone row.
+    children: [
+      { id: "testops", label: "Overview", path: "/testops", navVisible: true },
+      { id: "pipelines", label: "Pipelines", path: "/testops/pipelines", navVisible: true },
+      {
+        id: "tests-quality-coverage",
+        label: "Tests · Quality · Coverage",
+        path: "/testops/coverage",
+        navVisible: true,
+        isCluster: true,
+        ownedPaths: ["/testops/tests", "/quality", "/testops/coverage"],
+      },
+      { id: "risk", label: "Delivery Risk", path: "/testops/risk", navVisible: true },
+      {
+        id: "incident-correlation",
+        label: "Incident Correlation",
+        path: "/incident-correlation",
+        navVisible: true,
+      },
+      { id: "security", label: "Security", path: "/security", navVisible: true },
+      {
+        id: "risk-compounding",
+        label: "Compounding Risk",
+        path: "/risk/compounding",
+        navVisible: true,
+      },
+      {
+        id: "feature-flags",
+        label: "Feature Flags",
+        path: "/feature-flags",
+        navVisible: true,
+        // R4 low-value surface — rendered visually secondary in the list.
+        demoted: true,
+      },
+    ],
   },
   // ── Utility tray ────────────────────────────────────────────────────────────
   {
@@ -314,15 +468,57 @@ export const navAreas: readonly NavArea[] = [
     ownedPathPrefixes: ["/reports"],
     legacyActiveIds: ["reports"],
     hubItems: [],
+    // Report Center is the only built destination. Weekly Review / Executive
+    // Summary / Export History are PREVIEW (phantom routes held for reference);
+    // they are never rendered and never resolved until their pages exist — DO
+    // NOT create stub pages for them (CHAOS-2075).
+    children: [
+      { id: "report-center", label: "Report Center", path: "/reports", navVisible: true },
+      {
+        id: "weekly-review",
+        label: "Weekly Review",
+        path: "/reports/weekly",
+        navVisible: false,
+        preview: true,
+      },
+      {
+        id: "executive-summary",
+        label: "Executive Summary",
+        path: "/reports/executive",
+        navVisible: false,
+        preview: true,
+      },
+      {
+        id: "export-history",
+        label: "Export History",
+        path: "/reports/exports",
+        navVisible: false,
+        preview: true,
+      },
+    ],
   },
   {
     id: "admin",
     label: "Admin",
     href: "/admin",
     placement: "utility",
-    ownedPathPrefixes: ["/admin", "/settings"],
-    legacyActiveIds: ["admin", "settings"],
+    // `/data-health` (Data Confidence) is an Admin destination outside `/admin`.
+    ownedPathPrefixes: ["/admin", "/settings", "/data-health"],
+    legacyActiveIds: ["admin", "settings", "data-health"],
     hubItems: [],
+    // Built Admin destinations. Organization (distributed across admin subpages)
+    // and Billing (no page) are intentionally omitted — not phantom-previewed,
+    // just absent (CHAOS-2075).
+    children: [
+      { id: "settings", label: "Settings", path: "/admin/settings", navVisible: true },
+      { id: "connections", label: "Connections", path: "/admin/integrations", navVisible: true },
+      {
+        id: "data-confidence",
+        label: "Data Confidence",
+        path: "/data-health",
+        navVisible: true,
+      },
+    ],
   },
 ] as const;
 
@@ -365,4 +561,92 @@ export function selectedAreaIdForPathname(
   }
 
   return undefined;
+}
+
+/** The routes a child claims for active-state. Defaults to `[child.path]`. */
+function ownedPathsFor(child: NavChildRoute): readonly string[] {
+  return child.ownedPaths ?? [child.path];
+}
+
+/**
+ * Resolve the single active CHILD within an area (A10: exactly one selected).
+ * Only `navVisible` children are considered; the longest owned-path match wins,
+ * so a cluster child (e.g. Tests · Quality · Coverage) lights up across every
+ * path it fronts (`/quality`, `/testops/tests`, `/testops/coverage`) while a
+ * more specific sibling (Pipelines `/testops/pipelines`) still beats the
+ * area Overview (`/testops`). Returns `undefined` when no child owns the path
+ * (the area row is selected, but no child is).
+ */
+export function selectedChildForPathname(
+  area: NavArea,
+  pathname: string,
+): NavChildRoute | undefined {
+  let selected: { child: NavChildRoute; score: number } | undefined;
+
+  for (const child of area.children) {
+    if (!child.navVisible) continue;
+    for (const owned of ownedPathsFor(child)) {
+      if (pathMatchesPrefix(pathname, owned) && owned.length > (selected?.score ?? -1)) {
+        selected = { child, score: owned.length };
+      }
+    }
+  }
+
+  return selected?.child;
+}
+
+/**
+ * Resolve the area (and its active child, if any) for a pathname using the same
+ * longest-match rules the sidebar renders with. Shared by the breadcrumb/title
+ * helpers so route metadata can never drift from the sidebar (rule A6).
+ */
+function resolveAreaAndChild(
+  pathname: string,
+): { area: NavArea; child?: NavChildRoute } | undefined {
+  const areaId = selectedAreaIdForPathname(navAreas, pathname);
+  if (!areaId) return undefined;
+  const area = getAreaById(areaId);
+  if (!area) return undefined;
+  return { area, child: selectedChildForPathname(area, pathname) };
+}
+
+/**
+ * Config-derived location trail (Area → Child) for `<Breadcrumbs>` (rule A6:
+ * crumb labels are the sidebar labels, verbatim). The area crumb links to its
+ * landing route; the child crumb is the current page — rendered as the last,
+ * link-less crumb. When the pathname IS the area landing (or resolves to no
+ * child) the area is the single, current crumb.
+ *
+ * Returns `[]` for routes no area owns (callers fall back to bespoke crumbs).
+ */
+export function navTrailForPathname(pathname: string): Crumb[] {
+  const resolved = resolveAreaAndChild(pathname);
+  if (!resolved) return [];
+  const { area, child } = resolved;
+
+  // No distinct child (area landing, or child === the landing route): the area
+  // is the current page — a single, link-less crumb.
+  if (!child || basePath(child.path) === basePath(area.href)) {
+    return [{ label: area.label }];
+  }
+
+  return [{ label: area.label, href: area.href }, { label: child.label }];
+}
+
+/**
+ * The page title for a pathname — the active child's label, else the area's
+ * label (rule A6: page title === sidebar label === breadcrumb). Returns the
+ * empty string for routes no area owns so callers can supply their own.
+ */
+export function navTitleForPathname(pathname: string): string {
+  const resolved = resolveAreaAndChild(pathname);
+  if (!resolved) return "";
+  const { area, child } = resolved;
+  if (child && basePath(child.path) !== basePath(area.href)) return child.label;
+  return area.label;
+}
+
+/** Strip query/hash so route comparisons use the bare path. */
+function basePath(href: string): string {
+  return href.split("?")[0].split("#")[0];
 }

--- a/src/lib/navigation/workPageView.ts
+++ b/src/lib/navigation/workPageView.ts
@@ -1,0 +1,45 @@
+// ── Work page active-view resolution ─────────────────────────────────────────
+//
+// Extracted from src/app/(app)/work/page.tsx so the resolution is unit-testable
+// without rendering the RSC. The logic must stay in sync with the page.
+//
+// Rules (Codex review fix — CHAOS-2075):
+//   1. `?view=overview|work` — explicit view param wins.
+//   2. `?tab=<workTab>` without a `view` param — legacy deep link emitted by
+//      WorkTabNav before two-level nav; resolve to "work" so the Work content
+//      branch renders and the existing `tab` logic picks the sub-view.
+//   3. Bare `/work` (no view, no tab) → "overview".
+
+export type DiagnoseView = "overview" | "work";
+export const DIAGNOSE_VIEWS: DiagnoseView[] = ["overview", "work"];
+
+export const WORK_TABS = [
+  "landscape",
+  "heatmap",
+  "flow",
+  "investment",
+  "capacity",
+  "flame",
+  "evidence",
+  "graph",
+] as const;
+
+/**
+ * Resolve the active DiagnoseView from raw URL search params.
+ *
+ * @param viewParam - the raw `view` query param value (string | undefined)
+ * @param tabParam  - the raw `tab` query param value (string | undefined)
+ */
+export function resolveActiveView(
+  viewParam: string | undefined,
+  tabParam: string | undefined,
+): DiagnoseView {
+  if (DIAGNOSE_VIEWS.includes(viewParam as DiagnoseView)) {
+    return viewParam as DiagnoseView;
+  }
+  // Legacy ?tab= deep link: no explicit view but a valid work tab → show Work.
+  if (!viewParam && typeof tabParam === "string" && (WORK_TABS as readonly string[]).includes(tabParam)) {
+    return "work";
+  }
+  return "overview";
+}

--- a/tests/nav-reachability.spec.ts
+++ b/tests/nav-reachability.spec.ts
@@ -136,8 +136,9 @@ test.describe("primary navigation reachability (collapsed areas — CHAOS-2073)"
     await waitForHydration(page);
 
     // AI Workflows now lives in the Improve area's drill-down hub, not the sidebar.
+    // AreaHub renders aria-label="${area.label} signals" → "Improve signals".
     const improveHub = page.getByRole("region", {
-      name: "Improve destinations",
+      name: "Improve signals",
     });
     await clickUntilUrl(
       page,
@@ -170,7 +171,8 @@ test.describe("primary navigation reachability (collapsed areas — CHAOS-2073)"
       { path: "/testops/risk", selectedLabel: "Govern" },
       { path: "/bottleneck", selectedLabel: "Diagnose" },
       { path: "/risk/compounding", selectedLabel: "Govern" },
-      { path: "/operating-review", selectedLabel: "Cockpit" },
+      // Operating Review moved Cockpit → Improve (CHAOS-2075); PrimaryNav marks Improve active.
+      { path: "/operating-review", selectedLabel: "Improve" },
     ]) {
       await expectSingleSelectedArea(page, route.path, route.selectedLabel);
     }


### PR DESCRIPTION
## Summary
Two-level expandable area navigation — the active work area expands in the sidebar to show its child destinations, restoring findability for core workflows (Coverage, Pipelines, Security, Capacity, AI Workflows, Cognitive Load, Bottlenecks, Incident Correlation, Delivery Risk) that were previously reachable only via bottom-of-page cards. Builds on CHAOS-2074 (triage signal cards, merged) and pairs with it: **sidebar = findability, area Overview = triage**.

Stacked on `fix/nav-collapse-areas-chaos-2073` (→ #587).

## What changed
- **Route model** (extends the existing `navAreas` convention, not a parallel type): `NavChildRoute[]` per area with `navVisible`/`preview`/`ownedPaths`/`isCluster`/`demoted`; `selectedChildForPathname` (longest-`ownedPaths` active-child); `navTrailForPathname`/`navTitleForPathname` (breadcrumb + title from config, A6).
- **Two-level PrimaryNav**: the active **main** area auto-expands its children (indented, `--card-stroke` hairlines, no bright borders, Part C density); exactly one active selection.
- **Utility areas** (Reports, Admin/Settings) stay plain rows (bottom / person menu) — no expansion.
- **Tab cluster**: Tests · Quality · Coverage collapse to one sidebar child with a `ModeTabs` strip (`QualityCoverageTabs`), mirroring the AI Workflows cluster; AI subviews stay tabs.
- **Operating Review** moved Cockpit → Improve.
- **Bottom area cards** demoted to "Related workflows" (the 2074 triage signal cards remain; the sidebar is now primary discovery).
- **Framework**: A1/A2 updated for the two-level model (A2a from 2074 intact).
- **Route-safety gate**: only real routes are `navVisible`; phantom Reports/Admin entries are `preview`/omitted — no stub pages.

## Tests
- `pnpm test:unit`: **1549 pass / 181 files**; `tsc` clean. Active-state matrix (Cockpit; Diagnose/Work; Improve/AI Workflows; Improve/Operating Review; Govern/Coverage-cluster across /testops/coverage + /quality + /testops/tests; utility areas don't expand), one-active-child, preview-excluded, cluster active-state.
- `pnpm design-lint`: net −5 vs the pre-existing baseline (zero new violations).

## Review
In-house code review (no criticals; test-gap + cleanup fixes applied). A Codex review will be run before merge.

## Related
- Builds on CHAOS-2074 (#588, merged) — the findability half of the pair.
- Supersedes the flat-≤6 target in CHAOS-2073 (#587, this PR's base).

Screenshots (expanded sidebar — Govern/Diagnose/Improve + tab cluster) attaching shortly.