### PR TITLE
fix(improve): polarity-gated top signal + subarea no-data cards (CHAOS-2217)

### DIFF
--- a/src/components/navigation/AreaOverview.test.tsx
+++ b/src/components/navigation/AreaOverview.test.tsx
@@ -96,15 +96,11 @@ describe("AreaOverview — summarize + route (no hero/grid duplication)", () => 
 
         const grid = screen.getByTestId("area-overview-grid");
         const gridCards = within(grid).getAllByTestId("area-signal-card");
-        expect(gridCards.map((c) => c.getAttribute("data-signal-id"))).toEqual(["med"]);
+        expect(gridCards.map((c) => c.getAttribute("data-signal-id"))).toEqual(["med", "gap"]);
 
-        const emptyTier = screen.getByTestId("area-overview-empty-tier");
-        expect(within(emptyTier).getByText("Not yet connected")).toBeInTheDocument();
-        expect(within(emptyTier).getByRole("link", { name: "gap" })).toHaveAttribute(
-            "data-signal-id",
-            "gap",
-        );
-        expect(within(emptyTier).queryByTestId("area-signal-card")).toBeNull();
+        const gapCard = gridCards.find((c) => c.getAttribute("data-signal-id") === "gap")!;
+        expect(gapCard).toHaveAttribute("data-state", "unavailable");
+        expect(within(gapCard).getByTestId("area-signal-unavailable")).toBeInTheDocument();
     });
 
     it("never surfaces the 'No area metric unavailable' double-negative copy", () => {
@@ -120,10 +116,11 @@ describe("AreaOverview — summarize + route (no hero/grid duplication)", () => 
         renderOverview([signal("a", "unavailable"), signal("b", "unavailable")]);
         // No hero (an unavailable metric is never the top signal).
         expect(screen.queryByTestId("area-overview-hero")).toBeNull();
-        expect(screen.queryByTestId("area-overview-grid")).toBeNull();
-        const emptyTier = screen.getByTestId("area-overview-empty-tier");
-        expect(within(emptyTier).getAllByRole("link")).toHaveLength(2);
-        expect(within(emptyTier).queryAllByTestId("area-signal-card")).toHaveLength(0);
+        const grid = screen.getByTestId("area-overview-grid");
+        const gridCards = within(grid).getAllByTestId("area-signal-card");
+        expect(gridCards).toHaveLength(2);
+        expect(gridCards[0]).toHaveAttribute("data-signal-id", "a");
+        expect(gridCards[1]).toHaveAttribute("data-signal-id", "b");
     });
 
     it("renders a PREVIEW empty-tier chip as non-clickable, a routed one as a link (CHAOS-2217)", () => {
@@ -131,19 +128,21 @@ describe("AreaOverview — summarize + route (no hero/grid duplication)", () => 
             signal("routed", "unavailable"),
             signal("preview", "unavailable", { preview: true }),
         ]);
-        const emptyTier = screen.getByTestId("area-overview-empty-tier");
+        const grid = screen.getByTestId("area-overview-grid");
 
         // The preview chip is NOT a link (dead route can't 404) but stays visible.
-        const previewChip = within(emptyTier)
-            .getAllByText((_, el) => el?.getAttribute("data-signal-id") === "preview")
-            .find((el) => el.getAttribute("data-signal-id") === "preview")!;
+        const previewCards = within(grid).getAllByTestId("area-signal-card");
+        const previewChip = previewCards.find(
+            (el) => el.getAttribute("data-signal-id") === "preview",
+        )!;
         expect(previewChip.tagName).not.toBe("A");
         expect(previewChip.getAttribute("aria-disabled")).toBe("true");
 
         // The routed unavailable chip remains a link.
-        const routedLink = within(emptyTier).getByRole("link", { name: "routed" });
+        const routedLink = previewCards.find(
+            (el) => el.getAttribute("data-signal-id") === "routed",
+        )!;
+        expect(routedLink.tagName).toBe("A");
         expect(routedLink).toHaveAttribute("data-signal-id", "routed");
-        // Exactly one link in the tier (only the routed one).
-        expect(within(emptyTier).getAllByRole("link")).toHaveLength(1);
     });
 });

--- a/src/components/navigation/AreaOverview.tsx
+++ b/src/components/navigation/AreaOverview.tsx
@@ -1,7 +1,4 @@
-import Link from "next/link";
-
 import type { MetricFilter } from "@/lib/filters/types";
-import { withFilterParam } from "@/lib/filters/url";
 import { getAreaById, type NavAreaId } from "@/lib/navigation/areas";
 import type { AreaSignal } from "@/lib/areaSignals/types";
 import { isAvailable, sortBySeverity } from "@/lib/areaSignals/sort";
@@ -87,7 +84,7 @@ export function AreaOverview({
                 </div>
             ) : null}
 
