### PR TITLE
CHAOS-2165: Govern frontend correctness fixes — TestOps/Quality/Feature-Flags

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -49,9 +49,9 @@ Use tokens only. **No hardcoded hex or px in components**, if a value is missing
 
 ## Part D: CTA vocabulary registry (typed constants)
 
-Approved (add new ones here before use): `Open evidence`, `Inspect associations`, `Open artifact`, `Export report`, `Apply filters`, `Reset filters`, `Copy`; navigation `Back to Cockpit`, `Back to {area}`.
+Approved (add new ones here before use): `Open evidence`, `Inspect associations`, `Open artifact`, `Present in view`, `Export report`, `Apply filters`, `Reset filters`, `Copy`; navigation `Back to Cockpit`, `Back to {area}`.
 
-Migrate: `Re-orient in Cockpit` → `Back to Cockpit`; `Back to Metrics View` → `Back to {area}`; `Open Landscapes` / `Explore Work` → use a tab or `Back to {area}`; `Open Flame` → `Open artifact` (or register Open flame graph); standalone `EVIDENCE` label → `Open evidence`.
+Migrate: `Re-orient in Cockpit` → `Back to Cockpit`; `Back to Metrics View` → `Back to {area}`; `Open Landscapes` / `Explore Work` → use a tab or `Back to {area}`; `Open Flame` → `Open artifact` (or register Open flame graph); standalone `EVIDENCE` label → `Open evidence`; `Open in Explore` → `Open evidence` (or `Present in view` when the card expands inline rather than navigating).
 
 ## Part E: Shared primitives (build once, use everywhere)
 

--- a/src/app/(app)/feature-flags/page.tsx
+++ b/src/app/(app)/feature-flags/page.tsx
@@ -4,6 +4,7 @@ import { FeatureFlagTable } from "@/components/feature-flags/FeatureFlagTable";
 import { MetricCard } from "@/components/metrics/MetricCard";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { DataState } from "@/components/ui/DataState";
 import { checkApiHealth } from "@/lib/api/system";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
