### PR TITLE
fix(complexity): send active-window range to complexity query (CHAOS-2160)

### DIFF
--- a/src/app/(app)/complexity/page.tsx
+++ b/src/app/(app)/complexity/page.tsx
@@ -26,6 +26,11 @@ import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
 import { graphqlFetch } from "@/lib/graphql/server";
 import { COMPLEXITY_TIMESERIES_QUERY, HOTSPOTS_QUERY } from "@/lib/graphql/queries";
+import {
+    complexityScopeInputFromFilter,
+    complexityWindowFromFilter,
+    type ComplexityScopeInput,
+} from "@/lib/complexity/filters";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -56,6 +61,7 @@ async function fetchComplexityTimeseries(
     orgId: string,
     sinceUtc: string,
     untilUtc: string,
+    scopeInput: ComplexityScopeInput,
 ): Promise<ComplexityPoint[]> {
     try {
         const data = await graphqlFetch<ComplexityTimeseriesResponse>(
@@ -65,8 +71,9 @@ async function fetchComplexityTimeseries(
                     orgId,
                     sinceUtc,
                     untilUtc,
-                    granularity: "WEEK",
+                    granularity: "DAY",
                     scope: "REPO",
+                    ...scopeInput,
                     limit: 10,
                 },
             },
@@ -84,6 +91,7 @@ async function fetchHotspots(
     orgId: string,
     sinceUtc: string,
     untilUtc: string,
+    scopeInput: ComplexityScopeInput,
 ): Promise<HotspotRow[]> {
     try {
         const data = await graphqlFetch<HotspotsResponse>(
@@ -93,6 +101,7 @@ async function fetchHotspots(
                     orgId,
                     sinceUtc,
                     untilUtc,
+                    ...scopeInput,
                     limit: 50,
                 },
             },
@@ -158,17 +167,13 @@ export default async function ComplexityPage({ searchParams }: PageProps) {
 
     const orgId = session.user?.org_id ?? "demo-org";
 
-    // Default 90-day window
-    const until = new Date();
-    const since = new Date(until);
-    since.setDate(since.getDate() - 90);
-    const untilUtc = until.toISOString();
-    const sinceUtc = since.toISOString();
+    const { sinceUtc, untilUtc } = complexityWindowFromFilter(filters.time);
+    const scopeInput = complexityScopeInputFromFilter(filters);
 
     // Parallel pre-fetch — both queries are independent
     const [points, hotspotRows] = await Promise.all([
-        fetchComplexityTimeseries(orgId, sinceUtc, untilUtc),
-        fetchHotspots(orgId, sinceUtc, untilUtc),
+        fetchComplexityTimeseries(orgId, sinceUtc, untilUtc, scopeInput),
+        fetchHotspots(orgId, sinceUtc, untilUtc, scopeInput),
     ]);
 
     return (

--- a/src/lib/areaSignals/__tests__/diagnose.test.ts
+++ b/src/lib/areaSignals/__tests__/diagnose.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mock every Diagnose source at the module boundary ─────────────────────────
@@ -321,6 +322,28 @@ describe("getDiagnoseSignals — source → AreaSignal mapping", () => {
                 },
                 { orgId: "org-test" },
             );
+        });
+
+        it("preset-only range_days=14 uses range_days-1 span (14 inclusive dates, matching /complexity)", async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date("2026-06-08T12:00:00Z"));
+            const presetFilter = {
+                ...defaultMetricFilter,
+                time: { range_days: 14, compare_days: 14 },
+            };
+            await getDiagnoseSignals(presetFilter);
+            // range_days - 1 = 13 days back → 14 inclusive calendar dates.
+            expect(mockGraphql).toHaveBeenCalledWith(
+                expect.any(String),
+                {
+                    input: expect.objectContaining({
+                        sinceUtc: "2026-05-26T00:00:00Z",
+                        untilUtc: "2026-06-08T23:59:59Z",
+                    }),
+                },
+                expect.any(Object),
+            );
+            vi.useRealTimers();
         });
     });
 

--- a/src/lib/areaSignals/__tests__/diagnose.test.ts
+++ b/src/lib/areaSignals/__tests__/diagnose.test.ts
@@ -258,8 +258,7 @@ describe("getDiagnoseSignals — source → AreaSignal mapping", () => {
             });
         });
 