-            {gridSignals.length > 0 ? (
+            {gridSignals.length > 0 || unavailable.length > 0 ? (
                 <div
                     data-testid="area-overview-grid"
                     className="grid gap-3 md:grid-cols-2 lg:grid-cols-3"
@@ -100,45 +97,14 @@ export function AreaOverview({
                             role={role}
                         />
                     ))}
-                </div>
-            ) : null}
-
-            {unavailable.length > 0 ? (
-                <div
-                    data-testid="area-overview-empty-tier"
-                    className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-4 text-sm text-(--ink-muted)"
-                >
-                    <div className="flex flex-wrap items-center gap-2">
-                        <span className="mr-1 text-xs uppercase tracking-[0.18em]">
-                            Not yet connected
-                        </span>
-                        {unavailable.map((signal) => {
-                            const chipClassName =
-                                "rounded-full border border-(--card-stroke) bg-(--card-80) px-3 py-1 text-xs font-medium text-foreground";
-                            // Preview sub-area (route not built yet) → non-clickable chip so
-                            // it can't 404; a real-but-unconnected sub-area stays a link.
-                            return signal.preview === true ? (
-                                <span
-                                    key={signal.id}
-                                    data-signal-id={signal.id}
-                                    data-preview="true"
-                                    aria-disabled="true"
-                                    className={chipClassName}
-                                >
-                                    {signal.label}
-                                </span>
-                            ) : (
-                                <Link
-                                    key={signal.id}
-                                    href={withFilterParam(signal.href, filters, role)}
-                                    data-signal-id={signal.id}
-                                    className={`${chipClassName} transition hover:border-(--accent)`}
-                                >
-                                    {signal.label}
-                                </Link>
-                            );
-                        })}
-                    </div>
+                    {unavailable.map((signal) => (
+                        <AreaSignalCard
+                            key={signal.id}
+                            signal={signal}
+                            filters={filters}
+                            role={role}
+                        />
+                    ))}
                 </div>
             ) : null}
         </section>

--- a/src/components/navigation/AreaSignalCard.tsx
+++ b/src/components/navigation/AreaSignalCard.tsx
@@ -2,9 +2,9 @@ import Link from "next/link";
 
 import { DataState } from "@/components/ui/DataState";
 import {
-	AREA_STATE_BADGE,
-	AREA_STATE_LABEL,
-	DIRECTION_GLYPH,
+    AREA_STATE_BADGE,
+    AREA_STATE_LABEL,
+    DIRECTION_GLYPH,
 } from "@/components/home/severityTokens";
 import type { AreaSignal } from "@/lib/areaSignals/types";
 import { AREA_UNAVAILABLE_EMPTY_STATE } from "@/lib/design/emptyState";
@@ -24,152 +24,147 @@ import type { MetricFilter } from "@/lib/filters/types";
 // secondary — tighter padding, no emphasis — within their cluster.
 
 type AreaSignalCardProps = {
-	signal: AreaSignal;
-	filters: MetricFilter;
-	role?: string;
-	/** Top-signal emphasis (mirrors RankedSignals' lead card). */
-	emphasized?: boolean;
+    signal: AreaSignal;
+    filters: MetricFilter;
+    role?: string;
+    /** Top-signal emphasis (mirrors RankedSignals' lead card). */
+    emphasized?: boolean;
 };
 
-export function AreaSignalCard({
-	signal,
-	filters,
-	role,
-	emphasized = false,
-}: AreaSignalCardProps) {
-	const href = withFilterParam(signal.href, filters, role);
-	const demoted = signal.demoted === true;
-	// Preview sub-area: its route does not exist yet (nav child `preview: true`).
-	// Render the card NON-CLICKABLE so it stays visible + honest but can't 404.
-	// Keyed on the explicit `preview` flag, NOT on `state === "unavailable"`,
-	// which is shared by areas whose routes DO exist and must stay clickable.
-	const isPreview = signal.preview === true;
+export function AreaSignalCard({ signal, filters, role, emphasized = false }: AreaSignalCardProps) {
+    const href = withFilterParam(signal.href, filters, role);
+    const demoted = signal.demoted === true;
+    // Preview sub-area: its route does not exist yet (nav child `preview: true`).
+    // Render the card NON-CLICKABLE so it stays visible + honest but can't 404.
+    // Keyed on the explicit `preview` flag, NOT on `state === "unavailable"`,
+    // which is shared by areas whose routes DO exist and must stay clickable.
+    const isPreview = signal.preview === true;
 
-	// Unavailable → inline DataState (never a fabricated value). A real (routed)
-	// sub-area stays a link so it remains reachable; a preview sub-area renders as
-	// a plain <div> (same visual) so the dead route is never linked.
-	if (signal.state === "unavailable") {
-		// Base dashed treatment; only ROUTED (clickable) cards get the hover
-		// affordance — a preview card must not look interactive.
-		const unavailableBaseClassName =
-			"group block rounded-2xl border border-dashed border-(--card-stroke)/70 bg-(--card-80)/60 p-4 opacity-70 transition";
-		const unavailableClassName = `${unavailableBaseClassName} hover:border-(--accent) hover:opacity-100`;
-		const body = (
-			<>
-				<p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
-					{signal.label}
-				</p>
-				<DataState
-					variant="detector-unavailable"
-					title={AREA_UNAVAILABLE_EMPTY_STATE.title}
-					description={AREA_UNAVAILABLE_EMPTY_STATE.description}
-					className="mt-3"
-					data-testid="area-signal-unavailable"
-				/>
-			</>
-		);
+    // Unavailable → inline DataState (never a fabricated value). A real (routed)
+    // sub-area stays a link so it remains reachable; a preview sub-area renders as
+    // a plain <div> (same visual) so the dead route is never linked.
+    if (signal.state === "unavailable") {
+        // Base dashed treatment; only ROUTED (clickable) cards get the hover
+        // affordance — a preview card must not look interactive.
+        const unavailableBaseClassName =
+            "group block rounded-2xl border border-dashed border-(--card-stroke)/70 bg-(--card-80)/60 p-4 opacity-70 transition";
+        const unavailableClassName = `${unavailableBaseClassName} hover:border-(--accent) hover:opacity-100`;
+        const body = (
+            <>
+                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
+                    {signal.label}
+                </p>
+                <DataState
+                    variant="detector-unavailable"
+                    title={AREA_UNAVAILABLE_EMPTY_STATE.title}
+                    description={AREA_UNAVAILABLE_EMPTY_STATE.description}
+                    className="mt-3"
+                    data-testid="area-signal-unavailable"
+                />
+            </>
+        );
 
-		if (isPreview) {
-			return (
-				<div
-					data-testid="area-signal-card"
-					data-signal-id={signal.id}
-					data-state="unavailable"
-					data-tier="muted"
-					data-preview="true"
-					aria-disabled="true"
-					className={unavailableBaseClassName}
-				>
-					{body}
-				</div>
-			);
-		}
+        if (isPreview) {
+            return (
+                <div
+                    data-testid="area-signal-card"
+                    data-signal-id={signal.id}
+                    data-state="unavailable"
+                    data-tier="muted"
+                    data-preview="true"
+                    aria-disabled="true"
+                    className={unavailableBaseClassName}
+                >
+                    {body}
+                </div>
+            );
+        }
 
-		return (
-			<Link
-				href={href}
-				data-testid="area-signal-card"
-				data-signal-id={signal.id}
-				data-state="unavailable"
-				data-tier="muted"
-				className={unavailableClassName}
-			>
-				{body}
-			</Link>
-		);
-	}
+        return (
+            <Link
+                href={href}
+                data-testid="area-signal-card"
+                data-signal-id={signal.id}
+                data-state="unavailable"
+                data-tier="muted"
+                className={unavailableClassName}
+            >
+                {body}
+            </Link>
+        );
+    }
 
-	const badge = AREA_STATE_BADGE[signal.state];
-	const stateLabel = AREA_STATE_LABEL[signal.state];
+    const badge = AREA_STATE_BADGE[signal.state];
+    const stateLabel = AREA_STATE_LABEL[signal.state];
 
-	return (
-		<Link
-			href={href}
-			data-testid="area-signal-card"
-			data-signal-id={signal.id}
-			data-state={signal.state}
-			data-demoted={demoted ? "true" : "false"}
-			data-emphasized={emphasized ? "true" : "false"}
-			className={
-				emphasized
-					? "group relative block overflow-hidden rounded-3xl border border-(--accent)/30 bg-gradient-to-br from-(--card) to-(--card-80) p-6 shadow-lg ring-1 ring-(--accent)/10 transition hover:-translate-y-1 hover:border-(--accent)"
-					: demoted
-						? "group block rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3 transition hover:border-(--accent)"
-						: "group block overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card) p-4 transition hover:-translate-y-1 hover:border-(--accent)"
-			}
-		>
-			{emphasized ? (
-				<p className="text-xs font-semibold uppercase tracking-[0.28em] text-(--accent)">
-					Top signal
-				</p>
-			) : null}
+    return (
+        <Link
+            href={href}
+            data-testid="area-signal-card"
+            data-signal-id={signal.id}
+            data-state={signal.state}
+            data-demoted={demoted ? "true" : "false"}
+            data-emphasized={emphasized ? "true" : "false"}
+            className={
+                emphasized
+                    ? "group relative block overflow-hidden rounded-3xl border border-(--accent)/30 bg-gradient-to-br from-(--card) to-(--card-80) p-6 shadow-lg ring-1 ring-(--accent)/10 transition hover:-translate-y-1 hover:border-(--accent)"
+                    : demoted
+                      ? "group block rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3 transition hover:border-(--accent)"
+                      : "group block overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card) p-4 transition hover:-translate-y-1 hover:border-(--accent)"
+            }
+        >
+            {emphasized ? (
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-(--accent)">
+                    Top signal
+                </p>
+            ) : null}
 
-			<header className="mt-1 flex items-start justify-between gap-3">
-				<h3
-					className={
-						emphasized
-							? "font-(--font-display) text-xl leading-tight text-foreground"
-							: demoted
-								? "text-sm font-medium text-foreground"
-								: "font-(--font-display) text-base leading-tight text-foreground"
-					}
-				>
-					{signal.label}
-				</h3>
-				<span
-					data-testid="area-signal-badge"
-					className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-bold uppercase tracking-[0.18em] ${badge}`}
-				>
-					{stateLabel}
-				</span>
-			</header>
+            <header className="mt-1 flex items-start justify-between gap-3">
+                <h3
+                    className={
+                        emphasized
+                            ? "font-(--font-display) text-xl leading-tight text-foreground"
+                            : demoted
+                              ? "text-sm font-medium text-foreground"
+                              : "font-(--font-display) text-base leading-tight text-foreground"
+                    }
+                >
+                    {signal.label}
+                </h3>
+                <span
+                    data-testid="area-signal-badge"
+                    className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-bold uppercase tracking-[0.18em] ${badge}`}
+                >
+                    {stateLabel}
+                </span>
+            </header>
 
-			{/* Metric label + formatted value (+ optional trend glyph). A value-less
+            {/* Metric label + formatted value (+ optional trend glyph). A value-less
           neutral card (navigational sub-area) shows just its descriptor copy. */}
-			{signal.value ? (
-				<div className="mt-3 flex flex-wrap items-baseline gap-x-2 gap-y-1">
-					<span
-						data-testid="area-signal-value"
-						className={
-							demoted
-								? "metric-hero text-lg font-semibold text-foreground"
-								: "metric-hero text-2xl font-semibold text-foreground"
-						}
-					>
-						{signal.value}
-					</span>
-					{signal.direction ? (
-						<span aria-hidden className="text-xs text-(--ink-muted)">
-							{DIRECTION_GLYPH[signal.direction]}
-						</span>
-					) : null}
-					<span className="text-xs uppercase tracking-[0.12em] text-(--ink-muted)">
-						{signal.metricLabel}
-					</span>
-				</div>
-			) : (
-				<p className="mt-2 text-sm text-(--ink-muted)">{signal.metricLabel}</p>
-			)}
-		</Link>
-	);
+            {signal.value ? (
+                <div className="mt-3 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span
+                        data-testid="area-signal-value"
+                        className={
+                            demoted
+                                ? "metric-hero text-lg font-semibold text-foreground"
+                                : "metric-hero text-2xl font-semibold text-foreground"
+                        }
+                    >
+                        {signal.value}
+                    </span>
+                    {signal.direction ? (
+                        <span aria-hidden className="text-xs text-(--ink-muted)">
+                            {DIRECTION_GLYPH[signal.direction]}
+                        </span>
+                    ) : null}
+                    <span className="text-xs uppercase tracking-[0.12em] text-(--ink-muted)">
+                        {signal.metricLabel}
+                    </span>
+                </div>
+            ) : (
+                <p className="mt-2 text-sm text-(--ink-muted)">{signal.metricLabel}</p>
+            )}
+        </Link>
+    );
 }

--- a/src/components/navigation/AreaSignalCard.tsx
+++ b/src/components/navigation/AreaSignalCard.tsx
@@ -2,9 +2,9 @@ import Link from "next/link";
 
 import { DataState } from "@/components/ui/DataState";
 import {
-    AREA_STATE_BADGE,
-    AREA_STATE_LABEL,
-    DIRECTION_GLYPH,
+	AREA_STATE_BADGE,
+	AREA_STATE_LABEL,
+	DIRECTION_GLYPH,
 } from "@/components/home/severityTokens";
 import type { AreaSignal } from "@/lib/areaSignals/types";
 import { AREA_UNAVAILABLE_EMPTY_STATE } from "@/lib/design/emptyState";
@@ -24,144 +24,152 @@ import type { MetricFilter } from "@/lib/filters/types";
 // secondary — tighter padding, no emphasis — within their cluster.
 
 type AreaSignalCardProps = {
-    signal: AreaSignal;
-    filters: MetricFilter;
-    role?: string;
-    /** Top-signal emphasis (mirrors RankedSignals' lead card). */
-    emphasized?: boolean;
+	signal: AreaSignal;
+	filters: MetricFilter;
+	role?: string;
+	/** Top-signal emphasis (mirrors RankedSignals' lead card). */
+	emphasized?: boolean;
 };
 
-export function AreaSignalCard({ signal, filters, role, emphasized = false }: AreaSignalCardProps) {
-    const href = withFilterParam(signal.href, filters, role);
-    const demoted = signal.demoted === true;
-    // Preview sub-area: its route does not exist yet (nav child `preview: true`).
-    // Render the card NON-CLICKABLE so it stays visible + honest but can't 404.
-    // Keyed on the explicit `preview` flag, NOT on `state === "unavailable"`,
-    // which is shared by areas whose routes DO exist and must stay clickable.
-    const isPreview = signal.preview === true;
+export function AreaSignalCard({
+	signal,
+	filters,
+	role,
+	emphasized = false,
+}: AreaSignalCardProps) {
+	const href = withFilterParam(signal.href, filters, role);
+	const demoted = signal.demoted === true;
+	// Preview sub-area: its route does not exist yet (nav child `preview: true`).
+	// Render the card NON-CLICKABLE so it stays visible + honest but can't 404.
+	// Keyed on the explicit `preview` flag, NOT on `state === "unavailable"`,
+	// which is shared by areas whose routes DO exist and must stay clickable.
+	const isPreview = signal.preview === true;
 
-    // Unavailable → inline DataState (never a fabricated value). A real (routed)
-    // sub-area stays a link so it remains reachable; a preview sub-area renders as
-    // a plain <div> (same visual) so the dead route is never linked.
-    if (signal.state === "unavailable") {
-        const unavailableClassName =
-            "group block rounded-2xl border border-dashed border-(--card-stroke)/70 bg-(--card-80)/60 p-4 opacity-70 transition hover:border-(--accent) hover:opacity-100";
-        const body = (
-            <>
-                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
-                    {signal.label}
-                </p>
-                <DataState
-                    variant="detector-unavailable"
-                    title={AREA_UNAVAILABLE_EMPTY_STATE.title}
-                    description={AREA_UNAVAILABLE_EMPTY_STATE.description}
-                    className="mt-3"
-                    data-testid="area-signal-unavailable"
-                />
-            </>
-        );
+	// Unavailable → inline DataState (never a fabricated value). A real (routed)
+	// sub-area stays a link so it remains reachable; a preview sub-area renders as
+	// a plain <div> (same visual) so the dead route is never linked.
+	if (signal.state === "unavailable") {
+		// Base dashed treatment; only ROUTED (clickable) cards get the hover
+		// affordance — a preview card must not look interactive.
+		const unavailableBaseClassName =
+			"group block rounded-2xl border border-dashed border-(--card-stroke)/70 bg-(--card-80)/60 p-4 opacity-70 transition";
+		const unavailableClassName = `${unavailableBaseClassName} hover:border-(--accent) hover:opacity-100`;
+		const body = (
+			<>
+				<p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
+					{signal.label}
+				</p>
+				<DataState
+					variant="detector-unavailable"
+					title={AREA_UNAVAILABLE_EMPTY_STATE.title}
+					description={AREA_UNAVAILABLE_EMPTY_STATE.description}
+					className="mt-3"
+					data-testid="area-signal-unavailable"
+				/>
+			</>
+		);
 
-        if (isPreview) {
-            return (
-                <div
-                    data-testid="area-signal-card"
-                    data-signal-id={signal.id}
-                    data-state="unavailable"
-                    data-tier="muted"
-                    data-preview="true"
-                    aria-disabled="true"
-                    className={unavailableClassName}
-                >
-                    {body}
-                </div>
-            );
-        }
+		if (isPreview) {
+			return (
+				<div
+					data-testid="area-signal-card"
+					data-signal-id={signal.id}
+					data-state="unavailable"
+					data-tier="muted"
+					data-preview="true"
+					aria-disabled="true"
+					className={unavailableBaseClassName}
+				>
+					{body}
+				</div>
+			);
+		}
 
-        return (
-            <Link
-                href={href}
-                data-testid="area-signal-card"
-                data-signal-id={signal.id}
-                data-state="unavailable"
-                data-tier="muted"
-                className={unavailableClassName}
-            >
-                {body}
-            </Link>
-        );
-    }
+		return (
+			<Link
+				href={href}
+				data-testid="area-signal-card"
+				data-signal-id={signal.id}
+				data-state="unavailable"
+				data-tier="muted"
+				className={unavailableClassName}
+			>
+				{body}
+			</Link>
+		);
+	}
 
-    const badge = AREA_STATE_BADGE[signal.state];
-    const stateLabel = AREA_STATE_LABEL[signal.state];
+	const badge = AREA_STATE_BADGE[signal.state];
+	const stateLabel = AREA_STATE_LABEL[signal.state];
 
-    return (
-        <Link
-            href={href}
-            data-testid="area-signal-card"
-            data-signal-id={signal.id}
-            data-state={signal.state}
-            data-demoted={demoted ? "true" : "false"}
-            data-emphasized={emphasized ? "true" : "false"}
-            className={
-                emphasized
-                    ? "group relative block overflow-hidden rounded-3xl border border-(--accent)/30 bg-gradient-to-br from-(--card) to-(--card-80) p-6 shadow-lg ring-1 ring-(--accent)/10 transition hover:-translate-y-1 hover:border-(--accent)"
-                    : demoted
-                      ? "group block rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3 transition hover:border-(--accent)"
-                      : "group block overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card) p-4 transition hover:-translate-y-1 hover:border-(--accent)"
-            }
-        >
-            {emphasized ? (
-                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-(--accent)">
-                    Top signal
-                </p>
-            ) : null}
+	return (
+		<Link
+			href={href}
+			data-testid="area-signal-card"
+			data-signal-id={signal.id}
+			data-state={signal.state}
+			data-demoted={demoted ? "true" : "false"}
+			data-emphasized={emphasized ? "true" : "false"}
+			className={
+				emphasized
+					? "group relative block overflow-hidden rounded-3xl border border-(--accent)/30 bg-gradient-to-br from-(--card) to-(--card-80) p-6 shadow-lg ring-1 ring-(--accent)/10 transition hover:-translate-y-1 hover:border-(--accent)"
+					: demoted
+						? "group block rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3 transition hover:border-(--accent)"
+						: "group block overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card) p-4 transition hover:-translate-y-1 hover:border-(--accent)"
+			}
+		>
+			{emphasized ? (
+				<p className="text-xs font-semibold uppercase tracking-[0.28em] text-(--accent)">
+					Top signal
+				</p>
+			) : null}
 
-            <header className="mt-1 flex items-start justify-between gap-3">
-                <h3
-                    className={
-                        emphasized
-                            ? "font-(--font-display) text-xl leading-tight text-foreground"
-                            : demoted
-                              ? "text-sm font-medium text-foreground"
-                              : "font-(--font-display) text-base leading-tight text-foreground"
-                    }
-                >
-                    {signal.label}
-                </h3>
-                <span
-                    data-testid="area-signal-badge"
-                    className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-bold uppercase tracking-[0.18em] ${badge}`}
-                >
-                    {stateLabel}
-                </span>
-            </header>
+			<header className="mt-1 flex items-start justify-between gap-3">
+				<h3
+					className={
+						emphasized
+							? "font-(--font-display) text-xl leading-tight text-foreground"
+							: demoted
+								? "text-sm font-medium text-foreground"
+								: "font-(--font-display) text-base leading-tight text-foreground"
+					}
+				>
+					{signal.label}
+				</h3>
+				<span
+					data-testid="area-signal-badge"
+					className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-bold uppercase tracking-[0.18em] ${badge}`}
+				>
+					{stateLabel}
+				</span>
+			</header>
 
-            {/* Metric label + formatted value (+ optional trend glyph). A value-less
+			{/* Metric label + formatted value (+ optional trend glyph). A value-less
           neutral card (navigational sub-area) shows just its descriptor copy. */}
-            {signal.value ? (
-                <div className="mt-3 flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                    <span
-                        data-testid="area-signal-value"
-                        className={
-                            demoted
-                                ? "metric-hero text-lg font-semibold text-foreground"
-                                : "metric-hero text-2xl font-semibold text-foreground"
-                        }
-                    >
-                        {signal.value}
-                    </span>
-                    {signal.direction ? (
-                        <span aria-hidden className="text-xs text-(--ink-muted)">
-                            {DIRECTION_GLYPH[signal.direction]}
-                        </span>
-                    ) : null}
-                    <span className="text-xs uppercase tracking-[0.12em] text-(--ink-muted)">
-                        {signal.metricLabel}
-                    </span>
-                </div>
-            ) : (
-                <p className="mt-2 text-sm text-(--ink-muted)">{signal.metricLabel}</p>
-            )}
-        </Link>
-    );
+			{signal.value ? (
+				<div className="mt-3 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+					<span
+						data-testid="area-signal-value"
+						className={
+							demoted
+								? "metric-hero text-lg font-semibold text-foreground"
+								: "metric-hero text-2xl font-semibold text-foreground"
+						}
+					>
+						{signal.value}
+					</span>
+					{signal.direction ? (
+						<span aria-hidden className="text-xs text-(--ink-muted)">
+							{DIRECTION_GLYPH[signal.direction]}
+						</span>
+					) : null}
+					<span className="text-xs uppercase tracking-[0.12em] text-(--ink-muted)">
+						{signal.metricLabel}
+					</span>
+				</div>
+			) : (
+				<p className="mt-2 text-sm text-(--ink-muted)">{signal.metricLabel}</p>
+			)}
+		</Link>
+	);
 }

--- a/src/lib/areaSignals/__tests__/improve.test.ts
+++ b/src/lib/areaSignals/__tests__/improve.test.ts
@@ -55,19 +55,38 @@ beforeEach(() => {
         items: [opportunityItem(["https://example.com/evidence"]), opportunityItem([])],
     } as never);
     mockGetHomeData.mockResolvedValue(
-        homeWithDeltas([delta("Throughput", 19), delta("Cycle Time", 8), delta("Coverage", -4)]),
+        homeWithDeltas([delta("Churn", 19), delta("Cycle Time", 8), delta("Coverage", -4)]),
     );
 });
 
 describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
     // ── Top signal (synthesized worst opportunity) ────────────────────────────────
 
