### PR TITLE
fix(auth): clear sticky refresh_failed on login + rotate refresh token (CHAOS-2156)

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 interface RedirectError extends Error {
     digest: string;
@@ -6,9 +6,13 @@ interface RedirectError extends Error {
 }
 
 // Mock nextAuth.auth() — controls what the internal auth() wrapper returns
-const { mockNextAuthAuth } = vi.hoisted(() => ({
-    mockNextAuthAuth: vi.fn(),
-}));
+const { mockNextAuthAuth, nextAuthConfig } = vi.hoisted(() => {
+    const config: { value: unknown } = { value: null };
+    return {
+        mockNextAuthAuth: vi.fn(),
+        nextAuthConfig: config,
+    };
+});
 
 function createRedirectError(url: string): RedirectError {
     const error = new Error("NEXT_REDIRECT") as RedirectError;
@@ -24,12 +28,15 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("next-auth", () => ({
-    default: vi.fn(() => ({
-        auth: mockNextAuthAuth,
-        handlers: { GET: vi.fn(), POST: vi.fn() },
-        signIn: vi.fn(),
-        signOut: vi.fn(),
-    })),
+    default: vi.fn((config: unknown) => {
+        nextAuthConfig.value = config;
+        return {
+            auth: mockNextAuthAuth,
+            handlers: { GET: vi.fn(), POST: vi.fn() },
+            signIn: vi.fn(),
+            signOut: vi.fn(),
+        };
+    }),
     CredentialsSignin: class CredentialsSignin extends Error {
         code = "credentials";
     },
@@ -49,6 +56,10 @@ vi.mock("next-auth/providers/google", () => ({
 
 vi.mock("next-auth/providers/gitlab", () => ({
     default: vi.fn(),
+}));
+
+vi.mock("@/lib/origin", () => ({
+    getBackendUrl: () => "http://localhost:8000",
 }));
 
 import { requireSession } from "@/lib/auth";
@@ -175,5 +186,122 @@ describe("auth secret configuration", () => {
 
         vi.unstubAllEnvs();
         vi.resetModules();
+    });
+});
+
+describe("jwt callback — token lifecycle", () => {
+    interface JwtCallbackParams {
+        token: Record<string, unknown>;
+        user?: Record<string, unknown> | null;
+        account?: Record<string, unknown> | null;
+        trigger?: string;
+        session?: Record<string, unknown> | null;
+    }
+
+    type JwtCallback = (params: JwtCallbackParams) => Promise<Record<string, unknown>>;
+
+    interface NextAuthCallbacks {
+        jwt?: JwtCallback;
+    }
+
+    interface CapturedNextAuthConfig {
+        callbacks?: NextAuthCallbacks;
+    }
+
+    function getJwtCallback(): JwtCallback {
+        const config = nextAuthConfig.value as CapturedNextAuthConfig | null;
+        const jwt = config?.callbacks?.jwt;
+        if (!jwt) throw new Error("JWT callback not captured from NextAuth config");
+        return jwt;
+    }
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("(a) clears token.error on fresh credentials login", async () => {
+        const jwt = getJwtCallback();
+        const result = await jwt({
+            token: {
+                id: "old-user",
+                access_token: "stale-access",
+                refresh_token: "stale-refresh",
+                expires_at: Date.now() + 3600 * 1000,
+                last_validated: Date.now(),
+                error: "refresh_failed",
+            },
+            user: {
+                id: "user-2",
+                email: "fresh@example.com",
+                org_id: "org-1",
+                role: "member",
+                is_superuser: false,
+                permissions: [],
+                needs_onboarding: false,
+                access_token: "new-access-token",
+                refresh_token: "new-refresh-token",
+                expires_in: 3600,
+            },
+            account: null,
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.access_token).toBe("new-access-token");
+    });
+
+    it("(b) keeps tokens on transient 5xx refresh failure", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValueOnce({
+                ok: false,
+                status: 500,
+                json: async () => ({ detail: "Internal server error" }),
+            } as unknown as Response),
+        );
+
+        const jwt = getJwtCallback();
+        const result = await jwt({
+            token: {
+                id: "user-1",
+                access_token: "valid-access",
+                refresh_token: "valid-refresh",
+                expires_at: Date.now() - 1000,
+                last_validated: Date.now(),
+            },
+            user: null,
+            account: null,
+        });
+
+        expect(result.access_token).toBe("valid-access");
+        expect(result.refresh_token).toBe("valid-refresh");
+        expect(result.error).toBeUndefined();
+    });
+
+    it("(c) clears tokens on terminal 401 refresh failure", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                json: async () => ({ detail: "Invalid or expired refresh token" }),
+            } as unknown as Response),
+        );
+
+        const jwt = getJwtCallback();
+        const result = await jwt({
+            token: {
+                id: "user-1",
+                access_token: "valid-access",
+                refresh_token: "valid-refresh",
+                expires_at: Date.now() - 1000,
+                last_validated: Date.now(),
+            },
+            user: null,
+            account: null,
+        });
+
+        expect(result.access_token).toBeUndefined();
+        expect(result.refresh_token).toBeUndefined();
+        expect(result.error).toBe("refresh_failed");
     });
 });

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -156,6 +156,31 @@ describe("requireSession", () => {
         expect(result.user.org_id).toBe("org-123");
         expect(result.user.needs_onboarding).toBe(false);
     });
+
+    it("redirects to /auth/error?error=refresh_unavailable on transient refresh outage", async () => {
+        mockNextAuthAuth.mockResolvedValueOnce({
+            user: {
+                id: "user-1",
+                email: "test@example.com",
+                org_id: "org-123",
+                role: "owner",
+                is_superuser: false,
+                permissions: [],
+                needs_onboarding: false,
+            },
+            access_token: undefined,
+            error: "refresh_unavailable",
+        });
+
+        try {
+            await requireSession();
+            expect.fail("Should have thrown redirect");
+        } catch (error: unknown) {
+            const redirectErr = error as RedirectError;
+            expect(redirectErr.digest).toBe("NEXT_REDIRECT");
+            expect(redirectErr.url).toBe("/auth/error?error=refresh_unavailable");
+        }
+    });
 });
 
 describe("auth secret configuration", () => {
@@ -249,7 +274,7 @@ describe("jwt callback — token lifecycle", () => {
         expect(result.access_token).toBe("new-access-token");
     });
 
-    it("(b) keeps tokens on transient 5xx refresh failure", async () => {
+    it("(b) clears access_token but preserves refresh_token on transient 5xx failure", async () => {
         vi.stubGlobal(
             "fetch",
             vi.fn().mockResolvedValueOnce({
@@ -272,9 +297,9 @@ describe("jwt callback — token lifecycle", () => {
             account: null,
         });
 
-        expect(result.access_token).toBe("valid-access");
+        expect(result.access_token).toBeUndefined();
         expect(result.refresh_token).toBe("valid-refresh");
-        expect(result.error).toBeUndefined();
+        expect(result.error).toBe("refresh_unavailable");
     });
 
     it("(c) clears tokens on terminal 401 refresh failure", async () => {
@@ -303,5 +328,65 @@ describe("jwt callback — token lifecycle", () => {
         expect(result.access_token).toBeUndefined();
         expect(result.refresh_token).toBeUndefined();
         expect(result.error).toBe("refresh_failed");
+    });
+
+    it("(d) clears access_token but preserves refresh_token on network error (fetch throws)", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockRejectedValueOnce(new Error("fetch failed: ECONNREFUSED")),
+        );
+
+        const jwt = getJwtCallback();
+        const result = await jwt({
+            token: {
+                id: "user-1",
+                access_token: "valid-access",
+                refresh_token: "valid-refresh",
+                expires_at: Date.now() - 1000,
+                last_validated: Date.now(),
+            },
+            user: null,
+            account: null,
+        });
+
+        expect(result.access_token).toBeUndefined();
+        expect(result.refresh_token).toBe("valid-refresh");
+        expect(result.error).toBe("refresh_unavailable");
+    });
+
+    it("(e) clears error on refresh success after prior transient failure", async () => {
+        const newAccessToken = "recovered-access-token";
+        const newRefreshToken = "recovered-refresh-token";
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    access_token: newAccessToken,
+                    refresh_token: newRefreshToken,
+                    expires_in: 3600,
+                }),
+            } as unknown as Response),
+        );
+
+        const jwt = getJwtCallback();
+        const result = await jwt({
+            token: {
+                id: "user-1",
+                access_token: undefined,
+                refresh_token: "stale-refresh-token",
+                expires_at: Date.now() - 1000, // expired, triggers refresh retry
+                last_validated: Date.now() - 3600 * 1000,
+                error: "refresh_unavailable",
+            },
+            user: null,
+            account: null,
+        });
+
+        expect(result.access_token).toBe(newAccessToken);
+        expect(result.refresh_token).toBe(newRefreshToken);
+        expect(result.expires_at as number).toBeGreaterThan(Date.now());
+        expect(result.error).toBeUndefined();
     });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -160,6 +160,7 @@ const nextAuth = NextAuth({
                 token.refresh_token = user.refresh_token;
                 token.expires_at = Date.now() + (user.expires_in || 3600) * 1000;
                 token.last_validated = Date.now();
+                token.error = undefined;
             }
 
             // Social login: exchange OAuth token for backend JWT
@@ -281,6 +282,7 @@ const nextAuth = NextAuth({
                     if (res.ok) {
                         const data = await res.json();
                         token.access_token = data.access_token;
+                        token.refresh_token = data.refresh_token ?? token.refresh_token;
                         token.expires_at = now + (data.expires_in || 3600) * 1000;
                         token.last_validated = now;
                         if (data.user) {
@@ -290,7 +292,7 @@ const nextAuth = NextAuth({
                             token.role = data.user.role;
                             token.is_superuser = data.user.is_superuser ?? false;
                         }
-                    } else {
+                    } else if (res.status === 401) {
                         token.access_token = undefined;
                         token.refresh_token = undefined;
                         token.error = "refresh_failed";

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -282,9 +282,17 @@ const nextAuth = NextAuth({
                     if (res.ok) {
                         const data = await res.json();
                         token.access_token = data.access_token;
+                        // NOTE: Single-use token rotation — if multiple concurrent JWT callbacks
+                        // race (e.g., parallel SSR requests), a later callback may attempt to use
+                        // an already-rotated refresh_token and receive a 401. The ?? fallback below
+                        // preserves the most recently issued token if data.refresh_token is absent,
+                        // but a brief window exists between concurrent rotations.
+                        // A backend refresh-idempotency or grace-period mechanism is needed for a
+                        // full fix; this is tracked in a follow-up issue.
                         token.refresh_token = data.refresh_token ?? token.refresh_token;
                         token.expires_at = now + (data.expires_in || 3600) * 1000;
                         token.last_validated = now;
+                        token.error = undefined;
                         if (data.user) {
                             token.id = data.user.id;
                             token.email = data.user.email;
@@ -297,9 +305,21 @@ const nextAuth = NextAuth({
                         token.refresh_token = undefined;
                         token.error = "refresh_failed";
                         return token;
+                    } else {
+                        // Transient/5xx error — revoke access_token to prevent exposing an expired
+                        // bearer token, but keep refresh_token so the next JWT callback can retry
+                        // (self-healing). expires_at is left unchanged so tokenExpired stays true.
+                        token.access_token = undefined;
+                        token.error = "refresh_unavailable";
+                        return token;
                     }
                 } catch {
-                    // Network error — keep existing token, retry on next request
+                    // Network error — revoke access_token to prevent exposing an expired bearer
+                    // token, but keep refresh_token so the next JWT callback can retry (self-healing).
+                    // expires_at is left unchanged so tokenExpired stays true on the next call.
+                    token.access_token = undefined;
+                    token.error = "refresh_unavailable";
+                    return token;
                 }
             }
 
@@ -390,7 +410,12 @@ export async function auth(): Promise<Session | null> {
 
 export async function requireSession(callbackUrl?: string): Promise<Session> {
     const session = await getServerSession();
-    // Surface social login errors (e.g. 409 account conflict) before dropping the session
+    // Transient backend outage: access_token revoked but refresh_token preserved for retry.
+    // Redirect to /auth/error (not /auth/signin) — user is not hard-logged-out on a blip.
+    if (session?.error === "refresh_unavailable") {
+        redirect("/auth/error?error=refresh_unavailable");
+    }
+    // Terminal errors (social login failure, user invalidated, refresh_failed, etc.)
     if (session?.error) {
         redirect(`/auth/signin?error=${encodeURIComponent(session.error)}`);
     }


### PR DESCRIPTION
## Summary

Fixes flaky re-login after session timeout — surgical changes to `src/lib/auth.ts`.

### Ops Refresh Contract (from `/api/v1/auth/refresh` source)

**Token rotation:** The backend **always** rotates the refresh token. Every successful `/api/v1/auth/refresh` response includes a new `refresh_token`. The old token is revoked in the DB at the same time.

**Terminal vs transient status codes:** All explicit error responses return **HTTP 401**. 5xx / network errors come only from infrastructure and arrive as connection errors or upstream 5xx outside the route handler.

**Response shape:** `{ access_token, refresh_token, token_type, expires_in, user: { id, email, org_id, role, is_superuser } }`

---

### Fix 1 — Clear sticky `token.error` on fresh credentials login

`src/lib/auth.ts` — `if (user)` branch

Added `token.error = undefined;` so a fresh credentials login always clears a prior `refresh_failed` that was stuck on the token.

### Fix 2 — Persist rotated refresh token on SUCCESS

Added:
```ts
token.refresh_token = data.refresh_token ?? token.refresh_token;
```
The backend always rotates; without this the client was silently discarding the new token causing next refresh to 401 on reuse.

### Fix 3 (Oracle refinement) — Revoke expired bearer on transient failure; self-heal on next call

**Problem:** On non-401 / 5xx / network-error refresh paths the prior code left `access_token` unchanged, meaning an expired bearer continued to be handed to callers.

**Changes:**
- **5xx / non-401 response**: set `access_token = undefined`, keep `refresh_token` and `expires_at` (so the next JWT callback retries), set `error = "refresh_unavailable"`, return early.
- **Network-error catch**: same — `access_token = undefined`, `refresh_token` preserved, `error = "refresh_unavailable"`, return early.
- **Refresh SUCCESS**: add `token.error = undefined;` to clear any prior `refresh_unavailable` / `refresh_failed` once the backend recovers (self-healing).

### Fix 4 (Oracle refinement) — `requireSession()`: outage ≠ logout

`refresh_unavailable` is a **transient outage**, not a terminal auth failure. `/auth/error?error=refresh_unavailable` exists at `src/app/(auth)/auth/error/`, so the redirect target is:

```ts
if (session?.error === "refresh_unavailable") {
    redirect("/auth/error?error=refresh_unavailable");
}
```

Terminal errors (`refresh_failed`, `user_invalid`, social-login failures) continue to redirect to `/auth/signin`.

`auth()` already returns `null` when `access_token` is absent — no change needed there.

### Deferred — concurrent single-use rotation race (Finding B)

A code comment is added near the `token.refresh_token` rotation line explaining the limitation: if two concurrent SSR requests both attempt refresh with the same token, the second will 401. A proper fix requires backend refresh-idempotency or a grace period — not safe to implement frontend-only. A follow-up issue will track this.

---

### Tests (`src/lib/__tests__/auth.test.ts`)

| Test | Scenario | Expected |
|------|----------|----------|
| (a) | Fresh credentials login with prior `error: "refresh_failed"` on token | `token.error` cleared |
| (b) | Expired token, refresh returns HTTP 500 | `access_token` undefined, `refresh_token` preserved, `error = "refresh_unavailable"` |
| (c) | Expired token, refresh returns HTTP 401 | Tokens cleared, `error = "refresh_failed"` |
| (d) | Expired token, fetch throws (network error) | `access_token` undefined, `refresh_token` preserved, `error = "refresh_unavailable"` |
| (e) | Token has `error: "refresh_unavailable"`, refresh succeeds | New tokens, `error` cleared |
| requireSession | Session with `error: "refresh_unavailable"` | Redirects to `/auth/error?error=refresh_unavailable` (not `/auth/signin`) |

---

SCREENSHOT-WAIVER: auth.ts changes are purely server-side token lifecycle; no rendered UI is affected.

Closes CHAOS-2156