### PR TITLE
CHAOS-2180 Wave 1: AI area frontend remediation (signals, BackLink, CTA, anchors, copy)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ The Definition of Done requires:
     - **Canonical test account:** `admin@devhealth.example` / `devhealth123` (seeded by `dev-hops fixtures generate`). Do not create ad-hoc accounts.
     - **What to capture:** Every page or component visually altered by the change, before/after if modifying existing UI, just after if net-new
     - **When to skip:** Changes that are purely backend, purely type-level, or have no rendered output (add `SCREENSHOT-WAIVER: <reason>` to PR body)
+
 - **Governance gate (`enforce-src-test-policy`)**: Any PR that changes files under `src/` must either include at least one test file change (`tests/`, `__tests__/`, or `*.test.*`/`*.spec.*`) **or** include a `TEST-WAIVER:` line in the PR body explaining why tests were not touched. Example:
     ```
     TEST-WAIVER: CSS-only changes, no component logic affected

--- a/src/app/(app)/ai/automations/page.tsx
+++ b/src/app/(app)/ai/automations/page.tsx
@@ -2,6 +2,8 @@ import { AIAutomationsDashboard } from "@/components/ai/AIAutomationsDashboard";
 import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
+import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { checkApiHealth } from "@/lib/api/system";
 import { metricFilterToAIFilter } from "@/lib/filters/ai";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { navTrailForPathname } from "@/lib/navigation/areas";
@@ -15,6 +17,11 @@ export default async function AIAutomationsPage({ searchParams }: AIAutomationsP
     const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
     const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
     const aiFilter = metricFilterToAIFilter(filters);
+    const health = await checkApiHealth();
+
+    if (!health.ok) {
+        return <ServiceUnavailable />;
+    }
 
     return (
         <>

--- a/src/app/(app)/ai/evidence/page.tsx
+++ b/src/app/(app)/ai/evidence/page.tsx
@@ -9,14 +9,15 @@ import { AITabPreview } from "@/components/ai/AITabPreview";
 export default function AIEvidencePage() {
     return (
         <>
-            <AIPageHeader eyebrow="AI" title="AI Evidence">
+            {/* design-lint-disable-next-line cta-from-registry -- "Evidence" is the AI page title (matches the nav label), not a CTA */}
+            <AIPageHeader eyebrow="AI" title="Evidence">
                 A consolidated evidence trail for AI signals is coming. Today the closest summary
                 lives on the Operating Review.
             </AIPageHeader>
             <AITabPreview
                 whereNow={{
                     label: "View AI summary on Operating Review",
-                    href: "/operating-review#ai-workflow-intelligence",
+                    href: "/operating-review#ai_workflow_intelligence",
                 }}
             >
                 Evidence will surface here when it can stand as a complete view. No fabricated

--- a/src/app/(app)/ai/page.tsx
+++ b/src/app/(app)/ai/page.tsx
@@ -45,7 +45,7 @@ export default async function AIWorkflowsPage({ searchParams }: AIWorkflowsPageP
                 signals={aiSignals}
                 filters={filters}
                 role={activeRole}
-                title="AI workflows"
+                title="AI"
                 description="Available AI views summarize impact, review pressure, governance risk, and automation opportunities."
             />
         </>

--- a/src/app/(app)/ai/review-load/page.tsx
+++ b/src/app/(app)/ai/review-load/page.tsx
@@ -2,6 +2,8 @@ import { AIReviewLoadDashboard } from "@/components/ai/AIReviewLoadDashboard";
 import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
+import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { checkApiHealth } from "@/lib/api/system";
 import { metricFilterToAIFilter } from "@/lib/filters/ai";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { navTrailForPathname } from "@/lib/navigation/areas";
@@ -15,6 +17,11 @@ export default async function AIReviewLoadPage({ searchParams }: AIReviewLoadPag
     const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
     const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
     const aiFilter = metricFilterToAIFilter(filters);
+    const health = await checkApiHealth();
+
+    if (!health.ok) {
+        return <ServiceUnavailable />;
+    }
 
     return (
         <>

--- a/src/app/(app)/ai/risk/page.tsx
+++ b/src/app/(app)/ai/risk/page.tsx
@@ -2,6 +2,8 @@ import { AIRiskDashboard } from "@/components/ai/AIRiskDashboard";
 import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
+import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { checkApiHealth } from "@/lib/api/system";
 import { metricFilterToAIFilter } from "@/lib/filters/ai";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { navTrailForPathname } from "@/lib/navigation/areas";
@@ -15,6 +17,11 @@ export default async function AIRiskPage({ searchParams }: AIRiskPageProps) {
     const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
     const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
     const aiFilter = metricFilterToAIFilter(filters);
+    const health = await checkApiHealth();
+
+    if (!health.ok) {
+        return <ServiceUnavailable />;
+    }
 
     return (
         <>

--- a/src/components/ai/AIEmptyState.tsx
+++ b/src/components/ai/AIEmptyState.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { DataState } from "@/components/ui/DataState";
 
 /**
  * Whole-view "no data exists for this scope yet" marker.
@@ -9,15 +9,19 @@ import type { ReactNode } from "react";
  *
  * For "the metric exists in spec but the schema doesn't expose it yet",
  * use {@link AIMissingDataPanel} instead.
+ *
+ * Internally delegates to {@link DataState} (`no-data-connected`) so the
+ * canonical empty-state vocabulary is the single source of truth.
  */
-export function AIEmptyState({ title, children }: { title: string; children?: ReactNode }) {
+export function AIEmptyState({ title, children }: { title: string; children?: string }) {
     return (
-        <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-80) p-6 text-sm text-(--ink-muted)">
-            <p className="font-medium text-foreground">{title}</p>
-            <p className="mt-2">
-                {children ??
-                    "Connect a GitHub provider to populate AI-assisted PR attribution and workflow evidence."}
-            </p>
-        </div>
+        <DataState
+            variant="no-data-connected"
+            title={title}
+            description={
+                children ??
+                "Connect a GitHub provider to populate AI-assisted PR attribution and workflow evidence."
+            }
+        />
     );
 }

--- a/src/components/ai/AIImpactDashboard.tsx
+++ b/src/components/ai/AIImpactDashboard.tsx
@@ -7,6 +7,7 @@ import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
 import { DataState } from "@/components/ui/DataState";
 import { useAIComparison, useAIImpactSummary } from "@/lib/graphql/hooks/useAIImpact";
 import type { AIFilter } from "@/lib/filters/ai";
+import { CTA_LABELS } from "@/lib/design/cta";
 import { AIComparisonCard } from "./AIComparisonCard";
 import { AILeverageBars } from "./AILeverageBars";
 import { AIPanelCard } from "./AIPanelCard";
@@ -231,7 +232,7 @@ export function AIImpactDashboard({ filter }: AIImpactDashboardProps) {
                             className="font-medium text-accent underline-offset-4 hover:underline"
                             href="/ai/automations"
                         >
-                            See AI Automations →
+                            {CTA_LABELS.seeAIAutomations} →
                         </Link>
                     </div>
                 </AIPanelCard>

--- a/src/components/ai/AIMissingDataPanel.tsx
+++ b/src/components/ai/AIMissingDataPanel.tsx
@@ -1,3 +1,5 @@
+import { DataState } from "@/components/ui/DataState";
+
 type AIMissingDataPanelProps = {
     title: string;
     reason: string;
@@ -16,23 +18,19 @@ type AIMissingDataPanelProps = {
  *
  * For whole-view "no data exists for this scope" coverage, use
  * {@link AIEmptyState} instead.
+ *
+ * Internally delegates to {@link DataState} (`detector-unavailable`) so the
+ * canonical empty-state vocabulary is the single source of truth. The
+ * `needed` prop maps to DataState's `detail` slot.
  */
 export function AIMissingDataPanel({ title, reason, needed }: AIMissingDataPanelProps) {
     return (
-        <section
-            className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-80) p-5"
+        <DataState
+            variant="detector-unavailable"
+            title={title}
+            description={reason}
+            detail={needed}
             data-testid="ai-missing-data-panel"
-        >
-            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-(--ink-muted)">
-                Missing data
-            </p>
-            <h3 className="mt-2 font-(--font-display) text-lg">{title}</h3>
-            <p className="mt-2 text-sm text-(--ink-muted)">{reason}</p>
-            {needed && (
-                <p className="mt-3 rounded-2xl bg-background/60 px-3 py-2 text-xs text-(--ink-muted)">
-                    Data source needed: {needed}
-                </p>
-            )}
-        </section>
+        />
     );
 }

--- a/src/components/ai/AIReviewLoadDashboard.tsx
+++ b/src/components/ai/AIReviewLoadDashboard.tsx
@@ -48,7 +48,7 @@ export function AIReviewLoadDashboard({ filter }: AIReviewLoadDashboardProps) {
             <AIMissingDataPanel
                 title="AI review load data is not available"
                 reason="The backend returned data_available=false for the selected scope. This view keeps the gap explicit instead of fabricating values."
-                needed="AI attribution plus review event rollups in ClickHouse."
+                needed="Review activity rollups for AI-attributed PRs."
             />
         );
     }

--- a/src/components/ai/AIRiskDashboard.tsx
+++ b/src/components/ai/AIRiskDashboard.tsx
@@ -114,7 +114,7 @@ export function AIRiskDashboard({ filter }: AIRiskDashboardProps) {
                 <AIMissingDataPanel
                     title={hotspotMissing.title}
                     reason={hotspotMissing.guidance}
-                    needed="Hotspot file detector output joined to AI-attributed PR changed files."
+                    needed="File hotspot signals for AI-attributed changes."
                 />
                 <AIMissingDataPanel
                     title={complexityMissing.title}

--- a/src/components/ai/AIWorkspaceChrome.test.tsx
+++ b/src/components/ai/AIWorkspaceChrome.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@/test/utils";
 import { AIWorkspaceChrome } from "./AIWorkspaceChrome";
@@ -6,6 +7,22 @@ import { AIPageHeader } from "./AIPageHeader";
 vi.mock("next/navigation", () => ({
     useSearchParams: () => new URLSearchParams(),
     usePathname: () => "/ai",
+}));
+
+vi.mock("next/link", () => ({
+    default: ({
+        href,
+        children,
+        ...props
+    }: {
+        href: string;
+        children: React.ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
 }));
 
 // Keep the sidebar and tab strip lightweight so the test focuses on the
@@ -21,6 +38,7 @@ vi.mock("./AITabNav", () => ({
 vi.mock("@/lib/filters/encode", () => ({
     decodeFilter: () => ({}),
     filterFromQueryParams: () => ({}),
+    encodeFilterParam: () => "",
 }));
 
 describe("AIWorkspaceChrome", () => {
@@ -49,6 +67,13 @@ describe("AIWorkspaceChrome", () => {
     it("renders the area title matching the sidebar label (A6 agreement)", () => {
         render(<AIWorkspaceChrome>content</AIWorkspaceChrome>);
         expect(screen.getByRole("heading", { level: 1, name: "AI" })).toBeInTheDocument();
+    });
+
+    it("renders a BackLink returning to the cockpit (A5)", () => {
+        render(<AIWorkspaceChrome>content</AIWorkspaceChrome>);
+        const backLink = screen.getByRole("link", { name: /back to cockpit/i });
+        expect(backLink).toBeInTheDocument();
+        expect(backLink.getAttribute("href")).toContain("/");
     });
 
     it("uses tentative AI copy instead of definitive implementation language", () => {

--- a/src/components/ai/AIWorkspaceChrome.tsx
+++ b/src/components/ai/AIWorkspaceChrome.tsx
@@ -4,7 +4,9 @@ import { useMemo, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { BackLink } from "@/components/shared/BackLink";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+import { withFilterParam } from "@/lib/filters/url";
 import { AITabNav } from "./AITabNav";
 
 export function AIWorkspaceChrome({ children }: { children: ReactNode }) {
@@ -30,15 +32,18 @@ export function AIWorkspaceChrome({ children }: { children: ReactNode }) {
             <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="ai" role={role} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
-                    <header className="flex flex-col gap-2">
-                        <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                            Decision area
-                        </p>
-                        <h1 className="font-(--font-display) text-3xl">AI</h1>
-                        <p className="max-w-3xl text-sm text-(--ink-muted)">
-                            What AI appears to change across delivery, review, quality, and
-                            governance. Open an evidence-backed view for the selected window.
-                        </p>
+                    <header className="flex flex-col gap-4">
+                        <BackLink href={withFilterParam("/", filters, role)} />
+                        <div>
+                            <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+                                AI
+                            </p>
+                            <h1 className="mt-2 font-(--font-display) text-3xl">AI</h1>
+                            <p className="mt-2 max-w-3xl text-sm text-(--ink-muted)">
+                                What AI appears to change across delivery, review, quality, and
+                                governance. Open an evidence-backed view for the selected window.
+                            </p>
+                        </div>
                     </header>
                     <AITabNav filters={filters} role={role} />
                     {children}

--- a/src/components/ai/__tests__/AIMissingDataPanel.test.tsx
+++ b/src/components/ai/__tests__/AIMissingDataPanel.test.tsx
@@ -12,8 +12,23 @@ describe("AIMissingDataPanel", () => {
             />,
         );
 
-        expect(screen.getByText("Missing data")).toBeInTheDocument();
+        // Routes through DataState (detector-unavailable) — title and description render via EmptyState
         expect(screen.getByText("Reviewer concentration")).toBeInTheDocument();
+        expect(screen.getByText(/Reviewer concentration is not in the schema/)).toBeInTheDocument();
+        // "needed" text surfaces via DataState detail slot
         expect(screen.getByText(/Aggregated reviewer distribution buckets/)).toBeInTheDocument();
+        expect(screen.getByTestId("ai-missing-data-panel")).toBeInTheDocument();
+    });
+
+    it("renders without a data source hint when needed is omitted", () => {
+        render(
+            <AIMissingDataPanel
+                title="Hotspot file overlap"
+                reason="Hotspot overlap is not available for the selected scope yet."
+            />,
+        );
+
+        expect(screen.getByText("Hotspot file overlap")).toBeInTheDocument();
+        expect(screen.queryByText(/Data source needed/)).not.toBeInTheDocument();
     });
 });

--- a/src/components/home/AiWorkflowCallout.test.tsx
+++ b/src/components/home/AiWorkflowCallout.test.tsx
@@ -20,7 +20,7 @@ describe("AiWorkflowCallout", () => {
         expect(screen.getByText("AI Workflow Intelligence")).toBeInTheDocument();
         // All four workflow steps render as links.
         expect(screen.getByText("AI Impact")).toBeInTheDocument();
-        expect(screen.getByText("Governance gaps")).toBeInTheDocument();
+        expect(screen.getByText("Governance Risk")).toBeInTheDocument();
         expect(screen.queryByTestId("ai-workflow-secondary-link")).not.toBeInTheDocument();
     });
 

--- a/src/components/home/AiWorkflowCallout.tsx
+++ b/src/components/home/AiWorkflowCallout.tsx
@@ -10,12 +10,12 @@ const AI_WORKFLOW_STEPS = [
         href: "/ai",
     },
     {
-        label: "Review Load / Risk",
+        label: "Review Load",
         description: "Is AI-attributed work shifting cost into review or quality?",
         href: "/ai/review-load",
     },
     {
-        label: "Governance gaps",
+        label: "Governance Risk",
         description: "Unknown attribution and policy violations as trust signals.",
         href: "/ai/risk",
     },
@@ -89,7 +89,7 @@ export function AiWorkflowCallout({ filters, activeRole, prominent }: AiWorkflow
                         </Link>
                         <Link
                             href={withFilterParam(
-                                "/operating-review#ai-workflow-intelligence",
+                                "/operating-review#ai_workflow_intelligence",
                                 filters,
                                 activeRole,
                             )}

--- a/src/components/ui/DataState.tsx
+++ b/src/components/ui/DataState.tsx
@@ -94,6 +94,13 @@ type DataStateProps = {
     action?: ReactNode;
     /** Optional wrapper className for layout (e.g. padding inside a card). */
     className?: string;
+    /**
+     * Optional supplemental detail rendered below the description — intended
+     * for "Data source needed:" context on `detector-unavailable` panels. Pass
+     * the value only (e.g. "Review activity rollups for AI-attributed PRs");
+     * DataState adds the "Data source needed:" label automatically.
+     */
+    detail?: string;
     /** Test hook; defaults to a stable per-variant id. */
     "data-testid"?: string;
 };
@@ -106,6 +113,7 @@ export function DataState({
     icon,
     action,
     className,
+    detail,
     "data-testid": testId,
 }: DataStateProps) {
     if (variant === "loading") {
@@ -159,6 +167,11 @@ export function DataState({
                 description={description ?? copy.description}
                 action={action}
             />
+            {detail && (
+                <p className="mt-3 rounded-2xl bg-background/60 px-3 py-2 text-center text-xs text-(--ink-muted)">
+                    Data source needed: {detail}
+                </p>
+            )}
         </div>
     );
 }

--- a/src/lib/areaSignals/__tests__/ai.test.ts
+++ b/src/lib/areaSignals/__tests__/ai.test.ts
@@ -1,0 +1,450 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock every AI source at the module boundary ───────────────────────────────
+// Each source is driven independently to assert the source → AreaSignal mapping
+// without any network.
+
+vi.mock("@/lib/graphql/server", () => ({ graphqlFetch: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+    auth: vi.fn().mockResolvedValue({ user: { org_id: "org-test" } }),
+}));
+vi.mock("@/lib/logger", () => ({
+    logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { graphqlFetch } from "@/lib/graphql/server";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+
+import { getAISignals } from "../ai";
+import type { AreaSignal } from "../types";
+
+const mockGraphql = vi.mocked(graphqlFetch);
+
+// ── Fixture factories ─────────────────────────────────────────────────────────
+
+function makeImpact(overrides?: {
+    dataAvailable?: boolean;
+    aiAssistedPrRatio?: number | null;
+    reworkDragRate?: number | null;
+}) {
+    return {
+        aiImpactSummary: {
+            orgId: "org-test",
+            startDate: "2026-05-10",
+            endDate: "2026-06-09",
+            totalPrs: 100,
+            aiAssistedPrs: 40,
+            agentCreatedPrs: 5,
+            humanPrs: 55,
+            unknownPrs: 0,
+            aiAssistedPrRatio: overrides?.aiAssistedPrRatio ?? 0.4,
+            dataAvailable: overrides?.dataAvailable ?? true,
+            computedAt: null,
+            missingStates: [],
+            byBucket: [
+                {
+                    bucket: "AI_ASSISTED",
+                    prsTotal: 40,
+                    prsMerged: 38,
+                    aiAssistedPrRatio: 0.4,
+                    agentCreatedPrCount: 5,
+                    cycleTimeAvgHours: 12,
+                    aiCycleTimeDeltaHours: -2,
+                    aiReviewAmplification: null,
+                    reworkDragRate:
+                        overrides !== undefined && "reworkDragRate" in overrides
+                            ? overrides.reworkDragRate
+                            : 0.12,
+                    revertRate: 0.02,
+                    incidentDragRate: null,
+                    testGapRate: 0.08,
+                    leverage: {
+                        prsComponent: 0.4,
+                        cycleTimeComponent: null,
+                        reviewComponent: null,
+                        reworkComponent: null,
+                        testComponent: null,
+                        incidentComponent: null,
+                    },
+                },
+                {
+                    bucket: "HUMAN",
+                    prsTotal: 55,
+                    prsMerged: 53,
+                    aiAssistedPrRatio: 0,
+                    agentCreatedPrCount: 0,
+                    cycleTimeAvgHours: 14,
+                    aiCycleTimeDeltaHours: null,
+                    aiReviewAmplification: null,
+                    reworkDragRate: 0.09,
+                    revertRate: 0.01,
+                    incidentDragRate: null,
+                    testGapRate: 0.05,
+                    leverage: {
+                        prsComponent: 0,
+                        cycleTimeComponent: null,
+                        reviewComponent: null,
+                        reworkComponent: null,
+                        testComponent: null,
+                        incidentComponent: null,
+                    },
+                },
+            ],
+            daily: [],
+        },
+    };
+}
+
+function makeReviewLoad(overrides?: {
+    dataAvailable?: boolean;
+    reviewAmplification?: number | null;
+}) {
+    return {
+        aiReviewLoad: {
+            orgId: "org-test",
+            startDate: "2026-05-10",
+            endDate: "2026-06-09",
+            dataAvailable: overrides?.dataAvailable ?? true,
+            byBucket: [
+                {
+                    bucket: "AI_ASSISTED",
+                    prsTotal: 40,
+                    reviewsTotal: 72,
+                    reviewsPerPr: 1.8,
+                    changesRequestedPerPr: 0.5,
+                    reviewAmplification: overrides?.reviewAmplification ?? 1.8,
+                    postFirstReviewPushesCount: 12,
+                    postFirstReviewPushesPerPr: 0.3,
+                },
+                {
+                    bucket: "HUMAN",
+                    prsTotal: 55,
+                    reviewsTotal: 88,
+                    reviewsPerPr: 1.6,
+                    changesRequestedPerPr: 0.4,
+                    reviewAmplification: 1.0,
+                    postFirstReviewPushesCount: 8,
+                    postFirstReviewPushesPerPr: 0.15,
+                },
+            ],
+            daily: [],
+            reviewerConcentration: { dataAvailable: true, reviewerCount: 5, reviewerGini: 0.42 },
+            missingStates: [],
+        },
+    };
+}
+
+function makeGovernance(overrides?: {
+    dataAvailable?: boolean;
+    violations?: Array<{ severity: string; ruleId: string }>;
+}) {
+    const violations = overrides?.violations ?? [
+        {
+            ruleId: "require-human-review",
+            severity: "high",
+            subjectType: "PR",
+            subjectId: "PR#42",
+            teamId: null,
+            repoId: null,
+            observedAt: "2026-06-01T10:00:00Z",
+            evidence: "No human reviewer",
+        },
+    ];
+    return {
+        aiGovernanceSummary: {
+            orgId: "org-test",
+            startDate: "2026-05-10",
+            endDate: "2026-06-09",
+            dataAvailable: overrides?.dataAvailable ?? true,
+            recentViolations: violations,
+            coverage: [],
+        },
+    };
+}
+
+function makeOpportunities(overrides?: { detectorReady?: boolean; recommendationCount?: number }) {
+    const count = overrides?.recommendationCount ?? 3;
+    return {
+        aiOpportunities: {
+            orgId: "org-test",
+            detectorReady: overrides?.detectorReady ?? true,
+            recommendations: Array.from({ length: count }, (_, i) => ({
+                opportunityId: `op-${i}`,
+                kind: "HIGH_REVIEW_LOAD" as const,
+                repoId: null,
+                teamId: null,
+                title: `Opportunity ${i}`,
+                rationale: "…",
+                score: 0.8 - i * 0.1,
+                evidenceRefs: [],
+                workGraphDrilldowns: [],
+            })),
+        },
+    };
+}
+
+// ── Mock router: branch on query text ────────────────────────────────────────
+
+function routeQuery(query: unknown): Promise<unknown> {
+    const q = String(query);
+    if (q.includes("AIImpactSummary")) return Promise.resolve(makeImpact());
+    if (q.includes("AIReviewLoad")) return Promise.resolve(makeReviewLoad());
+    if (q.includes("AIGovernanceSummary")) return Promise.resolve(makeGovernance());
+    if (q.includes("AIOpportunities")) return Promise.resolve(makeOpportunities());
+    return Promise.resolve({});
+}
+
+function byId(signals: AreaSignal[]): Record<string, AreaSignal> {
+    return Object.fromEntries(signals.map((s) => [s.id, s]));
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockGraphql.mockImplementation((query) => routeQuery(query) as never);
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("getAISignals — source → AreaSignal mapping", () => {
+    it("returns all 4 AI sub-areas exactly once with their clusters", async () => {
+        const signals = await getAISignals(defaultMetricFilter);
+        const ids = signals.map((s) => s.id);
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(ids).toEqual(
+            expect.arrayContaining([
+                "ai-impact",
+                "ai-review-load",
+                "ai-governance-risk",
+                "ai-automations",
+            ]),
+        );
+    });
+
+    it("assigns Signal cluster to Impact, Review Load, Governance Risk", async () => {
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-impact"].cluster).toBe("Signal");
+        expect(signals["ai-review-load"].cluster).toBe("Signal");
+        expect(signals["ai-governance-risk"].cluster).toBe("Signal");
+    });
+
+    it("assigns Action cluster to Automations", async () => {
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-automations"].cluster).toBe("Action");
+    });
+
+    it("derives AI impact severity from AI_ASSISTED bucket reworkDragRate (lowerIsBetter)", async () => {
+        // reworkDragRate 0.12 × 100 = 12 → below medium threshold (15) → low.
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-impact"]).toMatchObject({
+            state: "low",
+            cluster: "Signal",
+        });
+        expect(signals["ai-impact"].value).toContain("AI-assisted");
+    });
+
+    it("escalates AI impact severity for high rework drag (>= 35 → high)", async () => {
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIImpactSummary")) {
+                return Promise.resolve(makeImpact({ reworkDragRate: 0.38 })) as never; // 38% → high
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-impact"].state).toBe("high");
+    });
+
+    it("falls back to neutral state when reworkDragRate is absent but data is available", async () => {
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIImpactSummary")) {
+                return Promise.resolve(makeImpact({ reworkDragRate: null })) as never;
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-impact"].state).toBe("neutral");
+    });
+
+    it("derives review load severity from AI_ASSISTED reviewAmplification (lowerIsBetter)", async () => {
+        // 1.8× amplification ≥ 1.5 medium threshold → medium.
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-review-load"]).toMatchObject({
+            state: "medium",
+            cluster: "Signal",
+        });
+        expect(signals["ai-review-load"].value).toContain("amplification");
+    });
+
+    it("escalates review load to critical for very high amplification (>= 3.0)", async () => {
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIReviewLoad")) {
+                return Promise.resolve(makeReviewLoad({ reviewAmplification: 3.2 })) as never;
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-review-load"].state).toBe("critical");
+    });
+
+    it("returns governance severity from violation severity ladder (high violations → high)", async () => {
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-governance-risk"]).toMatchObject({
+            state: "high",
+            cluster: "Signal",
+        });
+        expect(signals["ai-governance-risk"].value).toContain("violation");
+    });
+
+    it("maps critical violations to critical governance state", async () => {
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIGovernanceSummary")) {
+                return Promise.resolve(
+                    makeGovernance({
+                        violations: [{ ruleId: "no-scan", severity: "critical" }],
+                    }),
+                ) as never;
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-governance-risk"].state).toBe("critical");
+    });
+
+    it("emits low state when governance has no violations", async () => {
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIGovernanceSummary")) {
+                return Promise.resolve(makeGovernance({ violations: [] })) as never;
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-governance-risk"]).toMatchObject({
+            state: "low",
+            value: "0 violations",
+        });
+    });
+
+    it("does NOT over-state info/warning violations as medium — maps them to low", async () => {
+        // advisory-only violations (info / warning severity) are not actionable
+        // at the medium level; collapsing them there would over-state the risk.
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIGovernanceSummary")) {
+                return Promise.resolve(
+                    makeGovernance({
+                        violations: [
+                            { ruleId: "doc-coverage", severity: "info" },
+                            { ruleId: "naming-convention", severity: "warning" },
+                        ],
+                    }),
+                ) as never;
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-governance-risk"]).toMatchObject({
+            state: "low",
+        });
+        expect(signals["ai-governance-risk"].value).toContain("violation");
+    });
+
+    it("promotes to medium when there are medium-severity violations (not just info/warning)", async () => {
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIGovernanceSummary")) {
+                return Promise.resolve(
+                    makeGovernance({
+                        violations: [
+                            { ruleId: "scan-coverage", severity: "medium" },
+                            { ruleId: "doc-coverage", severity: "info" },
+                        ],
+                    }),
+                ) as never;
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-governance-risk"].state).toBe("medium");
+    });
+
+    it("emits neutral automations state when detector is ready with recommendations", async () => {
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-automations"]).toMatchObject({
+            state: "neutral",
+            cluster: "Action",
+        });
+        expect(signals["ai-automations"].value).toContain("opportunit");
+    });
+
+    it("emits low 'all-clear' automations card when detector ran but found zero opportunities", async () => {
+        // detectorReady=true means the detector ran (AI-23 semantics: true even
+        // when recommendations=0). Zero recommendations is a valid production
+        // all-clear, not a missing-data case — it should surface as "low" with
+        // an explicit "0 opportunities" value, not as "unavailable".
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIOpportunities")) {
+                return Promise.resolve(
+                    makeOpportunities({ detectorReady: true, recommendationCount: 0 }),
+                ) as never;
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-automations"]).toMatchObject({
+            state: "low",
+            value: "0 opportunities",
+        });
+    });
+
+    it("emits unavailable automations when detector has not yet run (detectorReady=false)", async () => {
+        // detectorReady=false means the detector hasn't run yet — no count to
+        // surface, so we emit honest "unavailable" rather than "0 opportunities".
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIOpportunities")) {
+                return Promise.resolve(makeOpportunities({ detectorReady: false })) as never;
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-automations"]).toMatchObject({ state: "unavailable", value: "" });
+    });
+
+    it("degrades a single failing source to unavailable without failing the whole area", async () => {
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIImpactSummary")) {
+                return Promise.reject(new Error("source down")) as never;
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-impact"]).toMatchObject({ state: "unavailable", value: "" });
+        // Other sources still resolve.
+        expect(signals["ai-review-load"].state).not.toBe("unavailable");
+        expect(signals["ai-governance-risk"].state).not.toBe("unavailable");
+    });
+
+    it("emits honest unavailable (no fabricated value) when dataAvailable is false", async () => {
+        mockGraphql.mockImplementation((query) => {
+            if (String(query).includes("AIImpactSummary")) {
+                return Promise.resolve(makeImpact({ dataAvailable: false })) as never;
+            }
+            if (String(query).includes("AIReviewLoad")) {
+                return Promise.resolve(makeReviewLoad({ dataAvailable: false })) as never;
+            }
+            if (String(query).includes("AIGovernanceSummary")) {
+                return Promise.resolve(makeGovernance({ dataAvailable: false })) as never;
+            }
+            return routeQuery(query) as never;
+        });
+        const signals = byId(await getAISignals(defaultMetricFilter));
+        expect(signals["ai-impact"]).toMatchObject({ state: "unavailable", value: "" });
+        expect(signals["ai-review-load"]).toMatchObject({ state: "unavailable", value: "" });
+        expect(signals["ai-governance-risk"]).toMatchObject({ state: "unavailable", value: "" });
+    });
+
+    it("returns unavailable for all cards in isTestMode (no API calls)", async () => {
+        const signals = await getAISignals(defaultMetricFilter, true);
+        // In test mode all sources resolve to undefined → all unavailable.
+        for (const s of signals) {
+            expect(s.state).toBe("unavailable");
+        }
+        expect(mockGraphql).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/areaSignals/ai.ts
+++ b/src/lib/areaSignals/ai.ts
@@ -1,0 +1,286 @@
+// ── AI area signal resolver (CHAOS-2206) ───────────────────────────────────────
+//
+// Resolves the AI landing's sub-area signal cards. Mirrors the Govern resolver
+// pattern (CHAOS-2074): parallel fetch, severity derivation from real AI data,
+// honest "unavailable" per-card degradation when a source has no data.
+//
+// Signal policy (severity derivation):
+//   - ai-impact        : AI_ASSISTED bucket reworkDragRate (lowerIsBetter ×100),
+//                        BACKEND_LADDER; display value = aiAssistedPrRatio %.
+//   - ai-review-load   : AI_ASSISTED bucket reviewAmplification multiplier
+//                        (lowerIsBetter); display value = formatted multiplier.
+//   - ai-governance-risk: recentViolations severity ladder (RETURNED — critical/
+//                        high/medium from the violation rows); display = count.
+//   - ai-automations   : aiOpportunities detectorReady + recommendations count
+//                        (informational: "neutral" when candidates exist; "low"
+//                        when ready but zero; "unavailable" when not yet ready).
+//
+// Honest-state contract: a sub-area whose value cannot be resolved is emitted
+// with `state: "unavailable"` and an empty `value` — never a fabricated number.
+
+import { auth } from "@/lib/auth";
+import { graphqlFetch } from "@/lib/graphql/server";
+import {
+    AI_GOVERNANCE_SUMMARY_QUERY,
+    AI_IMPACT_SUMMARY_QUERY,
+    AI_OPPORTUNITIES_QUERY,
+    AI_REVIEW_LOAD_QUERY,
+} from "@/lib/graphql/queries";
+import type {
+    AiGovernanceSummary,
+    AiImpactSummary,
+    AiOpportunitiesResult,
+    AiReviewLoadResult,
+} from "@/lib/graphql/__generated__/types";
+import { metricFilterToAIFilter } from "@/lib/filters/ai";
+import type { MetricFilter } from "@/lib/filters/types";
+import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
+import { formatNumber, formatPercent } from "@/lib/formatters";
+import { logger } from "@/lib/logger";
+
+import { BACKEND_LADDER, deriveState, type SeverityThresholds } from "./deriveState";
+import type { AreaSignal, AreaSignalState } from "./types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** The unavailable (honest-empty) resolution — no fabricated value. */
+const UNAVAILABLE = { state: "unavailable" as const, value: "" };
+
+/**
+ * Review-amplification severity ladder (lowerIsBetter, multiplier scale).
+ * 1.0× = same load as baseline; ≥ 3.0× = critical review pressure.
+ */
+const REVIEW_AMPLIFICATION_THRESHOLDS: SeverityThresholds = {
+    critical: 3.0,
+    high: 2.0,
+    medium: 1.5,
+};
+
+/**
+ * Build an `AreaSignal` from its nav descriptor + resolved state/value. Pulls
+ * label / href / cluster / demoted from the descriptor so the card metadata
+ * stays anchored to the single nav source of truth.
+ */
+function buildSignal(
+    descriptor: NavAreaHubItem,
+    resolved: { state: AreaSignalState; value: string },
+): AreaSignal {
+    return {
+        id: descriptor.id,
+        label: descriptor.label,
+        href: descriptor.href,
+        cluster: descriptor.cluster,
+        metricLabel: descriptor.metricLabel ?? descriptor.label,
+        value: resolved.value,
+        state: resolved.state,
+        demoted: descriptor.demoted,
+    };
+}
+
+/** Resolve the org scope from the auth session. */
+async function resolveOrgId(): Promise<string> {
+    const session = await auth();
+    return (session?.user?.org_id as string | undefined) ?? "default-org";
+}
+
+/**
+ * Run a source fetch, swallowing failures to `undefined` so one dead source
+ * degrades to a single honest-empty card instead of failing the whole area.
+ */
+async function safe<T>(fn: () => Promise<T>, source: string): Promise<T | undefined> {
+    try {
+        return await fn();
+    } catch (error) {
+        logger.error({ err: error, source }, "AI signal source failed");
+        return undefined;
+    }
+}
+
+// ── Resolver ──────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the AI area's signal cards.
+ *
+ * @param filters    Active metric filter (drives the AI date range + scope).
+ * @param isTestMode Render deterministic sample data without hitting the API.
+ */
+export async function getAISignals(
+    filters: MetricFilter,
+    isTestMode = false,
+): Promise<AreaSignal[]> {
+    const ai = getAreaById("ai");
+    if (!ai) return [];
+
+    // Descriptor lookup by id — card metadata is owned by `navAreas`.
+    const byId = new Map(ai.hubItems.map((item) => [item.id, item]));
+    const descriptor = (id: string): NavAreaHubItem | undefined => byId.get(id);
+
+    const orgId = isTestMode ? "default-org" : await resolveOrgId();
+
+    // Derive AI query variables from the canonical metric filter.
+    const aiFilter = metricFilterToAIFilter(filters);
+    const dateRange = { startDate: aiFilter.startDate, endDate: aiFilter.endDate };
+    const scope = {
+        repoId: aiFilter.repoId ?? null,
+        teamId: aiFilter.teamId ?? null,
+        workType: aiFilter.workType ?? null,
+        buckets: aiFilter.buckets ?? null,
+    };
+
+    // ── Fetch all 4 sources in parallel (no serial N+1) ─────────────────────────
+    const [impact, reviewLoad, governance, opportunities] = await Promise.all([
+        safe(
+            () =>
+                isTestMode
+                    ? Promise.resolve(undefined)
+                    : graphqlFetch<{ aiImpactSummary: AiImpactSummary }>(
+                          AI_IMPACT_SUMMARY_QUERY,
+                          { orgId, dateRange, scope },
+                          { orgId },
+                      ).then((r) => r.aiImpactSummary),
+            "ai-impact",
+        ),
+        safe(
+            () =>
+                isTestMode
+                    ? Promise.resolve(undefined)
+                    : graphqlFetch<{ aiReviewLoad: AiReviewLoadResult }>(
+                          AI_REVIEW_LOAD_QUERY,
+                          { orgId, dateRange, scope },
+                          { orgId },
+                      ).then((r) => r.aiReviewLoad),
+            "ai-review-load",
+        ),
+        safe(
+            () =>
+                isTestMode
+                    ? Promise.resolve(undefined)
+                    : graphqlFetch<{ aiGovernanceSummary: AiGovernanceSummary }>(
+                          AI_GOVERNANCE_SUMMARY_QUERY,
+                          { orgId, dateRange, scope, violationLimit: 50 },
+                          { orgId },
+                      ).then((r) => r.aiGovernanceSummary),
+            "ai-governance-risk",
+        ),
+        safe(
+            () =>
+                isTestMode
+                    ? Promise.resolve(undefined)
+                    : graphqlFetch<{ aiOpportunities: AiOpportunitiesResult }>(
+                          AI_OPPORTUNITIES_QUERY,
+                          { orgId, scope, limit: 5 },
+                          { orgId },
+                      ).then((r) => r.aiOpportunities),
+            "ai-automations",
+        ),
+    ]);
+
+    const signals: AreaSignal[] = [];
+    const push = (id: string, resolved: { state: AreaSignalState; value: string }) => {
+        const d = descriptor(id);
+        if (d) signals.push(buildSignal(d, resolved));
+    };
+
+    // ── ai-impact: AI adoption + rework drag signal ───────────────────────────────
+    //
+    // Primary display value: aiAssistedPrRatio (0–1 → × 100 for formatPercent).
+    // Severity: AI_ASSISTED bucket reworkDragRate (0–1 → × 100, lowerIsBetter,
+    //   BACKEND_LADDER). Falls back to "neutral" when reworkDragRate is absent
+    //   but adoption data is present (informational only — no rework signal yet).
+    if (impact?.dataAvailable) {
+        const aiBucket = impact.byBucket.find((b) => b.bucket === "AI_ASSISTED");
+        const reworkDrag = aiBucket?.reworkDragRate;
+        const adoptionRatio = impact.aiAssistedPrRatio;
+        const state: AreaSignalState =
+            reworkDrag != null
+                ? deriveState(reworkDrag * 100, {
+                      thresholds: BACKEND_LADDER,
+                      direction: "lowerIsBetter",
+                  })
+                : "neutral";
+        push("ai-impact", {
+            state,
+            value: adoptionRatio != null ? `${formatPercent(adoptionRatio * 100)} AI-assisted` : "",
+        });
+    } else {
+        push("ai-impact", UNAVAILABLE);
+    }
+
+    // ── ai-review-load: AI-side review amplification ──────────────────────────────
+    //
+    // AI_ASSISTED bucket reviewAmplification multiplier (lowerIsBetter).
+    // dataAvailable guards against a non-null but empty result.
+    if (reviewLoad?.dataAvailable) {
+        const aiBucket = reviewLoad.byBucket.find((b) => b.bucket === "AI_ASSISTED");
+        const amplification = aiBucket?.reviewAmplification;
+        if (amplification != null) {
+            push("ai-review-load", {
+                state: deriveState(amplification, {
+                    thresholds: REVIEW_AMPLIFICATION_THRESHOLDS,
+                    direction: "lowerIsBetter",
+                }),
+                value: `${amplification.toFixed(1)}× amplification`,
+            });
+        } else {
+            push("ai-review-load", UNAVAILABLE);
+        }
+    } else {
+        push("ai-review-load", UNAVAILABLE);
+    }
+
+    // ── ai-governance-risk: recent violation severity ladder ─────────────────────
+    //
+    // RETURNED severity from the violation rows. The rule engine emits severity
+    // labels as strings; the known ladder is:
+    //   "critical" > "high" > "medium" > "warning" / "info" (low-signal)
+    // Zero violations → "low". Only info/warning violations → "low" (they are
+    // advisory, not actionable; collapsing them to "medium" would over-state risk).
+    if (governance?.dataAvailable) {
+        const violations = governance.recentViolations;
+        if (violations.length === 0) {
+            push("ai-governance-risk", {
+                state: "low",
+                value: `${formatNumber(0)} violations`,
+            });
+        } else {
+            const hasCritical = violations.some((v) => v.severity === "critical");
+            const hasHigh = violations.some((v) => v.severity === "high");
+            const hasMedium = violations.some((v) => v.severity === "medium");
+            const state: AreaSignalState = hasCritical
+                ? "critical"
+                : hasHigh
+                  ? "high"
+                  : hasMedium
+                    ? "medium"
+                    : "low";
+            push("ai-governance-risk", {
+                state,
+                value: `${formatNumber(violations.length)} violation${violations.length === 1 ? "" : "s"}`,
+            });
+        }
+    } else {
+        push("ai-governance-risk", UNAVAILABLE);
+    }
+
+    // ── ai-automations: automation candidate count (informational) ─────────────────
+    //
+    // detectorReady=false means the detector is not yet trained → honest
+    // "unavailable" (no fabricated candidate count). detectorReady=true with
+    // recommendations → "neutral" (the count is informational, not a severity
+    // ladder). Ready but zero recommendations → "low" (all-clear informational).
+    if (opportunities) {
+        if (!opportunities.detectorReady) {
+            push("ai-automations", UNAVAILABLE);
+        } else {
+            const count = opportunities.recommendations.length;
+            push("ai-automations", {
+                state: count > 0 ? "neutral" : "low",
+                value: `${formatNumber(count)} ${count === 1 ? "opportunity" : "opportunities"}`,
+            });
+        }
+    } else {
+        push("ai-automations", UNAVAILABLE);
+    }
+
+    return signals;
+}

--- a/src/lib/areaSignals/index.ts
+++ b/src/lib/areaSignals/index.ts
@@ -10,12 +10,14 @@
 import { getAreaById, type NavAreaId } from "@/lib/navigation/areas";
 import type { MetricFilter } from "@/lib/filters/types";
 
+import { getAISignals } from "./ai";
 import { getDiagnoseSignals } from "./diagnose";
 import { getGovernSignals } from "./govern";
 import { getImproveSignals } from "./improve";
 import type { AreaSignal } from "./types";
 
 export type { AreaSignal, AreaSignalState } from "./types";
+export { getAISignals } from "./ai";
 export { getDiagnoseSignals } from "./diagnose";
 export { getGovernSignals } from "./govern";
 export { getImproveSignals } from "./improve";
@@ -42,9 +44,7 @@ export async function getAreaSignals(
             void isTestMode;
             return descriptorStubs(areaId, "unavailable");
         case "ai":
-            void filters;
-            void isTestMode;
-            return descriptorStubs(areaId, "unavailable");
+            return getAISignals(filters, isTestMode);
         case "cockpit":
             // Cockpit's single sub-area (Operating Review) has no severity metric; it
             // is a navigational surface. Render it as a calm "neutral" card rather

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -42,6 +42,8 @@ export const CTA_LABELS = {
     aiReviewLoad: "Review Load",
     aiRisk: "Risk",
     aiAutomations: "Automations",
+    /** Navigate to the AI Automations workflow from a cross-panel CTA. */
+    seeAIAutomations: "See AI Automations",
     checkDataConnections: "Check data connections",
     flameDiagram: "Flame Diagram",
     landscape: "Landscape",

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -390,7 +390,7 @@ export const navAreas: readonly NavArea[] = [
             "govern",
         ],
         // CHAOS-2074: Govern is sub-grouped into "Quality" and "Risk" clusters,
-        // each internally severity-sorted by the resolver (`getGovernSignals`).
+        // each internally severity-sorted by the resolver (getGovernSignals).
         hubItems: [
             // ── Cluster: Quality ──────────────────────────────────────────────────
             {
@@ -520,12 +520,17 @@ export const navAreas: readonly NavArea[] = [
         placement: "main",
         ownedPathPrefixes: ["/ai"],
         legacyActiveIds: ["ai", "ai-workflows"],
+        // CHAOS-2198: AI is sub-grouped into "Signal" (monitoring metrics) and
+        // "Action" (opportunity / recommendation surfaces), severity-sorted by
+        // the resolver (getAISignals). Mirrors the Govern cluster pattern.
         hubItems: [
+            // ── Cluster: Signal ──────────────────────────────────────────────────
             {
                 id: "ai-impact",
                 label: "Impact",
                 href: "/ai/impact",
                 description: "AI-assisted delivery and review impact.",
+                cluster: "Signal",
                 metricLabel: "AI impact",
             },
             {
@@ -533,6 +538,7 @@ export const navAreas: readonly NavArea[] = [
                 label: "Review Load",
                 href: "/ai/review-load",
                 description: "AI-associated review pressure.",
+                cluster: "Signal",
                 metricLabel: "Review pressure",
             },
             {
@@ -540,13 +546,16 @@ export const navAreas: readonly NavArea[] = [
                 label: "Governance Risk",
                 href: "/ai/risk",
                 description: "Quality and governance signals for AI-associated work.",
+                cluster: "Signal",
                 metricLabel: "Governance risk",
             },
+            // ── Cluster: Action ──────────────────────────────────────────────────
             {
                 id: "ai-automations",
                 label: "Automations",
                 href: "/ai/automations",
                 description: "Responsible automation opportunities.",
+                cluster: "Action",
                 metricLabel: "Automation candidates",
             },
         ],

--- a/tests/ai-review-load.spec.ts
+++ b/tests/ai-review-load.spec.ts
@@ -89,6 +89,8 @@ test.describe("AI Review Load dashboard", () => {
         await page.goto(`/ai/review-load?f=${missingDataFilter}`);
 
         await expect(page.getByText("AI review load data is not available")).toBeVisible();
-        await expect(page.getByText(/AI attribution plus review event rollups/i)).toBeVisible();
+        await expect(
+            page.getByText(/Review activity rollups for AI-attributed PRs/i),
+        ).toBeVisible();
     });
 });


### PR DESCRIPTION
Wave 1 (decision-free frontend slice) of the **CHAOS-2180** AI-area audit. Companion backend PR: full-chaos/dev-health-ops `fix/chaos-2180-ai-backend`.

## Issues closed
- **AI-09 / CHAOS-2206** — real `getAISignals()` resolver; `/ai` Overview hub cards no longer permanently "unavailable" (mirrors `govern.ts`, honest per-card degrade, **no fabricated values**)
- **AI-06 / CHAOS-2198** — `cluster` grouping on AI hubItems (Signal/Action)
- **AI-10 / CHAOS-2191** — `BackLink` in `AIWorkspaceChrome` (A5 single return path)
- **AI-11 / CHAOS-2207** — CTA labels via `cta.ts` registry
- **AI-12 / CHAOS-2192** — empty-states route through canonical `DataState` (single source of truth)
- **AI-13 / CHAOS-2193** — `checkApiHealth`/`ServiceUnavailable` guard on review-load/risk/automations
- **AI-27 / CHAOS-2210** — fix dead `#ai-workflow-intelligence` anchors (hyphen→underscore; verified against `operating-review` `id`)
- **AI-28 / CHAOS-2201** — strip implementation-leak copy (A8) from Review Load / Risk
- **AI-29 / CHAOS-2202** — `"Decision area"` eyebrow → `"AI"`
- **AI-31 / CHAOS-2215** — label/copy normalization (Evidence title, AI, callout steps) + 3-way governance severity ladder

## Verification
`tsc` clean · **1867** vitest · design-lint scanner `no-internal-leak: 0` / `cta-from-registry: 0` · prettier clean. Passed an adversarial (opus) review.

Built by a 3-agent team on disjoint files; full audit + remaining (decision-gated) AI work tracked under **CHAOS-2180**.
