### PR TITLE
fix(heatmap): stop cell-click route crash + unmask Error logs

### DIFF
--- a/src/components/charts/HeatmapPanel.test.tsx
+++ b/src/components/charts/HeatmapPanel.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@/test/utils";
 import { describe, expect, it, vi } from "vitest";
 
-import { HeatmapPanel } from "./HeatmapPanel";
+import { describeArtifact, HeatmapPanel } from "./HeatmapPanel";
 import type { HeatmapResponse } from "@/lib/types";
 
 // Stub the echarts-backed chart so the panel renders in jsdom without echarts.
@@ -97,5 +97,30 @@ describe("HeatmapPanel — hotspot evidence contract (CHAOS-2035)", () => {
 
         // No raw JSON dump of the evidence object.
         expect(screen.queryByText(/work_item_id/)).not.toBeInTheDocument();
+    });
+});
+
+describe("describeArtifact — unresolved-id crash guard (heatmap cell click)", () => {
+    const UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+    it("does not throw on a UUID id without a name in development mode", () => {
+        // The dev-only unresolved-id assertion previously threw here. Because
+        // describeArtifact runs inside a render-time useMemo, that throw escaped
+        // the fetch try/catch and tripped the route error boundary on cell click.
+        vi.stubEnv("NODE_ENV", "development");
+        try {
+            const item = { work_item_id: UUID, value: 3 };
+            expect(() => describeArtifact(item, 0)).not.toThrow();
+            const out = describeArtifact(item, 0);
+            expect(out.label).toBe("#550e8400");
+            expect(out.title).toBe(UUID);
+        } finally {
+            vi.unstubAllEnvs();
+        }
+    });
+
+    it("prefers an explicit name when present", () => {
+        const out = describeArtifact({ work_item_id: UUID, name: "Login flow" }, 0);
+        expect(out.label).toBe("Login flow");
     });
 });

--- a/src/components/charts/HeatmapPanel.tsx
+++ b/src/components/charts/HeatmapPanel.tsx
@@ -78,6 +78,24 @@ type ResolvedArtifact = {
  * UUID/path), a tooltip carrying the full identifier, and a timestamp.
  * Replaces the previous raw `JSON.stringify(item)` dump.
  */
