### PR TITLE
fix(nav): restore Diagnose Work analytical views (CHAOS-2079 remediation)

### DIFF
--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -256,7 +256,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
 						<div className="flex flex-wrap items-center gap-3">
 							<Link
 								href={withFilterParam(
-									"/flame?mode=cycle_breakdown",
+									"/work?tab=flame&mode=cycle_breakdown",
 									filters,
 									activeRole,
 								)}

--- a/src/app/(app)/work/page.tsx
+++ b/src/app/(app)/work/page.tsx
@@ -1,96 +1,341 @@
-import { redirect } from "next/navigation";
-
 import { FilterBar } from "@/components/filters/FilterBar";
+import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { AreaOverview } from "@/components/navigation/AreaOverview";
 import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
-import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { BackLink } from "@/components/shared/BackLink";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { checkApiHealth } from "@/lib/api/system";
-import { getDiagnoseSignals } from "@/lib/areaSignals/diagnose";
-import { getServerEnv } from "@/lib/config";
+import { getExplainData, getHomeData } from "@/lib/api/home";
+import { getInvestment } from "@/lib/api/investment";
+import { getHeatmap, getQuadrant } from "@/lib/api/visuals";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
+import { FALLBACK_DELTAS } from "@/lib/metrics/catalog";
+import { fetchOrNull } from "@/lib/fetchOrNull";
+import { getInvestmentMixForHydration } from "@/lib/graphql/investmentHydration";
+import { HydrateUrqlResults } from "@/lib/graphql/HydrateUrqlResults";
+import { normalizeInvestmentMix } from "@/lib/investmentMix";
+import { runtimeConfig } from "@/lib/runtimeConfig";
+import { LandscapeView } from "@/components/work/LandscapeView";
+import { HeatmapView } from "@/components/work/HeatmapView";
+import { FlowView } from "@/components/work/FlowView";
+import { InvestmentView } from "@/components/work/InvestmentView";
+import { CapacityView } from "@/components/work/CapacityView";
+import { FlameView } from "@/components/work/FlameView";
+import { EvidenceView } from "@/components/work/EvidenceView";
+import { GraphView } from "@/components/work/GraphView";
+import { WorkTabNav, type WorkTab } from "@/components/navigation/WorkTabNav";
+import { getDiagnoseSignals } from "@/lib/areaSignals/diagnose";
+import { getServerEnv } from "@/lib/config";
+import {
+	resolveActiveView,
+	type DiagnoseView,
+} from "@/lib/navigation/workPageView";
 
 type WorkPageProps = {
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+	searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-const legacyWorkDestinations: Record<string, string> = {
-  landscape: "/landscape",
-  heatmap: "/landscape",
-  flow: "/metrics?tab=flow",
-  investment: "/investment",
-  capacity: "/capacity",
-  flame: "/work",
-  evidence: "/work",
-  graph: "/work",
-};
+const findCategory = (
+	categories: Array<{ key: string; name: string; value: number }>,
+	tokens: string[],
+) =>
+	categories.find((category) =>
+		tokens.some((token) =>
+			`${category.key} ${category.name}`.toLowerCase().includes(token),
+		),
+	);
 
 export default async function WorkPage({ searchParams }: WorkPageProps) {
-  const params = (await searchParams) ?? {};
-  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
-  const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
-  const originParam = Array.isArray(params.origin) ? params.origin[0] : params.origin;
-  const tabParam = Array.isArray(params.tab) ? params.tab[0] : params.tab;
-  const viewParam = Array.isArray(params.view) ? params.view[0] : params.view;
-  const activeRole = typeof roleParam === "string" ? roleParam : undefined;
-  const activeOrigin = typeof originParam === "string" ? originParam : undefined;
+	const params = (await searchParams) ?? {};
+	const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+	const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+	const originParam = Array.isArray(params.origin)
+		? params.origin[0]
+		: params.origin;
+	const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+	const activeOrigin =
+		typeof originParam === "string" ? originParam : undefined;
 
-  const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+	const tabParam = Array.isArray(params.tab) ? params.tab[0] : params.tab;
+	const activeTab: WorkTab =
+		typeof tabParam === "string" &&
+		[
+			"landscape",
+			"heatmap",
+			"flow",
+			"investment",
+			"capacity",
+			"flame",
+			"evidence",
+			"graph",
+		].includes(tabParam)
+			? (tabParam as WorkTab)
+			: "landscape";
 
-  const legacyDestination =
-    typeof tabParam === "string" ? legacyWorkDestinations[tabParam] : undefined;
-  if (legacyDestination) {
-    redirect(withFilterParam(legacyDestination, filters, activeRole));
-  }
-  if (viewParam === "work") {
-    redirect(withFilterParam("/landscape", filters, activeRole));
-  }
+	const viewParam = Array.isArray(params.view) ? params.view[0] : params.view;
+	// resolveActiveView preserves legacy /work?tab=<workTab> deep links: when
+	// `view` is absent but a valid `tab` is present it returns "work" so the Work
+	// content branch renders and the existing `tab` logic picks the sub-view.
+	const activeView: DiagnoseView = resolveActiveView(viewParam, tabParam);
 
-  const env = getServerEnv();
-  const isTestMode =
-    env.DEV_HEALTH_TEST_MODE === "true" || env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
+	const filters = encodedFilter
+		? decodeFilter(encodedFilter)
+		: filterFromQueryParams(params);
+	const scopeId = filters.scope.ids[0] ?? "";
+	const quadrantScope: "org" | "team" | "repo" | "developer" =
+		filters.scope.level === "developer"
+			? "developer"
+			: filters.scope.level === "team" || filters.scope.level === "repo"
+				? filters.scope.level
+				: "org";
 
-  const [health, diagnoseSignals] = await Promise.all([
-    checkApiHealth(),
-    getDiagnoseSignals(filters, isTestMode),
-  ]);
+	const env = getServerEnv();
+	const isTestMode =
+		env.DEV_HEALTH_TEST_MODE === "true" ||
+		env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
 
-  if (!health.ok && !isTestMode) {
-    return <ServiceUnavailable />;
-  }
+	// When GraphQL transport is enabled we use the hydration-aware fetcher so
+	// the client-side <InvestmentView> useQuery resolves from cache instead of
+	// triggering a second network round-trip (CHAOS-1276 Phase C). Falls back
+	// to the REST path when GraphQL is disabled or session has no org_id.
+	const graphqlEnabled = runtimeConfig.useGraphQLAnalytics();
+	let hydrationOrgId: string | undefined;
+	if (graphqlEnabled) {
+		const { auth } = await import("@/lib/auth");
+		const session = await auth();
+		hydrationOrgId = session?.user?.org_id as string | undefined;
+	}
 
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-        <PrimaryNav filters={filters} active="diagnose" role={activeRole} />
-        <main className="flex min-w-0 flex-1 flex-col gap-8">
-          <header className="flex flex-col gap-4">
-            <BackLink href={withFilterParam("/", filters, activeRole)} />
-            <div>
-              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Diagnose</p>
-              <h1 className="mt-2 font-(--font-display) text-3xl">Diagnose</h1>
-              <p className="mt-2 text-sm text-(--ink-muted)">
-                Investigate flow, investment, landscape, people, code, complexity, cognitive load,
-                and bottlenecks from one durable area.
-              </p>
-            </div>
-          </header>
+	const investmentFetch =
+		graphqlEnabled && hydrationOrgId
+			? fetchOrNull(
+					getInvestmentMixForHydration(filters, hydrationOrgId),
+					"work/investment-hydration",
+				)
+			: fetchOrNull(
+					getInvestment(filters).then((data) => ({
+						data,
+						hydrationPayload: null,
+					})),
+					"work/investment",
+				);
 
-          <GlobalContextBar filters={filters} origin={activeOrigin} />
-          <FilterBar view="work" />
+	// Resolve the area's sub-area signals and the borrowed Work metric content
+	// in parallel — no waterfall.
+	const [
+		health,
+		home,
+		investmentResult,
+		wipExplain,
+		blockedExplain,
+		reviewHeatmap,
+		cycleThroughput,
+		wipThroughput,
+		reviewLoadLatency,
+		diagnoseSignals,
+	] = await Promise.all([
+		checkApiHealth(),
+		fetchOrNull(getHomeData(filters), "work/home-data"),
+		investmentFetch,
+		fetchOrNull(
+			getExplainData({ metric: "wip_saturation", filters }),
+			"work/explain-wip_saturation",
+		),
+		fetchOrNull(
+			getExplainData({ metric: "blocked_work", filters }),
+			"work/explain-blocked_work",
+		),
+		fetchOrNull(
+			getHeatmap({
+				type: "temporal_load",
+				metric: "review_wait_density",
+				scope_type: filters.scope.level,
+				scope_id: scopeId,
+				range_days: filters.time.range_days,
+				start_date: filters.time.start_date,
+				end_date: filters.time.end_date,
+			}),
+			"work/review-heatmap",
+		),
+		fetchOrNull(
+			getQuadrant({
+				type: "cycle_throughput",
+				scope_type: quadrantScope,
+				scope_id: scopeId,
+				range_days: filters.time.range_days,
+				bucket: "week",
+				start_date: filters.time.start_date,
+				end_date: filters.time.end_date,
+			}),
+			"work/cycle-throughput-quadrant",
+		),
+		fetchOrNull(
+			getQuadrant({
+				type: "wip_throughput",
+				scope_type: quadrantScope,
+				scope_id: scopeId,
+				range_days: filters.time.range_days,
+				bucket: "week",
+				start_date: filters.time.start_date,
+				end_date: filters.time.end_date,
+			}),
+			"work/wip-throughput-quadrant",
+		),
+		fetchOrNull(
+			getQuadrant({
+				type: "review_load_latency",
+				scope_type: quadrantScope,
+				scope_id: scopeId,
+				range_days: filters.time.range_days,
+				bucket: "week",
+				start_date: filters.time.start_date,
+				end_date: filters.time.end_date,
+			}),
+			"work/review-load-latency-quadrant",
+		),
+		getDiagnoseSignals(filters, isTestMode),
+	]);
 
-          <AreaOverview
-            areaId="diagnose"
-            signals={diagnoseSignals}
-            filters={filters}
-            role={activeRole}
-            title="Related workflows"
-            description="Diagnostic sub-areas, ordered by severity."
-          />
-        </main>
-      </div>
-    </div>
-  );
+	if (!health.ok && !isTestMode) {
+		return <ServiceUnavailable />;
+	}
+
+	const deltas = home?.deltas?.length ? home.deltas : FALLBACK_DELTAS;
+	const placeholderDeltas = !home?.deltas?.length;
+	const investment = investmentResult?.data ?? null;
+	const investmentHydrationPayload = investmentResult?.hydrationPayload ?? null;
+	const investmentMix = investment ? normalizeInvestmentMix(investment) : null;
+
+	const investmentCategoriesForSummary = investmentMix
+		? Object.entries(investmentMix.theme_distribution).map(([key, value]) => ({
+				key,
+				name: key.replace(/[_-]+/g, " "),
+				value,
+			}))
+		: [];
+
+	const planned = investmentMix
+		? (findCategory(investmentCategoriesForSummary, [
+				"planned",
+				"roadmap",
+				"feature",
+			]) ?? null)
+		: null;
+	const unplanned = investmentMix
+		? (findCategory(investmentCategoriesForSummary, [
+				"unplanned",
+				"interrupt",
+				"incident",
+				"support",
+				"ops",
+				"run",
+			]) ?? null)
+		: null;
+	const plannedTotal =
+		planned && unplanned ? planned.value + unplanned.value : 0;
+	const plannedPct = plannedTotal ? (planned?.value ?? 0) / plannedTotal : null;
+	const unplannedPct = plannedTotal
+		? (unplanned?.value ?? 0) / plannedTotal
+		: null;
+
+	return (
+		<div className="min-h-screen bg-background text-foreground">
+			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+				<PrimaryNav filters={filters} active="diagnose" role={activeRole} />
+				<main className="flex min-w-0 flex-1 flex-col gap-8">
+					<header className="flex flex-col gap-4">
+						<BackLink href={withFilterParam("/", filters, activeRole)} />
+						<div>
+							{/* A6: the area is named by the AREA ("Diagnose"), not a borrowed leaf. */}
+							<p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+								Diagnose
+							</p>
+							<h1 className="mt-2 font-(--font-display) text-3xl">Diagnose</h1>
+							<p className="mt-2 text-sm text-(--ink-muted)">
+								Investigate flow, investment, landscape, people, code,
+								complexity, cognitive load, and bottlenecks from one durable
+								area.
+							</p>
+						</div>
+					</header>
+
+					<GlobalContextBar filters={filters} origin={activeOrigin} />
+					<FilterBar view="work" />
+
+					{activeView === "work" ? (
+						<>
+							<WorkTabNav
+								activeTab={activeTab}
+								filters={filters}
+								role={activeRole}
+							/>
+
+							{activeTab === "landscape" && (
+								<LandscapeView
+									filters={filters}
+									activeRole={activeRole}
+									deltas={deltas}
+									placeholderDeltas={placeholderDeltas}
+									investmentMix={investmentMix}
+									cycleThroughput={cycleThroughput}
+									wipThroughput={wipThroughput}
+									reviewLoadLatency={reviewLoadLatency}
+									planned={planned}
+									unplanned={unplanned}
+									plannedPct={plannedPct}
+									unplannedPct={unplannedPct}
+								/>
+							)}
+
+							{activeTab === "heatmap" && (
+								<HeatmapView
+									filters={filters}
+									scopeId={scopeId}
+									reviewHeatmap={reviewHeatmap}
+								/>
+							)}
+
+							{activeTab === "flow" && (
+								<FlowView filters={filters} activeRole={activeRole} />
+							)}
+
+							{activeTab === "investment" && (
+								<>
+									<HydrateUrqlResults payload={investmentHydrationPayload} />
+									<InvestmentView filters={filters} activeRole={activeRole} />
+								</>
+							)}
+
+							{activeTab === "capacity" && <CapacityView filters={filters} />}
+
+							{activeTab === "flame" && <FlameView filters={filters} />}
+
+							{activeTab === "evidence" && (
+								<EvidenceView
+									filters={filters}
+									activeRole={activeRole}
+									wipExplain={wipExplain}
+									blockedExplain={blockedExplain}
+								/>
+							)}
+
+							{activeTab === "graph" && (
+								<GraphView filters={filters} activeRole={activeRole} />
+							)}
+						</>
+					) : (
+						<AreaOverview
+							areaId="diagnose"
+							signals={diagnoseSignals}
+							filters={filters}
+							role={activeRole}
+							title="Related workflows"
+							description="Diagnostic sub-areas, ordered by severity."
+						/>
+					)}
+				</main>
+			</div>
+		</div>
+	);
 }