+    it("gates the TOP SIGNAL by polarity (throughput up = NOT hero, churn up = hero, throughput down = 'Recover' hero)", async () => {
+        // Throughput up (+10) is GOOD (higher-is-better). Churn up (+5) is BAD (lower-is-better).
+        // Throughput down (-15) is BAD (higher-is-better).
+        mockGetHomeData.mockResolvedValue(
+            homeWithDeltas([
+                delta("Throughput", 10), // Good
+                delta("Churn", 5), // Bad
+                delta("Deploy Freq", -15, "deploy_freq"), // Bad
+            ]),
+        );
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals["improve-top-signal"]).toMatchObject({
+            label: "Recover Deploy Freq",
+            value: "-15%",
+            state: "high",
+            direction: "down",
+        });
+    });
+
     it("synthesizes a TOP SIGNAL from the worst worsened metric (label + signed delta + severity)", async () => {
         const signals = byId(await getImproveSignals(defaultMetricFilter));
 
         expect(signals["improve-top-signal"]).toMatchObject({
             id: "improve-top-signal",
-            label: "Reduce Throughput",
+            label: "Reduce Churn",
             href: "/opportunities",
             value: "+19%",
             // +19% maps to "high" (Penpot's ELEVATED lead), NOT neutral.
@@ -75,7 +94,7 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
             direction: "up",
         });
         // The secondary line frames the metric, it does NOT just repeat the label.
-        expect(signals["improve-top-signal"].metricLabel).toBe("Throughput shift");
+        expect(signals["improve-top-signal"].metricLabel).toBe("Churn shift");
     });
 
     it("makes the TOP SIGNAL the most-severe available signal (sorts above Opportunities)", async () => {
@@ -87,14 +106,18 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
         expect(topIdx).toBeLessThan(oppIdx);
     });
 
