### PR TITLE
feat(nav): AI area gated promotion, hide preview tabs (CHAOS-2087)

### DIFF
--- a/src/app/(app)/ai/attribution/page.tsx
+++ b/src/app/(app)/ai/attribution/page.tsx
@@ -2,26 +2,26 @@ import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { AITabPreview } from "@/components/ai/AITabPreview";
 
 /**
- * Attribution tab — preview. The attribution mix (human / assisted / review /
- * agent-created / unknown) currently lives as panels inside the Impact tab and
- * has not been split into its own backing query yet. Marked preview rather than
- * fabricating a separate data surface.
+ * Attribution tab — preview. The attribution mix currently lives as panels
+ * inside Impact. Marked preview rather than fabricating a separate surface.
  */
 export default function AIAttributionPage() {
 	return (
 		<>
-			<AIPageHeader eyebrow="AI Workflows" title="Attribution">
+			<AIPageHeader eyebrow="AI" title="Attribution">
 				A dedicated home for PR attribution — how work splits across human,
 				AI-assisted, AI-reviewed, agent-created, and unknown buckets — is
 				coming. Today these panels live within Impact.
 			</AIPageHeader>
 			<AITabPreview
-				whereNow={{ label: "View attribution mix in Impact", href: "/ai" }}
+				whereNow={{
+					label: "View attribution mix in Impact",
+					href: "/ai/impact",
+				}}
 			>
-				Attribution diagnostics will move here once the attribution mix is split
-				from the Impact summary into its own scoped query. For now the same
-				signals — including the unknown bucket kept visible for coverage gaps —
-				appear on the Impact tab.
+				Attribution diagnostics will move here when they can stand as a complete
+				view. For now the same signals — including the unknown bucket kept
+				visible for coverage gaps — appear on the Impact tab.
 			</AITabPreview>
 		</>
 	);

--- a/src/app/(app)/ai/automations/page.tsx
+++ b/src/app/(app)/ai/automations/page.tsx
@@ -23,9 +23,8 @@ export default async function AIAutomationsPage({
 	return (
 		<>
 			<AIPageHeader
-				eyebrow="AI Workflows"
+				eyebrow="AI"
 				title="Automations"
-				preview
 				breadcrumbs={[
 					...navTrailForPathname("/ai/automations").map((c) => ({
 						...c,

--- a/src/app/(app)/ai/evidence/page.tsx
+++ b/src/app/(app)/ai/evidence/page.tsx
@@ -2,28 +2,25 @@ import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { AITabPreview } from "@/components/ai/AITabPreview";
 
 /**
- * Evidence tab — preview. The "AI Workflow Intelligence" summary currently
- * lives on the dashboard and operating-review surfaces. A consolidated evidence
- * view under the AI area is scoped but not yet backed by its own data, so it is
- * marked preview rather than rendering an empty evidence panel.
+ * Evidence tab — preview. A consolidated evidence view under the AI area is
+ * scoped but not ready, so it is marked preview rather than rendering an empty
+ * evidence panel.
  */
 export default function AIEvidencePage() {
 	return (
 		<>
-			<AIPageHeader eyebrow="AI Workflows" title="Evidence">
-				A consolidated evidence trail for AI workflow signals — tracing each
-				pattern back to Work Graph edges and source PRs — is coming. Today the
-				AI Workflow Intelligence summary lives on the Operating Review.
+			<AIPageHeader eyebrow="AI" title="AI Evidence">
+				A consolidated evidence trail for AI signals is coming. Today the
+				closest summary lives on the Operating Review.
 			</AIPageHeader>
 			<AITabPreview
 				whereNow={{
-					label: "View AI Workflow Intelligence on Operating Review",
+					label: "View AI summary on Operating Review",
 					href: "/operating-review#ai-workflow-intelligence",
 				}}
 			>
-				Evidence will surface here once AI workflow signals are linked to their
-				underlying Work Graph edges. No fabricated evidence is shown until that
-				data is available.
+				Evidence will surface here when it can stand as a complete view. No
+				fabricated evidence is shown before that data is available.
 			</AITabPreview>
 		</>
 	);

--- a/src/app/(app)/ai/impact/page.tsx
+++ b/src/app/(app)/ai/impact/page.tsx
@@ -1,26 +1,55 @@
-import { redirect } from "next/navigation";
+import { AIImpactDashboard } from "@/components/ai/AIImpactDashboard";
+import { AIPageHeader } from "@/components/ai/AIPageHeader";
+import { FilterBar } from "@/components/filters/FilterBar";
+import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
+import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { checkApiHealth } from "@/lib/api/system";
+import { encodeAIFilterParam, metricFilterToAIFilter } from "@/lib/filters/ai";
+import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+import { navTrailForPathname } from "@/lib/navigation/areas";
 
-type AIImpactRedirectProps = {
+type AIImpactPageProps = {
 	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-/**
- * `/ai/impact` is now the `/ai` index (Impact tab). This redirect keeps the
- * previously-reachable deep link working — and avoids two routes resolving to
- * the same Impact content — by forwarding to `/ai` with filter params intact.
- */
-export default async function AIImpactRedirect({
+export default async function AIImpactPage({
 	searchParams,
-}: AIImpactRedirectProps) {
+}: AIImpactPageProps) {
 	const params = (await searchParams) ?? {};
-	const query = new URLSearchParams();
-	for (const [key, value] of Object.entries(params)) {
-		if (typeof value === "string") {
-			query.set(key, value);
-		} else if (Array.isArray(value) && value.length > 0) {
-			query.set(key, value[0]);
-		}
+	const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+	const filters = encodedFilter
+		? decodeFilter(encodedFilter)
+		: filterFromQueryParams(params);
+	const aiFilter = metricFilterToAIFilter(filters);
+	const health = await checkApiHealth();
+
+	if (!health.ok) {
+		return <ServiceUnavailable />;
 	}
-	const qs = query.toString();
-	redirect(qs ? `/ai?${qs}` : "/ai");
+
+	return (
+		<>
+			<AIPageHeader
+				eyebrow="AI"
+				title="Impact"
+				breadcrumbs={[
+					...navTrailForPathname("/ai/impact").map((c) => ({
+						...c,
+						href: c.href ?? "/ai",
+					})),
+					{ label: "Impact" },
+				]}
+			>
+				Org-wide view of how AI-assisted workflows appear to influence delivery,
+				review load, quality gaps, and operational drag.
+			</AIPageHeader>
+
+			<GlobalContextBar filters={filters} />
+			<FilterBar view="ai" />
+			<AIImpactDashboard filter={aiFilter} />
+			<p className="sr-only">
+				Encoded AI filter: {encodeAIFilterParam(aiFilter)}
+			</p>
+		</>
+	);
 }

--- a/src/app/(app)/ai/layout.tsx
+++ b/src/app/(app)/ai/layout.tsx
@@ -2,12 +2,6 @@ import { ReactNode } from "react";
 
 import { AIWorkspaceChrome } from "@/components/ai/AIWorkspaceChrome";
 
-/**
- * Shared layout for the unified "AI Workflows" area. Provides one sidebar entry
- * (PrimaryNav active="ai-workflows") and one tab strip so every AI surface —
- * Impact, Attribution, Review Load, Test Gaps, Governance Risk, Evidence,
- * Automations — lives behind a single coherent chrome.
- */
 export default function AILayout({ children }: { children: ReactNode }) {
 	return <AIWorkspaceChrome>{children}</AIWorkspaceChrome>;
 }

--- a/src/app/(app)/ai/page.tsx
+++ b/src/app/(app)/ai/page.tsx
@@ -1,10 +1,10 @@
-import { AIImpactDashboard } from "@/components/ai/AIImpactDashboard";
-import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { FilterBar } from "@/components/filters/FilterBar";
+import { AreaOverview } from "@/components/navigation/AreaOverview";
 import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { checkApiHealth } from "@/lib/api/system";
-import { encodeAIFilterParam, metricFilterToAIFilter } from "@/lib/filters/ai";
+import { getAreaSignals } from "@/lib/areaSignals";
+import { getServerEnv } from "@/lib/config";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 
 type AIWorkflowsPageProps = {
@@ -12,37 +12,47 @@ type AIWorkflowsPageProps = {
 };
 
 /**
- * `/ai` index — defaults to the Impact tab of the unified AI Workflows area.
- * Sidebar entry + tab strip are provided by the shared layout.
+ * `/ai` index — the AI area overview. The shared AreaOverview summarizes and
+ * routes to the real AI subviews; preview-only routes stay hidden from default
+ * navigation until they have distinct views.
  */
 export default async function AIWorkflowsPage({
 	searchParams,
 }: AIWorkflowsPageProps) {
 	const params = (await searchParams) ?? {};
 	const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+	const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+	const activeRole = typeof roleParam === "string" ? roleParam : undefined;
 	const filters = encodedFilter
 		? decodeFilter(encodedFilter)
 		: filterFromQueryParams(params);
-	const aiFilter = metricFilterToAIFilter(filters);
-	const health = await checkApiHealth();
 
-	if (!health.ok) {
+	const env = getServerEnv();
+	const isTestMode =
+		env.DEV_HEALTH_TEST_MODE === "true" ||
+		env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
+
+	const [health, aiSignals] = await Promise.all([
+		checkApiHealth(),
+		getAreaSignals("ai", filters, isTestMode),
+	]);
+
+	if (!health.ok && !isTestMode) {
 		return <ServiceUnavailable />;
 	}
 
 	return (
 		<>
-			<AIPageHeader eyebrow="AI Workflows" title="Impact">
-				Org-wide view of how AI-assisted workflows appear to influence delivery,
-				review load, quality gaps, and operational drag.
-			</AIPageHeader>
-
 			<GlobalContextBar filters={filters} />
 			<FilterBar view="ai" />
-			<AIImpactDashboard filter={aiFilter} />
-			<p className="sr-only">
-				Encoded AI filter: {encodeAIFilterParam(aiFilter)}
-			</p>
+			<AreaOverview
+				areaId="ai"
+				signals={aiSignals}
+				filters={filters}
+				role={activeRole}
+				title="AI workflows"
+				description="Real AI views that summarize impact, review pressure, governance risk, and automation opportunities."
+			/>
 		</>
 	);
 }

--- a/src/app/(app)/ai/review-load/page.tsx
+++ b/src/app/(app)/ai/review-load/page.tsx
@@ -23,7 +23,7 @@ export default async function AIReviewLoadPage({
 	return (
 		<>
 			<AIPageHeader
-				eyebrow="AI Workflows"
+				eyebrow="AI"
 				title="Review Load"
 				breadcrumbs={[
 					...navTrailForPathname("/ai/review-load").map((c) => ({

--- a/src/app/(app)/ai/risk/page.tsx
+++ b/src/app/(app)/ai/risk/page.tsx
@@ -21,7 +21,7 @@ export default async function AIRiskPage({ searchParams }: AIRiskPageProps) {
 	return (
 		<>
 			<AIPageHeader
-				eyebrow="AI Workflows"
+				eyebrow="AI"
 				title="Governance Risk"
 				breadcrumbs={[
 					...navTrailForPathname("/ai/risk").map((c) => ({

--- a/src/app/(app)/ai/test-gaps/page.tsx
+++ b/src/app/(app)/ai/test-gaps/page.tsx
@@ -3,14 +3,12 @@ import { AITabPreview } from "@/components/ai/AITabPreview";
 
 /**
  * Test Gaps tab — preview. Test-gap signals currently render as a panel inside
- * the Governance Risk dashboard. A dedicated tab is scoped but not yet split
- * into its own backing data, so it is marked preview rather than duplicating
- * the Risk panel.
+ * Governance Risk. Marked preview rather than duplicating the Risk panel.
  */
 export default function AITestGapsPage() {
 	return (
 		<>
-			<AIPageHeader eyebrow="AI Workflows" title="Test Gaps">
+			<AIPageHeader eyebrow="AI" title="Test Gaps">
 				A focused view of where AI-attributed change appears to land without
 				matching test coverage signals is coming. Today the test-gap rate is
 				surfaced inside Governance Risk.
@@ -21,9 +19,9 @@ export default function AITestGapsPage() {
 					href: "/ai/risk",
 				}}
 			>
-				Test-gap diagnostics will move here once the gap detector output is
-				split into its own scoped query. For now the test-gap rate and its
-				baseline delta appear on the Governance Risk tab.
+				Test-gap diagnostics will move here when they can stand as a complete
+				view. For now the test-gap rate and its baseline delta appear on the
+				Governance Risk tab.
 			</AITabPreview>
 		</>
 	);

--- a/src/components/ai/AITabNav.test.tsx
+++ b/src/components/ai/AITabNav.test.tsx
@@ -44,32 +44,33 @@ const filters: MetricFilter = {
 };
 
 describe("AITabNav", () => {
-	it("renders all AI tab labels", () => {
+	it("renders only real AI tab labels", () => {
 		pathnameMock.mockReturnValue("/ai");
 		render(<AITabNav filters={filters} />);
 		for (const label of [
+			"Overview",
 			"Impact",
-			"Attribution",
 			"Review Load",
-			"Test Gaps",
 			"Governance Risk",
-			"Evidence",
 			"Automations",
 		]) {
 			expect(screen.getByText(label)).toBeInTheDocument();
 		}
+		for (const hiddenLabel of ["Attribution", "Test Gaps", "Evidence"]) {
+			expect(screen.queryByText(hiddenLabel)).not.toBeInTheDocument();
+		}
 	});
 
-	it("defaults the Impact tab as active on /ai", () => {
+	it("defaults the Overview tab as active on /ai", () => {
 		pathnameMock.mockReturnValue("/ai");
 		render(<AITabNav filters={filters} />);
-		expect(screen.getByText("Impact").closest("a")).toHaveAttribute(
+		expect(screen.getByText("Overview").closest("a")).toHaveAttribute(
 			"aria-current",
 			"page",
 		);
 	});
 
-	it("treats the legacy /ai/impact path as the Impact tab", () => {
+	it("marks /ai/impact as the Impact tab", () => {
 		pathnameMock.mockReturnValue("/ai/impact");
 		render(<AITabNav filters={filters} />);
 		expect(screen.getByText("Impact").closest("a")).toHaveAttribute(
@@ -88,19 +89,22 @@ describe("AITabNav", () => {
 		);
 	});
 
-	it("marks preview tabs with a Preview badge", () => {
+	it("does not render preview badges for hidden placeholder routes", () => {
 		pathnameMock.mockReturnValue("/ai");
 		render(<AITabNav filters={filters} />);
-		// Attribution, Test Gaps, Evidence each carry a Preview badge.
-		expect(screen.getAllByText("Preview")).toHaveLength(3);
+		expect(screen.queryByText("Preview")).not.toBeInTheDocument();
 	});
 
 	it("points each tab at its route", () => {
 		pathnameMock.mockReturnValue("/ai");
 		render(<AITabNav filters={filters} />);
-		expect(screen.getByText("Impact").closest("a")).toHaveAttribute(
+		expect(screen.getByText("Overview").closest("a")).toHaveAttribute(
 			"href",
 			"/ai",
+		);
+		expect(screen.getByText("Impact").closest("a")).toHaveAttribute(
+			"href",
+			"/ai/impact",
 		);
 		expect(screen.getByText("Review Load").closest("a")).toHaveAttribute(
 			"href",

--- a/src/components/ai/AITabNav.tsx
+++ b/src/components/ai/AITabNav.tsx
@@ -6,77 +6,51 @@ import { ModeTabs, type ModeTabItem } from "@/components/shared/ModeTabs";
 import { withFilterParam } from "@/lib/filters/url";
 import type { MetricFilter } from "@/lib/filters/types";
 
-/**
- * Route-based tab strip for the unified AI Workflows area.
- *
- * Convention follows the route-per-tab pattern used by TestOps (each tab is
- * its own `/ai/*` route) rather than the `?tab=` query pattern used by
- * `/metrics`. This was chosen because every AI tab already maps to a distinct
- * data surface / dashboard, and keeping discrete routes preserves the
- * previously-reachable URLs (`/ai/review-load`, …) as deep links.
- *
- * `preview` tabs have no distinct backing data yet and render a clearly-scoped
- * preview surface — never a blank or broken destination.
- */
 export type AITabId =
-  | "impact"
-  | "attribution"
-  | "review-load"
-  | "test-gaps"
-  | "risk"
-  | "evidence"
-  | "automations";
+	| "overview"
+	| "impact"
+	| "review-load"
+	| "risk"
+	| "automations";
 
 type AITab = {
-  id: AITabId;
-  label: string;
-  href: string;
-  preview?: boolean;
+	id: AITabId;
+	label: string;
+	href: string;
 };
 
 const AI_TABS: AITab[] = [
-  { id: "impact", label: "Impact", href: "/ai" },
-  {
-    id: "attribution",
-    label: "Attribution",
-    href: "/ai/attribution",
-    preview: true,
-  },
-  { id: "review-load", label: "Review Load", href: "/ai/review-load" },
-  { id: "test-gaps", label: "Test Gaps", href: "/ai/test-gaps", preview: true },
-  { id: "risk", label: "Governance Risk", href: "/ai/risk" },
-  { id: "evidence", label: "Evidence", href: "/ai/evidence", preview: true },
-  { id: "automations", label: "Automations", href: "/ai/automations" },
+	{ id: "overview", label: "Overview", href: "/ai" },
+	{ id: "impact", label: "Impact", href: "/ai/impact" },
+	{ id: "review-load", label: "Review Load", href: "/ai/review-load" },
+	{ id: "risk", label: "Governance Risk", href: "/ai/risk" },
+	{ id: "automations", label: "Automations", href: "/ai/automations" },
 ];
 
-/** Resolve the active tab from the current pathname. `/ai` maps to Impact. */
 function activeTabFromPath(pathname: string): AITabId {
-  if (pathname === "/ai" || pathname === "/ai/impact") return "impact";
-  const match = AI_TABS.find(
-    (tab) => tab.href !== "/ai" && (pathname === tab.href || pathname.startsWith(tab.href + "/")),
-  );
-  return match?.id ?? "impact";
+	if (pathname === "/ai") return "overview";
+	const match = AI_TABS.find(
+		(tab) =>
+			tab.href !== "/ai" &&
+			(pathname === tab.href || pathname.startsWith(tab.href + "/")),
+	);
+	return match?.id ?? "overview";
 }
 
 type AITabNavProps = {
-  filters: MetricFilter;
-  role?: string;
+	filters: MetricFilter;
+	role?: string;
 };
 
 export function AITabNav({ filters, role }: AITabNavProps) {
-  const pathname = usePathname();
-  const activeTab = activeTabFromPath(pathname);
+	const pathname = usePathname();
+	const activeTab = activeTabFromPath(pathname);
 
-  const items: ModeTabItem<AITabId>[] = AI_TABS.map((tab) => ({
-    id: tab.id,
-    label: tab.label,
-    href: withFilterParam(tab.href, filters, role),
-    badge: tab.preview ? (
-      <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-1.5 py-0.5 text-[8px] font-semibold tracking-[0.12em] text-(--ink-muted)">
-        Preview
-      </span>
-    ) : undefined,
-  }));
+	const items: ModeTabItem<AITabId>[] = AI_TABS.map((tab) => ({
+		id: tab.id,
+		label: tab.label,
+		href: withFilterParam(tab.href, filters, role),
+	}));
 
-  return <ModeTabs items={items} activeId={activeTab} ariaLabel="AI Workflows" />;
+	return <ModeTabs items={items} activeId={activeTab} ariaLabel="AI views" />;
 }

--- a/src/components/ai/AITabPreview.tsx
+++ b/src/components/ai/AITabPreview.tsx
@@ -7,22 +7,13 @@ type AITabPreviewProps = {
 	whereNow?: { label: string; href: string };
 };
 
-/**
- * Clearly-scoped preview surface for AI tabs whose distinct backing data is not
- * yet split out (Attribution, Test Gaps, Evidence). Renders an explicit
- * "preview" state instead of fabricating data or a blank/broken destination,
- * and points to where the related signal is currently reachable.
- *
- * Local to the AI area for now; can be swapped for a shared preview component
- * (CHAOS-2045) without changing call sites.
- */
 export function AITabPreview({ children, whereNow }: AITabPreviewProps) {
 	return (
 		<section
 			data-testid="ai-tab-preview"
 			className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-8"
 		>
-			<span className="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-amber-400">
+			<span className="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-[0.15em] text-amber-400">
 				Preview
 			</span>
 			<p className="mt-4 max-w-2xl text-sm text-(--ink-muted)">{children}</p>

--- a/src/components/ai/AIWorkspaceChrome.test.tsx
+++ b/src/components/ai/AIWorkspaceChrome.test.tsx
@@ -15,7 +15,7 @@ vi.mock("@/components/navigation/PrimaryNav", () => ({
 }));
 
 vi.mock("./AITabNav", () => ({
-	AITabNav: () => <nav data-testid="ai-tab-nav" aria-label="AI Workflows" />,
+	AITabNav: () => <nav data-testid="ai-tab-nav" aria-label="AI views" />,
 }));
 
 vi.mock("@/lib/filters/encode", () => ({
@@ -24,11 +24,11 @@ vi.mock("@/lib/filters/encode", () => ({
 }));
 
 describe("AIWorkspaceChrome", () => {
-	it("renders the 'AI Workflows' area title as the page-level h1", () => {
+	it("renders the AI area title as the page-level h1", () => {
 		render(<AIWorkspaceChrome>content</AIWorkspaceChrome>);
 		const areaTitle = screen.getByRole("heading", {
 			level: 1,
-			name: "AI Workflows",
+			name: "AI",
 		});
 		expect(areaTitle).toBeInTheDocument();
 	});
@@ -37,7 +37,7 @@ describe("AIWorkspaceChrome", () => {
 		render(<AIWorkspaceChrome>content</AIWorkspaceChrome>);
 		const areaTitle = screen.getByRole("heading", {
 			level: 1,
-			name: "AI Workflows",
+			name: "AI",
 		});
 		const tabNav = screen.getByTestId("ai-tab-nav");
 		// DOCUMENT_POSITION_FOLLOWING (4) => tabNav comes after the area title.
@@ -49,23 +49,22 @@ describe("AIWorkspaceChrome", () => {
 
 	it("renders the area title matching the sidebar label (A6 agreement)", () => {
 		render(<AIWorkspaceChrome>content</AIWorkspaceChrome>);
-		// PrimaryNav active="ai-workflows" => label "AI Workflows".
 		expect(
-			screen.getByRole("heading", { level: 1, name: "AI Workflows" }),
+			screen.getByRole("heading", { level: 1, name: "AI" }),
 		).toBeInTheDocument();
 	});
 
 	it("demotes the per-tab title to a subordinate h2", () => {
 		render(
 			<AIWorkspaceChrome>
-				<AIPageHeader eyebrow="AI workflows" title="Impact">
+				<AIPageHeader eyebrow="AI" title="Impact">
 					Per-tab lede copy.
 				</AIPageHeader>
 			</AIWorkspaceChrome>,
 		);
 		// Area identity is the single h1.
 		expect(
-			screen.getByRole("heading", { level: 1, name: "AI Workflows" }),
+			screen.getByRole("heading", { level: 1, name: "AI" }),
 		).toBeInTheDocument();
 		// Per-tab name reads as a sub-section heading.
 		const tabTitle = screen.getByRole("heading", { level: 2, name: "Impact" });

--- a/src/components/ai/AIWorkspaceChrome.tsx
+++ b/src/components/ai/AIWorkspaceChrome.tsx
@@ -7,15 +7,6 @@ import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { AITabNav } from "./AITabNav";
 
-/**
- * Shared chrome for the unified AI Workflows area. Rendered once via
- * `src/app/(app)/ai/layout.tsx` so all AI tabs share a single sidebar entry
- * (`active="ai-workflows"`) plus one tab strip.
- *
- * Filters are read client-side from the URL because Next.js layouts do not
- * receive `searchParams`. This mirrors the `f`/`role` query convention used by
- * the per-page server components so deep links keep working.
- */
 export function AIWorkspaceChrome({ children }: { children: ReactNode }) {
 	const searchParams = useSearchParams();
 
@@ -37,16 +28,17 @@ export function AIWorkspaceChrome({ children }: { children: ReactNode }) {
 	return (
 		<div className="min-h-screen bg-background text-foreground">
 			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-				<PrimaryNav filters={filters} active="ai-workflows" role={role} />
+				<PrimaryNav filters={filters} active="ai" role={role} />
 				<main className="flex min-w-0 flex-1 flex-col gap-8">
 					<header className="flex flex-col gap-2">
 						<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-							Operating modes
+							Decision area
 						</p>
-						<h1 className="font-(--font-display) text-3xl">AI Workflows</h1>
+						<h1 className="font-(--font-display) text-3xl">AI</h1>
 						<p className="max-w-3xl text-sm text-(--ink-muted)">
-							Where AI-assisted effort shows up across delivery, review, and
-							risk. Switch tabs to explore each surface.
+							What AI is changing across delivery, review, quality, and
+							governance. Open a real view to inspect the evidence-backed
+							surface.
 						</p>
 					</header>
 					<AITabNav filters={filters} role={role} />

--- a/src/components/navigation/PrimaryNav.test.tsx
+++ b/src/components/navigation/PrimaryNav.test.tsx
@@ -8,436 +8,478 @@ import type { MetricFilter } from "@/lib/filters/types";
 const navigationMock = vi.hoisted(() => ({ pathname: "/dashboard" }));
 
 vi.mock("next/navigation", () => ({
-  usePathname: () => navigationMock.pathname,
-  useRouter: () => ({ refresh: vi.fn() }),
+	usePathname: () => navigationMock.pathname,
+	useRouter: () => ({ refresh: vi.fn() }),
 }));
 
 vi.mock("next-auth/react", () => ({
-  useSession: () => ({
-    data: { user: { org_id: "org-1" } },
-    update: vi.fn(),
-  }),
+	useSession: () => ({
+		data: { user: { org_id: "org-1" } },
+		update: vi.fn(),
+	}),
 }));
 
 function makeFilter(): MetricFilter {
-  return {
-    scope: { level: "repo", ids: ["my-repo"] },
-    time: {
-      range_days: 30,
-      compare_days: 0,
-      start_date: undefined,
-      end_date: undefined,
-    },
-    who: {},
-    what: {},
-    why: {},
-    how: {},
-  };
+	return {
+		scope: { level: "repo", ids: ["my-repo"] },
+		time: {
+			range_days: 30,
+			compare_days: 0,
+			start_date: undefined,
+			end_date: undefined,
+		},
+		who: {},
+		what: {},
+		why: {},
+		how: {},
+	};
 }
 
 beforeEach(() => {
-  navigationMock.pathname = "/dashboard";
+	navigationMock.pathname = "/dashboard";
 });
 
 function currentPageLinks() {
-  return screen.getAllByRole("link").filter((link) => link.getAttribute("aria-current") === "page");
+	return screen
+		.getAllByRole("link")
+		.filter((link) => link.getAttribute("aria-current") === "page");
 }
 
 describe("PrimaryNav — two-level decision-area surface (CHAOS-2079)", () => {
-  it("always renders the eight area rows", () => {
-    render(<PrimaryNav filters={makeFilter()} active="home" />);
+	it("always renders the eight area rows", () => {
+		render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-    for (const name of [
-      /^Cockpit$/i,
-      /^Diagnose$/i,
-      /^Plan$/i,
-      /^Improve$/i,
-      /^Govern$/i,
-      /^AI$/i,
-      /^Reports$/i,
-      /^Admin$/i,
-    ]) {
-      expect(screen.getByRole("link", { name })).toBeInTheDocument();
-    }
-  });
+		for (const name of [
+			/^Cockpit$/i,
+			/^Diagnose$/i,
+			/^Plan$/i,
+			/^Improve$/i,
+			/^Govern$/i,
+			/^AI$/i,
+			/^Reports$/i,
+			/^Admin$/i,
+		]) {
+			expect(screen.getByRole("link", { name })).toBeInTheDocument();
+		}
+	});
 
-  it("on a childless area (Cockpit) renders only the eight area rows", () => {
-    // Cockpit has no expandable children, so the sidebar shows exactly the areas.
-    navigationMock.pathname = "/dashboard";
-    render(<PrimaryNav filters={makeFilter()} active="home" />);
+	it("on a childless area (Cockpit) renders only the eight area rows", () => {
+		// Cockpit has no expandable children, so the sidebar shows exactly the areas.
+		navigationMock.pathname = "/dashboard";
+		render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-    const linkNames = screen
-      .getAllByRole("link")
-      .map((link) => (link.textContent ?? "").replace(/\s+/g, " ").trim());
+		const linkNames = screen
+			.getAllByRole("link")
+			.map((link) => (link.textContent ?? "").replace(/\s+/g, " ").trim());
 
-    expect(linkNames).toEqual([
-      "Cockpit",
-      "Diagnose",
-      "Plan",
-      "Improve",
-      "Govern",
-      "AI",
-      "Reports",
-      "Admin",
-    ]);
-  });
+		expect(linkNames).toEqual([
+			"Cockpit",
+			"Diagnose",
+			"Plan",
+			"Improve",
+			"Govern",
+			"AI",
+			"Reports",
+			"Admin",
+		]);
+	});
 
-  it("renders no expand/collapse buttons — rows are links, not toggles", () => {
-    render(<PrimaryNav filters={makeFilter()} active="home" />);
-    expect(screen.queryAllByRole("button")).toHaveLength(0);
-  });
+	it("renders no expand/collapse buttons — rows are links, not toggles", () => {
+		render(<PrimaryNav filters={makeFilter()} active="home" />);
+		expect(screen.queryAllByRole("button")).toHaveLength(0);
+	});
 
-  it("expands ONLY the active area's children; inactive areas stay collapsed", () => {
-    navigationMock.pathname = "/work";
-    render(<PrimaryNav filters={makeFilter()} active="work" />);
+	it("expands ONLY the active area's children; inactive areas stay collapsed", () => {
+		navigationMock.pathname = "/work";
+		render(<PrimaryNav filters={makeFilter()} active="work" />);
 
-    // Diagnose is active → its children render as indented rows.
-    expect(screen.getByTestId("nav-children-diagnose")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /^Flow$/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /^Bottlenecks$/i })).toBeInTheDocument();
+		// Diagnose is active → its children render as indented rows.
+		expect(screen.getByTestId("nav-children-diagnose")).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /^Flow$/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Bottlenecks$/i }),
+		).toBeInTheDocument();
 
-    // Govern is NOT active → none of its children appear.
-    expect(screen.queryByTestId("nav-children-govern")).toBeNull();
-    expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
-    expect(screen.queryByRole("link", { name: /^Security$/i })).toBeNull();
-  });
+		// Govern is NOT active → none of its children appear.
+		expect(screen.queryByTestId("nav-children-govern")).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Security$/i })).toBeNull();
+	});
 
-  it("never renders preview (navVisible:false) children — verified via Improve", () => {
-    // Improve's only navVisible child is Opportunities; Experiments and
-    // Automations are preview routes (J5) and must never render in the sidebar.
-    navigationMock.pathname = "/opportunities";
-    render(<PrimaryNav filters={makeFilter()} active="opportunities" />);
+	it("never renders preview (navVisible:false) children — verified via Improve", () => {
+		// Improve's only navVisible child is Opportunities; Experiments and
+		// Automations are preview routes (J5) and must never render in the sidebar.
+		navigationMock.pathname = "/opportunities";
+		render(<PrimaryNav filters={makeFilter()} active="opportunities" />);
 
-    expect(screen.getByRole("link", { name: /^Opportunities$/i })).toBeInTheDocument();
-    // No phantom/preview rows ever rendered.
-    expect(screen.queryByRole("link", { name: /^Experiments$/i })).toBeNull();
-    expect(screen.queryByRole("link", { name: /^Automations$/i })).toBeNull();
-  });
+		expect(
+			screen.getByRole("link", { name: /^Opportunities$/i }),
+		).toBeInTheDocument();
+		// No phantom/preview rows ever rendered.
+		expect(screen.queryByRole("link", { name: /^Experiments$/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Automations$/i })).toBeNull();
+	});
 
-  it("never renders redirect-only AI tabs as sidebar children", () => {
-    // AI is first-class (CHAOS-2079). Its real destinations expand as children;
-    // the redirect-only tabs (Impact/Attribution/Test Gaps/Evidence/Automations)
-    // are preview routes and must NOT appear in the sidebar (Framework A2).
-    navigationMock.pathname = "/ai/review-load";
-    render(<PrimaryNav filters={makeFilter()} active="ai" />);
+	it("renders real AI children and hides preview-only AI routes", () => {
+		navigationMock.pathname = "/ai/review-load";
+		render(<PrimaryNav filters={makeFilter()} active="ai" />);
 
-    // Real AI destinations render as sidebar children.
-    expect(screen.getByRole("link", { name: /^Overview$/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /^Review Load$/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /^Governance Risk$/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Overview$/i }),
+		).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /^Impact$/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Review Load$/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Governance Risk$/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Automations$/i }),
+		).toBeInTheDocument();
 
-    // Redirect-only preview tabs never appear in the sidebar.
-    for (const tab of [
-      /^Impact$/i,
-      /^Attribution$/i,
-      /^Test Gaps$/i,
-      /^Evidence$/i,
-      /^Automations$/i,
-    ]) {
-      expect(screen.queryByRole("link", { name: tab })).toBeNull();
-    }
-  });
+		for (const tab of [/^Attribution$/i, /^Test Gaps$/i, /^Evidence$/i]) {
+			expect(screen.queryByRole("link", { name: tab })).toBeNull();
+		}
+	});
 
-  it("fans out Tests / Quality / Coverage as separate Govern rows (no cluster)", () => {
-    navigationMock.pathname = "/testops/tests";
-    render(<PrimaryNav filters={makeFilter()} active="tests" />);
+	it("fans out Tests / Quality / Coverage as separate Govern rows (no cluster)", () => {
+		navigationMock.pathname = "/testops/tests";
+		render(<PrimaryNav filters={makeFilter()} active="tests" />);
 
-    // CHAOS-2079: the Tests · Quality · Coverage cluster is gone — each is a row.
-    expect(screen.queryByRole("link", { name: /Tests · Quality · Coverage/i })).toBeNull();
-    expect(screen.getByRole("link", { name: /^Tests$/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /^Quality$/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /^Coverage$/i })).toBeInTheDocument();
-    // Pipelines stays its own row.
-    expect(screen.getByRole("link", { name: /^Pipelines$/i })).toBeInTheDocument();
-  });
+		// CHAOS-2079: the Tests · Quality · Coverage cluster is gone — each is a row.
+		expect(
+			screen.queryByRole("link", { name: /Tests · Quality · Coverage/i }),
+		).toBeNull();
+		expect(screen.getByRole("link", { name: /^Tests$/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Quality$/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Coverage$/i }),
+		).toBeInTheDocument();
+		// Pipelines stays its own row.
+		expect(
+			screen.getByRole("link", { name: /^Pipelines$/i }),
+		).toBeInTheDocument();
+	});
 
-  it("links each area to its landing route", () => {
-    render(<PrimaryNav filters={makeFilter()} active="home" />);
+	it("links each area to its landing route", () => {
+		render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-    const expectations: Array<[RegExp, string]> = [
-      [/^Cockpit$/i, "/dashboard"],
-      [/^Diagnose$/i, "/work"],
-      [/^Plan$/i, "/plan"],
-      [/^Improve$/i, "/opportunities"],
-      [/^Govern$/i, "/testops"],
-      [/^AI$/i, "/ai"],
-      [/^Reports$/i, "/reports"],
-      [/^Admin$/i, "/admin"],
-    ];
+		const expectations: Array<[RegExp, string]> = [
+			[/^Cockpit$/i, "/dashboard"],
+			[/^Diagnose$/i, "/work"],
+			[/^Plan$/i, "/plan"],
+			[/^Improve$/i, "/opportunities"],
+			[/^Govern$/i, "/testops"],
+			[/^AI$/i, "/ai"],
+			[/^Reports$/i, "/reports"],
+			[/^Admin$/i, "/admin"],
+		];
 
-    for (const [name, href] of expectations) {
-      expect(screen.getByRole("link", { name })).toHaveAttribute(
-        "href",
-        expect.stringContaining(href),
-      );
-    }
-  });
+		for (const [name, href] of expectations) {
+			expect(screen.getByRole("link", { name })).toHaveAttribute(
+				"href",
+				expect.stringContaining(href),
+			);
+		}
+	});
 });
 
 describe("PrimaryNav — active child highlight (A10: one selected, distinct hover)", () => {
-  it.each([
-    { pathname: "/metrics", active: "metrics", child: /^Flow$/i },
-    { pathname: "/ai/review-load", active: "ai", child: /^Review Load$/i },
-    {
-      pathname: "/operating-review",
-      active: "operating-review",
-      child: /^Operating Review$/i,
-    },
-    { pathname: "/testops/coverage", active: "coverage", child: /^Coverage$/i },
-    { pathname: "/quality", active: "quality", child: /^Quality$/i },
-    { pathname: "/testops/tests", active: "tests", child: /^Tests$/i },
-  ])("marks exactly the child $child current for $pathname", ({ pathname, active, child }) => {
-    navigationMock.pathname = pathname;
-    render(<PrimaryNav filters={makeFilter()} active={active} />);
+	it.each([
+		{ pathname: "/metrics", active: "metrics", child: /^Flow$/i },
+		{ pathname: "/ai/review-load", active: "ai", child: /^Review Load$/i },
+		{
+			pathname: "/operating-review",
+			active: "operating-review",
+			child: /^Operating Review$/i,
+		},
+		{ pathname: "/testops/coverage", active: "coverage", child: /^Coverage$/i },
+		{ pathname: "/quality", active: "quality", child: /^Quality$/i },
+		{ pathname: "/testops/tests", active: "tests", child: /^Tests$/i },
+	])("marks exactly the child $child current for $pathname", ({
+		pathname,
+		active,
+		child,
+	}) => {
+		navigationMock.pathname = pathname;
+		render(<PrimaryNav filters={makeFilter()} active={active} />);
 
-    expect(screen.getByRole("link", { name: child })).toHaveAttribute("aria-current", "page");
-    // A10: exactly one selected destination across the whole sidebar.
-    expect(currentPageLinks()).toHaveLength(1);
-  });
+		expect(screen.getByRole("link", { name: child })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		// A10: exactly one selected destination across the whole sidebar.
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-  it("highlights the area row (not a child) on the area landing route", () => {
-    // /dashboard → Cockpit (no children); the area row itself is current.
-    navigationMock.pathname = "/dashboard";
-    render(<PrimaryNav filters={makeFilter()} active="home" />);
+	it("highlights the area row (not a child) on the area landing route", () => {
+		// /dashboard → Cockpit (no children); the area row itself is current.
+		navigationMock.pathname = "/dashboard";
+		render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-    expect(screen.getByRole("link", { name: /^Cockpit$/i })).toHaveAttribute(
-      "aria-current",
-      "page",
-    );
-    expect(currentPageLinks()).toHaveLength(1);
-  });
+		expect(screen.getByRole("link", { name: /^Cockpit$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-  it("does not mark the area row current when one of its children is active", () => {
-    // On /metrics the active destination is the Flow CHILD, so the Diagnose
-    // AREA row must NOT also carry aria-current (no double-selection, A10).
-    navigationMock.pathname = "/metrics";
-    render(<PrimaryNav filters={makeFilter()} active="metrics" />);
+	it("does not mark the area row current when one of its children is active", () => {
+		// On /metrics the active destination is the Flow CHILD, so the Diagnose
+		// AREA row must NOT also carry aria-current (no double-selection, A10).
+		navigationMock.pathname = "/metrics";
+		render(<PrimaryNav filters={makeFilter()} active="metrics" />);
 
-    expect(screen.getByRole("link", { name: /^Diagnose$/i })).not.toHaveAttribute("aria-current");
-    expect(screen.getByRole("link", { name: /^Flow$/i })).toHaveAttribute("aria-current", "page");
-  });
+		expect(
+			screen.getByRole("link", { name: /^Diagnose$/i }),
+		).not.toHaveAttribute("aria-current");
+		expect(screen.getByRole("link", { name: /^Flow$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+	});
 });
 
 describe("PrimaryNav — active-area resolution (A10: one selected at a time)", () => {
-  // Each row resolves to its owning area, and exactly one destination is
-  // selected sidebar-wide (A10). On an area-LANDING route the area row is the
-  // selection; on a CHILD route a child row inside that area is. `landing`
-  // flags whether the area row itself should carry aria-current.
-  it.each([
-    {
-      pathname: "/dashboard",
-      active: "home",
-      area: /^Cockpit$/i,
-      landing: true,
-    },
-    {
-      pathname: "/operating-review",
-      active: "operating-review",
-      area: /^Plan$/i,
-      landing: false,
-    },
-    { pathname: "/work", active: "work", area: /^Diagnose$/i, landing: true },
-    {
-      pathname: "/metrics",
-      active: "metrics",
-      area: /^Diagnose$/i,
-      landing: false,
-    },
-    {
-      pathname: "/people",
-      active: "people",
-      area: /^Diagnose$/i,
-      landing: false,
-    },
-    {
-      pathname: "/complexity",
-      active: "complexity",
-      area: /^Diagnose$/i,
-      landing: false,
-    },
-    {
-      pathname: "/bottleneck",
-      active: "bottleneck",
-      area: /^Diagnose$/i,
-      landing: false,
-    },
-    {
-      pathname: "/landscape",
-      active: "landscape",
-      area: /^Diagnose$/i,
-      landing: false,
-    },
-    {
-      pathname: "/opportunities",
-      active: "opportunities",
-      area: /^Improve$/i,
-      landing: true,
-    },
-    {
-      pathname: "/plan/delivery-forecast",
-      active: "delivery-forecast",
-      area: /^Plan$/i,
-      landing: false,
-    },
-    {
-      pathname: "/ai/review-load",
-      active: "ai",
-      area: /^AI$/i,
-      landing: false,
-    },
-    {
-      pathname: "/testops",
-      active: "testops",
-      area: /^Govern$/i,
-      landing: true,
-    },
-    {
-      pathname: "/testops/risk",
-      active: "risk",
-      area: /^Govern$/i,
-      landing: false,
-    },
-    {
-      pathname: "/quality",
-      active: "quality",
-      area: /^Govern$/i,
-      landing: false,
-    },
-    {
-      pathname: "/security",
-      active: "security",
-      area: /^Govern$/i,
-      landing: false,
-    },
-    {
-      pathname: "/risk/compounding",
-      active: "risk-compounding",
-      area: /^Govern$/i,
-      landing: false,
-    },
-    {
-      pathname: "/reports",
-      active: "reports",
-      area: /^Reports$/i,
-      landing: true,
-    },
-    { pathname: "/admin", active: "admin", area: /^Admin$/i, landing: true },
-  ])(
-    "resolves route $pathname to its owning area with exactly one selection",
-    ({ pathname, active, area, landing }) => {
-      navigationMock.pathname = pathname;
-      render(<PrimaryNav filters={makeFilter()} active={active} />);
+	// Each row resolves to its owning area, and exactly one destination is
+	// selected sidebar-wide (A10). On an area-LANDING route the area row is the
+	// selection; on a CHILD route a child row inside that area is. `landing`
+	// flags whether the area row itself should carry aria-current.
+	it.each([
+		{
+			pathname: "/dashboard",
+			active: "home",
+			area: /^Cockpit$/i,
+			landing: true,
+		},
+		{
+			pathname: "/operating-review",
+			active: "operating-review",
+			area: /^Plan$/i,
+			landing: false,
+		},
+		{ pathname: "/work", active: "work", area: /^Diagnose$/i, landing: true },
+		{
+			pathname: "/metrics",
+			active: "metrics",
+			area: /^Diagnose$/i,
+			landing: false,
+		},
+		{
+			pathname: "/people",
+			active: "people",
+			area: /^Diagnose$/i,
+			landing: false,
+		},
+		{
+			pathname: "/complexity",
+			active: "complexity",
+			area: /^Diagnose$/i,
+			landing: false,
+		},
+		{
+			pathname: "/bottleneck",
+			active: "bottleneck",
+			area: /^Diagnose$/i,
+			landing: false,
+		},
+		{
+			pathname: "/landscape",
+			active: "landscape",
+			area: /^Diagnose$/i,
+			landing: false,
+		},
+		{
+			pathname: "/opportunities",
+			active: "opportunities",
+			area: /^Improve$/i,
+			landing: true,
+		},
+		{
+			pathname: "/plan/delivery-forecast",
+			active: "delivery-forecast",
+			area: /^Plan$/i,
+			landing: false,
+		},
+		{
+			pathname: "/ai/review-load",
+			active: "ai",
+			area: /^AI$/i,
+			landing: false,
+		},
+		{
+			pathname: "/testops",
+			active: "testops",
+			area: /^Govern$/i,
+			landing: true,
+		},
+		{
+			pathname: "/testops/risk",
+			active: "risk",
+			area: /^Govern$/i,
+			landing: false,
+		},
+		{
+			pathname: "/quality",
+			active: "quality",
+			area: /^Govern$/i,
+			landing: false,
+		},
+		{
+			pathname: "/security",
+			active: "security",
+			area: /^Govern$/i,
+			landing: false,
+		},
+		{
+			pathname: "/risk/compounding",
+			active: "risk-compounding",
+			area: /^Govern$/i,
+			landing: false,
+		},
+		{
+			pathname: "/reports",
+			active: "reports",
+			area: /^Reports$/i,
+			landing: true,
+		},
+		{ pathname: "/admin", active: "admin", area: /^Admin$/i, landing: true },
+	])("resolves route $pathname to its owning area with exactly one selection", ({
+		pathname,
+		active,
+		area,
+		landing,
+	}) => {
+		navigationMock.pathname = pathname;
+		render(<PrimaryNav filters={makeFilter()} active={active} />);
 
-      // The owning area row is always rendered.
-      const areaRow = screen.getByRole("link", { name: area });
-      expect(areaRow).toBeInTheDocument();
-      // The area row carries aria-current only on its own landing route.
-      if (landing) {
-        expect(areaRow).toHaveAttribute("aria-current", "page");
-      } else {
-        expect(areaRow).not.toHaveAttribute("aria-current");
-      }
-      // A10: exactly one selected destination across the whole sidebar.
-      expect(currentPageLinks()).toHaveLength(1);
-    },
-  );
+		// The owning area row is always rendered.
+		const areaRow = screen.getByRole("link", { name: area });
+		expect(areaRow).toBeInTheDocument();
+		// The area row carries aria-current only on its own landing route.
+		if (landing) {
+			expect(areaRow).toHaveAttribute("aria-current", "page");
+		} else {
+			expect(areaRow).not.toHaveAttribute("aria-current");
+		}
+		// A10: exactly one selected destination across the whole sidebar.
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-  it("uses the longest pathname match and ignores a stale active prop", () => {
-    // /testops/risk belongs to Govern; the stale active="people" (Diagnose) must lose.
-    navigationMock.pathname = "/testops/risk";
-    render(<PrimaryNav filters={makeFilter()} active="people" />);
+	it("uses the longest pathname match and ignores a stale active prop", () => {
+		// /testops/risk belongs to Govern; the stale active="people" (Diagnose) must lose.
+		navigationMock.pathname = "/testops/risk";
+		render(<PrimaryNav filters={makeFilter()} active="people" />);
 
-    // Govern is the active area (its Delivery Risk child is the selection).
-    expect(screen.getByTestId("nav-children-govern")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /^Delivery Risk$/i })).toHaveAttribute(
-      "aria-current",
-      "page",
-    );
-    // Diagnose lost: not selected and not expanded.
-    expect(screen.getByRole("link", { name: /^Diagnose$/i })).not.toHaveAttribute("aria-current");
-    expect(screen.queryByTestId("nav-children-diagnose")).toBeNull();
-    expect(currentPageLinks()).toHaveLength(1);
-  });
+		// Govern is the active area (its Delivery Risk child is the selection).
+		expect(screen.getByTestId("nav-children-govern")).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Delivery Risk$/i }),
+		).toHaveAttribute("aria-current", "page");
+		// Diagnose lost: not selected and not expanded.
+		expect(
+			screen.getByRole("link", { name: /^Diagnose$/i }),
+		).not.toHaveAttribute("aria-current");
+		expect(screen.queryByTestId("nav-children-diagnose")).toBeNull();
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-  it("falls back to the active prop's area when no pathname prefix matches", () => {
-    // Evidence/detail routes (e.g. /prs/[id]) are not owned by any area prefix.
-    navigationMock.pathname = "/prs/123";
-    render(<PrimaryNav filters={makeFilter()} active="people" />);
+	it("falls back to the active prop's area when no pathname prefix matches", () => {
+		// Evidence/detail routes (e.g. /prs/[id]) are not owned by any area prefix.
+		navigationMock.pathname = "/prs/123";
+		render(<PrimaryNav filters={makeFilter()} active="people" />);
 
-    expect(screen.getByRole("link", { name: /^Diagnose$/i })).toHaveAttribute(
-      "aria-current",
-      "page",
-    );
-    expect(currentPageLinks()).toHaveLength(1);
-  });
+		expect(screen.getByRole("link", { name: /^Diagnose$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-  // REVIEW W1: /testops → Govern row active; Overview child rendered but NOT active.
-  it("pathname /testops → Govern area row active, Overview child rendered but not active (W1)", () => {
-    navigationMock.pathname = "/testops";
-    render(<PrimaryNav filters={makeFilter()} active="testops" />);
+	// REVIEW W1: /testops → Govern row active; Overview child rendered but NOT active.
+	it("pathname /testops → Govern area row active, Overview child rendered but not active (W1)", () => {
+		navigationMock.pathname = "/testops";
+		render(<PrimaryNav filters={makeFilter()} active="testops" />);
 
-    // Govern area row is the current page (area landing).
-    expect(screen.getByRole("link", { name: /^Govern$/i })).toHaveAttribute("aria-current", "page");
-    // Overview child is rendered (Govern is a main area and is active).
-    expect(screen.getByRole("link", { name: /^Overview$/i })).toBeInTheDocument();
-    // Overview child is NOT marked current (the area row owns the highlight).
-    expect(screen.getByRole("link", { name: /^Overview$/i })).not.toHaveAttribute("aria-current");
-    // A10: exactly one current-page link.
-    expect(currentPageLinks()).toHaveLength(1);
-  });
+		// Govern area row is the current page (area landing).
+		expect(screen.getByRole("link", { name: /^Govern$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		// Overview child is rendered (Govern is a main area and is active).
+		expect(
+			screen.getByRole("link", { name: /^Overview$/i }),
+		).toBeInTheDocument();
+		// Overview child is NOT marked current (the area row owns the highlight).
+		expect(
+			screen.getByRole("link", { name: /^Overview$/i }),
+		).not.toHaveAttribute("aria-current");
+		// A10: exactly one current-page link.
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-  // REVIEW W2: /testops/pipelines → Pipelines child active; Tests + Overview NOT active.
-  it("pathname /testops/pipelines → Pipelines child active, not Tests or Overview (W2)", () => {
-    navigationMock.pathname = "/testops/pipelines";
-    render(<PrimaryNav filters={makeFilter()} active="pipelines" />);
+	// REVIEW W2: /testops/pipelines → Pipelines child active; Tests + Overview NOT active.
+	it("pathname /testops/pipelines → Pipelines child active, not Tests or Overview (W2)", () => {
+		navigationMock.pathname = "/testops/pipelines";
+		render(<PrimaryNav filters={makeFilter()} active="pipelines" />);
 
-    // Pipelines child is the current page.
-    expect(screen.getByRole("link", { name: /^Pipelines$/i })).toHaveAttribute(
-      "aria-current",
-      "page",
-    );
-    // Sibling rows are rendered but NOT active.
-    expect(screen.getByRole("link", { name: /^Tests$/i })).not.toHaveAttribute("aria-current");
-    expect(screen.getByRole("link", { name: /^Overview$/i })).not.toHaveAttribute("aria-current");
-    // A10: exactly one current-page link.
-    expect(currentPageLinks()).toHaveLength(1);
-  });
+		// Pipelines child is the current page.
+		expect(screen.getByRole("link", { name: /^Pipelines$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		// Sibling rows are rendered but NOT active.
+		expect(screen.getByRole("link", { name: /^Tests$/i })).not.toHaveAttribute(
+			"aria-current",
+		);
+		expect(
+			screen.getByRole("link", { name: /^Overview$/i }),
+		).not.toHaveAttribute("aria-current");
+		// A10: exactly one current-page link.
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 });
 
 describe("PrimaryNav — utility-area gate (owner directive)", () => {
-  // Utility-placement areas (Reports, Admin) must render as plain rows with NO
-  // child expansion even when active. Only main-placement areas expand.
+	// Utility-placement areas (Reports, Admin) must render as plain rows with NO
+	// child expansion even when active. Only main-placement areas expand.
 
-  it("Reports area renders NO child rows when active at /reports", () => {
-    navigationMock.pathname = "/reports";
-    render(<PrimaryNav filters={makeFilter()} active="reports" />);
+	it("Reports area renders NO child rows when active at /reports", () => {
+		navigationMock.pathname = "/reports";
+		render(<PrimaryNav filters={makeFilter()} active="reports" />);
 
-    // Reports row is rendered and marked current (it's the area landing).
-    expect(screen.getByRole("link", { name: /^Reports$/i })).toHaveAttribute(
-      "aria-current",
-      "page",
-    );
-    // NO child container rendered for Reports.
-    expect(screen.queryByTestId("nav-children-reports")).toBeNull();
-    // Report Center (a navVisible child) must NOT appear in the sidebar.
-    expect(screen.queryByRole("link", { name: /^Report Center$/i })).toBeNull();
-    // Preview rows also absent (they were already suppressed, still absent).
-    expect(screen.queryByRole("link", { name: /^Weekly Review$/i })).toBeNull();
-    // A10: exactly one current-page link.
-    expect(currentPageLinks()).toHaveLength(1);
-  });
+		// Reports row is rendered and marked current (it's the area landing).
+		expect(screen.getByRole("link", { name: /^Reports$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		// NO child container rendered for Reports.
+		expect(screen.queryByTestId("nav-children-reports")).toBeNull();
+		// Report Center (a navVisible child) must NOT appear in the sidebar.
+		expect(screen.queryByRole("link", { name: /^Report Center$/i })).toBeNull();
+		// Preview rows also absent (they were already suppressed, still absent).
+		expect(screen.queryByRole("link", { name: /^Weekly Review$/i })).toBeNull();
+		// A10: exactly one current-page link.
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-  it("Admin area renders NO child rows when active at /admin/settings", () => {
-    navigationMock.pathname = "/admin/settings";
-    render(<PrimaryNav filters={makeFilter()} active="settings" />);
+	it("Admin area renders NO child rows when active at /admin/settings", () => {
+		navigationMock.pathname = "/admin/settings";
+		render(<PrimaryNav filters={makeFilter()} active="settings" />);
 
-    // Admin row is active (but the child Settings would have been current if expanded).
-    // Under the utility gate, no children render at all.
-    expect(screen.queryByTestId("nav-children-admin")).toBeNull();
-    expect(screen.queryByRole("link", { name: /^Settings$/i })).toBeNull();
-    expect(screen.queryByRole("link", { name: /^Connections$/i })).toBeNull();
-    // The Admin area row itself is the sole current-page link (no child selection).
-    expect(screen.getByRole("link", { name: /^Admin$/i })).toHaveAttribute("aria-current", "page");
-    expect(currentPageLinks()).toHaveLength(1);
-  });
+		// Admin row is active (but the child Settings would have been current if expanded).
+		// Under the utility gate, no children render at all.
+		expect(screen.queryByTestId("nav-children-admin")).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Settings$/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Connections$/i })).toBeNull();
+		// The Admin area row itself is the sole current-page link (no child selection).
+		expect(screen.getByRole("link", { name: /^Admin$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 });

--- a/src/lib/areaSignals/index.ts
+++ b/src/lib/areaSignals/index.ts
@@ -26,47 +26,54 @@ export { getImproveSignals } from "./improve";
  * return `[]` (no signal grid).
  */
 export async function getAreaSignals(
-  areaId: NavAreaId,
-  filters: MetricFilter,
-  isTestMode = false,
+	areaId: NavAreaId,
+	filters: MetricFilter,
+	isTestMode = false,
 ): Promise<AreaSignal[]> {
-  switch (areaId) {
-    case "govern":
-      return getGovernSignals(filters, isTestMode);
-    case "diagnose":
-      return getDiagnoseSignals(filters, isTestMode);
-    case "improve":
-      return getImproveSignals(filters, isTestMode);
-    case "plan":
-      void filters;
-      void isTestMode;
-      return descriptorStubs(areaId, "unavailable");
-    case "cockpit":
-      // Cockpit's single sub-area (Operating Review) has no severity metric; it
-      // is a navigational surface. Render it as a calm "neutral" card rather
-      // than implying a finding (leave-as-is per CHAOS-2074).
-      return descriptorStubs(areaId, "neutral");
-    default:
-      // reports / admin — no signal grid.
-      return [];
-  }
+	switch (areaId) {
+		case "govern":
+			return getGovernSignals(filters, isTestMode);
+		case "diagnose":
+			return getDiagnoseSignals(filters, isTestMode);
+		case "improve":
+			return getImproveSignals(filters, isTestMode);
+		case "plan":
+			void filters;
+			void isTestMode;
+			return descriptorStubs(areaId, "unavailable");
+		case "ai":
+			void filters;
+			void isTestMode;
+			return descriptorStubs(areaId, "unavailable");
+		case "cockpit":
+			// Cockpit's single sub-area (Operating Review) has no severity metric; it
+			// is a navigational surface. Render it as a calm "neutral" card rather
+			// than implying a finding (leave-as-is per CHAOS-2074).
+			return descriptorStubs(areaId, "neutral");
+		default:
+			// reports / admin — no signal grid.
+			return [];
+	}
 }
 
 /**
  * Map an area's nav descriptors to placeholder `AreaSignal`s in a given state.
  * "neutral" → calm navigational card for areas without severity metrics.
  */
-function descriptorStubs(areaId: NavAreaId, state: "unavailable" | "neutral"): AreaSignal[] {
-  const area = getAreaById(areaId);
-  if (!area) return [];
-  return area.hubItems.map((item) => ({
-    id: item.id,
-    label: item.label,
-    href: item.href,
-    cluster: item.cluster,
-    metricLabel: item.metricLabel ?? item.description ?? item.label,
-    value: "",
-    state,
-    demoted: item.demoted,
-  }));
+function descriptorStubs(
+	areaId: NavAreaId,
+	state: "unavailable" | "neutral",
+): AreaSignal[] {
+	const area = getAreaById(areaId);
+	if (!area) return [];
+	return area.hubItems.map((item) => ({
+		id: item.id,
+		label: item.label,
+		href: item.href,
+		cluster: item.cluster,
+		metricLabel: item.metricLabel ?? item.description ?? item.label,
+		value: "",
+		state,
+		demoted: item.demoted,
+	}));
 }

--- a/src/lib/navigation/__tests__/areas.test.ts
+++ b/src/lib/navigation/__tests__/areas.test.ts
@@ -3,282 +3,326 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 import {
-  navAreas,
-  getAreaById,
-  selectedAreaIdForPathname,
-  selectedChildForPathname,
-  navTrailForPathname,
-  navTitleForPathname,
-  type NavAreaId,
+	navAreas,
+	getAreaById,
+	selectedAreaIdForPathname,
+	selectedChildForPathname,
+	navTrailForPathname,
+	navTitleForPathname,
+	type NavAreaId,
 } from "../areas";
 
 const basePath = (href: string) => href.split("?")[0].split("#")[0];
 
 const areaById = (id: NavAreaId) => {
-  const area = getAreaById(id);
-  if (!area) throw new Error(`missing area ${id}`);
-  return area;
+	const area = getAreaById(id);
+	if (!area) throw new Error(`missing area ${id}`);
+	return area;
 };
 
 const routePageExists = (routePath: string) => {
-  const segments = basePath(routePath).split("/").filter(Boolean);
-  return [
-    join(process.cwd(), "src/app/(app)", ...segments, "page.tsx"),
-    join(process.cwd(), "src/app", ...segments, "page.tsx"),
-  ].some((candidate) => existsSync(candidate));
+	const segments = basePath(routePath).split("/").filter(Boolean);
+	return [
+		join(process.cwd(), "src/app/(app)", ...segments, "page.tsx"),
+		join(process.cwd(), "src/app", ...segments, "page.tsx"),
+	].some((candidate) => existsSync(candidate));
 };
 
 describe("navAreas — locked 8-area decision surface", () => {
-  it("declares exactly eight areas in canonical order", () => {
-    expect(navAreas.map((a) => a.id)).toEqual([
-      "cockpit",
-      "diagnose",
-      "plan",
-      "improve",
-      "govern",
-      "ai",
-      "reports",
-      "admin",
-    ]);
-  });
+	it("declares exactly eight areas in canonical order", () => {
+		expect(navAreas.map((a) => a.id)).toEqual([
+			"cockpit",
+			"diagnose",
+			"plan",
+			"improve",
+			"govern",
+			"ai",
+			"reports",
+			"admin",
+		]);
+	});
 
-  it("keeps the main spine to six areas and the utility tray to two", () => {
-    expect(navAreas.filter((a) => a.placement === "main").map((a) => a.id)).toEqual([
-      "cockpit",
-      "diagnose",
-      "plan",
-      "improve",
-      "govern",
-      "ai",
-    ]);
-    expect(navAreas.filter((a) => a.placement === "utility").map((a) => a.id)).toEqual([
-      "reports",
-      "admin",
-    ]);
-  });
+	it("keeps the main spine to six areas and the utility tray to two", () => {
+		expect(
+			navAreas.filter((a) => a.placement === "main").map((a) => a.id),
+		).toEqual(["cockpit", "diagnose", "plan", "improve", "govern", "ai"]);
+		expect(
+			navAreas.filter((a) => a.placement === "utility").map((a) => a.id),
+		).toEqual(["reports", "admin"]);
+	});
 });
 
 describe("navArea.children — locked child navigation", () => {
-  it("matches CHAOS-2079 locked child labels verbatim", () => {
-    expect(
-      Object.fromEntries(
-        navAreas.map((area) => [area.label, area.children.map((child) => child.label)]),
-      ),
-    ).toEqual({
-      Cockpit: [],
-      Diagnose: [
-        "Overview",
-        "Flow",
-        "Investment",
-        "Landscape",
-        "People",
-        "Code",
-        "Complexity",
-        "Cognitive Load",
-        "Bottlenecks",
-      ],
-      Plan: ["Overview", "Delivery Forecast", "Capacity", "Backlog Risk", "Operating Review"],
-      Improve: ["Opportunities", "Experiments", "Automations"],
-      Govern: [
-        "Overview",
-        "Pipelines",
-        "Tests",
-        "Quality",
-        "Coverage",
-        "Delivery Risk",
-        "Incident Correlation",
-        "Security",
-        "Feature Flags",
-        "Compounding Risk",
-      ],
-      AI: [
-        "Overview",
-        "Impact",
-        "Attribution",
-        "Review Load",
-        "Test Gaps",
-        "Governance Risk",
-        "Evidence",
-        "Automations",
-      ],
-      Reports: ["Report Center", "Weekly Review", "Executive Summary", "Export History"],
-      Admin: ["Organization", "Connections", "Data Confidence", "Settings", "Billing"],
-    });
-  });
+	it("matches CHAOS-2079 locked child labels verbatim", () => {
+		expect(
+			Object.fromEntries(
+				navAreas.map((area) => [
+					area.label,
+					area.children.map((child) => child.label),
+				]),
+			),
+		).toEqual({
+			Cockpit: [],
+			Diagnose: [
+				"Overview",
+				"Flow",
+				"Investment",
+				"Landscape",
+				"People",
+				"Code",
+				"Complexity",
+				"Cognitive Load",
+				"Bottlenecks",
+			],
+			Plan: [
+				"Overview",
+				"Delivery Forecast",
+				"Capacity",
+				"Backlog Risk",
+				"Operating Review",
+			],
+			Improve: ["Opportunities", "Experiments", "Automations"],
+			Govern: [
+				"Overview",
+				"Pipelines",
+				"Tests",
+				"Quality",
+				"Coverage",
+				"Delivery Risk",
+				"Incident Correlation",
+				"Security",
+				"Feature Flags",
+				"Compounding Risk",
+			],
+			AI: [
+				"Overview",
+				"Impact",
+				"Attribution",
+				"Review Load",
+				"Test Gaps",
+				"Governance Risk",
+				"Evidence",
+				"Automations",
+			],
+			Reports: [
+				"Report Center",
+				"Weekly Review",
+				"Executive Summary",
+				"Export History",
+			],
+			Admin: [
+				"Organization",
+				"Connections",
+				"Data Confidence",
+				"Settings",
+				"Billing",
+			],
+		});
+	});
 
-  it("has unique child ids across all areas", () => {
-    const ids = navAreas.flatMap((a) => a.children.map((c) => c.id));
-    expect(new Set(ids).size).toBe(ids.length);
-  });
+	it("has unique child ids across all areas", () => {
+		const ids = navAreas.flatMap((a) => a.children.map((c) => c.id));
+		expect(new Set(ids).size).toBe(ids.length);
+	});
 
-  it("marks every hidden child as preview-only", () => {
-    for (const child of navAreas.flatMap((a) => a.children)) {
-      if (!child.navVisible) expect(child.preview).toBe(true);
-    }
-  });
+	it("marks every hidden child as preview-only", () => {
+		for (const child of navAreas.flatMap((a) => a.children)) {
+			if (!child.navVisible) expect(child.preview).toBe(true);
+		}
+	});
 
-  it("does not expose a navVisible child without a real app page", () => {
-    for (const area of navAreas) {
-      for (const child of area.children.filter((c) => c.navVisible)) {
-        expect(routePageExists(child.path), `${area.id}:${child.label} -> ${child.path}`).toBe(
-          true,
-        );
-      }
-    }
-  });
+	it("does not expose a navVisible child without a real app page", () => {
+		for (const area of navAreas) {
+			for (const child of area.children.filter((c) => c.navVisible)) {
+				expect(
+					routePageExists(child.path),
+					`${area.id}:${child.label} -> ${child.path}`,
+				).toBe(true);
+			}
+		}
+	});
 });
 
 describe("selectedAreaIdForPathname", () => {
-  const cases: Array<{ pathname: string; expected: NavAreaId }> = [
-    { pathname: "/dashboard", expected: "cockpit" },
-    { pathname: "/work", expected: "diagnose" },
-    { pathname: "/metrics", expected: "diagnose" },
-    { pathname: "/investment", expected: "diagnose" },
-    { pathname: "/people/abc", expected: "diagnose" },
-    { pathname: "/landscape", expected: "diagnose" },
-    { pathname: "/plan", expected: "plan" },
-    { pathname: "/plan/delivery-forecast", expected: "plan" },
-    { pathname: "/capacity-planning", expected: "plan" },
-    { pathname: "/operating-review", expected: "plan" },
-    { pathname: "/opportunities", expected: "improve" },
-    { pathname: "/ai/impact", expected: "ai" },
-    { pathname: "/ai/review-load", expected: "ai" },
-    { pathname: "/testops", expected: "govern" },
-    { pathname: "/testops/risk", expected: "govern" },
-    { pathname: "/quality", expected: "govern" },
-    { pathname: "/security/repos/123", expected: "govern" },
-    { pathname: "/risk/compounding", expected: "govern" },
-    { pathname: "/feature-flags", expected: "govern" },
-    { pathname: "/reports/new", expected: "reports" },
-    { pathname: "/admin/users", expected: "admin" },
-    { pathname: "/settings", expected: "admin" },
-  ];
+	const cases: Array<{ pathname: string; expected: NavAreaId }> = [
+		{ pathname: "/dashboard", expected: "cockpit" },
+		{ pathname: "/work", expected: "diagnose" },
+		{ pathname: "/metrics", expected: "diagnose" },
+		{ pathname: "/investment", expected: "diagnose" },
+		{ pathname: "/people/abc", expected: "diagnose" },
+		{ pathname: "/landscape", expected: "diagnose" },
+		{ pathname: "/plan", expected: "plan" },
+		{ pathname: "/plan/delivery-forecast", expected: "plan" },
+		{ pathname: "/capacity-planning", expected: "plan" },
+		{ pathname: "/operating-review", expected: "plan" },
+		{ pathname: "/opportunities", expected: "improve" },
+		{ pathname: "/ai/impact", expected: "ai" },
+		{ pathname: "/ai/review-load", expected: "ai" },
+		{ pathname: "/testops", expected: "govern" },
+		{ pathname: "/testops/risk", expected: "govern" },
+		{ pathname: "/quality", expected: "govern" },
+		{ pathname: "/security/repos/123", expected: "govern" },
+		{ pathname: "/risk/compounding", expected: "govern" },
+		{ pathname: "/feature-flags", expected: "govern" },
+		{ pathname: "/reports/new", expected: "reports" },
+		{ pathname: "/admin/users", expected: "admin" },
+		{ pathname: "/settings", expected: "admin" },
+	];
 
-  it.each(cases)("resolves $pathname to $expected", ({ pathname, expected }) => {
-    expect(selectedAreaIdForPathname(navAreas, pathname)).toBe(expected);
-  });
+	it.each(cases)("resolves $pathname to $expected", ({
+		pathname,
+		expected,
+	}) => {
+		expect(selectedAreaIdForPathname(navAreas, pathname)).toBe(expected);
+	});
 
-  it("prefers the longest prefix and ignores a stale fallback", () => {
-    expect(selectedAreaIdForPathname(navAreas, "/testops/risk", "people")).toBe("govern");
-  });
+	it("prefers the longest prefix and ignores a stale fallback", () => {
+		expect(selectedAreaIdForPathname(navAreas, "/testops/risk", "people")).toBe(
+			"govern",
+		);
+	});
 
-  it("falls back to the area owning the active id when no path matches", () => {
-    expect(selectedAreaIdForPathname(navAreas, "/prs/123", "people")).toBe("diagnose");
-    expect(selectedAreaIdForPathname(navAreas, "/issues/9", "security")).toBe("govern");
-  });
+	it("falls back to the area owning the active id when no path matches", () => {
+		expect(selectedAreaIdForPathname(navAreas, "/prs/123", "people")).toBe(
+			"diagnose",
+		);
+		expect(selectedAreaIdForPathname(navAreas, "/issues/9", "security")).toBe(
+			"govern",
+		);
+	});
 
-  it("returns undefined when neither path nor fallback resolves", () => {
-    expect(selectedAreaIdForPathname(navAreas, "/prs/123")).toBeUndefined();
-    expect(selectedAreaIdForPathname(navAreas, "/prs/123", "nonexistent")).toBeUndefined();
-  });
+	it("returns undefined when neither path nor fallback resolves", () => {
+		expect(selectedAreaIdForPathname(navAreas, "/prs/123")).toBeUndefined();
+		expect(
+			selectedAreaIdForPathname(navAreas, "/prs/123", "nonexistent"),
+		).toBeUndefined();
+	});
 
-  it("does not match a sibling prefix by string-prefix accident", () => {
-    expect(selectedAreaIdForPathname(navAreas, "/capacity-planning")).toBe("plan");
-  });
+	it("does not match a sibling prefix by string-prefix accident", () => {
+		expect(selectedAreaIdForPathname(navAreas, "/capacity-planning")).toBe(
+			"plan",
+		);
+	});
 });
 
 describe("getAreaById", () => {
-  it("returns the matching area", () => {
-    expect(getAreaById("govern")?.label).toBe("Govern");
-  });
+	it("returns the matching area", () => {
+		expect(getAreaById("govern")?.label).toBe("Govern");
+	});
 });
 
 describe("selectedChildForPathname — active child (A10: exactly one)", () => {
-  const cases: Array<{
-    areaId: NavAreaId;
-    pathname: string;
-    childId: string | undefined;
-  }> = [
-    { areaId: "cockpit", pathname: "/dashboard", childId: undefined },
-    { areaId: "diagnose", pathname: "/work", childId: "diagnose-overview" },
-    { areaId: "diagnose", pathname: "/metrics", childId: "flow" },
-    { areaId: "diagnose", pathname: "/investment", childId: "investment" },
-    { areaId: "diagnose", pathname: "/landscape", childId: "landscape" },
-    {
-      areaId: "plan",
-      pathname: "/plan",
-      childId: "plan-overview",
-    },
-    {
-      areaId: "plan",
-      pathname: "/plan/delivery-forecast",
-      childId: "delivery-forecast",
-    },
-    {
-      areaId: "plan",
-      pathname: "/operating-review",
-      childId: "operating-review",
-    },
-    { areaId: "improve", pathname: "/opportunities", childId: "opportunities" },
-    { areaId: "ai", pathname: "/ai", childId: "ai-overview" },
-    { areaId: "ai", pathname: "/ai/review-load", childId: "ai-review-load" },
-    { areaId: "govern", pathname: "/testops", childId: "testops" },
-    { areaId: "govern", pathname: "/testops/pipelines", childId: "pipelines" },
-    { areaId: "govern", pathname: "/testops/coverage", childId: "coverage" },
-    { areaId: "govern", pathname: "/quality", childId: "quality" },
-    { areaId: "govern", pathname: "/testops/tests", childId: "tests" },
-    { areaId: "govern", pathname: "/testops/risk", childId: "risk" },
-    { areaId: "reports", pathname: "/reports", childId: "report-center" },
-    { areaId: "admin", pathname: "/admin", childId: "organization" },
-    { areaId: "admin", pathname: "/admin/sync", childId: "connections" },
-    { areaId: "admin", pathname: "/data-health", childId: "data-confidence" },
-    { areaId: "admin", pathname: "/settings", childId: "settings" },
-  ];
+	const cases: Array<{
+		areaId: NavAreaId;
+		pathname: string;
+		childId: string | undefined;
+	}> = [
+		{ areaId: "cockpit", pathname: "/dashboard", childId: undefined },
+		{ areaId: "diagnose", pathname: "/work", childId: "diagnose-overview" },
+		{ areaId: "diagnose", pathname: "/metrics", childId: "flow" },
+		{ areaId: "diagnose", pathname: "/investment", childId: "investment" },
+		{ areaId: "diagnose", pathname: "/landscape", childId: "landscape" },
+		{
+			areaId: "plan",
+			pathname: "/plan",
+			childId: "plan-overview",
+		},
+		{
+			areaId: "plan",
+			pathname: "/plan/delivery-forecast",
+			childId: "delivery-forecast",
+		},
+		{
+			areaId: "plan",
+			pathname: "/operating-review",
+			childId: "operating-review",
+		},
+		{ areaId: "improve", pathname: "/opportunities", childId: "opportunities" },
+		{ areaId: "ai", pathname: "/ai", childId: "ai-overview" },
+		{ areaId: "ai", pathname: "/ai/impact", childId: "ai-impact" },
+		{ areaId: "ai", pathname: "/ai/review-load", childId: "ai-review-load" },
+		{ areaId: "govern", pathname: "/testops", childId: "testops" },
+		{ areaId: "govern", pathname: "/testops/pipelines", childId: "pipelines" },
+		{ areaId: "govern", pathname: "/testops/coverage", childId: "coverage" },
+		{ areaId: "govern", pathname: "/quality", childId: "quality" },
+		{ areaId: "govern", pathname: "/testops/tests", childId: "tests" },
+		{ areaId: "govern", pathname: "/testops/risk", childId: "risk" },
+		{ areaId: "reports", pathname: "/reports", childId: "report-center" },
+		{ areaId: "admin", pathname: "/admin", childId: "organization" },
+		{ areaId: "admin", pathname: "/admin/sync", childId: "connections" },
+		{ areaId: "admin", pathname: "/data-health", childId: "data-confidence" },
+		{ areaId: "admin", pathname: "/settings", childId: "settings" },
+	];
 
-  it.each(cases)("$pathname → child $childId", ({ areaId, pathname, childId }) => {
-    expect(selectedChildForPathname(areaById(areaId), pathname)?.id).toBe(childId);
-  });
+	it.each(cases)("$pathname → child $childId", ({
+		areaId,
+		pathname,
+		childId,
+	}) => {
+		expect(selectedChildForPathname(areaById(areaId), pathname)?.id).toBe(
+			childId,
+		);
+	});
 
-  it("prefers the more specific sibling over the area Overview", () => {
-    expect(selectedChildForPathname(areaById("govern"), "/testops/pipelines")?.id).toBe(
-      "pipelines",
-    );
-  });
+	it("prefers the more specific sibling over the area Overview", () => {
+		expect(
+			selectedChildForPathname(areaById("govern"), "/testops/pipelines")?.id,
+		).toBe("pipelines");
+	});
 
-  it("never selects a preview (navVisible:false) child", () => {
-    const previewPaths = navAreas.flatMap((area) =>
-      area.children
-        .filter((child) => !child.navVisible)
-        .map((child) => [area.id, child.path] as const),
-    );
-    for (const [areaId, path] of previewPaths) {
-      expect(selectedChildForPathname(areaById(areaId), path)?.navVisible).not.toBe(false);
-    }
-  });
+	it("never selects a preview (navVisible:false) child", () => {
+		const previewPaths = navAreas.flatMap((area) =>
+			area.children
+				.filter((child) => !child.navVisible)
+				.map((child) => [area.id, child.path] as const),
+		);
+		for (const [areaId, path] of previewPaths) {
+			expect(
+				selectedChildForPathname(areaById(areaId), path)?.navVisible,
+			).not.toBe(false);
+		}
+	});
 
-  it("returns undefined for an owned area route with no matching child", () => {
-    expect(selectedChildForPathname(areaById("admin"), "/admin/users")).toBeUndefined();
-  });
+	it("returns undefined for an owned area route with no matching child", () => {
+		expect(
+			selectedChildForPathname(areaById("admin"), "/admin/users"),
+		).toBeUndefined();
+	});
 });
 
 describe("navTitleForPathname / navTrailForPathname (A6: labels agree)", () => {
-  it("titles child pages with the child sidebar label", () => {
-    expect(navTitleForPathname("/work")).toBe("Overview");
-    expect(navTitleForPathname("/metrics")).toBe("Flow");
-    expect(navTitleForPathname("/landscape")).toBe("Landscape");
-    expect(navTitleForPathname("/plan")).toBe("Overview");
-    expect(navTitleForPathname("/plan/delivery-forecast")).toBe("Delivery Forecast");
-    expect(navTitleForPathname("/ai/review-load")).toBe("Review Load");
-    expect(navTitleForPathname("/quality")).toBe("Quality");
-    expect(navTitleForPathname("/settings")).toBe("Settings");
-  });
+	it("titles child pages with the child sidebar label", () => {
+		expect(navTitleForPathname("/work")).toBe("Overview");
+		expect(navTitleForPathname("/metrics")).toBe("Flow");
+		expect(navTitleForPathname("/landscape")).toBe("Landscape");
+		expect(navTitleForPathname("/plan")).toBe("Overview");
+		expect(navTitleForPathname("/plan/delivery-forecast")).toBe(
+			"Delivery Forecast",
+		);
+		expect(navTitleForPathname("/ai/impact")).toBe("Impact");
+		expect(navTitleForPathname("/ai/review-load")).toBe("Review Load");
+		expect(navTitleForPathname("/quality")).toBe("Quality");
+		expect(navTitleForPathname("/settings")).toBe("Settings");
+	});
 
-  it("keeps Cockpit as a single area crumb because it has no children", () => {
-    expect(navTrailForPathname("/dashboard")).toEqual([{ label: "Cockpit" }]);
-    expect(navTitleForPathname("/dashboard")).toBe("Cockpit");
-  });
+	it("keeps Cockpit as a single area crumb because it has no children", () => {
+		expect(navTrailForPathname("/dashboard")).toEqual([{ label: "Cockpit" }]);
+		expect(navTitleForPathname("/dashboard")).toBe("Cockpit");
+	});
 
-  it("builds an Area → Child trail whose last crumb label === the child label", () => {
-    const trail = navTrailForPathname("/admin/sync");
-    expect(trail.map((c) => c.label)).toEqual(["Admin", "Connections"]);
-    expect(trail[0]?.href).toBe(areaById("admin").href);
-    expect(trail[trail.length - 1]?.href).toBeUndefined();
-    const child = areaById("admin").children.find((c) => c.id === "connections");
-    expect(trail[trail.length - 1]?.label).toBe(child?.label);
-  });
+	it("builds an Area → Child trail whose last crumb label === the child label", () => {
+		const trail = navTrailForPathname("/admin/sync");
+		expect(trail.map((c) => c.label)).toEqual(["Admin", "Connections"]);
+		expect(trail[0]?.href).toBe(areaById("admin").href);
+		expect(trail[trail.length - 1]?.href).toBeUndefined();
+		const child = areaById("admin").children.find(
+			(c) => c.id === "connections",
+		);
+		expect(trail[trail.length - 1]?.label).toBe(child?.label);
+	});
 
-  it("returns an empty trail/title for routes no area owns", () => {
-    expect(navTrailForPathname("/prs/123")).toEqual([]);
-    expect(navTitleForPathname("/prs/123")).toBe("");
-  });
+	it("returns an empty trail/title for routes no area owns", () => {
+		expect(navTrailForPathname("/prs/123")).toEqual([]);
+		expect(navTitleForPathname("/prs/123")).toBe("");
+	});
 });

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -25,38 +25,38 @@
 import type { Crumb } from "@/components/Breadcrumbs";
 
 export type NavAreaId =
-  | "cockpit"
-  | "diagnose"
-  | "plan"
-  | "improve"
-  | "govern"
-  | "ai"
-  | "reports"
-  | "admin";
+	| "cockpit"
+	| "diagnose"
+	| "plan"
+	| "improve"
+	| "govern"
+	| "ai"
+	| "reports"
+	| "admin";
 
 export type NavAreaHubItem = {
-  id: string;
-  label: string;
-  href: string;
-  description?: string;
-  // ── Signal-card descriptors (CHAOS-2074) ───────────────────────────────────
-  // Static metadata the area resolver pairs with a fetched value to build an
-  // `AreaSignal`. Kept here (the single nav source of truth) so the sidebar,
-  // landing hub, and signal resolvers can never drift. The *value* + *state* are
-  // resolved at request time by the area resolver (see `@/lib/areaSignals`);
-  // these fields only describe HOW a sub-area surfaces as a card.
-  /**
-   * Optional sub-group header within a dense area. Govern groups into
-   * "Quality" / "Risk"; flat areas (Diagnose, Improve) leave this undefined.
-   */
-  cluster?: string;
-  /** Short metric name shown on the card (e.g. "Line coverage", "Open criticals"). */
-  metricLabel?: string;
-  /**
-   * R4 low-value single surface (e.g. Feature Flags): render visually secondary
-   * within its cluster rather than at equal billing.
-   */
-  demoted?: boolean;
+	id: string;
+	label: string;
+	href: string;
+	description?: string;
+	// ── Signal-card descriptors (CHAOS-2074) ───────────────────────────────────
+	// Static metadata the area resolver pairs with a fetched value to build an
+	// `AreaSignal`. Kept here (the single nav source of truth) so the sidebar,
+	// landing hub, and signal resolvers can never drift. The *value* + *state* are
+	// resolved at request time by the area resolver (see `@/lib/areaSignals`);
+	// these fields only describe HOW a sub-area surfaces as a card.
+	/**
+	 * Optional sub-group header within a dense area. Govern groups into
+	 * "Quality" / "Risk"; flat areas (Diagnose, Improve) leave this undefined.
+	 */
+	cluster?: string;
+	/** Short metric name shown on the card (e.g. "Line coverage", "Open criticals"). */
+	metricLabel?: string;
+	/**
+	 * R4 low-value single surface (e.g. Feature Flags): render visually secondary
+	 * within its cluster rather than at equal billing.
+	 */
+	demoted?: boolean;
 };
 
 /**
@@ -71,626 +71,653 @@ export type NavAreaHubItem = {
  * `navVisible`; phantom/not-yet-built routes are `preview` and never rendered.
  */
 export type NavChildRoute = {
-  id: string;
-  label: string;
-  /** The child's canonical route — the sidebar row links here. */
-  path: string;
-  /** Rendered in the sidebar only when true. Preview routes stay false. */
-  navVisible: boolean;
-  /** Phantom/not-yet-built route held for reference; never rendered. */
-  preview?: boolean;
-  /**
-   * Routes whose active state resolves to THIS child (longest match wins among
-   * a single area's navVisible children). Defaults to `[path]`. A cluster child
-   * lists every route it fronts (e.g. `/testops/tests`, `/quality`).
-   */
-  ownedPaths?: string[];
-  exact?: boolean;
-  /** R4 low-value surface — render visually secondary within the list. */
-  demoted?: boolean;
-  /**
-   * True when this single row fronts several destinations behind one in-page
-   * tab strip (Phase 2). The sidebar shows ONE row; the tab strip lives on the
-   * page, not in the sidebar.
-   */
-  isCluster?: boolean;
+	id: string;
+	label: string;
+	/** The child's canonical route — the sidebar row links here. */
+	path: string;
+	/** Rendered in the sidebar only when true. Preview routes stay false. */
+	navVisible: boolean;
+	/** Phantom/not-yet-built route held for reference; never rendered. */
+	preview?: boolean;
+	/**
+	 * Routes whose active state resolves to THIS child (longest match wins among
+	 * a single area's navVisible children). Defaults to `[path]`. A cluster child
+	 * lists every route it fronts (e.g. `/testops/tests`, `/quality`).
+	 */
+	ownedPaths?: string[];
+	exact?: boolean;
+	/** R4 low-value surface — render visually secondary within the list. */
+	demoted?: boolean;
+	/**
+	 * True when this single row fronts several destinations behind one in-page
+	 * tab strip (Phase 2). The sidebar shows ONE row; the tab strip lives on the
+	 * page, not in the sidebar.
+	 */
+	isCluster?: boolean;
 };
 
 export type NavArea = {
-  id: NavAreaId;
-  label: string;
-  /** The area's landing route — what the sidebar row links to. */
-  href: string;
-  placement: "main" | "utility";
-  /**
-   * Route prefixes this area owns, used for active-state resolution. A pathname
-   * is matched against every area's prefixes; the longest matching prefix wins
-   * (so `/testops/risk` resolves to Govern, `/risk/compounding` to Govern, etc).
-   */
-  ownedPathPrefixes: string[];
-  /**
-   * Legacy per-page `active="…"` ids (the pre-collapse leaf ids). Used only as a
-   * fallback when no pathname prefix matches, so existing `<PrimaryNav active=…>`
-   * call sites keep highlighting the correct area without editing every page.
-   */
-  legacyActiveIds: string[];
-  /**
-   * Leaf destinations reachable from this area's landing page via `AreaHub`.
-   * Empty for areas whose only destination is the landing route itself.
-   */
-  hubItems: NavAreaHubItem[];
-  /**
-   * The two-level sidebar route tree (CHAOS-2075): the destinations the active
-   * area expands to as indented rows. DISTINCT from `hubItems` — see
-   * {@link NavChildRoute}. Empty when the area's only destination is its landing
-   * route (e.g. Cockpit).
-   */
-  children: NavChildRoute[];
+	id: NavAreaId;
+	label: string;
+	/** The area's landing route — what the sidebar row links to. */
+	href: string;
+	placement: "main" | "utility";
+	/**
+	 * Route prefixes this area owns, used for active-state resolution. A pathname
+	 * is matched against every area's prefixes; the longest matching prefix wins
+	 * (so `/testops/risk` resolves to Govern, `/risk/compounding` to Govern, etc).
+	 */
+	ownedPathPrefixes: string[];
+	/**
+	 * Legacy per-page `active="…"` ids (the pre-collapse leaf ids). Used only as a
+	 * fallback when no pathname prefix matches, so existing `<PrimaryNav active=…>`
+	 * call sites keep highlighting the correct area without editing every page.
+	 */
+	legacyActiveIds: string[];
+	/**
+	 * Leaf destinations reachable from this area's landing page via `AreaHub`.
+	 * Empty for areas whose only destination is the landing route itself.
+	 */
+	hubItems: NavAreaHubItem[];
+	/**
+	 * The two-level sidebar route tree (CHAOS-2075): the destinations the active
+	 * area expands to as indented rows. DISTINCT from `hubItems` — see
+	 * {@link NavChildRoute}. Empty when the area's only destination is its landing
+	 * route (e.g. Cockpit).
+	 */
+	children: NavChildRoute[];
 };
 
 export const navAreas: readonly NavArea[] = [
-  // ── Main spine ──────────────────────────────────────────────────────────────
-  {
-    id: "cockpit",
-    label: "Cockpit",
-    href: "/dashboard",
-    placement: "main",
-    ownedPathPrefixes: ["/dashboard"],
-    legacyActiveIds: ["home", "cockpit"],
-    hubItems: [],
-    // Cockpit's only destination is its landing route — no expandable children.
-    children: [],
-  },
-  {
-    id: "diagnose",
-    label: "Diagnose",
-    href: "/work",
-    placement: "main",
-    ownedPathPrefixes: [
-      "/work",
-      "/metrics",
-      "/team-flow",
-      "/investment",
-      "/people",
-      "/code",
-      "/landscape",
-      "/complexity",
-      "/cognitive-load",
-      "/bottleneck",
-    ],
-    legacyActiveIds: [
-      "work",
-      "flow",
-      "investment",
-      "people",
-      "code",
-      "landscape",
-      "complexity",
-      "cognitive-load",
-      "bottleneck",
-      "diagnose",
-    ],
-    // CHAOS-2074: Diagnose is FLAT (no clusters). Descriptors placed here; Phase
-    // 2 wires the resolver fetching (see `@/lib/areaSignals/getAreaSignals`).
-    hubItems: [
-      {
-        id: "flow",
-        label: "Flow",
-        href: "/metrics",
-        description: "Flow trends and delivery movement.",
-        metricLabel: "Deploy frequency",
-      },
-      {
-        id: "investment",
-        label: "Investment",
-        href: "/investment",
-        description: "Effort and attention allocation.",
-        metricLabel: "Planned allocation",
-      },
-      {
-        id: "people",
-        label: "People",
-        href: "/people",
-        description: "Individual reflection surfaces.",
-        // No area-level metric → resolver surfaces "unavailable" (DataState).
-        metricLabel: "No area metric",
-      },
-      {
-        id: "code",
-        label: "Code",
-        href: "/code",
-        description: "Code health and ownership.",
-        metricLabel: "Code churn",
-      },
-      {
-        id: "landscape",
-        label: "Landscape",
-        href: "/landscape",
-        description: "System landscape overview.",
-        // Gap: no resolver-backed metric yet → "unavailable" (DataState).
-        metricLabel: "No area metric",
-      },
-      {
-        id: "complexity",
-        label: "Complexity",
-        href: "/complexity",
-        description: "Complexity trend and hotspots.",
-        metricLabel: "Avg complexity",
-      },
-      {
-        id: "cognitive-load",
-        label: "Cognitive Load",
-        href: "/cognitive-load",
-        description: "Focus and context-switch pressure.",
-        // Gap: no resolver-backed metric yet → "unavailable" (DataState).
-        metricLabel: "No area metric",
-      },
-      {
-        id: "bottleneck",
-        label: "Bottlenecks",
-        href: "/bottleneck",
-        description: "Flow bottleneck detection.",
-        metricLabel: "WIP saturation",
-      },
-    ],
-    children: [
-      {
-        id: "diagnose-overview",
-        label: "Overview",
-        path: "/work",
-        navVisible: true,
-      },
-      { id: "flow", label: "Flow", path: "/metrics", navVisible: true },
-      {
-        id: "investment",
-        label: "Investment",
-        path: "/investment",
-        navVisible: true,
-      },
-      {
-        id: "landscape",
-        label: "Landscape",
-        path: "/landscape",
-        navVisible: true,
-      },
-      { id: "people", label: "People", path: "/people", navVisible: true },
-      { id: "code", label: "Code", path: "/code", navVisible: true },
-      {
-        id: "complexity",
-        label: "Complexity",
-        path: "/complexity",
-        navVisible: true,
-      },
-      {
-        id: "cognitive-load",
-        label: "Cognitive Load",
-        path: "/cognitive-load",
-        navVisible: true,
-      },
-      {
-        id: "bottleneck",
-        label: "Bottlenecks",
-        path: "/bottleneck",
-        navVisible: true,
-      },
-    ],
-  },
-  {
-    id: "plan",
-    label: "Plan",
-    href: "/plan",
-    placement: "main",
-    ownedPathPrefixes: ["/plan", "/capacity-planning", "/operating-review"],
-    legacyActiveIds: [
-      "capacity-planning",
-      "delivery-forecast",
-      "capacity",
-      "operating-review",
-      "plan",
-    ],
-    hubItems: [
-      {
-        id: "delivery-forecast",
-        label: "Delivery Forecast",
-        href: "/plan/delivery-forecast",
-        description: "Monte Carlo throughput forecasting.",
-        metricLabel: "Forecast window",
-      },
-      {
-        id: "operating-review",
-        label: "Operating Review",
-        href: "/operating-review",
-        description: "Weekly planning and review agenda.",
-        metricLabel: "Review cadence",
-      },
-    ],
-    children: [
-      {
-        id: "plan-overview",
-        label: "Overview",
-        path: "/plan",
-        navVisible: true,
-      },
-      {
-        id: "delivery-forecast",
-        label: "Delivery Forecast",
-        path: "/plan/delivery-forecast",
-        navVisible: true,
-      },
-      {
-        id: "capacity",
-        label: "Capacity",
-        path: "/plan/capacity",
-        navVisible: false,
-        preview: true,
-      },
-      {
-        id: "backlog-risk",
-        label: "Backlog Risk",
-        path: "/plan/backlog-risk",
-        navVisible: false,
-        preview: true,
-      },
-      {
-        id: "operating-review",
-        label: "Operating Review",
-        path: "/operating-review",
-        navVisible: true,
-      },
-    ],
-  },
-  {
-    id: "improve",
-    label: "Improve",
-    href: "/opportunities",
-    placement: "main",
-    ownedPathPrefixes: ["/opportunities"],
-    legacyActiveIds: ["opportunities", "experiments", "automations", "improve"],
-    // CHAOS-2074: Improve is FLAT (no clusters). Opportunities is the area's own
-    // landing route (`href: "/opportunities"`), so it is NOT duplicated as a hub
-    // item — its volume signal bubbles at the area level via the resolver.
-    // Descriptors placed here; Phase 2 wires the resolver fetching.
-    hubItems: [],
-    children: [
-      {
-        id: "opportunities",
-        label: "Opportunities",
-        path: "/opportunities",
-        navVisible: true,
-      },
-      {
-        id: "experiments",
-        label: "Experiments",
-        path: "/improve/experiments",
-        navVisible: false,
-        preview: true,
-      },
-      {
-        id: "improve-automations",
-        label: "Automations",
-        path: "/improve/automations",
-        navVisible: false,
-        preview: true,
-      },
-    ],
-  },
-  {
-    id: "govern",
-    label: "Govern",
-    href: "/testops",
-    placement: "main",
-    ownedPathPrefixes: [
-      "/testops",
-      "/quality",
-      "/security",
-      "/feature-flags",
-      "/incident-correlation",
-      "/risk",
-    ],
-    legacyActiveIds: [
-      "testops",
-      "pipelines",
-      "tests",
-      "quality",
-      "coverage",
-      "risk",
-      "incident-correlation",
-      "security",
-      "feature-flags",
-      "risk-compounding",
-      "govern",
-    ],
-    // CHAOS-2074: Govern is sub-grouped into "Quality" and "Risk" clusters,
-    // each internally severity-sorted by the resolver (`getGovernSignals`).
-    hubItems: [
-      // ── Cluster: Quality ──────────────────────────────────────────────────
-      {
-        id: "coverage",
-        label: "Coverage",
-        href: "/testops/coverage",
-        description: "Coverage delta.",
-        cluster: "Quality",
-        metricLabel: "Line coverage",
-      },
-      {
-        id: "tests",
-        label: "Tests",
-        href: "/testops/tests",
-        description: "Test reliability and flake.",
-        cluster: "Quality",
-        metricLabel: "Flake rate",
-      },
-      {
-        id: "pipelines",
-        label: "Pipelines",
-        href: "/testops/pipelines",
-        description: "Pipeline stability.",
-        cluster: "Quality",
-        metricLabel: "Success rate",
-      },
-      {
-        id: "quality",
-        label: "Quality",
-        href: "/quality",
-        description: "Reliability and rework.",
-        cluster: "Quality",
-        metricLabel: "Change failure rate",
-      },
-      // ── Cluster: Risk ─────────────────────────────────────────────────────
-      {
-        id: "security",
-        label: "Security",
-        href: "/security",
-        description: "Security posture.",
-        cluster: "Risk",
-        metricLabel: "Open criticals",
-      },
-      {
-        id: "risk",
-        label: "Delivery Risk",
-        href: "/testops/risk",
-        description: "Delivery risk drag.",
-        cluster: "Risk",
-        metricLabel: "Release confidence",
-      },
-      {
-        id: "incident-correlation",
-        label: "Incident Correlation",
-        href: "/incident-correlation",
-        description: "Incidents correlated to changes.",
-        cluster: "Risk",
-        metricLabel: "Change failure rate",
-      },
-      {
-        id: "risk-compounding",
-        label: "Compounding Risk",
-        href: "/risk/compounding",
-        description: "Compounding risk signals.",
-        cluster: "Risk",
-        metricLabel: "Worst risk score",
-      },
-      {
-        id: "feature-flags",
-        label: "Feature Flags",
-        href: "/feature-flags",
-        description: "Flag lifecycle and debt.",
-        cluster: "Risk",
-        metricLabel: "Active flags",
-        // R4: low-value single surface — render secondary, not equal billing.
-        demoted: true,
-      },
-    ],
-    children: [
-      { id: "testops", label: "Overview", path: "/testops", navVisible: true },
-      {
-        id: "pipelines",
-        label: "Pipelines",
-        path: "/testops/pipelines",
-        navVisible: true,
-      },
-      { id: "tests", label: "Tests", path: "/testops/tests", navVisible: true },
-      {
-        id: "quality",
-        label: "Quality",
-        path: "/quality",
-        navVisible: true,
-      },
-      {
-        id: "coverage",
-        label: "Coverage",
-        path: "/testops/coverage",
-        navVisible: true,
-      },
-      {
-        id: "risk",
-        label: "Delivery Risk",
-        path: "/testops/risk",
-        navVisible: true,
-      },
-      {
-        id: "incident-correlation",
-        label: "Incident Correlation",
-        path: "/incident-correlation",
-        navVisible: true,
-      },
-      {
-        id: "security",
-        label: "Security",
-        path: "/security",
-        navVisible: true,
-      },
-      {
-        id: "feature-flags",
-        label: "Feature Flags",
-        path: "/feature-flags",
-        navVisible: true,
-        // R4 low-value surface — rendered visually secondary in the list.
-        demoted: true,
-      },
-      {
-        id: "risk-compounding",
-        label: "Compounding Risk",
-        path: "/risk/compounding",
-        navVisible: true,
-      },
-    ],
-  },
-  {
-    id: "ai",
-    label: "AI",
-    href: "/ai",
-    placement: "main",
-    ownedPathPrefixes: ["/ai"],
-    legacyActiveIds: ["ai", "ai-workflows"],
-    hubItems: [],
-    children: [
-      { id: "ai-overview", label: "Overview", path: "/ai", navVisible: true },
-      {
-        id: "ai-impact",
-        label: "Impact",
-        path: "/ai/impact",
-        navVisible: false,
-        preview: true,
-      },
-      {
-        id: "ai-attribution",
-        label: "Attribution",
-        path: "/ai/attribution",
-        navVisible: false,
-        preview: true,
-      },
-      {
-        id: "ai-review-load",
-        label: "Review Load",
-        path: "/ai/review-load",
-        navVisible: true,
-      },
-      {
-        id: "ai-test-gaps",
-        label: "Test Gaps",
-        path: "/ai/test-gaps",
-        navVisible: false,
-        preview: true,
-      },
-      {
-        id: "ai-governance-risk",
-        label: "Governance Risk",
-        path: "/ai/risk",
-        navVisible: true,
-      },
-      {
-        id: "ai-evidence",
-        label: "Evidence",
-        path: "/ai/evidence",
-        navVisible: false,
-        preview: true,
-      },
-      {
-        id: "ai-automations",
-        label: "Automations",
-        path: "/ai/automations",
-        navVisible: false,
-        preview: true,
-      },
-    ],
-  },
-  // ── Utility tray ────────────────────────────────────────────────────────────
-  {
-    id: "reports",
-    label: "Reports",
-    href: "/reports",
-    placement: "utility",
-    ownedPathPrefixes: ["/reports"],
-    legacyActiveIds: ["reports"],
-    hubItems: [],
-    // Report Center is the only built destination. Weekly Review / Executive
-    // Summary / Export History are PREVIEW (phantom routes held for reference);
-    // they are never rendered and never resolved until their pages exist — DO
-    // NOT create stub pages for them (CHAOS-2075).
-    children: [
-      {
-        id: "report-center",
-        label: "Report Center",
-        path: "/reports",
-        navVisible: true,
-        exact: true,
-      },
-      {
-        id: "weekly-review",
-        label: "Weekly Review",
-        path: "/reports/weekly",
-        navVisible: false,
-        preview: true,
-      },
-      {
-        id: "executive-summary",
-        label: "Executive Summary",
-        path: "/reports/executive",
-        navVisible: false,
-        preview: true,
-      },
-      {
-        id: "export-history",
-        label: "Export History",
-        path: "/reports/exports",
-        navVisible: false,
-        preview: true,
-      },
-    ],
-  },
-  {
-    id: "admin",
-    label: "Admin",
-    href: "/admin",
-    placement: "utility",
-    // `/data-health` (Data Confidence) is an Admin destination outside `/admin`.
-    ownedPathPrefixes: ["/admin", "/settings", "/data-health"],
-    legacyActiveIds: ["admin", "settings", "data-health"],
-    hubItems: [],
-    children: [
-      {
-        id: "organization",
-        label: "Organization",
-        path: "/admin",
-        navVisible: true,
-        exact: true,
-      },
-      {
-        id: "connections",
-        label: "Connections",
-        path: "/admin/sync",
-        navVisible: true,
-      },
-      {
-        id: "data-confidence",
-        label: "Data Confidence",
-        path: "/data-health",
-        navVisible: true,
-      },
-      {
-        id: "settings",
-        label: "Settings",
-        path: "/settings",
-        navVisible: true,
-      },
-      {
-        id: "billing",
-        label: "Billing",
-        path: "/admin/billing",
-        navVisible: false,
-        preview: true,
-      },
-    ],
-  },
+	// ── Main spine ──────────────────────────────────────────────────────────────
+	{
+		id: "cockpit",
+		label: "Cockpit",
+		href: "/dashboard",
+		placement: "main",
+		ownedPathPrefixes: ["/dashboard"],
+		legacyActiveIds: ["home", "cockpit"],
+		hubItems: [],
+		// Cockpit's only destination is its landing route — no expandable children.
+		children: [],
+	},
+	{
+		id: "diagnose",
+		label: "Diagnose",
+		href: "/work",
+		placement: "main",
+		ownedPathPrefixes: [
+			"/work",
+			"/metrics",
+			"/team-flow",
+			"/investment",
+			"/people",
+			"/code",
+			"/landscape",
+			"/complexity",
+			"/cognitive-load",
+			"/bottleneck",
+		],
+		legacyActiveIds: [
+			"work",
+			"flow",
+			"investment",
+			"people",
+			"code",
+			"landscape",
+			"complexity",
+			"cognitive-load",
+			"bottleneck",
+			"diagnose",
+		],
+		// CHAOS-2074: Diagnose is FLAT (no clusters). Descriptors placed here; Phase
+		// 2 wires the resolver fetching (see `@/lib/areaSignals/getAreaSignals`).
+		hubItems: [
+			{
+				id: "flow",
+				label: "Flow",
+				href: "/metrics",
+				description: "Flow trends and delivery movement.",
+				metricLabel: "Deploy frequency",
+			},
+			{
+				id: "investment",
+				label: "Investment",
+				href: "/investment",
+				description: "Effort and attention allocation.",
+				metricLabel: "Planned allocation",
+			},
+			{
+				id: "people",
+				label: "People",
+				href: "/people",
+				description: "Individual reflection surfaces.",
+				// No area-level metric → resolver surfaces "unavailable" (DataState).
+				metricLabel: "No area metric",
+			},
+			{
+				id: "code",
+				label: "Code",
+				href: "/code",
+				description: "Code health and ownership.",
+				metricLabel: "Code churn",
+			},
+			{
+				id: "landscape",
+				label: "Landscape",
+				href: "/landscape",
+				description: "System landscape overview.",
+				// Gap: no resolver-backed metric yet → "unavailable" (DataState).
+				metricLabel: "No area metric",
+			},
+			{
+				id: "complexity",
+				label: "Complexity",
+				href: "/complexity",
+				description: "Complexity trend and hotspots.",
+				metricLabel: "Avg complexity",
+			},
+			{
+				id: "cognitive-load",
+				label: "Cognitive Load",
+				href: "/cognitive-load",
+				description: "Focus and context-switch pressure.",
+				// Gap: no resolver-backed metric yet → "unavailable" (DataState).
+				metricLabel: "No area metric",
+			},
+			{
+				id: "bottleneck",
+				label: "Bottlenecks",
+				href: "/bottleneck",
+				description: "Flow bottleneck detection.",
+				metricLabel: "WIP saturation",
+			},
+		],
+		children: [
+			{
+				id: "diagnose-overview",
+				label: "Overview",
+				path: "/work",
+				navVisible: true,
+			},
+			{ id: "flow", label: "Flow", path: "/metrics", navVisible: true },
+			{
+				id: "investment",
+				label: "Investment",
+				path: "/investment",
+				navVisible: true,
+			},
+			{
+				id: "landscape",
+				label: "Landscape",
+				path: "/landscape",
+				navVisible: true,
+			},
+			{ id: "people", label: "People", path: "/people", navVisible: true },
+			{ id: "code", label: "Code", path: "/code", navVisible: true },
+			{
+				id: "complexity",
+				label: "Complexity",
+				path: "/complexity",
+				navVisible: true,
+			},
+			{
+				id: "cognitive-load",
+				label: "Cognitive Load",
+				path: "/cognitive-load",
+				navVisible: true,
+			},
+			{
+				id: "bottleneck",
+				label: "Bottlenecks",
+				path: "/bottleneck",
+				navVisible: true,
+			},
+		],
+	},
+	{
+		id: "plan",
+		label: "Plan",
+		href: "/plan",
+		placement: "main",
+		ownedPathPrefixes: ["/plan", "/capacity-planning", "/operating-review"],
+		legacyActiveIds: [
+			"capacity-planning",
+			"delivery-forecast",
+			"capacity",
+			"operating-review",
+			"plan",
+		],
+		hubItems: [
+			{
+				id: "delivery-forecast",
+				label: "Delivery Forecast",
+				href: "/plan/delivery-forecast",
+				description: "Monte Carlo throughput forecasting.",
+				metricLabel: "Forecast window",
+			},
+			{
+				id: "operating-review",
+				label: "Operating Review",
+				href: "/operating-review",
+				description: "Weekly planning and review agenda.",
+				metricLabel: "Review cadence",
+			},
+		],
+		children: [
+			{
+				id: "plan-overview",
+				label: "Overview",
+				path: "/plan",
+				navVisible: true,
+			},
+			{
+				id: "delivery-forecast",
+				label: "Delivery Forecast",
+				path: "/plan/delivery-forecast",
+				navVisible: true,
+			},
+			{
+				id: "capacity",
+				label: "Capacity",
+				path: "/plan/capacity",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "backlog-risk",
+				label: "Backlog Risk",
+				path: "/plan/backlog-risk",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "operating-review",
+				label: "Operating Review",
+				path: "/operating-review",
+				navVisible: true,
+			},
+		],
+	},
+	{
+		id: "improve",
+		label: "Improve",
+		href: "/opportunities",
+		placement: "main",
+		ownedPathPrefixes: ["/opportunities"],
+		legacyActiveIds: ["opportunities", "experiments", "automations", "improve"],
+		// CHAOS-2074: Improve is FLAT (no clusters). Opportunities is the area's own
+		// landing route (`href: "/opportunities"`), so it is NOT duplicated as a hub
+		// item — its volume signal bubbles at the area level via the resolver.
+		// Descriptors placed here; Phase 2 wires the resolver fetching.
+		hubItems: [],
+		children: [
+			{
+				id: "opportunities",
+				label: "Opportunities",
+				path: "/opportunities",
+				navVisible: true,
+			},
+			{
+				id: "experiments",
+				label: "Experiments",
+				path: "/improve/experiments",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "improve-automations",
+				label: "Automations",
+				path: "/improve/automations",
+				navVisible: false,
+				preview: true,
+			},
+		],
+	},
+	{
+		id: "govern",
+		label: "Govern",
+		href: "/testops",
+		placement: "main",
+		ownedPathPrefixes: [
+			"/testops",
+			"/quality",
+			"/security",
+			"/feature-flags",
+			"/incident-correlation",
+			"/risk",
+		],
+		legacyActiveIds: [
+			"testops",
+			"pipelines",
+			"tests",
+			"quality",
+			"coverage",
+			"risk",
+			"incident-correlation",
+			"security",
+			"feature-flags",
+			"risk-compounding",
+			"govern",
+		],
+		// CHAOS-2074: Govern is sub-grouped into "Quality" and "Risk" clusters,
+		// each internally severity-sorted by the resolver (`getGovernSignals`).
+		hubItems: [
+			// ── Cluster: Quality ──────────────────────────────────────────────────
+			{
+				id: "coverage",
+				label: "Coverage",
+				href: "/testops/coverage",
+				description: "Coverage delta.",
+				cluster: "Quality",
+				metricLabel: "Line coverage",
+			},
+			{
+				id: "tests",
+				label: "Tests",
+				href: "/testops/tests",
+				description: "Test reliability and flake.",
+				cluster: "Quality",
+				metricLabel: "Flake rate",
+			},
+			{
+				id: "pipelines",
+				label: "Pipelines",
+				href: "/testops/pipelines",
+				description: "Pipeline stability.",
+				cluster: "Quality",
+				metricLabel: "Success rate",
+			},
+			{
+				id: "quality",
+				label: "Quality",
+				href: "/quality",
+				description: "Reliability and rework.",
+				cluster: "Quality",
+				metricLabel: "Change failure rate",
+			},
+			// ── Cluster: Risk ─────────────────────────────────────────────────────
+			{
+				id: "security",
+				label: "Security",
+				href: "/security",
+				description: "Security posture.",
+				cluster: "Risk",
+				metricLabel: "Open criticals",
+			},
+			{
+				id: "risk",
+				label: "Delivery Risk",
+				href: "/testops/risk",
+				description: "Delivery risk drag.",
+				cluster: "Risk",
+				metricLabel: "Release confidence",
+			},
+			{
+				id: "incident-correlation",
+				label: "Incident Correlation",
+				href: "/incident-correlation",
+				description: "Incidents correlated to changes.",
+				cluster: "Risk",
+				metricLabel: "Change failure rate",
+			},
+			{
+				id: "risk-compounding",
+				label: "Compounding Risk",
+				href: "/risk/compounding",
+				description: "Compounding risk signals.",
+				cluster: "Risk",
+				metricLabel: "Worst risk score",
+			},
+			{
+				id: "feature-flags",
+				label: "Feature Flags",
+				href: "/feature-flags",
+				description: "Flag lifecycle and debt.",
+				cluster: "Risk",
+				metricLabel: "Active flags",
+				// R4: low-value single surface — render secondary, not equal billing.
+				demoted: true,
+			},
+		],
+		children: [
+			{ id: "testops", label: "Overview", path: "/testops", navVisible: true },
+			{
+				id: "pipelines",
+				label: "Pipelines",
+				path: "/testops/pipelines",
+				navVisible: true,
+			},
+			{ id: "tests", label: "Tests", path: "/testops/tests", navVisible: true },
+			{
+				id: "quality",
+				label: "Quality",
+				path: "/quality",
+				navVisible: true,
+			},
+			{
+				id: "coverage",
+				label: "Coverage",
+				path: "/testops/coverage",
+				navVisible: true,
+			},
+			{
+				id: "risk",
+				label: "Delivery Risk",
+				path: "/testops/risk",
+				navVisible: true,
+			},
+			{
+				id: "incident-correlation",
+				label: "Incident Correlation",
+				path: "/incident-correlation",
+				navVisible: true,
+			},
+			{
+				id: "security",
+				label: "Security",
+				path: "/security",
+				navVisible: true,
+			},
+			{
+				id: "feature-flags",
+				label: "Feature Flags",
+				path: "/feature-flags",
+				navVisible: true,
+				// R4 low-value surface — rendered visually secondary in the list.
+				demoted: true,
+			},
+			{
+				id: "risk-compounding",
+				label: "Compounding Risk",
+				path: "/risk/compounding",
+				navVisible: true,
+			},
+		],
+	},
+	{
+		id: "ai",
+		label: "AI",
+		href: "/ai",
+		placement: "main",
+		ownedPathPrefixes: ["/ai"],
+		legacyActiveIds: ["ai", "ai-workflows"],
+		hubItems: [
+			{
+				id: "ai-impact",
+				label: "Impact",
+				href: "/ai/impact",
+				description: "AI-assisted delivery and review impact.",
+				metricLabel: "AI impact",
+			},
+			{
+				id: "ai-review-load",
+				label: "Review Load",
+				href: "/ai/review-load",
+				description: "AI-associated review pressure.",
+				metricLabel: "Review pressure",
+			},
+			{
+				id: "ai-governance-risk",
+				label: "Governance Risk",
+				href: "/ai/risk",
+				description: "Quality and governance signals for AI-associated work.",
+				metricLabel: "Governance risk",
+			},
+			{
+				id: "ai-automations",
+				label: "Automations",
+				href: "/ai/automations",
+				description: "Responsible automation opportunities.",
+				metricLabel: "Automation candidates",
+			},
+		],
+		children: [
+			{ id: "ai-overview", label: "Overview", path: "/ai", navVisible: true },
+			{
+				id: "ai-impact",
+				label: "Impact",
+				path: "/ai/impact",
+				navVisible: true,
+			},
+			{
+				id: "ai-attribution",
+				label: "Attribution",
+				path: "/ai/attribution",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "ai-review-load",
+				label: "Review Load",
+				path: "/ai/review-load",
+				navVisible: true,
+			},
+			{
+				id: "ai-test-gaps",
+				label: "Test Gaps",
+				path: "/ai/test-gaps",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "ai-governance-risk",
+				label: "Governance Risk",
+				path: "/ai/risk",
+				navVisible: true,
+			},
+			{
+				id: "ai-evidence",
+				label: "Evidence",
+				path: "/ai/evidence",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "ai-automations",
+				label: "Automations",
+				path: "/ai/automations",
+				navVisible: true,
+			},
+		],
+	},
+	// ── Utility tray ────────────────────────────────────────────────────────────
+	{
+		id: "reports",
+		label: "Reports",
+		href: "/reports",
+		placement: "utility",
+		ownedPathPrefixes: ["/reports"],
+		legacyActiveIds: ["reports"],
+		hubItems: [],
+		// Report Center is the only built destination. Weekly Review / Executive
+		// Summary / Export History are PREVIEW (phantom routes held for reference);
+		// they are never rendered and never resolved until their pages exist — DO
+		// NOT create stub pages for them (CHAOS-2075).
+		children: [
+			{
+				id: "report-center",
+				label: "Report Center",
+				path: "/reports",
+				navVisible: true,
+				exact: true,
+			},
+			{
+				id: "weekly-review",
+				label: "Weekly Review",
+				path: "/reports/weekly",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "executive-summary",
+				label: "Executive Summary",
+				path: "/reports/executive",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "export-history",
+				label: "Export History",
+				path: "/reports/exports",
+				navVisible: false,
+				preview: true,
+			},
+		],
+	},
+	{
+		id: "admin",
+		label: "Admin",
+		href: "/admin",
+		placement: "utility",
+		// `/data-health` (Data Confidence) is an Admin destination outside `/admin`.
+		ownedPathPrefixes: ["/admin", "/settings", "/data-health"],
+		legacyActiveIds: ["admin", "settings", "data-health"],
+		hubItems: [],
+		children: [
+			{
+				id: "organization",
+				label: "Organization",
+				path: "/admin",
+				navVisible: true,
+				exact: true,
+			},
+			{
+				id: "connections",
+				label: "Connections",
+				path: "/admin/sync",
+				navVisible: true,
+			},
+			{
+				id: "data-confidence",
+				label: "Data Confidence",
+				path: "/data-health",
+				navVisible: true,
+			},
+			{
+				id: "settings",
+				label: "Settings",
+				path: "/settings",
+				navVisible: true,
+			},
+			{
+				id: "billing",
+				label: "Billing",
+				path: "/admin/billing",
+				navVisible: false,
+				preview: true,
+			},
+		],
+	},
 ] as const;
 
 export function getAreaById(id: NavAreaId): NavArea | undefined {
-  return navAreas.find((area) => area.id === id);
+	return navAreas.find((area) => area.id === id);
 }
 
 /** True when `pathname` is exactly `prefix` or a descendant of it. */
 function pathMatchesPrefix(pathname: string, prefix: string): boolean {
-  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+	return pathname === prefix || pathname.startsWith(`${prefix}/`);
 }
 
 /**
@@ -699,35 +726,40 @@ function pathMatchesPrefix(pathname: string, prefix: string): boolean {
  * matches the pathname, fall back to the legacy `active` prop id.
  */
 export function selectedAreaIdForPathname(
-  areas: readonly NavArea[],
-  pathname: string,
-  fallbackActive?: string,
+	areas: readonly NavArea[],
+	pathname: string,
+	fallbackActive?: string,
 ): NavAreaId | undefined {
-  let selected: { id: NavAreaId; score: number } | undefined;
+	let selected: { id: NavAreaId; score: number } | undefined;
 
-  for (const area of areas) {
-    for (const prefix of area.ownedPathPrefixes) {
-      if (pathMatchesPrefix(pathname, prefix) && prefix.length > (selected?.score ?? -1)) {
-        selected = { id: area.id, score: prefix.length };
-      }
-    }
-  }
+	for (const area of areas) {
+		for (const prefix of area.ownedPathPrefixes) {
+			if (
+				pathMatchesPrefix(pathname, prefix) &&
+				prefix.length > (selected?.score ?? -1)
+			) {
+				selected = { id: area.id, score: prefix.length };
+			}
+		}
+	}
 
-  if (selected) return selected.id;
+	if (selected) return selected.id;
 
-  if (fallbackActive) {
-    const fallbackArea = areas.find(
-      (area) => area.id === fallbackActive || area.legacyActiveIds.includes(fallbackActive),
-    );
-    if (fallbackArea) return fallbackArea.id;
-  }
+	if (fallbackActive) {
+		const fallbackArea = areas.find(
+			(area) =>
+				area.id === fallbackActive ||
+				area.legacyActiveIds.includes(fallbackActive),
+		);
+		if (fallbackArea) return fallbackArea.id;
+	}
 
-  return undefined;
+	return undefined;
 }
 
 /** The routes a child claims for active-state. Defaults to `[child.path]`. */
 function ownedPathsFor(child: NavChildRoute): readonly string[] {
-  return child.ownedPaths ?? [child.path];
+	return child.ownedPaths ?? [child.path];
 }
 
 /**
@@ -740,22 +772,24 @@ function ownedPathsFor(child: NavChildRoute): readonly string[] {
  * (the area row is selected, but no child is).
  */
 export function selectedChildForPathname(
-  area: NavArea,
-  pathname: string,
+	area: NavArea,
+	pathname: string,
 ): NavChildRoute | undefined {
-  let selected: { child: NavChildRoute; score: number } | undefined;
+	let selected: { child: NavChildRoute; score: number } | undefined;
 
-  for (const child of area.children) {
-    if (!child.navVisible) continue;
-    for (const owned of ownedPathsFor(child)) {
-      const matches = child.exact ? pathname === owned : pathMatchesPrefix(pathname, owned);
-      if (matches && owned.length > (selected?.score ?? -1)) {
-        selected = { child, score: owned.length };
-      }
-    }
-  }
+	for (const child of area.children) {
+		if (!child.navVisible) continue;
+		for (const owned of ownedPathsFor(child)) {
+			const matches = child.exact
+				? pathname === owned
+				: pathMatchesPrefix(pathname, owned);
+			if (matches && owned.length > (selected?.score ?? -1)) {
+				selected = { child, score: owned.length };
+			}
+		}
+	}
 
-  return selected?.child;
+	return selected?.child;
 }
 
 /**
@@ -764,13 +798,13 @@ export function selectedChildForPathname(
  * helpers so route metadata can never drift from the sidebar (rule A6).
  */
 function resolveAreaAndChild(
-  pathname: string,
+	pathname: string,
 ): { area: NavArea; child?: NavChildRoute } | undefined {
-  const areaId = selectedAreaIdForPathname(navAreas, pathname);
-  if (!areaId) return undefined;
-  const area = getAreaById(areaId);
-  if (!area) return undefined;
-  return { area, child: selectedChildForPathname(area, pathname) };
+	const areaId = selectedAreaIdForPathname(navAreas, pathname);
+	if (!areaId) return undefined;
+	const area = getAreaById(areaId);
+	if (!area) return undefined;
+	return { area, child: selectedChildForPathname(area, pathname) };
 }
 
 /**
@@ -782,15 +816,15 @@ function resolveAreaAndChild(
  * Returns `[]` for routes no area owns (callers fall back to bespoke crumbs).
  */
 export function navTrailForPathname(pathname: string): Crumb[] {
-  const resolved = resolveAreaAndChild(pathname);
-  if (!resolved) return [];
-  const { area, child } = resolved;
+	const resolved = resolveAreaAndChild(pathname);
+	if (!resolved) return [];
+	const { area, child } = resolved;
 
-  if (!child) {
-    return [{ label: area.label }];
-  }
+	if (!child) {
+		return [{ label: area.label }];
+	}
 
-  return [{ label: area.label, href: area.href }, { label: child.label }];
+	return [{ label: area.label, href: area.href }, { label: child.label }];
 }
 
 /**
@@ -799,14 +833,14 @@ export function navTrailForPathname(pathname: string): Crumb[] {
  * empty string for routes no area owns so callers can supply their own.
  */
 export function navTitleForPathname(pathname: string): string {
-  const resolved = resolveAreaAndChild(pathname);
-  if (!resolved) return "";
-  const { area, child } = resolved;
-  if (child) return child.label;
-  return area.label;
+	const resolved = resolveAreaAndChild(pathname);
+	if (!resolved) return "";
+	const { area, child } = resolved;
+	if (child) return child.label;
+	return area.label;
 }
 
 /** Strip query/hash so route comparisons use the bare path. */
 export function basePath(href: string): string {
-  return href.split("?")[0].split("#")[0];
+	return href.split("?")[0].split("#")[0];
 }

--- a/tests/ai-navigation.spec.ts
+++ b/tests/ai-navigation.spec.ts
@@ -1,109 +1,131 @@
 import { test, expect, type Page } from "@playwright/test";
 
-import { clickUntilHeading, clickUntilUrl, waitForHydration } from "./helpers/nav";
+import {
+	clickUntilHeading,
+	clickUntilUrl,
+	waitForHydration,
+} from "./helpers/nav";
 import { encodeFilter } from "../src/lib/filters/encode";
 import { defaultMetricFilter } from "../src/lib/filters/defaults";
 
 /**
  * CHAOS-1588 / CHAOS-1767: AI workflow navigation e2e.
  *
- * Asserts the unified AI Workflows sidebar entry routes to the `/ai` workspace
- * and the route-based tab strip moves between Impact, Review Load, Governance
- * Risk, and Automations cleanly.
+ * Asserts the AI sidebar entry routes to the `/ai` overview and the route-based
+ * tab strip moves between real AI subviews cleanly.
  */
 
 const defaultFilter = encodeFilter({
-  ...defaultMetricFilter,
-  time: { range_days: 30, compare_days: 30 },
+	...defaultMetricFilter,
+	time: { range_days: 30, compare_days: 30 },
 });
 
-// J1 (CHAOS-2080): AI is now a top-level area, so on every /ai route the sidebar
-// expands to AI's navVisible children (Overview / Review Load / Governance Risk).
-// Those sidebar rows share their labels with the in-page tab strip, so tab
-// locators MUST be scoped to the tab strip (<nav aria-label="AI Workflows">) to
-// stay unambiguous under Playwright strict mode.
-const aiTabStrip = (page: Page) => page.getByRole("navigation", { name: "AI Workflows" });
-const impactTab = (page: Page) => aiTabStrip(page).getByRole("link", { name: /^Impact$/ });
-const reviewLoadTab = (page: Page) => aiTabStrip(page).getByRole("link", { name: /^Review Load$/ });
+const aiTabStrip = (page: Page) =>
+	page.getByRole("navigation", { name: "AI views" });
+const overviewTab = (page: Page) =>
+	aiTabStrip(page).getByRole("link", { name: /^Overview$/ });
+const impactTab = (page: Page) =>
+	aiTabStrip(page).getByRole("link", { name: /^Impact$/ });
+const reviewLoadTab = (page: Page) =>
+	aiTabStrip(page).getByRole("link", { name: /^Review Load$/ });
 const governanceRiskTab = (page: Page) =>
-  aiTabStrip(page).getByRole("link", { name: /^Governance Risk$/ });
+	aiTabStrip(page).getByRole("link", { name: /^Governance Risk$/ });
 const automationsTab = (page: Page) =>
-  aiTabStrip(page).getByRole("link", { name: /^Automations$/ });
+	aiTabStrip(page).getByRole("link", { name: /^Automations$/ });
 
 test.describe("AI workflow primary navigation", () => {
-  test("Home exposes the AI Workflows entry path (gated when AI is not dominant)", async ({
-    page,
-  }) => {
-    // clickUntilUrl retries can consume up to 30s under load; widen the budget so
-    // the retry window doesn't collide with the default 30s test timeout.
-    test.slow();
-    await page.goto(`/dashboard?f=${defaultFilter}`);
-    await waitForHydration(page);
+	test("Home exposes the AI entry path when the cockpit callout is secondary", async ({
+		page,
+	}) => {
+		// clickUntilUrl retries can consume up to 30s under load; widen the budget so
+		// the retry window doesn't collide with the default 30s test timeout.
+		test.slow();
+		await page.goto(`/dashboard?f=${defaultFilter}`);
+		await waitForHydration(page);
 
-    // AI Workflow Intelligence is conditional (CHAOS-2051): when AI is not the
-    // dominant signal it collapses to a single secondary entry into the AI area.
-    const aiEntry = page.getByRole("link", { name: /Open AI Workflows/ });
-    await expect(aiEntry).toBeVisible();
+		const aiEntry = page.getByRole("link", { name: /Open AI/ });
+		await expect(aiEntry).toBeVisible();
 
-    // Heavy dashboard hydrates slowly under suite load; allow a longer retry
-    // budget (paired with test.slow()) so the entry click reliably lands.
-    await clickUntilUrl(page, aiEntry, /\/ai(\?|$)/, 60000);
-    await expect(page.getByRole("heading", { name: "Impact", exact: true })).toBeVisible();
-  });
+		// Heavy dashboard hydrates slowly under suite load; allow a longer retry
+		// budget (paired with test.slow()) so the entry click reliably lands.
+		await clickUntilUrl(page, aiEntry, /\/ai(\?|$)/, 60000);
+		await expect(page.getByTestId("area-overview")).toBeVisible();
+	});
 
-  test("nav links route between the three AI views", async ({ page }) => {
-    await page.goto(`/ai/impact?f=${defaultFilter}`);
+	test("nav links route between real AI views", async ({ page }) => {
+		await page.goto(`/ai/impact?f=${defaultFilter}`);
 
-    await expect(page.getByRole("heading", { name: "Impact", exact: true })).toBeVisible();
-    await expect(page.getByTestId("ai-impact-dashboard")).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "Impact", exact: true }),
+		).toBeVisible();
+		await expect(page.getByTestId("ai-impact-dashboard")).toBeVisible();
 
-    await clickUntilUrl(page, reviewLoadTab(page), /\/ai\/review-load/);
-    await expect(page.getByRole("heading", { name: "Review Load", exact: true })).toBeVisible();
-    await expect(page.getByTestId("ai-review-load-dashboard")).toBeVisible();
+		await clickUntilUrl(page, reviewLoadTab(page), /\/ai\/review-load/);
+		await expect(
+			page.getByRole("heading", { name: "Review Load", exact: true }),
+		).toBeVisible();
+		await expect(page.getByTestId("ai-review-load-dashboard")).toBeVisible();
 
-    await clickUntilUrl(page, governanceRiskTab(page), /\/ai\/risk/);
-    await expect(page.getByRole("heading", { name: "Governance Risk", exact: true })).toBeVisible();
-    await expect(page.getByTestId("ai-risk-dashboard")).toBeVisible();
+		await clickUntilUrl(page, governanceRiskTab(page), /\/ai\/risk/);
+		await expect(
+			page.getByRole("heading", { name: "Governance Risk", exact: true }),
+		).toBeVisible();
+		await expect(page.getByTestId("ai-risk-dashboard")).toBeVisible();
 
-    await clickUntilUrl(page, impactTab(page), /\/ai(\?|$)/);
-    await expect(page.getByRole("heading", { name: "Impact", exact: true })).toBeVisible();
-  });
+		await clickUntilUrl(page, overviewTab(page), /\/ai(\?|$)/);
+		await expect(page.getByTestId("area-overview")).toBeVisible();
 
-  test("Automations link owns the active nav state on its own route", async ({ page }) => {
-    await page.goto(`/ai/impact?f=${defaultFilter}`);
+		await clickUntilUrl(page, impactTab(page), /\/ai\/impact/);
+		await expect(
+			page.getByRole("heading", { name: "Impact", exact: true }),
+		).toBeVisible();
+	});
 
-    await clickUntilUrl(page, automationsTab(page), /\/ai\/automations/);
+	test("Automations link owns the active nav state on its own route", async ({
+		page,
+	}) => {
+		await page.goto(`/ai/impact?f=${defaultFilter}`);
 
-    await expect(automationsTab(page)).toHaveAttribute("aria-current", "page");
-    await expect(impactTab(page)).not.toHaveAttribute("aria-current", "page");
-  });
+		await clickUntilUrl(page, automationsTab(page), /\/ai\/automations/);
 
-  test("FilterBar is the canonical chrome on every AI route (CHAOS-1773)", async ({ page }) => {
-    // CHAOS-1773: all AI surfaces now render the canonical FilterBar instead
-    // of the bespoke AIFilterBar that used native date inputs and selects.
-    for (const route of ["/ai/impact", "/ai/review-load", "/ai/automations", "/ai/risk"]) {
-      await page.goto(`${route}?f=${defaultFilter}`);
-      const filterBar = page.getByTestId("filter-bar");
-      await expect(filterBar).toBeVisible();
-      await expect(filterBar).toHaveAttribute("data-view", "ai");
-    }
-  });
+		await expect(automationsTab(page)).toHaveAttribute("aria-current", "page");
+		await expect(impactTab(page)).not.toHaveAttribute("aria-current", "page");
+	});
 
-  test("filter encoding round-trips across AI navigation", async ({ page }) => {
-    const customFilter = encodeFilter({
-      ...defaultMetricFilter,
-      time: { range_days: 7, compare_days: 7 },
-    });
+	test("FilterBar is the canonical chrome on every AI route (CHAOS-1773)", async ({
+		page,
+	}) => {
+		// CHAOS-1773: all AI surfaces now render the canonical FilterBar instead
+		// of the bespoke AIFilterBar that used native date inputs and selects.
+		for (const route of [
+			"/ai",
+			"/ai/impact",
+			"/ai/review-load",
+			"/ai/automations",
+			"/ai/risk",
+		]) {
+			await page.goto(`${route}?f=${defaultFilter}`);
+			const filterBar = page.getByTestId("filter-bar");
+			await expect(filterBar).toBeVisible();
+			await expect(filterBar).toHaveAttribute("data-view", "ai");
+		}
+	});
 
-    await page.goto(`/ai/impact?f=${customFilter}`);
-    await expect(page.getByTestId("filter-bar")).toBeVisible();
+	test("filter encoding round-trips across AI navigation", async ({ page }) => {
+		const customFilter = encodeFilter({
+			...defaultMetricFilter,
+			time: { range_days: 7, compare_days: 7 },
+		});
 
-    await clickUntilHeading(
-      page,
-      reviewLoadTab(page),
-      page.getByRole("heading", { name: "Review Load", exact: true }),
-    );
-    await expect(page).toHaveURL(/\/ai\/review-load/);
-    await expect(page.getByTestId("filter-bar")).toBeVisible();
-  });
+		await page.goto(`/ai/impact?f=${customFilter}`);
+		await expect(page.getByTestId("filter-bar")).toBeVisible();
+
+		await clickUntilHeading(
+			page,
+			reviewLoadTab(page),
+			page.getByRole("heading", { name: "Review Load", exact: true }),
+		);
+		await expect(page).toHaveURL(/\/ai\/review-load/);
+		await expect(page.getByTestId("filter-bar")).toBeVisible();
+	});
 });

--- a/tests/ai-tabs.spec.ts
+++ b/tests/ai-tabs.spec.ts
@@ -1,38 +1,57 @@
 import { expect, test } from "@playwright/test";
 
 const aiTabs = [
-  { name: "Impact", path: "/ai" },
-  { name: "Attribution", path: "/ai/attribution" },
-  { name: "Review Load", path: "/ai/review-load" },
-  { name: "Test Gaps", path: "/ai/test-gaps" },
-  { name: "Governance Risk", path: "/ai/risk" },
-  { name: "Evidence", path: "/ai/evidence" },
-  { name: "Automations", path: "/ai/automations" },
+	{ name: "Impact", path: "/ai/impact" },
+	{ name: "Review Load", path: "/ai/review-load" },
+	{ name: "Governance Risk", path: "/ai/risk" },
+	{ name: "Automations", path: "/ai/automations" },
 ] as const;
 
-test.describe("AI Workflows tabs", () => {
-  test("/ai defaults to the Impact tab", async ({ page }) => {
-    await page.goto("/ai");
+test.describe("AI views", () => {
+	test("/ai renders the AI overview", async ({ page }) => {
+		await page.goto("/ai");
 
-    await expect(page).toHaveURL(/\/ai(?:[?#].*)?$/);
-    await expect(page.getByRole("heading", { level: 2, name: "Impact" })).toBeVisible();
-    await expect(page.getByRole("link", { name: /^Impact$/ })).toHaveAttribute(
-      "aria-current",
-      "page",
-    );
-  });
+		await expect(page).toHaveURL(/\/ai(?:[?#].*)?$/);
+		await expect(
+			page.getByRole("heading", { level: 1, name: "AI" }),
+		).toBeVisible();
+		await expect(page.getByTestId("area-overview")).toBeVisible();
+		const tabStrip = page.getByRole("navigation", { name: "AI views" });
+		await expect(
+			tabStrip.getByRole("link", { name: /^Overview$/ }),
+		).toHaveAttribute("aria-current", "page");
+	});
 
-  test("each AI tab renders a distinct heading and distinct content", async ({ page }) => {
-    const rendered = new Map<string, string>();
+	test("each visible AI tab renders a distinct heading and distinct content", async ({
+		page,
+	}) => {
+		const rendered = new Map<string, string>();
 
-    for (const tab of aiTabs) {
-      await page.goto(tab.path);
-      await expect(page.getByRole("heading", { level: 2, name: tab.name })).toBeVisible();
-      const mainText = await page.locator("main").innerText();
-      expect(mainText, `${tab.name} should include its heading`).toContain(tab.name);
-      rendered.set(tab.name, mainText.replace(/\s+/g, " ").trim());
-    }
+		for (const tab of aiTabs) {
+			await page.goto(tab.path);
+			await expect(
+				page.getByRole("heading", { level: 2, name: tab.name }),
+			).toBeVisible();
+			const mainText = await page.locator("main").innerText();
+			expect(mainText, `${tab.name} should include its heading`).toContain(
+				tab.name,
+			);
+			rendered.set(tab.name, mainText.replace(/\s+/g, " ").trim());
+		}
 
-    expect(new Set(rendered.values()).size).toBe(rendered.size);
-  });
+		expect(new Set(rendered.values()).size).toBe(rendered.size);
+	});
+
+	test("preview-only AI routes are hidden from the tab strip", async ({
+		page,
+	}) => {
+		await page.goto("/ai");
+		const tabStrip = page.getByRole("navigation", { name: "AI views" });
+
+		for (const hiddenTab of ["Attribution", "Test Gaps", "Evidence"]) {
+			await expect(tabStrip.getByRole("link", { name: hiddenTab })).toHaveCount(
+				0,
+			);
+		}
+	});
 });

--- a/tests/nav-reachability.spec.ts
+++ b/tests/nav-reachability.spec.ts
@@ -1,77 +1,81 @@
-import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import {
+	expect,
+	test,
+	type APIRequestContext,
+	type Page,
+} from "@playwright/test";
 
 import { clickUntilUrl, waitForHydration } from "./helpers/nav";
 
 const primaryAreas = [
-  { label: "Cockpit", path: "/dashboard" },
-  { label: "Diagnose", path: "/work" },
-  { label: "Plan", path: "/plan" },
-  { label: "Improve", path: "/opportunities" },
-  { label: "Govern", path: "/testops" },
-  { label: "AI", path: "/ai" },
-  { label: "Reports", path: "/reports" },
-  { label: "Admin", path: "/admin" },
+	{ label: "Cockpit", path: "/dashboard" },
+	{ label: "Diagnose", path: "/work" },
+	{ label: "Plan", path: "/plan" },
+	{ label: "Improve", path: "/opportunities" },
+	{ label: "Govern", path: "/testops" },
+	{ label: "AI", path: "/ai" },
+	{ label: "Reports", path: "/reports" },
+	{ label: "Admin", path: "/admin" },
 ] as const;
 
 // Leaf labels that must NOT appear as flat sidebar rows anymore.
 const collapsedLeafLabels = [
-  "Flow",
-  "Investment",
-  "Landscape",
-  "People",
-  "Code",
-  "Complexity",
-  "Cognitive Load",
-  "Bottlenecks",
-  "Operating Review",
-  "Delivery Forecast",
-  "AI Workflows",
-  "Pipelines",
-  "Tests",
-  "Quality",
-  "Coverage",
-  "Delivery Risk",
-  "Incident Correlation",
-  "Security",
-  "Feature Flags",
-  "Compounding Risk",
-  "Report Center",
+	"Flow",
+	"Investment",
+	"Landscape",
+	"People",
+	"Code",
+	"Complexity",
+	"Cognitive Load",
+	"Bottlenecks",
+	"Operating Review",
+	"Delivery Forecast",
+	"Pipelines",
+	"Tests",
+	"Quality",
+	"Coverage",
+	"Delivery Risk",
+	"Incident Correlation",
+	"Security",
+	"Feature Flags",
+	"Compounding Risk",
+	"Report Center",
 ] as const;
 
 const reachableRoutes = [
-  "/dashboard",
-  "/plan",
-  "/plan/delivery-forecast",
-  "/operating-review",
-  "/work",
-  "/metrics",
-  "/people",
-  "/code",
-  "/landscape",
-  "/complexity",
-  "/cognitive-load",
-  "/bottleneck",
-  "/opportunities",
-  "/ai",
-  "/ai/impact",
-  "/ai/attribution",
-  "/ai/review-load",
-  "/ai/test-gaps",
-  "/ai/risk",
-  "/ai/evidence",
-  "/ai/automations",
-  "/testops",
-  "/testops/pipelines",
-  "/testops/tests",
-  "/testops/coverage",
-  "/testops/risk",
-  "/quality",
-  "/security",
-  "/feature-flags",
-  "/incident-correlation",
-  "/risk/compounding",
-  "/reports",
-  "/admin",
+	"/dashboard",
+	"/plan",
+	"/plan/delivery-forecast",
+	"/operating-review",
+	"/work",
+	"/metrics",
+	"/people",
+	"/code",
+	"/landscape",
+	"/complexity",
+	"/cognitive-load",
+	"/bottleneck",
+	"/opportunities",
+	"/ai",
+	"/ai/impact",
+	"/ai/attribution",
+	"/ai/review-load",
+	"/ai/test-gaps",
+	"/ai/risk",
+	"/ai/evidence",
+	"/ai/automations",
+	"/testops",
+	"/testops/pipelines",
+	"/testops/tests",
+	"/testops/coverage",
+	"/testops/risk",
+	"/quality",
+	"/security",
+	"/feature-flags",
+	"/incident-correlation",
+	"/risk/compounding",
+	"/reports",
+	"/admin",
 ] as const;
 
 /**
@@ -82,218 +86,229 @@ const reachableRoutes = [
  * route reachable / not a 404". Retries absorb transient dev-server aborts under load.
  */
 async function expectReachable(request: APIRequestContext, path: string) {
-  await expect(async () => {
-    const response = await request.get(path);
-    const status = response.status();
-    expect(status, `${path} returned ${status}`).not.toBe(404);
-    expect(status, `${path} returned ${status}`).toBeLessThan(500);
-  }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
+	await expect(async () => {
+		const response = await request.get(path);
+		const status = response.status();
+		expect(status, `${path} returned ${status}`).not.toBe(404);
+		expect(status, `${path} returned ${status}`).toBeLessThan(500);
+	}).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
 }
 
-async function expectSingleSelectedArea(page: Page, path: string, selectedLabel: string) {
-  await page.goto(path);
+async function expectSingleSelectedArea(
+	page: Page,
+	path: string,
+	selectedLabel: string,
+) {
+	await page.goto(path);
 
-  // CHAOS-2075 two-level nav: aria-current marks the current-page link (a child
-  // leaf on a leaf route, the area row on a landing), so the active AREA is marked
-  // with data-active instead. Assert exactly one area is active and it's the
-  // expected one — rendered from usePathname(), independent of the ?f= append.
-  const selectedArea = page.locator('aside a[data-active="true"]');
-  await expect(selectedArea).toHaveCount(1, { timeout: 15000 });
-  await expect(selectedArea).toHaveText(selectedLabel);
+	// CHAOS-2075 two-level nav: aria-current marks the current-page link (a child
+	// leaf on a leaf route, the area row on a landing), so the active AREA is marked
+	// with data-active instead. Assert exactly one area is active and it's the
+	// expected one — rendered from usePathname(), independent of the ?f= append.
+	const selectedArea = page.locator('aside a[data-active="true"]');
+	await expect(selectedArea).toHaveCount(1, { timeout: 15000 });
+	await expect(selectedArea).toHaveText(selectedLabel);
 }
 
 test.describe("primary navigation reachability", () => {
-  test("sidebar surfaces exactly the decision areas as links, no flat leaf rows", async ({
-    page,
-  }) => {
-    await page.goto("/dashboard");
-    await waitForHydration(page);
+	test("sidebar surfaces exactly the decision areas as links, no flat leaf rows", async ({
+		page,
+	}) => {
+		await page.goto("/dashboard");
+		await waitForHydration(page);
 
-    const aside = page.locator("aside");
+		const aside = page.locator("aside");
 
-    for (const area of primaryAreas) {
-      await expect(aside.getByRole("link", { name: area.label, exact: true })).toHaveAttribute(
-        "href",
-        new RegExp(`${area.path}(?:[?#].*)?`),
-      );
-    }
+		for (const area of primaryAreas) {
+			await expect(
+				aside.getByRole("link", { name: area.label, exact: true }),
+			).toHaveAttribute("href", new RegExp(`${area.path}(?:[?#].*)?`));
+		}
 
-    // Leaf destinations are no longer enumerated flat in the sidebar.
-    for (const leaf of collapsedLeafLabels) {
-      await expect(aside.getByRole("link", { name: leaf, exact: true })).toHaveCount(0);
-    }
-  });
+		// Leaf destinations are no longer enumerated flat in the sidebar.
+		for (const leaf of collapsedLeafLabels) {
+			await expect(
+				aside.getByRole("link", { name: leaf, exact: true }),
+			).toHaveCount(0);
+		}
+	});
 
-  test("reaches Plan as a top-level area and routes its visible subviews", async ({
-    page,
-    request,
-  }) => {
-    await page.goto("/dashboard");
-    await waitForHydration(page);
+	test("reaches Plan as a top-level area and routes its visible subviews", async ({
+		page,
+		request,
+	}) => {
+		await page.goto("/dashboard");
+		await waitForHydration(page);
 
-    const sidebar = page.locator("aside");
+		const sidebar = page.locator("aside");
 
-    await clickUntilUrl(
-      page,
-      sidebar.getByRole("link", { name: "Plan", exact: true }),
-      /\/plan(?:[?#].*)?$/,
-    );
+		await clickUntilUrl(
+			page,
+			sidebar.getByRole("link", { name: "Plan", exact: true }),
+			/\/plan(?:[?#].*)?$/,
+		);
 
-    const planChildren = page.getByTestId("nav-children-plan");
-    await expect(planChildren).toBeVisible({ timeout: 15000 });
+		const planChildren = page.getByTestId("nav-children-plan");
+		await expect(planChildren).toBeVisible({ timeout: 15000 });
 
-    for (const child of [
-      { label: "Overview", url: /\/plan(?:[?#].*)?$/, path: "/plan" },
-      {
-        label: "Delivery Forecast",
-        url: /\/plan\/delivery-forecast(?:[?#].*)?$/,
-        path: "/plan/delivery-forecast",
-      },
-      {
-        label: "Operating Review",
-        url: /\/operating-review(?:[?#].*)?$/,
-        path: "/operating-review",
-      },
-    ]) {
-      await clickUntilUrl(
-        page,
-        planChildren.getByRole("link", { name: child.label, exact: true }),
-        child.url,
-      );
-      await expectReachable(request, child.path);
-    }
-  });
+		for (const child of [
+			{ label: "Overview", url: /\/plan(?:[?#].*)?$/, path: "/plan" },
+			{
+				label: "Delivery Forecast",
+				url: /\/plan\/delivery-forecast(?:[?#].*)?$/,
+				path: "/plan/delivery-forecast",
+			},
+			{
+				label: "Operating Review",
+				url: /\/operating-review(?:[?#].*)?$/,
+				path: "/operating-review",
+			},
+		]) {
+			await clickUntilUrl(
+				page,
+				planChildren.getByRole("link", { name: child.label, exact: true }),
+				child.url,
+			);
+			await expectReachable(request, child.path);
+		}
+	});
 
-  test("reaches Diagnose as a top-level area and routes its visible subviews", async ({
-    page,
-    request,
-  }) => {
-    await page.goto("/dashboard");
-    await waitForHydration(page);
+	test("reaches Diagnose as a top-level area and routes its visible subviews", async ({
+		page,
+		request,
+	}) => {
+		await page.goto("/dashboard");
+		await waitForHydration(page);
 
-    const sidebar = page.locator("aside");
+		const sidebar = page.locator("aside");
 
-    await clickUntilUrl(
-      page,
-      sidebar.getByRole("link", { name: "Diagnose", exact: true }),
-      /\/work(?:[?#].*)?$/,
-    );
+		await clickUntilUrl(
+			page,
+			sidebar.getByRole("link", { name: "Diagnose", exact: true }),
+			/\/work(?:[?#].*)?$/,
+		);
 
-    const diagnoseChildren = page.getByTestId("nav-children-diagnose");
-    await expect(diagnoseChildren).toBeVisible({ timeout: 15000 });
+		const diagnoseChildren = page.getByTestId("nav-children-diagnose");
+		await expect(diagnoseChildren).toBeVisible({ timeout: 15000 });
 
-    for (const child of [
-      { label: "Overview", url: /\/work(?:[?#].*)?$/, path: "/work" },
-      { label: "Flow", url: /\/metrics(?:[?#].*)?$/, path: "/metrics" },
-      {
-        label: "Investment",
-        url: /\/investment(?:[?#].*)?$/,
-        path: "/investment",
-      },
-      {
-        label: "Landscape",
-        url: /\/landscape(?:[?#].*)?$/,
-        path: "/landscape",
-      },
-      { label: "People", url: /\/people(?:[?#].*)?$/, path: "/people" },
-      { label: "Code", url: /\/code(?:[?#].*)?$/, path: "/code" },
-      {
-        label: "Complexity",
-        url: /\/complexity(?:[?#].*)?$/,
-        path: "/complexity",
-      },
-      {
-        label: "Cognitive Load",
-        url: /\/cognitive-load(?:[?#].*)?$/,
-        path: "/cognitive-load",
-      },
-      {
-        label: "Bottlenecks",
-        url: /\/bottleneck(?:[?#].*)?$/,
-        path: "/bottleneck",
-      },
-    ]) {
-      await clickUntilUrl(
-        page,
-        diagnoseChildren.getByRole("link", { name: child.label, exact: true }),
-        child.url,
-      );
-      await expectReachable(request, child.path);
-    }
-  });
+		for (const child of [
+			{ label: "Overview", url: /\/work(?:[?#].*)?$/, path: "/work" },
+			{ label: "Flow", url: /\/metrics(?:[?#].*)?$/, path: "/metrics" },
+			{
+				label: "Investment",
+				url: /\/investment(?:[?#].*)?$/,
+				path: "/investment",
+			},
+			{
+				label: "Landscape",
+				url: /\/landscape(?:[?#].*)?$/,
+				path: "/landscape",
+			},
+			{ label: "People", url: /\/people(?:[?#].*)?$/, path: "/people" },
+			{ label: "Code", url: /\/code(?:[?#].*)?$/, path: "/code" },
+			{
+				label: "Complexity",
+				url: /\/complexity(?:[?#].*)?$/,
+				path: "/complexity",
+			},
+			{
+				label: "Cognitive Load",
+				url: /\/cognitive-load(?:[?#].*)?$/,
+				path: "/cognitive-load",
+			},
+			{
+				label: "Bottlenecks",
+				url: /\/bottleneck(?:[?#].*)?$/,
+				path: "/bottleneck",
+			},
+		]) {
+			await clickUntilUrl(
+				page,
+				diagnoseChildren.getByRole("link", { name: child.label, exact: true }),
+				child.url,
+			);
+			await expectReachable(request, child.path);
+		}
+	});
 
-  test("every former leaf destination still resolves without 404", async ({ request }) => {
-    // ~30 sequential SSR reachability fetches; Turbopack cold-compiles each route
-    // on first hit under suite load, which overruns the default 30s test budget.
-    test.setTimeout(120_000);
-    for (const route of reachableRoutes) {
-      await expectReachable(request, route);
-    }
-  });
+	test("every former leaf destination still resolves without 404", async ({
+		request,
+	}) => {
+		// ~30 sequential SSR reachability fetches; Turbopack cold-compiles each route
+		// on first hit under suite load, which overruns the default 30s test budget.
+		test.setTimeout(120_000);
+		for (const route of reachableRoutes) {
+			await expectReachable(request, route);
+		}
+	});
 
-  test("reaches AI as a top-level area and routes its visible subviews", async ({
-    page,
-    request,
-  }) => {
-    // J1 (CHAOS-2080): AI is now a first-class TOP-LEVEL decision area — it no
-    // longer lives as a drill-down under Improve. Reach it directly from the
-    // sidebar spine, then walk only its navVisible children (areas.ts). The
-    // redirect/preview AI routes (/ai/impact, /ai/attribution, /ai/test-gaps,
-    // /ai/evidence, /ai/automations) are navVisible:false and surfaced solely via
-    // the in-page tab strip (covered by ai-navigation.spec.ts), so they are
-    // intentionally NOT sidebar destinations here.
-    await page.goto("/dashboard");
-    await waitForHydration(page);
+	test("reaches AI as a top-level area and routes its visible subviews", async ({
+		page,
+		request,
+	}) => {
+		await page.goto("/dashboard");
+		await waitForHydration(page);
 
-    const sidebar = page.locator("aside");
+		const sidebar = page.locator("aside");
 
-    // The AI area row is a top-level sibling of Diagnose/Improve/Govern and links
-    // to the /ai workspace.
-    await clickUntilUrl(
-      page,
-      sidebar.getByRole("link", { name: "AI", exact: true }),
-      /\/ai(?:[?#].*)?$/,
-    );
+		// The AI area row is a top-level sibling of Diagnose/Improve/Govern and links
+		// to the /ai workspace.
+		await clickUntilUrl(
+			page,
+			sidebar.getByRole("link", { name: "AI", exact: true }),
+			/\/ai(?:[?#].*)?$/,
+		);
 
-    // The active AI area expands to exactly its navVisible children (areas.ts):
-    // Overview (/ai), Review Load (/ai/review-load), Governance Risk (/ai/risk).
-    const aiChildren = page.getByTestId("nav-children-ai");
-    await expect(aiChildren).toBeVisible({ timeout: 15000 });
+		// The active AI area expands to exactly its navVisible children (areas.ts).
+		const aiChildren = page.getByTestId("nav-children-ai");
+		await expect(aiChildren).toBeVisible({ timeout: 15000 });
 
-    for (const child of [
-      { label: "Overview", url: /\/ai(?:[?#].*)?$/, path: "/ai" },
-      {
-        label: "Review Load",
-        url: /\/ai\/review-load(?:[?#].*)?$/,
-        path: "/ai/review-load",
-      },
-      {
-        label: "Governance Risk",
-        url: /\/ai\/risk(?:[?#].*)?$/,
-        path: "/ai/risk",
-      },
-    ]) {
-      await clickUntilUrl(
-        page,
-        aiChildren.getByRole("link", { name: child.label, exact: true }),
-        child.url,
-      );
-      await expectReachable(request, child.path);
-    }
-  });
+		for (const child of [
+			{ label: "Overview", url: /\/ai(?:[?#].*)?$/, path: "/ai" },
+			{
+				label: "Impact",
+				url: /\/ai\/impact(?:[?#].*)?$/,
+				path: "/ai/impact",
+			},
+			{
+				label: "Review Load",
+				url: /\/ai\/review-load(?:[?#].*)?$/,
+				path: "/ai/review-load",
+			},
+			{
+				label: "Governance Risk",
+				url: /\/ai\/risk(?:[?#].*)?$/,
+				path: "/ai/risk",
+			},
+			{
+				label: "Automations",
+				url: /\/ai\/automations(?:[?#].*)?$/,
+				path: "/ai/automations",
+			},
+		]) {
+			await clickUntilUrl(
+				page,
+				aiChildren.getByRole("link", { name: child.label, exact: true }),
+				child.url,
+			);
+			await expectReachable(request, child.path);
+		}
+	});
 
-  test("marks exactly one area as selected for representative leaf routes", async ({ page }) => {
-    for (const route of [
-      { path: "/metrics?tab=dora", selectedLabel: "Diagnose" },
-      { path: "/landscape", selectedLabel: "Diagnose" },
-      { path: "/testops/coverage", selectedLabel: "Govern" },
-      { path: "/testops/risk", selectedLabel: "Govern" },
-      { path: "/bottleneck", selectedLabel: "Diagnose" },
-      { path: "/risk/compounding", selectedLabel: "Govern" },
-      { path: "/plan/delivery-forecast", selectedLabel: "Plan" },
-      { path: "/operating-review", selectedLabel: "Plan" },
-    ]) {
-      await expectSingleSelectedArea(page, route.path, route.selectedLabel);
-    }
-  });
+	test("marks exactly one area as selected for representative leaf routes", async ({
+		page,
+	}) => {
+		for (const route of [
+			{ path: "/metrics?tab=dora", selectedLabel: "Diagnose" },
+			{ path: "/landscape", selectedLabel: "Diagnose" },
+			{ path: "/testops/coverage", selectedLabel: "Govern" },
+			{ path: "/testops/risk", selectedLabel: "Govern" },
+			{ path: "/bottleneck", selectedLabel: "Diagnose" },
+			{ path: "/risk/compounding", selectedLabel: "Govern" },
+			{ path: "/plan/delivery-forecast", selectedLabel: "Plan" },
+			{ path: "/operating-review", selectedLabel: "Plan" },
+		]) {
+			await expectSingleSelectedArea(page, route.path, route.selectedLabel);
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- Promote AI to a gated first-class top-level area using shared AreaOverview.
- Hide preview/redirect-only AI tabs from nav/tab surfaces while keeping deep routes reachable.
- Strip implementation-leak copy and move Impact to /ai/impact as a real sibling view.
- Remove AI Workflows from Improve.

## Promotion gate
- Decision: promote AI as first-class.
- Real visible subviews: Impact, Review Load, Governance Risk, Automations (4).
- Hidden preview-only routes: Attribution, Test Gaps, Evidence.

## Tests
- pnpm test:unit
- pnpm build
- changed-file design lint via eslint/design rules
- pnpm exec playwright test tests/ai-navigation.spec.ts tests/ai-tabs.spec.ts tests/nav-reachability.spec.ts --project=authenticated

## Visual evidence
Screenshots captured locally for all visible AI views:
- chaos-2087-ai-overview-after.png
- chaos-2087-ai-impact-after.png
- chaos-2087-ai-review-load-after.png
- chaos-2087-ai-governance-risk-after.png
- chaos-2087-ai-automations-after.png

Closes CHAOS-2087