--- a/src/components/navigation/WorkTabNav.test.tsx
+++ b/src/components/navigation/WorkTabNav.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/utils";
+import { WorkTabNav } from "./WorkTabNav";
+import type { MetricFilter } from "@/lib/filters/types";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/filters/url", () => ({
+  withFilterParam: (href: string) => href,
+}));
+
+const filters: MetricFilter = {
+  scope: { level: "repo", ids: [] },
+  time: { range_days: 30, compare_days: 0, start_date: undefined, end_date: undefined },
+  who: {},
+  what: {},
+  why: {},
+  how: {},
+};
+
+describe("WorkTabNav", () => {
+  it("renders all tab labels", () => {
+    render(<WorkTabNav activeTab="landscape" filters={filters} />);
+    for (const label of [
+      "Landscape",
+      "Heatmap",
+      "Flow",
+      "Investment",
+      "Capacity",
+      "Flame",
+      "Evidence",
+      "Work Graph",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("marks the active tab with aria-current='page'", () => {
+    render(<WorkTabNav activeTab="flow" filters={filters} />);
+    const activeLink = screen.getByText("Flow").closest("a");
+    expect(activeLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("does not mark inactive tabs with aria-current", () => {
+    render(<WorkTabNav activeTab="flow" filters={filters} />);
+    const inactiveLink = screen.getByText("Landscape").closest("a");
+    expect(inactiveLink).not.toHaveAttribute("aria-current");
+  });
+
+  it("sets correct href for each tab", () => {
+    render(<WorkTabNav activeTab="landscape" filters={filters} />);
+    const flowLink = screen.getByText("Flow").closest("a");
+    expect(flowLink).toHaveAttribute("href", "/work?tab=flow");
+  });
+});

--- a/src/components/navigation/WorkTabNav.tsx
+++ b/src/components/navigation/WorkTabNav.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { ModeTabs, type ModeTabItem } from "@/components/shared/ModeTabs";
+import { withFilterParam } from "@/lib/filters/url";
+import type { MetricFilter } from "@/lib/filters/types";
+
+export type WorkTab =
+  | "landscape"
+  | "heatmap"
+  | "flow"
+  | "investment"
+  | "flame"
+  | "evidence"
+  | "capacity"
+  | "graph";
+
+type WorkTabNavProps = {
+  activeTab: WorkTab;
+  filters: MetricFilter;
+  role?: string;
+};
+
+const tabs = [
+  { id: "landscape", label: "Landscape" },
+  { id: "heatmap", label: "Heatmap" },
+  { id: "flow", label: "Flow" },
+  { id: "investment", label: "Investment" },
+  { id: "capacity", label: "Capacity" },
+  { id: "flame", label: "Flame" },
+  { id: "evidence", label: "Evidence" },
+  { id: "graph", label: "Work Graph" },
+] as const;
+
+export function WorkTabNav({ activeTab, filters, role }: WorkTabNavProps) {
+  const items: ModeTabItem<WorkTab>[] = tabs.map((tab) => ({
+    id: tab.id,
+    label: tab.label,
+    href: withFilterParam(`/work?tab=${tab.id}`, filters, role),
+  }));
+
+  return <ModeTabs items={items} activeId={activeTab} ariaLabel="Work views" />;
+}

--- a/src/lib/navigation/__tests__/areas.test.ts
+++ b/src/lib/navigation/__tests__/areas.test.ts
@@ -65,6 +65,7 @@ describe("navArea.children — locked child navigation", () => {
 			Cockpit: [],
 			Diagnose: [
 				"Overview",
+				"Work",
 				"Flow",
 				"Investment",
 				"Landscape",

--- a/src/lib/navigation/__tests__/workPageView.test.ts
+++ b/src/lib/navigation/__tests__/workPageView.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { resolveActiveView, WORK_TABS } from "../workPageView";
+
+// Unit tests for the work/page.tsx activeView resolution logic (CHAOS-2075,
+// Codex review fix): legacy ?tab= deep links must resolve to "work", not
+// silently fall through to "overview".
+
+describe("resolveActiveView", () => {
+  describe("explicit ?view= param", () => {
+    it("returns 'overview' when view=overview", () => {
+      expect(resolveActiveView("overview", undefined)).toBe("overview");
+    });
+
+    it("returns 'work' when view=work", () => {
+      expect(resolveActiveView("work", undefined)).toBe("work");
+    });
+
+    it("?view=work wins even when a tab param is also present", () => {
+      expect(resolveActiveView("work", "flow")).toBe("work");
+    });
+
+    it("?view=overview wins even when a tab param is also present", () => {
+      expect(resolveActiveView("overview", "flow")).toBe("overview");
+    });
+
+    it("ignores an unknown view param and falls through to legacy-tab / default logic", () => {
+      // Unknown view + valid tab → legacy deep-link path → "work"
+      expect(resolveActiveView("unknown", "flow")).toBe("overview");
+    });
+  });
+
+  describe("legacy ?tab= deep links (no view param)", () => {
+    it.each(WORK_TABS)(
+      "resolves to 'work' when view is absent and tab=%s",
+      (tab) => {
+        expect(resolveActiveView(undefined, tab)).toBe("work");
+      },
+    );
+
+    it("resolves /work?tab=flow to 'work' (primary Codex finding)", () => {
+      expect(resolveActiveView(undefined, "flow")).toBe("work");
+    });
+
+    it("resolves /work?tab=investment to 'work'", () => {
+      expect(resolveActiveView(undefined, "investment")).toBe("work");
+    });
+
+    it("resolves /work?tab=flame to 'work'", () => {
+      expect(resolveActiveView(undefined, "flame")).toBe("work");
+    });
+
+    it("ignores an invalid tab value and returns 'overview'", () => {
+      expect(resolveActiveView(undefined, "not-a-tab")).toBe("overview");
+    });
+  });
+
+  describe("bare /work (no params)", () => {
+    it("returns 'overview' when both view and tab are absent", () => {
+      expect(resolveActiveView(undefined, undefined)).toBe("overview");
+    });
+
+    it("returns 'overview' when view is an empty string", () => {
+      expect(resolveActiveView("", undefined)).toBe("overview");
+    });
+  });
+});

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -240,6 +240,12 @@ export const navAreas: readonly NavArea[] = [
 				path: "/work",
 				navVisible: true,
 			},
+			{
+				id: "work",
+				label: "Work",
+				path: "/work?view=work",
+				navVisible: true,
+			},
 			{ id: "flow", label: "Flow", path: "/metrics", navVisible: true },
 			{
 				id: "investment",

--- a/src/lib/navigation/workPageView.ts
+++ b/src/lib/navigation/workPageView.ts
@@ -1,0 +1,45 @@
+// ── Work page active-view resolution ─────────────────────────────────────────
+//
+// Extracted from src/app/(app)/work/page.tsx so the resolution is unit-testable
+// without rendering the RSC. The logic must stay in sync with the page.
+//
+// Rules (Codex review fix — CHAOS-2075):
+//   1. `?view=overview|work` — explicit view param wins.
+//   2. `?tab=<workTab>` without a `view` param — legacy deep link emitted by
+//      WorkTabNav before two-level nav; resolve to "work" so the Work content
+//      branch renders and the existing `tab` logic picks the sub-view.
+//   3. Bare `/work` (no view, no tab) → "overview".
+
+export type DiagnoseView = "overview" | "work";
+export const DIAGNOSE_VIEWS: DiagnoseView[] = ["overview", "work"];
+
+export const WORK_TABS = [
+  "landscape",
+  "heatmap",
+  "flow",
+  "investment",
+  "capacity",
+  "flame",
+  "evidence",
+  "graph",
+] as const;
+
+/**
+ * Resolve the active DiagnoseView from raw URL search params.
+ *
+ * @param viewParam - the raw `view` query param value (string | undefined)
+ * @param tabParam  - the raw `tab` query param value (string | undefined)
+ */
+export function resolveActiveView(
+  viewParam: string | undefined,
+  tabParam: string | undefined,
+): DiagnoseView {
+  if (DIAGNOSE_VIEWS.includes(viewParam as DiagnoseView)) {
+    return viewParam as DiagnoseView;
+  }
+  // Legacy ?tab= deep link: no explicit view but a valid work tab → show Work.
+  if (!viewParam && typeof tabParam === "string" && (WORK_TABS as readonly string[]).includes(tabParam)) {
+    return "work";
+  }
+  return "overview";
+}

--- a/tests/work-navigation.spec.ts
+++ b/tests/work-navigation.spec.ts
@@ -5,95 +5,135 @@ import { defaultMetricFilter } from "../src/lib/filters/defaults";
 import { clickUntilUrl, waitForHydration } from "./helpers/nav";
 
 const filterWith30d = encodeFilterParam({
-  ...defaultMetricFilter,
-  time: { ...defaultMetricFilter.time, range_days: 30, compare_days: 30 },
+	...defaultMetricFilter,
+	time: { ...defaultMetricFilter.time, range_days: 30, compare_days: 30 },
 });
 
 const diagnoseChildren = [
-  { label: "Overview", href: /\/work(?:[?#].*)?$/ },
-  { label: "Flow", href: /\/metrics(?:[?#].*)?$/ },
-  { label: "Investment", href: /\/investment(?:[?#].*)?$/ },
-  { label: "Landscape", href: /\/landscape(?:[?#].*)?$/ },
-  { label: "People", href: /\/people(?:[?#].*)?$/ },
-  { label: "Code", href: /\/code(?:[?#].*)?$/ },
-  { label: "Complexity", href: /\/complexity(?:[?#].*)?$/ },
-  { label: "Cognitive Load", href: /\/cognitive-load(?:[?#].*)?$/ },
-  { label: "Bottlenecks", href: /\/bottleneck(?:[?#].*)?$/ },
+	{ label: "Overview", href: /\/work(?:[?#].*)?$/ },
+	{ label: "Flow", href: /\/metrics(?:[?#].*)?$/ },
+	{ label: "Investment", href: /\/investment(?:[?#].*)?$/ },
+	{ label: "Landscape", href: /\/landscape(?:[?#].*)?$/ },
+	{ label: "People", href: /\/people(?:[?#].*)?$/ },
+	{ label: "Code", href: /\/code(?:[?#].*)?$/ },
+	{ label: "Complexity", href: /\/complexity(?:[?#].*)?$/ },
+	{ label: "Cognitive Load", href: /\/cognitive-load(?:[?#].*)?$/ },
+	{ label: "Bottlenecks", href: /\/bottleneck(?:[?#].*)?$/ },
 ] as const;
 
 test.describe("Diagnose navigation", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/work");
-    await waitForHydration(page);
-    await expect(page.getByRole("heading", { name: "Diagnose", level: 1 })).toBeVisible({
-      timeout: 15000,
-    });
-  });
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/work");
+		await waitForHydration(page);
+		await expect(
+			page.getByRole("heading", { name: "Diagnose", level: 1 }),
+		).toBeVisible({
+			timeout: 15000,
+		});
+	});
 
-  test("overview renders AreaOverview without Work tabs", async ({ page }) => {
-    await expect(page.getByTestId("area-overview")).toBeVisible();
-    await expect(page.getByRole("navigation", { name: "Diagnose views" })).toHaveCount(0);
-    await expect(page.getByRole("navigation", { name: "Work views" })).toHaveCount(0);
-    await expect(page.getByRole("link", { name: "Work", exact: true })).toHaveCount(0);
-  });
+	test("overview renders AreaOverview without Work tabs", async ({ page }) => {
+		await expect(page.getByTestId("area-overview")).toBeVisible();
+		await expect(
+			page.getByRole("navigation", { name: "Diagnose views" }),
+		).toHaveCount(0);
+		await expect(
+			page.getByRole("navigation", { name: "Work views" }),
+		).toHaveCount(0);
+		// The overview must not expose an in-page "Work" mode-tab. The sidebar
+		// "Work" destination (a Diagnose child) is intentional and lives in <aside>,
+		// outside <main>.
+		await expect(
+			page.getByRole("main").getByRole("link", { name: "Work", exact: true }),
+		).toHaveCount(0);
+	});
 
-  test("sidebar exposes first-class Diagnose children", async ({ page }) => {
-    const children = page.getByTestId("nav-children-diagnose");
-    await expect(children).toBeVisible();
+	test("sidebar exposes first-class Diagnose children", async ({ page }) => {
+		const children = page.getByTestId("nav-children-diagnose");
+		await expect(children).toBeVisible();
 
-    for (const child of diagnoseChildren) {
-      await expect(children.getByRole("link", { name: child.label, exact: true })).toHaveAttribute(
-        "href",
-        child.href,
-      );
-    }
-  });
+		for (const child of diagnoseChildren) {
+			await expect(
+				children.getByRole("link", { name: child.label, exact: true }),
+			).toHaveAttribute("href", child.href);
+		}
+	});
 
-  test("routes Flow Investment and Landscape as Diagnose destinations", async ({ page }) => {
-    const children = page.getByTestId("nav-children-diagnose");
+	test("routes Flow Investment and Landscape as Diagnose destinations", async ({
+		page,
+	}) => {
+		const children = page.getByTestId("nav-children-diagnose");
 
-    await clickUntilUrl(
-      page,
-      children.getByRole("link", { name: "Flow", exact: true }),
-      /\/metrics(?:[?#].*)?$/,
-    );
-    await expect(page.getByRole("heading", { name: "Monitoring view" })).toBeVisible();
+		await clickUntilUrl(
+			page,
+			children.getByRole("link", { name: "Flow", exact: true }),
+			/\/metrics(?:[?#].*)?$/,
+		);
+		await expect(
+			page.getByRole("heading", { name: "Monitoring view" }),
+		).toBeVisible();
 
-    await page.goto("/work");
-    await clickUntilUrl(
-      page,
-      page.getByTestId("nav-children-diagnose").getByRole("link", {
-        name: "Investment",
-        exact: true,
-      }),
-      /\/investment(?:[?#].*)?$/,
-    );
-    await expect(page.getByRole("heading", { name: "Unlock investment view" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "Upgrade to Team" })).toBeVisible();
+		await page.goto("/work");
+		await clickUntilUrl(
+			page,
+			page.getByTestId("nav-children-diagnose").getByRole("link", {
+				name: "Investment",
+				exact: true,
+			}),
+			/\/investment(?:[?#].*)?$/,
+		);
+		await expect(
+			page.getByRole("heading", { name: "Unlock investment view" }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("link", { name: "Upgrade to Team" }),
+		).toBeVisible();
 
-    await page.goto("/work");
-    await clickUntilUrl(
-      page,
-      page.getByTestId("nav-children-diagnose").getByRole("link", {
-        name: "Landscape",
-        exact: true,
-      }),
-      /\/landscape(?:[?#].*)?$/,
-    );
-    await expect(page.getByRole("heading", { name: "Landscape" })).toBeVisible();
-  });
+		await page.goto("/work");
+		await clickUntilUrl(
+			page,
+			page.getByTestId("nav-children-diagnose").getByRole("link", {
+				name: "Landscape",
+				exact: true,
+			}),
+			/\/landscape(?:[?#].*)?$/,
+		);
+		await expect(
+			page.getByRole("heading", { name: "Landscape" }),
+		).toBeVisible();
+	});
 
-  test("legacy Work deep links redirect to first-class destinations", async ({ page }) => {
-    await page.goto(`/work?tab=investment&f=${filterWith30d}`);
-    await expect(page).toHaveURL(/\/investment/);
-    expect(decodeFilter(new URL(page.url()).searchParams.get("f")).time.range_days).toBe(30);
+	test("legacy Work deep links render the analytical views in the Diagnose hub", async ({
+		page,
+	}) => {
+		// CHAOS-2079 remediation: /work?tab=<view> must render the view inside the
+		// restored Diagnose work hub (resolveActiveView -> "work"), NOT redirect
+		// away or dead-end. Flame/Work-Graph previously looped back to the overview.
+		const cases = [
+			{ tab: "investment", label: "Investment" },
+			{ tab: "flow", label: "Flow" },
+			{ tab: "landscape", label: "Landscape" },
+			{ tab: "flame", label: "Flame" },
+		] as const;
 
-    await page.goto(`/work?tab=flow&f=${filterWith30d}`);
-    await expect(page).toHaveURL(/\/metrics\?tab=flow/);
-    expect(decodeFilter(new URL(page.url()).searchParams.get("f")).time.range_days).toBe(30);
+		for (const { tab, label } of cases) {
+			await page.goto(`/work?tab=${tab}&f=${filterWith30d}`);
+			await waitForHydration(page);
 
-    await page.goto(`/work?tab=landscape&f=${filterWith30d}`);
-    await expect(page).toHaveURL(/\/landscape/);
-    expect(decodeFilter(new URL(page.url()).searchParams.get("f")).time.range_days).toBe(30);
-  });
+			// Stays in the hub — no redirect away to a first-class route.
+			await expect(page).toHaveURL(new RegExp(`/work\\?tab=${tab}`));
+
+			// The Work views tab strip is present and the deep-linked tab is active.
+			const workNav = page.getByRole("navigation", { name: "Work views" });
+			await expect(workNav).toBeVisible();
+			await expect(
+				workNav.getByRole("link", { name: label, exact: true }),
+			).toHaveAttribute("aria-current", "page");
+
+			// Filter context is preserved across the deep link.
+			expect(
+				decodeFilter(new URL(page.url()).searchParams.get("f")).time.range_days,
+			).toBe(30);
+		}
+	});
 });


### PR DESCRIPTION
## Summary

First remediation PR for the CHAOS-2079 IA restructure that **over-removed core functionality**. J3/CHAOS-2083 replaced the `/work` page with a redirect tombstone, orphaning the 8 Work analytical view components. Flame & Work-Graph deep links **looped back to the Diagnose overview** (dead-end); Heatmap pointed at the wrong route. This restores reachability without reverting the good J1/J2/J9 structure.

## What changed

- **Restore `/work?view=work` hub** with all 8 tab branches: Landscape, Heatmap, Flow, Investment, Capacity, Flame, Evidence, Work Graph (`work/page.tsx`).
- **Restore J3-deleted glue** (verbatim from base `cff025f`): `WorkTabNav` + `workPageView` (`resolveActiveView`) **plus their unit tests**.
- **Keep the J2/J9 improvements**: bare `/work` stays the J9 `AreaOverview`; top-level `GlobalContextBar` (J2). No "Work" mode-tab resurrected on the overview — the views are drill-down destinations, respecting J1's flattened sidebar.
- **Add a `Work` sidebar destination under Diagnose** → `/work?view=work` (per product owner request).
- **Fix the one true dead link**: `explore` `/flame?mode=…` (404) → `/work?tab=flame&mode=…`. Every other `/work?tab=…` deep link (FlowView, InspectPanel, InvestigationPanel, workGraphDrilldownUrl) now resolves automatically via the restored `resolveActiveView`.
- **E2E**: rewrote `work-navigation` test that *encoded the regression* (`legacy Work deep links redirect to first-class destinations` → `render the analytical views in the Diagnose hub`); scoped the overview "no in-page Work tab" check to `<main>` so the new sidebar destination is allowed.

## Functionality-preservation check (the lesson from this regression)

Diffed every touched surface against base `cff025f`:
- Every pre-2079 Work view is reachable again (`/work?view=work&tab=<view>`); verified in-browser all 8 tabs render and the URL holds.
- Bare `/work` overview is **unchanged** (J9 `AreaOverview` + sidebar Diagnose children).
- **No view replaced by a summary card.** No route became unreachable. The only removed behavior is the looping redirect tombstone, which was itself the bug.

## Gates

- `pnpm test:unit` — **1552 passed** (incl. 23 restored-module tests + 103 nav tests)
- `pnpm build` — exit 0
- `DESIGN_LINT=true eslint <changed files>` — clean
- E2E: `work-navigation` 5/5, `nav-reachability` + `nav-cta-screenshots` 13/13 (**18/18**)

## Visual evidence

Captured in-browser (test-mode dev server, seeded `admin@devhealth.example`) — restored views render with the full WorkTabNav strip:
- `chaos-2079-work-hub-sidebar-after.png` — `/work?view=work` hub + new "Work" sidebar link (8 tabs)
- `chaos-2079-work-flame-after.png` — Flame view (previously dead-end loop)
- `chaos-2079-work-graph-after.png` — Work Graph view (previously dead-end loop)

(Screenshots attached to the linked Linear issue / PR thread.)

## Follow-ups filed

- **CHAOS-2095** — decide durable IA homes for Flame/Work-Graph/Heatmap/Evidence/Capacity (the `/work` hub is an intentional, tracked interim deviation from the locked IA).
- **CHAOS-2094** — restore role-aware cockpit "key shifts" delta row (separate pre-2079 regression from CHAOS-2049).

Refs CHAOS-2079, CHAOS-2095