-    it("picks the LARGEST positive delta as the top signal (not the first)", async () => {
+    it("picks the LARGEST absolute delta in the wrong direction as the top signal (not the first)", async () => {
         mockGetHomeData.mockResolvedValue(
-            homeWithDeltas([delta("Cycle Time", 8), delta("Throughput", 27), delta("Churn", 12)]),
+            homeWithDeltas([
+                delta("Cycle Time", 8),
+                delta("Throughput", -27), // Bad
+                delta("Churn", 12), // Bad
+            ]),
         );
         const signals = byId(await getImproveSignals(defaultMetricFilter));
         expect(signals["improve-top-signal"]).toMatchObject({
-            label: "Reduce Throughput",
-            value: "+27%",
+            label: "Recover Throughput",
+            value: "-27%",
             // ≥25 → critical.
             state: "critical",
         });
@@ -108,7 +131,7 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
             [2, "low"],
         ];
         for (const [deltaPct, expected] of cases) {
-            mockGetHomeData.mockResolvedValue(homeWithDeltas([delta("Throughput", deltaPct)]));
+            mockGetHomeData.mockResolvedValue(homeWithDeltas([delta("Churn", deltaPct)]));
             const signals = byId(await getImproveSignals(defaultMetricFilter));
             expect(signals["improve-top-signal"].state, `${deltaPct}% → ${expected}`).toBe(
                 expected,
@@ -118,7 +141,7 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
 
     it("omits the TOP SIGNAL when NO metric worsened (Opportunities leads as neutral, no fabricated severity)", async () => {
         mockGetHomeData.mockResolvedValue(
-            homeWithDeltas([delta("Throughput", -5), delta("Cycle Time", -2)]),
+            homeWithDeltas([delta("Throughput", 5), delta("Cycle Time", -2)]),
         );
         const signals = await getImproveSignals(defaultMetricFilter);
         expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
@@ -207,7 +230,9 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
         expect(signals["improve-top-signal"]).toBeUndefined();
         // Other signals still resolve
         expect(signals.experiments).toMatchObject({ state: "unavailable" });
-        expect(signals["improve-automations"]).toMatchObject({ state: "unavailable" });
+        expect(signals["improve-automations"]).toMatchObject({
+            state: "unavailable",
+        });
     });
 
     // ── Preview sub-areas (Experiments / Automations) ─────────────────────────────

--- a/src/lib/areaSignals/__tests__/improve.test.ts
+++ b/src/lib/areaSignals/__tests__/improve.test.ts
@@ -6,11 +6,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // without any network.
 
 vi.mock("@/lib/api/home", () => ({
-	getOpportunities: vi.fn(),
-	getHomeData: vi.fn(),
+    getOpportunities: vi.fn(),
+    getHomeData: vi.fn(),
 }));
 vi.mock("@/lib/logger", () => ({
-	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+    logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
 import { getHomeData, getOpportunities } from "@/lib/api/home";
@@ -23,361 +23,342 @@ const mockGetOpportunities = vi.mocked(getOpportunities);
 const mockGetHomeData = vi.mocked(getHomeData);
 
 function byId(signals: AreaSignal[]): Record<string, AreaSignal> {
-	return Object.fromEntries(signals.map((s) => [s.id, s]));
+    return Object.fromEntries(signals.map((s) => [s.id, s]));
 }
 
 const opportunityItem = (evidenceLinks: string[] = []) => ({
-	id: "opp-1",
-	title: "Reduce cycle time",
-	rationale: "Cycle time is high",
-	evidence_links: evidenceLinks,
-	suggested_experiments: [],
+    id: "opp-1",
+    title: "Reduce cycle time",
+    rationale: "Cycle time is high",
+    evidence_links: evidenceLinks,
+    suggested_experiments: [],
 });
 
-const delta = (
-	label: string,
-	deltaPct: number,
-	metric = label.toLowerCase(),
-) => ({
-	metric,
-	label,
-	value: 0,
-	unit: "%",
-	delta_pct: deltaPct,
-	spark: [],
+const delta = (label: string, deltaPct: number, metric = label.toLowerCase()) => ({
+    metric,
+    label,
+    value: 0,
+    unit: "%",
+    delta_pct: deltaPct,
+    spark: [],
 });
 
 // Home payload with only the fields the resolver reads (deltas). Other required
 // HomeResponse fields are irrelevant to the top-signal derivation.
-const homeWithDeltas = (deltas: ReturnType<typeof delta>[]) =>
-	({ deltas }) as never;
+const homeWithDeltas = (deltas: ReturnType<typeof delta>[]) => ({ deltas }) as never;
 
 beforeEach(() => {
-	vi.clearAllMocks();
-	// Default: some opportunities with evidence links + a worsened metric so the
-	// synthesized top signal is present.
-	mockGetOpportunities.mockResolvedValue({
-		items: [
-			opportunityItem(["https://example.com/evidence"]),
-			opportunityItem([]),
-		],
-	} as never);
-	mockGetHomeData.mockResolvedValue(
-		homeWithDeltas([
-			delta("Churn", 19),
-			delta("Cycle Time", 8),
-			delta("Coverage", -4),
-		]),
-	);
+    vi.clearAllMocks();
+    // Default: some opportunities with evidence links + a worsened metric so the
+    // synthesized top signal is present.
+    mockGetOpportunities.mockResolvedValue({
+        items: [opportunityItem(["https://example.com/evidence"]), opportunityItem([])],
+    } as never);
+    mockGetHomeData.mockResolvedValue(
+        homeWithDeltas([delta("Churn", 19), delta("Cycle Time", 8), delta("Coverage", -4)]),
+    );
 });
 
 describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
-	// ── Top signal (synthesized worst opportunity) ────────────────────────────────
+    // ── Top signal (synthesized worst opportunity) ────────────────────────────────
 
-	it("gates the TOP SIGNAL by polarity (throughput up = NOT hero, churn up = hero, throughput down = 'Recover' hero)", async () => {
-		// Throughput up (+10) is GOOD (higher-is-better). Churn up (+5) is BAD (lower-is-better).
-		// Throughput down (-15) is BAD (higher-is-better).
-		mockGetHomeData.mockResolvedValue(
-			homeWithDeltas([
-				delta("Throughput", 10), // Good
-				delta("Churn", 5), // Bad
-				delta("Deploy Freq", -15, "deploy_freq"), // Bad
-			]),
-		);
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
-		expect(signals["improve-top-signal"]).toMatchObject({
-			label: "Recover Deploy Freq",
-			value: "-15%",
-			state: "high",
-			direction: "down",
-		});
-	});
+    it("gates the TOP SIGNAL by polarity (throughput up = NOT hero, churn up = hero, throughput down = 'Recover' hero)", async () => {
+        // Throughput up (+10) is GOOD (higher-is-better). Churn up (+5) is BAD (lower-is-better).
+        // Throughput down (-15) is BAD (higher-is-better).
+        mockGetHomeData.mockResolvedValue(
+            homeWithDeltas([
+                delta("Throughput", 10), // Good
+                delta("Churn", 5), // Bad
+                delta("Deploy Freq", -15, "deploy_freq"), // Bad
+            ]),
+        );
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals["improve-top-signal"]).toMatchObject({
+            label: "Recover Deploy Freq",
+            value: "-15%",
+            state: "high",
+            direction: "down",
+        });
+    });
 
-	it("promotes a declining higher-is-better metric (coverage) over a smaller lower-is-better rise", async () => {
-		// Coverage falling 12% is WORSE than churn rising 6% — the catalog polarity
-		// must classify coverage (higher-is-better) as worsened on a NEGATIVE delta.
-		mockGetHomeData.mockResolvedValue(
-			homeWithDeltas([
-				delta("Churn", 6), // Bad, but smaller magnitude
-				delta("Coverage", -12), // Worse: higher-is-better metric declining
-			]),
-		);
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
-		expect(signals["improve-top-signal"]).toMatchObject({
-			label: "Recover Coverage",
-			value: "-12%",
-			state: "medium",
-			direction: "down",
-		});
-	});
+    it("promotes a declining higher-is-better metric (coverage) over a smaller lower-is-better rise", async () => {
+        // Coverage falling 12% is WORSE than churn rising 6% — the catalog polarity
+        // must classify coverage (higher-is-better) as worsened on a NEGATIVE delta.
+        mockGetHomeData.mockResolvedValue(
+            homeWithDeltas([
+                delta("Churn", 6), // Bad, but smaller magnitude
+                delta("Coverage", -12), // Worse: higher-is-better metric declining
+            ]),
+        );
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals["improve-top-signal"]).toMatchObject({
+            label: "Recover Coverage",
+            value: "-12%",
+            state: "medium",
+            direction: "down",
+        });
+    });
 
-	it("NEVER promotes a metric with unknown polarity to the hero (fails closed)", async () => {
-		// A metric key absent from the catalog must be excluded from hero
-		// promotion entirely — never assumed lower-is-better.
-		mockGetHomeData.mockResolvedValue(
-			homeWithDeltas([delta("Mystery Metric", 42, "mystery_metric")]),
-		);
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
-		expect(signals["improve-top-signal"]).toBeUndefined();
-	});
+    it("NEVER promotes a metric with unknown polarity to the hero (fails closed)", async () => {
+        // A metric key absent from the catalog must be excluded from hero
+        // promotion entirely — never assumed lower-is-better.
+        mockGetHomeData.mockResolvedValue(
+            homeWithDeltas([delta("Mystery Metric", 42, "mystery_metric")]),
+        );
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals["improve-top-signal"]).toBeUndefined();
+    });
 
-	it("synthesizes a TOP SIGNAL from the worst worsened metric (label + signed delta + severity)", async () => {
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
+    it("synthesizes a TOP SIGNAL from the worst worsened metric (label + signed delta + severity)", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
 
-		expect(signals["improve-top-signal"]).toMatchObject({
-			id: "improve-top-signal",
-			label: "Reduce Churn",
-			href: "/opportunities",
-			value: "+19%",
-			// +19% maps to "high" (Penpot's ELEVATED lead), NOT neutral.
-			state: "high",
-			direction: "up",
-		});
-		// The secondary line frames the metric, it does NOT just repeat the label.
-		expect(signals["improve-top-signal"].metricLabel).toBe("Churn shift");
-	});
+        expect(signals["improve-top-signal"]).toMatchObject({
+            id: "improve-top-signal",
+            label: "Reduce Churn",
+            href: "/opportunities",
+            value: "+19%",
+            // +19% maps to "high" (Penpot's ELEVATED lead), NOT neutral.
+            state: "high",
+            direction: "up",
+        });
+        // The secondary line frames the metric, it does NOT just repeat the label.
+        expect(signals["improve-top-signal"].metricLabel).toBe("Churn shift");
+    });
 
-	it("makes the TOP SIGNAL the most-severe available signal (sorts above Opportunities)", async () => {
-		const signals = await getImproveSignals(defaultMetricFilter);
-		const topIdx = signals.findIndex((s) => s.id === "improve-top-signal");
-		const oppIdx = signals.findIndex((s) => s.id === "opportunities");
-		expect(topIdx).toBeGreaterThanOrEqual(0);
-		// Worst-opportunity hero outranks the neutral Opportunities count card.
-		expect(topIdx).toBeLessThan(oppIdx);
-	});
+    it("makes the TOP SIGNAL the most-severe available signal (sorts above Opportunities)", async () => {
+        const signals = await getImproveSignals(defaultMetricFilter);
+        const topIdx = signals.findIndex((s) => s.id === "improve-top-signal");
+        const oppIdx = signals.findIndex((s) => s.id === "opportunities");
+        expect(topIdx).toBeGreaterThanOrEqual(0);
+        // Worst-opportunity hero outranks the neutral Opportunities count card.
+        expect(topIdx).toBeLessThan(oppIdx);
+    });
 
-	it("picks the LARGEST absolute delta in the wrong direction as the top signal (not the first)", async () => {
-		mockGetHomeData.mockResolvedValue(
-			homeWithDeltas([
-				delta("Cycle Time", 8),
-				delta("Throughput", -27), // Bad
-				delta("Churn", 12), // Bad
-			]),
-		);
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
-		expect(signals["improve-top-signal"]).toMatchObject({
-			label: "Recover Throughput",
-			value: "-27%",
-			// ≥25 → critical.
-			state: "critical",
-		});
-	});
+    it("picks the LARGEST absolute delta in the wrong direction as the top signal (not the first)", async () => {
+        mockGetHomeData.mockResolvedValue(
+            homeWithDeltas([
+                delta("Cycle Time", 8),
+                delta("Throughput", -27), // Bad
+                delta("Churn", 12), // Bad
+            ]),
+        );
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals["improve-top-signal"]).toMatchObject({
+            label: "Recover Throughput",
+            value: "-27%",
+            // ≥25 → critical.
+            state: "critical",
+        });
+    });
 
-	it("maps delta magnitude onto the severity ladder", async () => {
-		const cases: Array<[number, string]> = [
-			[30, "critical"],
-			[20, "high"],
-			[9, "medium"],
-			[2, "low"],
-		];
-		for (const [deltaPct, expected] of cases) {
-			mockGetHomeData.mockResolvedValue(
-				homeWithDeltas([delta("Churn", deltaPct)]),
-			);
-			const signals = byId(await getImproveSignals(defaultMetricFilter));
-			expect(
-				signals["improve-top-signal"].state,
-				`${deltaPct}% → ${expected}`,
-			).toBe(expected);
-		}
-	});
+    it("maps delta magnitude onto the severity ladder", async () => {
+        const cases: Array<[number, string]> = [
+            [30, "critical"],
+            [20, "high"],
+            [9, "medium"],
+            [2, "low"],
+        ];
+        for (const [deltaPct, expected] of cases) {
+            mockGetHomeData.mockResolvedValue(homeWithDeltas([delta("Churn", deltaPct)]));
+            const signals = byId(await getImproveSignals(defaultMetricFilter));
+            expect(signals["improve-top-signal"].state, `${deltaPct}% → ${expected}`).toBe(
+                expected,
+            );
+        }
+    });
 
-	it("omits the TOP SIGNAL when NO metric worsened (Opportunities leads as neutral, no fabricated severity)", async () => {
-		mockGetHomeData.mockResolvedValue(
-			homeWithDeltas([delta("Throughput", 5), delta("Cycle Time", -2)]),
-		);
-		const signals = await getImproveSignals(defaultMetricFilter);
-		expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
-		// The lead available signal is now Opportunities (neutral), never a fake severity.
-		const available = signals.filter((s) => s.state !== "unavailable");
-		expect(available[0].id).toBe("opportunities");
-		expect(available.every((s) => s.state === "neutral")).toBe(true);
-	});
+    it("omits the TOP SIGNAL when NO metric worsened (Opportunities leads as neutral, no fabricated severity)", async () => {
+        mockGetHomeData.mockResolvedValue(
+            homeWithDeltas([delta("Throughput", 5), delta("Cycle Time", -2)]),
+        );
+        const signals = await getImproveSignals(defaultMetricFilter);
+        expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
+        // The lead available signal is now Opportunities (neutral), never a fake severity.
+        const available = signals.filter((s) => s.state !== "unavailable");
+        expect(available[0].id).toBe("opportunities");
+        expect(available.every((s) => s.state === "neutral")).toBe(true);
+    });
 
-	it("omits the TOP SIGNAL when there are zero open opportunities (hero must link to a real opportunity)", async () => {
-		mockGetOpportunities.mockResolvedValue({ items: [] } as never);
-		// Even with a worsened metric, no opportunities → no synthesized hero.
-		const signals = await getImproveSignals(defaultMetricFilter);
-		expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
-	});
+    it("omits the TOP SIGNAL when there are zero open opportunities (hero must link to a real opportunity)", async () => {
+        mockGetOpportunities.mockResolvedValue({ items: [] } as never);
+        // Even with a worsened metric, no opportunities → no synthesized hero.
+        const signals = await getImproveSignals(defaultMetricFilter);
+        expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
+    });
 
-	it("omits the TOP SIGNAL when home data is unavailable (no deltas to rank)", async () => {
-		mockGetHomeData.mockRejectedValue(new Error("home down"));
-		const signals = await getImproveSignals(defaultMetricFilter);
-		expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
-		// Opportunities still resolves from its own (successful) fetch.
-		expect(byId(signals).opportunities).toMatchObject({ state: "neutral" });
-	});
+    it("omits the TOP SIGNAL when home data is unavailable (no deltas to rank)", async () => {
+        mockGetHomeData.mockRejectedValue(new Error("home down"));
+        const signals = await getImproveSignals(defaultMetricFilter);
+        expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
+        // Opportunities still resolves from its own (successful) fetch.
+        expect(byId(signals).opportunities).toMatchObject({ state: "neutral" });
+    });
 
-	// ── Opportunities workflow card (short value, no rainbow) ──────────────────────
+    // ── Opportunities workflow card (short value, no rainbow) ──────────────────────
 
-	it("emits a SHORT Opportunities value with the evidence count on the secondary line", async () => {
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
+    it("emits a SHORT Opportunities value with the evidence count on the secondary line", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
 
-		expect(signals.opportunities).toMatchObject({
-			id: "opportunities",
-			label: "Opportunities",
-			href: "/opportunities",
-			state: "neutral",
-			// SHORT numeric so the gradient metric-hero reads clean (no rainbow phrase).
-			value: "2 open",
-			// Evidence count moves to the secondary metricLabel line.
-			metricLabel: "1 evidence-linked",
-		});
-		// The long "N OPEN · M EVIDENCE-LINKED" phrase must NOT be the gradient value.
-		expect(signals.opportunities.value).not.toContain("·");
-		expect(signals.opportunities.value).not.toContain("EVIDENCE");
-	});
+        expect(signals.opportunities).toMatchObject({
+            id: "opportunities",
+            label: "Opportunities",
+            href: "/opportunities",
+            state: "neutral",
+            // SHORT numeric so the gradient metric-hero reads clean (no rainbow phrase).
+            value: "2 open",
+            // Evidence count moves to the secondary metricLabel line.
+            metricLabel: "1 evidence-linked",
+        });
+        // The long "N OPEN · M EVIDENCE-LINKED" phrase must NOT be the gradient value.
+        expect(signals.opportunities.value).not.toContain("·");
+        expect(signals.opportunities.value).not.toContain("EVIDENCE");
+    });
 
-	it("labels the secondary line 'open opportunities' when none are evidence-linked", async () => {
-		mockGetOpportunities.mockResolvedValue({
-			items: [opportunityItem([]), opportunityItem([])],
-		} as never);
+    it("labels the secondary line 'open opportunities' when none are evidence-linked", async () => {
+        mockGetOpportunities.mockResolvedValue({
+            items: [opportunityItem([]), opportunityItem([])],
+        } as never);
 
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
-		expect(signals.opportunities).toMatchObject({
-			state: "neutral",
-			value: "2 open",
-			metricLabel: "open opportunities",
-		});
-	});
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.opportunities).toMatchObject({
+            state: "neutral",
+            value: "2 open",
+            metricLabel: "open opportunities",
+        });
+    });
 
-	it("does NOT repeat the card label as its own metricLabel (no 'Opportunities · Opportunities data')", async () => {
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
-		expect(signals.opportunities.metricLabel).not.toBe("Opportunities");
-		expect(signals.opportunities.metricLabel.toLowerCase()).not.toContain(
-			"opportunities data",
-		);
-	});
+    it("does NOT repeat the card label as its own metricLabel (no 'Opportunities · Opportunities data')", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.opportunities.metricLabel).not.toBe("Opportunities");
+        expect(signals.opportunities.metricLabel.toLowerCase()).not.toContain("opportunities data");
+    });
 
-	it("treats a SUCCESSFUL empty result as a healthy '0 open' neutral (not unavailable)", async () => {
-		mockGetOpportunities.mockResolvedValue({ items: [] } as never);
+    it("treats a SUCCESSFUL empty result as a healthy '0 open' neutral (not unavailable)", async () => {
+        mockGetOpportunities.mockResolvedValue({ items: [] } as never);
 
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
-		expect(signals.opportunities).toMatchObject({
-			state: "neutral",
-			value: "0 open",
-		});
-		expect(signals.opportunities.state).not.toBe("unavailable");
-	});
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.opportunities).toMatchObject({
+            state: "neutral",
+            value: "0 open",
+        });
+        expect(signals.opportunities.state).not.toBe("unavailable");
+    });
 
-	it("degrades Opportunities to UNAVAILABLE ONLY when the fetch fails", async () => {
-		mockGetOpportunities.mockRejectedValue(new Error("backend down"));
+    it("degrades Opportunities to UNAVAILABLE ONLY when the fetch fails", async () => {
+        mockGetOpportunities.mockRejectedValue(new Error("backend down"));
 
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
-		expect(signals.opportunities).toMatchObject({
-			state: "unavailable",
-			value: "",
-		});
-		// A failed fetch must NOT masquerade as a "0 open" healthy zero.
-		expect(signals.opportunities.value).not.toContain("open");
-		// No synthesized hero either (no opportunities to link to).
-		expect(signals["improve-top-signal"]).toBeUndefined();
-		// Other signals still resolve
-		expect(signals.experiments).toMatchObject({ state: "unavailable" });
-		expect(signals["improve-automations"]).toMatchObject({
-			state: "unavailable",
-		});
-	});
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.opportunities).toMatchObject({
+            state: "unavailable",
+            value: "",
+        });
+        // A failed fetch must NOT masquerade as a "0 open" healthy zero.
+        expect(signals.opportunities.value).not.toContain("open");
+        // No synthesized hero either (no opportunities to link to).
+        expect(signals["improve-top-signal"]).toBeUndefined();
+        // Other signals still resolve
+        expect(signals.experiments).toMatchObject({ state: "unavailable" });
+        expect(signals["improve-automations"]).toMatchObject({
+            state: "unavailable",
+        });
+    });
 
