### PR TITLE
fix(diagnose): add Open evidence linkbacks (Landscape, Cognitive Load, Work Graph) (CHAOS-2159)

### DIFF
--- a/src/app/(app)/cognitive-load/page.tsx
+++ b/src/app/(app)/cognitive-load/page.tsx
@@ -192,7 +192,12 @@ export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadP
                   value: formatLoad(avgPrInterruptionLoad),
                   delta: `${sinceDate} – ${untilDate}`,
                   deltaTone: "text-(--ink-muted)",
-                  interpretation: avgPrInterruptionLoad > 15 ? "Rising" : avgPrInterruptionLoad > 8 ? "Watch" : "Easing",
+                  interpretation:
+                      avgPrInterruptionLoad > 15
+                          ? "Rising"
+                          : avgPrInterruptionLoad > 8
+                            ? "Watch"
+                            : "Easing",
                   description:
                       "Reviews, first-review events, and review feedback interrupting focused delivery.",
               },
@@ -210,25 +215,44 @@ export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadP
                   value: formatLoad(avgReviewRequestLoad),
                   delta: `avg over ${cognitiveLoadData?.totalDays ?? rawSignals.length} days`,
                   deltaTone: avgReviewRequestLoad > 10 ? "text-rose-600" : "text-(--ink-muted)",
-                  interpretation: avgReviewRequestLoad > 10 ? "Rising" : avgReviewRequestLoad > 5 ? "Watch" : "Low",
+                  interpretation:
+                      avgReviewRequestLoad > 10
+                          ? "Rising"
+                          : avgReviewRequestLoad > 5
+                            ? "Watch"
+                            : "Low",
                   description:
                       "Aggregate review requests handled by the team, never a person-level queue ranking.",
               },
               {
                   label: "After-hours trend",
                   value: avgAfterHours != null ? formatPct(avgAfterHours) : "—",
-                  delta: avgAfterHours != null ? (teamId ? "team-scoped" : "org-wide") : "no team scope",
-                  deltaTone: avgAfterHours != null && avgAfterHours > 0.3 ? "text-amber-600" : "text-(--ink-muted)",
-                  interpretation: avgAfterHours == null ? "N/A" : avgAfterHours > 0.3 ? "Watch" : "Stable",
+                  delta:
+                      avgAfterHours != null
+                          ? teamId
+                              ? "team-scoped"
+                              : "org-wide"
+                          : "no team scope",
+                  deltaTone:
+                      avgAfterHours != null && avgAfterHours > 0.3
+                          ? "text-amber-600"
+                          : "text-(--ink-muted)",
+                  interpretation:
+                      avgAfterHours == null ? "N/A" : avgAfterHours > 0.3 ? "Watch" : "Stable",
                   description: "Existing commit-time rollups outside weekday business hours.",
               },
               {
                   label: "Weekend trend",
                   value: avgWeekend != null ? formatPct(avgWeekend) : "—",
-                  delta: avgWeekend != null ? (teamId ? "team-scoped" : "org-wide") : "no team scope",
-                  deltaTone: avgWeekend != null && avgWeekend > 0.2 ? "text-amber-600" : "text-emerald-600",
+                  delta:
+                      avgWeekend != null ? (teamId ? "team-scoped" : "org-wide") : "no team scope",
+                  deltaTone:
+                      avgWeekend != null && avgWeekend > 0.2
+                          ? "text-amber-600"
+                          : "text-emerald-600",
                   interpretation: avgWeekend == null ? "N/A" : avgWeekend > 0.2 ? "Watch" : "Lower",
-                  description: "Existing weekend activity ratio, aggregated before it reaches this surface.",
+                  description:
+                      "Existing weekend activity ratio, aggregated before it reaches this surface.",
               },
           ]
         : null; // null signals no data — rendered as empty state below
@@ -239,7 +263,11 @@ export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadP
     // A real zero is plotted (zero is data); only a genuinely empty window is empty.
     const toTrend = (pick: (s: (typeof rawSignals)[number]) => number): TrendPoint[] =>
         rawSignals
-            .map((s) => ({ day: s.day, label: s.day.slice(5), value: Math.round(pick(s)) }))
+            .map((s) => ({
+                day: s.day,
+                label: s.day.slice(5),
+                value: Math.round(pick(s)),
+            }))
             .sort((a, b) => a.day.localeCompare(b.day));
     const contextSpreadTrend = toTrend((s) => s.contextSpreadCount);
     const interruptionTrend = toTrend((s) => s.prInterruptionLoad);