+/**
+ * Resolve an entity id to a render-safe { label, title }. A degraded UUID/hash
+ * id falls back to a stable short token (e.g. "#a1b2c3d4") — opting into the
+ * `unresolvedFallback` contract so the dev-only unresolved-id assertion does not
+ * throw during render (which crashed the heatmap evidence list on cell click).
+ */
+function entityArtifactLabel(
+    id: string | null | undefined,
+    options: { name?: string | null; fallback?: string } = {},
+): { label: string; title: string } {
+    const { label, title, short } = resolveEntityLabel(id, {
+        name: options.name ?? undefined,
+        fallback: options.fallback,
+        unresolvedFallback: "Unresolved",
+    });
+    return { label: short ?? label, title };
+}
+
 export function describeArtifact(item: Record<string, unknown>, index: number): ResolvedArtifact {
     const explicitName =
         asText(item.title) ?? asText(item.name) ?? asText(item.repo_name) ?? asText(item.author);
@@ -92,9 +110,7 @@ export function describeArtifact(item: Record<string, unknown>, index: number): 
     const deployment = asText(item.deployment_id);
 
     if (path) {
-        const { label, title } = resolveEntityLabel(path, {
-            name: explicitName ?? undefined,
-        });
+        const { label, title } = entityArtifactLabel(path, { name: explicitName });
         return { type: "File", label, title, timestamp, value, link };
     }
     if (commit) {
@@ -110,7 +126,7 @@ export function describeArtifact(item: Record<string, unknown>, index: number): 
     if (number !== null) {
         const repo = asText(item.repo_id);
         const repoLabel = repo
-            ? resolveEntityLabel(repo, { name: asText(item.repo_name) ?? undefined }).label
+            ? entityArtifactLabel(repo, { name: asText(item.repo_name) }).label
             : null;
         return {
             type: "PR",
@@ -122,19 +138,19 @@ export function describeArtifact(item: Record<string, unknown>, index: number): 
         };
     }
     if (workItem) {
-        const { label, title } = resolveEntityLabel(workItem, {
-            name: explicitName ?? undefined,
+        const { label, title } = entityArtifactLabel(workItem, {
+            name: explicitName,
         });
         return { type: "Work item", label, title, timestamp, value, link };
     }
     if (deployment) {
-        const { label, title } = resolveEntityLabel(deployment, {
-            name: explicitName ?? undefined,
+        const { label, title } = entityArtifactLabel(deployment, {
+            name: explicitName,
         });
         return { type: "Deployment", label, title, timestamp, value, link };
     }
 
-    const { label, title } = resolveEntityLabel(explicitName, {
+    const { label, title } = entityArtifactLabel(explicitName, {
         fallback: `Item ${index + 1}`,
     });
     return { type: "Item", label, title, timestamp, value, link };

--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { serializeErrors } from "../logger";
+
+describe("serializeErrors (browser logger Error serialization)", () => {
+    it("converts an Error value to a plain { name, message, stack } object", () => {
+        const err = new Error("boom");
+        const out = serializeErrors({ err, digest: "abc" }) as Record<
+            string,
+            { name: string; message: string; stack: string }
+        > & { digest: string };
+
+        // The bug: spreading an Error into a plain object yields {}, which
+        // serializes/prints as "[object Error]" and loses message + stack.
+        expect(out.err.name).toBe("Error");
+        expect(out.err.message).toBe("boom");
+        expect(typeof out.err.stack).toBe("string");
+        expect(out.digest).toBe("abc");
+        expect(String(out.err)).not.toBe("[object Error]");
+    });
+
+    it("serializes a top-level Error argument", () => {
+        const out = serializeErrors(new Error("top")) as {
+            message: string;
+            name: string;
+        };
+        expect(out.message).toBe("top");
+        expect(out.name).toBe("Error");
+    });
+
+    it("leaves non-Error values untouched", () => {
+        const input = { a: 1, b: "two", c: { nested: true } };
+        expect(serializeErrors(input)).toEqual(input);
+        expect(serializeErrors("plain")).toBe("plain");
+        expect(serializeErrors(null)).toBe(null);
+    });
+});

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -54,6 +54,28 @@ const LOG_FORMAT: LogFormat = (() => {
 })();
 
 /**
+ * Replace Error values (top-level or one level deep) with plain
+ * { name, message, stack } objects so they serialize legibly instead of
+ * collapsing to "[object Error]" in the browser console / forwarded logs.
+ */
+export function serializeErrors(obj: unknown): unknown {
+    if (obj instanceof Error) {
+        return { name: obj.name, message: obj.message, stack: obj.stack };
+    }
+    if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+        const result: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(obj)) {
+            result[key] =
+                value instanceof Error
+                    ? { name: value.name, message: value.message, stack: value.stack }
+                    : value;
+        }
+        return result;
+    }
+    return obj;
+}
+
+/**
  * Browser-side shim — pino cannot run in the browser.
  * Maps to console methods so existing DevTools workflows still work.
  */
@@ -67,8 +89,10 @@ function createBrowserLogger(bindings: Record<string, unknown> = {}): Logger {
             if (levels.indexOf(level) < minIdx) return;
             if (typeof objOrMsg === "string") {
                 consoleFn(`[${level}]`, objOrMsg, bindings);
+            } else if (objOrMsg instanceof Error) {
+                consoleFn(`[${level}]`, msg ?? "", serializeErrors({ ...bindings, err: objOrMsg }));
             } else {
-                consoleFn(`[${level}]`, msg ?? "", { ...bindings, ...objOrMsg });
+                consoleFn(`[${level}]`, msg ?? "", serializeErrors({ ...bindings, ...objOrMsg }));
             }
         };
 


### PR DESCRIPTION
## Summary
Two coupled bugs behind "Diagnose > Cognitive Load > Heatmap: clicking a square errors out".

1. **Root crash** — `describeArtifact` (src/components/charts/HeatmapPanel.tsx) called `resolveEntityLabel` on UUID `repo_id`/`work_item_id`/`deployment_id` evidence rows **without** `unresolvedFallback`. In development, `entityLabel.ts`'s `assertUnresolvedFallback` throws — and because `describeArtifact` runs in a render-time `useMemo`, that throw escapes the fetch try/catch and trips the route error boundary (`ErrorView`). Fixed via a small `entityArtifactLabel` helper that opts into `unresolvedFallback: "Unresolved"` and renders the existing stable short token (`#a1b2c3d4`) — preserving current UX, no crash.
2. **Masking** — the browser logger (`src/lib/logger.ts`) spread `Error` objects into a plain object, so `ErrorView`'s `logger.error({ err }, ...)` serialized to `[object Error]`, hiding every route error's message/stack. Added `serializeErrors` to convert `Error` values to `{ name, message, stack }`.

## Test
- `src/lib/__tests__/logger.test.ts` — `serializeErrors` converts Error values (not `[object Error]`).
- `src/components/charts/HeatmapPanel.test.tsx` — `describeArtifact` no longer throws on a UUID id in dev mode and keeps the `#550e8400` short token.
- `vitest` 7/7 pass; `tsc --noEmit` clean; `eslint` clean.

SCREENSHOT-WAIVER: crash-guard + logger change; verified via unit tests. Live browser capture intentionally skipped to avoid spawning a dev server that contends for the shared stack's port (an earlier agent killed a shared process doing exactly this — never again).