-	// ── Preview sub-areas (Experiments / Automations) ─────────────────────────────
+    // ── Preview sub-areas (Experiments / Automations) ─────────────────────────────
 
-	it("emits honest UNAVAILABLE + preview for Experiments (no backend / no route)", async () => {
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
+    it("emits honest UNAVAILABLE + preview for Experiments (no backend / no route)", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
 
-		expect(signals.experiments).toMatchObject({
-			id: "experiments",
-			label: "Experiments",
-			href: "/improve/experiments",
-			state: "unavailable",
-			value: "",
-			preview: true,
-		});
-	});
+        expect(signals.experiments).toMatchObject({
+            id: "experiments",
+            label: "Experiments",
+            href: "/improve/experiments",
+            state: "unavailable",
+            value: "",
+            preview: true,
+        });
+    });
 
-	it("emits honest UNAVAILABLE + preview for Automations (no backend / no route)", async () => {
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
+    it("emits honest UNAVAILABLE + preview for Automations (no backend / no route)", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
 
-		expect(signals["improve-automations"]).toMatchObject({
-			id: "improve-automations",
-			label: "Automations",
-			href: "/improve/automations",
-			state: "unavailable",
-			value: "",
-			preview: true,
-		});
-	});
+        expect(signals["improve-automations"]).toMatchObject({
+            id: "improve-automations",
+            label: "Automations",
+            href: "/improve/automations",
+            state: "unavailable",
+            value: "",
+            preview: true,
+        });
+    });
 
-	it("does NOT mark the real Opportunities card as preview (stays clickable)", async () => {
-		const signals = byId(await getImproveSignals(defaultMetricFilter));
-		expect(signals.opportunities.preview).not.toBe(true);
-	});
+    it("does NOT mark the real Opportunities card as preview (stays clickable)", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.opportunities.preview).not.toBe(true);
+    });
 
-	// ── Shape / ordering / wiring ─────────────────────────────────────────────────
+    // ── Shape / ordering / wiring ─────────────────────────────────────────────────
 
-	it("returns the 3 sub-areas plus the synthesized top signal, each once", async () => {
-		const signals = await getImproveSignals(defaultMetricFilter);
-		const ids = signals.map((s) => s.id);
-		expect(new Set(ids).size).toBe(ids.length);
-		expect(ids).toEqual(
-			expect.arrayContaining([
-				"improve-top-signal",
-				"opportunities",
-				"experiments",
-				"improve-automations",
-			]),
-		);
-		expect(ids).toHaveLength(4);
-	});
+    it("returns the 3 sub-areas plus the synthesized top signal, each once", async () => {
+        const signals = await getImproveSignals(defaultMetricFilter);
+        const ids = signals.map((s) => s.id);
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(ids).toEqual(
+            expect.arrayContaining([
+                "improve-top-signal",
+                "opportunities",
+                "experiments",
+                "improve-automations",
+            ]),
+        );
+        expect(ids).toHaveLength(4);
+    });
 
-	it("sorts real signals first, unavailable last", async () => {
-		const signals = await getImproveSignals(defaultMetricFilter);
-		const opportunitiesIdx = signals.findIndex((s) => s.id === "opportunities");
-		const experimentsIdx = signals.findIndex((s) => s.id === "experiments");
-		const automationsIdx = signals.findIndex(
-			(s) => s.id === "improve-automations",
-		);
-		expect(opportunitiesIdx).toBeLessThan(experimentsIdx);
-		expect(opportunitiesIdx).toBeLessThan(automationsIdx);
-	});
+    it("sorts real signals first, unavailable last", async () => {
+        const signals = await getImproveSignals(defaultMetricFilter);
+        const opportunitiesIdx = signals.findIndex((s) => s.id === "opportunities");
+        const experimentsIdx = signals.findIndex((s) => s.id === "experiments");
+        const automationsIdx = signals.findIndex((s) => s.id === "improve-automations");
+        expect(opportunitiesIdx).toBeLessThan(experimentsIdx);
+        expect(opportunitiesIdx).toBeLessThan(automationsIdx);
+    });
 
-	it("uses filters (passes them to both sources, not voided)", async () => {
-		const customFilter = {
-			...defaultMetricFilter,
-			time: { range_days: 30, compare_days: 30 },
-		};
-		await getImproveSignals(customFilter);
-		expect(mockGetOpportunities).toHaveBeenCalledWith(customFilter);
-		expect(mockGetHomeData).toHaveBeenCalledWith(customFilter);
-	});
+    it("uses filters (passes them to both sources, not voided)", async () => {
+        const customFilter = {
+            ...defaultMetricFilter,
+            time: { range_days: 30, compare_days: 30 },
+        };
+        await getImproveSignals(customFilter);
+        expect(mockGetOpportunities).toHaveBeenCalledWith(customFilter);
+        expect(mockGetHomeData).toHaveBeenCalledWith(customFilter);
+    });
 
-	it("fetches both REST sources UNCONDITIONALLY (isTestMode is not a fetch gate)", async () => {
-		// Mirrors getDiagnoseSignals/getGovernSignals: home + opportunities are
-		// MSW-mockable REST, so they are always fetched (under Playwright the dev
-		// server points BACKEND_URL at the mock). isTestMode must NOT short-circuit
-		// them, or the Overview would render an all-empty hero in e2e.
-		await getImproveSignals(defaultMetricFilter, true);
-		expect(mockGetOpportunities).toHaveBeenCalledWith(defaultMetricFilter);
-		expect(mockGetHomeData).toHaveBeenCalledWith(defaultMetricFilter);
-	});
+    it("fetches both REST sources UNCONDITIONALLY (isTestMode is not a fetch gate)", async () => {
+        // Mirrors getDiagnoseSignals/getGovernSignals: home + opportunities are
+        // MSW-mockable REST, so they are always fetched (under Playwright the dev
+        // server points BACKEND_URL at the mock). isTestMode must NOT short-circuit
+        // them, or the Overview would render an all-empty hero in e2e.
+        await getImproveSignals(defaultMetricFilter, true);
+        expect(mockGetOpportunities).toHaveBeenCalledWith(defaultMetricFilter);
+        expect(mockGetHomeData).toHaveBeenCalledWith(defaultMetricFilter);
+    });
 
-	it("degrades the 3 sub-areas to UNAVAILABLE (no top signal) when BOTH sources fail", async () => {
-		// The genuine "not connected" path: both REST fetches throw → safe()
-		// swallows to undefined → opportunities unavailable, no deltas to rank, and
-		// Experiments/Automations stay preview. This is the honest-empty Overview.
-		mockGetOpportunities.mockRejectedValue(new Error("opps down"));
-		mockGetHomeData.mockRejectedValue(new Error("home down"));
+    it("degrades the 3 sub-areas to UNAVAILABLE (no top signal) when BOTH sources fail", async () => {
+        // The genuine "not connected" path: both REST fetches throw → safe()
+        // swallows to undefined → opportunities unavailable, no deltas to rank, and
+        // Experiments/Automations stay preview. This is the honest-empty Overview.
+        mockGetOpportunities.mockRejectedValue(new Error("opps down"));
+        mockGetHomeData.mockRejectedValue(new Error("home down"));
 
-		const signals = await getImproveSignals(defaultMetricFilter, true);
-		expect(signals).toHaveLength(3);
-		expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
-		for (const signal of signals) {
-			expect(signal.state).toBe("unavailable");
-			expect(signal.value).toBe("");
-		}
-		const byIdMap = byId(signals);
-		expect(byIdMap.experiments.preview).toBe(true);
-		expect(byIdMap["improve-automations"].preview).toBe(true);
-		expect(byIdMap.opportunities.preview).not.toBe(true);
-	});
+        const signals = await getImproveSignals(defaultMetricFilter, true);
+        expect(signals).toHaveLength(3);
+        expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
+        for (const signal of signals) {
+            expect(signal.state).toBe("unavailable");
+            expect(signal.value).toBe("");
+        }
+        const byIdMap = byId(signals);
+        expect(byIdMap.experiments.preview).toBe(true);
+        expect(byIdMap["improve-automations"].preview).toBe(true);
+        expect(byIdMap.opportunities.preview).not.toBe(true);
+    });
 });