@@ -374,7 +402,12 @@ export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadP
                                     window={windowLabel}
                                 />
                             ) : (
-                                <OverviewView signals={signals} window={windowLabel} />
+                                <OverviewView
+                                    signals={signals}
+                                    window={windowLabel}
+                                    filters={filters}
+                                    activeRole={activeRole}
+                                />
                             )}
                         </>
                     )}

--- a/src/app/(app)/landscape/page.tsx
+++ b/src/app/(app)/landscape/page.tsx
@@ -24,7 +24,7 @@ import { graphqlFetch } from "@/lib/graphql/server";
 import { HOTSPOTS_QUERY } from "@/lib/graphql/queries";
 import type { BusFactor } from "@/lib/graphql/types";
 import type { QuadrantResponse } from "@/lib/types";
-import { withFilterParam } from "@/lib/filters/url";
+import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
 import { navTrailForPathname } from "@/lib/navigation/areas";
 
 const QUADRANT_CARDS = [
@@ -427,7 +427,9 @@ export default async function LandscapePage({ searchParams }: LandscapePageProps
 
     const [health, hotspots, busFactor, ...quadrantData] = await Promise.all([
         checkApiHealth(),
-        orgId ? fetchHotspots(orgId, since.toISOString(), until.toISOString()) : Promise.resolve([]),
+        orgId
+            ? fetchHotspots(orgId, since.toISOString(), until.toISOString())
+            : Promise.resolve([]),
         fetchOrNull(getBusFactorData(filters), "landscape/bus-factor"),
         ...quadrantPromises,
     ]);
@@ -539,6 +541,16 @@ export default async function LandscapePage({ searchParams }: LandscapePageProps
                                         filters={filters}
                                         chartHeight={420}
                                         emptyState="Quadrant data unavailable for this scope."
+                                        relatedLinks={[
+                                            {
+                                                label: CTA_LABELS.openEvidence,
+                                                href: buildExploreUrl({
+                                                    metric: primaryCard.type,
+                                                    filters,
+                                                    role: activeRole,
+                                                }),
+                                            },
+                                        ]}
                                     />
                                 </div>
                                 <div className="flex flex-col gap-8">
@@ -555,6 +567,16 @@ export default async function LandscapePage({ searchParams }: LandscapePageProps
                                                 filters={filters}
                                                 chartHeight={320}
                                                 emptyState="Quadrant data unavailable for this scope."
+                                                relatedLinks={[
+                                                    {
+                                                        label: CTA_LABELS.openEvidence,
+                                                        href: buildExploreUrl({
+                                                            metric: card.type,
+                                                            filters,
+                                                            role: activeRole,
+                                                        }),
+                                                    },
+                                                ]}
                                             />
                                         );
                                     })}

--- a/src/app/(app)/landscape/page.tsx
+++ b/src/app/(app)/landscape/page.tsx
@@ -25,6 +25,7 @@ import { HOTSPOTS_QUERY } from "@/lib/graphql/queries";
 import type { BusFactor } from "@/lib/graphql/types";
 import type { QuadrantResponse } from "@/lib/types";
 import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
