### PR TITLE
feat(design-system): P0 foundations - ChartFrame, MetricDelta, FilterPills, tokens (CHAOS-2125/2124/2123/2122)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[.{editorconfig,*.yml,*.yaml}]
+indent_style = space
+indent_size = 2
+

--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -3,6 +3,7 @@ import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
 import { MetricCard } from "@/components/metrics/MetricCard";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { ChartFrame } from "@/components/charts/ChartFrame";
 import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
 import { HorizontalBarChart } from "@/components/charts/HorizontalBarChart";
 import { checkApiHealth } from "@/lib/api/system";
@@ -203,14 +204,22 @@ export default async function CoveragePage({
 					</section>
 
 					<section className="grid gap-6 lg:grid-cols-2">
-						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-							<h2 className="font-(--font-display) text-xl mb-4">
-								Line Coverage Trend
-							</h2>
+						<ChartFrame
+							title="Line Coverage Trend"
+							interpretation="Line coverage appears over time so drops are visible before they become release risk."
+							threshold={{
+								label: "Target baseline",
+								value: "80%",
+								tone: "info",
+							}}
+							isEmpty={timeseriesData.length === 0}
+							stateTitle="Coverage trend not populated"
+							stateDescription="Coverage history appears here once CI coverage data is connected for this scope."
+						>
 							<div className="h-64">
 								<TimeseriesChart data={timeseriesData} valueFormat="percent" />
 							</div>
-						</div>
+						</ChartFrame>
 						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
 							<h2 className="font-(--font-display) text-xl mb-4">
 								Coverage by Repository

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,7 +16,7 @@
     --background: #fffbfe;
     --foreground: #1c1b1f;
     --ink-muted: #49454f;
-    --accent: #6750a4;
+    --accent: #f89d28;
     --accent-2: #625b71;
     --accent-3: #7d5260;
     --accent-negative: #b3261e;
@@ -57,7 +57,7 @@
         --background: #1c1b1f;
         --foreground: #e6e1e5;
         --ink-muted: #cac4d0;
-        --accent: #d0bcff;
+        --accent: #ffb347;
         --accent-2: #ccc2dc;
         --accent-3: #efb8c8;
         --accent-negative: #f2b8b5;
@@ -580,6 +580,45 @@
     );
 }
 
