### PR TITLE
fix(lint): honor _-prefixed unused convention + unique QuadrantPanel keys

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,6 +46,16 @@ const eslintConfig = defineConfig([
                         "Empty .catch(() => {}) swallows errors. Use fetchOrNull() or log the error explicitly.",
                 },
             ],
+            // Honor the `_`-prefix convention for intentionally-unused args/vars
+            // (e.g. signature-required Sentry `_hint`, forward-designed `_surface`).
+            "@typescript-eslint/no-unused-vars": [
+                "warn",
+                {
+                    argsIgnorePattern: "^_",
+                    varsIgnorePattern: "^_",
+                    caughtErrorsIgnorePattern: "^_",
+                },
+            ],
         },
     },
     ...(enableDesignLint

--- a/src/components/charts/QuadrantPanel.tsx
+++ b/src/components/charts/QuadrantPanel.tsx
@@ -454,8 +454,8 @@ export function QuadrantPanel({
                             </p>
                             {selectablePoints.length > 0 && (
                                 <div className="mt-3 flex flex-wrap gap-2">
-                                    {selectablePoints.map((point) => {
-                                        const pointKey = `${point.entity_id}:${point.window_start}:${point.window_end}`;
+                                    {selectablePoints.map((point, index) => {
+                                        const pointKey = `${point.entity_id}:${point.window_start}:${point.window_end}:${index}`;
                                         return isPersonScope ? (
                                             <span
                                                 key={pointKey}


### PR DESCRIPTION
## Summary
Quick cleanup of the two outstanding lint warnings and the React duplicate-key warning surfaced during the IA E2E runs.

- **eslint** — add `@typescript-eslint/no-unused-vars` `argsIgnorePattern` / `varsIgnorePattern` / `caughtErrorsIgnorePattern` `"^_"`. Both flagged params were already underscore-prefixed (the standard "intentionally unused" signal): the signature-required Sentry `_hint` and the forward-designed `_surface` in `applyLensPriority`. No signature/test churn. `pnpm exec eslint src` → **0 problems**.
- **QuadrantPanel** — append the map `index` to the selectable-point React key so it stays unique when `entity_id`/`window_start`/`window_end` are absent in sample/E2E data (previously every point keyed as `undefined:undefined:undefined`, triggering "Encountered two children with the same key"). Key-only change; no rendered output difference.

## Verification
- `pnpm exec eslint src` — 0 problems
- `pnpm typecheck` — clean
- `pnpm exec vitest run` (lensContext / scrubber / quadrantPanel) — 41/41
- `pnpm exec playwright test nav-reachability work-navigation --project=authenticated` — 12 passed; **browser console "same key" warning count: 0**
- `pnpm build` — succeeded (105/105 static pages)

SCREENSHOT-WAIVER: React-key-only change; no rendered UI difference.
TEST-WAIVER: behavior-neutral fixes (eslint config + React key uniqueness); covered by existing unit + E2E suites, with the duplicate-key console warning verified gone.