### PR TITLE
fix(nav): Flow CTA + Work deep-link canonicalization (CHAOS-2093)

### DIFF
--- a/src/app/(app)/plan/capacity/page.tsx
+++ b/src/app/(app)/plan/capacity/page.tsx
@@ -50,7 +50,7 @@ export default async function PlanCapacityPage({ searchParams }: PlanCapacityPag
 
     const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
 
-    const graphqlEnabled = runtimeConfig["useGraphQLAnalytics"]();
+    const graphqlEnabled = runtimeConfig.useGraphQLAnalytics();
     let hydrationOrgId: string | undefined;
     if (graphqlEnabled) {
         const { auth } = await import("@/lib/auth");

--- a/src/app/(app)/plan/delivery-forecast/page.tsx
+++ b/src/app/(app)/plan/delivery-forecast/page.tsx
@@ -112,7 +112,7 @@ export default async function DeliveryForecastPage({ searchParams }: DeliveryFor
     return (
         <div className="min-h-screen bg-background text-foreground">
             <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-                <PrimaryNav filters={filters} active="delivery-forecast" role={activeRole} />
+                <PrimaryNav filters={filters} active="plan" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">
                         <div>

--- a/src/components/charts/InvestigationPanel.tsx
+++ b/src/components/charts/InvestigationPanel.tsx
@@ -33,25 +33,25 @@ export function InvestigationPanel({
     const origin = title ? `From: ${title}` : `From: ${data.axes.x.label} × ${data.axes.y.label}`;
 
     const cycleBreakdownFlameHref = withFilterParam(
-        "/work?tab=flame&mode=cycle_breakdown",
+        "/work?view=work&tab=flame&mode=cycle_breakdown",
         filters,
         undefined,
         origin,
     );
     const throughputFlameHref = withFilterParam(
-        "/work?tab=flame&mode=throughput",
+        "/work?view=work&tab=flame&mode=throughput",
         filters,
         undefined,
         origin,
     );
     const hotspotsFlameHref = withFilterParam(
-        "/work?tab=flame&mode=code_hotspots",
+        "/work?view=work&tab=flame&mode=code_hotspots",
         filters,
         undefined,
         origin,
     );
 
-    const heatmapPath = "/work?tab=heatmap";
+    const heatmapPath = "/work?view=work&tab=heatmap";
     const heatmapHref = withFilterParam(heatmapPath, filters, undefined, origin);
 
     const investmentHref = withFilterParam(
@@ -63,8 +63,18 @@ export function InvestigationPanel({
 
     const investigationPaths = useMemo(() => {
         const paths = [
-            { id: "explain", label: "Explain this state", href: metricExplainHref, type: "review" },
-            { id: "heatmaps", label: "View related patterns", href: heatmapHref, type: "wip" },
+            {
+                id: "explain",
+                label: "Explain this state",
+                href: metricExplainHref,
+                type: "review",
+            },
+            {
+                id: "heatmaps",
+                label: "View related patterns",
+                href: heatmapHref,
+                type: "wip",
+            },
             {
                 id: "cycle",
                 label: "View time breakdown",
@@ -83,7 +93,12 @@ export function InvestigationPanel({
                 href: hotspotsFlameHref,
                 type: "churn",
             },
-            { id: "investment", label: "View flow", href: investmentHref, type: "investment" },
+            {
+                id: "investment",
+                label: "View flow",
+                href: investmentHref,
+                type: "investment",
+            },
         ];
 
         const sorted = [...paths].sort((a, b) => {

--- a/src/components/work/FlowView.tsx
+++ b/src/components/work/FlowView.tsx
@@ -171,7 +171,12 @@ export function FlowView({ filters, activeRole }: FlowViewProps) {
     }, []);
 
     const { handleTreemapClick, handleInvestmentMixClick, handleSankeyClick, handleAreaClick } =
-        useFlowHandlers({ investmentMix, dataset, setSelection, setInvestmentMixFocusTheme });
+        useFlowHandlers({
+            investmentMix,
+            dataset,
+            setSelection,
+            setInvestmentMixFocusTheme,
+        });
 
     const isLoading = resolvedKey !== requestKey;
     const hasData = !!(dataset && dataset.nodes.length > 0);
@@ -197,7 +202,7 @@ export function FlowView({ filters, activeRole }: FlowViewProps) {
         if (!selection) return null;
         const nodeName = selection.key ?? selection.path[selection.path.length - 1];
         return withFilterParam(
-            `/work?tab=flame&mode=${flameMode}&context_node=${nodeName}`,
+            `/work?view=work&tab=flame&mode=${flameMode}&context_node=${nodeName}`,
             filters,
             activeRole,
         );

--- a/src/components/work/FlowView/InspectPanel.test.tsx
+++ b/src/components/work/FlowView/InspectPanel.test.tsx
@@ -57,7 +57,7 @@ describe("InspectPanel Work Graph drilldown", () => {
         );
 
         const link = screen.getByText("Open Work Graph").closest("a");
-        expect(link).toHaveAttribute("href", expect.stringContaining("/work?tab=graph&"));
+        expect(link).toHaveAttribute("href", expect.stringContaining("/work?view=work&tab=graph&"));
         expect(link).toHaveAttribute("href", expect.stringContaining("f="));
         expect(link).toHaveAttribute("href", expect.stringContaining("role=manager"));
         expect(link).toHaveAttribute(
@@ -69,7 +69,7 @@ describe("InspectPanel Work Graph drilldown", () => {
     it("omits graph_connection for investment selections", () => {
         const href = buildFlowWorkGraphUrl({ view: "investment_mix" }, filters);
 
-        expect(href).toContain("/work?tab=graph&f=");
+        expect(href).toContain("/work?view=work&tab=graph&f=");
         expect(href).not.toContain("graph_connection=");
     });
 
@@ -118,7 +118,7 @@ describe("InspectPanel Work Graph drilldown", () => {
         );
 
         const link = screen.getByText("Open Work Graph").closest("a");
-        expect(link).toHaveAttribute("href", expect.stringContaining("/work?tab=graph&"));
+        expect(link).toHaveAttribute("href", expect.stringContaining("/work?view=work&tab=graph&"));
         expect(link).toHaveAttribute(
             "href",
             expect.stringContaining("graph_connection=change-to-code"),

--- a/src/components/work/FlowView/InspectPanel.tsx
+++ b/src/components/work/FlowView/InspectPanel.tsx
@@ -21,7 +21,7 @@ export const buildFlowWorkGraphUrl = (
               what: { ...filters.what, repos: [selection.hotspot.repoId] },
           }
         : filters;
-    const baseHref = withFilterParam("/work?tab=graph", drilldownFilters, activeRole);
+    const baseHref = withFilterParam("/work?view=work&tab=graph", drilldownFilters, activeRole);
     const connection = WORK_GRAPH_CONNECTION_BY_VIEW[selection.view];
     const [path, query = ""] = baseHref.split("?", 2);
     const params = new URLSearchParams(query);

--- a/src/components/work/LandscapeView.tsx
+++ b/src/components/work/LandscapeView.tsx
@@ -118,7 +118,7 @@ export function LandscapeView({
                     <div className="flex flex-wrap items-center justify-between gap-2">
                         <h2 className="font-(--font-display) text-xl">Investment Mix</h2>
                         <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.2em] text-(--accent-2)">
-                            <Link href={withFilterParam("/work?tab=flow", filters, activeRole)}>
+                            <Link href={withFilterParam("/metrics?tab=flow", filters, activeRole)}>
                                 {CTA_LABELS.openMetrics}
                             </Link>
                             <Link
@@ -155,7 +155,7 @@ export function LandscapeView({
                     <div className="flex items-center justify-between">
                         <h2 className="font-(--font-display) text-xl">Planned vs Unplanned</h2>
                         <Link
-                            href={withFilterParam("/work?tab=flow", filters, activeRole)}
+                            href={withFilterParam("/metrics?tab=flow", filters, activeRole)}
                             className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
                         >
                             {CTA_LABELS.openMetrics}

--- a/src/lib/areaSignals/__tests__/sort.test.ts
+++ b/src/lib/areaSignals/__tests__/sort.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { groupByCluster, isAvailable, sortBySeverity, topSignals } from "../sort";
+import { groupByCluster, isAvailable, sortBySeverity } from "../sort";
 import type { AreaSignal, AreaSignalState } from "../types";
 
 function signal(id: string, state: AreaSignalState, cluster?: string, demoted = false): AreaSignal {
@@ -89,22 +89,5 @@ describe("groupByCluster", () => {
     it("sinks unavailable signals to the bottom within their cluster", () => {
         const input = [signal("u", "unavailable", "Quality"), signal("ok", "medium", "Quality")];
         expect(groupByCluster(input)[0].signals.map((s) => s.id)).toEqual(["ok", "u"]);
-    });
-});
-
-describe("topSignals", () => {
-    it("returns the top N available signals by severity, excluding unavailable", () => {
-        const input = [
-            signal("u", "unavailable"),
-            signal("low", "low"),
-            signal("crit", "critical"),
-            signal("high", "high"),
-            signal("med", "medium"),
-        ];
-        expect(topSignals(input, 3).map((s) => s.id)).toEqual(["crit", "high", "med"]);
-    });
-
-    it("never bubbles an unavailable metric even when it is the only signal", () => {
-        expect(topSignals([signal("u", "unavailable")], 3)).toEqual([]);
     });
 });

--- a/src/lib/areaSignals/sort.ts
+++ b/src/lib/areaSignals/sort.ts
@@ -44,15 +44,6 @@ export function sortBySeverity(signals: readonly AreaSignal[]): AreaSignal[] {
         .map(({ signal }) => signal);
 }
 
-/**
- * The top N signals across the whole area by severity, used to bubble the
- * leading sub-area signal(s) up to the area overview (Framework A2a). Only
- * available signals bubble — an unavailable metric is never "the top signal".
- */
-export function topSignals(signals: readonly AreaSignal[], count = 3): AreaSignal[] {
-    return sortBySeverity(signals.filter(isAvailable)).slice(0, count);
-}
-
 export type SignalCluster = {
     /** Cluster header, or `undefined` for the flat (unclustered) bucket. */
     cluster: string | undefined;

--- a/src/lib/navigation/__fixtures__/iaPreservationBaseline.ts
+++ b/src/lib/navigation/__fixtures__/iaPreservationBaseline.ts
@@ -200,44 +200,49 @@ export const iaPreservationBaseline = {
         {
             source: "InvestigationPanel",
             intent: "cycle breakdown flame view",
-            href: "/work?tab=flame&mode=cycle_breakdown",
+            href: "/work?view=work&tab=flame&mode=cycle_breakdown",
             expectedTab: "flame",
         },
         {
             source: "InvestigationPanel",
             intent: "throughput flame view",
-            href: "/work?tab=flame&mode=throughput",
+            href: "/work?view=work&tab=flame&mode=throughput",
             expectedTab: "flame",
         },
         {
             source: "InvestigationPanel",
             intent: "code hotspots flame view",
-            href: "/work?tab=flame&mode=code_hotspots",
+            href: "/work?view=work&tab=flame&mode=code_hotspots",
             expectedTab: "flame",
         },
         {
             source: "InvestigationPanel",
             intent: "related patterns heatmap view",
-            href: "/work?tab=heatmap",
+            href: "/work?view=work&tab=heatmap",
             expectedTab: "heatmap",
         },
         {
             source: "FlowView",
             intent: "selected node flame view",
-            href: "/work?tab=flame&mode=throughput&context_node=Selected%20Node",
+            href: "/work?view=work&tab=flame&mode=throughput&context_node=Selected%20Node",
             expectedTab: "flame",
         },
         {
             source: "FlowView/InspectPanel",
             intent: "work graph view",
-            href: "/work?tab=graph",
+            href: "/work?view=work&tab=graph",
             expectedTab: "graph",
         },
+    ],
+    // Direct destination links (NOT Work workbench deep-links): these point at a
+    // real area destination. LandscapeView's 'Open metrics' CTA goes straight to the
+    // Flow destination (/metrics?tab=flow), reversing the old 2-hop /work?tab=flow.
+    directDestinationLinks: [
         {
             source: "LandscapeView",
-            intent: "flow view",
-            href: "/work?tab=flow",
-            expectedTab: "flow",
+            intent: "open metrics (flow)",
+            href: "/metrics?tab=flow",
+            expectedPath: "/metrics",
         },
     ],
 } as const;

--- a/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
+++ b/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
@@ -106,6 +106,10 @@ const expectDeepLinkResolvesToWorkbenchTab = (href: string, expectedTab: string)
         throw new Error(`${href} does not target a registered Work tab`);
     }
     expect(activeView, `${href} should not fall through to Diagnose Overview`).toBe("work");
+    expect(
+        url.searchParams.get("view"),
+        `${href} should canonically pin view=work so a future resolver change can't reintroduce the loopback`,
+    ).toBe("work");
 };
 
 const listRouteFiles = (directory: string): string[] => {
@@ -189,6 +193,18 @@ describe("IA preservation invariant #3 — no dead investigation deep-links", ()
         "resolves $source $intent to its $expectedTab workbench view",
         (entry) => {
             expectDeepLinkResolvesToWorkbenchTab(entry.href, entry.expectedTab);
+        },
+    );
+
+    it.each(iaPreservationBaseline.directDestinationLinks)(
+        "points $source $intent straight at $expectedPath (no /work loopback)",
+        (entry) => {
+            const url = parseHref(entry.href);
+            expect(
+                url.pathname,
+                `${entry.href} should be a direct destination, not a /work workbench loopback`,
+            ).toBe(entry.expectedPath);
+            expect(routePageExists(entry.href), entry.href).toBe(true);
         },
     );
 });


### PR DESCRIPTION
## Summary
Phase 2 of the realign-ia track (CHAOS-2093). **Verification first re-scoped this ticket** — three of its items were stale or risky and were dropped (see below). This PR ships only the verified-safe subset.

### Shipped
- **LandscapeView "Open metrics" CTAs** → `/metrics?tab=flow` (was the 2-hop `/work?tab=flow`). Verified `/metrics?tab=flow` renders the Flow view (sankey.spec); bare `/metrics` defaults to `dora`.
- **Canonicalize investigation deep-links** to `/work?view=work&tab=<tab>` (`InvestigationPanel`, `FlowView`, `InspectPanel/`) — pins the Work branch explicitly so a future resolver change can't reintroduce the loopback.
- **IA invariant #3 tightened** to assert `view=work`, plus a new **direct-destination invariant** guarding the LandscapeView `/metrics` CTA against regressing to `/work`. Baseline updated.
- `delivery-forecast`: `PrimaryNav active="plan"` (area-id convention, was leaf id `delivery-forecast`).
- `capacity`: dropped `runtimeConfig["useGraphQLAnalytics"]()` bracket-access type bypass.
- Removed dead `topSignals` export + its test.

### Dropped after verification (NOT done — with rationale)
- **Plan FilterBar `view="capacity-planning"` → `"plan"`**: ❌ STALE. `plan` is **not** a valid `FilterBarView`; `capacity-planning` is the correct behavior-backed key. The change would type-error and strip the intended slim filters.
- **dashboard `AreaHub` → `AreaOverview`**: ❌ Non-trivial. Cockpit has empty `hubItems`/`children`; both components render null. Cockpit's real signals are `home.signals`/`RankedSignals`, not `getAreaSignals("cockpit")`. Needs its own scoped ticket.
- `/capacity` ownedPathPrefixes + `useFilterOptions` dedup / `formatSelection`: deferred (touch canonical nav / already-merged CHAOS-2092 territory).

### Context (not a bug here)
The ticket's HIGH "investigation deep-links land on Diagnose Overview" loopback was **already fixed** at HEAD by the CHAOS-2075 resolver fix (`resolveActiveView` routes `?tab=<workTab>` → Work). This PR's invariant #3 now guards that fix.

## Verification
- `pnpm test:unit` → **1578 passed (189 files)** (−2 = removed dead `topSignals` tests)
- IA invariant + sort tests → 31 passed
- LSP clean on changed files
- `pnpm design-lint` → **344 errors = exact pre-existing baseline, 0 regression**

TEST-WAIVER: n/a — tests included (invariant suite + InspectPanel assertions updated).
SCREENSHOT-WAIVER: all changes are href / nav-active-prop / type / dead-code — no rendered visual change. Guarded by tests instead.

Refs CHAOS-2093