-        it("computes mean across multiple complexity points", async () => {
-            // Two points: 20 + 40 → mean 30 → high (>=25, <40).
+        it("computes mean from the latest complexity point per repo", async () => {
             mockGraphql.mockResolvedValue({
                 complexityTimeseries: {
                     points: [
@@ -290,7 +289,38 @@ describe("getDiagnoseSignals — source → AreaSignal mapping", () => {
                 },
             } as never);
             const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
-            expect(signals.complexity).toMatchObject({ state: "high" });
+            expect(signals.complexity).toMatchObject({
+                state: "critical",
+                value: "40",
+            });
+        });
+
+        it("passes active date and scope filters to the complexity query", async () => {
+            const filtered = {
+                ...defaultMetricFilter,
+                time: {
+                    ...defaultMetricFilter.time,
+                    start_date: "2026-03-05",
+                    end_date: "2026-06-07",
+                },
+                scope: { level: "repo" as const, ids: ["repo-active"] },
+            };
+            await getDiagnoseSignals(filtered);
+            expect(mockGraphql).toHaveBeenCalledWith(
+                expect.any(String),
+                {
+                    input: expect.objectContaining({
+                        orgId: "org-test",
+                        sinceUtc: "2026-03-05T00:00:00Z",
+                        untilUtc: "2026-06-07T23:59:59Z",
+                        granularity: "DAY",
+                        scope: "REPO",
+                        repoIds: ["repo-active"],
+                        teamIds: null,
+                    }),
+                },
+                { orgId: "org-test" },
+            );
         });
     });
 
@@ -303,13 +333,19 @@ describe("getDiagnoseSignals — source → AreaSignal mapping", () => {
         it("Landscape derives medium from bus factor 2.4 (higherIsBetter, thresholds {critical:1.5, high:2, medium:3})", async () => {
             // value=2.4: >= high(2) but < medium(3) → medium in higherIsBetter polarity.
             const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
-            expect(signals.landscape).toMatchObject({ state: "medium", value: "2.4" });
+            expect(signals.landscape).toMatchObject({
+                state: "medium",
+                value: "2.4",
+            });
         });
 
         it("Landscape is unavailable when getBusFactorData returns null", async () => {
             mockGetBusFactorData.mockResolvedValue(null);
             const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
-            expect(signals.landscape).toMatchObject({ state: "unavailable", value: "" });
+            expect(signals.landscape).toMatchObject({
+                state: "unavailable",
+                value: "",
+            });
         });
 
         it("Landscape is unavailable when bus factor has no repos", async () => {
@@ -322,12 +358,18 @@ describe("getDiagnoseSignals — source → AreaSignal mapping", () => {
                 evidenceSampleCount: 0,
             });
             const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
-            expect(signals.landscape).toMatchObject({ state: "unavailable", value: "" });
+            expect(signals.landscape).toMatchObject({
+                state: "unavailable",
+                value: "",
+            });
         });
 
         it("Cognitive Load derives high from avg interruption load 16 (lowerIsBetter, thresholds {medium:8, high:15, critical:25})", async () => {
             const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
-            expect(signals["cognitive-load"]).toMatchObject({ state: "high", value: "16" });
+            expect(signals["cognitive-load"]).toMatchObject({
+                state: "high",
+                value: "16",
+            });
         });
 
         it("Cognitive Load is unavailable when no cognitiveLoad signals are returned", async () => {

--- a/src/lib/areaSignals/diagnose.ts
+++ b/src/lib/areaSignals/diagnose.ts
@@ -29,6 +29,7 @@ import { getBusFactorData } from "@/lib/api/code";
 import { graphqlFetch } from "@/lib/graphql/server";
 import { COMPLEXITY_TIMESERIES_QUERY } from "@/lib/graphql/queries";
 import type { ComplexityTimeseriesResult } from "@/lib/graphql/__generated__/types";
+import { complexityScopeInputFromFilter } from "@/lib/complexity/filters";
 import { getCognitiveLoadViaGraphQL } from "@/lib/graphql/cognitiveLoadFetchers";
 import type { CognitiveLoadResult } from "@/lib/graphql/cognitiveLoadFetchers";
 import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
@@ -126,11 +127,17 @@ function homeSignalByMetric(
     return match ? (match as { metric: string; severity: AreaSignalState }) : undefined;
 }
 
-/** Compute mean cyclomaticPerKloc across all points in a complexity result. */
 function meanCyclomaticPerKloc(result: ComplexityTimeseriesResult | undefined): number | undefined {
     const points = result?.points ?? [];
     if (points.length === 0) return undefined;
-    const values = points
+    const latestByScope = new Map<string, (typeof points)[number]>();
+    for (const point of points) {
+        const current = latestByScope.get(point.scopeId);
+        if (!current || point.date > current.date) {
+            latestByScope.set(point.scopeId, point);
+        }
+    }
+    const values = [...latestByScope.values()]
         .map((p) => p.cyclomaticPerKloc)
         .filter((v): v is number => typeof v === "number" && !isNaN(v));
     if (values.length === 0) return undefined;
@@ -203,6 +210,7 @@ export async function getDiagnoseSignals(
     // Resolve the org scope server-side (the complexity GraphQL call needs it
     // threaded in as a variable AND as the `X-Org-Id` header).
     const orgId = isTestMode ? "default-org" : await resolveOrgId();
+    const complexityScopeInput = complexityScopeInputFromFilter(filters);
 
     // cognitiveLoad only supports org-wide or team aggregation (the resolver takes orgId
     // plus an optional teamId). Repo/service/developer filters cannot be honored, so the
@@ -229,15 +237,18 @@ export async function getDiagnoseSignals(
             () =>
                 isTestMode
                     ? Promise.resolve(undefined)
-                    : graphqlFetch<{ complexityTimeseries: ComplexityTimeseriesResult }>(
+                    : graphqlFetch<{
+                          complexityTimeseries: ComplexityTimeseriesResult;
+                      }>(
                           COMPLEXITY_TIMESERIES_QUERY,
                           {
                               input: {
                                   orgId,
                                   sinceUtc: startDate + "T00:00:00Z",
                                   untilUtc: endDate + "T23:59:59Z",
-                                  granularity: "WEEK",
+                                  granularity: "DAY",
                                   scope: "REPO",
+                                  ...complexityScopeInput,
                                   limit: 50,
                               },
                           },
@@ -305,8 +316,7 @@ export async function getDiagnoseSignals(
     // higherIsBetter polarity. DERIVE.
     // CHAOS-2074: provisional thresholds — see LANDSCAPE_BUSFACTOR_THRESHOLDS above.
     const busFactorValue = busFactor?.value;
-    const hasBusFactor =
-        typeof busFactorValue === "number" && (busFactor?.repos?.length ?? 0) > 0;
+    const hasBusFactor = typeof busFactorValue === "number" && (busFactor?.repos?.length ?? 0) > 0;
     push(
         "landscape",
         hasBusFactor

--- a/src/lib/areaSignals/diagnose.ts
+++ b/src/lib/areaSignals/diagnose.ts
@@ -29,7 +29,10 @@ import { getBusFactorData } from "@/lib/api/code";
 import { graphqlFetch } from "@/lib/graphql/server";
 import { COMPLEXITY_TIMESERIES_QUERY } from "@/lib/graphql/queries";
 import type { ComplexityTimeseriesResult } from "@/lib/graphql/__generated__/types";
-import { complexityScopeInputFromFilter } from "@/lib/complexity/filters";
+import {
+    complexityScopeInputFromFilter,
+    complexityWindowFromFilter,
+} from "@/lib/complexity/filters";
 import { getCognitiveLoadViaGraphQL } from "@/lib/graphql/cognitiveLoadFetchers";
 import type { CognitiveLoadResult } from "@/lib/graphql/cognitiveLoadFetchers";
 import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
@@ -199,13 +202,12 @@ export async function getDiagnoseSignals(
     const byId = new Map(diagnose.hubItems.map((item) => [item.id, item]));
     const descriptor = (id: string): NavAreaHubItem | undefined => byId.get(id);
 
-    // Shared date range for the complexity GraphQL call.
-    const rangeDays = filters.time?.range_days ?? 14;
-    const today = new Date();
-    const endDate = filters.time?.end_date ?? today.toISOString().slice(0, 10);
-    const startDate =
-        filters.time?.start_date ??
-        new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
+    // Shared date window for the complexity and cognitive-load GraphQL calls.
+    // complexityWindowFromFilter uses `range_days - 1` so a 14-day preset covers
+    // exactly 14 inclusive calendar days, matching the /complexity page.
+    const { sinceUtc, untilUtc } = complexityWindowFromFilter(filters.time);
+    const sinceDate = sinceUtc.slice(0, 10);
+    const untilDate = untilUtc.slice(0, 10);
 
     // Resolve the org scope server-side (the complexity GraphQL call needs it
     // threaded in as a variable AND as the `X-Org-Id` header).
@@ -244,8 +246,8 @@ export async function getDiagnoseSignals(
                           {
                               input: {
                                   orgId,
-                                  sinceUtc: startDate + "T00:00:00Z",
-                                  untilUtc: endDate + "T23:59:59Z",
+                                  sinceUtc,
+                                  untilUtc,
                                   granularity: "DAY",
                                   scope: "REPO",
                                   ...complexityScopeInput,
@@ -263,8 +265,8 @@ export async function getDiagnoseSignals(
                     ? Promise.resolve(undefined)
                     : getCognitiveLoadViaGraphQL({
                           orgId,
-                          sinceDate: startDate,
-                          untilDate: endDate,
+                          sinceDate,
+                          untilDate,
                           teamId: cognitiveLoadTeamId,
                       }),
             "cognitive-load",

--- a/src/lib/complexity/__tests__/filters.test.ts
+++ b/src/lib/complexity/__tests__/filters.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+
+import { complexityScopeInputFromFilter, complexityWindowFromFilter } from "../filters";
+
+describe("complexity filter helpers", () => {
+    it("uses explicit active date bounds as inclusive UTC instants", () => {
+        expect(
+            complexityWindowFromFilter({
+                range_days: 90,
+                compare_days: 90,
+                start_date: "2026-03-05",
+                end_date: "2026-06-07",
+            }),
+        ).toEqual({
+            sinceUtc: "2026-03-05T00:00:00Z",
+            untilUtc: "2026-06-07T23:59:59Z",
+        });
+    });
+
+    it("derives a range_days window without dropping the current day", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-06-08T12:00:00Z"));
+        expect(complexityWindowFromFilter({ range_days: 3, compare_days: 3 })).toEqual({
+            sinceUtc: "2026-06-06T00:00:00Z",
+            untilUtc: "2026-06-08T23:59:59Z",
+        });
+        vi.useRealTimers();
+    });
+
+    it("maps repo and team filters to complexity query inputs", () => {
+        expect(
+            complexityScopeInputFromFilter({
+                ...defaultMetricFilter,
+                scope: { level: "repo", ids: ["repo-a", "repo-b"] },
+            }),
+        ).toEqual({ repoIds: ["repo-a", "repo-b"], teamIds: null });
+
+        expect(
+            complexityScopeInputFromFilter({
+                ...defaultMetricFilter,
+                scope: { level: "team", ids: ["team-a"] },
+            }),
+        ).toEqual({ repoIds: null, teamIds: ["team-a"] });
+    });
+
+    it("falls back to selected repository artifacts when scope is org", () => {
+        expect(
+            complexityScopeInputFromFilter({
+                ...defaultMetricFilter,
+                what: { ...defaultMetricFilter.what, repos: ["repo-from-what"] },
+            }),
+        ).toEqual({ repoIds: ["repo-from-what"], teamIds: null });
+    });
+});

--- a/src/lib/complexity/filters.ts
+++ b/src/lib/complexity/filters.ts
@@ -1,0 +1,38 @@
+import type { MetricFilter } from "@/lib/filters/types";
+
+export type ComplexityScopeInput = {
+    repoIds?: string[] | null;
+    teamIds?: string[] | null;
+};
+
+export function complexityWindowFromFilter(time: MetricFilter["time"]): {
+    sinceUtc: string;
+    untilUtc: string;
+} {
+    if (time.start_date && time.end_date) {
+        return {
+            sinceUtc: `${time.start_date}T00:00:00Z`,
+            untilUtc: `${time.end_date}T23:59:59Z`,
+        };
+    }
+    const end = new Date();
+    const start = new Date(end);
+    start.setDate(end.getDate() - (time.range_days - 1));
+    const isoDate = (d: Date) => d.toISOString().slice(0, 10);
+    return {
+        sinceUtc: `${isoDate(start)}T00:00:00Z`,
+        untilUtc: `${isoDate(end)}T23:59:59Z`,
+    };
+}
+
+export function complexityScopeInputFromFilter(filters: MetricFilter): ComplexityScopeInput {
+    const repoIds =
+        filters.scope.level === "repo" && filters.scope.ids.length > 0
+            ? filters.scope.ids
+            : filters.what.repos && filters.what.repos.length > 0
+              ? filters.what.repos
+              : null;
+    const teamIds =
+        filters.scope.level === "team" && filters.scope.ids.length > 0 ? filters.scope.ids : null;
+    return { repoIds, teamIds };
+}


### PR DESCRIPTION
## Summary
- Sends the active filter window to Complexity Overview instead of a hardcoded rolling window.
- Switches complexity overview and Diagnose complexity calls to daily granularity and passes repo/team scope filters.
- Aligns Diagnose complexity card with the dashboard by averaging the latest point per repo in the active window.

## Tests
- `./node_modules/.bin/vitest run src/lib/areaSignals/__tests__/diagnose.test.ts src/lib/complexity/__tests__/filters.test.ts src/components/complexity/ComplexityDashboard.test.tsx` (59 passed)
- `./node_modules/.bin/tsc --noEmit`
- `DESIGN_LINT=true ./node_modules/.bin/eslint <changed files>`
- `node scripts/design-lint.mjs` (0/0/0/0)
- Full `DESIGN_LINT=true ./node_modules/.bin/eslint src` still reports the known ~333 backlog; no changed-file errors.

SCREENSHOT-WAIVER: rendered complexity page changes require live backend data; per CHAOS-2160 instructions, leader owns live verification and screenshots.

Part of CHAOS-2160