### PR TITLE
CHAOS-2177: Fix Security filter base64url crash (browser-safe encode/decode)

### DIFF
--- a/src/lib/filters/__tests__/security.browser.test.tsx
+++ b/src/lib/filters/__tests__/security.browser.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Browser (jsdom) environment tests for encodeSecurityFilter / decodeSecurityFilter.
+ *
+ * This file lives alongside security.test.ts but uses the .tsx extension so
+ * vitest picks it up under the "components" project (environment: "jsdom") per
+ * vitest.config.ts — that's where the Buffer polyfill is active and where the
+ * "base64url" encoding bug manifested as:
+ *   TypeError: Unknown encoding: base64url
+ *
+ * The node-env tests in security.test.ts exercise the same code but with
+ * Node's native Buffer, which supports "base64url". These tests verify the fix
+ * holds specifically in the polyfill context that crashed the browser.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+    decodeSecurityFilter,
+    defaultSecurityFilter,
+    encodeSecurityFilter,
+} from "@/lib/filters/security";
+import type { SecurityFilter } from "@/lib/filters/security";
+
+describe("encodeSecurityFilter / decodeSecurityFilter — browser (jsdom) environment", () => {
+    it("round-trips a filter with all three pill dimensions without throwing", () => {
+        const filter: SecurityFilter = {
+            severities: ["critical", "high"],
+            states: ["open", "detected"],
+            sources: ["dependabot", "code_scanning"],
+        };
+        // Must not throw (the "base64url" bug crashed here in jsdom)
+        const encoded = encodeSecurityFilter(filter);
+        const decoded = decodeSecurityFilter(encoded);
+        expect(decoded).toEqual(filter);
+    });
+
+    it("round-trips a filter containing non-ASCII values (UTF-8 safety)", () => {
+        // Repo and team names can contain accented characters, CJK, emoji, etc.
+        const filter: SecurityFilter = {
+            severities: ["medium"],
+            states: ["open"],
+            sources: ["advisory"],
+            search: "répo-名前-🔒",
+        };
+        const encoded = encodeSecurityFilter(filter);
+        expect(() => decodeSecurityFilter(encoded)).not.toThrow();
+        const decoded = decodeSecurityFilter(encoded);
+        expect(decoded).toEqual(filter);
+    });
+
+    it("encoded value is a valid base64url string (no +, /, or = characters)", () => {
+        const encoded = encodeSecurityFilter({ severities: ["critical"], openOnly: true });
+        expect(encoded).not.toMatch(/[+/=]/);
+    });
+
+    it("decodeSecurityFilter returns default when given undefined", () => {
+        expect(decodeSecurityFilter(undefined)).toEqual(defaultSecurityFilter());
+    });
+
+    it("decodeSecurityFilter returns default on invalid input without throwing", () => {
+        expect(() => decodeSecurityFilter("!!!not-valid!!!")).not.toThrow();
+        expect(decodeSecurityFilter("!!!not-valid!!!")).toEqual(defaultSecurityFilter());
+    });
+});

--- a/src/lib/filters/security.ts
+++ b/src/lib/filters/security.ts
@@ -1,18 +1,50 @@
+/**
+ * Encodes a UTF-8 string as base64url.
+ *
+ * Uses "base64" (not "base64url") when a Buffer is present because the
+ * browser Buffer polyfill (injected by Next.js/webpack) does NOT support
+ * the "base64url" encoding name and throws `TypeError: Unknown encoding`.
+ * The URL-safe substitution is applied manually instead.
+ *
+ * Falls back to TextEncoder + btoa for environments where Buffer is absent.
+ */
 const toBase64Url = (value: string): string => {
+    let base64: string;
     if (typeof Buffer !== "undefined") {
-        return Buffer.from(value, "utf-8").toString("base64url");
+        // "base64" is supported by the browser polyfill; "base64url" is not.
+        base64 = Buffer.from(value, "utf-8").toString("base64");
+    } else {
+        // TextEncoder guarantees correct UTF-8 byte handling (unlike raw btoa).
+        const bytes = new TextEncoder().encode(value);
+        let binary = "";
+        for (let i = 0; i < bytes.length; i++) {
+            binary += String.fromCharCode(bytes[i]);
+        }
+        base64 = btoa(binary);
     }
-    const encoded = btoa(unescape(encodeURIComponent(value)));
-    return encoded.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+    return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 };
 
+/**
+ * Decodes a base64url string to a UTF-8 string.
+ * Symmetric counterpart to toBase64Url — restores standard base64 padding
+ * and characters before decoding so the round-trip is lossless.
+ */
 const fromBase64Url = (value: string): string => {
-    if (typeof Buffer !== "undefined") {
-        return Buffer.from(value, "base64url").toString("utf-8");
-    }
+    // Restore standard base64: swap url-safe chars back and re-pad to 4-char boundary.
     const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
     const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
-    return decodeURIComponent(escape(atob(padded)));
+    if (typeof Buffer !== "undefined") {
+        // "base64" is supported by the browser polyfill; "base64url" is not.
+        return Buffer.from(padded, "base64").toString("utf-8");
+    }
+    // TextDecoder guarantees correct UTF-8 decoding (unlike escape/decodeURIComponent).
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return new TextDecoder().decode(bytes);
 };
 
 const stableStringify = (input: unknown): string => {


### PR DESCRIPTION
## Summary

Fixes **CHAOS-2177** — Govern → Security filter pills crashed with `Unknown encoding: base64url` on every click, so **all security filtering was dead**.

## Root cause

`toBase64Url` (`src/lib/filters/security.ts`) encoded via Node Buffer's `"base64url"` encoding. In the browser, `Buffer` is the webpack polyfill — it supports `"base64"`/`"utf-8"` but **not** `"base64url"` → `TypeError`. The encode runs client-side on pill click, and `typeof Buffer !== "undefined"` is `true` in the browser, so it always took the broken path.

## Fix

`toBase64Url` + `fromBase64Url` now use standard `"base64"` + manual URL-safe substitution (`+`→`-`, `/`→`_`, strip `=`), symmetric, UTF-8 via TextEncoder/TextDecoder (Buffer utf-8 on the Node path). **Output is bit-for-bit identical to the previous `base64url` output — no URL format change; existing encoded filter links still decode.**

## Verification

`tsc --noEmit` clean · **5 jsdom round-trip tests** (all three filter dims + non-ASCII), run in the jsdom vitest project where the Buffer polyfill is active and the bug manifested.

## Follow-on (out of scope, filed)

**CHAOS-2178** — `encode.ts` (MetricFilter) and `ai.ts` carry the same `base64url` call but guard on `isServer` (browser takes a safe else-branch), so they don't crash today — latent. Recommend extracting a shared `toBase64Url`/`fromBase64Url` helper.

Related: CHAOS-2165 (govern epic) · CHAOS-2128 (filter-bar implementation).