+:root,
+:root[data-theme="light"],
+:root[data-palette][data-theme="light"] {
+    --accent: #f89d28;
+    --positive: #16a34a;
+    --caution: #f59e0b;
+    --info: #2563eb;
+    --radius-sm: 6px;
+    --radius-md: 10px;
+    --radius-lg: 16px;
+    --radius-pill: 999px;
+    --elevation-card: 0 18px 48px -34px rgb(15 23 42 / 0.25);
+    --elevation-drawer: 0 28px 80px -36px rgb(15 23 42 / 0.35);
+    --card-stroke-active: color-mix(in srgb, var(--accent) 42%, var(--card-stroke));
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --accent: #ffb347;
+        --positive: #34d399;
+        --caution: #fbbf24;
+        --info: #60a5fa;
+        --elevation-card: 0 22px 58px -40px rgb(0 0 0 / 0.65);
+        --elevation-drawer: 0 32px 90px -42px rgb(0 0 0 / 0.75);
+        --card-stroke-active: color-mix(in srgb, var(--accent) 45%, var(--card-stroke));
+    }
+}
+
+:root[data-theme="dark"],
+:root[data-palette][data-theme="dark"] {
+    --accent: #ffb347;
+    --positive: #34d399;
+    --caution: #fbbf24;
+    --info: #60a5fa;
+    --elevation-card: 0 22px 58px -40px rgb(0 0 0 / 0.65);
+    --elevation-drawer: 0 32px 90px -42px rgb(0 0 0 / 0.75);
+    --card-stroke-active: color-mix(in srgb, var(--accent) 45%, var(--card-stroke));
+}
+
 /* ============================================================
  * TAILWIND THEME BRIDGE
  * Map design tokens into Tailwind's color / font namespaces.
@@ -587,7 +626,17 @@
 @theme inline {
     --color-background: var(--background);
     --color-card: var(--card);
+    --color-card-stroke: var(--card-stroke);
+    --color-card-stroke-active: var(--card-stroke-active);
     --color-foreground: var(--foreground);
+    --color-ink-muted: var(--ink-muted);
+    --color-accent: var(--accent);
+    --color-accent-2: var(--accent-2);
+    --color-accent-3: var(--accent-3);
+    --color-accent-negative: var(--accent-negative);
+    --color-positive: var(--positive);
+    --color-caution: var(--caution);
+    --color-info: var(--info);
     --color-app-gradient: var(--app-gradient);
     --font-sans: var(--font-body);
     --font-display: var(--font-display);

--- a/src/components/RoleSelector.test.tsx
+++ b/src/components/RoleSelector.test.tsx
@@ -4,51 +4,51 @@ import { RoleSelector } from "./RoleSelector";
 
 const mockPush = vi.fn();
 const mockSearchParams = {
-	get: vi.fn().mockReturnValue(null),
-	toString: vi.fn().mockReturnValue(""),
-	has: vi.fn().mockReturnValue(false),
+    get: vi.fn().mockReturnValue(null),
+    toString: vi.fn().mockReturnValue(""),
+    has: vi.fn().mockReturnValue(false),
 };
 
 vi.mock("next/navigation", () => ({
-	useRouter: () => ({ push: mockPush }),
-	usePathname: () => "/dashboard",
-	useSearchParams: () => mockSearchParams,
+    useRouter: () => ({ push: mockPush }),
+    usePathname: () => "/dashboard",
+    useSearchParams: () => mockSearchParams,
 }));
 
 describe("RoleSelector", () => {
-	it("renders the role selector container", () => {
-		render(<RoleSelector />);
-		expect(screen.getByTestId("role-selector")).toBeInTheDocument();
-	});
+    it("renders the role selector container", () => {
+        render(<RoleSelector />);
+        expect(screen.getByTestId("role-selector")).toBeInTheDocument();
+    });
 
-	it("renders 'Lens' label", () => {
-		render(<RoleSelector />);
-		expect(screen.getByText(/lens/i)).toBeInTheDocument();
-	});
+    it("renders 'Lens' label", () => {
+        render(<RoleSelector />);
+        expect(screen.getByText(/lens/i)).toBeInTheDocument();
+    });
 
-	it("renders IC, EM, PM, and Leadership buttons", () => {
-		render(<RoleSelector />);
-		expect(screen.getByText("IC")).toBeInTheDocument();
-		expect(screen.getByText("EM")).toBeInTheDocument();
-		expect(screen.getByText("PM")).toBeInTheDocument();
-		expect(screen.getByText("Leadership")).toBeInTheDocument();
-	});
+    it("renders IC, EM, PM, and Leadership buttons", () => {
+        render(<RoleSelector />);
+        expect(screen.getByText("IC")).toBeInTheDocument();
+        expect(screen.getByText("EM")).toBeInTheDocument();
+        expect(screen.getByText("PM")).toBeInTheDocument();
+        expect(screen.getByText("Leadership")).toBeInTheDocument();
+    });
 
-	it("marks the default role as active (aria-checked=true)", () => {
-		render(<RoleSelector />);
-		// Default role is "ic"
-		const icRadio = screen.getByRole("radio", { name: "IC" });
-		expect(icRadio).toHaveAttribute("aria-checked", "true");
-	});
+    it("marks the default role as active (aria-checked=true)", () => {
+        render(<RoleSelector />);
+        // Default role is "ic"
+        const icRadio = screen.getByRole("radio", { name: "IC" });
+        expect(icRadio).toHaveAttribute("aria-checked", "true");
+    });
 
-	it("calls router.push when a role button is clicked", () => {
-		render(<RoleSelector />);
-		fireEvent.click(screen.getByText("EM"));
-		expect(mockPush).toHaveBeenCalled();
-	});
+    it("calls router.push when a role button is clicked", () => {
+        render(<RoleSelector />);
+        fireEvent.click(screen.getByText("EM"));
+        expect(mockPush).toHaveBeenCalled();
+    });
 
-	it("applies optional className to the container", () => {
-		render(<RoleSelector className="custom-class" />);
-		expect(screen.getByTestId("role-selector")).toHaveClass("custom-class");
-	});
+    it("applies optional className to the container", () => {
+        render(<RoleSelector className="custom-class" />);
+        expect(screen.getByTestId("role-selector")).toHaveClass("custom-class");
+    });
 });

--- a/src/components/RoleSelector.test.tsx
+++ b/src/components/RoleSelector.test.tsx
@@ -4,51 +4,51 @@ import { RoleSelector } from "./RoleSelector";
 
 const mockPush = vi.fn();
 const mockSearchParams = {
-    get: vi.fn().mockReturnValue(null),
-    toString: vi.fn().mockReturnValue(""),
-    has: vi.fn().mockReturnValue(false),
+	get: vi.fn().mockReturnValue(null),
+	toString: vi.fn().mockReturnValue(""),
+	has: vi.fn().mockReturnValue(false),
 };
 
 vi.mock("next/navigation", () => ({
-    useRouter: () => ({ push: mockPush }),
-    usePathname: () => "/dashboard",
-    useSearchParams: () => mockSearchParams,
+	useRouter: () => ({ push: mockPush }),
+	usePathname: () => "/dashboard",
+	useSearchParams: () => mockSearchParams,
 }));
 
 describe("RoleSelector", () => {
-    it("renders the role selector container", () => {
-        render(<RoleSelector />);
-        expect(screen.getByTestId("role-selector")).toBeInTheDocument();
-    });
+	it("renders the role selector container", () => {
+		render(<RoleSelector />);
+		expect(screen.getByTestId("role-selector")).toBeInTheDocument();
+	});
 
-    it("renders 'Lens' label", () => {
-        render(<RoleSelector />);
-        expect(screen.getByText(/lens/i)).toBeInTheDocument();
-    });
+	it("renders 'Lens' label", () => {
+		render(<RoleSelector />);
+		expect(screen.getByText(/lens/i)).toBeInTheDocument();
+	});
 
-    it("renders IC, EM, PM, and Leadership buttons", () => {
-        render(<RoleSelector />);
-        expect(screen.getByText("IC")).toBeInTheDocument();
-        expect(screen.getByText("EM")).toBeInTheDocument();
-        expect(screen.getByText("PM")).toBeInTheDocument();
-        expect(screen.getByText("Leadership")).toBeInTheDocument();
-    });
+	it("renders IC, EM, PM, and Leadership buttons", () => {
+		render(<RoleSelector />);
+		expect(screen.getByText("IC")).toBeInTheDocument();
+		expect(screen.getByText("EM")).toBeInTheDocument();
+		expect(screen.getByText("PM")).toBeInTheDocument();
+		expect(screen.getByText("Leadership")).toBeInTheDocument();
+	});
 
-    it("marks the default role as active (aria-checked=true)", () => {
-        render(<RoleSelector />);
-        // Default role is "ic"
-        const icButton = screen.getByText("IC").closest("button");
-        expect(icButton).toHaveAttribute("aria-checked", "true");
-    });
+	it("marks the default role as active (aria-checked=true)", () => {
+		render(<RoleSelector />);
+		// Default role is "ic"
+		const icRadio = screen.getByRole("radio", { name: "IC" });
+		expect(icRadio).toHaveAttribute("aria-checked", "true");
+	});
 
-    it("calls router.push when a role button is clicked", () => {
-        render(<RoleSelector />);
-        fireEvent.click(screen.getByText("EM"));
-        expect(mockPush).toHaveBeenCalled();
-    });
+	it("calls router.push when a role button is clicked", () => {
+		render(<RoleSelector />);
+		fireEvent.click(screen.getByText("EM"));
+		expect(mockPush).toHaveBeenCalled();
+	});
 
-    it("applies optional className to the container", () => {
-        render(<RoleSelector className="custom-class" />);
-        expect(screen.getByTestId("role-selector")).toHaveClass("custom-class");
-    });
+	it("applies optional className to the container", () => {
+		render(<RoleSelector className="custom-class" />);
+		expect(screen.getByTestId("role-selector")).toHaveClass("custom-class");
+	});
 });

--- a/src/components/charts/ChartFrame.test.tsx
+++ b/src/components/charts/ChartFrame.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+
+import { ChartFrame } from "./ChartFrame";
+
+describe("ChartFrame", () => {
+	it("renders the title, interpretation, threshold and chart children when data is ready", () => {
+		render(
+			<ChartFrame
+				title="Line Coverage Trend"
+				interpretation="Coverage appears stable across the selected window."
+				threshold="Target baseline: 80%"
+			>
+				<div data-testid="chart-child">chart body</div>
+			</ChartFrame>,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: "Line Coverage Trend" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Coverage appears stable across the selected window."),
+		).toBeInTheDocument();
+		expect(screen.getByText("Target baseline: 80%")).toBeInTheDocument();
+		expect(screen.getByTestId("chart-child")).toBeInTheDocument();
+	});
+
+	it("renders a loading DataState instead of chart children", () => {
+		render(
+			<ChartFrame
+				title="Pipeline Trend"
+				interpretation="Loading latest pipeline health."
+				isLoading
+			>
+				<div data-testid="chart-child">chart body</div>
+			</ChartFrame>,
+		);
+
+		expect(screen.getByTestId("data-state-loading")).toBeInTheDocument();
+		expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
+	});
+
+	it("renders an error DataState instead of chart children", () => {
+		render(
+			<ChartFrame
+				title="Pipeline Trend"
+				interpretation="Pipeline health could not be loaded."
+				isError
+				stateMessage="The trend request failed."
+			>
+				<div data-testid="chart-child">chart body</div>
+			</ChartFrame>,
+		);
+
+		expect(screen.getByTestId("data-state-error")).toBeInTheDocument();
+		expect(screen.getByText("The trend request failed.")).toBeInTheDocument();
+		expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
+	});
+
+	it("renders an empty DataState instead of chart children", () => {
+		render(
+			<ChartFrame
+				title="Pipeline Trend"
+				interpretation="Pipeline health appears once source data is available."
+				isEmpty
+				stateTitle="No pipeline data"
+				stateDescription="Connect CI data to populate this chart."
+			>
+				<div data-testid="chart-child">chart body</div>
+			</ChartFrame>,
+		);
+
+		expect(
+			screen.getByTestId("data-state-preview-not-populated"),
+		).toBeInTheDocument();
+		expect(screen.getByText("No pipeline data")).toBeInTheDocument();
+		expect(
+			screen.getByText("Connect CI data to populate this chart."),
+		).toBeInTheDocument();
+		expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
+	});
+
+	it("prioritizes an explicit state over boolean flags", () => {
+		render(
+			<ChartFrame
+				title="Pipeline Trend"
+				interpretation="State precedence check."
+				state="error"
+				isLoading
+				isEmpty
+				stateMessage="explicit error wins"
+			>
+				<div data-testid="chart-child">chart body</div>
+			</ChartFrame>,
+		);
+
+		expect(screen.getByTestId("data-state-error")).toBeInTheDocument();
+		expect(screen.queryByTestId("data-state-loading")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
+	});
+
+	it("renders descriptor annotations whose value is zero", () => {
+		render(
+			<ChartFrame
+				title="Threshold Breaches"
+				interpretation="Zero is a meaningful value."
+				threshold={{ label: "Breaches", value: 0 }}
+			>
+				<div data-testid="chart-child">chart body</div>
+			</ChartFrame>,
+		);
+
+		expect(screen.getByText("Breaches")).toBeInTheDocument();
+		expect(screen.getByText("0")).toBeInTheDocument();
+	});
+});

--- a/src/components/charts/ChartFrame.test.tsx
+++ b/src/components/charts/ChartFrame.test.tsx
@@ -4,113 +4,107 @@ import { render, screen } from "@/test/utils";
 import { ChartFrame } from "./ChartFrame";
 
 describe("ChartFrame", () => {
-	it("renders the title, interpretation, threshold and chart children when data is ready", () => {
-		render(
-			<ChartFrame
-				title="Line Coverage Trend"
-				interpretation="Coverage appears stable across the selected window."
-				threshold="Target baseline: 80%"
-			>
-				<div data-testid="chart-child">chart body</div>
-			</ChartFrame>,
-		);
+    it("renders the title, interpretation, threshold and chart children when data is ready", () => {
+        render(
+            <ChartFrame
+                title="Line Coverage Trend"
+                interpretation="Coverage appears stable across the selected window."
+                threshold="Target baseline: 80%"
+            >
+                <div data-testid="chart-child">chart body</div>
+            </ChartFrame>,
+        );
 
-		expect(
-			screen.getByRole("heading", { name: "Line Coverage Trend" }),
-		).toBeInTheDocument();
-		expect(
-			screen.getByText("Coverage appears stable across the selected window."),
-		).toBeInTheDocument();
-		expect(screen.getByText("Target baseline: 80%")).toBeInTheDocument();
-		expect(screen.getByTestId("chart-child")).toBeInTheDocument();
-	});
+        expect(screen.getByRole("heading", { name: "Line Coverage Trend" })).toBeInTheDocument();
+        expect(
+            screen.getByText("Coverage appears stable across the selected window."),
+        ).toBeInTheDocument();
+        expect(screen.getByText("Target baseline: 80%")).toBeInTheDocument();
+        expect(screen.getByTestId("chart-child")).toBeInTheDocument();
+    });
 
-	it("renders a loading DataState instead of chart children", () => {
-		render(
-			<ChartFrame
-				title="Pipeline Trend"
-				interpretation="Loading latest pipeline health."
-				isLoading
-			>
-				<div data-testid="chart-child">chart body</div>
-			</ChartFrame>,
-		);
+    it("renders a loading DataState instead of chart children", () => {
+        render(
+            <ChartFrame
+                title="Pipeline Trend"
+                interpretation="Loading latest pipeline health."
+                isLoading
+            >
+                <div data-testid="chart-child">chart body</div>
+            </ChartFrame>,
+        );
 
-		expect(screen.getByTestId("data-state-loading")).toBeInTheDocument();
-		expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
-	});
+        expect(screen.getByTestId("data-state-loading")).toBeInTheDocument();
+        expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
+    });
 
-	it("renders an error DataState instead of chart children", () => {
-		render(
-			<ChartFrame
-				title="Pipeline Trend"
-				interpretation="Pipeline health could not be loaded."
-				isError
-				stateMessage="The trend request failed."
-			>
-				<div data-testid="chart-child">chart body</div>
-			</ChartFrame>,
-		);
+    it("renders an error DataState instead of chart children", () => {
+        render(
+            <ChartFrame
+                title="Pipeline Trend"
+                interpretation="Pipeline health could not be loaded."
+                isError
+                stateMessage="The trend request failed."
+            >
+                <div data-testid="chart-child">chart body</div>
+            </ChartFrame>,
+        );
 
-		expect(screen.getByTestId("data-state-error")).toBeInTheDocument();
-		expect(screen.getByText("The trend request failed.")).toBeInTheDocument();
-		expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
-	});
+        expect(screen.getByTestId("data-state-error")).toBeInTheDocument();
+        expect(screen.getByText("The trend request failed.")).toBeInTheDocument();
+        expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
+    });
 
-	it("renders an empty DataState instead of chart children", () => {
-		render(
-			<ChartFrame
-				title="Pipeline Trend"
-				interpretation="Pipeline health appears once source data is available."
-				isEmpty
-				stateTitle="No pipeline data"
-				stateDescription="Connect CI data to populate this chart."
-			>
-				<div data-testid="chart-child">chart body</div>
-			</ChartFrame>,
-		);
+    it("renders an empty DataState instead of chart children", () => {
+        render(
+            <ChartFrame
+                title="Pipeline Trend"
+                interpretation="Pipeline health appears once source data is available."
+                isEmpty
+                stateTitle="No pipeline data"
+                stateDescription="Connect CI data to populate this chart."
+            >
+                <div data-testid="chart-child">chart body</div>
+            </ChartFrame>,
+        );
 
-		expect(
-			screen.getByTestId("data-state-preview-not-populated"),
-		).toBeInTheDocument();
-		expect(screen.getByText("No pipeline data")).toBeInTheDocument();
-		expect(
-			screen.getByText("Connect CI data to populate this chart."),
-		).toBeInTheDocument();
-		expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
-	});
+        expect(screen.getByTestId("data-state-preview-not-populated")).toBeInTheDocument();
+        expect(screen.getByText("No pipeline data")).toBeInTheDocument();
+        expect(screen.getByText("Connect CI data to populate this chart.")).toBeInTheDocument();
+        expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
+    });
 
-	it("prioritizes an explicit state over boolean flags", () => {
-		render(
-			<ChartFrame
-				title="Pipeline Trend"
-				interpretation="State precedence check."
-				state="error"
-				isLoading
-				isEmpty
-				stateMessage="explicit error wins"
-			>
-				<div data-testid="chart-child">chart body</div>
-			</ChartFrame>,
-		);
+    it("prioritizes an explicit state over boolean flags", () => {
+        render(
+            <ChartFrame
+                title="Pipeline Trend"
+                interpretation="State precedence check."
+                state="error"
+                isLoading
+                isEmpty
+                stateMessage="explicit error wins"
+            >
+                <div data-testid="chart-child">chart body</div>
+            </ChartFrame>,
+        );
 
-		expect(screen.getByTestId("data-state-error")).toBeInTheDocument();
-		expect(screen.queryByTestId("data-state-loading")).not.toBeInTheDocument();
-		expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
-	});
+        expect(screen.getByTestId("data-state-error")).toBeInTheDocument();
+        expect(screen.queryByTestId("data-state-loading")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
+    });
 
-	it("renders descriptor annotations whose value is zero", () => {
-		render(
-			<ChartFrame
-				title="Threshold Breaches"
-				interpretation="Zero is a meaningful value."
-				threshold={{ label: "Breaches", value: 0 }}
-			>
-				<div data-testid="chart-child">chart body</div>
-			</ChartFrame>,
-		);
+    it("renders descriptor annotations whose value is zero", () => {
+        render(
+            <ChartFrame
+                title="Threshold Breaches"
+                interpretation="Zero is a meaningful value."
+                threshold={{ label: "Breaches", value: 0 }}
+            >
+                <div data-testid="chart-child">chart body</div>
+            </ChartFrame>,
+        );
 
-		expect(screen.getByText("Breaches")).toBeInTheDocument();
-		expect(screen.getByText("0")).toBeInTheDocument();
-	});
+        expect(screen.getByText("Breaches")).toBeInTheDocument();
+        expect(screen.getByText("0")).toBeInTheDocument();
+    });
 });

--- a/src/components/charts/ChartFrame.tsx
+++ b/src/components/charts/ChartFrame.tsx
@@ -1,0 +1,163 @@
+import type { ReactNode } from "react";
+
+import { DataState, type DataStateVariant } from "@/components/ui/DataState";
+
+type ChartFrameAnnotationTone =
+	| "default"
+	| "positive"
+	| "caution"
+	| "negative"
+	| "info";
+
+type ChartFrameAnnotationDescriptor = {
+	label: string;
+	value?: ReactNode;
+	tone?: ChartFrameAnnotationTone;
+};
+
+type ChartFrameAnnotation = ReactNode | ChartFrameAnnotationDescriptor;
+
+type ChartFrameProps = {
+	title: ReactNode;
+	interpretation: ReactNode;
+	children: ReactNode;
+	threshold?: ChartFrameAnnotation;
+	band?: ChartFrameAnnotation;
+	state?: DataStateVariant;
+	isLoading?: boolean;
+	isError?: boolean;
+	isEmpty?: boolean;
+	stateTitle?: string;
+	stateDescription?: string;
+	stateMessage?: string;
+	stateAction?: ReactNode;
+	className?: string;
+	chartClassName?: string;
+	"data-testid"?: string;
+};
+
+const annotationToneClassName: Record<ChartFrameAnnotationTone, string> = {
+	default: "border-(--card-stroke) bg-(--card-80) text-(--ink-muted)",
+	positive: "border-(--positive)/30 bg-(--positive)/10 text-(--positive)",
+	caution: "border-(--caution)/30 bg-(--caution)/10 text-(--caution)",
+	negative:
+		"border-(--accent-negative)/30 bg-(--accent-negative)/10 text-(--accent-negative)",
+	info: "border-(--info)/30 bg-(--info)/10 text-(--info)",
+};
+
+function isAnnotationDescriptor(
+	annotation: ChartFrameAnnotation,
+): annotation is ChartFrameAnnotationDescriptor {
+	return (
+		!!annotation &&
+		typeof annotation === "object" &&
+		!Array.isArray(annotation) &&
+		"label" in annotation
+	);
+}
+
+const annotationPresent = (annotation: ChartFrameAnnotation) =>
+	annotation != null && annotation !== false;
+
+function renderAnnotation(annotation: ChartFrameAnnotation, label: string) {
+	if (!annotationPresent(annotation)) {
+		return null;
+	}
+
+	if (!isAnnotationDescriptor(annotation)) {
+		return <div className="text-sm text-(--ink-muted)">{annotation}</div>;
+	}
+
+	const tone = annotation.tone ?? "default";
+	return (
+		<div
+			data-annotation={label}
+			className={`inline-flex items-center gap-2 rounded-(--radius-pill) border px-3 py-1 text-xs font-medium ${annotationToneClassName[tone]}`}
+		>
+			<span>{annotation.label}</span>
+			{annotation.value !== null &&
+				annotation.value !== undefined &&
+				annotation.value !== false && (
+					<span className="text-foreground">{annotation.value}</span>
+				)}
+		</div>
+	);
+}
+
+function resolveDataState({
+	state,
+	isLoading,
+	isError,
+	isEmpty,
+}: Pick<
+	ChartFrameProps,
+	"state" | "isLoading" | "isError" | "isEmpty"
+>): DataStateVariant | null {
+	if (state) return state;
+	if (isLoading) return "loading";
+	if (isError) return "error";
+	if (isEmpty) return "preview-not-populated";
+	return null;
+}
+
+export function ChartFrame({
+	title,
+	interpretation,
+	children,
+	threshold,
+	band,
+	state,
+	isLoading,
+	isError,
+	isEmpty,
+	stateTitle,
+	stateDescription,
+	stateMessage,
+	stateAction,
+	className,
+	chartClassName,
+	"data-testid": testId,
+}: ChartFrameProps) {
+	const dataState = resolveDataState({ state, isLoading, isError, isEmpty });
+	const hasAnnotations =
+		annotationPresent(threshold) || annotationPresent(band);
+
+	return (
+		<section
+			className={`rounded-(--radius-lg) border border-(--card-stroke) bg-(--card) p-5 shadow-(--elevation-card) ${className ?? ""}`.trim()}
+			data-testid={testId}
+		>
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div className="min-w-0 space-y-1">
+					<h3 className="font-(--font-display) text-base font-semibold text-foreground">
+						{title}
+					</h3>
+					<div className="text-sm text-(--ink-muted)">{interpretation}</div>
+				</div>
+				{hasAnnotations && (
+					<div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+						{renderAnnotation(threshold, "Chart threshold")}
+						{renderAnnotation(band, "Chart band")}
+					</div>
+				)}
+			</div>
+
+			<div
+				className={`mt-4 rounded-(--radius-md) ${chartClassName ?? ""}`.trim()}
+			>
+				{dataState ? (
+					<DataState
+						variant={dataState}
+						title={stateTitle}
+						description={stateDescription}
+						message={stateMessage}
+						action={stateAction}
+						className="min-h-64"
+					/>
+				) : (
+					children
+				)}
+			</div>
+		</section>
+	);
+}

--- a/src/components/charts/ChartFrame.tsx
+++ b/src/components/charts/ChartFrame.tsx
@@ -2,162 +2,150 @@ import type { ReactNode } from "react";
 
 import { DataState, type DataStateVariant } from "@/components/ui/DataState";
 
-type ChartFrameAnnotationTone =
-	| "default"
-	| "positive"
-	| "caution"
-	| "negative"
-	| "info";
+type ChartFrameAnnotationTone = "default" | "positive" | "caution" | "negative" | "info";
 
 type ChartFrameAnnotationDescriptor = {
-	label: string;
-	value?: ReactNode;
-	tone?: ChartFrameAnnotationTone;
+    label: string;
+    value?: ReactNode;
+    tone?: ChartFrameAnnotationTone;
 };
 
 type ChartFrameAnnotation = ReactNode | ChartFrameAnnotationDescriptor;
 
 type ChartFrameProps = {
-	title: ReactNode;
-	interpretation: ReactNode;
-	children: ReactNode;
-	threshold?: ChartFrameAnnotation;
-	band?: ChartFrameAnnotation;
-	state?: DataStateVariant;
-	isLoading?: boolean;
-	isError?: boolean;
-	isEmpty?: boolean;
-	stateTitle?: string;
-	stateDescription?: string;
-	stateMessage?: string;
-	stateAction?: ReactNode;
-	className?: string;
-	chartClassName?: string;
-	"data-testid"?: string;
+    title: ReactNode;
+    interpretation: ReactNode;
+    children: ReactNode;
+    threshold?: ChartFrameAnnotation;
+    band?: ChartFrameAnnotation;
+    state?: DataStateVariant;
+    isLoading?: boolean;
+    isError?: boolean;
+    isEmpty?: boolean;
+    stateTitle?: string;
+    stateDescription?: string;
+    stateMessage?: string;
+    stateAction?: ReactNode;
+    className?: string;
+    chartClassName?: string;
+    "data-testid"?: string;
 };
 
 const annotationToneClassName: Record<ChartFrameAnnotationTone, string> = {
-	default: "border-(--card-stroke) bg-(--card-80) text-(--ink-muted)",
-	positive: "border-(--positive)/30 bg-(--positive)/10 text-(--positive)",
-	caution: "border-(--caution)/30 bg-(--caution)/10 text-(--caution)",
-	negative:
-		"border-(--accent-negative)/30 bg-(--accent-negative)/10 text-(--accent-negative)",
-	info: "border-(--info)/30 bg-(--info)/10 text-(--info)",
+    default: "border-(--card-stroke) bg-(--card-80) text-(--ink-muted)",
+    positive: "border-(--positive)/30 bg-(--positive)/10 text-(--positive)",
+    caution: "border-(--caution)/30 bg-(--caution)/10 text-(--caution)",
+    negative: "border-(--accent-negative)/30 bg-(--accent-negative)/10 text-(--accent-negative)",
+    info: "border-(--info)/30 bg-(--info)/10 text-(--info)",
 };
 
 function isAnnotationDescriptor(
-	annotation: ChartFrameAnnotation,
+    annotation: ChartFrameAnnotation,
 ): annotation is ChartFrameAnnotationDescriptor {
-	return (
-		!!annotation &&
-		typeof annotation === "object" &&
-		!Array.isArray(annotation) &&
-		"label" in annotation
-	);
+    return (
+        !!annotation &&
+        typeof annotation === "object" &&
+        !Array.isArray(annotation) &&
+        "label" in annotation
+    );
 }
 
 const annotationPresent = (annotation: ChartFrameAnnotation) =>
-	annotation != null && annotation !== false;
+    annotation != null && annotation !== false;
 
 function renderAnnotation(annotation: ChartFrameAnnotation, label: string) {
-	if (!annotationPresent(annotation)) {
-		return null;
-	}
+    if (!annotationPresent(annotation)) {
+        return null;
+    }
 
-	if (!isAnnotationDescriptor(annotation)) {
-		return <div className="text-sm text-(--ink-muted)">{annotation}</div>;
-	}
+    if (!isAnnotationDescriptor(annotation)) {
+        return <div className="text-sm text-(--ink-muted)">{annotation}</div>;
+    }
 
-	const tone = annotation.tone ?? "default";
-	return (
-		<div
-			data-annotation={label}
-			className={`inline-flex items-center gap-2 rounded-(--radius-pill) border px-3 py-1 text-xs font-medium ${annotationToneClassName[tone]}`}
-		>
-			<span>{annotation.label}</span>
-			{annotation.value !== null &&
-				annotation.value !== undefined &&
-				annotation.value !== false && (
-					<span className="text-foreground">{annotation.value}</span>
-				)}
-		</div>
-	);
+    const tone = annotation.tone ?? "default";
+    return (
+        <div
+            data-annotation={label}
+            className={`inline-flex items-center gap-2 rounded-(--radius-pill) border px-3 py-1 text-xs font-medium ${annotationToneClassName[tone]}`}
+        >
+            <span>{annotation.label}</span>
+            {annotation.value !== null &&
+                annotation.value !== undefined &&
+                annotation.value !== false && (
+                    <span className="text-foreground">{annotation.value}</span>
+                )}
+        </div>
+    );
 }
 
 function resolveDataState({
-	state,
-	isLoading,
-	isError,
-	isEmpty,
-}: Pick<
-	ChartFrameProps,
-	"state" | "isLoading" | "isError" | "isEmpty"
->): DataStateVariant | null {
-	if (state) return state;
-	if (isLoading) return "loading";
-	if (isError) return "error";
-	if (isEmpty) return "preview-not-populated";
-	return null;
+    state,
+    isLoading,
+    isError,
+    isEmpty,
+}: Pick<ChartFrameProps, "state" | "isLoading" | "isError" | "isEmpty">): DataStateVariant | null {
+    if (state) return state;
+    if (isLoading) return "loading";
+    if (isError) return "error";
+    if (isEmpty) return "preview-not-populated";
+    return null;
 }
 
 export function ChartFrame({
-	title,
-	interpretation,
-	children,
-	threshold,
-	band,
-	state,
-	isLoading,
-	isError,
-	isEmpty,
-	stateTitle,
-	stateDescription,
-	stateMessage,
-	stateAction,
-	className,
-	chartClassName,
-	"data-testid": testId,
+    title,
+    interpretation,
+    children,
+    threshold,
+    band,
+    state,
+    isLoading,
+    isError,
+    isEmpty,
+    stateTitle,
+    stateDescription,
+    stateMessage,
+    stateAction,
+    className,
+    chartClassName,
+    "data-testid": testId,
 }: ChartFrameProps) {
-	const dataState = resolveDataState({ state, isLoading, isError, isEmpty });
-	const hasAnnotations =
-		annotationPresent(threshold) || annotationPresent(band);
+    const dataState = resolveDataState({ state, isLoading, isError, isEmpty });
+    const hasAnnotations = annotationPresent(threshold) || annotationPresent(band);
 
-	return (
-		<section
-			className={`rounded-(--radius-lg) border border-(--card-stroke) bg-(--card) p-5 shadow-(--elevation-card) ${className ?? ""}`.trim()}
-			data-testid={testId}
-		>
-			<div className="flex flex-wrap items-start justify-between gap-4">
-				<div className="min-w-0 space-y-1">
-					<h3 className="font-(--font-display) text-base font-semibold text-foreground">
-						{title}
-					</h3>
-					<div className="text-sm text-(--ink-muted)">{interpretation}</div>
-				</div>
-				{hasAnnotations && (
-					<div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-						{renderAnnotation(threshold, "Chart threshold")}
-						{renderAnnotation(band, "Chart band")}
-					</div>
-				)}
-			</div>
+    return (
+        <section
+            className={`rounded-(--radius-lg) border border-(--card-stroke) bg-(--card) p-5 shadow-(--elevation-card) ${className ?? ""}`.trim()}
+            data-testid={testId}
+        >
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0 space-y-1">
+                    <h3 className="font-(--font-display) text-base font-semibold text-foreground">
+                        {title}
+                    </h3>
+                    <div className="text-sm text-(--ink-muted)">{interpretation}</div>
+                </div>
+                {hasAnnotations && (
+                    <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+                        {renderAnnotation(threshold, "Chart threshold")}
+                        {renderAnnotation(band, "Chart band")}
+                    </div>
+                )}
+            </div>
 
-			<div
-				className={`mt-4 rounded-(--radius-md) ${chartClassName ?? ""}`.trim()}
-			>
-				{dataState ? (
-					<DataState
-						variant={dataState}
-						title={stateTitle}
-						description={stateDescription}
-						message={stateMessage}
-						action={stateAction}
-						className="min-h-64"
-					/>
-				) : (
-					children
-				)}
-			</div>
-		</section>
-	);
+            <div className={`mt-4 rounded-(--radius-md) ${chartClassName ?? ""}`.trim()}>
+                {dataState ? (
+                    <DataState
+                        variant={dataState}
+                        title={stateTitle}
+                        description={stateDescription}
+                        message={stateMessage}
+                        action={stateAction}
+                        className="min-h-64"
+                    />
+                ) : (
+                    children
+                )}
+            </div>
+        </section>
+    );
 }

--- a/src/components/metrics/MetricCard.test.tsx
+++ b/src/components/metrics/MetricCard.test.tsx
@@ -4,42 +4,49 @@ import { MetricCard } from "./MetricCard";
 import { render, screen } from "@/test/utils";
 
 describe("MetricCard delta slot (metric coherence: never a bare '--')", () => {
-    it("renders the default 'No prior period' labeled state when delta is missing", () => {
-        render(<MetricCard label="Success Rate" href="#" value={80} unit="%" />);
-        expect(screen.getByText("No prior period")).toBeInTheDocument();
-        // The delta slot must never show a bare '--' (value is present, so no '--' anywhere).
-        expect(screen.queryByText("--")).not.toBeInTheDocument();
-    });
+	it("renders the default 'No prior period' labeled state when delta is missing", () => {
+		render(<MetricCard label="Success Rate" href="#" value={80} unit="%" />);
+		expect(screen.getByText(/No prior period/)).toBeInTheDocument();
+		// The delta slot must never show a bare '--' (value is present, so no '--' anywhere).
+		expect(screen.queryByText("--")).not.toBeInTheDocument();
+	});
 
-    it("honors a custom deltaUnavailableLabel ('Insufficient history')", () => {
-        render(
-            <MetricCard
-                label="Failure Rate"
-                href="#"
-                value={9}
-                unit="%"
-                deltaUnavailableLabel="Insufficient history"
-            />,
-        );
-        expect(screen.getByText("Insufficient history")).toBeInTheDocument();
-        expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
-    });
+	it("honors a custom deltaUnavailableLabel ('Insufficient history')", () => {
+		render(
+			<MetricCard
+				label="Failure Rate"
+				href="#"
+				value={9}
+				unit="%"
+				deltaUnavailableLabel="Insufficient history"
+			/>,
+		);
+		expect(screen.getByText(/Insufficient history/)).toBeInTheDocument();
+		expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
+	});
 
-    it("exposes the no-comparison reason via a title tooltip", () => {
-        render(<MetricCard label="Pass Rate" href="#" value={98} unit="%" />);
-        const label = screen.getByText("No prior period");
-        expect(label).toHaveAttribute("title", "No prior period available to compute a change");
-    });
+	it("exposes the no-comparison reason via a title tooltip", () => {
+		render(<MetricCard label="Pass Rate" href="#" value={98} unit="%" />);
+		const label = screen.getByText(/No prior period/);
+		expect(label).toHaveAttribute(
+			"title",
+			"No prior period available to compute a change",
+		);
+	});
 
-    it("renders a formatted delta when one is provided (no labeled fallback)", () => {
-        render(<MetricCard label="Coverage" href="#" value={72} unit="%" delta={5} />);
-        expect(screen.getByText("+5%")).toBeInTheDocument();
-        expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
-    });
+	it("renders a formatted delta when one is provided (no labeled fallback)", () => {
+		render(
+			<MetricCard label="Coverage" href="#" value={72} unit="%" delta={5} />,
+		);
+		expect(screen.getByText(/\+5%/)).toBeInTheDocument();
+		expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
+	});
 
-    it("renders a negative delta and still avoids the labeled fallback", () => {
-        render(<MetricCard label="Queue Time" href="#" value={12} unit="m" delta={-3} />);
-        expect(screen.getByText("-3%")).toBeInTheDocument();
-        expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
-    });
+	it("renders a negative delta and still avoids the labeled fallback", () => {
+		render(
+			<MetricCard label="Queue Time" href="#" value={12} unit="m" delta={-3} />,
+		);
+		expect(screen.getByText(/-3%/)).toBeInTheDocument();
+		expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
+	});
 });

--- a/src/components/metrics/MetricCard.test.tsx
+++ b/src/components/metrics/MetricCard.test.tsx
@@ -4,49 +4,42 @@ import { MetricCard } from "./MetricCard";
 import { render, screen } from "@/test/utils";
 
 describe("MetricCard delta slot (metric coherence: never a bare '--')", () => {
-	it("renders the default 'No prior period' labeled state when delta is missing", () => {
-		render(<MetricCard label="Success Rate" href="#" value={80} unit="%" />);
-		expect(screen.getByText(/No prior period/)).toBeInTheDocument();
-		// The delta slot must never show a bare '--' (value is present, so no '--' anywhere).
-		expect(screen.queryByText("--")).not.toBeInTheDocument();
-	});
+    it("renders the default 'No prior period' labeled state when delta is missing", () => {
+        render(<MetricCard label="Success Rate" href="#" value={80} unit="%" />);
+        expect(screen.getByText(/No prior period/)).toBeInTheDocument();
+        // The delta slot must never show a bare '--' (value is present, so no '--' anywhere).
+        expect(screen.queryByText("--")).not.toBeInTheDocument();
+    });
 
-	it("honors a custom deltaUnavailableLabel ('Insufficient history')", () => {
-		render(
-			<MetricCard
-				label="Failure Rate"
-				href="#"
-				value={9}
-				unit="%"
-				deltaUnavailableLabel="Insufficient history"
-			/>,
-		);
-		expect(screen.getByText(/Insufficient history/)).toBeInTheDocument();
-		expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
-	});
+    it("honors a custom deltaUnavailableLabel ('Insufficient history')", () => {
+        render(
+            <MetricCard
+                label="Failure Rate"
+                href="#"
+                value={9}
+                unit="%"
+                deltaUnavailableLabel="Insufficient history"
+            />,
+        );
+        expect(screen.getByText(/Insufficient history/)).toBeInTheDocument();
+        expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
+    });
 
-	it("exposes the no-comparison reason via a title tooltip", () => {
-		render(<MetricCard label="Pass Rate" href="#" value={98} unit="%" />);
-		const label = screen.getByText(/No prior period/);
-		expect(label).toHaveAttribute(
-			"title",
-			"No prior period available to compute a change",
-		);
-	});
+    it("exposes the no-comparison reason via a title tooltip", () => {
+        render(<MetricCard label="Pass Rate" href="#" value={98} unit="%" />);
+        const label = screen.getByText(/No prior period/);
+        expect(label).toHaveAttribute("title", "No prior period available to compute a change");
+    });
 
-	it("renders a formatted delta when one is provided (no labeled fallback)", () => {
-		render(
-			<MetricCard label="Coverage" href="#" value={72} unit="%" delta={5} />,
-		);
-		expect(screen.getByText(/\+5%/)).toBeInTheDocument();
-		expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
-	});
+    it("renders a formatted delta when one is provided (no labeled fallback)", () => {
+        render(<MetricCard label="Coverage" href="#" value={72} unit="%" delta={5} />);
+        expect(screen.getByText(/\+5%/)).toBeInTheDocument();
+        expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
+    });
 
-	it("renders a negative delta and still avoids the labeled fallback", () => {
-		render(
-			<MetricCard label="Queue Time" href="#" value={12} unit="m" delta={-3} />,
-		);
-		expect(screen.getByText(/-3%/)).toBeInTheDocument();
-		expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
-	});
+    it("renders a negative delta and still avoids the labeled fallback", () => {
+        render(<MetricCard label="Queue Time" href="#" value={12} unit="m" delta={-3} />);
+        expect(screen.getByText(/-3%/)).toBeInTheDocument();
+        expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
+    });
 });

--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -2,96 +2,79 @@ import Link from "next/link";
 import { LineagePopover } from "@/app/(app)/data-health/_components/LineagePopover";
 
 import { SparklineChart } from "@/components/charts/SparklineChart";
-import { formatDelta, formatMetricValue } from "@/lib/formatters";
+import { MetricDelta } from "@/components/shared/MetricDelta";
+import { formatMetricValue } from "@/lib/formatters";
 import type { SparkPoint } from "@/lib/types";
 
-const deltaTone = (value?: number) => {
-    if (value === undefined || value === null) {
-        return "text-(--ink-muted)";
-    }
-    return value > 0
-        ? "text-(--accent-3)"
-        : value < 0
-          ? "text-(--accent-negative)"
-          : "text-(--ink-muted)";
-};
-
 type MetricCardProps = {
-    label: string;
-    href: string;
-    value?: number;
-    unit?: string;
-    delta?: number;
-    /** Label shown in the delta slot when no delta is available (never a bare "--"). */
-    deltaUnavailableLabel?: string;
-    spark?: SparkPoint[];
-    caption?: string;
-    className?: string;
-    lineageMetricId?: string;
+	label: string;
+	href: string;
+	value?: number;
+	unit?: string;
+	delta?: number;
+	/** Label shown in the delta slot when no delta is available (never a bare "--"). */
+	deltaUnavailableLabel?: string;
+	spark?: SparkPoint[];
+	caption?: string;
+	className?: string;
+	lineageMetricId?: string;
 };
 
 export function MetricCard({
-    label,
-    href,
-    value,
-    unit,
-    delta,
-    deltaUnavailableLabel = "No prior period",
-    spark,
-    caption,
-    className,
-    lineageMetricId,
+	label,
+	href,
+	value,
+	unit,
+	delta,
+	deltaUnavailableLabel = "No prior period",
+	spark,
+	caption,
+	className,
+	lineageMetricId,
 }: MetricCardProps) {
-    const sparkValues = spark?.map((point) => point.value) ?? [];
-    const sparkLabels = spark?.map((point) => point.ts) ?? [];
+	const sparkValues = spark?.map((point) => point.value) ?? [];
+	const sparkLabels = spark?.map((point) => point.ts) ?? [];
 
-    return (
-        <Link
-            href={href}
-            className={`group rounded-3xl border border-(--card-stroke) bg-card p-4 transition hover:-translate-y-1 hover:shadow-lg ${className ?? ""}`}
-        >
-            <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-                <div className="flex items-center">
-                    <span>{label}</span>
-                    {lineageMetricId && <LineagePopover metricId={lineageMetricId} />}
-                </div>
-                <span className={deltaTone(delta)}>
-                    {delta === undefined || delta === null ? (
-                        <span
-                            title="No prior period available to compute a change"
-                            className="text-[10px] normal-case tracking-normal"
-                        >
-                            {deltaUnavailableLabel}
-                        </span>
-                    ) : (
-                        formatDelta(delta)
-                    )}
-                </span>
-            </div>
-            <div className="mt-3 flex items-center justify-between gap-4">
-                <div>
-                    <p className="text-2xl font-semibold metric-hero">
-                        {value === undefined || value === null
-                            ? "--"
-                            : formatMetricValue(value, unit ?? "")}
-                    </p>
-                    <p className="mt-2 text-xs text-(--ink-muted)">
-                        {caption ?? "Open in Explore"}
-                    </p>
-                </div>
-                <div className="h-16 w-full">
-                    {sparkValues.length > 1 ? (
-                        <SparklineChart data={sparkValues} categories={sparkLabels} height={64} />
-                    ) : (
-                        <div
-                            title="Not enough data points to plot a trend yet"
-                            className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-2 text-center text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)"
-                        >
-                            No trend yet
-                        </div>
-                    )}
-                </div>
-            </div>
-        </Link>
-    );
+	return (
+		<Link
+			href={href}
+			className={`group rounded-3xl border border-(--card-stroke) bg-card p-4 transition hover:-translate-y-1 hover:shadow-lg ${className ?? ""}`}
+		>
+			<div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+				<div className="flex items-center">
+					<span>{label}</span>
+					{lineageMetricId && <LineagePopover metricId={lineageMetricId} />}
+				</div>
+				<MetricDelta value={delta} unavailableLabel={deltaUnavailableLabel} />
+			</div>
+			<div className="mt-3 flex items-center justify-between gap-4">
+				<div>
+					<p className="text-2xl font-semibold metric-hero">
+						{value === undefined || value === null
+							? "--"
+							: formatMetricValue(value, unit ?? "")}
+					</p>
+					<p className="mt-2 text-xs text-(--ink-muted)">
+						{caption ?? "Open in Explore"}
+					</p>
+				</div>
+				<div className="h-16 w-full">
+					{sparkValues.length > 1 ? (
+						<SparklineChart
+							data={sparkValues}
+							categories={sparkLabels}
+							height={64}
+						/>
+					) : (
+						<div
+							title="Not enough data points to plot a trend yet"
+							className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-2 text-center text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)"
+						>
+							No trend yet
+						</div>
+					)}
+				</div>
+			</div>
+		</Link>
+	);
 }