@@ -42,14 +43,35 @@ export default async function FeatureFlagsPage({ searchParams }: FeatureFlagsPag
         filters?.time?.start_date ??
         new Date(today.getTime() - rangeDays * 86_400_000).toISOString().slice(0, 10);
 
+    // fetchFeatureFlagsData re-throws on total failure (honest over silent-zero).
+    // Catch it here so a flags-fetch error degrades to a page-local error rather
+    // than rejecting the whole Promise.all and hitting the (app)/error.tsx boundary
+    // (which replaces the entire app shell including the sidebar).
     const [health, ffData, flagList] = await Promise.all([
         checkApiHealth(),
-        fetchFeatureFlagsData({ startDate, endDate }, isTestMode),
+        fetchFeatureFlagsData({ startDate, endDate }, isTestMode).catch(() => null),
         fetchFeatureFlagList(0, 20),
     ]);
 
     if (!health.ok && !isTestMode) {
         return <ServiceUnavailable />;
+    }
+
+    if (!ffData) {
+        return (
+            <div className="min-h-screen bg-background text-foreground">
+                <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+                    <PrimaryNav filters={filters} active="feature-flags" role={activeRole} />
+                    <main className="flex min-w-0 flex-1 flex-col gap-8">
+                        <DataState
+                            variant="error"
+                            title="Feature flags unavailable"
+                            message="Unable to load feature flag metrics. Try refreshing the page."
+                        />
+                    </main>
+                </div>
+            </div>
+        );
     }
 
     const { summary } = ffData;

--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -187,7 +187,6 @@ export default async function CoveragePage({
 								<MetricCard
 									key={id}
 									label={def.label}
-									href="#"
 									value={value}
 									unit={
 										def.unit === "percentage"

--- a/src/app/(app)/testops/page.tsx
+++ b/src/app/(app)/testops/page.tsx
@@ -9,7 +9,7 @@ import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
 import { fetchTestOpsData } from "@/lib/testops/fetchers";
 import { TESTOPS_MEASURES } from "@/lib/testops/constants";
-import { TimeseriesResult, TimeseriesBucket } from "@/lib/graphql/schemas/analytics";
+import { getLatestValue, getSparkline, getDelta } from "@/lib/testops/aggregateSeries";
 import { getServerEnv } from "@/lib/config";
 
 import { TestOpsTabs } from "./TestOpsTabs";
@@ -17,21 +17,6 @@ import { TestOpsTabs } from "./TestOpsTabs";
 type TestOpsPageProps = {
     searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
-
-function getLatestValue(timeseries: TimeseriesResult[], measureId: string) {
-    const series = timeseries.find((s) => s.measure === measureId);
-    if (!series || !series.buckets || series.buckets.length === 0) return undefined;
-    return series.buckets[series.buckets.length - 1].value;
-}
-
-function getSparkline(timeseries: TimeseriesResult[], measureId: string) {
-    const series = timeseries.find((s) => s.measure === measureId);
-    if (!series || !series.buckets) return undefined;
-    return series.buckets.map((b: TimeseriesBucket) => ({
-        ts: b.date,
-        value: b.value,
-    }));
-}
 
 export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
     const params = (await searchParams) ?? {};
@@ -164,12 +149,12 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
 
                             const value = getLatestValue(ts, id);
                             const spark = getSparkline(ts, id);
+                            const delta = getDelta(ts, id);
 
                             return (
                                 <MetricCard
                                     key={id}
                                     label={def.label}
-                                    href="#"
                                     value={value}
                                     unit={
                                         def.unit === "percentage"
@@ -178,6 +163,9 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
                                               ? "m"
                                               : ""
                                     }
+                                    delta={delta}
+                                    deltaUnavailableLabel="Insufficient history"
+                                    inverseGood={def.goodDirection === "down"}
                                     spark={spark}
                                     caption={def.description}
                                 />

--- a/src/app/(app)/testops/pipelines/page.tsx
+++ b/src/app/(app)/testops/pipelines/page.tsx
@@ -14,6 +14,12 @@ import { fetchTestOpsData } from "@/lib/testops/fetchers";
 import { TESTOPS_MEASURES } from "@/lib/testops/constants";
 import { buildFailurePatternsModel, UNATTRIBUTED_LABEL } from "@/lib/testops/failure-patterns";
 import {
+    mergeSeriesByMeasure,
+    getLatestValue,
+    getSparkline,
+    getDelta,
+} from "@/lib/testops/aggregateSeries";
+import {
     TimeseriesResult,
     TimeseriesBucket,
     BreakdownResult,
@@ -25,32 +31,6 @@ import { TestOpsTabs } from "../TestOpsTabs";
 type PipelinesPageProps = {
     searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
-
-function getLatestValue(timeseries: TimeseriesResult[], measureId: string) {
-    const series = timeseries.find((s) => s.measure === measureId);
-    if (!series || !series.buckets || series.buckets.length === 0) return undefined;
-    return series.buckets[series.buckets.length - 1].value;
-}
-
-function getSparkline(timeseries: TimeseriesResult[], measureId: string) {
-    const series = timeseries.find((s) => s.measure === measureId);
-    if (!series || !series.buckets) return undefined;
-    return series.buckets.map((b: TimeseriesBucket) => ({
-        ts: b.date,
-        value: b.value,
-    }));
-}
-
-/** Period-over-period change (%) from first to last bucket; undefined when history is insufficient. */
-function getDelta(timeseries: TimeseriesResult[], measureId: string) {
-    const series = timeseries.find((s) => s.measure === measureId);
-    const buckets = series?.buckets;
-    if (!buckets || buckets.length < 2) return undefined;
-    const prev = buckets[0].value;
-    const curr = buckets[buckets.length - 1].value;
-    if (prev === 0) return undefined;
-    return ((curr - prev) / Math.abs(prev)) * 100;
-}
 
 export default async function PipelinesPage({ searchParams }: PipelinesPageProps) {
     const params = (await searchParams) ?? {};
@@ -136,9 +116,7 @@ export default async function PipelinesPage({ searchParams }: PipelinesPageProps
         { id: "PIPELINE_RERUN_RATE", ts: pipelineTimeseries },
     ];
 
-    const successRateSeries = pipelineTimeseries.find(
-        (s: TimeseriesResult) => s.measure === "PIPELINE_SUCCESS_RATE",
-    );
+    const successRateSeries = mergeSeriesByMeasure(pipelineTimeseries, "PIPELINE_SUCCESS_RATE");
     const failureBreakdown = pipelineBreakdowns.find(
         (b: BreakdownResult) => b.measure === "PIPELINE_FAILURE_RATE",
     );
@@ -188,7 +166,6 @@ export default async function PipelinesPage({ searchParams }: PipelinesPageProps
                                 <MetricCard
                                     key={id}
                                     label={def.label}
-                                    href="#"
                                     value={value}
                                     unit={
                                         def.unit === "percentage"
@@ -199,6 +176,7 @@ export default async function PipelinesPage({ searchParams }: PipelinesPageProps
                                     }
                                     delta={delta}
                                     deltaUnavailableLabel="Insufficient history"
+                                    inverseGood={def.goodDirection === "down"}
                                     spark={spark}
                                     caption={def.description}
                                 />

--- a/src/app/(app)/testops/risk/page.tsx
+++ b/src/app/(app)/testops/risk/page.tsx
@@ -178,7 +178,6 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
                     <section className="grid gap-4 lg:grid-cols-3">
                         <MetricCard
                             label="Release Confidence"
-                            href="#"
                             value={
                                 riskData.release_confidence
                                     ? riskData.release_confidence * 100
@@ -191,7 +190,6 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
                         />
                         <MetricCard
                             label="Quality Drag"
-                            href="#"
                             value={riskData.quality_drag_hours}
                             unit="h"
                             delta={riskData.drag_delta}
@@ -200,7 +198,6 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
                         />
                         <MetricCard
                             label="Pipeline Stability"
-                            href="#"
                             value={
                                 riskData.pipeline_stability
                                     ? riskData.pipeline_stability * 100

--- a/src/app/(app)/testops/tests/page.tsx
+++ b/src/app/(app)/testops/tests/page.tsx
@@ -12,6 +12,12 @@ import { withFilterParam } from "@/lib/filters/url";
 import { fetchTestOpsData } from "@/lib/testops/fetchers";
 import { TESTOPS_MEASURES } from "@/lib/testops/constants";
 import {
+    mergeSeriesByMeasure,
+    getLatestValue,
+    getSparkline,
+    getDelta,
+} from "@/lib/testops/aggregateSeries";
+import {
     TimeseriesResult,
     TimeseriesBucket,
     BreakdownResult,
@@ -24,32 +30,6 @@ import { TestOpsTabs } from "../TestOpsTabs";
 type TestsPageProps = {
     searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
-
-function getLatestValue(timeseries: TimeseriesResult[], measureId: string) {
-    const series = timeseries.find((s) => s.measure === measureId);
-    if (!series || !series.buckets || series.buckets.length === 0) return undefined;
-    return series.buckets[series.buckets.length - 1].value;
-}
-
-function getSparkline(timeseries: TimeseriesResult[], measureId: string) {
-    const series = timeseries.find((s) => s.measure === measureId);
-    if (!series || !series.buckets) return undefined;
-    return series.buckets.map((b: TimeseriesBucket) => ({
-        ts: b.date,
-        value: b.value,
-    }));
-}
-
-/** Period-over-period change (%) from first to last bucket; undefined when history is insufficient. */
-function getDelta(timeseries: TimeseriesResult[], measureId: string) {
-    const series = timeseries.find((s) => s.measure === measureId);
-    const buckets = series?.buckets;
-    if (!buckets || buckets.length < 2) return undefined;
-    const prev = buckets[0].value;
-    const curr = buckets[buckets.length - 1].value;
-    if (prev === 0) return undefined;
-    return ((curr - prev) / Math.abs(prev)) * 100;
-}
 
 export default async function TestsPage({ searchParams }: TestsPageProps) {
     const params = (await searchParams) ?? {};
@@ -128,9 +108,7 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
         { id: "TEST_SUITE_DURATION_P95", ts: testTimeseries },
     ];
 
-    const passRateSeries = testTimeseries.find(
-        (s: TimeseriesResult) => s.measure === "TEST_PASS_RATE",
-    );
+    const passRateSeries = mergeSeriesByMeasure(testTimeseries, "TEST_PASS_RATE");
     const flakeBreakdown = testBreakdowns.find(
         (b: BreakdownResult) => b.measure === "TEST_FLAKE_RATE",
     );
@@ -196,7 +174,6 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
                                 <MetricCard
                                     key={id}
                                     label={def.label}
-                                    href="#"
                                     value={value}
                                     unit={
                                         def.unit === "percentage"
@@ -207,6 +184,7 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
                                     }
                                     delta={delta}
                                     deltaUnavailableLabel="Insufficient history"
+                                    inverseGood={def.goodDirection === "down"}
                                     spark={spark}
                                     caption={def.description}
                                 />

--- a/src/components/charts/SparklineChart.test.tsx
+++ b/src/components/charts/SparklineChart.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { formatSparklineTooltipDate } from "./SparklineChart";
+
+describe("formatSparklineTooltipDate", () => {
+    it("formats an ISO datetime string as a short date (not the raw ISO)", () => {
+        // Raw input mirrors what Pydantic serialises: YYYY-MM-DDT00:00:00
+        const result = formatSparklineTooltipDate("2026-06-04T00:00:00");
+        // Must NOT echo back the raw ISO string
+        expect(result).not.toBe("2026-06-04T00:00:00");
+        // Must contain the day number
+        expect(result).toMatch(/4/);
+        // Must contain a month abbreviation
+        expect(result).toMatch(/Jun/i);
+    });
+
+    it("formats a plain ISO date string (no time component)", () => {
+        const result = formatSparklineTooltipDate("2026-01-15");
+        expect(result).not.toBe("2026-01-15");
+        expect(result).toMatch(/15/);
+        expect(result).toMatch(/Jan/i);
+    });
+
+    it("returns the raw string unchanged for non-date input", () => {
+        expect(formatSparklineTooltipDate("not-a-date")).toBe("not-a-date");
+        expect(formatSparklineTooltipDate("Week 42")).toBe("Week 42");
+        expect(formatSparklineTooltipDate("Sprint 3")).toBe("Sprint 3");
+    });
+
+    it("handles numeric categories by converting to string", () => {
+        // Numeric index categories (e.g. 1, 2, 3) should return the raw stringified number
+        // because integers are not valid dates
+        expect(formatSparklineTooltipDate(1)).toBe("1");
+        expect(formatSparklineTooltipDate(42)).toBe("42");
+    });
+});

--- a/src/components/charts/SparklineChart.tsx
+++ b/src/components/charts/SparklineChart.tsx
@@ -19,6 +19,47 @@ type SparklineChartProps = {
     style?: CSSProperties;
 };
 
+type SparklineTooltipParam = {
+    axisValue?: string | number;
+    value?: number | string;
+    marker?: string;
+};
+
+const SHORT_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+};
+
+/**
+ * Matches ISO 8601 date strings: `YYYY-MM-DD` optionally followed by a time
+ * component (`T…`). Capturing groups: [1]=year, [2]=month, [3]=day.
+ */
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})(T[\d:Z.+-]*)?$/;
+
+/**
+ * Formats an axis value for the sparkline tooltip.
+ * If the value matches an ISO date string (YYYY-MM-DD…), returns a short
+ * human-readable date (e.g. "Jun 4"). The date components are parsed locally
+ * to avoid UTC-midnight timezone shifting.
+ * Falls back to the raw string so non-date sparklines are unaffected.
+ */
+export function formatSparklineTooltipDate(axisValue: string | number): string {
+    const str = String(axisValue);
+    const match = ISO_DATE_RE.exec(str);
+    if (match) {
+        // Use local Date constructor (year, month-1, day) to avoid UTC-to-local
+        // timezone shifting that `new Date("YYYY-MM-DD")` causes.
+        const year = parseInt(match[1], 10);
+        const month = parseInt(match[2], 10) - 1;
+        const day = parseInt(match[3], 10);
+        const date = new Date(year, month, day);
+        if (!isNaN(date.getTime())) {
+            return date.toLocaleDateString(undefined, SHORT_DATE_FORMAT);
+        }
+    }
+    return str;
+}
+
 export function SparklineChart({
     data,
     categories,
@@ -48,6 +89,14 @@ export function SparklineChart({
                         color: chartTheme.text,
                     },
                     axisPointer: { type: "line" },
+                    formatter: (params: unknown): string => {
+                        const list = Array.isArray(params) ? params : [params];
+                        const first = list[0] as SparklineTooltipParam | undefined;
+                        const axisValue = first?.axisValue ?? "";
+                        const label = formatSparklineTooltipDate(axisValue);
+                        const value = first?.value !== undefined ? first.value : "";
+                        return `${first?.marker ?? ""}${label}: ${value}`;
+                    },
                 },
                 grid: { left: 8, right: 8, top: 10, bottom: 10 },
                 xAxis: {

--- a/src/components/metrics/MetricCard.test.tsx
+++ b/src/components/metrics/MetricCard.test.tsx
@@ -43,3 +43,30 @@ describe("MetricCard delta slot (metric coherence: never a bare '--')", () => {
         expect(screen.queryByText("No prior period")).not.toBeInTheDocument();
     });
 });
+
+describe("MetricCard link affordance (no placeholder href='#')", () => {
+    it("renders as a non-link with no 'Open evidence' cue when href is omitted", () => {
+        render(<MetricCard label="Line Coverage" value={85} unit="%" />);
+        // No anchor → the card no longer looks clickable when it goes nowhere.
+        expect(screen.queryByRole("link")).not.toBeInTheDocument();
+        expect(screen.queryByText("Open evidence")).not.toBeInTheDocument();
+    });
+
+    it("renders a real link with the 'Open evidence' cue when href is provided", () => {
+        render(<MetricCard label="Line Coverage" href="/explore" value={85} unit="%" />);
+        expect(screen.getByRole("link")).toHaveAttribute("href", "/explore");
+        expect(screen.getByText("Open evidence")).toBeInTheDocument();
+    });
+});
+
+describe("MetricCard inverse-good delta coloring (lower-is-better metrics)", () => {
+    it("colors a positive delta as caution without inverting the displayed number", () => {
+        render(<MetricCard label="Failure Rate" value={36} unit="%" delta={5} inverseGood />);
+        // Truthful number: an increase reads as +5%, never a negated -5%.
+        const deltaEl = screen.getByText(/\+5%/);
+        expect(screen.queryByText(/-5%/)).not.toBeInTheDocument();
+        // ...but the tone is a regression (caution/negative), not positive/green.
+        expect(deltaEl.className).toContain("--accent-negative");
+        expect(deltaEl.className).not.toContain("--positive");
+    });
+});

--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -8,12 +8,19 @@ import type { SparkPoint } from "@/lib/types";
 
 type MetricCardProps = {
     label: string;
-    href: string;
+    /**
+     * Drill-down destination. When omitted the card renders as a non-link
+     * (no fake hover affordance, no "Open evidence" caption) instead of a
+     * placeholder `href="#"` that goes nowhere.
+     */
+    href?: string;
     value?: number;
     unit?: string;
     delta?: number;
     /** Label shown in the delta slot when no delta is available (never a bare "--"). */
     deltaUnavailableLabel?: string;
+    /** Lower-is-better metric: an increase is colored as negative (forwarded to MetricDelta). */
+    inverseGood?: boolean;
     spark?: SparkPoint[];
     caption?: string;
     className?: string;
@@ -27,6 +34,7 @@ export function MetricCard({
     unit,
     delta,
     deltaUnavailableLabel = "No prior period",
+    inverseGood,
     spark,
     caption,
     className,
@@ -34,18 +42,24 @@ export function MetricCard({
 }: MetricCardProps) {
     const sparkValues = spark?.map((point) => point.value) ?? [];
     const sparkLabels = spark?.map((point) => point.ts) ?? [];
+    // Only a real destination earns the clickable affordance + "Open evidence" cue.
+    const captionText = caption ?? (href ? "Open evidence" : null);
+    const cardClassName = `group rounded-3xl border border-(--card-stroke) bg-card p-4 ${
+        href ? "transition hover:-translate-y-1 hover:shadow-lg" : ""
+    } ${className ?? ""}`;
 
-    return (
-        <Link
-            href={href}
-            className={`group rounded-3xl border border-(--card-stroke) bg-card p-4 transition hover:-translate-y-1 hover:shadow-lg ${className ?? ""}`}
-        >
+    const body = (
+        <>
             <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                 <div className="flex items-center">
                     <span>{label}</span>
                     {lineageMetricId && <LineagePopover metricId={lineageMetricId} />}
                 </div>
-                <MetricDelta value={delta} unavailableLabel={deltaUnavailableLabel} />
+                <MetricDelta
+                    value={delta}
+                    unavailableLabel={deltaUnavailableLabel}
+                    inverseGood={inverseGood}
+                />
             </div>
             <div className="mt-3 flex items-center justify-between gap-4">
                 <div>
@@ -54,9 +68,9 @@ export function MetricCard({
                             ? "--"
                             : formatMetricValue(value, unit ?? "")}
                     </p>
-                    <p className="mt-2 text-xs text-(--ink-muted)">
-                        {caption ?? "Open in Explore"}
-                    </p>
+                    {captionText && (
+                        <p className="mt-2 text-xs text-(--ink-muted)">{captionText}</p>
+                    )}
                 </div>
                 <div className="h-16 w-full">
                     {sparkValues.length > 1 ? (
@@ -71,6 +85,16 @@ export function MetricCard({
                     )}
                 </div>
             </div>
+        </>
+    );
+
+    if (!href) {
+        return <div className={cardClassName}>{body}</div>;
+    }
+
+    return (
+        <Link href={href} className={cardClassName}>
+            {body}
         </Link>
     );
 }

--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -31,6 +31,36 @@ describe("formatters", () => {
         expect(formatMetricValue(11, "%")).toBe("11%");
         expect(formatMetricValue(8, "hours")).toBe("8h");
     });
+
+    describe("formatMetricValue duration (unit='m')", () => {
+        // Values arrive in minutes (fetcher normalises real seconds→minutes;
+        // sample data is already in minutes). The formatter only labels the unit.
+
+        it("formats an already-minutes value with 1 decimal and 'm' suffix", () => {
+            // Sample: PIPELINE_DURATION_P95 ends at 12 → "12m"
+            expect(formatMetricValue(12, "m")).toBe("12m");
+        });
+
+        it("formats a fractional-minutes value to 1 decimal", () => {
+            // e.g. 9.345 minutes → "9.3m"
+            expect(formatMetricValue(9.345, "m")).toBe("9.3m");
+        });
+
+        it("formats a sub-minute value (0.5 min = 30 s after normalisation)", () => {
+            expect(formatMetricValue(0.5, "m")).toBe("0.5m");
+        });
+
+        it("does NOT divide by 60 — 12 stays 12, not 0.2", () => {
+            // Regression guard: the old bug divided sample values by 60,
+            // turning 12m into 0.2m. The formatter must not convert units.
+            expect(formatMetricValue(12, "m")).not.toBe("0.2m");
+        });
+
+        it("does not affect non-duration units", () => {
+            expect(formatMetricValue(42, "%")).toBe("42%");
+            expect(formatMetricValue(3, "days")).toBe("3d");
+        });
+    });
 });
 
 describe("formatter caching", () => {

--- a/src/lib/feature-flags/__tests__/fetchers.test.ts
+++ b/src/lib/feature-flags/__tests__/fetchers.test.ts
@@ -1,6 +1,33 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { WorkGraphEdge } from "@/lib/graphql/types";
 import { getDistinctSourceIds, getRegistryEdges, parseToggleEvidence } from "../graph";
+import {
+    latestFromSpark,
+    deltaFromSpark,
+    classifySeverity,
+    fetchFeatureFlagsData,
+} from "../fetchers";
+
+// ── Module mocks ────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/auth", () => ({
+    auth: vi.fn().mockResolvedValue({ user: { org_id: "org-test" } }),
+}));
+
+vi.mock("@/lib/graphql/urqlClient", () => ({
+    graphqlFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+    logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const { graphqlFetch } = await import("@/lib/graphql/urqlClient");
+const { auth } = await import("@/lib/auth");
+const mockGraphql = vi.mocked(graphqlFetch);
+const mockAuth = vi.mocked(auth);
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
 function makeEdge(overrides: Partial<WorkGraphEdge>): WorkGraphEdge {
     return {
@@ -17,6 +44,70 @@ function makeEdge(overrides: Partial<WorkGraphEdge>): WorkGraphEdge {
         provider: overrides.provider ?? "launchdarkly",
     };
 }
+
+/** Build a minimal successful graphqlFetch response for fetchFeatureFlagsData.
+ *
+ * Uses query-string discrimination rather than call-order sequencing because
+ * fetchFeatureFlagTimeseries calls graphqlFetch before registry/impact (those
+ * helpers await resolveOrgId first, deferring their graphqlFetch calls).
+ */
+function mockSuccessfulFetch(timeseriesBuckets: {
+    friction?: number[];
+    error?: number[];
+    activation?: number[];
+    coverage?: number[];
+}) {
+    const makeTimeseries = (measure: string, values: number[]) => ({
+        dimension: "REPO",
+        dimensionValue: "repo-a",
+        measure,
+        buckets: values.map((value, i) => ({
+            date: `2026-05-${String(i + 1).padStart(2, "0")}`,
+            value,
+        })),
+    });
+
+    const emptyEdgesResponse = {
+        workGraphEdges: {
+            edges: [],
+            totalCount: 0,
+            pageInfo: { hasNextPage: false, hasPreviousPage: false },
+        },
+    };
+
+    mockGraphql.mockImplementation((query) => {
+        // In this codebase all queries are plain strings (not TypedDocumentNode).
+        const qs = typeof query === "string" ? query : "";
+        if (qs.includes("FeatureFlagTimeseries")) {
+            return Promise.resolve({
+                analytics: {
+                    timeseries: [
+                        makeTimeseries(
+                            "FLAG_ACTIVATION_RATE",
+                            timeseriesBuckets.activation ?? [10, 12],
+                        ),
+                        makeTimeseries(
+                            "FLAG_FRICTION_DELTA",
+                            timeseriesBuckets.friction ?? [8, 14],
+                        ),
+                        makeTimeseries(
+                            "FLAG_ERROR_RATE_DELTA",
+                            timeseriesBuckets.error ?? [-3, -5],
+                        ),
+                        makeTimeseries(
+                            "FLAG_COVERAGE_RATIO",
+                            timeseriesBuckets.coverage ?? [60, 70],
+                        ),
+                    ],
+                },
+            });
+        }
+        // FeatureFlagRegistry and ReleaseImpact both return empty edge sets.
+        return Promise.resolve(emptyEdgesResponse);
+    });
+}
+
+// ── Graph helper tests (unchanged from prior suite) ─────────────────────────
 
 describe("feature flag fetcher helpers", () => {
     it("keeps one registry edge per flag identity", () => {
@@ -84,5 +175,192 @@ describe("feature flag fetcher helpers", () => {
 
         expect(getDistinctSourceIds(edges).size).toBe(2);
         expect(getDistinctSourceIds(edges, "IMPACTS").size).toBe(1);
+    });
+});
+
+// ── latestFromSpark ──────────────────────────────────────────────────────────
+
+describe("latestFromSpark", () => {
+    it("returns null for an empty sparkline", () => {
+        expect(latestFromSpark([])).toBeNull();
+    });
+
+    it("returns the single value when there is exactly one point", () => {
+        expect(latestFromSpark([{ ts: "2026-05-01", value: 42 }])).toBe(42);
+    });
+
+    it("returns the last value for a multi-point sparkline", () => {
+        const spark = [
+            { ts: "2026-05-01", value: 10 },
+            { ts: "2026-05-02", value: 20 },
+            { ts: "2026-05-03", value: 7 },
+        ];
+        expect(latestFromSpark(spark)).toBe(7);
+    });
+});
+
+// ── deltaFromSpark ──────────────────────────────────────────────────────────
+
+describe("deltaFromSpark", () => {
+    it("returns null for an empty sparkline", () => {
+        expect(deltaFromSpark([])).toBeNull();
+    });
+
+    it("returns null for a single-point sparkline (no prior period)", () => {
+        expect(deltaFromSpark([{ ts: "2026-05-01", value: 42 }])).toBeNull();
+    });
+
+    it("returns last minus first, rounded to one decimal place", () => {
+        const spark = [
+            { ts: "2026-05-01", value: 10 },
+            { ts: "2026-05-07", value: 18.35 },
+        ];
+        expect(deltaFromSpark(spark)).toBe(8.4);
+    });
+
+    it("returns a negative delta when the sparkline trends downward", () => {
+        const spark = [
+            { ts: "2026-05-01", value: 25 },
+            { ts: "2026-05-02", value: 20 },
+            { ts: "2026-05-03", value: 18 },
+        ];
+        expect(deltaFromSpark(spark)).toBe(-7);
+    });
+
+    it("returns 0.0 when first and last values are equal", () => {
+        const spark = [
+            { ts: "2026-05-01", value: 50 },
+            { ts: "2026-05-02", value: 50 },
+        ];
+        expect(deltaFromSpark(spark)).toBe(0);
+    });
+});
+
+// ── classifySeverity ────────────────────────────────────────────────────────
+
+describe("classifySeverity", () => {
+    it.each([
+        [0, "low"],
+        [4.9, "low"],
+        [5, "moderate"],
+        [14.9, "moderate"],
+        [15, "high"],
+        [24.9, "high"],
+        [25, "critical"],
+        [100, "critical"],
+    ] as const)("classifySeverity(%s) → %s", (delta, expected) => {
+        expect(classifySeverity(delta)).toBe(expected);
+    });
+
+    it("uses absolute value so negative deltas classify the same as positive", () => {
+        expect(classifySeverity(-20)).toBe("high");
+        expect(classifySeverity(-5)).toBe("moderate");
+    });
+});
+
+// ── fetchFeatureFlagsData — real-delta wiring ───────────────────────────────
+
+describe("fetchFeatureFlagsData — real-delta wiring", () => {
+    const DATE_RANGE = { startDate: "2026-05-01", endDate: "2026-05-14" };
+
+    beforeEach(() => {
+        mockGraphql.mockReset();
+        mockAuth.mockResolvedValue({ user: { org_id: "org-test" } } as never);
+    });
+
+    it("sources releaseFrictionDelta from the last FLAG_FRICTION_DELTA bucket", async () => {
+        mockSuccessfulFetch({ friction: [5, 18] });
+        const result = await fetchFeatureFlagsData(DATE_RANGE);
+        // Last bucket of FLAG_FRICTION_DELTA is 18 → card value should be 18
+        expect(result.summary.releaseFrictionDelta).toBe(18);
+    });
+
+    it("derives releaseFrictionSeverity from the wired friction delta", async () => {
+        mockSuccessfulFetch({ friction: [2, 16] });
+        const result = await fetchFeatureFlagsData(DATE_RANGE);
+        // 16 >= 15 → "high"
+        expect(result.summary.releaseFrictionSeverity).toBe("high");
+    });
+
+    it("sources releaseErrorRateDelta from the last FLAG_ERROR_RATE_DELTA bucket", async () => {
+        mockSuccessfulFetch({ error: [-1, -6.5] });
+        const result = await fetchFeatureFlagsData(DATE_RANGE);
+        expect(result.summary.releaseErrorRateDelta).toBe(-6.5);
+    });
+
+    it("leaves activeFlagsDelta undefined — no FLAG_ACTIVE_COUNT_DELTA measure exposed", async () => {
+        mockSuccessfulFetch({ activation: [10, 12, 14] });
+        const result = await fetchFeatureFlagsData(DATE_RANGE);
+        // Activation-rate Δ must NOT be surfaced as a count Δ (unit mismatch).
+        expect(result.summary.activeFlagsDelta).toBeUndefined();
+    });
+
+    it("sources coverageRatio from last FLAG_COVERAGE_RATIO bucket (rounds to int)", async () => {
+        mockSuccessfulFetch({ coverage: [60, 73.7] });
+        const result = await fetchFeatureFlagsData(DATE_RANGE);
+        expect(result.summary.coverageRatio).toBe(74);
+    });
+
+    it("leaves coverageRatioDelta undefined — no FLAG_COVERAGE_RATIO_DELTA measure exposed", async () => {
+        mockSuccessfulFetch({ coverage: [60, 70] });
+        const result = await fetchFeatureFlagsData(DATE_RANGE);
+        // Ratio first→last Δ must NOT be surfaced as a coverage Δ (unit mismatch).
+        expect(result.summary.coverageRatioDelta).toBeUndefined();
+    });
+
+    it("card and sparkline values agree for friction (both from FLAG_FRICTION_DELTA)", async () => {
+        mockSuccessfulFetch({ friction: [3, 11] });
+        const result = await fetchFeatureFlagsData(DATE_RANGE);
+        const spark = result.summary.releaseFrictionSpark;
+        expect(spark.at(-1)?.value).toBe(result.summary.releaseFrictionDelta);
+    });
+
+    it("card and sparkline values agree for error rate (both from FLAG_ERROR_RATE_DELTA)", async () => {
+        mockSuccessfulFetch({ error: [-2, -9] });
+        const result = await fetchFeatureFlagsData(DATE_RANGE);
+        const spark = result.summary.releaseErrorRateSpark;
+        expect(spark.at(-1)?.value).toBe(result.summary.releaseErrorRateDelta);
+    });
+
+    it("activeFlagsDelta is always undefined regardless of sparkline length", async () => {
+        mockSuccessfulFetch({ activation: [10] });
+        const result = await fetchFeatureFlagsData(DATE_RANGE);
+        expect(result.summary.activeFlagsDelta).toBeUndefined();
+    });
+
+    it("coverageRatioDelta is always undefined regardless of sparkline length", async () => {
+        mockSuccessfulFetch({ coverage: [65] });
+        const result = await fetchFeatureFlagsData(DATE_RANGE);
+        expect(result.summary.coverageRatioDelta).toBeUndefined();
+    });
+});
+
+// ── fetchFeatureFlagsData — error fallback ───────────────────────────────────
+//
+// Sub-fetchers (registry, releaseImpact, timeseries) each have their own
+// try/catch, so a graphqlFetch failure is swallowed before reaching the outer
+// catch. The outer catch fires when resolveOrgId() — called unconditionally at
+// the top of fetchFeatureFlagsData — throws. We trigger that by rejecting auth().
+
+describe("fetchFeatureFlagsData — error fallback", () => {
+    const DATE_RANGE = { startDate: "2026-05-01", endDate: "2026-05-14" };
+
+    beforeEach(() => {
+        mockGraphql.mockReset();
+        // Restore the default auth mock after each test.
+        mockAuth.mockResolvedValue({ user: { org_id: "org-test" } } as never);
+    });
+
+    it("re-throws on total fetch failure instead of returning an all-zero summary", async () => {
+        // Reject auth() so resolveOrgId() throws inside fetchFeatureFlagsData.
+        mockAuth.mockRejectedValueOnce(new Error("auth network error"));
+        await expect(fetchFeatureFlagsData(DATE_RANGE)).rejects.toThrow("auth network error");
+    });
+
+    it("does not silently return a zero-valued 'healthy' summary on failure", async () => {
+        mockAuth.mockRejectedValueOnce(new Error("session expired"));
+        const result = await fetchFeatureFlagsData(DATE_RANGE).catch(() => null);
+        // result must be null (thrown), never an object masquerading as healthy zeros
+        expect(result).toBeNull();
     });
 });

--- a/src/lib/feature-flags/fetchers.ts
+++ b/src/lib/feature-flags/fetchers.ts
@@ -129,6 +129,27 @@ export async function fetchReleaseImpact(
 }
 
 /**
+ * Returns the value of the last bucket in a sparkline, or null when the
+ * sparkline is empty. Use this to derive a card "current value" from the
+ * same timeseries source that backs the sparkline, so card and trend agree.
+ */
+export function latestFromSpark(spark: SparkPoint[]): number | null {
+    if (spark.length === 0) return null;
+    return spark[spark.length - 1].value;
+}
+
+/**
+ * Returns the first→last change across a sparkline (last − first), rounded to
+ * one decimal place. Returns null when fewer than two data points are present.
+ * Use this to compute a period-over-period delta from an existing sparkline
+ * when no dedicated delta measure is exposed by the backend.
+ */
+export function deltaFromSpark(spark: SparkPoint[]): number | null {
+    if (spark.length < 2) return null;
+    return Math.round((spark[spark.length - 1].value - spark[0].value) * 10) / 10;
+}
+
+/**
  * Merge timeseries results for a given measure into a single sparkline.
  * When multiple dimension values exist (e.g. multiple repos), values
  * for the same date bucket are averaged.
@@ -179,7 +200,7 @@ async function fetchFeatureFlagTimeseries(
     }
 }
 
-function classifySeverity(delta: number): "low" | "moderate" | "high" | "critical" {
+export function classifySeverity(delta: number): "low" | "moderate" | "high" | "critical" {
     const abs = Math.abs(delta);
     if (abs >= 25) return "critical";
     if (abs >= 15) return "high";
@@ -206,59 +227,65 @@ export async function fetchFeatureFlagsData(
         ]);
 
         const activeFlags = registry.totalCount;
-        const impactEdges = impact.edges.filter((edge) => edge.edgeType === "IMPACTS");
-        const frictionEdges = impactEdges.filter((edge) => edge.evidence?.includes("friction"));
-        const errorEdges = impactEdges.filter((edge) => edge.evidence?.includes("error"));
 
-        const avgFriction =
-            frictionEdges.length > 0
-                ? (frictionEdges.reduce((sum, e) => sum + (e.confidence ?? 0), 0) /
-                      frictionEdges.length) *
-                  100
-                : 0;
-        const avgError =
-            errorEdges.length > 0
-                ? (errorEdges.reduce((sum, e) => sum + (e.confidence ?? 0), 0) /
-                      errorEdges.length) *
-                  100
-                : 0;
+        // Build sparklines first — all card values and deltas derive from the
+        // same timeseries source so card and sparkline always agree.
+        const activeFlagsSpark = mergeToSpark(timeseries, "FLAG_ACTIVATION_RATE");
+        const frictionSpark = mergeToSpark(timeseries, "FLAG_FRICTION_DELTA");
+        const errorSpark = mergeToSpark(timeseries, "FLAG_ERROR_RATE_DELTA");
+        const coverageRatioSpark = mergeToSpark(timeseries, "FLAG_COVERAGE_RATIO");
 
-        const totalReleases = getDistinctSourceIds(impact.edges).size || 1;
-        const withTelemetry = getDistinctSourceIds(impactEdges).size;
-        const coverageRatio = Math.round((withTelemetry / totalReleases) * 100);
+        // FLAG_FRICTION_DELTA and FLAG_ERROR_RATE_DELTA are exposed via the analytics
+        // timeseries API and are the canonical source for these card values.
+        // Using the last bucket ensures the card matches the sparkline endpoint.
+        const releaseFrictionDelta = latestFromSpark(frictionSpark) ?? 0;
+        const releaseErrorRateDelta = latestFromSpark(errorSpark) ?? 0;
+
+        // coverageRatio: source from FLAG_COVERAGE_RATIO timeseries (matches sparkline).
+        // Fall back to work-graph computation when no timeseries data is available.
+        // NOTE: The || 1 denominator fabrication has been removed — an empty release
+        // graph returns 0 rather than a synthetic 100% coverage figure.
+        const coverageRatioFromTimeseries = latestFromSpark(coverageRatioSpark);
+        let coverageRatio: number;
+        if (coverageRatioFromTimeseries !== null) {
+            coverageRatio = Math.round(coverageRatioFromTimeseries);
+        } else {
+            const impactEdges = impact.edges.filter((edge) => edge.edgeType === "IMPACTS");
+            const totalReleases = getDistinctSourceIds(impact.edges).size;
+            const withTelemetry = getDistinctSourceIds(impactEdges).size;
+            // When no releases exist yet, coverage is genuinely unknown — use 0.
+            coverageRatio =
+                totalReleases > 0 ? Math.round((withTelemetry / totalReleases) * 100) : 0;
+        }
+
+        // activeFlagsDelta and coverageRatioDelta are intentionally omitted:
+        // FLAG_ACTIVE_COUNT_DELTA and FLAG_COVERAGE_RATIO_DELTA are not yet exposed
+        // by the analytics schema. Using a proxy (e.g. FLAG_ACTIVATION_RATE first→last
+        // Δ) would conflate a rate measure with a count metric and mislead users.
+        // The card renders deltaUnavailableLabel ("No prior period") when the field
+        // is undefined — which is the honest state.
+        // TODO(backend): expose FLAG_ACTIVE_COUNT_DELTA + FLAG_COVERAGE_RATIO_DELTA.
 
         return {
             summary: {
                 activeFlags,
-                activeFlagsDelta: 0,
-                activeFlagsSpark: mergeToSpark(timeseries, "FLAG_ACTIVATION_RATE"),
-                releaseFrictionDelta: Math.round(avgFriction * 10) / 10,
-                releaseFrictionSeverity: classifySeverity(avgFriction),
-                releaseFrictionSpark: mergeToSpark(timeseries, "FLAG_FRICTION_DELTA"),
-                releaseErrorRateDelta: Math.round(-avgError * 10) / 10,
-                releaseErrorRateSpark: mergeToSpark(timeseries, "FLAG_ERROR_RATE_DELTA"),
+                // activeFlagsDelta: intentionally absent — see comment above
+                activeFlagsSpark,
+                releaseFrictionDelta,
+                releaseFrictionSeverity: classifySeverity(releaseFrictionDelta),
+                releaseFrictionSpark: frictionSpark,
+                releaseErrorRateDelta,
+                releaseErrorRateSpark: errorSpark,
                 coverageRatio,
-                coverageRatioDelta: 0,
-                coverageRatioSpark: mergeToSpark(timeseries, "FLAG_COVERAGE_RATIO"),
+                // coverageRatioDelta: intentionally absent — see comment above
+                coverageRatioSpark,
             },
         };
     } catch (error) {
         logger.error({ err: error }, "Failed to fetch feature flags summary");
-        return {
-            summary: {
-                activeFlags: 0,
-                activeFlagsDelta: 0,
-                activeFlagsSpark: [],
-                releaseFrictionDelta: 0,
-                releaseFrictionSeverity: "low",
-                releaseFrictionSpark: [],
-                releaseErrorRateDelta: 0,
-                releaseErrorRateSpark: [],
-                coverageRatio: 0,
-                coverageRatioDelta: 0,
-                coverageRatioSpark: [],
-            },
-        };
+        // Re-throw so callers receive an honest error signal rather than an
+        // all-zero summary that masquerades as healthy data.
+        throw error;
     }
 }
 

--- a/src/lib/feature-flags/sample-data.ts
+++ b/src/lib/feature-flags/sample-data.ts
@@ -22,7 +22,7 @@ function generateSparkline(
 export const SAMPLE_FEATURE_FLAGS_DATA: FeatureFlagsData = {
     summary: {
         activeFlags: 23,
-        activeFlagsDelta: 8.3,
+        // activeFlagsDelta omitted — FLAG_ACTIVE_COUNT_DELTA not yet exposed
         activeFlagsSpark: generateSparkline(14, 20, 2, 0.2),
 
         releaseFrictionDelta: 12.4,
@@ -33,7 +33,7 @@ export const SAMPLE_FEATURE_FLAGS_DATA: FeatureFlagsData = {
         releaseErrorRateSpark: generateSparkline(14, 5, 1.5, -0.1),
 
         coverageRatio: 72,
-        coverageRatioDelta: 5.2,
+        // coverageRatioDelta omitted — FLAG_COVERAGE_RATIO_DELTA not yet exposed
         coverageRatioSpark: generateSparkline(14, 65, 4, 0.5),
     },
 };

--- a/src/lib/feature-flags/types.ts
+++ b/src/lib/feature-flags/types.ts
@@ -29,7 +29,12 @@ export interface FeatureFlagData {
 
 export type FeatureFlagSummary = {
     activeFlags: number;
-    activeFlagsDelta: number;
+    /**
+     * Undefined when no backend measure for active-flag count delta is exposed
+     * (FLAG_ACTIVE_COUNT_DELTA is not yet in the analytics schema). The card
+     * renders its deltaUnavailableLabel ("No prior period") in this case.
+     */
+    activeFlagsDelta?: number;
     activeFlagsSpark: SparkPoint[];
 
     releaseFrictionDelta: number;
@@ -40,7 +45,12 @@ export type FeatureFlagSummary = {
     releaseErrorRateSpark: SparkPoint[];
 
     coverageRatio: number;
-    coverageRatioDelta: number;
+    /**
+     * Undefined when no backend measure for coverage-ratio delta is exposed
+     * (FLAG_COVERAGE_RATIO_DELTA is not yet in the analytics schema). The card
+     * renders its deltaUnavailableLabel ("No prior period") in this case.
+     */
+    coverageRatioDelta?: number;
     coverageRatioSpark: SparkPoint[];
 };
 

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -78,6 +78,12 @@ export const formatMetricValue = (value: number, unit: string) => {
     if (unit === "loc") {
         return formatNumber(value, { notation: "compact" });
     }
+    // Duration values are expressed in minutes by the time they reach the
+    // formatter (the fetcher normalises seconds→minutes for real data; sample
+    // data is already in minutes). The formatter only labels the unit.
+    if (unit === "m") {
+        return `${formatNumber(value, { maximumFractionDigits: 1 })}m`;
+    }
     return `${formatNumber(value)} ${unit}`.trim();
 };
 

--- a/src/lib/testops/__tests__/aggregateSeries.test.ts
+++ b/src/lib/testops/__tests__/aggregateSeries.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from "vitest";
+
+import { mergeSeriesByMeasure, getLatestValue, getSparkline, getDelta } from "../aggregateSeries";
+import { TESTOPS_MEASURES } from "../constants";
+import type { TimeseriesResult } from "@/lib/graphql/schemas/analytics";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSeries(
+    measure: string,
+    dimensionValue: string,
+    buckets: { date: string; value: number }[],
+): TimeseriesResult {
+    return { dimension: "TEAM", dimensionValue, measure, buckets };
+}
+
+// ---------------------------------------------------------------------------
+// mergeSeriesByMeasure
+// ---------------------------------------------------------------------------
+
+describe("mergeSeriesByMeasure", () => {
+    it("returns undefined when no series match the measureId", () => {
+        const result = mergeSeriesByMeasure([], "TEST_PASS_RATE");
+        expect(result).toBeUndefined();
+    });
+
+    it("returns the single series unchanged when only one matches", () => {
+        const single = makeSeries("TEST_PASS_RATE", "team-1", [{ date: "2024-01-01", value: 95 }]);
+        const result = mergeSeriesByMeasure([single], "TEST_PASS_RATE");
+        expect(result).toBe(single); // same reference — no copy
+    });
+
+    it("averages matching series for a rate/percentage measure (multi-team)", () => {
+        const teamA = makeSeries("TEST_FLAKE_RATE", "team-a", [
+            { date: "2024-01-01", value: 10 },
+            { date: "2024-01-02", value: 20 },
+        ]);
+        const teamB = makeSeries("TEST_FLAKE_RATE", "team-b", [
+            { date: "2024-01-01", value: 30 },
+            { date: "2024-01-02", value: 40 },
+        ]);
+        const result = mergeSeriesByMeasure([teamA, teamB], "TEST_FLAKE_RATE");
+
+        expect(result).toBeDefined();
+        expect(result!.dimensionValue).toBe("org");
+        expect(result!.measure).toBe("TEST_FLAKE_RATE");
+        expect(result!.buckets).toEqual([
+            { date: "2024-01-01", value: 20 }, // (10 + 30) / 2
+            { date: "2024-01-02", value: 30 }, // (20 + 40) / 2
+        ]);
+    });
+
+    it("sums matching series for a COUNT measure", () => {
+        const teamA = makeSeries("COUNT", "team-a", [{ date: "2024-01-01", value: 100 }]);
+        const teamB = makeSeries("COUNT", "team-b", [{ date: "2024-01-01", value: 200 }]);
+        const result = mergeSeriesByMeasure([teamA, teamB], "COUNT");
+
+        expect(result!.buckets[0].value).toBe(300); // 100 + 200
+    });
+
+    it("ignores series for other measures", () => {
+        const flake = makeSeries("TEST_FLAKE_RATE", "team-a", [{ date: "2024-01-01", value: 5 }]);
+        const pass = makeSeries("TEST_PASS_RATE", "team-a", [{ date: "2024-01-01", value: 90 }]);
+        const result = mergeSeriesByMeasure([flake, pass], "TEST_FLAKE_RATE");
+
+        expect(result!.buckets).toHaveLength(1);
+        expect(result!.buckets[0].value).toBe(5);
+    });
+
+    it("handles sparse teams — dates present in only some series", () => {
+        const teamA = makeSeries("PIPELINE_SUCCESS_RATE", "team-a", [
+            { date: "2024-01-01", value: 80 },
+            { date: "2024-01-02", value: 90 },
+        ]);
+        // team-b only has one date
+        const teamB = makeSeries("PIPELINE_SUCCESS_RATE", "team-b", [
+            { date: "2024-01-02", value: 70 },
+        ]);
+        const result = mergeSeriesByMeasure([teamA, teamB], "PIPELINE_SUCCESS_RATE");
+
+        // 2024-01-01: only team-a → 80 / 1 = 80
+        // 2024-01-02: both teams → (90 + 70) / 2 = 80
+        expect(result!.buckets).toEqual([
+            { date: "2024-01-01", value: 80 },
+            { date: "2024-01-02", value: 80 },
+        ]);
+    });
+
+    it("returns sorted dates ascending when series have out-of-order buckets", () => {
+        const teamA = makeSeries("TEST_PASS_RATE", "team-a", [
+            { date: "2024-01-03", value: 85 },
+            { date: "2024-01-01", value: 75 },
+        ]);
+        const teamB = makeSeries("TEST_PASS_RATE", "team-b", [{ date: "2024-01-02", value: 80 }]);
+        const result = mergeSeriesByMeasure([teamA, teamB], "TEST_PASS_RATE");
+        const dates = result!.buckets.map((b) => b.date);
+        expect(dates).toEqual(["2024-01-01", "2024-01-02", "2024-01-03"]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getLatestValue
+// ---------------------------------------------------------------------------
+
+describe("getLatestValue", () => {
+    it("returns undefined for empty timeseries", () => {
+        expect(getLatestValue([], "TEST_PASS_RATE")).toBeUndefined();
+    });
+
+    it("returns undefined for measure with empty buckets", () => {
+        const series = makeSeries("TEST_PASS_RATE", "team-a", []);
+        expect(getLatestValue([series], "TEST_PASS_RATE")).toBeUndefined();
+    });
+
+    it("returns the last bucket value of the merged series", () => {
+        const teamA = makeSeries("TEST_PASS_RATE", "team-a", [
+            { date: "2024-01-01", value: 80 },
+            { date: "2024-01-02", value: 90 },
+        ]);
+        const teamB = makeSeries("TEST_PASS_RATE", "team-b", [
+            { date: "2024-01-01", value: 60 },
+            { date: "2024-01-02", value: 70 },
+        ]);
+        // merged last bucket = (90 + 70) / 2 = 80
+        expect(getLatestValue([teamA, teamB], "TEST_PASS_RATE")).toBe(80);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getSparkline
+// ---------------------------------------------------------------------------
+
+describe("getSparkline", () => {
+    it("returns undefined when no series match", () => {
+        expect(getSparkline([], "TEST_FLAKE_RATE")).toBeUndefined();
+    });
+
+    it("returns sparkline points for merged series", () => {
+        const teamA = makeSeries("TEST_FLAKE_RATE", "team-a", [
+            { date: "2024-01-01", value: 4 },
+            { date: "2024-01-02", value: 6 },
+        ]);
+        const teamB = makeSeries("TEST_FLAKE_RATE", "team-b", [
+            { date: "2024-01-01", value: 8 },
+            { date: "2024-01-02", value: 10 },
+        ]);
+        const spark = getSparkline([teamA, teamB], "TEST_FLAKE_RATE");
+        expect(spark).toEqual([
+            { ts: "2024-01-01", value: 6 }, // (4 + 8) / 2
+            { ts: "2024-01-02", value: 8 }, // (6 + 10) / 2
+        ]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getDelta
+// ---------------------------------------------------------------------------
+
+describe("getDelta", () => {
+    it("returns undefined for empty timeseries", () => {
+        expect(getDelta([], "TEST_PASS_RATE")).toBeUndefined();
+    });
+
+    it("returns undefined when fewer than 2 buckets exist after merge", () => {
+        const series = makeSeries("TEST_PASS_RATE", "team-a", [{ date: "2024-01-01", value: 80 }]);
+        expect(getDelta([series], "TEST_PASS_RATE")).toBeUndefined();
+    });
+
+    it("returns undefined when first bucket value is zero (division guard)", () => {
+        const series = makeSeries("TEST_PASS_RATE", "team-a", [
+            { date: "2024-01-01", value: 0 },
+            { date: "2024-01-02", value: 50 },
+        ]);
+        expect(getDelta([series], "TEST_PASS_RATE")).toBeUndefined();
+    });
+
+    it("computes period-over-period delta for a single-team series", () => {
+        const series = makeSeries("TEST_PASS_RATE", "team-a", [
+            { date: "2024-01-01", value: 80 },
+            { date: "2024-01-10", value: 100 },
+        ]);
+        // ((100 - 80) / 80) * 100 = 25%
+        expect(getDelta([series], "TEST_PASS_RATE")).toBeCloseTo(25);
+    });
+
+    it("computes delta on the merged multi-team series, not a single team", () => {
+        // team-a: 20 → 40 alone would be +100%
+        // team-b: 80 → 80 alone would be 0%
+        // merged: (20+80)/2=50 → (40+80)/2=60 → ((60-50)/50)*100 = +20%
+        const teamA = makeSeries("PIPELINE_SUCCESS_RATE", "team-a", [
+            { date: "2024-01-01", value: 20 },
+            { date: "2024-01-10", value: 40 },
+        ]);
+        const teamB = makeSeries("PIPELINE_SUCCESS_RATE", "team-b", [
+            { date: "2024-01-01", value: 80 },
+            { date: "2024-01-10", value: 80 },
+        ]);
+        expect(getDelta([teamA, teamB], "PIPELINE_SUCCESS_RATE")).toBeCloseTo(20);
+    });
+
+    it("a multi-day merged series does not trip 'No trend yet' (length >= 2)", () => {
+        const teamA = makeSeries("TEST_FLAKE_RATE", "team-a", [
+            { date: "2024-01-01", value: 5 },
+            { date: "2024-01-02", value: 3 },
+            { date: "2024-01-03", value: 4 },
+        ]);
+        const teamB = makeSeries("TEST_FLAKE_RATE", "team-b", [
+            { date: "2024-01-01", value: 7 },
+            { date: "2024-01-02", value: 5 },
+            { date: "2024-01-03", value: 6 },
+        ]);
+        const merged = mergeSeriesByMeasure([teamA, teamB], "TEST_FLAKE_RATE");
+        // Merged has 3 buckets — getDelta should return a number, not undefined
+        expect(merged!.buckets.length).toBeGreaterThanOrEqual(2);
+        expect(getDelta([teamA, teamB], "TEST_FLAKE_RATE")).not.toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// goodDirection / inverseGood regression (C2)
+// ---------------------------------------------------------------------------
+
+describe("getDelta truthfulness + goodDirection for inverseGood wiring", () => {
+    it("FAILURE_RATE increase: getDelta returns the RAW positive number (+100%), not negated", () => {
+        // Regression guard: the displayed number must be truthful.
+        // A Failure Rate going 5% → 10% is an increase of +100% — the raw delta
+        // must stay +100% so MetricDelta can render "↑ +100%" (correct direction
+        // and number). MetricCard sets inverseGood=true for this metric so
+        // MetricDelta colours the positive delta RED (caution), not green.
+        const failureSeries = makeSeries("PIPELINE_FAILURE_RATE", "team-a", [
+            { date: "2024-01-01", value: 5 },
+            { date: "2024-01-10", value: 10 },
+        ]);
+        const delta = getDelta([failureSeries], "PIPELINE_FAILURE_RATE");
+
+        // Number must be truthful — an increase stays positive
+        expect(delta).toBeGreaterThan(0);
+        expect(delta).toBeCloseTo(100); // (10-5)/5 * 100
+
+        // goodDirection "down" on this metric means the PAGE passes inverseGood=true
+        // to MetricCard → MetricDelta colours a positive delta as caution (red).
+        expect(TESTOPS_MEASURES["PIPELINE_FAILURE_RATE"].goodDirection).toBe("down");
+    });
+
+    it("PASS_RATE increase: getDelta returns a positive number and goodDirection is 'up' (green)", () => {
+        const passSeries = makeSeries("TEST_PASS_RATE", "team-a", [
+            { date: "2024-01-01", value: 90 },
+            { date: "2024-01-10", value: 99 },
+        ]);
+        const delta = getDelta([passSeries], "TEST_PASS_RATE");
+
+        expect(delta).toBeGreaterThan(0);
+        // goodDirection "up" → inverseGood=false → positive delta colours green (correct)
+        expect(TESTOPS_MEASURES["TEST_PASS_RATE"].goodDirection).toBe("up");
+    });
+
+    it("all 'down' metrics in TESTOPS_MEASURES have goodDirection === 'down'", () => {
+        const downMetrics = [
+            "PIPELINE_FAILURE_RATE",
+            "PIPELINE_DURATION_P95",
+            "PIPELINE_QUEUE_TIME",
+            "PIPELINE_RERUN_RATE",
+            "TEST_FAILURE_RATE",
+            "TEST_FLAKE_RATE",
+            "TEST_SUITE_DURATION_P95",
+        ];
+        for (const id of downMetrics) {
+            expect(TESTOPS_MEASURES[id]?.goodDirection).toBe("down");
+        }
+    });
+});

--- a/src/lib/testops/__tests__/fetchers.test.ts
+++ b/src/lib/testops/__tests__/fetchers.test.ts
@@ -9,7 +9,12 @@ vi.mock("@/lib/graphql/urqlClient", () => ({
     graphqlFetch: vi.fn(),
 }));
 
-import { fetchRiskMetrics, fetchTestOpsData, fetchCoverageMetrics } from "../fetchers";
+import {
+    fetchRiskMetrics,
+    fetchTestOpsData,
+    fetchCoverageMetrics,
+    normalizeAnalyticsDurations,
+} from "../fetchers";
 import { SAMPLE_RISK_DATA } from "../sample-data";
 import { auth } from "@/lib/auth";
 import { graphqlFetch } from "@/lib/graphql/urqlClient";
@@ -142,5 +147,96 @@ describe("fetchCoverageMetrics schema hardening (CHAOS-2078)", () => {
         const result = await fetchCoverageMetrics({ timeseries: [], breakdowns: [] }, false);
 
         expect(result).toEqual(good);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeAnalyticsDurations (C1 regression guard)
+// ---------------------------------------------------------------------------
+
+describe("normalizeAnalyticsDurations", () => {
+    it("converts PIPELINE_DURATION_P95 bucket values from seconds to minutes", () => {
+        const input = {
+            timeseries: [
+                {
+                    dimension: "TEAM",
+                    dimensionValue: "all",
+                    measure: "PIPELINE_DURATION_P95",
+                    buckets: [
+                        { date: "2024-01-01", value: 720 }, // 720s = 12 min
+                        { date: "2024-01-02", value: 600 }, // 600s = 10 min
+                    ],
+                },
+            ],
+            breakdowns: [],
+        };
+        const result = normalizeAnalyticsDurations(input);
+        const ts = result.timeseries[0];
+        expect(ts.buckets[0].value).toBeCloseTo(12);
+        expect(ts.buckets[1].value).toBeCloseTo(10);
+    });
+
+    it("converts PIPELINE_QUEUE_TIME and TEST_SUITE_DURATION_P95 values", () => {
+        const input = {
+            timeseries: [
+                {
+                    dimension: "TEAM",
+                    dimensionValue: "all",
+                    measure: "PIPELINE_QUEUE_TIME",
+                    buckets: [{ date: "2024-01-01", value: 60 }], // 60s = 1 min
+                },
+                {
+                    dimension: "TEAM",
+                    dimensionValue: "all",
+                    measure: "TEST_SUITE_DURATION_P95",
+                    buckets: [{ date: "2024-01-01", value: 258 }], // 258s = 4.3 min
+                },
+            ],
+            breakdowns: [],
+        };
+        const result = normalizeAnalyticsDurations(input);
+        expect(result.timeseries[0].buckets[0].value).toBeCloseTo(1);
+        expect(result.timeseries[1].buckets[0].value).toBeCloseTo(4.3);
+    });
+
+    it("does NOT convert non-duration measures (e.g. PIPELINE_SUCCESS_RATE)", () => {
+        const input = {
+            timeseries: [
+                {
+                    dimension: "TEAM",
+                    dimensionValue: "all",
+                    measure: "PIPELINE_SUCCESS_RATE",
+                    buckets: [{ date: "2024-01-01", value: 92 }],
+                },
+            ],
+            breakdowns: [],
+        };
+        const result = normalizeAnalyticsDurations(input);
+        // Value must remain 92 — dividing by 60 would corrupt the percentage
+        expect(result.timeseries[0].buckets[0].value).toBe(92);
+    });
+
+    it("sample data passthrough — 12 stays 12 (not converted a second time)", () => {
+        // Sample PIPELINE_DURATION_P95 last value is 12 (already in minutes).
+        // normalizeAnalyticsDurations is NOT called on sample data paths;
+        // this test guards against accidental double-conversion if it were.
+        const sampleLike = {
+            timeseries: [
+                {
+                    dimension: "TEAM",
+                    dimensionValue: "all",
+                    measure: "PIPELINE_SUCCESS_RATE", // non-duration, must pass through
+                    buckets: [{ date: "2024-01-07", value: 91 }],
+                },
+            ],
+            breakdowns: [],
+        };
+        const result = normalizeAnalyticsDurations(sampleLike);
+        expect(result.timeseries[0].buckets[0].value).toBe(91);
+    });
+
+    it("returns empty timeseries unchanged", () => {
+        const input = { timeseries: [], breakdowns: [] };
+        expect(normalizeAnalyticsDurations(input)).toEqual(input);
     });
 });

--- a/src/lib/testops/aggregateSeries.ts
+++ b/src/lib/testops/aggregateSeries.ts
@@ -1,0 +1,109 @@
+import type { TimeseriesResult, TimeseriesBucket } from "@/lib/graphql/schemas/analytics";
+
+// Measures that represent raw counts and should be **summed** when merging
+// across teams. All other measures (rates, percentages, percentiles, durations)
+// are **averaged** — summing percentages or p95 latencies across teams is
+// mathematically wrong.
+//
+// Approximation note: a volume-weighted org rollup would be more accurate for
+// rate measures (e.g. weighting PIPELINE_SUCCESS_RATE by pipeline count per
+// team). That requires server-side denominator data not yet available in the
+// per-team TimeseriesResult payload. A client-side unweighted mean is the best
+// available approximation; it may diverge from the true org rate when teams
+// have very different volumes. The correct long-term fix is to compute the
+// aggregate server-side and return a single org-level series — tracked as a
+// deferred backend improvement.
+const COUNT_MEASURES = new Set(["COUNT"]);
+
+function isSumMeasure(measureId: string): boolean {
+    return COUNT_MEASURES.has(measureId);
+}
+
+/**
+ * Merges every `TimeseriesResult` whose `measure === measureId` into a single
+ * synthetic org-level series by combining values per date bucket across teams.
+ *
+ * - Rate / percentage / percentile / duration measures → **mean** per date.
+ * - Raw-count measures (`COUNT`) → **sum** per date.
+ *
+ * Returns `undefined` when no matching series exist (matches prior `.find()`
+ * behaviour so callers can still check for `undefined`).
+ */
+export function mergeSeriesByMeasure(
+    timeseries: TimeseriesResult[],
+    measureId: string,
+): TimeseriesResult | undefined {
+    const matching = timeseries.filter((s) => s.measure === measureId);
+    if (matching.length === 0) return undefined;
+    if (matching.length === 1) return matching[0];
+
+    // Accumulate all values per date across every team series.
+    const dateMap = new Map<string, number[]>();
+    for (const series of matching) {
+        for (const bucket of series.buckets) {
+            const existing = dateMap.get(bucket.date);
+            if (existing) {
+                existing.push(bucket.value);
+            } else {
+                dateMap.set(bucket.date, [bucket.value]);
+            }
+        }
+    }
+
+    // Sort dates ascending, matching the SQL `bucket ASC` ordering.
+    const sortedDates = Array.from(dateMap.keys()).sort();
+
+    const useSum = isSumMeasure(measureId);
+    const mergedBuckets: TimeseriesBucket[] = sortedDates.map((date) => {
+        const values = dateMap.get(date)!;
+        const total = values.reduce((a, b) => a + b, 0);
+        const combined = useSum ? total : total / values.length;
+        return { date, value: combined };
+    });
+
+    return {
+        dimension: matching[0].dimension,
+        // "org" signals this is a rolled-up aggregate, not a single-team series.
+        dimensionValue: "org",
+        measure: measureId,
+        buckets: mergedBuckets,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Page-level helpers (shared across tests, pipelines, and overview pages)
+// ---------------------------------------------------------------------------
+
+/** Returns the most recent bucket value for `measureId`, merged across all teams. */
+export function getLatestValue(
+    timeseries: TimeseriesResult[],
+    measureId: string,
+): number | undefined {
+    const series = mergeSeriesByMeasure(timeseries, measureId);
+    if (!series || series.buckets.length === 0) return undefined;
+    return series.buckets[series.buckets.length - 1].value;
+}
+
+/** Returns sparkline data for `measureId`, merged across all teams. */
+export function getSparkline(
+    timeseries: TimeseriesResult[],
+    measureId: string,
+): { ts: string; value: number }[] | undefined {
+    const series = mergeSeriesByMeasure(timeseries, measureId);
+    if (!series) return undefined;
+    return series.buckets.map((b: TimeseriesBucket) => ({ ts: b.date, value: b.value }));
+}
+
+/**
+ * Period-over-period change (%) from first to last bucket, merged across all
+ * teams. Returns `undefined` when history is insufficient.
+ */
+export function getDelta(timeseries: TimeseriesResult[], measureId: string): number | undefined {
+    const series = mergeSeriesByMeasure(timeseries, measureId);
+    const buckets = series?.buckets;
+    if (!buckets || buckets.length < 2) return undefined;
+    const prev = buckets[0].value;
+    const curr = buckets[buckets.length - 1].value;
+    if (prev === 0) return undefined;
+    return ((curr - prev) / Math.abs(prev)) * 100;
+}

--- a/src/lib/testops/fetchers.ts
+++ b/src/lib/testops/fetchers.ts
@@ -23,6 +23,33 @@ import {
 
 const EMPTY_ANALYTICS: AnalyticsResult = { timeseries: [], breakdowns: [] };
 
+// Duration measures whose backend buckets are stored in seconds. Sample data is
+// already in minutes, so this normalisation is applied only in real (non-test) mode.
+const DURATION_MEASURES_SECONDS = new Set([
+    "PIPELINE_DURATION_P95",
+    "PIPELINE_QUEUE_TIME",
+    "TEST_SUITE_DURATION_P95",
+]);
+
+/**
+ * Converts duration-measure bucket values from seconds to minutes.
+ * All other measures are passed through unchanged.
+ * Safe to call with empty / partial results.
+ */
+export function normalizeAnalyticsDurations(result: AnalyticsResult): AnalyticsResult {
+    return {
+        ...result,
+        timeseries: result.timeseries.map((series) =>
+            DURATION_MEASURES_SECONDS.has(series.measure)
+                ? {
+                      ...series,
+                      buckets: series.buckets.map((b) => ({ ...b, value: b.value / 60 })),
+                  }
+                : series,
+        ),
+    };
+}
+
 /** Resolve orgId from the auth session, falling back to "default-org". */
 async function resolveOrgId(orgId?: string): Promise<string> {
     if (orgId) return orgId;
@@ -60,9 +87,12 @@ export async function fetchTestOpsData(
             }),
         ]);
 
+        // Normalise duration measures from seconds (backend) to minutes so that
+        // the display layer (formatMetricValue with unit "m") can label without
+        // converting. Sample data is already in minutes and is NOT passed here.
         return {
-            pipelines: pipelinesRes.analytics,
-            tests: testsRes.analytics,
+            pipelines: normalizeAnalyticsDurations(pipelinesRes.analytics),
+            tests: normalizeAnalyticsDurations(testsRes.analytics),
             coverage: coverageRes.analytics,
         };
     } catch (error) {


### PR DESCRIPTION
## Summary

Frontend half of the **Govern IA audit** ([CHAOS-2165](https://linear.app/fullchaos/issue/CHAOS-2165)) — TestOps / Quality / Feature-Flags correctness fixes from the 2026-06-09 screenshot audit, hardened by a **codex adversarial review** and a **Penpot / design-system alignment** pass.

## Issues addressed
| Issue | Fix |
|---|---|
| CHAOS-2166 | `SparklineChart` tooltip date `formatter` (shared) — kills the raw `2026-06-04T00:00:00` artifact |
| CHAOS-2167 | TestOps per-team `.find()` → org-level aggregation (`aggregateSeries.ts`, mean/sum by measure type) |
| CHAOS-2168 | Duration normalized seconds→minutes at the **fetcher boundary** (real-data path only; sample data already in minutes, untouched) |
| CHAOS-2169 | Feature-flag cards use real measures; count/coverage deltas honestly "No prior period" (no rate-as-count proxy); page degrades to `ServiceUnavailable` instead of tripping the heavy `(app)/error.tsx` |
| CHAOS-2175 | `MetricCard` `href` optional → honest non-link cards (**matches Penpot** — Govern cards have no drill-down); Overview deltas wired |

## Adversarial-review fixes (codex, 3× P2)
- **Duration layer:** the global ÷60 in `formatMetricValue` broke sample-mode (already minutes); moved to the fetcher boundary.
- **Delta direction:** a lower-is-better increase rendered green. Now `MetricDelta.inverseGood` colors it caution **without inverting the displayed number** (`MetricCard` forwards `inverseGood`; pages pass `goodDirection === "down"`).
- **Honest deltas:** removed the activation-rate→count proxy (showed `+4%` when the count was unchanged).
- **Graceful failure:** the honest re-throw no longer trips the full-app error boundary — page renders a local `DataState` error, sidebar intact.

## Design alignment (CHAOS-2176)
- `MetricCard` caption → `Open evidence`; `docs/design-system.md` Part D registers `Present in view` and migrates `Open in Explore → Open evidence`.
- Penpot mock sync (duration units + CTA labels) tracked in **CHAOS-2176** (the Penpot file was read-only this session).

## Verification
`tsc --noEmit` clean · **vitest 1827 pass** · `design-lint` clean · prettier clean. Codex adversarial + Penpot/design-system reviews — all findings resolved.

SCREENSHOT-WAIVER: The most visible changes (durations→minutes, non-zero rerun rate, real CFR) only render correctly after a `dev-hops fixtures generate --with-metrics` reseed (data-state, not code — see CHAOS-2170). Frontend-only changes are component/unit-tested; visual verification per `docs/agent-visual-testing.md` is recommended post-reseed.

Related: CHAOS-2165 (epic) · CHAOS-2166–2169 / 2175 · CHAOS-2176 (Penpot) · the dev-health-ops PR (backend half).
