### PR TITLE
fix(plan): restore real Monte Carlo forecast under Plan (CHAOS-2079 remediation)

### DIFF
--- a/src/app/(app)/plan/capacity/page.tsx
+++ b/src/app/(app)/plan/capacity/page.tsx
@@ -1,0 +1,112 @@
+import { UpgradeGate } from "@/components/billing/UpgradeGate";
+import { FilterBar } from "@/components/filters/FilterBar";
+import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
+import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { BackLink } from "@/components/shared/BackLink";
+import { ModeTabs } from "@/components/shared/ModeTabs";
+import { CapacityView } from "@/components/work/CapacityView";
+import { getCurrentOrg, getOrgEntitlements } from "@/lib/admin/server";
+import { checkApiHealth } from "@/lib/api/system";
+import { fetchOrNull } from "@/lib/fetchOrNull";
+import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+import { withFilterParam } from "@/lib/filters/url";
+import { getCapacityForecastForHydration } from "@/lib/graphql/capacityHydration";
+import { HydrateUrqlResults } from "@/lib/graphql/HydrateUrqlResults";
+import { planForecastTabs, type PlanForecastView } from "@/lib/navigation/planForecastTabs";
+import { runtimeConfig } from "@/lib/runtimeConfig";
+
+type PlanCapacityPageProps = {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+export default async function PlanCapacityPage({ searchParams }: PlanCapacityPageProps) {
+  // Run health check, org fetch, and entitlements fetch as concurrently as possible.
+  const orgPromise = fetchOrNull(getCurrentOrg(), "plan/capacity/org");
+  const entitlementsPromise = orgPromise.then((orgResult) => {
+    const orgId = orgResult?.data?.id;
+    return orgId ? fetchOrNull(getOrgEntitlements(orgId), "plan/capacity/entitlements") : null;
+  });
+
+  const [health, , entitlements] = await Promise.all([
+    checkApiHealth(),
+    orgPromise,
+    entitlementsPromise,
+  ]);
+
+  if (!health.ok) {
+    return <ServiceUnavailable />;
+  }
+
+  const features = entitlements?.data?.features ?? {};
+  const currentTier = entitlements?.data?.tier;
+
+  const params = (await searchParams) ?? {};
+  const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+  const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+  const originParam = Array.isArray(params.origin) ? params.origin[0] : params.origin;
+  const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+  const activeOrigin = typeof originParam === "string" ? originParam : undefined;
+
+  const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+
+  const graphqlEnabled = runtimeConfig["useGraphQLAnalytics"]();
+  let hydrationOrgId: string | undefined;
+  if (graphqlEnabled) {
+    const { auth } = await import("@/lib/auth");
+    const session = await auth();
+    hydrationOrgId = session?.user?.org_id as string | undefined;
+  }
+
+  const capacityResult =
+    graphqlEnabled && hydrationOrgId
+      ? await fetchOrNull(
+          getCapacityForecastForHydration(filters, hydrationOrgId),
+          "plan/capacity/forecast-hydration",
+        )
+      : null;
+
+  const capacityHydrationPayload = capacityResult?.hydrationPayload ?? null;
+
+  const forecastTabs = planForecastTabs(filters, activeRole);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+        <PrimaryNav filters={filters} active="capacity" role={activeRole} />
+        <main className="flex min-w-0 flex-1 flex-col gap-8">
+          <header className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">Plan</p>
+              <h1 className="mt-2 font-(--font-display) text-3xl">Monte Carlo Forecast</h1>
+              <p className="mt-2 text-sm text-(--ink-muted)">
+                Monte Carlo simulation of work completion (P50/P85/P95) from historical throughput.
+                Adjust the date range to control how much history informs the forecast.
+              </p>
+            </div>
+            <BackLink href={withFilterParam("/plan", filters, activeRole)} />
+          </header>
+
+          <ModeTabs<PlanForecastView>
+            items={forecastTabs}
+            activeId="monte-carlo"
+            ariaLabel="Plan forecast views"
+          />
+
+          <GlobalContextBar filters={filters} origin={activeOrigin} />
+          <FilterBar view="capacity-planning" />
+
+          <UpgradeGate
+            feature="capacity_forecast"
+            requiredTier="team"
+            currentTier={currentTier}
+            features={features}
+          >
+            <HydrateUrqlResults payload={capacityHydrationPayload} />
+            <CapacityView filters={filters} orgId={hydrationOrgId} />
+          </UpgradeGate>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/plan/delivery-forecast/page.tsx
+++ b/src/app/(app)/plan/delivery-forecast/page.tsx
@@ -3,12 +3,12 @@ import { FilterBar } from "@/components/filters/FilterBar";
 import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
-import { ModeTabs, type ModeTabItem } from "@/components/shared/ModeTabs";
+import { ModeTabs } from "@/components/shared/ModeTabs";
 import { checkApiHealth } from "@/lib/api/system";
 import { requireSession } from "@/lib/auth";
 import { fetchOrNull } from "@/lib/fetchOrNull";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
-import { withFilterParam } from "@/lib/filters/url";
+import { planForecastTabs, type PlanForecastView } from "@/lib/navigation/planForecastTabs";
 import { formatNumber } from "@/lib/formatters";
 import { getThroughputForecastViaGraphQL } from "@/lib/graphql/capacityFetchers";
 import type { ThroughputRiskOverlay } from "@/lib/graphql/types";
@@ -16,8 +16,6 @@ import type { ThroughputRiskOverlay } from "@/lib/graphql/types";
 type DeliveryForecastPageProps = {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
-
-type DeliveryForecastView = "monte-carlo";
 
 function firstParam(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
@@ -125,18 +123,10 @@ export default async function DeliveryForecastPage({ searchParams }: DeliveryFor
             </div>
           </header>
 
-          <ModeTabs<DeliveryForecastView>
-            items={
-              [
-                {
-                  id: "monte-carlo",
-                  label: "Monte Carlo",
-                  href: withFilterParam("/plan/delivery-forecast", filters, activeRole),
-                },
-              ] satisfies ReadonlyArray<ModeTabItem<DeliveryForecastView>>
-            }
-            activeId="monte-carlo"
-            ariaLabel="Delivery Forecast views"
+          <ModeTabs<PlanForecastView>
+            items={planForecastTabs(filters, activeRole)}
+            activeId="delivery-forecast"
+            ariaLabel="Plan forecast views"
           />
 
           <GlobalContextBar filters={filters} origin={originParam} />

--- a/src/lib/navigation/__tests__/planForecastTabs.test.ts
+++ b/src/lib/navigation/__tests__/planForecastTabs.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+
+import { planForecastTabs } from "../planForecastTabs";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+
+// CHAOS-2079 / J4 remediation: the Plan forecast surfaces must expose BOTH the
+// Delivery Forecast summary and the real Monte Carlo distribution as sibling
+// tabs. The "Monte Carlo" tab must point at the real forecast route
+// (/plan/capacity), not self-link back to the summary.
+describe("planForecastTabs", () => {
+  it("returns the Delivery Forecast and Monte Carlo tabs in order", () => {
+    const tabs = planForecastTabs(defaultMetricFilter);
+    expect(tabs.map((t) => t.id)).toEqual(["delivery-forecast", "monte-carlo"]);
+    expect(tabs.map((t) => t.label)).toEqual(["Delivery Forecast", "Monte Carlo"]);
+  });
+
+  it("points Delivery Forecast at /plan/delivery-forecast", () => {
+    const [delivery] = planForecastTabs(defaultMetricFilter);
+    expect(delivery.href).toContain("/plan/delivery-forecast");
+  });
+
+  it("points Monte Carlo at the real forecast route /plan/capacity (not a self-link)", () => {
+    const monteCarlo = planForecastTabs(defaultMetricFilter).find((t) => t.id === "monte-carlo");
+    expect(monteCarlo?.href).toContain("/plan/capacity");
+    expect(monteCarlo?.href).not.toContain("/plan/delivery-forecast");
+  });
+
+  it("preserves the filter param on each destination", () => {
+    const tabs = planForecastTabs(defaultMetricFilter);
+    for (const tab of tabs) {
+      expect(tab.href).toContain("f=");
+    }
+  });
+
+  it("threads the active role through when provided", () => {
+    const tabs = planForecastTabs(defaultMetricFilter, "leadership");
+    for (const tab of tabs) {
+      expect(tab.href).toContain("role=leadership");
+    }
+  });
+});

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -327,8 +327,7 @@ export const navAreas: readonly NavArea[] = [
 				id: "capacity",
 				label: "Capacity",
 				path: "/plan/capacity",
-				navVisible: false,
-				preview: true,
+				navVisible: true,
 			},
 			{
 				id: "backlog-risk",

--- a/src/lib/navigation/planForecastTabs.ts
+++ b/src/lib/navigation/planForecastTabs.ts
@@ -1,0 +1,35 @@
+import { withFilterParam } from "@/lib/filters/url";
+import type { MetricFilter } from "@/lib/filters/types";
+
+// Plan forecast sub-views (CHAOS-2079 / J4 remediation). The two surfaces share
+// one ModeTabs strip so they read as sibling views of the same Plan screen:
+//   - "Delivery Forecast" → rolling-throughput summary (P50/P75/P90 weeks, risk
+//     overlays) at /plan/delivery-forecast.
+//   - "Monte Carlo" → the real percentile distribution forecast
+//     (ConfidenceBandChart + ThroughputHistogram) at /plan/capacity.
+export type PlanForecastView = "delivery-forecast" | "monte-carlo";
+
+export type PlanForecastTab = {
+  id: PlanForecastView;
+  label: string;
+  href: string;
+};
+
+/**
+ * Build the shared Plan forecast tab strip, preserving the active filter +
+ * role context on every destination.
+ */
+export function planForecastTabs(filters: MetricFilter, role?: string): PlanForecastTab[] {
+  return [
+    {
+      id: "delivery-forecast",
+      label: "Delivery Forecast",
+      href: withFilterParam("/plan/delivery-forecast", filters, role),
+    },
+    {
+      id: "monte-carlo",
+      label: "Monte Carlo",
+      href: withFilterParam("/plan/capacity", filters, role),
+    },
+  ];
+}

--- a/tests/capacity-planning.spec.ts
+++ b/tests/capacity-planning.spec.ts
@@ -40,12 +40,34 @@ test.describe("Delivery Forecast page", () => {
     await expect(page.getByText(/Scope:\s*All teams/i)).toBeVisible();
   });
 
-  test("renders Monte Carlo as the local delivery forecast view", async ({ page }) => {
+  test("exposes Delivery Forecast (active) and Monte Carlo sibling tabs", async ({ page }) => {
     await page.goto("/plan/delivery-forecast");
 
-    const link = page.getByRole("link", { name: /^Monte Carlo$/i });
-    await expect(link).toBeVisible();
-    await expect(link).toHaveAttribute("aria-current", "page");
+    const tabs = page.getByRole("navigation", { name: "Plan forecast views" });
+    await expect(tabs.getByRole("link", { name: /^Delivery Forecast$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    // CHAOS-2079 / J4: the Monte Carlo tab must point at the REAL forecast route
+    // (/plan/capacity), not self-link back to the summary.
+    const monteCarlo = tabs.getByRole("link", { name: /^Monte Carlo$/i });
+    await expect(monteCarlo).toHaveAttribute("href", /\/plan\/capacity/);
+    await expect(monteCarlo).not.toHaveAttribute("aria-current", "page");
+  });
+
+  test("Monte Carlo view at /plan/capacity renders the real forecast surface", async ({ page }) => {
+    await page.goto("/plan/capacity");
+
+    await expect(page.getByRole("heading", { name: /Monte Carlo Forecast/i })).toBeVisible();
+    const tabs = page.getByRole("navigation", { name: "Plan forecast views" });
+    await expect(tabs.getByRole("link", { name: /^Monte Carlo$/i })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    await expect(tabs.getByRole("link", { name: /^Delivery Forecast$/i })).toHaveAttribute(
+      "href",
+      /\/plan\/delivery-forecast/,
+    );
   });
 
   test("renders the unified global context bar above the forecast (CHAOS-2081)", async ({

--- a/tests/nav-reachability.spec.ts
+++ b/tests/nav-reachability.spec.ts
@@ -46,6 +46,7 @@ const reachableRoutes = [
 	"/dashboard",
 	"/plan",
 	"/plan/delivery-forecast",
+	"/plan/capacity",
 	"/operating-review",
 	"/work",
 	"/metrics",
@@ -306,6 +307,7 @@ test.describe("primary navigation reachability", () => {
 			{ path: "/bottleneck", selectedLabel: "Diagnose" },
 			{ path: "/risk/compounding", selectedLabel: "Govern" },
 			{ path: "/plan/delivery-forecast", selectedLabel: "Plan" },
+			{ path: "/plan/capacity", selectedLabel: "Plan" },
 			{ path: "/operating-review", selectedLabel: "Plan" },
 		]) {
 			await expectSingleSelectedArea(page, route.path, route.selectedLabel);


### PR DESCRIPTION
## Summary

Second remediation PR for CHAOS-2079. J4/CHAOS-2084 renamed Capacity Planning → Delivery Forecast and made "Monte Carlo View" a tab — but the tab **self-linked** back to the throughput summary, and the real percentile **distribution** forecast (`ConfidenceBandChart` + `ThroughputHistogram` + `ForecastCard`) only lived at the orphaned `/capacity` route, **never reachable under Plan**. So "Monte Carlo View" was a relabeled summary, not an actual Monte Carlo forecast.

## What changed

- **New `/plan/capacity` page** mounts the real `CapacityView` Monte Carlo stack with Plan chrome — `UpgradeGate` (team tier) + GraphQL hydration preserved exactly as `/capacity`.
- **Shared `planForecastTabs` helper** — both Plan forecast surfaces now render a real 2-tab strip (**Delivery Forecast | Monte Carlo**) instead of a self-link:
  - `/plan/delivery-forecast`: "Delivery Forecast" active; "Monte Carlo" → `/plan/capacity`.
  - `/plan/capacity`: "Monte Carlo" active; "Delivery Forecast" → `/plan/delivery-forecast`.
- **`areas.ts`**: Plan "Capacity" child promoted from `preview`/hidden → `navVisible` (areas.ts already advertised `/plan/capacity`; now it has a page).

## Functionality-preservation check

- The real Monte Carlo distribution forecast is now reachable **under Plan**; verified in-browser the page renders `ForecastCard` + Completion-Projection confidence bands + Throughput-Distribution histogram (canvas charts, not upgrade-gated for the seeded enterprise org).
- The "Monte Carlo" tab is now an **actual Monte Carlo forecast**, not a relabeled summary.
- `/capacity` and the Delivery Forecast summary are untouched and still reachable. No capability replaced by a summary card.

## Gates

- `pnpm test:unit` — **1557 passed** (incl. new `planForecastTabs` unit test)
- `pnpm build` — exit 0 (`/plan/capacity` in route manifest)
- `prettier --check` + `DESIGN_LINT eslint` on changed files — clean
- E2E: `capacity-planning` + `nav-reachability` — **14/14** (validates the 2-tab strip, `/plan/capacity` reachability, and Plan selected-area)

## Tests

- New `planForecastTabs.test.ts` (5 cases): tab order/labels, Monte Carlo → `/plan/capacity` (not self-link), filter/role preserved.
- Rewrote the `capacity-planning` test that asserted the **self-linking** Monte Carlo tab → now asserts the 2-tab strip + the real `/plan/capacity` surface.
- Added `/plan/capacity` to `nav-reachability` routes + selected-area coverage.

## Visual evidence

Captured in-browser (seeded `admin@devhealth.example`):
- `chaos-2079-plan-capacity-monte-carlo-after.png` — `/plan/capacity` real Monte Carlo forecast (confidence bands + histogram), Monte Carlo tab active.
- `chaos-2079-plan-delivery-forecast-tabs-after.png` — delivery-forecast with the 2-tab strip, "Monte Carlo" → `/plan/capacity`.

Refs CHAOS-2079, CHAOS-2084