### PR TITLE
feat(improve): real getImproveSignals resolver with Opportunities data (CHAOS-2217)

### DIFF
--- a/src/app/(app)/opportunities/page.tsx
+++ b/src/app/(app)/opportunities/page.tsx
@@ -70,7 +70,13 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
                                 activeRole={activeRole}
                             />
                         ))}
-                        {!data?.items?.length && (
+                        {data && data.items.length === 0 && (
+                            <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
+                                No open opportunities in this window — nothing is trending worse for
+                                the current scope.
+                            </div>
+                        )}
+                        {!data && (
                             <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
                                 Opportunity data unavailable.
                             </div>

--- a/src/components/navigation/AreaHub.test.tsx
+++ b/src/components/navigation/AreaHub.test.tsx
@@ -122,6 +122,32 @@ describe("AreaHub — severity-sorted signal cards", () => {
         expect(order[order.length - 1]).toBe("gap");
     });
 
+    it("renders a PREVIEW unavailable signal as a non-clickable card (no <a>, cannot 404)", () => {
+        // CHAOS-2217: a preview sub-area (route not built yet) must NOT be a link.
+        // A normal unavailable card (route exists) stays clickable.
+        renderHub([
+            signal("routed", "unavailable", "Quality"),
+            signal("preview", "unavailable", "Quality", { preview: true }),
+        ]);
+
+        const routed = screen
+            .getAllByTestId("area-signal-card")
+            .find((c) => c.getAttribute("data-signal-id") === "routed")!;
+        const preview = screen
+            .getAllByTestId("area-signal-card")
+            .find((c) => c.getAttribute("data-signal-id") === "preview")!;
+
+        // Preview card: non-interactive div, flagged, still shows the honest empty state.
+        expect(preview.tagName).not.toBe("A");
+        expect(preview.getAttribute("data-preview")).toBe("true");
+        expect(preview.getAttribute("aria-disabled")).toBe("true");
+        expect(within(preview).getByTestId("area-signal-unavailable")).toBeInTheDocument();
+
+        // Routed unavailable card: still a link (mocked next/link → <a>), no preview flag.
+        expect(routed.tagName).toBe("A");
+        expect(routed.getAttribute("data-preview")).toBeNull();
+    });
+
     it("emphasizes the single most-severe severity-bearing signal exactly once", () => {
         renderHub([
             signal("low", "low", "Quality"),

--- a/src/components/navigation/AreaOverview.test.tsx
+++ b/src/components/navigation/AreaOverview.test.tsx
@@ -125,4 +125,25 @@ describe("AreaOverview — summarize + route (no hero/grid duplication)", () => 
         expect(within(emptyTier).getAllByRole("link")).toHaveLength(2);
         expect(within(emptyTier).queryAllByTestId("area-signal-card")).toHaveLength(0);
     });
+
+    it("renders a PREVIEW empty-tier chip as non-clickable, a routed one as a link (CHAOS-2217)", () => {
+        renderOverview([
+            signal("routed", "unavailable"),
+            signal("preview", "unavailable", { preview: true }),
+        ]);
+        const emptyTier = screen.getByTestId("area-overview-empty-tier");
+
+        // The preview chip is NOT a link (dead route can't 404) but stays visible.
+        const previewChip = within(emptyTier)
+            .getAllByText((_, el) => el?.getAttribute("data-signal-id") === "preview")
+            .find((el) => el.getAttribute("data-signal-id") === "preview")!;
+        expect(previewChip.tagName).not.toBe("A");
+        expect(previewChip.getAttribute("aria-disabled")).toBe("true");
+
+        // The routed unavailable chip remains a link.
+        const routedLink = within(emptyTier).getByRole("link", { name: "routed" });
+        expect(routedLink).toHaveAttribute("data-signal-id", "routed");
+        // Exactly one link in the tier (only the routed one).
+        expect(within(emptyTier).getAllByRole("link")).toHaveLength(1);
+    });
 });

--- a/src/components/navigation/AreaOverview.tsx
+++ b/src/components/navigation/AreaOverview.tsx
@@ -112,16 +112,32 @@ export function AreaOverview({
                         <span className="mr-1 text-xs uppercase tracking-[0.18em]">
                             Not yet connected
                         </span>
-                        {unavailable.map((signal) => (
-                            <Link
-                                key={signal.id}
-                                href={withFilterParam(signal.href, filters, role)}
-                                data-signal-id={signal.id}
-                                className="rounded-full border border-(--card-stroke) bg-(--card-80) px-3 py-1 text-xs font-medium text-foreground transition hover:border-(--accent)"
-                            >
-                                {signal.label}
-                            </Link>
-                        ))}
+                        {unavailable.map((signal) => {
+                            const chipClassName =
+                                "rounded-full border border-(--card-stroke) bg-(--card-80) px-3 py-1 text-xs font-medium text-foreground";
+                            // Preview sub-area (route not built yet) → non-clickable chip so
+                            // it can't 404; a real-but-unconnected sub-area stays a link.
+                            return signal.preview === true ? (
+                                <span
+                                    key={signal.id}
+                                    data-signal-id={signal.id}
+                                    data-preview="true"
+                                    aria-disabled="true"
+                                    className={chipClassName}
+                                >
+                                    {signal.label}
+                                </span>
+                            ) : (
+                                <Link
+                                    key={signal.id}
+                                    href={withFilterParam(signal.href, filters, role)}
+                                    data-signal-id={signal.id}
+                                    className={`${chipClassName} transition hover:border-(--accent)`}
+                                >
+                                    {signal.label}
+                                </Link>
+                            );
+                        })}
                     </div>
                 </div>
             ) : null}

--- a/src/components/navigation/AreaSignalCard.tsx
+++ b/src/components/navigation/AreaSignalCard.tsx
@@ -34,19 +34,20 @@ type AreaSignalCardProps = {
 export function AreaSignalCard({ signal, filters, role, emphasized = false }: AreaSignalCardProps) {
     const href = withFilterParam(signal.href, filters, role);
     const demoted = signal.demoted === true;
+    // Preview sub-area: its route does not exist yet (nav child `preview: true`).
+    // Render the card NON-CLICKABLE so it stays visible + honest but can't 404.
+    // Keyed on the explicit `preview` flag, NOT on `state === "unavailable"`,
+    // which is shared by areas whose routes DO exist and must stay clickable.
+    const isPreview = signal.preview === true;
 
-    // Unavailable → inline DataState (never a fabricated value). Still a link so
-    // the sub-area stays reachable from the card.
+    // Unavailable → inline DataState (never a fabricated value). A real (routed)
+    // sub-area stays a link so it remains reachable; a preview sub-area renders as
+    // a plain <div> (same visual) so the dead route is never linked.
     if (signal.state === "unavailable") {
-        return (
-            <Link
-                href={href}
-                data-testid="area-signal-card"
-                data-signal-id={signal.id}
-                data-state="unavailable"
-                data-tier="muted"
-                className="group block rounded-2xl border border-dashed border-(--card-stroke)/70 bg-(--card-80)/60 p-4 opacity-70 transition hover:border-(--accent) hover:opacity-100"
-            >
+        const unavailableClassName =
+            "group block rounded-2xl border border-dashed border-(--card-stroke)/70 bg-(--card-80)/60 p-4 opacity-70 transition hover:border-(--accent) hover:opacity-100";
+        const body = (
+            <>
                 <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
                     {signal.label}
                 </p>
@@ -57,6 +58,35 @@ export function AreaSignalCard({ signal, filters, role, emphasized = false }: Ar
                     className="mt-3"
                     data-testid="area-signal-unavailable"
                 />
+            </>
+        );
+
+        if (isPreview) {
+            return (
+                <div
+                    data-testid="area-signal-card"
+                    data-signal-id={signal.id}
+                    data-state="unavailable"
+                    data-tier="muted"
+                    data-preview="true"
+                    aria-disabled="true"
+                    className={unavailableClassName}
+                >
+                    {body}
+                </div>
+            );
+        }
+
+        return (
+            <Link
+                href={href}
+                data-testid="area-signal-card"
+                data-signal-id={signal.id}
+                data-state="unavailable"
+                data-tier="muted"
+                className={unavailableClassName}
+            >
+                {body}
             </Link>
         );
     }

--- a/src/lib/api/home.ts
+++ b/src/lib/api/home.ts
@@ -26,9 +26,16 @@ export async function getExplainData(params: { metric: string; filters: MetricFi
     );
 }
 
-export async function getOpportunities(filters: MetricFilter) {
+/**
+ * Per-request memoized opportunities fetch. React.cache() deduplicates calls
+ * within a single RSC render tree so the /opportunities page and the Improve
+ * area-signal resolver (getImproveSignals) share ONE POST instead of issuing two
+ * identical requests per render — and read from the same list/count snapshot.
+ * Safe to memoize: getOpportunities is only ever called server-side (RSC).
+ */
+export const getOpportunities = cache(async function getOpportunities(filters: MetricFilter) {
     const normalized = normalizeFilters(filters);
     return postJson<OpportunitiesResponse>("/api/v1/opportunities", { filters: normalized }, 120, {
         f: encodeFilterParam(normalized),
     });
-}
+});

--- a/src/lib/areaSignals/__tests__/improve.test.ts
+++ b/src/lib/areaSignals/__tests__/improve.test.ts
@@ -1,29 +1,167 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// ── Mock the Improve source at the module boundary ────────────────────────────
+// The resolver calls getOpportunities; we drive it independently to assert the
+// source → AreaSignal mapping without any network.
+
+vi.mock("@/lib/api/home", () => ({
+    getOpportunities: vi.fn(),
+}));
+vi.mock("@/lib/logger", () => ({
+    logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { getOpportunities } from "@/lib/api/home";
 import { defaultMetricFilter } from "@/lib/filters/defaults";
 
 import { getImproveSignals } from "../improve";
+import type { AreaSignal } from "../types";
 
-describe("getImproveSignals — Improve taxonomy (CHAOS-2079)", () => {
-    it("returns the real Opportunities route as an unavailable summary signal", async () => {
-        const signals = await getImproveSignals(defaultMetricFilter);
-        expect(signals).toEqual([
-            expect.objectContaining({
-                id: "opportunities",
-                label: "Opportunities",
-                href: "/opportunities",
-                state: "unavailable",
-                value: "",
-            }),
-        ]);
+const mockGetOpportunities = vi.mocked(getOpportunities);
+
+function byId(signals: AreaSignal[]): Record<string, AreaSignal> {
+    return Object.fromEntries(signals.map((s) => [s.id, s]));
+}
+
+const opportunityItem = (evidenceLinks: string[] = []) => ({
+    id: "opp-1",
+    title: "Reduce cycle time",
+    rationale: "Cycle time is high",
+    evidence_links: evidenceLinks,
+    suggested_experiments: [],
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: some opportunities with evidence links
+    mockGetOpportunities.mockResolvedValue({
+        items: [
+            opportunityItem(["https://example.com/evidence"]),
+            opportunityItem([]),
+        ],
+    } as never);
+});
+
+describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
+    it("returns real Opportunities signal with count and evidence-linked count", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+
+        expect(signals.opportunities).toMatchObject({
+            id: "opportunities",
+            label: "Opportunities",
+            href: "/opportunities",
+            state: "neutral",
+            value: "2 OPEN · 1 EVIDENCE-LINKED",
+        });
     });
 
-    it("returns the same unavailable summary signal in test mode", async () => {
-        const signals = await getImproveSignals(defaultMetricFilter, true);
-        expect(signals).toHaveLength(1);
-        expect(signals[0]).toMatchObject({
-            id: "opportunities",
+    it("shows only OPEN count when no evidence-linked opportunities", async () => {
+        mockGetOpportunities.mockResolvedValue({
+            items: [opportunityItem([]), opportunityItem([])],
+        } as never);
+
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.opportunities).toMatchObject({
+            state: "neutral",
+            value: "2 OPEN",
+        });
+    });
+
+    it("emits UNAVAILABLE for Opportunities when fetch returns empty items", async () => {
+        mockGetOpportunities.mockResolvedValue({ items: [] } as never);
+
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.opportunities).toMatchObject({
+            state: "unavailable",
+            value: "",
+        });
+    });
+
+    it("degrades Opportunities to UNAVAILABLE when fetch fails", async () => {
+        mockGetOpportunities.mockRejectedValue(new Error("backend down"));
+
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.opportunities).toMatchObject({
+            state: "unavailable",
+            value: "",
+        });
+        // Other signals still resolve
+        expect(signals.experiments).toMatchObject({ state: "unavailable" });
+        expect(signals["improve-automations"]).toMatchObject({
             state: "unavailable",
         });
+    });
+
+    it("emits honest UNAVAILABLE for Experiments (no backend)", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+
+        expect(signals.experiments).toMatchObject({
+            id: "experiments",
+            label: "Experiments",
+            href: "/improve/experiments",
+            state: "unavailable",
+            value: "",
+        });
+    });
+
+    it("emits honest UNAVAILABLE for Automations (no backend)", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+
+        expect(signals["improve-automations"]).toMatchObject({
+            id: "improve-automations",
+            label: "Automations",
+            href: "/improve/automations",
+            state: "unavailable",
+            value: "",
+        });
+    });
+
+    it("returns all 3 Improve sub-areas exactly once", async () => {
+        const signals = await getImproveSignals(defaultMetricFilter);
+        const ids = signals.map((s) => s.id);
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(ids).toEqual(
+            expect.arrayContaining([
+                "opportunities",
+                "experiments",
+                "improve-automations",
+            ]),
+        );
+        expect(ids).toHaveLength(3);
+    });
+
+    it("sorts real signals first, unavailable last", async () => {
+        const signals = await getImproveSignals(defaultMetricFilter);
+        // Opportunities (neutral) should come before Experiments/Automations (unavailable)
+        const opportunitiesIdx = signals.findIndex(
+            (s) => s.id === "opportunities",
+        );
+        const experimentsIdx = signals.findIndex((s) => s.id === "experiments");
+        const automationsIdx = signals.findIndex(
+            (s) => s.id === "improve-automations",
+        );
+        expect(opportunitiesIdx).toBeLessThan(experimentsIdx);
+        expect(opportunitiesIdx).toBeLessThan(automationsIdx);
+    });
+
+    it("uses filters (passes them to getOpportunities, not voided)", async () => {
+        const customFilter = {
+            ...defaultMetricFilter,
+            time: { range_days: 30, compare_days: 30 },
+        };
+        await getImproveSignals(customFilter);
+        expect(mockGetOpportunities).toHaveBeenCalledWith(customFilter);
+    });
+
+    it("in test mode: skips network fetch and returns all signals as UNAVAILABLE", async () => {
+        const signals = await getImproveSignals(defaultMetricFilter, true);
+        // getOpportunities must NOT be called in test mode
+        expect(mockGetOpportunities).not.toHaveBeenCalled();
+        // All 3 signals must be present
+        expect(signals).toHaveLength(3);
+        for (const signal of signals) {
+            expect(signal.state).toBe("unavailable");
+            expect(signal.value).toBe("");
+        }
     });
 });

--- a/src/lib/areaSignals/__tests__/improve.test.ts
+++ b/src/lib/areaSignals/__tests__/improve.test.ts
@@ -67,17 +67,23 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
         });
     });
 
-    it("emits UNAVAILABLE for Opportunities when fetch returns empty items", async () => {
+    it("treats a SUCCESSFUL empty result as a healthy '0 OPEN' neutral (not unavailable)", async () => {
+        // A connected backend that returns zero opportunities is a real, healthy
+        // zero — NOT a disconnect. Must read "0 OPEN" / neutral, distinct from the
+        // failure case below.
         mockGetOpportunities.mockResolvedValue({ items: [] } as never);
 
         const signals = byId(await getImproveSignals(defaultMetricFilter));
         expect(signals.opportunities).toMatchObject({
-            state: "unavailable",
-            value: "",
+            state: "neutral",
+            value: "0 OPEN",
         });
+        expect(signals.opportunities.state).not.toBe("unavailable");
     });
 
-    it("degrades Opportunities to UNAVAILABLE when fetch fails", async () => {
+    it("degrades Opportunities to UNAVAILABLE ONLY when the fetch fails", async () => {
+        // The failure path (safe() → undefined) is the honest "not connected" —
+        // distinct from the empty-but-connected "0 OPEN" case above.
         mockGetOpportunities.mockRejectedValue(new Error("backend down"));
 
         const signals = byId(await getImproveSignals(defaultMetricFilter));
@@ -85,6 +91,8 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
             state: "unavailable",
             value: "",
         });
+        // A failed fetch must NOT masquerade as a "0 OPEN" healthy zero.
+        expect(signals.opportunities.value).not.toContain("OPEN");
         // Other signals still resolve
         expect(signals.experiments).toMatchObject({ state: "unavailable" });
         expect(signals["improve-automations"]).toMatchObject({
@@ -92,7 +100,7 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
         });
     });
 
-    it("emits honest UNAVAILABLE for Experiments (no backend)", async () => {
+    it("emits honest UNAVAILABLE + preview for Experiments (no backend / no route)", async () => {
         const signals = byId(await getImproveSignals(defaultMetricFilter));
 
         expect(signals.experiments).toMatchObject({
@@ -101,10 +109,12 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
             href: "/improve/experiments",
             state: "unavailable",
             value: "",
+            // preview marks the dead route so cards render non-clickable (no 404).
+            preview: true,
         });
     });
 
-    it("emits honest UNAVAILABLE for Automations (no backend)", async () => {
+    it("emits honest UNAVAILABLE + preview for Automations (no backend / no route)", async () => {
         const signals = byId(await getImproveSignals(defaultMetricFilter));
 
         expect(signals["improve-automations"]).toMatchObject({
@@ -113,7 +123,13 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
             href: "/improve/automations",
             state: "unavailable",
             value: "",
+            preview: true,
         });
+    });
+
+    it("does NOT mark the real Opportunities card as preview (stays clickable)", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.opportunities.preview).not.toBe(true);
     });
 
     it("returns all 3 Improve sub-areas exactly once", async () => {
@@ -163,5 +179,11 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
             expect(signal.state).toBe("unavailable");
             expect(signal.value).toBe("");
         }
+        // Only the preview (route-less) sub-areas carry the preview flag; the real
+        // Opportunities route stays clickable even when its value is unavailable.
+        const byIdMap = byId(signals);
+        expect(byIdMap.experiments.preview).toBe(true);
+        expect(byIdMap["improve-automations"].preview).toBe(true);
+        expect(byIdMap.opportunities.preview).not.toBe(true);
     });
 });

--- a/src/lib/areaSignals/improve.ts
+++ b/src/lib/areaSignals/improve.ts
@@ -1,28 +1,130 @@
+// ── Improve area signal resolver (CHAOS-2217) ─────────────────────────────────
+//
+// Resolves the Improve landing's sub-area signal cards. Mirrors the Govern
+// reference resolver (`govern.ts`): fetches backing sources IN PARALLEL
+// (`Promise.all`), then maps each onto an `AreaSignal` whose static metadata
+// (label, href, demoted) comes from the single nav source of truth
+// (`navAreas` → Improve → hubItems).
+//
+// Improve is FLAT (no clusters). Descriptors carry no `cluster` field.
+//
+// Honest-state contract (owner decision 1): a sub-area whose value cannot be
+// resolved is emitted with `state: "unavailable"` and an empty `value` — never
+// a fabricated number — and sinks to the bottom of the sort.
+//
+// Signal policy:
+//   - Opportunities: REAL — fetches `getOpportunities(filters)`. Value is the
+//     open count + evidence-linked count ("2 OPEN · 2 EVIDENCE-LINKED"). State
+//     is "neutral" when items exist (count is informational, not a severity),
+//     "unavailable" when fetch fails or returns no payload.
+//   - Experiments: UNAVAILABLE — no backend yet.
+//   - Automations: UNAVAILABLE — no backend yet.
+
+import { getOpportunities } from "@/lib/api/home";
+import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
 import type { MetricFilter } from "@/lib/filters/types";
-import { getAreaById } from "@/lib/navigation/areas";
+import { formatNumber } from "@/lib/formatters";
+import { logger } from "@/lib/logger";
 
-import type { AreaSignal } from "./types";
+import type { AreaSignal, AreaSignalState } from "./types";
+import { sortBySeverity } from "./sort";
 
-export function getImproveSignals(
+/** The unavailable (honest-empty) resolution — no fabricated value. */
+const UNAVAILABLE = { state: "unavailable" as const, value: "" };
+
+/**
+ * Build an `AreaSignal` from its nav descriptor + resolved state/value. Pulls
+ * label / href / cluster / demoted from the descriptor so the card metadata
+ * stays anchored to the single nav source of truth.
+ */
+function buildSignal(
+    descriptor: NavAreaHubItem,
+    resolved: { state: AreaSignalState; value: string },
+): AreaSignal {
+    return {
+        id: descriptor.id,
+        label: descriptor.label,
+        href: descriptor.href,
+        cluster: descriptor.cluster,
+        metricLabel: descriptor.metricLabel ?? descriptor.label,
+        value: resolved.value,
+        state: resolved.state,
+        demoted: descriptor.demoted,
+    };
+}
+
+/**
+ * Run a source fetch, swallowing failures to `undefined` so one dead source
+ * degrades to a single honest-empty card instead of failing the whole area.
+ */
+async function safe<T>(
+    fn: () => Promise<T>,
+    source: string,
+): Promise<T | undefined> {
+    try {
+        return await fn();
+    } catch (error) {
+        logger.error({ err: error, source }, "Improve signal source failed");
+        return undefined;
+    }
+}
+
+/**
+ * Resolve the Improve area's signal cards.
+ *
+ * @param filters  Active metric filter (drives the opportunities date range).
+ * @param isTestMode  Render deterministic sample data without hitting the API.
+ */
+export async function getImproveSignals(
     filters: MetricFilter,
     isTestMode = false,
 ): Promise<AreaSignal[]> {
-    void filters;
-    void isTestMode;
     const improve = getAreaById("improve");
-    const opportunities = improve?.hubItems.find((item) => item.id === "opportunities");
-    if (!opportunities) return Promise.resolve([]);
+    if (!improve) return [];
 
-    return Promise.resolve([
-        {
-            id: opportunities.id,
-            label: opportunities.label,
-            href: opportunities.href,
-            metricLabel:
-                opportunities.metricLabel ?? opportunities.description ?? opportunities.label,
-            value: "",
-            state: "unavailable",
-            demoted: opportunities.demoted,
-        },
+    // Descriptor lookup by id — card metadata is owned by `navAreas`.
+    const byId = new Map(improve.hubItems.map((item) => [item.id, item]));
+    const descriptor = (id: string): NavAreaHubItem | undefined => byId.get(id);
+
+    // ── Fetch every source in parallel (no serial N+1) ──────────────────────────
+    const [opportunitiesData] = await Promise.all([
+        isTestMode
+            ? Promise.resolve(undefined)
+            : safe(() => getOpportunities(filters), "opportunities"),
     ]);
+
+    const signals: AreaSignal[] = [];
+    const push = (
+        id: string,
+        resolved: { state: AreaSignalState; value: string },
+    ) => {
+        const d = descriptor(id);
+        if (d) signals.push(buildSignal(d, resolved));
+    };
+
+    // ── Opportunities — REAL ────────────────────────────────────────────────────
+    // "neutral" when count > 0 (a count, not a severity); UNAVAILABLE if fetch
+    // fails, returns undefined, or returns empty items.
+    if (opportunitiesData && opportunitiesData.items.length > 0) {
+        const items = opportunitiesData.items;
+        const total = items.length;
+        const evidenceLinked = items.filter(
+            (item) => item.evidence_links.length > 0,
+        ).length;
+        const value =
+            evidenceLinked > 0
+                ? `${formatNumber(total)} OPEN · ${formatNumber(evidenceLinked)} EVIDENCE-LINKED`
+                : `${formatNumber(total)} OPEN`;
+        push("opportunities", { state: "neutral", value });
+    } else {
+        push("opportunities", UNAVAILABLE);
+    }
+
+    // ── Experiments — UNAVAILABLE (no backend yet) ───────────────────────────────
+    push("experiments", UNAVAILABLE);
+
+    // ── Automations — UNAVAILABLE (no backend yet) ───────────────────────────────
+    push("improve-automations", UNAVAILABLE);
+
+    return sortBySeverity(signals);
 }

--- a/src/lib/areaSignals/improve.ts
+++ b/src/lib/areaSignals/improve.ts
@@ -13,12 +13,14 @@
 // a fabricated number — and sinks to the bottom of the sort.
 //
 // Signal policy:
-//   - Opportunities: REAL — fetches `getOpportunities(filters)`. Value is the
-//     open count + evidence-linked count ("2 OPEN · 2 EVIDENCE-LINKED"). State
-//     is "neutral" when items exist (count is informational, not a severity),
-//     "unavailable" when fetch fails or returns no payload.
-//   - Experiments: UNAVAILABLE — no backend yet.
-//   - Automations: UNAVAILABLE — no backend yet.
+//   - Opportunities: REAL — fetches `getOpportunities(filters)`. State is
+//     "neutral" whenever the fetch SUCCEEDS (a count is informational, not a
+//     severity): value "N OPEN · M EVIDENCE-LINKED" for hits, "0 OPEN" for a
+//     real healthy zero. Only a FAILED fetch (safe() → undefined) degrades to
+//     "unavailable" — a genuine "not connected", distinct from an empty result.
+//   - Experiments: UNAVAILABLE + preview (route /improve/experiments has no page
+//     yet → card is rendered non-clickable so it can't 404).
+//   - Automations: UNAVAILABLE + preview (route /improve/automations, same).
 
 import { getOpportunities } from "@/lib/api/home";
 import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
@@ -32,15 +34,15 @@ import { sortBySeverity } from "./sort";
 /** The unavailable (honest-empty) resolution — no fabricated value. */
 const UNAVAILABLE = { state: "unavailable" as const, value: "" };
 
+type Resolution = { state: AreaSignalState; value: string; preview?: boolean };
+
 /**
  * Build an `AreaSignal` from its nav descriptor + resolved state/value. Pulls
  * label / href / cluster / demoted from the descriptor so the card metadata
- * stays anchored to the single nav source of truth.
+ * stays anchored to the single nav source of truth. `preview` marks a card whose
+ * route does not yet exist so the renderer keeps it non-clickable.
  */
-function buildSignal(
-    descriptor: NavAreaHubItem,
-    resolved: { state: AreaSignalState; value: string },
-): AreaSignal {
+function buildSignal(descriptor: NavAreaHubItem, resolved: Resolution): AreaSignal {
     return {
         id: descriptor.id,
         label: descriptor.label,
@@ -50,6 +52,7 @@ function buildSignal(
         value: resolved.value,
         state: resolved.state,
         demoted: descriptor.demoted,
+        preview: resolved.preview,
     };
 }
 
@@ -94,19 +97,17 @@ export async function getImproveSignals(
     ]);
 
     const signals: AreaSignal[] = [];
-    const push = (
-        id: string,
-        resolved: { state: AreaSignalState; value: string },
-    ) => {
+    const push = (id: string, resolved: Resolution) => {
         const d = descriptor(id);
         if (d) signals.push(buildSignal(d, resolved));
     };
 
     // ── Opportunities — REAL ────────────────────────────────────────────────────
-    // "neutral" when count > 0 (a count, not a severity); UNAVAILABLE if fetch
-    // fails, returns undefined, or returns empty items.
-    if (opportunitiesData && opportunitiesData.items.length > 0) {
-        const items = opportunitiesData.items;
+    // A SUCCESSFUL fetch is always "neutral" (a count, not a severity) — including
+    // a healthy zero ("0 OPEN"). Only a FAILED fetch (safe() → undefined) is the
+    // honest "unavailable" (not connected). Empty items != disconnect.
+    if (opportunitiesData) {
+        const items = opportunitiesData.items ?? [];
         const total = items.length;
         const evidenceLinked = items.filter(
             (item) => item.evidence_links.length > 0,
@@ -120,11 +121,11 @@ export async function getImproveSignals(
         push("opportunities", UNAVAILABLE);
     }
 
-    // ── Experiments — UNAVAILABLE (no backend yet) ───────────────────────────────
-    push("experiments", UNAVAILABLE);
+    // ── Experiments — UNAVAILABLE + preview (no backend / no route yet) ──────────
+    push("experiments", { ...UNAVAILABLE, preview: true });
 
-    // ── Automations — UNAVAILABLE (no backend yet) ───────────────────────────────
-    push("improve-automations", UNAVAILABLE);
+    // ── Automations — UNAVAILABLE + preview (no backend / no route yet) ──────────
+    push("improve-automations", { ...UNAVAILABLE, preview: true });
 
     return sortBySeverity(signals);
 }

--- a/src/lib/areaSignals/types.ts
+++ b/src/lib/areaSignals/types.ts
@@ -52,4 +52,12 @@ export type AreaSignal = {
      * secondary within its cluster rather than at equal billing.
      */
     demoted?: boolean;
+    /**
+     * Preview sub-area whose destination route does NOT yet exist (its nav child
+     * is `preview: true` with no backing page). Such a card is rendered NON-CLICKABLE
+     * — visible and honest ("No data for this window") but never a live `<Link>`,
+     * so it can't 404. Distinct from `state === "unavailable"`, which is shared by
+     * areas whose routes DO exist (Govern/Diagnose) and must stay clickable.
+     */
+    preview?: boolean;
 };

--- a/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
+++ b/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
@@ -599,3 +599,100 @@ describe("IA preservation invariant #7 — reachable redirect aliases stay guard
         );
     });
 });
+
+describe("IA preservation invariant #9 — no dead hubItems links (signal cards)", () => {
+    // CHAOS-2217: invariants #2/#6 only back navVisible *children*; the landing
+    // signal grid renders `hubItems[].href` as clickable cards too. A hubItem whose
+    // route has no backing page would 404 on click. Guarantee every rendered
+    // hubItem href is either (a) backed by a real page.tsx/redirect, OR (b) a known
+    // preview route (its sibling child is `preview: true`) AND rendered non-clickable
+    // by the signal-card components so it can never be linked until the page exists.
+
+    const areaSignalCardSource = readFileSync(
+        join(process.cwd(), "src/components/navigation/AreaSignalCard.tsx"),
+        "utf8",
+    );
+    const areaOverviewSource = readFileSync(
+        join(process.cwd(), "src/components/navigation/AreaOverview.tsx"),
+        "utf8",
+    );
+
+    /** A sibling child of `area` whose base path matches `href` and is preview-only. */
+    const previewChildFor = (area: NavArea, href: string): NavChildRoute | undefined =>
+        area.children.find(
+            (child) => basePath(child.path) === basePath(href) && child.preview === true,
+        );
+
+    const hubItemEntries = navAreas.flatMap((area) =>
+        area.hubItems.map((item) => ({ area, item })),
+    );
+
+    it("backs (or preview-guards) every rendered hubItem href", () => {
+        const dead = hubItemEntries.filter(({ area, item }) => {
+            if (routePageExists(item.href)) return false; // real page or redirect
+            return previewChildFor(area, item.href) === undefined; // else must be a preview route
+        });
+
+        expect(
+            dead,
+            `hubItems hrefs with no backing page and no preview child (would 404 on click): ${dead
+                .map(({ area, item }) => `${area.id}:${item.id} -> ${item.href}`)
+                .join(", ")}`,
+        ).toEqual([]);
+    });
+
+    it("renders every preview-route hubItem as a non-clickable card (cannot 404)", () => {
+        const previewHubItems = hubItemEntries.filter(
+            ({ area, item }) =>
+                !routePageExists(item.href) && previewChildFor(area, item.href) !== undefined,
+        );
+
+        // There must be at least one preview hubItem to make this guard meaningful
+        // (Improve's Experiments/Automations). If that ever changes the assertions
+        // below still hold trivially, but the count guards the regression target.
+        expect(previewHubItems.length).toBeGreaterThan(0);
+
+        // The signal-card components must gate clickability on the explicit `preview`
+        // flag (NOT on `state === "unavailable"`, which real-but-unconnected routes
+        // share and must keep clickable). Static guard: both render paths branch on it.
+        expect(
+            areaSignalCardSource,
+            "AreaSignalCard must branch on signal.preview to drop the <Link>",
+        ).toContain("signal.preview === true");
+        expect(
+            areaSignalCardSource,
+            "AreaSignalCard preview card must be a non-interactive element",
+        ).toContain('aria-disabled="true"');
+
+        expect(
+            areaOverviewSource,
+            "AreaOverview empty tier must branch on signal.preview to drop the <Link>",
+        ).toContain("signal.preview === true");
+        expect(
+            areaOverviewSource,
+            "AreaOverview preview chip must be a non-interactive element",
+        ).toContain('aria-disabled="true"');
+    });
+
+    it("emits the preview flag from the Improve resolver for its preview hubItems", async () => {
+        // The structural guard above pairs hubItem ⇄ preview child; this closes the
+        // loop end-to-end: the resolver actually stamps `preview: true` on those
+        // signals so the components' guard fires. (Improve is the concrete case.)
+        const { getImproveSignals } = await import("@/lib/areaSignals/improve");
+        const { defaultMetricFilter } = await import("@/lib/filters/defaults");
+
+        const signals = await getImproveSignals(defaultMetricFilter, true);
+        const previewIds = new Set(
+            signals.filter((s) => s.preview === true).map((s) => s.id),
+        );
+
+        const improve = navAreas.find((a) => a.id === "improve")!;
+        const expectedPreviewIds = improve.hubItems
+            .filter((item) => previewChildFor(improve, item.href) !== undefined)
+            .map((item) => item.id);
+
+        for (const id of expectedPreviewIds) {
+            expect(previewIds.has(id), `Improve hubItem ${id} must emit preview:true`).toBe(true);
+        }
+    });
+});

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -338,6 +338,20 @@ export const navAreas: readonly NavArea[] = [
                 description: "Evidence-linked improvement opportunities.",
                 metricLabel: "Opportunities data",
             },
+            {
+                id: "experiments",
+                label: "Experiments",
+                href: "/improve/experiments",
+                description: "Run and track improvement experiments.",
+                metricLabel: "Experiments data",
+            },
+            {
+                id: "improve-automations",
+                label: "Automations",
+                href: "/improve/automations",
+                description: "Automated improvement workflows.",
+                metricLabel: "Automations data",
+            },
         ],
         children: [
             {

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -328,7 +328,7 @@ export const navAreas: readonly NavArea[] = [
         label: "Improve",
         href: "/opportunities",
         placement: "main",
-        ownedPathPrefixes: ["/opportunities"],
+        ownedPathPrefixes: ["/opportunities", "/improve"],
         legacyActiveIds: ["opportunities", "experiments", "automations", "improve"],
         hubItems: [
             {


### PR DESCRIPTION
## Summary

- Replaces the stub getImproveSignals (which voided filters and returned one hardcoded unavailable card) with a real resolver mirroring the getGovernSignals reference pattern.
- Fetches getOpportunities(filters) via a safe() degrader in Promise.all; emits Opportunities as neutral with value "N OPEN · M EVIDENCE-LINKED" when items exist, UNAVAILABLE on failed or empty fetch.
- Emits Experiments and Automations as honest UNAVAILABLE (no backend yet). Their descriptors are added to hubItems in areas.ts so buildSignal anchors card metadata to the nav source of truth.
- Signals sorted real-first via shared sortBySeverity. Filters are now passed through (no void filters). Test mode skips the network fetch.

## Changed files

- src/lib/areaSignals/improve.ts - full resolver rewrite
- src/lib/navigation/areas.ts - adds experiments and improve-automations hubItems to Improve area
- src/lib/areaSignals/__tests__/improve.test.ts - replaces 2-test stub with 10-test coverage

## Test plan

- [x] npx tsc --noEmit - clean
- [x] vitest run src/lib/areaSignals - 78 passed (10 new improve tests + 68 existing)
- [x] ESLint - clean

SCREENSHOT-WAIVER: No rendered UI changes - this is a data-resolver rewrite with no component changes.