--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -7,74 +7,70 @@ import { formatMetricValue } from "@/lib/formatters";
 import type { SparkPoint } from "@/lib/types";
 
 type MetricCardProps = {
-	label: string;
-	href: string;
-	value?: number;
-	unit?: string;
-	delta?: number;
-	/** Label shown in the delta slot when no delta is available (never a bare "--"). */
-	deltaUnavailableLabel?: string;
-	spark?: SparkPoint[];
-	caption?: string;
-	className?: string;
-	lineageMetricId?: string;
+    label: string;
+    href: string;
+    value?: number;
+    unit?: string;
+    delta?: number;
+    /** Label shown in the delta slot when no delta is available (never a bare "--"). */
+    deltaUnavailableLabel?: string;
+    spark?: SparkPoint[];
+    caption?: string;
+    className?: string;
+    lineageMetricId?: string;
 };
 
 export function MetricCard({
-	label,
-	href,
-	value,
-	unit,
-	delta,
-	deltaUnavailableLabel = "No prior period",
-	spark,
-	caption,
-	className,
-	lineageMetricId,
+    label,
+    href,
+    value,
+    unit,
+    delta,
+    deltaUnavailableLabel = "No prior period",
+    spark,
+    caption,
+    className,
+    lineageMetricId,
 }: MetricCardProps) {
-	const sparkValues = spark?.map((point) => point.value) ?? [];
-	const sparkLabels = spark?.map((point) => point.ts) ?? [];
+    const sparkValues = spark?.map((point) => point.value) ?? [];
+    const sparkLabels = spark?.map((point) => point.ts) ?? [];
 
-	return (
-		<Link
-			href={href}
-			className={`group rounded-3xl border border-(--card-stroke) bg-card p-4 transition hover:-translate-y-1 hover:shadow-lg ${className ?? ""}`}
-		>
-			<div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-				<div className="flex items-center">
-					<span>{label}</span>
-					{lineageMetricId && <LineagePopover metricId={lineageMetricId} />}
-				</div>
-				<MetricDelta value={delta} unavailableLabel={deltaUnavailableLabel} />
-			</div>
-			<div className="mt-3 flex items-center justify-between gap-4">
-				<div>
-					<p className="text-2xl font-semibold metric-hero">
-						{value === undefined || value === null
-							? "--"
-							: formatMetricValue(value, unit ?? "")}
-					</p>
-					<p className="mt-2 text-xs text-(--ink-muted)">
-						{caption ?? "Open in Explore"}
-					</p>
-				</div>
-				<div className="h-16 w-full">
-					{sparkValues.length > 1 ? (
-						<SparklineChart
-							data={sparkValues}
-							categories={sparkLabels}
-							height={64}
-						/>
-					) : (
-						<div
-							title="Not enough data points to plot a trend yet"
-							className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-2 text-center text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)"
-						>
-							No trend yet
-						</div>
-					)}
-				</div>
-			</div>
-		</Link>
-	);
+    return (
+        <Link
+            href={href}
+            className={`group rounded-3xl border border-(--card-stroke) bg-card p-4 transition hover:-translate-y-1 hover:shadow-lg ${className ?? ""}`}
+        >
+            <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                <div className="flex items-center">
+                    <span>{label}</span>
+                    {lineageMetricId && <LineagePopover metricId={lineageMetricId} />}
+                </div>
+                <MetricDelta value={delta} unavailableLabel={deltaUnavailableLabel} />
+            </div>
+            <div className="mt-3 flex items-center justify-between gap-4">
+                <div>
+                    <p className="text-2xl font-semibold metric-hero">
+                        {value === undefined || value === null
+                            ? "--"
+                            : formatMetricValue(value, unit ?? "")}
+                    </p>
+                    <p className="mt-2 text-xs text-(--ink-muted)">
+                        {caption ?? "Open in Explore"}
+                    </p>
+                </div>
+                <div className="h-16 w-full">
+                    {sparkValues.length > 1 ? (
+                        <SparklineChart data={sparkValues} categories={sparkLabels} height={64} />
+                    ) : (
+                        <div
+                            title="Not enough data points to plot a trend yet"
+                            className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-2 text-center text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)"
+                        >
+                            No trend yet
+                        </div>
+                    )}
+                </div>
+            </div>
+        </Link>
+    );
 }

