### PR TITLE
feat(layout): left-align nav and let content use full width

### DIFF
--- a/src/app/(app)/admin/layout.tsx
+++ b/src/app/(app)/admin/layout.tsx
@@ -20,7 +20,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
     return (
         <div className="min-h-screen">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
                 <AdminSidebar isSuperuser={isSuperuser} features={features} />
                 <AdminTierProvider tier={tier} features={features}>
                     <main className="flex min-w-0 flex-1 flex-col gap-10">{children}</main>

--- a/src/app/(app)/bottleneck/loading.tsx
+++ b/src/app/(app)/bottleneck/loading.tsx
@@ -15,7 +15,7 @@ function NavSkeleton() {
 export default function Loading() {
     return (
         <div className="min-h-screen text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <NavSkeleton />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     {/* Header */}

--- a/src/app/(app)/bottleneck/page.tsx
+++ b/src/app/(app)/bottleneck/page.tsx
@@ -115,7 +115,7 @@ export default async function BottleneckPage({ searchParams }: BottleneckPagePro
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="bottleneck" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/capacity/page.tsx
+++ b/src/app/(app)/capacity/page.tsx
@@ -70,7 +70,7 @@ export default async function CapacityPage({ searchParams }: CapacityPageProps) 
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="capacity" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <UpgradeGate

--- a/src/app/(app)/code/page.tsx
+++ b/src/app/(app)/code/page.tsx
@@ -103,7 +103,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="code" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/cognitive-load/page.tsx
+++ b/src/app/(app)/cognitive-load/page.tsx
@@ -192,7 +192,12 @@ export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadP
                   value: formatLoad(avgPrInterruptionLoad),
                   delta: `${sinceDate} – ${untilDate}`,
                   deltaTone: "text-(--ink-muted)",
-                  interpretation: avgPrInterruptionLoad > 15 ? "Rising" : avgPrInterruptionLoad > 8 ? "Watch" : "Easing",
+                  interpretation:
+                      avgPrInterruptionLoad > 15
+                          ? "Rising"
+                          : avgPrInterruptionLoad > 8
+                            ? "Watch"
+                            : "Easing",
                   description:
                       "Reviews, first-review events, and review feedback interrupting focused delivery.",
               },
@@ -210,25 +215,44 @@ export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadP
                   value: formatLoad(avgReviewRequestLoad),
                   delta: `avg over ${cognitiveLoadData?.totalDays ?? rawSignals.length} days`,
                   deltaTone: avgReviewRequestLoad > 10 ? "text-rose-600" : "text-(--ink-muted)",
-                  interpretation: avgReviewRequestLoad > 10 ? "Rising" : avgReviewRequestLoad > 5 ? "Watch" : "Low",
+                  interpretation:
+                      avgReviewRequestLoad > 10
+                          ? "Rising"
+                          : avgReviewRequestLoad > 5
+                            ? "Watch"
+                            : "Low",
                   description:
                       "Aggregate review requests handled by the team, never a person-level queue ranking.",
               },
               {
                   label: "After-hours trend",
                   value: avgAfterHours != null ? formatPct(avgAfterHours) : "—",
-                  delta: avgAfterHours != null ? (teamId ? "team-scoped" : "org-wide") : "no team scope",
-                  deltaTone: avgAfterHours != null && avgAfterHours > 0.3 ? "text-amber-600" : "text-(--ink-muted)",
-                  interpretation: avgAfterHours == null ? "N/A" : avgAfterHours > 0.3 ? "Watch" : "Stable",
+                  delta:
+                      avgAfterHours != null
+                          ? teamId
+                              ? "team-scoped"
+                              : "org-wide"
+                          : "no team scope",
+                  deltaTone:
+                      avgAfterHours != null && avgAfterHours > 0.3
+                          ? "text-amber-600"
+                          : "text-(--ink-muted)",
+                  interpretation:
+                      avgAfterHours == null ? "N/A" : avgAfterHours > 0.3 ? "Watch" : "Stable",
                   description: "Existing commit-time rollups outside weekday business hours.",
               },
               {
                   label: "Weekend trend",
                   value: avgWeekend != null ? formatPct(avgWeekend) : "—",
-                  delta: avgWeekend != null ? (teamId ? "team-scoped" : "org-wide") : "no team scope",
-                  deltaTone: avgWeekend != null && avgWeekend > 0.2 ? "text-amber-600" : "text-emerald-600",
+                  delta:
+                      avgWeekend != null ? (teamId ? "team-scoped" : "org-wide") : "no team scope",
+                  deltaTone:
+                      avgWeekend != null && avgWeekend > 0.2
+                          ? "text-amber-600"
+                          : "text-emerald-600",
                   interpretation: avgWeekend == null ? "N/A" : avgWeekend > 0.2 ? "Watch" : "Lower",
-                  description: "Existing weekend activity ratio, aggregated before it reaches this surface.",
+                  description:
+                      "Existing weekend activity ratio, aggregated before it reaches this surface.",
               },
           ]
         : null; // null signals no data — rendered as empty state below
@@ -257,7 +281,7 @@ export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadP
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="cognitive-load" role={activeRole} />
                 <main
                     className="flex min-w-0 flex-1 flex-col gap-6"

--- a/src/app/(app)/complexity/loading.tsx
+++ b/src/app/(app)/complexity/loading.tsx
@@ -15,7 +15,7 @@ function NavSkeleton() {
 export default function Loading() {
     return (
         <div className="min-h-screen text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <NavSkeleton />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     {/* Header */}

--- a/src/app/(app)/complexity/page.tsx
+++ b/src/app/(app)/complexity/page.tsx
@@ -178,7 +178,7 @@ export default async function ComplexityPage({ searchParams }: PageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="complexity" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8" data-testid="complexity-page">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/dashboard/loading.tsx
+++ b/src/app/(app)/dashboard/loading.tsx
@@ -15,7 +15,7 @@ function NavSkeleton() {
 export default function Loading() {
     return (
         <div className="min-h-screen text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
                 <NavSkeleton />
                 <main className="flex min-w-0 flex-1 flex-col gap-10">
                     {/* Header card */}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -105,7 +105,7 @@ export default async function Home({ searchParams }: HomePageProps) {
 
     return (
         <div className="min-h-screen bg-(image:--hero-gradient) text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="home" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-10">
                     <header className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.4)]">

--- a/src/app/(app)/data-health/layout.tsx
+++ b/src/app/(app)/data-health/layout.tsx
@@ -12,7 +12,7 @@ export default async function DataHealthLayout({ children }: { children: React.R
 
     return (
         <div className="min-h-screen">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-20 pt-10">
+            <div className="flex w-full flex-col gap-6 px-6 pb-20 pt-10">
                 <AdminTierProvider tier={tier} features={features}>
                     <main className="flex min-w-0 flex-1 flex-col gap-10">{children}</main>
                 </AdminTierProvider>

--- a/src/app/(app)/deployments/[deployment_id]/page.tsx
+++ b/src/app/(app)/deployments/[deployment_id]/page.tsx
@@ -27,7 +27,7 @@ export default async function DeploymentDetailPage({ params }: DeploymentDetailP
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={defaultMetricFilter} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-start justify-between gap-4">

--- a/src/app/(app)/diagnose/page.tsx
+++ b/src/app/(app)/diagnose/page.tsx
@@ -37,7 +37,7 @@ export default async function DiagnosePage({ searchParams }: DiagnosePageProps) 
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="diagnose" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-col gap-4">

--- a/src/app/(app)/diagnose/work-graph/page.tsx
+++ b/src/app/(app)/diagnose/work-graph/page.tsx
@@ -120,7 +120,7 @@ export default async function WorkGraphPage({ searchParams }: WorkGraphPageProps
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="diagnose" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-col gap-4">

--- a/src/app/(app)/explore/loading.tsx
+++ b/src/app/(app)/explore/loading.tsx
@@ -13,7 +13,7 @@ function NavSkeleton() {
 export default function Loading() {
     return (
         <div className="min-h-screen text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <NavSkeleton />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     {/* Header */}

--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -202,7 +202,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-start justify-between gap-4">

--- a/src/app/(app)/feature-flags/page.tsx
+++ b/src/app/(app)/feature-flags/page.tsx
@@ -57,7 +57,7 @@ export default async function FeatureFlagsPage({ searchParams }: FeatureFlagsPag
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="feature-flags" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/govern/page.tsx
+++ b/src/app/(app)/govern/page.tsx
@@ -73,7 +73,7 @@ export default async function GovernPage({ searchParams }: GovernPageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="govern" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-col gap-4">

--- a/src/app/(app)/incident-correlation/page.tsx
+++ b/src/app/(app)/incident-correlation/page.tsx
@@ -113,7 +113,7 @@ export default async function IncidentCorrelationPage({ searchParams }: PageProp
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="incident-correlation" role={activeRole} />
                 <main
                     className="flex min-w-0 flex-1 flex-col gap-8"

--- a/src/app/(app)/investment/page.tsx
+++ b/src/app/(app)/investment/page.tsx
@@ -80,7 +80,7 @@ export default async function InvestmentPage({ searchParams }: InvestmentPagePro
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="investment" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <UpgradeGate feature="investment_view" requiredTier="team" features={features}>

--- a/src/app/(app)/issues/[issue_id]/page.tsx
+++ b/src/app/(app)/issues/[issue_id]/page.tsx
@@ -41,7 +41,7 @@ export default async function IssueDetailPage({ params }: IssueDetailPageProps) 
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={defaultMetricFilter} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-start justify-between gap-4">

--- a/src/app/(app)/landscape/page.tsx
+++ b/src/app/(app)/landscape/page.tsx
@@ -427,7 +427,9 @@ export default async function LandscapePage({ searchParams }: LandscapePageProps
 
     const [health, hotspots, busFactor, ...quadrantData] = await Promise.all([
         checkApiHealth(),
-        orgId ? fetchHotspots(orgId, since.toISOString(), until.toISOString()) : Promise.resolve([]),
+        orgId
+            ? fetchHotspots(orgId, since.toISOString(), until.toISOString())
+            : Promise.resolve([]),
         fetchOrNull(getBusFactorData(filters), "landscape/bus-factor"),
         ...quadrantPromises,
     ]);
@@ -457,7 +459,7 @@ export default async function LandscapePage({ searchParams }: LandscapePageProps
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="landscape" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-start justify-between gap-4">

--- a/src/app/(app)/metrics/loading.tsx
+++ b/src/app/(app)/metrics/loading.tsx
@@ -15,7 +15,7 @@ function NavSkeleton() {
 export default function Loading() {
     return (
         <div className="min-h-screen text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <NavSkeleton />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     {/* Header */}

--- a/src/app/(app)/metrics/page.tsx
+++ b/src/app/(app)/metrics/page.tsx
@@ -26,10 +26,7 @@ type MetricsPageProps = {
     searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-type QuadrantType =
-    | "churn_throughput"
-    | "cycle_throughput"
-    | "wip_throughput";
+type QuadrantType = "churn_throughput" | "cycle_throughput" | "wip_throughput";
 
 type MetricTab = {
     id: string;
@@ -151,7 +148,7 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="metrics" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/operating-review/page.tsx
+++ b/src/app/(app)/operating-review/page.tsx
@@ -72,7 +72,7 @@ export default async function OperatingReviewPage({ searchParams }: OperatingRev
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="operating-review" />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/opportunities/page.tsx
+++ b/src/app/(app)/opportunities/page.tsx
@@ -41,7 +41,7 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="opportunities" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-col gap-4">

--- a/src/app/(app)/people/[person_id]/metrics/[metric]/page.tsx
+++ b/src/app/(app)/people/[person_id]/metrics/[metric]/page.tsx
@@ -198,7 +198,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="people" />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-start justify-between gap-4">

--- a/src/app/(app)/people/[person_id]/page.tsx
+++ b/src/app/(app)/people/[person_id]/page.tsx
@@ -134,7 +134,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="people" />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-start justify-between gap-4">

--- a/src/app/(app)/people/page.tsx
+++ b/src/app/(app)/people/page.tsx
@@ -20,7 +20,7 @@ export default async function PeoplePage({ searchParams }: PeoplePageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="people" />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/plan/capacity/page.tsx
+++ b/src/app/(app)/plan/capacity/page.tsx
@@ -68,7 +68,7 @@ export default async function PlanCapacityPage({ searchParams }: PlanCapacityPag
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="capacity" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/plan/page.tsx
+++ b/src/app/(app)/plan/page.tsx
@@ -105,7 +105,7 @@ export default async function PlanPage({ searchParams }: PlanPageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="plan" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/prs/[pr_id]/page.tsx
+++ b/src/app/(app)/prs/[pr_id]/page.tsx
@@ -41,7 +41,7 @@ export default async function PrDetailPage({ params }: PrDetailPageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={defaultMetricFilter} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-start justify-between gap-4">

--- a/src/app/(app)/quality/page.tsx
+++ b/src/app/(app)/quality/page.tsx
@@ -69,7 +69,7 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="quality" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/reports/[id]/page.tsx
+++ b/src/app/(app)/reports/[id]/page.tsx
@@ -231,7 +231,7 @@ export default function SingleReportPage() {
     if (isLoading) {
         return (
             <div className="min-h-screen bg-background text-foreground">
-                <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+                <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                     <PrimaryNav filters={defaultMetricFilter} active="reports" />
                     <main className="flex min-w-0 flex-1 flex-col gap-8">
                         <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-10 text-center">
@@ -246,7 +246,7 @@ export default function SingleReportPage() {
     if (!report) {
         return (
             <div className="min-h-screen bg-background text-foreground">
-                <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+                <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                     <PrimaryNav filters={defaultMetricFilter} active="reports" />
                     <main className="flex min-w-0 flex-1 flex-col gap-8">
                         <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-10 text-center">
@@ -373,7 +373,7 @@ export default function SingleReportPage() {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={defaultMetricFilter} active="reports" />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     {error && (

--- a/src/app/(app)/reports/new/page.tsx
+++ b/src/app/(app)/reports/new/page.tsx
@@ -70,7 +70,7 @@ export default function NewReportPage() {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={defaultMetricFilter} active="reports" />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-start justify-between gap-4">

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -28,7 +28,7 @@ export default async function ReportsPage({ searchParams }: ReportsPageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="reports" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/risk/compounding/page.tsx
+++ b/src/app/(app)/risk/compounding/page.tsx
@@ -165,7 +165,7 @@ export default async function CompoundingRiskPage({ searchParams }: CompoundingR
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="risk-compounding" role={activeRole} />
                 <main
                     className="flex min-w-0 flex-1 flex-col gap-8"

--- a/src/app/(app)/security/loading.tsx
+++ b/src/app/(app)/security/loading.tsx
@@ -3,7 +3,7 @@ import { SkeletonLine } from "@/components/ui/Skeleton";
 export default function SecurityLoading() {
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 {/* Nav skeleton */}
                 <div className="w-full md:max-w-[220px] md:shrink-0">
                     <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-4">

--- a/src/app/(app)/security/page.tsx
+++ b/src/app/(app)/security/page.tsx
@@ -24,7 +24,7 @@ export default async function SecurityPage({ searchParams }: SecurityPageProps) 
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={navFilters} active="security" />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header>

--- a/src/app/(app)/security/repos/[repoId]/page.tsx
+++ b/src/app/(app)/security/repos/[repoId]/page.tsx
@@ -27,7 +27,7 @@ export default async function RepoSecurityPage({ params, searchParams }: RepoSec
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={navFilters} active="security" />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header>

--- a/src/app/(app)/superadmin/layout.tsx
+++ b/src/app/(app)/superadmin/layout.tsx
@@ -8,7 +8,7 @@ export default async function SuperadminLayout({ children }: { children: React.R
 
     return (
         <div className="min-h-screen">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
                 <SuperadminSidebar canAccessOrgAdmin={hasOrgAccess} />
                 <main className="flex min-w-0 flex-1 flex-col gap-10">{children}</main>
             </div>

--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -150,7 +150,7 @@ export default async function CoveragePage({
 
 	return (
 		<div className="min-h-screen bg-background text-foreground">
-			<div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+			<div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
 				<PrimaryNav filters={filters} active="testops" role={activeRole} />
 				<main className="flex min-w-0 flex-1 flex-col gap-8">
 					<header className="flex flex-col gap-4">

--- a/src/app/(app)/testops/page.tsx
+++ b/src/app/(app)/testops/page.tsx
@@ -127,7 +127,7 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="testops" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-col gap-4">

--- a/src/app/(app)/testops/pipelines/page.tsx
+++ b/src/app/(app)/testops/pipelines/page.tsx
@@ -154,7 +154,7 @@ export default async function PipelinesPage({ searchParams }: PipelinesPageProps
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="testops" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-col gap-4">

--- a/src/app/(app)/testops/risk/page.tsx
+++ b/src/app/(app)/testops/risk/page.tsx
@@ -151,7 +151,7 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="risk" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-center justify-between gap-4">

--- a/src/app/(app)/testops/tests/page.tsx
+++ b/src/app/(app)/testops/tests/page.tsx
@@ -162,7 +162,7 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="testops" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-col gap-4">

--- a/src/app/(app)/work/loading.tsx
+++ b/src/app/(app)/work/loading.tsx
@@ -15,7 +15,7 @@ function NavSkeleton() {
 export default function Loading() {
     return (
         <div className="min-h-screen text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <NavSkeleton />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     {/* Header */}

--- a/src/components/ai/AIWorkspaceChrome.tsx
+++ b/src/components/ai/AIWorkspaceChrome.tsx
@@ -27,7 +27,7 @@ export function AIWorkspaceChrome({ children }: { children: ReactNode }) {
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="ai" role={role} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary

Left-aligns the primary nav and lets the content area use the full viewport width across the authenticated app shell — Penpot-style canvas with the nav pinned to the left edge.

Every `(app)` route wrapped `PrimaryNav` + `<main>` in a centered, width-capped container:

```
mx-auto flex w-full max-w-7xl flex-col ...
```

`mx-auto` centered the whole shell and `max-w-7xl` (1280px) capped it. Both are removed:

```
flex w-full flex-col ...
```

The `<aside>` nav (already `md:max-w-56 md:shrink-0`) now sits flush-left, and `<main>` (already `flex-1 min-w-0`) expands to fill the remaining horizontal space. Charts, metric cards, and tables get far more room on wide displays.

## Scope

- Applied uniformly to all `(app)` route shells, their `loading.tsx` states, and the AI workspace chrome (`AIWorkspaceChrome.tsx`) — 48 files.
- Marketing and auth pages intentionally **untouched** — they keep their `max-w-7xl` reading-width caps.
- CSS class-string change only. No logic, props, or component API changes. (Prettier reflowed a few multi-line `className` strings.)

## Verification

- `eslint src` (changed files): clean
- `tsc --noEmit`: exit 0
- design-lint static scan: 0 violations
- `prettier --check`: clean
- Authenticated Playwright screenshots at 1920px (sample-data/test mode)

## Screenshots (after)

**Cockpit / dashboard** — nav at left edge, content full width:

![dashboard full width](https://github.com/full-chaos/dev-health-web/releases/download/gh-attach-assets/chaos-fullwidth-dashboard.png)

**Metrics** — the four DORA cards now span the full row instead of being boxed into 1280px:

![metrics full width](https://github.com/full-chaos/dev-health-web/releases/download/gh-attach-assets/chaos-fullwidth-metrics.png)

TEST-WAIVER: CSS-only layout change (removal of `mx-auto`/`max-w-7xl` shell container classes); no component logic affected. Verified visually via authenticated Playwright screenshots at 1920px.