+import { LANDSCAPE_EVIDENCE_METRICS } from "@/lib/metrics/landscape";
 import { navTrailForPathname } from "@/lib/navigation/areas";
 
 const QUADRANT_CARDS = [
@@ -545,7 +546,9 @@ export default async function LandscapePage({ searchParams }: LandscapePageProps
                                             {
                                                 label: CTA_LABELS.openEvidence,
                                                 href: buildExploreUrl({
-                                                    metric: primaryCard.type,
+                                                    metric: LANDSCAPE_EVIDENCE_METRICS[
+                                                        primaryCard.type
+                                                    ],
                                                     filters,
                                                     role: activeRole,
                                                 }),
@@ -571,7 +574,9 @@ export default async function LandscapePage({ searchParams }: LandscapePageProps
                                                     {
                                                         label: CTA_LABELS.openEvidence,
                                                         href: buildExploreUrl({
-                                                            metric: card.type,
+                                                            metric: LANDSCAPE_EVIDENCE_METRICS[
+                                                                card.type
+                                                            ],
                                                             filters,
                                                             role: activeRole,
                                                         }),

--- a/src/components/cognitive-load/CognitiveLoadViews.test.tsx
+++ b/src/components/cognitive-load/CognitiveLoadViews.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { render, screen } from "@/test/utils";
 import { CTA_LABELS } from "@/lib/design/cta";
+import { METRIC_CATALOG } from "@/lib/metrics/catalog";
 import type { MetricFilter } from "@/lib/filters/types";
 
 import { OverviewView, contextSpreadSummary, loadDriverSummary } from "./CognitiveLoadViews";
@@ -26,7 +27,9 @@ describe("OverviewView", () => {
         const link = screen.getByRole("link", { name: CTA_LABELS.openEvidence });
         const href = link.getAttribute("href") ?? "";
         expect(href).toContain("/explore");
-        expect(href).toContain("metric=pr_interruption_load");
+        expect(href).toContain("metric=review_latency");
+        // catalog membership: review_latency must be a real explainable metric.
+        expect(METRIC_CATALOG.map((m) => m.metric)).toContain("review_latency");
         // scope-preserving: filter + role carried through to Explore.
         expect(href).toContain("f=");
         expect(href).toContain("role=engineer");

--- a/src/components/cognitive-load/CognitiveLoadViews.test.tsx
+++ b/src/components/cognitive-load/CognitiveLoadViews.test.tsx
@@ -1,6 +1,37 @@
 import { describe, expect, it } from "vitest";
 
-import { contextSpreadSummary, loadDriverSummary } from "./CognitiveLoadViews";
+import { render, screen } from "@/test/utils";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { MetricFilter } from "@/lib/filters/types";
+
+import { OverviewView, contextSpreadSummary, loadDriverSummary } from "./CognitiveLoadViews";
+
+const filters = {
+    scope: { level: "team" as const, ids: ["team-1"] },
+    time: { range_days: 30 },
+    what: { repos: [] },
+} as unknown as MetricFilter;
+
+describe("OverviewView", () => {
+    it("renders a scope-preserving Open evidence linkback", () => {
+        render(
+            <OverviewView
+                signals={null}
+                window={{ sinceDate: "2026-05-01", untilDate: "2026-05-31" }}
+                filters={filters}
+                activeRole="engineer"
+            />,
+        );
+
+        const link = screen.getByRole("link", { name: CTA_LABELS.openEvidence });
+        const href = link.getAttribute("href") ?? "";
+        expect(href).toContain("/explore");
+        expect(href).toContain("metric=pr_interruption_load");
+        // scope-preserving: filter + role carried through to Explore.
+        expect(href).toContain("f=");
+        expect(href).toContain("role=engineer");
+    });
+});
 
 describe("contextSpreadSummary", () => {
     it("reports the chronological last day as Latest even for unsorted Dec→Jan input", () => {
@@ -18,7 +49,11 @@ describe("contextSpreadSummary", () => {
     });
 
     it("is empty for an empty trend", () => {
-        expect(contextSpreadSummary([])).toEqual({ hasData: false, latest: null, peak: null });
+        expect(contextSpreadSummary([])).toEqual({
+            hasData: false,
+            latest: null,
+            peak: null,
+        });
     });
 });
 

--- a/src/components/cognitive-load/CognitiveLoadViews.tsx
+++ b/src/components/cognitive-load/CognitiveLoadViews.tsx
@@ -68,7 +68,7 @@ export function OverviewView({
                     <div className="flex items-center gap-4">
                         <Link
                             href={buildExploreUrl({
-                                metric: "pr_interruption_load",
+                                metric: "review_latency",
                                 filters,
                                 role: activeRole,
                             })}

--- a/src/components/cognitive-load/CognitiveLoadViews.tsx
+++ b/src/components/cognitive-load/CognitiveLoadViews.tsx
@@ -14,7 +14,10 @@ import { ChartFrame } from "@/components/charts/ChartFrame";
 import { HorizontalBarChart } from "@/components/charts/HorizontalBarChart";
 import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
 import { orderTimeseriesPoints } from "@/components/charts/timeseriesData";
-
+import Link from "next/link";
+import { CTA_LABELS } from "@/lib/design/cta";
+import { buildExploreUrl } from "@/lib/filters/url";
+import type { MetricFilter } from "@/lib/filters/types";
 export type TrendPoint = { day: string; value: number; label?: string };
 
 export type LoadDriver = { label: string; value: number };
@@ -42,9 +45,13 @@ function emptyDescription(window: WindowLabel, hint: string): string {
 export function OverviewView({
     signals,
     window,
+    filters,
+    activeRole,
 }: {
     signals: LoadKpi[] | null;
     window: WindowLabel;
+    filters: MetricFilter;
+    activeRole?: string;
 }) {
     return (
         <>
@@ -58,9 +65,21 @@ export function OverviewView({
                             What is pulling attention apart?
                         </h2>
                     </div>
-                    <span className="rounded-full border border-(--accent)/30 bg-(--accent)/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-(--accent)">
-                        Team signal
-                    </span>
+                    <div className="flex items-center gap-4">
+                        <Link
+                            href={buildExploreUrl({
+                                metric: "pr_interruption_load",
+                                filters,
+                                role: activeRole,
+                            })}
+                            className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+                        >
+                            {CTA_LABELS.openEvidence}
+                        </Link>
+                        <span className="rounded-full border border-(--accent)/30 bg-(--accent)/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-(--accent)">
+                            Team signal
+                        </span>
+                    </div>
                 </div>
                 <p className="mt-3 max-w-3xl text-sm leading-6 text-(--ink-muted)">
                     Read these as pressure cues. The values point to review load, context spread,
@@ -76,8 +95,9 @@ export function OverviewView({
                         <p className="mt-2 text-sm leading-6">
                             No cognitive-load signals found for{" "}
                             <span className="font-medium text-foreground">{window.sinceDate}</span>{" "}
-                            to <span className="font-medium text-foreground">{window.untilDate}</span>
-                            . Try widening the date range or switching to a team scope.
+                            to{" "}
+                            <span className="font-medium text-foreground">{window.untilDate}</span>.
+                            Try widening the date range or switching to a team scope.
                         </p>
                     </div>
                 ) : (
@@ -169,7 +189,11 @@ export function ContextSwitchingView({
             interpretation="Distinct repos, PRs, reviews, and touched file areas the team moved across each day. Higher spread means attention is split over more surfaces."
             threshold={
                 latest != null
-                    ? { label: "Latest", value: String(latest), tone: latest > 6 ? "caution" : "default" }
+                    ? {
+                          label: "Latest",
+                          value: String(latest),
+                          tone: latest > 6 ? "caution" : "default",
+                      }
                     : undefined
             }
             band={peak != null ? { label: "Window peak", value: String(peak) } : undefined}
@@ -203,7 +227,10 @@ export function FocusPressureView({
                 interpretation="Reviews, first-review events, and review feedback interrupting focused delivery, per day."
                 isEmpty={interruption.length === 0}
                 stateTitle="No interruption data"
-                stateDescription={emptyDescription(window, "Widen the window or pick a team scope.")}
+                stateDescription={emptyDescription(
+                    window,
+                    "Widen the window or pick a team scope.",
+                )}
                 data-testid="cognitive-load-focus-pressure-interruption"
             >
                 <TimeseriesChart data={interruption} height={280} />
@@ -213,7 +240,10 @@ export function FocusPressureView({
                 interpretation="Aggregate review requests the team absorbed per day — never a person-level queue ranking."
                 isEmpty={reviewRequest.length === 0}
                 stateTitle="No review-request data"
-                stateDescription={emptyDescription(window, "Widen the window or pick a team scope.")}
+                stateDescription={emptyDescription(
+                    window,
+                    "Widen the window or pick a team scope.",
+                )}
                 data-testid="cognitive-load-focus-pressure-review"
             >
                 <TimeseriesChart data={reviewRequest} height={280} />
@@ -273,7 +303,11 @@ export function LoadDriversView({
             interpretation="Average daily contribution of each load signal across the window. The longest bar is the dominant driver of cognitive load."
             threshold={
                 top && topShare != null
-                    ? { label: "Top driver", value: `${top.label} · ${topShare}%`, tone: "caution" }
+                    ? {
+                          label: "Top driver",
+                          value: `${top.label} · ${topShare}%`,
+                          tone: "caution",
+                      }
                     : undefined
             }
             isEmpty={isEmpty}

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GraphView } from "@/components/work/GraphView";
 import type { MetricFilter } from "@/lib/filters/types";
+import { CTA_LABELS } from "@/lib/design/cta";
 
 const { mockUseSearchParams, mockUseWorkGraphEdges, mockUseOrgId } = vi.hoisted(() => ({
     mockUseSearchParams: vi.fn(() => new URLSearchParams()),
@@ -376,9 +377,27 @@ describe("GraphView", () => {
         });
 
         const reviewEdges = [
-            { reviewer: "alice@example.com", author: "bob@example.com", reviewsCount: 12, day: "2026-05-01", repoId: "repo-1" },
-            { reviewer: "alice@example.com", author: "bob@example.com", reviewsCount: 5, day: "2026-05-02", repoId: "repo-1" },
-            { reviewer: "carol@example.com", author: "bob@example.com", reviewsCount: 3, day: "2026-05-01", repoId: "repo-1" },
+            {
+                reviewer: "alice@example.com",
+                author: "bob@example.com",
+                reviewsCount: 12,
+                day: "2026-05-01",
+                repoId: "repo-1",
+            },
+            {
+                reviewer: "alice@example.com",
+                author: "bob@example.com",
+                reviewsCount: 5,
+                day: "2026-05-02",
+                repoId: "repo-1",
+            },
+            {
+                reviewer: "carol@example.com",
+                author: "bob@example.com",
+                reviewsCount: 3,
+                day: "2026-05-01",
+                repoId: "repo-1",
+            },
         ];
 
         render(
@@ -427,5 +446,24 @@ describe("GraphView", () => {
         // We match the description paragraph to avoid ambiguity with the heading.
         expect(screen.getByText("Failed to load review network data")).toBeInTheDocument();
         expect(screen.queryByTestId("work-graph-explorer")).not.toBeInTheDocument();
+    });
+
+    it("renders a scope-preserving Open evidence linkback in the explorer header", () => {
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        const link = screen.getByRole("link", { name: CTA_LABELS.openEvidence });
+        const href = link.getAttribute("href") ?? "";
+        expect(href).toContain("/explore");
+        expect(href).toContain("metric=throughput");
+        // scope-preserving: the encoded filter param is carried through.
+        expect(href).toContain("f=");
     });
 });

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
+import Link from "next/link";
 
 import { WorkGraphExplorer, WorkGraphLegend } from "@/components/charts/WorkGraphExplorer";
 import { DataState } from "@/components/ui/DataState";
@@ -10,6 +11,7 @@ import type { WorkGraphEdge, WorkGraphEdgeType, WorkGraphNodeType } from "@/lib/
 import type { ReviewEdgeRow } from "@/lib/graphql/reviewEdgesFetchers";
 import type { MetricFilter } from "@/lib/filters/types";
 import { CTA_LABELS } from "@/lib/design/cta";
+import { buildExploreUrl } from "@/lib/filters/url";
 import { useOrgId } from "@/lib/graphql/provider";
 import { formatNumber } from "@/lib/formatters";
 import {
@@ -269,8 +271,6 @@ export function GraphView({
         return { incomingEdges, outgoingEdges };
     }, [selectedNode, displayEdges]);
 
-    void activeRole;
-
     // ── Derived table tabs (no force-directed canvas) ───────────────────────────
     if (activeTab === "inflow-outflow") {
         return <InflowOutflowView edges={edges} loading={loading} error={error} />;
@@ -297,8 +297,7 @@ export function GraphView({
     };
     const tabDescription: Record<"overview" | "dependencies", string> = {
         overview: "Visualize relationships between issues, PRs, commits, and files.",
-        dependencies:
-            "Blocking, related, duplicate, and parent-child links between work items.",
+        dependencies: "Blocking, related, duplicate, and parent-child links between work items.",
     };
     const graphTab = activeTab as "overview" | "dependencies";
     const emptyCopy =
@@ -317,8 +316,20 @@ export function GraphView({
                             <h3 className="text-lg font-medium">{tabHeading[graphTab]}</h3>
                             <p className="text-sm text-(--ink-muted)">{tabDescription[graphTab]}</p>
                         </div>
-                        <div className="text-xs text-(--ink-muted)">
-                            {loading ? "Loading..." : `${formatNumber(tabEdges.length)} edges`}
+                        <div className="flex items-center gap-4">
+                            <Link
+                                href={buildExploreUrl({
+                                    metric: "throughput",
+                                    filters,
+                                    role: activeRole,
+                                })}
+                                className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+                            >
+                                {CTA_LABELS.openEvidence}
+                            </Link>
+                            <div className="text-xs text-(--ink-muted)">
+                                {loading ? "Loading..." : `${formatNumber(tabEdges.length)} edges`}
+                            </div>
                         </div>
                     </div>
 
@@ -587,7 +598,12 @@ function ArtifactsView({ edges, loading, error }: DerivedViewProps) {
     const rows = useMemo(() => {
         const counts = new Map<
             string,
-            { type: WorkGraphNodeType; id: string; degree: number; evidence: string | null }
+            {
+                type: WorkGraphNodeType;
+                id: string;
+                degree: number;
+                evidence: string | null;
+            }
         >();
         const bump = (type: WorkGraphNodeType, id: string, evidence: string | null) => {
             const key = `${type}:${id}`;
@@ -668,7 +684,9 @@ function ArtifactsView({ edges, loading, error }: DerivedViewProps) {
                                         {row.evidence ? (
                                             <q className="line-clamp-2 text-xs">{row.evidence}</q>
                                         ) : (
-                                            <span className="text-xs italic">No linked evidence</span>
+                                            <span className="text-xs italic">
+                                                No linked evidence
+                                            </span>
                                         )}
                                     </td>
                                 </tr>
@@ -863,10 +881,7 @@ function ReviewNetworkView({ edges, loading, error }: ReviewNetworkViewProps) {
     // Derive unique reviewers + authors for a quick summary line.
     const reviewerCount = useMemo(() => new Set(rows.map((r) => r.reviewer)).size, [rows]);
     const authorCount = useMemo(() => new Set(rows.map((r) => r.author)).size, [rows]);
-    const totalReviews = useMemo(
-        () => rows.reduce((sum, r) => sum + r.totalReviews, 0),
-        [rows],
-    );
+    const totalReviews = useMemo(() => rows.reduce((sum, r) => sum + r.totalReviews, 0), [rows]);
     const maxReviews = rows.reduce((m, r) => Math.max(m, r.totalReviews), 1);
 
     return (
@@ -878,8 +893,7 @@ function ReviewNetworkView({ edges, loading, error }: ReviewNetworkViewProps) {
                 <h3 className="text-lg font-semibold tracking-tight">Review Network</h3>
                 <p className="mt-1 text-sm text-(--ink-muted)">
                     Reviewer→author collaboration pairs from code review activity, ranked by review
-                    count. Data sourced from{" "}
-                    <code className="text-xs">review_edges_daily</code>.
+                    count. Data sourced from <code className="text-xs">review_edges_daily</code>.
                 </p>
             </div>
 
@@ -920,10 +934,7 @@ function ReviewNetworkView({ edges, loading, error }: ReviewNetworkViewProps) {
                         </span>
                     </div>
                     <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90)">
-                        <table
-                            className="w-full text-sm"
-                            data-testid="review-network-table"
-                        >
+                        <table className="w-full text-sm" data-testid="review-network-table">
                             <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
                                 <tr>
                                     <th className="px-5 py-3 text-left">Reviewer</th>
@@ -940,10 +951,7 @@ function ReviewNetworkView({ edges, loading, error }: ReviewNetworkViewProps) {
                                         className="border-t border-(--card-stroke)/60"
                                     >
                                         <td className="px-5 py-3 align-middle">
-                                            <span
-                                                className="font-medium"
-                                                title={row.reviewer}
-                                            >
+                                            <span className="font-medium" title={row.reviewer}>
                                                 {emailDisplayName(row.reviewer)}
                                             </span>
                                             <span className="ml-1.5 text-xs text-(--ink-muted)">
@@ -951,10 +959,7 @@ function ReviewNetworkView({ edges, loading, error }: ReviewNetworkViewProps) {
                                             </span>
                                         </td>
                                         <td className="px-5 py-3 align-middle">
-                                            <span
-                                                className="font-medium"
-                                                title={row.author}
-                                            >
+                                            <span className="font-medium" title={row.author}>
                                                 {emailDisplayName(row.author)}
                                             </span>
                                             <span className="ml-1.5 text-xs text-(--ink-muted)">

--- a/src/lib/__tests__/landscape-evidence-metrics.test.ts
+++ b/src/lib/__tests__/landscape-evidence-metrics.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { METRIC_CATALOG } from "@/lib/metrics/catalog";
+import { LANDSCAPE_EVIDENCE_METRICS } from "@/lib/metrics/landscape";
+
+describe("LANDSCAPE_EVIDENCE_METRICS", () => {
+    const catalogIds = METRIC_CATALOG.map((m) => m.metric as string);
+
+    it("every quadrant maps to a metric id present in METRIC_CATALOG", () => {
+        for (const [quadrantType, metric] of Object.entries(LANDSCAPE_EVIDENCE_METRICS)) {
+            expect(
+                catalogIds.includes(metric),
+                `quadrant "${quadrantType}" maps to "${metric}" which is NOT in METRIC_CATALOG`,
+            ).toBe(true);
+        }
+    });
+
+    it("cycle_throughput quadrant links to cycle_time", () => {
+        expect(LANDSCAPE_EVIDENCE_METRICS["cycle_throughput"]).toBe("cycle_time");
+    });
+
+    it("churn_throughput quadrant links to churn", () => {
+        expect(LANDSCAPE_EVIDENCE_METRICS["churn_throughput"]).toBe("churn");
+    });
+});

--- a/src/lib/metrics/landscape.ts
+++ b/src/lib/metrics/landscape.ts
@@ -1,0 +1,14 @@
+/**
+ * Maps each Landscape quadrant type to the catalog metric used for the
+ * "Open evidence" linkback. Quadrant type ids are visualization-only keys
+ * and are NOT valid catalog metric ids — use this mapping instead.
+ *
+ * Tested in src/lib/__tests__/landscape-evidence-metrics.test.ts to ensure
+ * every value remains a member of METRIC_CATALOG.
+ */
+export const LANDSCAPE_EVIDENCE_METRICS: Record<string, string> = {
+    /** Cycle Time × Throughput quadrant → cycle_time axis metric */
+    cycle_throughput: "cycle_time",
+    /** Churn × Throughput quadrant → churn axis metric */
+    churn_throughput: "churn",
+};


### PR DESCRIPTION
## Summary

Adds the peer scope-preserving **"Open evidence"** CTA (`CTA_LABELS.openEvidence` + `buildExploreUrl`) to the three Diagnose views that lacked it, matching the existing pattern in `metrics/page.tsx`.

- **Landscape** (`src/app/(app)/landscape/page.tsx`): populate the (previously unused) `QuadrantPanel.relatedLinks` prop on both the primary and secondary quadrants. Metric = quadrant type (`cycle_throughput` / `churn_throughput`). `buildExploreUrl` is a pure module, safe to call from this server component; `QuadrantPanel` (client) renders the link.
- **Cognitive Load** (`src/components/cognitive-load/CognitiveLoadViews.tsx`, `src/app/(app)/cognitive-load/page.tsx`): header linkback in `OverviewView` (metric `pr_interruption_load`), consistent with the PR #622 per-tab views (left untouched). The page now passes `filters` + `activeRole`. Also fixes an unbalanced wrapper `<div>`.
- **Work Graph** (`src/components/work/GraphView.tsx`): header linkback in the explorer (metric `throughput`), consuming the previously-unused `activeRole`.

## Metric per view
| View | Metric |
|------|--------|
| Landscape (primary/secondary quadrants) | `cycle_throughput` / `churn_throughput` (quadrant type) |
| Cognitive Load (Overview) | `pr_interruption_load` |
| Work Graph (explorer) | `throughput` |

## Tests
- `CognitiveLoadViews.test.tsx`: new `OverviewView` render test asserts the scope-preserving link (`/explore`, `metric=pr_interruption_load`, `f=`, `role=`).
- `GraphView.test.tsx`: new test asserts the explorer header link (`/explore`, `metric=throughput`, `f=`).

## Verification
- `tsc --noEmit`: clean
- `vitest` (GraphView + CognitiveLoadViews): 20/20 pass
- design-lint: eslint clean on changed files; static scan 0/0/0/0

SCREENSHOT-WAIVER: leader performs live visual verification; CTAs are registry-sourced text links added to existing headers/panels.

Closes CHAOS-2159

## Visual evidence (live-verified)
![chaos-2159-2157-landscape-after.png](https://github.com/full-chaos/dev-health-web/releases/download/gh-attach-assets/chaos-2159-2157-landscape-after.png)