--- a/src/components/security/SecurityFilterBarWrapper.test.tsx
+++ b/src/components/security/SecurityFilterBarWrapper.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { within } from "@testing-library/react";
+import { cleanup, render, screen, userEvent } from "@/test/utils";
+
+import {
+	decodeSecurityFilter,
+	defaultSecurityFilter,
+	encodeSecurityFilter,
+} from "@/lib/filters/security";
+import { SecurityFilterBarWrapper } from "./SecurityFilterBarWrapper";
+
+const mockReplace = vi.fn();
+let currentSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+	usePathname: () => "/security",
+	useRouter: () => ({
+		replace: mockReplace,
+		refresh: vi.fn(),
+		push: vi.fn(),
+		back: vi.fn(),
+		forward: vi.fn(),
+		prefetch: vi.fn(),
+	}),
+	useSearchParams: () => ({
+		get: (key: string) => currentSearchParams.get(key),
+		toString: () => currentSearchParams.toString(),
+		has: (key: string) => currentSearchParams.has(key),
+	}),
+}));
+
+function renderBar(
+	encodedFilter = encodeSecurityFilter(defaultSecurityFilter()),
+) {
+	currentSearchParams = new URLSearchParams({ f: encodedFilter });
+	return render(<SecurityFilterBarWrapper encodedFilter={encodedFilter} />);
+}
+
+function lastSecurityFilter() {
+	const href = mockReplace.mock.calls.at(-1)?.[0] as string;
+	const url = new URL(href, "https://dev-health.test");
+	return decodeSecurityFilter(url.searchParams.get("f") ?? undefined);
+}
+
+describe("SecurityFilterBarWrapper", () => {
+	beforeEach(() => {
+		mockReplace.mockClear();
+		currentSearchParams = new URLSearchParams();
+	});
+
+	afterEach(() => cleanup());
+
+	it("renders FilterPills for severity, state, and source filters", () => {
+		renderBar();
+
+		expect(
+			screen.getByRole("radiogroup", { name: "Security severity" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("radiogroup", { name: "Security state" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("radiogroup", { name: "Security source" }),
+		).toBeInTheDocument();
+	});
+
+	it("updates the encoded security filter when a severity pill is selected", async () => {
+		renderBar();
+
+		await userEvent.click(screen.getByRole("radio", { name: "Critical" }));
+
+		expect(mockReplace).toHaveBeenCalled();
+		expect(lastSecurityFilter()).toMatchObject({
+			openOnly: true,
+			severities: ["critical"],
+		});
+	});
+
+	it("shows multi-value severities as Multiple and lets All clear the narrowing", async () => {
+		renderBar(
+			encodeSecurityFilter({
+				openOnly: true,
+				severities: ["critical", "high"],
+			}),
+		);
+
+		const severity = within(
+			screen.getByRole("radiogroup", { name: "Security severity" }),
+		);
+		const multiple = severity.getByRole("radio", { name: /Multiple \(2\)/ });
+		const all = severity.getByRole("radio", { name: "All" });
+		expect(multiple).toHaveAttribute("aria-checked", "true");
+		expect(all).toHaveAttribute("aria-checked", "false");
+
+		await userEvent.click(all);
+
+		expect(mockReplace).toHaveBeenCalled();
+		expect(lastSecurityFilter()).toMatchObject({ openOnly: true });
+		expect(lastSecurityFilter().severities).toBeUndefined();
+	});
+});

--- a/src/components/security/SecurityFilterBarWrapper.test.tsx
+++ b/src/components/security/SecurityFilterBarWrapper.test.tsx
@@ -3,9 +3,9 @@ import { within } from "@testing-library/react";
 import { cleanup, render, screen, userEvent } from "@/test/utils";
 
 import {
-	decodeSecurityFilter,
-	defaultSecurityFilter,
-	encodeSecurityFilter,
+    decodeSecurityFilter,
+    defaultSecurityFilter,
+    encodeSecurityFilter,
 } from "@/lib/filters/security";
 import { SecurityFilterBarWrapper } from "./SecurityFilterBarWrapper";
 
@@ -13,89 +13,79 @@ const mockReplace = vi.fn();
 let currentSearchParams = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
-	usePathname: () => "/security",
-	useRouter: () => ({
-		replace: mockReplace,
-		refresh: vi.fn(),
-		push: vi.fn(),
-		back: vi.fn(),
-		forward: vi.fn(),
-		prefetch: vi.fn(),
-	}),
-	useSearchParams: () => ({
-		get: (key: string) => currentSearchParams.get(key),
-		toString: () => currentSearchParams.toString(),
-		has: (key: string) => currentSearchParams.has(key),
-	}),
+    usePathname: () => "/security",
+    useRouter: () => ({
+        replace: mockReplace,
+        refresh: vi.fn(),
+        push: vi.fn(),
+        back: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    useSearchParams: () => ({
+        get: (key: string) => currentSearchParams.get(key),
+        toString: () => currentSearchParams.toString(),
+        has: (key: string) => currentSearchParams.has(key),
+    }),
 }));
 
-function renderBar(
-	encodedFilter = encodeSecurityFilter(defaultSecurityFilter()),
-) {
-	currentSearchParams = new URLSearchParams({ f: encodedFilter });
-	return render(<SecurityFilterBarWrapper encodedFilter={encodedFilter} />);
+function renderBar(encodedFilter = encodeSecurityFilter(defaultSecurityFilter())) {
+    currentSearchParams = new URLSearchParams({ f: encodedFilter });
+    return render(<SecurityFilterBarWrapper encodedFilter={encodedFilter} />);
 }
 
 function lastSecurityFilter() {
-	const href = mockReplace.mock.calls.at(-1)?.[0] as string;
-	const url = new URL(href, "https://dev-health.test");
-	return decodeSecurityFilter(url.searchParams.get("f") ?? undefined);
+    const href = mockReplace.mock.calls.at(-1)?.[0] as string;
+    const url = new URL(href, "https://dev-health.test");
+    return decodeSecurityFilter(url.searchParams.get("f") ?? undefined);
 }
 
 describe("SecurityFilterBarWrapper", () => {
-	beforeEach(() => {
-		mockReplace.mockClear();
-		currentSearchParams = new URLSearchParams();
-	});
+    beforeEach(() => {
+        mockReplace.mockClear();
+        currentSearchParams = new URLSearchParams();
+    });
 
-	afterEach(() => cleanup());
+    afterEach(() => cleanup());
 
-	it("renders FilterPills for severity, state, and source filters", () => {
-		renderBar();
+    it("renders FilterPills for severity, state, and source filters", () => {
+        renderBar();
 
-		expect(
-			screen.getByRole("radiogroup", { name: "Security severity" }),
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole("radiogroup", { name: "Security state" }),
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole("radiogroup", { name: "Security source" }),
-		).toBeInTheDocument();
-	});
+        expect(screen.getByRole("radiogroup", { name: "Security severity" })).toBeInTheDocument();
+        expect(screen.getByRole("radiogroup", { name: "Security state" })).toBeInTheDocument();
+        expect(screen.getByRole("radiogroup", { name: "Security source" })).toBeInTheDocument();
+    });
 
-	it("updates the encoded security filter when a severity pill is selected", async () => {
-		renderBar();
+    it("updates the encoded security filter when a severity pill is selected", async () => {
+        renderBar();
 
-		await userEvent.click(screen.getByRole("radio", { name: "Critical" }));
+        await userEvent.click(screen.getByRole("radio", { name: "Critical" }));
 
-		expect(mockReplace).toHaveBeenCalled();
-		expect(lastSecurityFilter()).toMatchObject({
-			openOnly: true,
-			severities: ["critical"],
-		});
-	});
+        expect(mockReplace).toHaveBeenCalled();
+        expect(lastSecurityFilter()).toMatchObject({
+            openOnly: true,
+            severities: ["critical"],
+        });
+    });
 
-	it("shows multi-value severities as Multiple and lets All clear the narrowing", async () => {
-		renderBar(
-			encodeSecurityFilter({
-				openOnly: true,
-				severities: ["critical", "high"],
-			}),
-		);
+    it("shows multi-value severities as Multiple and lets All clear the narrowing", async () => {
+        renderBar(
+            encodeSecurityFilter({
+                openOnly: true,
+                severities: ["critical", "high"],
+            }),
+        );
 
-		const severity = within(
-			screen.getByRole("radiogroup", { name: "Security severity" }),
-		);
-		const multiple = severity.getByRole("radio", { name: /Multiple \(2\)/ });
-		const all = severity.getByRole("radio", { name: "All" });
-		expect(multiple).toHaveAttribute("aria-checked", "true");
-		expect(all).toHaveAttribute("aria-checked", "false");
+        const severity = within(screen.getByRole("radiogroup", { name: "Security severity" }));
+        const multiple = severity.getByRole("radio", { name: /Multiple \(2\)/ });
+        const all = severity.getByRole("radio", { name: "All" });
+        expect(multiple).toHaveAttribute("aria-checked", "true");
+        expect(all).toHaveAttribute("aria-checked", "false");
 
-		await userEvent.click(all);
+        await userEvent.click(all);
 
-		expect(mockReplace).toHaveBeenCalled();
-		expect(lastSecurityFilter()).toMatchObject({ openOnly: true });
-		expect(lastSecurityFilter().severities).toBeUndefined();
-	});
+        expect(mockReplace).toHaveBeenCalled();
+        expect(lastSecurityFilter()).toMatchObject({ openOnly: true });
+        expect(lastSecurityFilter().severities).toBeUndefined();
+    });
 });

--- a/src/components/security/SecurityFilterBarWrapper.tsx
+++ b/src/components/security/SecurityFilterBarWrapper.tsx
@@ -1,23 +1,183 @@
 "use client";
 
-/**
- * SecurityFilterBarWrapper
- *
- * Wraps the security-specific filter controls. Currently renders a placeholder
- * filter area; the full URL-based security filter UI is managed by SecurityAlertQueue
- * via its locked-pill and inline state. A dedicated SecurityFilterBar component
- * can be added here in a follow-up without changing the page component contract.
- */
+import { useCallback } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import {
+	FilterPills,
+	type FilterPillOption,
+} from "@/components/shared/FilterPills";
+import {
+	decodeSecurityFilter,
+	encodeSecurityFilter,
+	type SecurityFilter,
+	type SecuritySeverity,
+	type SecuritySource,
+	type SecurityState,
+} from "@/lib/filters/security";
+
+type SeverityFilterValue = "all" | "multiple" | SecuritySeverity;
+type SourceFilterValue = "all" | "multiple" | SecuritySource;
+type StateFilterValue = "all" | "open" | "multiple" | SecurityState;
+
+const SEVERITY_OPTIONS: FilterPillOption<SeverityFilterValue>[] = [
+	{ id: "all", label: "All" },
+	{ id: "critical", label: "Critical" },
+	{ id: "high", label: "High" },
+	{ id: "medium", label: "Medium" },
+	{ id: "low", label: "Low" },
+	{ id: "unknown", label: "Unknown" },
+];
+
+const STATE_OPTIONS: FilterPillOption<StateFilterValue>[] = [
+	{ id: "open", label: "Open" },
+	{ id: "all", label: "All" },
+	{ id: "fixed", label: "Fixed" },
+	{ id: "dismissed", label: "Dismissed" },
+	{ id: "detected", label: "Detected" },
+	{ id: "confirmed", label: "Confirmed" },
+	{ id: "resolved", label: "Resolved" },
+];
+
+const SOURCE_OPTIONS: FilterPillOption<SourceFilterValue>[] = [
+	{ id: "all", label: "All" },
+	{ id: "dependabot", label: "Dependabot" },
+	{ id: "code_scanning", label: "Code scanning" },
+	{ id: "advisory", label: "Advisory" },
+	{ id: "gitlab_vulnerability", label: "GitLab vulnerability" },
+	{ id: "gitlab_dependency", label: "GitLab dependency" },
+];
+
+const multipleOption = (count: number): FilterPillOption<"multiple"> => ({
+	id: "multiple",
+	label: `Multiple (${count})`,
+	title: "Multiple values active — pick one to replace, or All to clear",
+});
 
 interface SecurityFilterBarWrapperProps {
-    /** Currently unused — filter is read from URL by child client components. */
-    encodedFilter?: string;
+	encodedFilter?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function SecurityFilterBarWrapper({ encodedFilter }: SecurityFilterBarWrapperProps) {
-    // Security filter controls (severity / source / state / date / search chips)
-    // are planned for Wave 3. For now this is intentionally empty to preserve
-    // the page component slot contract established in the spec.
-    return null;
+export function SecurityFilterBarWrapper({
+	encodedFilter,
+}: SecurityFilterBarWrapperProps) {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const filter = encodedFilter
+		? decodeSecurityFilter(encodedFilter)
+		: decodeSecurityFilter(searchParams.get("f") ?? undefined);
+
+	const replaceFilter = useCallback(
+		(nextFilter: SecurityFilter) => {
+			const params = new URLSearchParams(searchParams.toString());
+			params.set("f", encodeSecurityFilter(nextFilter));
+			router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+		},
+		[pathname, router, searchParams],
+	);
+
+	const severityCount = filter.severities?.length ?? 0;
+	const stateCount = filter.states?.length ?? 0;
+	const sourceCount = filter.sources?.length ?? 0;
+
+	const severityValue: SeverityFilterValue =
+		filter.severities?.length === 1
+			? filter.severities[0]
+			: severityCount > 1
+				? "multiple"
+				: "all";
+	const stateValue: StateFilterValue = filter.openOnly
+		? "open"
+		: filter.states?.length === 1
+			? filter.states[0]
+			: stateCount > 1
+				? "multiple"
+				: "all";
+	const sourceValue: SourceFilterValue =
+		filter.sources?.length === 1
+			? filter.sources[0]
+			: sourceCount > 1
+				? "multiple"
+				: "all";
+
+	const severityOptions: FilterPillOption<SeverityFilterValue>[] =
+		severityCount > 1
+			? [multipleOption(severityCount), ...SEVERITY_OPTIONS]
+			: SEVERITY_OPTIONS;
+	const stateOptions: FilterPillOption<StateFilterValue>[] =
+		stateCount > 1 && !filter.openOnly
+			? [multipleOption(stateCount), ...STATE_OPTIONS]
+			: STATE_OPTIONS;
+	const sourceOptions: FilterPillOption<SourceFilterValue>[] =
+		sourceCount > 1
+			? [multipleOption(sourceCount), ...SOURCE_OPTIONS]
+			: SOURCE_OPTIONS;
+
+	const setSeverity = (value: SeverityFilterValue) => {
+		const next = { ...filter };
+		if (value === "all" || value === "multiple") {
+			delete next.severities;
+		} else {
+			next.severities = [value];
+		}
+		replaceFilter(next);
+	};
+
+	const setState = (value: StateFilterValue) => {
+		const next = { ...filter };
+		if (value === "open") {
+			next.openOnly = true;
+			delete next.states;
+		} else if (value === "all" || value === "multiple") {
+			next.openOnly = false;
+			delete next.states;
+		} else {
+			next.openOnly = false;
+			next.states = [value];
+		}
+		replaceFilter(next);
+	};
+
+	const setSource = (value: SourceFilterValue) => {
+		const next = { ...filter };
+		if (value === "all" || value === "multiple") {
+			delete next.sources;
+		} else {
+			next.sources = [value];
+		}
+		replaceFilter(next);
+	};
+
+	return (
+		<section
+			aria-label="Security filters"
+			className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4"
+			data-testid="security-filter-bar"
+		>
+			<div className="flex flex-col gap-3">
+				<FilterPills
+					options={severityOptions}
+					value={severityValue}
+					onChange={setSeverity}
+					ariaLabel="Security severity"
+					leadingLabel="Severity"
+				/>
+				<FilterPills
+					options={stateOptions}
+					value={stateValue}
+					onChange={setState}
+					ariaLabel="Security state"
+					leadingLabel="State"
+				/>
+				<FilterPills
+					options={sourceOptions}
+					value={sourceValue}
+					onChange={setSource}
+					ariaLabel="Security source"
+					leadingLabel="Source"
+				/>
+			</div>
+		</section>
+	);
 }

--- a/src/components/security/SecurityFilterBarWrapper.tsx
+++ b/src/components/security/SecurityFilterBarWrapper.tsx
@@ -3,17 +3,14 @@
 import { useCallback } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
+import { FilterPills, type FilterPillOption } from "@/components/shared/FilterPills";
 import {
-	FilterPills,
-	type FilterPillOption,
-} from "@/components/shared/FilterPills";
-import {
-	decodeSecurityFilter,
-	encodeSecurityFilter,
-	type SecurityFilter,
-	type SecuritySeverity,
-	type SecuritySource,
-	type SecurityState,
+    decodeSecurityFilter,
+    encodeSecurityFilter,
+    type SecurityFilter,
+    type SecuritySeverity,
+    type SecuritySource,
+    type SecurityState,
 } from "@/lib/filters/security";
 
 type SeverityFilterValue = "all" | "multiple" | SecuritySeverity;
@@ -21,163 +18,153 @@ type SourceFilterValue = "all" | "multiple" | SecuritySource;
 type StateFilterValue = "all" | "open" | "multiple" | SecurityState;
 
 const SEVERITY_OPTIONS: FilterPillOption<SeverityFilterValue>[] = [
-	{ id: "all", label: "All" },
-	{ id: "critical", label: "Critical" },
-	{ id: "high", label: "High" },
-	{ id: "medium", label: "Medium" },
-	{ id: "low", label: "Low" },
-	{ id: "unknown", label: "Unknown" },
+    { id: "all", label: "All" },
+    { id: "critical", label: "Critical" },
+    { id: "high", label: "High" },
+    { id: "medium", label: "Medium" },
+    { id: "low", label: "Low" },
+    { id: "unknown", label: "Unknown" },
 ];
 
 const STATE_OPTIONS: FilterPillOption<StateFilterValue>[] = [
-	{ id: "open", label: "Open" },
-	{ id: "all", label: "All" },
-	{ id: "fixed", label: "Fixed" },
-	{ id: "dismissed", label: "Dismissed" },
-	{ id: "detected", label: "Detected" },
-	{ id: "confirmed", label: "Confirmed" },
-	{ id: "resolved", label: "Resolved" },
+    { id: "open", label: "Open" },
+    { id: "all", label: "All" },
+    { id: "fixed", label: "Fixed" },
+    { id: "dismissed", label: "Dismissed" },
+    { id: "detected", label: "Detected" },
+    { id: "confirmed", label: "Confirmed" },
+    { id: "resolved", label: "Resolved" },
 ];
 
 const SOURCE_OPTIONS: FilterPillOption<SourceFilterValue>[] = [
-	{ id: "all", label: "All" },
-	{ id: "dependabot", label: "Dependabot" },
-	{ id: "code_scanning", label: "Code scanning" },
-	{ id: "advisory", label: "Advisory" },
-	{ id: "gitlab_vulnerability", label: "GitLab vulnerability" },
-	{ id: "gitlab_dependency", label: "GitLab dependency" },
+    { id: "all", label: "All" },
+    { id: "dependabot", label: "Dependabot" },
+    { id: "code_scanning", label: "Code scanning" },
+    { id: "advisory", label: "Advisory" },
+    { id: "gitlab_vulnerability", label: "GitLab vulnerability" },
+    { id: "gitlab_dependency", label: "GitLab dependency" },
 ];
 
 const multipleOption = (count: number): FilterPillOption<"multiple"> => ({
-	id: "multiple",
-	label: `Multiple (${count})`,
-	title: "Multiple values active — pick one to replace, or All to clear",
+    id: "multiple",
+    label: `Multiple (${count})`,
+    title: "Multiple values active — pick one to replace, or All to clear",
 });
 
 interface SecurityFilterBarWrapperProps {
-	encodedFilter?: string;
+    encodedFilter?: string;
 }
 
-export function SecurityFilterBarWrapper({
-	encodedFilter,
-}: SecurityFilterBarWrapperProps) {
-	const router = useRouter();
-	const pathname = usePathname();
-	const searchParams = useSearchParams();
-	const filter = encodedFilter
-		? decodeSecurityFilter(encodedFilter)
-		: decodeSecurityFilter(searchParams.get("f") ?? undefined);
+export function SecurityFilterBarWrapper({ encodedFilter }: SecurityFilterBarWrapperProps) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const filter = encodedFilter
+        ? decodeSecurityFilter(encodedFilter)
+        : decodeSecurityFilter(searchParams.get("f") ?? undefined);
 
-	const replaceFilter = useCallback(
-		(nextFilter: SecurityFilter) => {
-			const params = new URLSearchParams(searchParams.toString());
-			params.set("f", encodeSecurityFilter(nextFilter));
-			router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-		},
-		[pathname, router, searchParams],
-	);
+    const replaceFilter = useCallback(
+        (nextFilter: SecurityFilter) => {
+            const params = new URLSearchParams(searchParams.toString());
+            params.set("f", encodeSecurityFilter(nextFilter));
+            router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+        },
+        [pathname, router, searchParams],
+    );
 
-	const severityCount = filter.severities?.length ?? 0;
-	const stateCount = filter.states?.length ?? 0;
-	const sourceCount = filter.sources?.length ?? 0;
+    const severityCount = filter.severities?.length ?? 0;
+    const stateCount = filter.states?.length ?? 0;
+    const sourceCount = filter.sources?.length ?? 0;
 
-	const severityValue: SeverityFilterValue =
-		filter.severities?.length === 1
-			? filter.severities[0]
-			: severityCount > 1
-				? "multiple"
-				: "all";
-	const stateValue: StateFilterValue = filter.openOnly
-		? "open"
-		: filter.states?.length === 1
-			? filter.states[0]
-			: stateCount > 1
-				? "multiple"
-				: "all";
-	const sourceValue: SourceFilterValue =
-		filter.sources?.length === 1
-			? filter.sources[0]
-			: sourceCount > 1
-				? "multiple"
-				: "all";
+    const severityValue: SeverityFilterValue =
+        filter.severities?.length === 1
+            ? filter.severities[0]
+            : severityCount > 1
+              ? "multiple"
+              : "all";
+    const stateValue: StateFilterValue = filter.openOnly
+        ? "open"
+        : filter.states?.length === 1
+          ? filter.states[0]
+          : stateCount > 1
+            ? "multiple"
+            : "all";
+    const sourceValue: SourceFilterValue =
+        filter.sources?.length === 1 ? filter.sources[0] : sourceCount > 1 ? "multiple" : "all";
 
-	const severityOptions: FilterPillOption<SeverityFilterValue>[] =
-		severityCount > 1
-			? [multipleOption(severityCount), ...SEVERITY_OPTIONS]
-			: SEVERITY_OPTIONS;
-	const stateOptions: FilterPillOption<StateFilterValue>[] =
-		stateCount > 1 && !filter.openOnly
-			? [multipleOption(stateCount), ...STATE_OPTIONS]
-			: STATE_OPTIONS;
-	const sourceOptions: FilterPillOption<SourceFilterValue>[] =
-		sourceCount > 1
-			? [multipleOption(sourceCount), ...SOURCE_OPTIONS]
-			: SOURCE_OPTIONS;
+    const severityOptions: FilterPillOption<SeverityFilterValue>[] =
+        severityCount > 1 ? [multipleOption(severityCount), ...SEVERITY_OPTIONS] : SEVERITY_OPTIONS;
+    const stateOptions: FilterPillOption<StateFilterValue>[] =
+        stateCount > 1 && !filter.openOnly
+            ? [multipleOption(stateCount), ...STATE_OPTIONS]
+            : STATE_OPTIONS;
+    const sourceOptions: FilterPillOption<SourceFilterValue>[] =
+        sourceCount > 1 ? [multipleOption(sourceCount), ...SOURCE_OPTIONS] : SOURCE_OPTIONS;
 
-	const setSeverity = (value: SeverityFilterValue) => {
-		const next = { ...filter };
-		if (value === "all" || value === "multiple") {
-			delete next.severities;
-		} else {
-			next.severities = [value];
-		}
-		replaceFilter(next);
-	};
+    const setSeverity = (value: SeverityFilterValue) => {
+        const next = { ...filter };
+        if (value === "all" || value === "multiple") {
+            delete next.severities;
+        } else {
+            next.severities = [value];
+        }
+        replaceFilter(next);
+    };
 
-	const setState = (value: StateFilterValue) => {
-		const next = { ...filter };
-		if (value === "open") {
-			next.openOnly = true;
-			delete next.states;
-		} else if (value === "all" || value === "multiple") {
-			next.openOnly = false;
-			delete next.states;
-		} else {
-			next.openOnly = false;
-			next.states = [value];
-		}
-		replaceFilter(next);
-	};
+    const setState = (value: StateFilterValue) => {
+        const next = { ...filter };
+        if (value === "open") {
+            next.openOnly = true;
+            delete next.states;
+        } else if (value === "all" || value === "multiple") {
+            next.openOnly = false;
+            delete next.states;
+        } else {
+            next.openOnly = false;
+            next.states = [value];
+        }
+        replaceFilter(next);
+    };
 
-	const setSource = (value: SourceFilterValue) => {
-		const next = { ...filter };
-		if (value === "all" || value === "multiple") {
-			delete next.sources;
-		} else {
-			next.sources = [value];
-		}
-		replaceFilter(next);
-	};
+    const setSource = (value: SourceFilterValue) => {
+        const next = { ...filter };
+        if (value === "all" || value === "multiple") {
+            delete next.sources;
+        } else {
+            next.sources = [value];
+        }
+        replaceFilter(next);
+    };
 
-	return (
-		<section
-			aria-label="Security filters"
-			className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4"
-			data-testid="security-filter-bar"
-		>
-			<div className="flex flex-col gap-3">
-				<FilterPills
-					options={severityOptions}
-					value={severityValue}
-					onChange={setSeverity}
-					ariaLabel="Security severity"
-					leadingLabel="Severity"
-				/>
-				<FilterPills
-					options={stateOptions}
-					value={stateValue}
-					onChange={setState}
-					ariaLabel="Security state"
-					leadingLabel="State"
-				/>
-				<FilterPills
-					options={sourceOptions}
-					value={sourceValue}
-					onChange={setSource}
-					ariaLabel="Security source"
-					leadingLabel="Source"
-				/>
-			</div>
-		</section>
-	);
+    return (
+        <section
+            aria-label="Security filters"
+            className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4"
+            data-testid="security-filter-bar"
+        >
+            <div className="flex flex-col gap-3">
+                <FilterPills
+                    options={severityOptions}
+                    value={severityValue}
+                    onChange={setSeverity}
+                    ariaLabel="Security severity"
+                    leadingLabel="Severity"
+                />
+                <FilterPills
+                    options={stateOptions}
+                    value={stateValue}
+                    onChange={setState}
+                    ariaLabel="Security state"
+                    leadingLabel="State"
+                />
+                <FilterPills
+                    options={sourceOptions}
+                    value={sourceValue}
+                    onChange={setSource}
+                    ariaLabel="Security source"
+                    leadingLabel="Source"
+                />
+            </div>
+        </section>
+    );
 }

--- a/src/components/shared/FilterPills.test.tsx
+++ b/src/components/shared/FilterPills.test.tsx
@@ -4,105 +4,101 @@ import userEvent from "@testing-library/user-event";
 import { FilterPills, type FilterPillOption } from "./FilterPills";
 
 const options: FilterPillOption[] = [
-	{ id: "week", label: "Week" },
-	{ id: "month", label: "Month" },
+    { id: "week", label: "Week" },
+    { id: "month", label: "Month" },
 ];
 
 describe("FilterPills", () => {
-	it("renders a radiogroup with one radio per option", () => {
-		render(
-			<FilterPills
-				options={options}
-				value="week"
-				onChange={vi.fn()}
-				ariaLabel="Time grain"
-			/>,
-		);
-		expect(
-			screen.getByRole("radiogroup", { name: "Time grain" }),
-		).toBeInTheDocument();
-		expect(screen.getAllByRole("radio")).toHaveLength(2);
-	});
+    it("renders a radiogroup with one radio per option", () => {
+        render(
+            <FilterPills
+                options={options}
+                value="week"
+                onChange={vi.fn()}
+                ariaLabel="Time grain"
+            />,
+        );
+        expect(screen.getByRole("radiogroup", { name: "Time grain" })).toBeInTheDocument();
+        expect(screen.getAllByRole("radio")).toHaveLength(2);
+    });
 
-	it("marks the selected option with aria-checked=true", () => {
-		render(
-			<FilterPills
-				options={options}
-				value="month"
-				onChange={vi.fn()}
-				ariaLabel="Time grain"
-			/>,
-		);
-		expect(screen.getByRole("radio", { name: "Month" })).toHaveAttribute(
-			"aria-checked",
-			"true",
-		);
-		expect(screen.getByRole("radio", { name: "Week" })).toHaveAttribute(
-			"aria-checked",
-			"false",
-		);
-	});
+    it("marks the selected option with aria-checked=true", () => {
+        render(
+            <FilterPills
+                options={options}
+                value="month"
+                onChange={vi.fn()}
+                ariaLabel="Time grain"
+            />,
+        );
+        expect(screen.getByRole("radio", { name: "Month" })).toHaveAttribute(
+            "aria-checked",
+            "true",
+        );
+        expect(screen.getByRole("radio", { name: "Week" })).toHaveAttribute(
+            "aria-checked",
+            "false",
+        );
+    });
 
-	it("styles the active option with the primary accent token", () => {
-		render(
-			<FilterPills
-				options={options}
-				value="month"
-				onChange={vi.fn()}
-				ariaLabel="Time grain"
-			/>,
-		);
+    it("styles the active option with the primary accent token", () => {
+        render(
+            <FilterPills
+                options={options}
+                value="month"
+                onChange={vi.fn()}
+                ariaLabel="Time grain"
+            />,
+        );
 
-		const active = screen
-			.getByRole("radio", { name: "Month" })
-			.closest("label");
-		expect(active).toHaveClass("border-(--accent)");
-		expect(active).toHaveClass("bg-(--accent)/15");
-		expect(active).toHaveClass("text-(--accent)");
-		expect(active?.className).not.toContain("--accent-2");
-	});
+        const active = screen.getByRole("radio", { name: "Month" }).closest("label");
+        expect(active).toHaveClass("border-(--accent)");
+        expect(active).toHaveClass("bg-(--accent)/15");
+        expect(active).toHaveClass("text-(--accent)");
+        expect(active?.className).not.toContain("--accent-2");
+    });
 
-	it("calls onChange with the option id", async () => {
-		const onChange = vi.fn();
-		const user = userEvent.setup();
-		render(
-			<FilterPills
-				options={options}
-				value="week"
-				onChange={onChange}
-				ariaLabel="Time grain"
-			/>,
-		);
-		await user.click(screen.getByRole("radio", { name: "Month" }));
-		expect(onChange).toHaveBeenCalledWith("month");
-	});
+    it("calls onChange with the option id", async () => {
+        const onChange = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <FilterPills
+                options={options}
+                value="week"
+                onChange={onChange}
+                ariaLabel="Time grain"
+            />,
+        );
+        await user.click(screen.getByRole("radio", { name: "Month" }));
+        expect(onChange).toHaveBeenCalledWith("month");
+    });
 
-	it("renders an optional leading label and test id", () => {
-		render(
-			<FilterPills
-				options={options}
-				value="week"
-				onChange={vi.fn()}
-				ariaLabel="Time grain"
-				leadingLabel="Grain"
-				testId="grain-pills"
-			/>,
-		);
-		expect(screen.getByText("Grain")).toBeInTheDocument();
-		expect(screen.getByTestId("grain-pills")).toBeInTheDocument();
-	});
+    it("renders an optional leading label and test id", () => {
+        render(
+            <FilterPills
+                options={options}
+                value="week"
+                onChange={vi.fn()}
+                ariaLabel="Time grain"
+                leadingLabel="Grain"
+                testId="grain-pills"
+            />,
+        );
+        expect(screen.getByText("Grain")).toBeInTheDocument();
+        expect(screen.getByTestId("grain-pills")).toBeInTheDocument();
+    });
 
-	it("wires keyboard focus styling to the focusable input", () => {
-		render(
-			<FilterPills
-				options={options}
-				value="week"
-				onChange={vi.fn()}
-				ariaLabel="Time grain"
-			/>,
-		);
-		const pill = screen.getByRole("radio", { name: "Week" }).closest("label");
-		expect(pill?.className).toContain("has-[:focus-visible]:ring-2");
-		expect(pill?.className).toContain("has-[:focus-visible]:ring-(--accent)");
-	});
+    it("wires keyboard focus styling to the focusable input", () => {
+        render(
+            <FilterPills
+                options={options}
+                value="week"
+                onChange={vi.fn()}
+                ariaLabel="Time grain"
+            />,
+        );
+        const pill = screen.getByRole("radio", { name: "Week" }).closest("label");
+        expect(pill?.className).toContain("has-[:focus-visible]:ring-2");
+        expect(pill?.className).toContain("has-[:focus-visible]:ring-(--accent)");
+    });
 });

--- a/src/components/shared/FilterPills.test.tsx
+++ b/src/components/shared/FilterPills.test.tsx
@@ -4,70 +4,105 @@ import userEvent from "@testing-library/user-event";
 import { FilterPills, type FilterPillOption } from "./FilterPills";
 
 const options: FilterPillOption[] = [
-    { id: "week", label: "Week" },
-    { id: "month", label: "Month" },
+	{ id: "week", label: "Week" },
+	{ id: "month", label: "Month" },
 ];
 
 describe("FilterPills", () => {
-    it("renders a radiogroup with one radio per option", () => {
-        render(
-            <FilterPills
-                options={options}
-                value="week"
-                onChange={vi.fn()}
-                ariaLabel="Time grain"
-            />,
-        );
-        expect(screen.getByRole("radiogroup", { name: "Time grain" })).toBeInTheDocument();
-        expect(screen.getAllByRole("radio")).toHaveLength(2);
-    });
+	it("renders a radiogroup with one radio per option", () => {
+		render(
+			<FilterPills
+				options={options}
+				value="week"
+				onChange={vi.fn()}
+				ariaLabel="Time grain"
+			/>,
+		);
+		expect(
+			screen.getByRole("radiogroup", { name: "Time grain" }),
+		).toBeInTheDocument();
+		expect(screen.getAllByRole("radio")).toHaveLength(2);
+	});
 
-    it("marks the selected option with aria-checked=true", () => {
-        render(
-            <FilterPills
-                options={options}
-                value="month"
-                onChange={vi.fn()}
-                ariaLabel="Time grain"
-            />,
-        );
-        expect(screen.getByRole("radio", { name: "Month" })).toHaveAttribute(
-            "aria-checked",
-            "true",
-        );
-        expect(screen.getByRole("radio", { name: "Week" })).toHaveAttribute(
-            "aria-checked",
-            "false",
-        );
-    });
+	it("marks the selected option with aria-checked=true", () => {
+		render(
+			<FilterPills
+				options={options}
+				value="month"
+				onChange={vi.fn()}
+				ariaLabel="Time grain"
+			/>,
+		);
+		expect(screen.getByRole("radio", { name: "Month" })).toHaveAttribute(
+			"aria-checked",
+			"true",
+		);
+		expect(screen.getByRole("radio", { name: "Week" })).toHaveAttribute(
+			"aria-checked",
+			"false",
+		);
+	});
 
-    it("calls onChange with the option id", async () => {
-        const onChange = vi.fn();
-        const user = userEvent.setup();
-        render(
-            <FilterPills
-                options={options}
-                value="week"
-                onChange={onChange}
-                ariaLabel="Time grain"
-            />,
-        );
-        await user.click(screen.getByRole("radio", { name: "Month" }));
-        expect(onChange).toHaveBeenCalledWith("month");
-    });
+	it("styles the active option with the primary accent token", () => {
+		render(
+			<FilterPills
+				options={options}
+				value="month"
+				onChange={vi.fn()}
+				ariaLabel="Time grain"
+			/>,
+		);
 
-    it("renders an optional leading label and test id", () => {
-        render(
-            <FilterPills
-                options={options}
-                value="week"
-                onChange={vi.fn()}
-                ariaLabel="Time grain"
-                leadingLabel="Grain"
-                testId="grain-pills"
-            />,
-        );
-        expect(screen.getByText("Grain")).toBeInTheDocument();
-        expect(screen.getByTestId("grain-pills")).toBeInTheDocument();
-    });
+		const active = screen
+			.getByRole("radio", { name: "Month" })
+			.closest("label");
+		expect(active).toHaveClass("border-(--accent)");
+		expect(active).toHaveClass("bg-(--accent)/15");
+		expect(active).toHaveClass("text-(--accent)");
+		expect(active?.className).not.toContain("--accent-2");
+	});
+
+	it("calls onChange with the option id", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<FilterPills
+				options={options}
+				value="week"
+				onChange={onChange}
+				ariaLabel="Time grain"
+			/>,
+		);
+		await user.click(screen.getByRole("radio", { name: "Month" }));
+		expect(onChange).toHaveBeenCalledWith("month");
+	});
+
+	it("renders an optional leading label and test id", () => {
+		render(
+			<FilterPills
+				options={options}
+				value="week"
+				onChange={vi.fn()}
+				ariaLabel="Time grain"
+				leadingLabel="Grain"
+				testId="grain-pills"
+			/>,
+		);
+		expect(screen.getByText("Grain")).toBeInTheDocument();
+		expect(screen.getByTestId("grain-pills")).toBeInTheDocument();
+	});
+
+	it("wires keyboard focus styling to the focusable input", () => {
+		render(
+			<FilterPills
+				options={options}
+				value="week"
+				onChange={vi.fn()}
+				ariaLabel="Time grain"
+			/>,
+		);
+		const pill = screen.getByRole("radio", { name: "Week" }).closest("label");
+		expect(pill?.className).toContain("has-[:focus-visible]:ring-2");
+		expect(pill?.className).toContain("has-[:focus-visible]:ring-(--accent)");
+	});
 });

--- a/src/components/shared/FilterPills.tsx
+++ b/src/components/shared/FilterPills.tsx
@@ -1,32 +1,32 @@
 import { useId, type ReactNode } from "react";
 
 export type FilterPillOption<TId extends string = string> = {
-	id: TId;
-	label: string;
-	icon?: ReactNode;
-	/** Optional native title / tooltip. */
-	title?: string;
+    id: TId;
+    label: string;
+    icon?: ReactNode;
+    /** Optional native title / tooltip. */
+    title?: string;
 };
 
 type FilterPillsProps<TId extends string = string> = {
-	options: ReadonlyArray<FilterPillOption<TId>>;
-	value: TId;
-	onChange: (value: TId) => void;
-	/** Accessible name for the group. */
-	ariaLabel: string;
-	/** Optional quiet leading label rendered before the pills. */
-	leadingLabel?: string;
-	className?: string;
-	/** Optional test id applied to the root container. */
-	testId?: string;
+    options: ReadonlyArray<FilterPillOption<TId>>;
+    value: TId;
+    onChange: (value: TId) => void;
+    /** Accessible name for the group. */
+    ariaLabel: string;
+    /** Optional quiet leading label rendered before the pills. */
+    leadingLabel?: string;
+    className?: string;
+    /** Optional test id applied to the root container. */
+    testId?: string;
 };
 
 const ACTIVE = "border-(--accent) bg-(--accent)/15 text-(--accent)";
 const INACTIVE =
-	"border-(--card-stroke) bg-(--card-80) text-(--ink-muted) hover:border-(--accent)/40 hover:text-foreground";
+    "border-(--card-stroke) bg-(--card-80) text-(--ink-muted) hover:border-(--accent)/40 hover:text-foreground";
 
 const PILL =
-	"inline-flex items-center gap-1.5 rounded-(--radius-pill) border px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.15em] transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--accent)";
+    "inline-flex items-center gap-1.5 rounded-(--radius-pill) border px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.15em] transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--accent)";
 
 /**
  * Segmented selection primitive (framework A3).
@@ -39,53 +39,49 @@ const PILL =
  * (actions).
  */
 export function FilterPills<TId extends string = string>({
-	options,
-	value,
-	onChange,
-	ariaLabel,
-	leadingLabel,
-	className,
-	testId,
+    options,
+    value,
+    onChange,
+    ariaLabel,
+    leadingLabel,
+    className,
+    testId,
 }: FilterPillsProps<TId>) {
-	const name = useId();
+    const name = useId();
 
-	return (
-		<div
-			className={`flex flex-wrap items-center gap-2 ${className ?? ""}`.trim()}
-			data-testid={testId}
-		>
-			{leadingLabel ? (
-				<span className="text-xs uppercase tracking-[0.25em] text-(--ink-muted)">
-					{leadingLabel}
-				</span>
-			) : null}
-			<div
-				className="flex flex-wrap gap-1"
-				role="radiogroup"
-				aria-label={ariaLabel}
-			>
-				{options.map((option) => {
-					const isActive = option.id === value;
-					return (
-						<label
-							key={option.id}
-							title={option.title}
-							className={`${PILL} ${isActive ? ACTIVE : INACTIVE}`}
-						>
-							<input
-								type="radio"
-								name={name}
-								checked={isActive}
-								aria-checked={isActive}
-								onChange={() => onChange(option.id)}
-								className="sr-only"
-							/>
-							{option.icon}
-							<span>{option.label}</span>
-						</label>
-					);
-				})}
-			</div>
-		</div>
-	);
+    return (
+        <div
+            className={`flex flex-wrap items-center gap-2 ${className ?? ""}`.trim()}
+            data-testid={testId}
+        >
+            {leadingLabel ? (
+                <span className="text-xs uppercase tracking-[0.25em] text-(--ink-muted)">
+                    {leadingLabel}
+                </span>
+            ) : null}
+            <div className="flex flex-wrap gap-1" role="radiogroup" aria-label={ariaLabel}>
+                {options.map((option) => {
+                    const isActive = option.id === value;
+                    return (
+                        <label
+                            key={option.id}
+                            title={option.title}
+                            className={`${PILL} ${isActive ? ACTIVE : INACTIVE}`}
+                        >
+                            <input
+                                type="radio"
+                                name={name}
+                                checked={isActive}
+                                aria-checked={isActive}
+                                onChange={() => onChange(option.id)}
+                                className="sr-only"
+                            />
+                            {option.icon}
+                            <span>{option.label}</span>
+                        </label>
+                    );
+                })}
+            </div>
+        </div>
+    );
 }

--- a/src/components/shared/FilterPills.tsx
+++ b/src/components/shared/FilterPills.tsx
@@ -1,82 +1,91 @@
-"use client";
-
-import type { ReactNode } from "react";
+import { useId, type ReactNode } from "react";
 
 export type FilterPillOption<TId extends string = string> = {
-    id: TId;
-    label: string;
-    icon?: ReactNode;
-    /** Optional native title / tooltip. */
-    title?: string;
+	id: TId;
+	label: string;
+	icon?: ReactNode;
+	/** Optional native title / tooltip. */
+	title?: string;
 };
 
 type FilterPillsProps<TId extends string = string> = {
-    options: ReadonlyArray<FilterPillOption<TId>>;
-    value: TId;
-    onChange: (value: TId) => void;
-    /** Accessible name for the group. */
-    ariaLabel: string;
-    /** Optional quiet leading label rendered before the pills. */
-    leadingLabel?: string;
-    className?: string;
-    /** Optional test id applied to the root container. */
-    testId?: string;
+	options: ReadonlyArray<FilterPillOption<TId>>;
+	value: TId;
+	onChange: (value: TId) => void;
+	/** Accessible name for the group. */
+	ariaLabel: string;
+	/** Optional quiet leading label rendered before the pills. */
+	leadingLabel?: string;
+	className?: string;
+	/** Optional test id applied to the root container. */
+	testId?: string;
 };
 
-const ACTIVE = "border-(--accent-2) bg-(--accent-2)/15 text-(--accent-2)";
+const ACTIVE = "border-(--accent) bg-(--accent)/15 text-(--accent)";
 const INACTIVE =
-    "border-(--card-stroke) bg-(--card-80) text-(--ink-muted) hover:border-(--accent-2)/40 hover:text-foreground";
+	"border-(--card-stroke) bg-(--card-80) text-(--ink-muted) hover:border-(--accent)/40 hover:text-foreground";
 
 const PILL =
-    "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.15em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-2)";
+	"inline-flex items-center gap-1.5 rounded-(--radius-pill) border px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.15em] transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--accent)";
 
 /**
  * Segmented selection primitive (framework A3).
  *
- * The rounded-pill idiom is reserved for *single-select toggles that filter or
- * reshape the current view* (role lens, chart type, …). It is a radiogroup —
- * exactly one option is selected at a time. Keep it distinct from
- * {@link ModeTabs} (route/sub-view switching) and {@link BackLink} (return
- * path); a return path must never be rendered as a filter pill.
+ * The rounded-pill idiom is reserved for *single-select A3 toggles* that filter,
+ * scope, change status, or segment the current view. It is a radiogroup —
+ * exactly one option is selected at a time — and must not be used for
+ * navigation, back links, or CTA actions. Keep it distinct from {@link ModeTabs}
+ * (route/sub-view switching), {@link BackLink} (return path), and {@link Button}
+ * (actions).
  */
 export function FilterPills<TId extends string = string>({
-    options,
-    value,
-    onChange,
-    ariaLabel,
-    leadingLabel,
-    className,
-    testId,
+	options,
+	value,
+	onChange,
+	ariaLabel,
+	leadingLabel,
+	className,
+	testId,
 }: FilterPillsProps<TId>) {
-    return (
-        <div
-            className={`flex flex-wrap items-center gap-2 ${className ?? ""}`.trim()}
-            data-testid={testId}
-        >
-            {leadingLabel ? (
-                <span className="text-[10px] uppercase tracking-[0.25em] text-(--ink-muted)">
-                    {leadingLabel}
-                </span>
-            ) : null}
-            <div className="flex flex-wrap gap-1" role="radiogroup" aria-label={ariaLabel}>
-                {options.map((option) => {
-                    const isActive = option.id === value;
-                    return (
-                        <button
-                            key={option.id}
-                            type="button"
-                            role="radio"
-                            aria-checked={isActive}
-                            title={option.title}
-                            onClick={() => onChange(option.id)}
-                            className={`${PILL} ${isActive ? ACTIVE : INACTIVE}`}
-                        >
-                            {option.icon}
-                            <span>{option.label}</span>
-                        </button>
-                    );
-                })}
-            </div>
-        </div>
-    );
+	const name = useId();
+
+	return (
+		<div
+			className={`flex flex-wrap items-center gap-2 ${className ?? ""}`.trim()}
+			data-testid={testId}
+		>
+			{leadingLabel ? (
+				<span className="text-xs uppercase tracking-[0.25em] text-(--ink-muted)">
+					{leadingLabel}
+				</span>
+			) : null}
+			<div
+				className="flex flex-wrap gap-1"
+				role="radiogroup"
+				aria-label={ariaLabel}
+			>
+				{options.map((option) => {
+					const isActive = option.id === value;
+					return (
+						<label
+							key={option.id}
+							title={option.title}
+							className={`${PILL} ${isActive ? ACTIVE : INACTIVE}`}
+						>
+							<input
+								type="radio"
+								name={name}
+								checked={isActive}
+								aria-checked={isActive}
+								onChange={() => onChange(option.id)}
+								className="sr-only"
+							/>
+							{option.icon}
+							<span>{option.label}</span>
+						</label>
+					);
+				})}
+			</div>
+		</div>
+	);
 }

--- a/src/components/shared/MetricDelta.test.tsx
+++ b/src/components/shared/MetricDelta.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+
+import { MetricDelta } from "./MetricDelta";
+
+describe("MetricDelta", () => {
+	it("renders rounded signed zero as 0% with muted tone", () => {
+		render(<MetricDelta value={-0.2} />);
+
+		const delta = screen.getByText("· 0%");
+		expect(delta).toBeInTheDocument();
+		expect(delta).not.toHaveTextContent("-0%");
+		expect(delta).toHaveClass("text-(--ink-muted)");
+	});
+
+	it("renders a positive percent delta with positive tone", () => {
+		render(<MetricDelta value={12} />);
+
+		const delta = screen.getByText("↑ +12%");
+		expect(delta).toHaveClass("text-(--positive)");
+	});
+
+	it("renders a negative percent delta with negative tone", () => {
+		render(<MetricDelta value={-8} />);
+
+		const delta = screen.getByText("↓ -8%");
+		expect(delta).toHaveClass("text-(--accent-negative)");
+	});
+
+	it("renders unavailable values with muted tone", () => {
+		render(<MetricDelta value={null} unavailableLabel="No comparison" />);
+
+		const delta = screen.getByText("· No comparison");
+		expect(delta).toHaveClass("text-(--ink-muted)");
+	});
+
+	it("swaps positive and negative tones when inverseGood is true", () => {
+		render(<MetricDelta value={12} inverseGood />);
+
+		const delta = screen.getByText("↑ +12%");
+		expect(delta).toHaveClass("text-(--accent-negative)");
+	});
+
+	it("renders a number-format delta without a percent sign", () => {
+		render(<MetricDelta value={5} format="number" />);
+
+		const delta = screen.getByText("↑ +5");
+		expect(delta).toHaveClass("text-(--positive)");
+	});
+
+	it("formats non-zero precision percent deltas", () => {
+		render(<MetricDelta value={2.5} precision={1} />);
+
+		expect(screen.getByText("↑ +2.5%")).toBeInTheDocument();
+	});
+
+	it("treats NaN as unavailable", () => {
+		render(<MetricDelta value={Number.NaN} />);
+
+		expect(screen.getByText("· No prior period")).toHaveClass(
+			"text-(--ink-muted)",
+		);
+	});
+
+	it("treats Infinity as unavailable", () => {
+		render(<MetricDelta value={Number.POSITIVE_INFINITY} />);
+
+		expect(screen.getByText("· No prior period")).toHaveClass(
+			"text-(--ink-muted)",
+		);
+	});
+});

--- a/src/components/shared/MetricDelta.test.tsx
+++ b/src/components/shared/MetricDelta.test.tsx
@@ -4,69 +4,65 @@ import { render, screen } from "@/test/utils";
 import { MetricDelta } from "./MetricDelta";
 
 describe("MetricDelta", () => {
-	it("renders rounded signed zero as 0% with muted tone", () => {
-		render(<MetricDelta value={-0.2} />);
+    it("renders rounded signed zero as 0% with muted tone", () => {
+        render(<MetricDelta value={-0.2} />);
 
-		const delta = screen.getByText("· 0%");
-		expect(delta).toBeInTheDocument();
-		expect(delta).not.toHaveTextContent("-0%");
-		expect(delta).toHaveClass("text-(--ink-muted)");
-	});
+        const delta = screen.getByText("· 0%");
+        expect(delta).toBeInTheDocument();
+        expect(delta).not.toHaveTextContent("-0%");
+        expect(delta).toHaveClass("text-(--ink-muted)");
+    });
 
-	it("renders a positive percent delta with positive tone", () => {
-		render(<MetricDelta value={12} />);
+    it("renders a positive percent delta with positive tone", () => {
+        render(<MetricDelta value={12} />);
 
-		const delta = screen.getByText("↑ +12%");
-		expect(delta).toHaveClass("text-(--positive)");
-	});
+        const delta = screen.getByText("↑ +12%");
+        expect(delta).toHaveClass("text-(--positive)");
+    });
 
-	it("renders a negative percent delta with negative tone", () => {
-		render(<MetricDelta value={-8} />);
+    it("renders a negative percent delta with negative tone", () => {
+        render(<MetricDelta value={-8} />);
 
-		const delta = screen.getByText("↓ -8%");
-		expect(delta).toHaveClass("text-(--accent-negative)");
-	});
+        const delta = screen.getByText("↓ -8%");
+        expect(delta).toHaveClass("text-(--accent-negative)");
+    });
 
-	it("renders unavailable values with muted tone", () => {
-		render(<MetricDelta value={null} unavailableLabel="No comparison" />);
+    it("renders unavailable values with muted tone", () => {
+        render(<MetricDelta value={null} unavailableLabel="No comparison" />);
 
-		const delta = screen.getByText("· No comparison");
-		expect(delta).toHaveClass("text-(--ink-muted)");
-	});
+        const delta = screen.getByText("· No comparison");
+        expect(delta).toHaveClass("text-(--ink-muted)");
+    });
 
-	it("swaps positive and negative tones when inverseGood is true", () => {
-		render(<MetricDelta value={12} inverseGood />);
+    it("swaps positive and negative tones when inverseGood is true", () => {
+        render(<MetricDelta value={12} inverseGood />);
 
-		const delta = screen.getByText("↑ +12%");
-		expect(delta).toHaveClass("text-(--accent-negative)");
-	});
+        const delta = screen.getByText("↑ +12%");
+        expect(delta).toHaveClass("text-(--accent-negative)");
+    });
 
-	it("renders a number-format delta without a percent sign", () => {
-		render(<MetricDelta value={5} format="number" />);
+    it("renders a number-format delta without a percent sign", () => {
+        render(<MetricDelta value={5} format="number" />);
 
-		const delta = screen.getByText("↑ +5");
-		expect(delta).toHaveClass("text-(--positive)");
-	});
+        const delta = screen.getByText("↑ +5");
+        expect(delta).toHaveClass("text-(--positive)");
+    });
 
-	it("formats non-zero precision percent deltas", () => {
-		render(<MetricDelta value={2.5} precision={1} />);
+    it("formats non-zero precision percent deltas", () => {
+        render(<MetricDelta value={2.5} precision={1} />);
 
-		expect(screen.getByText("↑ +2.5%")).toBeInTheDocument();
-	});
+        expect(screen.getByText("↑ +2.5%")).toBeInTheDocument();
+    });
 
-	it("treats NaN as unavailable", () => {
-		render(<MetricDelta value={Number.NaN} />);
+    it("treats NaN as unavailable", () => {
+        render(<MetricDelta value={Number.NaN} />);
 
-		expect(screen.getByText("· No prior period")).toHaveClass(
-			"text-(--ink-muted)",
-		);
-	});
+        expect(screen.getByText("· No prior period")).toHaveClass("text-(--ink-muted)");
+    });
 
-	it("treats Infinity as unavailable", () => {
-		render(<MetricDelta value={Number.POSITIVE_INFINITY} />);
+    it("treats Infinity as unavailable", () => {
+        render(<MetricDelta value={Number.POSITIVE_INFINITY} />);
 
-		expect(screen.getByText("· No prior period")).toHaveClass(
-			"text-(--ink-muted)",
-		);
-	});
+        expect(screen.getByText("· No prior period")).toHaveClass("text-(--ink-muted)");
+    });
 });

--- a/src/components/shared/MetricDelta.tsx
+++ b/src/components/shared/MetricDelta.tsx
@@ -1,0 +1,95 @@
+import { formatDelta, formatNumber } from "@/lib/formatters";
+
+type MetricDeltaFormat = "percent" | "number";
+
+type MetricDeltaProps = {
+	value: number | null | undefined;
+	format?: MetricDeltaFormat;
+	unavailableLabel?: string;
+	inverseGood?: boolean;
+	precision?: number;
+	className?: string;
+};
+
+const BASE =
+	"inline-flex items-center gap-1 text-[10px] normal-case tracking-normal";
+const POSITIVE_TONE = "text-(--positive)";
+const NEGATIVE_TONE = "text-(--accent-negative)";
+const MUTED_TONE = "text-(--ink-muted)";
+
+const clampPrecision = (precision: number) =>
+	Math.max(0, Math.min(6, precision));
+
+const roundToPrecision = (value: number, precision: number) => {
+	const factor = 10 ** precision;
+	const rounded = Math.round(value * factor) / factor;
+	return Object.is(rounded, -0) ? 0 : rounded;
+};
+
+const formatSignedNumberDelta = (rounded: number, precision: number) => {
+	const sign = rounded > 0 ? "+" : rounded < 0 ? "-" : "";
+	return `${sign}${formatNumber(Math.abs(rounded), {
+		maximumFractionDigits: precision,
+	})}`;
+};
+
+const formatSignedPercentDelta = (
+	value: number,
+	rounded: number,
+	precision: number,
+) => {
+	if (precision === 0) {
+		return formatDelta(value);
+	}
+	return `${formatSignedNumberDelta(rounded, precision)}%`;
+};
+
+const toneFor = (rounded: number, inverseGood: boolean) => {
+	if (rounded === 0) {
+		return MUTED_TONE;
+	}
+	if (rounded > 0) {
+		return inverseGood ? NEGATIVE_TONE : POSITIVE_TONE;
+	}
+	return inverseGood ? POSITIVE_TONE : NEGATIVE_TONE;
+};
+
+export function MetricDelta({
+	value,
+	format = "percent",
+	unavailableLabel = "No prior period",
+	inverseGood = false,
+	precision = 0,
+	className,
+}: MetricDeltaProps) {
+	const safePrecision = clampPrecision(precision);
+	const isUnavailable =
+		value === null || value === undefined || !Number.isFinite(value);
+
+	if (isUnavailable) {
+		return (
+			<span
+				title="No prior period available to compute a change"
+				className={`${BASE} ${MUTED_TONE} ${className ?? ""}`.trim()}
+			>
+				· {unavailableLabel}
+			</span>
+		);
+	}
+
+	const rounded = roundToPrecision(value, safePrecision);
+	const glyph = rounded > 0 ? "↑" : rounded < 0 ? "↓" : "·";
+	const label =
+		format === "percent"
+			? formatSignedPercentDelta(value, rounded, safePrecision)
+			: formatSignedNumberDelta(rounded, safePrecision);
+
+	return (
+		<span
+			title={rounded === 0 ? "No change" : undefined}
+			className={`${BASE} ${toneFor(rounded, inverseGood)} ${className ?? ""}`.trim()}
+		>
+			{glyph} {label}
+		</span>
+	);
+}

--- a/src/components/shared/MetricDelta.tsx
+++ b/src/components/shared/MetricDelta.tsx
@@ -3,93 +3,86 @@ import { formatDelta, formatNumber } from "@/lib/formatters";
 type MetricDeltaFormat = "percent" | "number";
 
 type MetricDeltaProps = {
-	value: number | null | undefined;
-	format?: MetricDeltaFormat;
-	unavailableLabel?: string;
-	inverseGood?: boolean;
-	precision?: number;
-	className?: string;
+    value: number | null | undefined;
+    format?: MetricDeltaFormat;
+    unavailableLabel?: string;
+    inverseGood?: boolean;
+    precision?: number;
+    className?: string;
 };
 
-const BASE =
-	"inline-flex items-center gap-1 text-[10px] normal-case tracking-normal";
+const BASE = "inline-flex items-center gap-1 text-[10px] normal-case tracking-normal";
 const POSITIVE_TONE = "text-(--positive)";
 const NEGATIVE_TONE = "text-(--accent-negative)";
 const MUTED_TONE = "text-(--ink-muted)";
 
-const clampPrecision = (precision: number) =>
-	Math.max(0, Math.min(6, precision));
+const clampPrecision = (precision: number) => Math.max(0, Math.min(6, precision));
 
 const roundToPrecision = (value: number, precision: number) => {
-	const factor = 10 ** precision;
-	const rounded = Math.round(value * factor) / factor;
-	return Object.is(rounded, -0) ? 0 : rounded;
+    const factor = 10 ** precision;
+    const rounded = Math.round(value * factor) / factor;
+    return Object.is(rounded, -0) ? 0 : rounded;
 };
 
 const formatSignedNumberDelta = (rounded: number, precision: number) => {
-	const sign = rounded > 0 ? "+" : rounded < 0 ? "-" : "";
-	return `${sign}${formatNumber(Math.abs(rounded), {
-		maximumFractionDigits: precision,
-	})}`;
+    const sign = rounded > 0 ? "+" : rounded < 0 ? "-" : "";
+    return `${sign}${formatNumber(Math.abs(rounded), {
+        maximumFractionDigits: precision,
+    })}`;
 };
 
-const formatSignedPercentDelta = (
-	value: number,
-	rounded: number,
-	precision: number,
-) => {
-	if (precision === 0) {
-		return formatDelta(value);
-	}
-	return `${formatSignedNumberDelta(rounded, precision)}%`;
+const formatSignedPercentDelta = (value: number, rounded: number, precision: number) => {
+    if (precision === 0) {
+        return formatDelta(value);
+    }
+    return `${formatSignedNumberDelta(rounded, precision)}%`;
 };
 
 const toneFor = (rounded: number, inverseGood: boolean) => {
-	if (rounded === 0) {
-		return MUTED_TONE;
-	}
-	if (rounded > 0) {
-		return inverseGood ? NEGATIVE_TONE : POSITIVE_TONE;
-	}
-	return inverseGood ? POSITIVE_TONE : NEGATIVE_TONE;
+    if (rounded === 0) {
+        return MUTED_TONE;
+    }
+    if (rounded > 0) {
+        return inverseGood ? NEGATIVE_TONE : POSITIVE_TONE;
+    }
+    return inverseGood ? POSITIVE_TONE : NEGATIVE_TONE;
 };
 
 export function MetricDelta({
-	value,
-	format = "percent",
-	unavailableLabel = "No prior period",
-	inverseGood = false,
-	precision = 0,
-	className,
+    value,
+    format = "percent",
+    unavailableLabel = "No prior period",
+    inverseGood = false,
+    precision = 0,
+    className,
 }: MetricDeltaProps) {
-	const safePrecision = clampPrecision(precision);
-	const isUnavailable =
-		value === null || value === undefined || !Number.isFinite(value);
+    const safePrecision = clampPrecision(precision);
+    const isUnavailable = value === null || value === undefined || !Number.isFinite(value);
 
-	if (isUnavailable) {
-		return (
-			<span
-				title="No prior period available to compute a change"
-				className={`${BASE} ${MUTED_TONE} ${className ?? ""}`.trim()}
-			>
-				· {unavailableLabel}
-			</span>
-		);
-	}
+    if (isUnavailable) {
+        return (
+            <span
+                title="No prior period available to compute a change"
+                className={`${BASE} ${MUTED_TONE} ${className ?? ""}`.trim()}
+            >
+                · {unavailableLabel}
+            </span>
+        );
+    }
 
-	const rounded = roundToPrecision(value, safePrecision);
-	const glyph = rounded > 0 ? "↑" : rounded < 0 ? "↓" : "·";
-	const label =
-		format === "percent"
-			? formatSignedPercentDelta(value, rounded, safePrecision)
-			: formatSignedNumberDelta(rounded, safePrecision);
+    const rounded = roundToPrecision(value, safePrecision);
+    const glyph = rounded > 0 ? "↑" : rounded < 0 ? "↓" : "·";
+    const label =
+        format === "percent"
+            ? formatSignedPercentDelta(value, rounded, safePrecision)
+            : formatSignedNumberDelta(rounded, safePrecision);
 
-	return (
-		<span
-			title={rounded === 0 ? "No change" : undefined}
-			className={`${BASE} ${toneFor(rounded, inverseGood)} ${className ?? ""}`.trim()}
-		>
-			{glyph} {label}
-		</span>
-	);
+    return (
+        <span
+            title={rounded === 0 ? "No change" : undefined}
+            className={`${BASE} ${toneFor(rounded, inverseGood)} ${className ?? ""}`.trim()}
+        >
+            {glyph} {label}
+        </span>
+    );
 }

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1504,4 +1504,3 @@ enum WorkGraphProvenance {
   EXPLICIT_TEXT
   HEURISTIC
 }
-


### PR DESCRIPTION
## Summary
Phase 0 (Foundations) of the Market-Ready UX epic (**CHAOS-2121**): the Part E shared primitives + locked C1-C4 design tokens that block P4/P5. Base branch is `chaos-2079-ia-restructure` (the unmerged IA-restructure integration line this work builds on).

## Changes
- **Tokens (CHAOS-2125)** — `globals.css`: accent->orange (D1), status tokens `--positive/--caution/--accent-negative/--info` (C2), radius + elevation scales (C4), `--card-stroke-active` for active-only bright borders (CHAOS-2067).
- **ChartFrame (CHAOS-2122)** — new `src/components/charts/ChartFrame.tsx`: title / interpretation / threshold / band slots + DataState empty/error/loading; wraps the TestOps coverage chart as the reference adoption.
- **MetricDelta (CHAOS-2123)** — new `src/components/shared/MetricDelta.tsx`: signed-zero-safe (never `-0%`/`-0`), `formatNumber`/`formatDelta` only, up/down/flat affordance + status-token color, `inverseGood`; adopted in `MetricCard`.
- **FilterPills (CHAOS-2124)** — active state cyan `--accent-2`->`--accent` (orange) + keyboard-focus fix (`has-[:focus-visible]`); wired the previously-null `SecurityFilterBarWrapper` (severity/state/source) with a `Multiple (N)` state so multi-value filters never display as `All`.

## Verification
- `tsc --noEmit` clean
- 29 P0 unit tests pass (ChartFrame, MetricDelta, FilterPills, SecurityFilterBarWrapper, MetricCard)
- `design-lint` 339->337 (zero new violations; 2 removed)
- Reviewed by **Codex (adversarial)** + **Oracle**; all findings remediated: broken MetricCard test, security-filter "All" misrepresentation, FilterPills invisible keyboard focus, ChartFrame zero-value annotations, and edge-test coverage.

## Screenshots
Captured against the working-tree dev server on `:3000` (docker `web` bind-mounts source). PNGs saved at the platform root:
- `chaos-2124-security-filterbar-after.png` — Security: Severity/State/Source filter pills, **active pills orange**, real alert data.
- `chaos-2123-2125-dashboard-after.png` — Dashboard: MetricCards with up/down delta arrows, time-window + lens pills selected in **orange**.
- `chaos-2122-chartframe-coverage-after.png` — TestOps coverage chart wrapped in ChartFrame.

> Binary image upload isn't supported via `gh`/`linear-cli` in this environment; PNGs are at the platform root for drag-and-drop attachment.

Closes CHAOS-2122, CHAOS-2123, CHAOS-2124, CHAOS-2125