--- a/src/lib/areaSignals/__tests__/improve.test.ts
+++ b/src/lib/areaSignals/__tests__/improve.test.ts
@@ -6,11 +6,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // without any network.
 
 vi.mock("@/lib/api/home", () => ({
-    getOpportunities: vi.fn(),
-    getHomeData: vi.fn(),
+	getOpportunities: vi.fn(),
+	getHomeData: vi.fn(),
 }));
 vi.mock("@/lib/logger", () => ({
-    logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
 import { getHomeData, getOpportunities } from "@/lib/api/home";
@@ -23,314 +23,361 @@ const mockGetOpportunities = vi.mocked(getOpportunities);
 const mockGetHomeData = vi.mocked(getHomeData);
 
 function byId(signals: AreaSignal[]): Record<string, AreaSignal> {
-    return Object.fromEntries(signals.map((s) => [s.id, s]));
+	return Object.fromEntries(signals.map((s) => [s.id, s]));
 }
 
 const opportunityItem = (evidenceLinks: string[] = []) => ({
-    id: "opp-1",
-    title: "Reduce cycle time",
-    rationale: "Cycle time is high",
-    evidence_links: evidenceLinks,
-    suggested_experiments: [],
+	id: "opp-1",
+	title: "Reduce cycle time",
+	rationale: "Cycle time is high",
+	evidence_links: evidenceLinks,
+	suggested_experiments: [],
 });
 
-const delta = (label: string, deltaPct: number, metric = label.toLowerCase()) => ({
-    metric,
-    label,
-    value: 0,
-    unit: "%",
-    delta_pct: deltaPct,
-    spark: [],
+const delta = (
+	label: string,
+	deltaPct: number,
+	metric = label.toLowerCase(),
+) => ({
+	metric,
+	label,
+	value: 0,
+	unit: "%",
+	delta_pct: deltaPct,
+	spark: [],
 });
 
 // Home payload with only the fields the resolver reads (deltas). Other required
 // HomeResponse fields are irrelevant to the top-signal derivation.
-const homeWithDeltas = (deltas: ReturnType<typeof delta>[]) => ({ deltas }) as never;
+const homeWithDeltas = (deltas: ReturnType<typeof delta>[]) =>
+	({ deltas }) as never;
 
 beforeEach(() => {
-    vi.clearAllMocks();
-    // Default: some opportunities with evidence links + a worsened metric so the
-    // synthesized top signal is present.
-    mockGetOpportunities.mockResolvedValue({
-        items: [opportunityItem(["https://example.com/evidence"]), opportunityItem([])],
-    } as never);
-    mockGetHomeData.mockResolvedValue(
-        homeWithDeltas([delta("Churn", 19), delta("Cycle Time", 8), delta("Coverage", -4)]),
-    );
+	vi.clearAllMocks();
+	// Default: some opportunities with evidence links + a worsened metric so the
+	// synthesized top signal is present.
+	mockGetOpportunities.mockResolvedValue({
+		items: [
+			opportunityItem(["https://example.com/evidence"]),
+			opportunityItem([]),
+		],
+	} as never);
+	mockGetHomeData.mockResolvedValue(
+		homeWithDeltas([
+			delta("Churn", 19),
+			delta("Cycle Time", 8),
+			delta("Coverage", -4),
+		]),
+	);
 });
 
 describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
-    // ── Top signal (synthesized worst opportunity) ────────────────────────────────
+	// ── Top signal (synthesized worst opportunity) ────────────────────────────────
 
-    it("gates the TOP SIGNAL by polarity (throughput up = NOT hero, churn up = hero, throughput down = 'Recover' hero)", async () => {
-        // Throughput up (+10) is GOOD (higher-is-better). Churn up (+5) is BAD (lower-is-better).
-        // Throughput down (-15) is BAD (higher-is-better).
-        mockGetHomeData.mockResolvedValue(
-            homeWithDeltas([
-                delta("Throughput", 10), // Good
-                delta("Churn", 5), // Bad
-                delta("Deploy Freq", -15, "deploy_freq"), // Bad
-            ]),
-        );
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
-        expect(signals["improve-top-signal"]).toMatchObject({
-            label: "Recover Deploy Freq",
-            value: "-15%",
-            state: "high",
-            direction: "down",
-        });
-    });
+	it("gates the TOP SIGNAL by polarity (throughput up = NOT hero, churn up = hero, throughput down = 'Recover' hero)", async () => {
+		// Throughput up (+10) is GOOD (higher-is-better). Churn up (+5) is BAD (lower-is-better).
+		// Throughput down (-15) is BAD (higher-is-better).
+		mockGetHomeData.mockResolvedValue(
+			homeWithDeltas([
+				delta("Throughput", 10), // Good
+				delta("Churn", 5), // Bad
+				delta("Deploy Freq", -15, "deploy_freq"), // Bad
+			]),
+		);
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
+		expect(signals["improve-top-signal"]).toMatchObject({
+			label: "Recover Deploy Freq",
+			value: "-15%",
+			state: "high",
+			direction: "down",
+		});
+	});
 
-    it("synthesizes a TOP SIGNAL from the worst worsened metric (label + signed delta + severity)", async () => {
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
+	it("promotes a declining higher-is-better metric (coverage) over a smaller lower-is-better rise", async () => {
+		// Coverage falling 12% is WORSE than churn rising 6% — the catalog polarity
+		// must classify coverage (higher-is-better) as worsened on a NEGATIVE delta.
+		mockGetHomeData.mockResolvedValue(
+			homeWithDeltas([
+				delta("Churn", 6), // Bad, but smaller magnitude
+				delta("Coverage", -12), // Worse: higher-is-better metric declining
+			]),
+		);
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
+		expect(signals["improve-top-signal"]).toMatchObject({
+			label: "Recover Coverage",
+			value: "-12%",
+			state: "medium",
+			direction: "down",
+		});
+	});
 
-        expect(signals["improve-top-signal"]).toMatchObject({
-            id: "improve-top-signal",
-            label: "Reduce Churn",
-            href: "/opportunities",
-            value: "+19%",
-            // +19% maps to "high" (Penpot's ELEVATED lead), NOT neutral.
-            state: "high",
-            direction: "up",
-        });
-        // The secondary line frames the metric, it does NOT just repeat the label.
-        expect(signals["improve-top-signal"].metricLabel).toBe("Churn shift");
-    });
+	it("NEVER promotes a metric with unknown polarity to the hero (fails closed)", async () => {
+		// A metric key absent from the catalog must be excluded from hero
+		// promotion entirely — never assumed lower-is-better.
+		mockGetHomeData.mockResolvedValue(
+			homeWithDeltas([delta("Mystery Metric", 42, "mystery_metric")]),
+		);
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
+		expect(signals["improve-top-signal"]).toBeUndefined();
+	});
 
-    it("makes the TOP SIGNAL the most-severe available signal (sorts above Opportunities)", async () => {
-        const signals = await getImproveSignals(defaultMetricFilter);
-        const topIdx = signals.findIndex((s) => s.id === "improve-top-signal");
-        const oppIdx = signals.findIndex((s) => s.id === "opportunities");
-        expect(topIdx).toBeGreaterThanOrEqual(0);
-        // Worst-opportunity hero outranks the neutral Opportunities count card.
-        expect(topIdx).toBeLessThan(oppIdx);
-    });
+	it("synthesizes a TOP SIGNAL from the worst worsened metric (label + signed delta + severity)", async () => {
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
 
-    it("picks the LARGEST absolute delta in the wrong direction as the top signal (not the first)", async () => {
-        mockGetHomeData.mockResolvedValue(
-            homeWithDeltas([
-                delta("Cycle Time", 8),
-                delta("Throughput", -27), // Bad
-                delta("Churn", 12), // Bad
-            ]),
-        );
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
-        expect(signals["improve-top-signal"]).toMatchObject({
-            label: "Recover Throughput",
-            value: "-27%",
-            // ≥25 → critical.
-            state: "critical",
-        });
-    });
+		expect(signals["improve-top-signal"]).toMatchObject({
+			id: "improve-top-signal",
+			label: "Reduce Churn",
+			href: "/opportunities",
+			value: "+19%",
+			// +19% maps to "high" (Penpot's ELEVATED lead), NOT neutral.
+			state: "high",
+			direction: "up",
+		});
+		// The secondary line frames the metric, it does NOT just repeat the label.
+		expect(signals["improve-top-signal"].metricLabel).toBe("Churn shift");
+	});
 
-    it("maps delta magnitude onto the severity ladder", async () => {
-        const cases: Array<[number, string]> = [
-            [30, "critical"],
-            [20, "high"],
-            [9, "medium"],
-            [2, "low"],
-        ];
-        for (const [deltaPct, expected] of cases) {
-            mockGetHomeData.mockResolvedValue(homeWithDeltas([delta("Churn", deltaPct)]));
-            const signals = byId(await getImproveSignals(defaultMetricFilter));
-            expect(signals["improve-top-signal"].state, `${deltaPct}% → ${expected}`).toBe(
-                expected,
-            );
-        }
-    });
+	it("makes the TOP SIGNAL the most-severe available signal (sorts above Opportunities)", async () => {
+		const signals = await getImproveSignals(defaultMetricFilter);
+		const topIdx = signals.findIndex((s) => s.id === "improve-top-signal");
+		const oppIdx = signals.findIndex((s) => s.id === "opportunities");
+		expect(topIdx).toBeGreaterThanOrEqual(0);
+		// Worst-opportunity hero outranks the neutral Opportunities count card.
+		expect(topIdx).toBeLessThan(oppIdx);
+	});
 
-    it("omits the TOP SIGNAL when NO metric worsened (Opportunities leads as neutral, no fabricated severity)", async () => {
-        mockGetHomeData.mockResolvedValue(
-            homeWithDeltas([delta("Throughput", 5), delta("Cycle Time", -2)]),
-        );
-        const signals = await getImproveSignals(defaultMetricFilter);
-        expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
-        // The lead available signal is now Opportunities (neutral), never a fake severity.
-        const available = signals.filter((s) => s.state !== "unavailable");
-        expect(available[0].id).toBe("opportunities");
-        expect(available.every((s) => s.state === "neutral")).toBe(true);
-    });
+	it("picks the LARGEST absolute delta in the wrong direction as the top signal (not the first)", async () => {
+		mockGetHomeData.mockResolvedValue(
+			homeWithDeltas([
+				delta("Cycle Time", 8),
+				delta("Throughput", -27), // Bad
+				delta("Churn", 12), // Bad
+			]),
+		);
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
+		expect(signals["improve-top-signal"]).toMatchObject({
+			label: "Recover Throughput",
+			value: "-27%",
+			// ≥25 → critical.
+			state: "critical",
+		});
+	});
 
-    it("omits the TOP SIGNAL when there are zero open opportunities (hero must link to a real opportunity)", async () => {
-        mockGetOpportunities.mockResolvedValue({ items: [] } as never);
-        // Even with a worsened metric, no opportunities → no synthesized hero.
-        const signals = await getImproveSignals(defaultMetricFilter);
-        expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
-    });
+	it("maps delta magnitude onto the severity ladder", async () => {
+		const cases: Array<[number, string]> = [
+			[30, "critical"],
+			[20, "high"],
+			[9, "medium"],
+			[2, "low"],
+		];
+		for (const [deltaPct, expected] of cases) {
+			mockGetHomeData.mockResolvedValue(
+				homeWithDeltas([delta("Churn", deltaPct)]),
+			);
+			const signals = byId(await getImproveSignals(defaultMetricFilter));
+			expect(
+				signals["improve-top-signal"].state,
+				`${deltaPct}% → ${expected}`,
+			).toBe(expected);
+		}
+	});
 
-    it("omits the TOP SIGNAL when home data is unavailable (no deltas to rank)", async () => {
-        mockGetHomeData.mockRejectedValue(new Error("home down"));
-        const signals = await getImproveSignals(defaultMetricFilter);
-        expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
-        // Opportunities still resolves from its own (successful) fetch.
-        expect(byId(signals).opportunities).toMatchObject({ state: "neutral" });
-    });
+	it("omits the TOP SIGNAL when NO metric worsened (Opportunities leads as neutral, no fabricated severity)", async () => {
+		mockGetHomeData.mockResolvedValue(
+			homeWithDeltas([delta("Throughput", 5), delta("Cycle Time", -2)]),
+		);
+		const signals = await getImproveSignals(defaultMetricFilter);
+		expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
+		// The lead available signal is now Opportunities (neutral), never a fake severity.
+		const available = signals.filter((s) => s.state !== "unavailable");
+		expect(available[0].id).toBe("opportunities");
+		expect(available.every((s) => s.state === "neutral")).toBe(true);
+	});
 
-    // ── Opportunities workflow card (short value, no rainbow) ──────────────────────
+	it("omits the TOP SIGNAL when there are zero open opportunities (hero must link to a real opportunity)", async () => {
+		mockGetOpportunities.mockResolvedValue({ items: [] } as never);
+		// Even with a worsened metric, no opportunities → no synthesized hero.
+		const signals = await getImproveSignals(defaultMetricFilter);
+		expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
+	});
 
-    it("emits a SHORT Opportunities value with the evidence count on the secondary line", async () => {
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
+	it("omits the TOP SIGNAL when home data is unavailable (no deltas to rank)", async () => {
+		mockGetHomeData.mockRejectedValue(new Error("home down"));
+		const signals = await getImproveSignals(defaultMetricFilter);
+		expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
+		// Opportunities still resolves from its own (successful) fetch.
+		expect(byId(signals).opportunities).toMatchObject({ state: "neutral" });
+	});
 
-        expect(signals.opportunities).toMatchObject({
-            id: "opportunities",
-            label: "Opportunities",
-            href: "/opportunities",
-            state: "neutral",
-            // SHORT numeric so the gradient metric-hero reads clean (no rainbow phrase).
-            value: "2 open",
-            // Evidence count moves to the secondary metricLabel line.
-            metricLabel: "1 evidence-linked",
-        });
-        // The long "N OPEN · M EVIDENCE-LINKED" phrase must NOT be the gradient value.
-        expect(signals.opportunities.value).not.toContain("·");
-        expect(signals.opportunities.value).not.toContain("EVIDENCE");
-    });
+	// ── Opportunities workflow card (short value, no rainbow) ──────────────────────
 
-    it("labels the secondary line 'open opportunities' when none are evidence-linked", async () => {
-        mockGetOpportunities.mockResolvedValue({
-            items: [opportunityItem([]), opportunityItem([])],
-        } as never);
+	it("emits a SHORT Opportunities value with the evidence count on the secondary line", async () => {
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
 
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
-        expect(signals.opportunities).toMatchObject({
-            state: "neutral",
-            value: "2 open",
-            metricLabel: "open opportunities",
-        });
-    });
+		expect(signals.opportunities).toMatchObject({
+			id: "opportunities",
+			label: "Opportunities",
+			href: "/opportunities",
+			state: "neutral",
+			// SHORT numeric so the gradient metric-hero reads clean (no rainbow phrase).
+			value: "2 open",
+			// Evidence count moves to the secondary metricLabel line.
+			metricLabel: "1 evidence-linked",
+		});
+		// The long "N OPEN · M EVIDENCE-LINKED" phrase must NOT be the gradient value.
+		expect(signals.opportunities.value).not.toContain("·");
+		expect(signals.opportunities.value).not.toContain("EVIDENCE");
+	});
 
-    it("does NOT repeat the card label as its own metricLabel (no 'Opportunities · Opportunities data')", async () => {
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
-        expect(signals.opportunities.metricLabel).not.toBe("Opportunities");
-        expect(signals.opportunities.metricLabel.toLowerCase()).not.toContain("opportunities data");
-    });
+	it("labels the secondary line 'open opportunities' when none are evidence-linked", async () => {
+		mockGetOpportunities.mockResolvedValue({
+			items: [opportunityItem([]), opportunityItem([])],
+		} as never);
 
-    it("treats a SUCCESSFUL empty result as a healthy '0 open' neutral (not unavailable)", async () => {
-        mockGetOpportunities.mockResolvedValue({ items: [] } as never);
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
+		expect(signals.opportunities).toMatchObject({
+			state: "neutral",
+			value: "2 open",
+			metricLabel: "open opportunities",
+		});
+	});
 
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
-        expect(signals.opportunities).toMatchObject({
-            state: "neutral",
-            value: "0 open",
-        });
-        expect(signals.opportunities.state).not.toBe("unavailable");
-    });
+	it("does NOT repeat the card label as its own metricLabel (no 'Opportunities · Opportunities data')", async () => {
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
+		expect(signals.opportunities.metricLabel).not.toBe("Opportunities");
+		expect(signals.opportunities.metricLabel.toLowerCase()).not.toContain(
+			"opportunities data",
+		);
+	});
 
-    it("degrades Opportunities to UNAVAILABLE ONLY when the fetch fails", async () => {
-        mockGetOpportunities.mockRejectedValue(new Error("backend down"));
+	it("treats a SUCCESSFUL empty result as a healthy '0 open' neutral (not unavailable)", async () => {
+		mockGetOpportunities.mockResolvedValue({ items: [] } as never);
 
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
-        expect(signals.opportunities).toMatchObject({
-            state: "unavailable",
-            value: "",
-        });
-        // A failed fetch must NOT masquerade as a "0 open" healthy zero.
-        expect(signals.opportunities.value).not.toContain("open");
-        // No synthesized hero either (no opportunities to link to).
-        expect(signals["improve-top-signal"]).toBeUndefined();
-        // Other signals still resolve
-        expect(signals.experiments).toMatchObject({ state: "unavailable" });
-        expect(signals["improve-automations"]).toMatchObject({
-            state: "unavailable",
-        });
-    });
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
+		expect(signals.opportunities).toMatchObject({
+			state: "neutral",
+			value: "0 open",
+		});
+		expect(signals.opportunities.state).not.toBe("unavailable");
+	});
 
-    // ── Preview sub-areas (Experiments / Automations) ─────────────────────────────
+	it("degrades Opportunities to UNAVAILABLE ONLY when the fetch fails", async () => {
+		mockGetOpportunities.mockRejectedValue(new Error("backend down"));
 
-    it("emits honest UNAVAILABLE + preview for Experiments (no backend / no route)", async () => {
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
+		expect(signals.opportunities).toMatchObject({
+			state: "unavailable",
+			value: "",
+		});
+		// A failed fetch must NOT masquerade as a "0 open" healthy zero.
+		expect(signals.opportunities.value).not.toContain("open");
+		// No synthesized hero either (no opportunities to link to).
+		expect(signals["improve-top-signal"]).toBeUndefined();
+		// Other signals still resolve
+		expect(signals.experiments).toMatchObject({ state: "unavailable" });
+		expect(signals["improve-automations"]).toMatchObject({
+			state: "unavailable",
+		});
+	});
 
-        expect(signals.experiments).toMatchObject({
-            id: "experiments",
-            label: "Experiments",
-            href: "/improve/experiments",
-            state: "unavailable",
-            value: "",
-            preview: true,
-        });
-    });
+	// ── Preview sub-areas (Experiments / Automations) ─────────────────────────────
 
-    it("emits honest UNAVAILABLE + preview for Automations (no backend / no route)", async () => {
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
+	it("emits honest UNAVAILABLE + preview for Experiments (no backend / no route)", async () => {
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
 
-        expect(signals["improve-automations"]).toMatchObject({
-            id: "improve-automations",
-            label: "Automations",
-            href: "/improve/automations",
-            state: "unavailable",
-            value: "",
-            preview: true,
-        });
-    });
+		expect(signals.experiments).toMatchObject({
+			id: "experiments",
+			label: "Experiments",
+			href: "/improve/experiments",
+			state: "unavailable",
+			value: "",
+			preview: true,
+		});
+	});
 
-    it("does NOT mark the real Opportunities card as preview (stays clickable)", async () => {
-        const signals = byId(await getImproveSignals(defaultMetricFilter));
-        expect(signals.opportunities.preview).not.toBe(true);
-    });
+	it("emits honest UNAVAILABLE + preview for Automations (no backend / no route)", async () => {
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
 
-    // ── Shape / ordering / wiring ─────────────────────────────────────────────────
+		expect(signals["improve-automations"]).toMatchObject({
+			id: "improve-automations",
+			label: "Automations",
+			href: "/improve/automations",
+			state: "unavailable",
+			value: "",
+			preview: true,
+		});
+	});
 
-    it("returns the 3 sub-areas plus the synthesized top signal, each once", async () => {
-        const signals = await getImproveSignals(defaultMetricFilter);
-        const ids = signals.map((s) => s.id);
-        expect(new Set(ids).size).toBe(ids.length);
-        expect(ids).toEqual(
-            expect.arrayContaining([
-                "improve-top-signal",
-                "opportunities",
-                "experiments",
-                "improve-automations",
-            ]),
-        );
-        expect(ids).toHaveLength(4);
-    });
+	it("does NOT mark the real Opportunities card as preview (stays clickable)", async () => {
+		const signals = byId(await getImproveSignals(defaultMetricFilter));
+		expect(signals.opportunities.preview).not.toBe(true);
+	});
 
-    it("sorts real signals first, unavailable last", async () => {
-        const signals = await getImproveSignals(defaultMetricFilter);
-        const opportunitiesIdx = signals.findIndex((s) => s.id === "opportunities");
-        const experimentsIdx = signals.findIndex((s) => s.id === "experiments");
-        const automationsIdx = signals.findIndex((s) => s.id === "improve-automations");
-        expect(opportunitiesIdx).toBeLessThan(experimentsIdx);
-        expect(opportunitiesIdx).toBeLessThan(automationsIdx);
-    });
+	// ── Shape / ordering / wiring ─────────────────────────────────────────────────
 
-    it("uses filters (passes them to both sources, not voided)", async () => {
-        const customFilter = {
-            ...defaultMetricFilter,
-            time: { range_days: 30, compare_days: 30 },
-        };
-        await getImproveSignals(customFilter);
-        expect(mockGetOpportunities).toHaveBeenCalledWith(customFilter);
-        expect(mockGetHomeData).toHaveBeenCalledWith(customFilter);
-    });
+	it("returns the 3 sub-areas plus the synthesized top signal, each once", async () => {
+		const signals = await getImproveSignals(defaultMetricFilter);
+		const ids = signals.map((s) => s.id);
+		expect(new Set(ids).size).toBe(ids.length);
+		expect(ids).toEqual(
+			expect.arrayContaining([
+				"improve-top-signal",
+				"opportunities",
+				"experiments",
+				"improve-automations",
+			]),
+		);
+		expect(ids).toHaveLength(4);
+	});
 
-    it("fetches both REST sources UNCONDITIONALLY (isTestMode is not a fetch gate)", async () => {
-        // Mirrors getDiagnoseSignals/getGovernSignals: home + opportunities are
-        // MSW-mockable REST, so they are always fetched (under Playwright the dev
-        // server points BACKEND_URL at the mock). isTestMode must NOT short-circuit
-        // them, or the Overview would render an all-empty hero in e2e.
-        await getImproveSignals(defaultMetricFilter, true);
-        expect(mockGetOpportunities).toHaveBeenCalledWith(defaultMetricFilter);
-        expect(mockGetHomeData).toHaveBeenCalledWith(defaultMetricFilter);
-    });
+	it("sorts real signals first, unavailable last", async () => {
+		const signals = await getImproveSignals(defaultMetricFilter);
+		const opportunitiesIdx = signals.findIndex((s) => s.id === "opportunities");
+		const experimentsIdx = signals.findIndex((s) => s.id === "experiments");
+		const automationsIdx = signals.findIndex(
+			(s) => s.id === "improve-automations",
+		);
+		expect(opportunitiesIdx).toBeLessThan(experimentsIdx);
+		expect(opportunitiesIdx).toBeLessThan(automationsIdx);
+	});
 
-    it("degrades the 3 sub-areas to UNAVAILABLE (no top signal) when BOTH sources fail", async () => {
-        // The genuine "not connected" path: both REST fetches throw → safe()
-        // swallows to undefined → opportunities unavailable, no deltas to rank, and
-        // Experiments/Automations stay preview. This is the honest-empty Overview.
-        mockGetOpportunities.mockRejectedValue(new Error("opps down"));
-        mockGetHomeData.mockRejectedValue(new Error("home down"));
+	it("uses filters (passes them to both sources, not voided)", async () => {
+		const customFilter = {
+			...defaultMetricFilter,
+			time: { range_days: 30, compare_days: 30 },
+		};
+		await getImproveSignals(customFilter);
+		expect(mockGetOpportunities).toHaveBeenCalledWith(customFilter);
+		expect(mockGetHomeData).toHaveBeenCalledWith(customFilter);
+	});
 
-        const signals = await getImproveSignals(defaultMetricFilter, true);
-        expect(signals).toHaveLength(3);
-        expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
-        for (const signal of signals) {
-            expect(signal.state).toBe("unavailable");
-            expect(signal.value).toBe("");
-        }
-        const byIdMap = byId(signals);
-        expect(byIdMap.experiments.preview).toBe(true);
-        expect(byIdMap["improve-automations"].preview).toBe(true);
-        expect(byIdMap.opportunities.preview).not.toBe(true);
-    });
+	it("fetches both REST sources UNCONDITIONALLY (isTestMode is not a fetch gate)", async () => {
+		// Mirrors getDiagnoseSignals/getGovernSignals: home + opportunities are
+		// MSW-mockable REST, so they are always fetched (under Playwright the dev
+		// server points BACKEND_URL at the mock). isTestMode must NOT short-circuit
+		// them, or the Overview would render an all-empty hero in e2e.
+		await getImproveSignals(defaultMetricFilter, true);
+		expect(mockGetOpportunities).toHaveBeenCalledWith(defaultMetricFilter);
+		expect(mockGetHomeData).toHaveBeenCalledWith(defaultMetricFilter);
+	});
+
+	it("degrades the 3 sub-areas to UNAVAILABLE (no top signal) when BOTH sources fail", async () => {
+		// The genuine "not connected" path: both REST fetches throw → safe()
+		// swallows to undefined → opportunities unavailable, no deltas to rank, and
+		// Experiments/Automations stay preview. This is the honest-empty Overview.
+		mockGetOpportunities.mockRejectedValue(new Error("opps down"));
+		mockGetHomeData.mockRejectedValue(new Error("home down"));
+
+		const signals = await getImproveSignals(defaultMetricFilter, true);
+		expect(signals).toHaveLength(3);
+		expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
+		for (const signal of signals) {
+			expect(signal.state).toBe("unavailable");
+			expect(signal.value).toBe("");
+		}
+		const byIdMap = byId(signals);
+		expect(byIdMap.experiments.preview).toBe(true);
+		expect(byIdMap["improve-automations"].preview).toBe(true);
+		expect(byIdMap.opportunities.preview).not.toBe(true);
+	});
 });

--- a/src/lib/areaSignals/improve.ts
+++ b/src/lib/areaSignals/improve.ts
@@ -43,6 +43,7 @@ import { logger } from "@/lib/logger";
 
 import type { AreaSignal, AreaSignalState } from "./types";
 import { sortBySeverity } from "./sort";
+import { getMetricPolarity } from "@/lib/metrics/catalog";
 
 /** The unavailable (honest-empty) resolution — no fabricated value. */
 const UNAVAILABLE = { state: "unavailable" as const, value: "" };
@@ -67,10 +68,13 @@ function severityForDelta(deltaPct: number): Exclude<AreaSignalState, "neutral" 
 
 /** The single worst worsened metric (largest absolute delta in the wrong direction), or undefined when none worsened. */
 function worstWorsenedDelta(deltas: MetricDelta[] | undefined): MetricDelta | undefined {
-    const HIGHER_IS_BETTER = new Set(["throughput", "ci_success", "deploy_freq"]);
     const worsened = (deltas ?? []).filter((d) => {
-        const isHigherBetter = HIGHER_IS_BETTER.has(d.metric);
-        return isHigherBetter ? d.delta_pct < 0 : d.delta_pct > 0;
+        const polarity = getMetricPolarity(d.metric);
+        if (!polarity) {
+            logger.warn({ metric: d.metric }, "Unknown metric polarity, excluding from top signal");
+            return false;
+        }
+        return polarity === "higherIsBetter" ? d.delta_pct < 0 : d.delta_pct > 0;
     });
     if (worsened.length === 0) return undefined;
     return [...worsened].sort((a, b) => Math.abs(b.delta_pct) - Math.abs(a.delta_pct))[0];
@@ -165,7 +169,8 @@ export async function getImproveSignals(
     // count leads as a neutral, no fabricated severity).
     const worst = worstWorsenedDelta(homeData?.deltas);
     if (worst && openCount && openCount > 0) {
-        const isHigherBetter = ["throughput", "ci_success", "deploy_freq"].includes(worst.metric);
+        const polarity = getMetricPolarity(worst.metric);
+        const isHigherBetter = polarity === "higherIsBetter";
         const action = isHigherBetter ? "Recover" : "Reduce";
         const sign = worst.delta_pct > 0 ? "+" : "";
         signals.push({

--- a/src/lib/areaSignals/improve.ts
+++ b/src/lib/areaSignals/improve.ts
@@ -15,10 +15,11 @@
 //
 // Signal policy:
 //   - Top signal (synthesized): the SINGLE worst worsened metric (home
-//     `deltas[]` with `delta_pct > 0`, max) — the same ranking the backend uses
+//     `deltas[]` with `delta_pct > 0` for lower-is-better, or `< 0` for
+//     higher-is-better, max absolute shift) — the same ranking the backend uses
 //     to build opportunity cards (`build_opportunities_response` sorts the
-//     positive deltas desc; `items[0]` is this metric). Emitted as a severity
-//     card ("Reduce <metric>" · +N%) linking to `/opportunities`, so
+//     worsened deltas desc; `items[0]` is this metric). Emitted as a severity
+//     card ("Reduce <metric>" or "Recover <metric>" · ±N%) linking to `/opportunities`, so
 //     `AreaOverview` promotes it to the hero and Opportunities drops to a
 //     workflow card. GATED on opportunities actually being present so the hero
 //     always links to a real opportunity. Zero worsened metrics → no top signal
@@ -64,11 +65,15 @@ function severityForDelta(deltaPct: number): Exclude<AreaSignalState, "neutral" 
     return "low";
 }
 
-/** The single worst worsened metric (largest positive delta), or undefined when none worsened. */
+/** The single worst worsened metric (largest absolute delta in the wrong direction), or undefined when none worsened. */
 function worstWorsenedDelta(deltas: MetricDelta[] | undefined): MetricDelta | undefined {
-    const worsened = (deltas ?? []).filter((d) => d.delta_pct > 0);
+    const HIGHER_IS_BETTER = new Set(["throughput", "ci_success", "deploy_freq"]);
+    const worsened = (deltas ?? []).filter((d) => {
+        const isHigherBetter = HIGHER_IS_BETTER.has(d.metric);
+        return isHigherBetter ? d.delta_pct < 0 : d.delta_pct > 0;
+    });
     if (worsened.length === 0) return undefined;
-    return [...worsened].sort((a, b) => b.delta_pct - a.delta_pct)[0];
+    return [...worsened].sort((a, b) => Math.abs(b.delta_pct) - Math.abs(a.delta_pct))[0];
 }
 
 /**
@@ -160,14 +165,17 @@ export async function getImproveSignals(
     // count leads as a neutral, no fabricated severity).
     const worst = worstWorsenedDelta(homeData?.deltas);
     if (worst && openCount && openCount > 0) {
+        const isHigherBetter = ["throughput", "ci_success", "deploy_freq"].includes(worst.metric);
+        const action = isHigherBetter ? "Recover" : "Reduce";
+        const sign = worst.delta_pct > 0 ? "+" : "";
         signals.push({
             id: TOP_SIGNAL_ID,
-            label: `Reduce ${worst.label}`,
+            label: `${action} ${worst.label}`,
             href: "/opportunities",
             metricLabel: `${worst.label} shift`,
-            value: `+${formatNumber(worst.delta_pct, { maximumFractionDigits: 0 })}%`,
-            state: severityForDelta(worst.delta_pct),
-            direction: "up",
+            value: `${sign}${formatNumber(worst.delta_pct, { maximumFractionDigits: 0 })}%`,
+            state: severityForDelta(Math.abs(worst.delta_pct)),
+            direction: isHigherBetter ? "down" : "up",
         });
     }
 
@@ -195,10 +203,18 @@ export async function getImproveSignals(
     }
 
     // ── Experiments — UNAVAILABLE + preview (no backend / no route yet) ──────────
-    push("experiments", { ...UNAVAILABLE, preview: true, metricLabel: "Experiments" });
+    push("experiments", {
+        ...UNAVAILABLE,
+        preview: true,
+        metricLabel: "Experiments",
+    });
 
     // ── Automations — UNAVAILABLE + preview (no backend / no route yet) ──────────
-    push("improve-automations", { ...UNAVAILABLE, preview: true, metricLabel: "Automations" });
+    push("improve-automations", {
+        ...UNAVAILABLE,
+        preview: true,
+        metricLabel: "Automations",
+    });
 
     return sortBySeverity(signals);
 }

--- a/src/lib/metrics/catalog.ts
+++ b/src/lib/metrics/catalog.ts
@@ -1,14 +1,105 @@
 import type { MetricDelta } from "@/lib/types";
 
+export type MetricPolarity = "lowerIsBetter" | "higherIsBetter";
+
 export const METRIC_CATALOG = [
-    { metric: "cycle_time", label: "Cycle Time", unit: "days" },
-    { metric: "review_latency", label: "Review Latency", unit: "hours" },
-    { metric: "throughput", label: "Throughput", unit: "items" },
-    { metric: "deploy_freq", label: "Deploy Frequency", unit: "deploys" },
-    { metric: "churn", label: "Code Churn", unit: "loc" },
-    { metric: "wip_saturation", label: "WIP Saturation", unit: "%" },
-    { metric: "blocked_work", label: "Blocked Work", unit: "hours" },
-    { metric: "change_failure_rate", label: "Change Failure Rate", unit: "%" },
+    {
+        metric: "cycle_time",
+        label: "Cycle Time",
+        unit: "days",
+        polarity: "lowerIsBetter",
+    },
+    {
+        metric: "review_latency",
+        label: "Review Latency",
+        unit: "hours",
+        polarity: "lowerIsBetter",
+    },
+    {
+        metric: "throughput",
+        label: "Throughput",
+        unit: "items",
+        polarity: "higherIsBetter",
+    },
+    {
+        metric: "deploy_freq",
+        label: "Deploy Frequency",
+        unit: "deploys",
+        polarity: "higherIsBetter",
+    },
+    {
+        metric: "churn",
+        label: "Code Churn",
+        unit: "loc",
+        polarity: "lowerIsBetter",
+    },
+    {
+        metric: "wip_saturation",
+        label: "WIP Saturation",
+        unit: "%",
+        polarity: "lowerIsBetter",
+    },
+    {
+        metric: "blocked_work",
+        label: "Blocked Work",
+        unit: "hours",
+        polarity: "lowerIsBetter",
+    },
+    {
+        metric: "change_failure_rate",
+        label: "Change Failure Rate",
+        unit: "%",
+        polarity: "lowerIsBetter",
+    },
+    {
+        metric: "ci_success",
+        label: "CI Success Rate",
+        unit: "%",
+        polarity: "higherIsBetter",
+    },
+    {
+        metric: "pr_rework_ratio",
+        label: "PR Rework Ratio",
+        unit: "%",
+        polarity: "lowerIsBetter",
+    },
+    {
+        metric: "rework_ratio",
+        label: "Rework Ratio",
+        unit: "%",
+        polarity: "lowerIsBetter",
+    },
+    {
+        metric: "compounding_risk",
+        label: "Compounding Risk",
+        unit: "score",
+        polarity: "lowerIsBetter",
+    },
+    {
+        metric: "coverage",
+        label: "Coverage",
+        unit: "%",
+        polarity: "higherIsBetter",
+    },
+    {
+        metric: "review_load",
+        label: "Review Load",
+        unit: "reviews",
+        polarity: "lowerIsBetter",
+    },
+    { metric: "wip", label: "WIP", unit: "items", polarity: "lowerIsBetter" },
+    {
+        metric: "wip_overlap",
+        label: "WIP Overlap",
+        unit: "items",
+        polarity: "lowerIsBetter",
+    },
+    {
+        metric: "churn_loc",
+        label: "Churn LOC",
+        unit: "loc",
+        polarity: "lowerIsBetter",
+    },
 ] as const;
 
 type MetricMeta = (typeof METRIC_CATALOG)[number];
@@ -36,3 +127,5 @@ export const getMetricLabel = (metric: string) => {
 };
 
 export const getMetricUnit = (metric: string) => metricMetaByKey.get(metric)?.unit ?? "";
+export const getMetricPolarity = (metric: string): MetricPolarity | undefined =>
+    metricMetaByKey.get(metric)?.polarity;

--- a/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
+++ b/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
@@ -660,9 +660,9 @@ describe("IA preservation invariant #9 — no dead hubItems links (signal cards)
         // below still hold trivially, but the count guards the regression target.
         expect(previewHubItems.length).toBeGreaterThan(0);
 
-        // The signal-card components must gate clickability on the explicit `preview`
+        // The signal-card component must gate clickability on the explicit `preview`
         // flag (NOT on `state === "unavailable"`, which real-but-unconnected routes
-        // share and must keep clickable). Static guard: both render paths branch on it.
+        // share and must keep clickable). Static guard: the render path branches on it.
         expect(
             areaSignalCardSource,
             "AreaSignalCard must branch on signal.preview to drop the <Link>",
@@ -672,14 +672,18 @@ describe("IA preservation invariant #9 — no dead hubItems links (signal cards)
             "AreaSignalCard preview card must be a non-interactive element",
         ).toContain('aria-disabled="true"');
 
+        // AreaOverview no longer owns an empty-tier chip strip (CHAOS-2217):
+        // unavailable signals render as dashed AreaSignalCards in the main grid,
+        // so the preview guard lives in AreaSignalCard alone. Assert the
+        // delegation so a reintroduced bespoke tier would trip this invariant.
         expect(
             areaOverviewSource,
-            "AreaOverview empty tier must branch on signal.preview to drop the <Link>",
-        ).toContain("signal.preview === true");
+            "AreaOverview must render unavailable signals through AreaSignalCard (no bespoke empty tier)",
+        ).toContain("AreaSignalCard");
         expect(
             areaOverviewSource,
-            "AreaOverview preview chip must be a non-interactive element",
-        ).toContain('aria-disabled="true"');
+            "AreaOverview must not reintroduce the chip-strip empty tier",
+        ).not.toContain("Not yet connected");
     });
 
     it("emits the preview flag from the Improve resolver for its preview hubItems", async () => {

--- a/tests/cognitive-load.spec.ts
+++ b/tests/cognitive-load.spec.ts
@@ -20,12 +20,12 @@ test.describe("IA rejection regressions", () => {
         await page.goto("/work");
         await waitForHydration(page);
 
-        const emptyTier = page.getByTestId("area-overview-empty-tier");
-        await expect(emptyTier).toBeVisible();
-        await expect(emptyTier.getByTestId("area-signal-unavailable")).toHaveCount(0);
-        await expect(emptyTier.getByRole("link", { name: "People" })).not.toBeVisible();
-        await expect(emptyTier.getByRole("link", { name: "Landscape" })).toBeVisible();
-        await expect(emptyTier.getByRole("link", { name: "Cognitive Load" })).toBeVisible();
+        const grid = page.getByTestId("area-overview-grid");
+        await expect(grid).toBeVisible();
+        await expect(grid.getByTestId("area-signal-unavailable")).not.toHaveCount(0);
+        await expect(grid.getByRole("link", { name: "People" })).not.toBeVisible();
+        await expect(grid.getByRole("link", { name: "Landscape" })).toBeVisible();
+        await expect(grid.getByRole("link", { name: "Cognitive Load" })).toBeVisible();
 
         // People remains reachable via the active Diagnose sidebar navigation
         const diagnoseNav = page.getByTestId("nav-children-diagnose");

--- a/tests/improve-overview.spec.ts
+++ b/tests/improve-overview.spec.ts
@@ -73,17 +73,17 @@ test.describe("Improve Overview landing", () => {
     test("keeps Experiments + Automations as non-clickable preview chips", async ({ page }) => {
         await page.goto("/improve", { waitUntil: "domcontentloaded" });
 
-        const emptyTier = page.getByTestId("area-overview-empty-tier");
-        await expect(emptyTier).toBeVisible();
+        const grid = page.getByTestId("area-overview-grid");
+        await expect(grid).toBeVisible();
 
         for (const label of ["Experiments", "Automations"]) {
-            const chip = emptyTier.locator("[data-signal-id]", { hasText: label });
-            await expect(chip).toHaveAttribute("data-preview", "true");
-            await expect(chip).toHaveAttribute("aria-disabled", "true");
+            const card = grid.locator("[data-signal-id]", { hasText: label });
+            await expect(card).toHaveAttribute("data-preview", "true");
+            await expect(card).toHaveAttribute("aria-disabled", "true");
         }
         // Preview chips are never links (dead route can't 404).
-        await expect(emptyTier.getByRole("link", { name: "Experiments" })).toHaveCount(0);
-        await expect(emptyTier.getByRole("link", { name: "Automations" })).toHaveCount(0);
+        await expect(grid.getByRole("link", { name: "Experiments" })).toHaveCount(0);
+        await expect(grid.getByRole("link", { name: "Automations" })).toHaveCount(0);
     });
 
     test("marks Improve as the single selected area on /improve", async ({ page }) => {


### PR DESCRIPTION
## Summary

Visual + correctness fixes for the `/improve` Overview, per Penpot and the Govern reference treatment:

- **Polarity-gated top signal**: the hero now only surfaces metrics whose delta direction is actually *bad*. Polarity lives in the shared metric catalog (`getMetricPolarity()`); unknown metric keys **fail closed** (excluded from hero promotion + logged). No more "Reduce Throughput · CRITICAL" when throughput rose. Falling higher-is-better metrics render as "Recover X · −N% ↓".
- **All subareas render as cards**: the "NOT YET CONNECTED" chip strip in the shared `AreaOverview` is replaced by dashed "No data for this window" cards in the main grid (matches the Penpot no-data treatment). Applies consistently to Govern/Diagnose/Improve.
- Preview (route-less) cards stay non-clickable and no longer fake a hover affordance.

## Before / After

| Before | After |
| --- | --- |
| ![current-improve.png](https://github.com/user-attachments/assets/35a50f1c-ebfd-498b-b4a4-bbd0c61f8ade) | ![after-improve-final.png](https://github.com/user-attachments/assets/224b7766-3a3e-4a4e-963e-1f4b5c162a24) |

## Testing

- `vitest`: 23 tests in `improve.test.ts` (incl. new regressions: coverage-decline beats smaller churn rise; unknown polarity never becomes hero) + 77 navigation component tests pass.
- Playwright specs (`improve-overview.spec.ts`, `cognitive-load.spec.ts`) updated for the dashed-card grid.
- Codex adversarial review: **approve** (after fail-closed polarity catalog rework).

Closes CHAOS-2217
