### PR TITLE
feat(nav): hide Operating Review from Plan nav pending rethink (CHAOS-2181)

### DIFF
--- a/src/components/navigation/PrimaryNav.test.tsx
+++ b/src/components/navigation/PrimaryNav.test.tsx
@@ -8,445 +8,473 @@ import type { MetricFilter } from "@/lib/filters/types";
 const navigationMock = vi.hoisted(() => ({ pathname: "/dashboard" }));
 
 vi.mock("next/navigation", () => ({
-    usePathname: () => navigationMock.pathname,
-    useRouter: () => ({ refresh: vi.fn() }),
+	usePathname: () => navigationMock.pathname,
+	useRouter: () => ({ refresh: vi.fn() }),
 }));
 
 vi.mock("next-auth/react", () => ({
-    useSession: () => ({
-        data: { user: { org_id: "org-1" } },
-        update: vi.fn(),
-    }),
+	useSession: () => ({
+		data: { user: { org_id: "org-1" } },
+		update: vi.fn(),
+	}),
 }));
 
 function makeFilter(): MetricFilter {
-    return {
-        scope: { level: "repo", ids: ["my-repo"] },
-        time: {
-            range_days: 30,
-            compare_days: 0,
-            start_date: undefined,
-            end_date: undefined,
-        },
-        who: {},
-        what: {},
-        why: {},
-        how: {},
-    };
+	return {
+		scope: { level: "repo", ids: ["my-repo"] },
+		time: {
+			range_days: 30,
+			compare_days: 0,
+			start_date: undefined,
+			end_date: undefined,
+		},
+		who: {},
+		what: {},
+		why: {},
+		how: {},
+	};
 }
 
 beforeEach(() => {
-    navigationMock.pathname = "/dashboard";
+	navigationMock.pathname = "/dashboard";
 });
 
 function currentPageLinks() {
-    return screen
-        .getAllByRole("link")
-        .filter((link) => link.getAttribute("aria-current") === "page");
+	return screen
+		.getAllByRole("link")
+		.filter((link) => link.getAttribute("aria-current") === "page");
 }
 
 describe("PrimaryNav — two-level decision-area surface (CHAOS-2079)", () => {
-    it("always renders the eight area rows", () => {
-        render(<PrimaryNav filters={makeFilter()} active="home" />);
+	it("always renders the eight area rows", () => {
+		render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-        for (const name of [
-            /^Cockpit$/i,
-            /^Diagnose$/i,
-            /^Plan$/i,
-            /^Improve$/i,
-            /^Govern$/i,
-            /^AI$/i,
-            /^Reports$/i,
-            /^Admin$/i,
-        ]) {
-            expect(screen.getByRole("link", { name })).toBeInTheDocument();
-        }
-    });
+		for (const name of [
+			/^Cockpit$/i,
+			/^Diagnose$/i,
+			/^Plan$/i,
+			/^Improve$/i,
+			/^Govern$/i,
+			/^AI$/i,
+			/^Reports$/i,
+			/^Admin$/i,
+		]) {
+			expect(screen.getByRole("link", { name })).toBeInTheDocument();
+		}
+	});
 
-    it("on a childless area (Cockpit) renders only the eight area rows", () => {
-        // Cockpit has no expandable children, so the sidebar shows exactly the areas.
-        navigationMock.pathname = "/dashboard";
-        render(<PrimaryNav filters={makeFilter()} active="home" />);
+	it("on a childless area (Cockpit) renders only the eight area rows", () => {
+		// Cockpit has no expandable children, so the sidebar shows exactly the areas.
+		navigationMock.pathname = "/dashboard";
+		render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-        const linkNames = screen
-            .getAllByRole("link")
-            .map((link) => (link.textContent ?? "").replace(/\s+/g, " ").trim());
+		const linkNames = screen
+			.getAllByRole("link")
+			.map((link) => (link.textContent ?? "").replace(/\s+/g, " ").trim());
 
-        expect(linkNames).toEqual([
-            "Cockpit",
-            "Diagnose",
-            "Plan",
-            "Improve",
-            "Govern",
-            "AI",
-            "Reports",
-            "Admin",
-        ]);
-    });
+		expect(linkNames).toEqual([
+			"Cockpit",
+			"Diagnose",
+			"Plan",
+			"Improve",
+			"Govern",
+			"AI",
+			"Reports",
+			"Admin",
+		]);
+	});
 
-    it("renders no expand/collapse buttons — rows are links, not toggles", () => {
-        render(<PrimaryNav filters={makeFilter()} active="home" />);
-        expect(screen.queryAllByRole("button")).toHaveLength(0);
-    });
+	it("renders no expand/collapse buttons — rows are links, not toggles", () => {
+		render(<PrimaryNav filters={makeFilter()} active="home" />);
+		expect(screen.queryAllByRole("button")).toHaveLength(0);
+	});
 
-    it("expands ONLY the active area's children; inactive areas stay collapsed", () => {
-        navigationMock.pathname = "/work";
-        render(<PrimaryNav filters={makeFilter()} active="work" />);
+	it("expands ONLY the active area's children; inactive areas stay collapsed", () => {
+		navigationMock.pathname = "/work";
+		render(<PrimaryNav filters={makeFilter()} active="work" />);
 
-        // Diagnose is active → its children render as indented rows.
-        expect(screen.getByTestId("nav-children-diagnose")).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /^Flow$/i })).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /^Bottlenecks$/i })).toBeInTheDocument();
+		// Diagnose is active → its children render as indented rows.
+		expect(screen.getByTestId("nav-children-diagnose")).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /^Flow$/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Bottlenecks$/i }),
+		).toBeInTheDocument();
 
-        // Govern is NOT active → none of its children appear.
-        expect(screen.queryByTestId("nav-children-govern")).toBeNull();
-        expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
-        expect(screen.queryByRole("link", { name: /^Security$/i })).toBeNull();
-    });
+		// Govern is NOT active → none of its children appear.
+		expect(screen.queryByTestId("nav-children-govern")).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Security$/i })).toBeNull();
+	});
 
-    it("never renders preview (navVisible:false) children — verified via Improve", () => {
-        navigationMock.pathname = "/opportunities";
-        render(<PrimaryNav filters={makeFilter()} active="opportunities" />);
+	it("never renders preview (navVisible:false) children — verified via Improve", () => {
+		navigationMock.pathname = "/opportunities";
+		render(<PrimaryNav filters={makeFilter()} active="opportunities" />);
 
-        expect(screen.getByRole("link", { name: /^Opportunities$/i })).toBeInTheDocument();
-        expect(screen.queryByRole("link", { name: /^Experiments$/i })).toBeNull();
-        expect(screen.queryByRole("link", { name: /^Automations$/i })).toBeNull();
-    });
+		expect(
+			screen.getByRole("link", { name: /^Opportunities$/i }),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: /^Experiments$/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Automations$/i })).toBeNull();
+	});
 
-    it("renders real AI children and hides preview-only AI routes", () => {
-        navigationMock.pathname = "/ai/review-load";
-        render(<PrimaryNav filters={makeFilter()} active="ai" />);
+	it("renders real AI children and hides preview-only AI routes", () => {
+		navigationMock.pathname = "/ai/review-load";
+		render(<PrimaryNav filters={makeFilter()} active="ai" />);
 
-        expect(screen.getByRole("link", { name: /^Overview$/i })).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /^Impact$/i })).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /^Review Load$/i })).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /^Governance Risk$/i })).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /^Automations$/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Overview$/i }),
+		).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /^Impact$/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Review Load$/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Governance Risk$/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Automations$/i }),
+		).toBeInTheDocument();
 
-        for (const tab of [/^Attribution$/i, /^Test Gaps$/i, /^Evidence$/i]) {
-            expect(screen.queryByRole("link", { name: tab })).toBeNull();
-        }
-    });
+		for (const tab of [/^Attribution$/i, /^Test Gaps$/i, /^Evidence$/i]) {
+			expect(screen.queryByRole("link", { name: tab })).toBeNull();
+		}
+	});
 
-    it("renders TestOps as the single Govern cluster row instead of separate Tests/Pipelines/Coverage rows", () => {
-        navigationMock.pathname = "/testops/tests";
-        render(<PrimaryNav filters={makeFilter()} active="tests" />);
+	it("renders TestOps as the single Govern cluster row instead of separate Tests/Pipelines/Coverage rows", () => {
+		navigationMock.pathname = "/testops/tests";
+		render(<PrimaryNav filters={makeFilter()} active="tests" />);
 
-        expect(screen.queryByRole("link", { name: /Tests · Quality · Coverage/i })).toBeNull();
-        expect(screen.getAllByRole("link", { name: /^TestOps$/i })).toHaveLength(1);
-        expect(screen.queryByRole("link", { name: /^Tests$/i })).toBeNull();
-        expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
-        expect(screen.queryByRole("link", { name: /^Coverage$/i })).toBeNull();
-        expect(screen.getByRole("link", { name: /^Quality$/i })).toBeInTheDocument();
-    });
+		expect(
+			screen.queryByRole("link", { name: /Tests · Quality · Coverage/i }),
+		).toBeNull();
+		expect(screen.getAllByRole("link", { name: /^TestOps$/i })).toHaveLength(1);
+		expect(screen.queryByRole("link", { name: /^Tests$/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Coverage$/i })).toBeNull();
+		expect(
+			screen.getByRole("link", { name: /^Quality$/i }),
+		).toBeInTheDocument();
+	});
 
-    it("links each area to its landing route", () => {
-        render(<PrimaryNav filters={makeFilter()} active="home" />);
+	it("links each area to its landing route", () => {
+		render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-        const expectations: Array<[RegExp, string]> = [
-            [/^Cockpit$/i, "/dashboard"],
-            [/^Diagnose$/i, "/diagnose"],
-            [/^Plan$/i, "/plan"],
-            [/^Improve$/i, "/improve"],
-            [/^Govern$/i, "/govern"],
-            [/^AI$/i, "/ai"],
-            [/^Reports$/i, "/reports"],
-            [/^Admin$/i, "/admin"],
-        ];
+		const expectations: Array<[RegExp, string]> = [
+			[/^Cockpit$/i, "/dashboard"],
+			[/^Diagnose$/i, "/diagnose"],
+			[/^Plan$/i, "/plan"],
+			[/^Improve$/i, "/improve"],
+			[/^Govern$/i, "/govern"],
+			[/^AI$/i, "/ai"],
+			[/^Reports$/i, "/reports"],
+			[/^Admin$/i, "/admin"],
+		];
 
-        for (const [name, href] of expectations) {
-            expect(screen.getByRole("link", { name })).toHaveAttribute(
-                "href",
-                expect.stringContaining(href),
-            );
-        }
-    });
+		for (const [name, href] of expectations) {
+			expect(screen.getByRole("link", { name })).toHaveAttribute(
+				"href",
+				expect.stringContaining(href),
+			);
+		}
+	});
 });
 
 describe("PrimaryNav — active child highlight (A10: one selected, distinct hover)", () => {
-    it.each([
-        { pathname: "/metrics", active: "metrics", child: /^Flow$/i },
-        { pathname: "/ai/review-load", active: "ai", child: /^Review Load$/i },
-        {
-            pathname: "/plan/capacity",
-            active: "capacity",
-            child: /^Capacity Forecast$/i,
-        },
-        { pathname: "/testops/coverage", active: "coverage", child: /^TestOps$/i },
-        { pathname: "/quality", active: "quality", child: /^Quality$/i },
-        { pathname: "/testops/tests", active: "tests", child: /^TestOps$/i },
-    ])("marks exactly the child $child current for $pathname", ({ pathname, active, child }) => {
-        navigationMock.pathname = pathname;
-        render(<PrimaryNav filters={makeFilter()} active={active} />);
+	it.each([
+		{ pathname: "/metrics", active: "metrics", child: /^Flow$/i },
+		{ pathname: "/ai/review-load", active: "ai", child: /^Review Load$/i },
+		{
+			pathname: "/plan/capacity",
+			active: "capacity",
+			child: /^Capacity Forecast$/i,
+		},
+		{ pathname: "/testops/coverage", active: "coverage", child: /^TestOps$/i },
+		{ pathname: "/quality", active: "quality", child: /^Quality$/i },
+		{ pathname: "/testops/tests", active: "tests", child: /^TestOps$/i },
+	])("marks exactly the child $child current for $pathname", ({
+		pathname,
+		active,
+		child,
+	}) => {
+		navigationMock.pathname = pathname;
+		render(<PrimaryNav filters={makeFilter()} active={active} />);
 
-        expect(screen.getByRole("link", { name: child })).toHaveAttribute("aria-current", "page");
-        // A10: exactly one selected destination across the whole sidebar.
-        expect(currentPageLinks()).toHaveLength(1);
-    });
+		expect(screen.getByRole("link", { name: child })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		// A10: exactly one selected destination across the whole sidebar.
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-    it("highlights the area row (not a child) on the area landing route", () => {
-        // /dashboard → Cockpit (no children); the area row itself is current.
-        navigationMock.pathname = "/dashboard";
-        render(<PrimaryNav filters={makeFilter()} active="home" />);
+	it("highlights the area row (not a child) on the area landing route", () => {
+		// /dashboard → Cockpit (no children); the area row itself is current.
+		navigationMock.pathname = "/dashboard";
+		render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-        expect(screen.getByRole("link", { name: /^Cockpit$/i })).toHaveAttribute(
-            "aria-current",
-            "page",
-        );
-        expect(currentPageLinks()).toHaveLength(1);
-    });
+		expect(screen.getByRole("link", { name: /^Cockpit$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-    it("does not mark the area row current when one of its children is active", () => {
-        // On /metrics the active destination is the Flow CHILD, so the Diagnose
-        // AREA row must NOT also carry aria-current (no double-selection, A10).
-        navigationMock.pathname = "/metrics";
-        render(<PrimaryNav filters={makeFilter()} active="metrics" />);
+	it("does not mark the area row current when one of its children is active", () => {
+		// On /metrics the active destination is the Flow CHILD, so the Diagnose
+		// AREA row must NOT also carry aria-current (no double-selection, A10).
+		navigationMock.pathname = "/metrics";
+		render(<PrimaryNav filters={makeFilter()} active="metrics" />);
 
-        expect(screen.getByRole("link", { name: /^Diagnose$/i })).not.toHaveAttribute(
-            "aria-current",
-        );
-        expect(screen.getByRole("link", { name: /^Flow$/i })).toHaveAttribute(
-            "aria-current",
-            "page",
-        );
-    });
+		expect(
+			screen.getByRole("link", { name: /^Diagnose$/i }),
+		).not.toHaveAttribute("aria-current");
+		expect(screen.getByRole("link", { name: /^Flow$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+	});
 });
 
 describe("PrimaryNav — active-area resolution (A10: one selected at a time)", () => {
-    // Each row resolves to its owning area, and exactly one destination is
-    // selected sidebar-wide (A10). On an area-LANDING route the area row is the
-    // selection; on a CHILD route a child row inside that area is. `landing`
-    // flags whether the area row itself should carry aria-current.
-    it.each([
-        {
-            pathname: "/dashboard",
-            active: "home",
-            area: /^Cockpit$/i,
-            landing: true,
-        },
-        {
-            pathname: "/operating-review",
-            active: "operating-review",
-            area: /^Plan$/i,
-            landing: false,
-            child: /^Operating Review$/i,
-        },
-        { pathname: "/work", active: "work", area: /^Diagnose$/i, landing: true },
-        {
-            pathname: "/metrics",
-            active: "metrics",
-            area: /^Diagnose$/i,
-            landing: false,
-        },
-        {
-            pathname: "/people",
-            active: "people",
-            area: /^Diagnose$/i,
-            landing: false,
-        },
-        {
-            pathname: "/complexity",
-            active: "complexity",
-            area: /^Diagnose$/i,
-            landing: false,
-        },
-        {
-            pathname: "/bottleneck",
-            active: "bottleneck",
-            area: /^Diagnose$/i,
-            landing: false,
-        },
-        {
-            pathname: "/landscape",
-            active: "landscape",
-            area: /^Diagnose$/i,
-            landing: false,
-        },
-        {
-            pathname: "/opportunities",
-            active: "opportunities",
-            area: /^Improve$/i,
-            landing: false,
-            child: /^Opportunities$/i,
-        },
-        {
-            pathname: "/plan/capacity",
-            active: "capacity",
-            area: /^Plan$/i,
-            landing: false,
-        },
-        {
-            pathname: "/ai/review-load",
-            active: "ai",
-            area: /^AI$/i,
-            landing: false,
-        },
-        {
-            pathname: "/testops",
-            active: "testops",
-            area: /^Govern$/i,
-            landing: false,
-            child: /^TestOps$/i,
-        },
-        {
-            pathname: "/testops/risk",
-            active: "risk",
-            area: /^Govern$/i,
-            landing: false,
-        },
-        {
-            pathname: "/quality",
-            active: "quality",
-            area: /^Govern$/i,
-            landing: false,
-        },
-        {
-            pathname: "/security",
-            active: "security",
-            area: /^Govern$/i,
-            landing: false,
-        },
-        {
-            pathname: "/risk/compounding",
-            active: "risk-compounding",
-            area: /^Govern$/i,
-            landing: false,
-        },
-        {
-            pathname: "/reports",
-            active: "reports",
-            area: /^Reports$/i,
-            landing: true,
-        },
-        { pathname: "/admin", active: "admin", area: /^Admin$/i, landing: true },
-    ])(
-        "resolves route $pathname to its owning area with exactly one selection",
-        ({ pathname, active, area, landing, child }) => {
-            navigationMock.pathname = pathname;
-            render(<PrimaryNav filters={makeFilter()} active={active} />);
+	// Each row resolves to its owning area, and exactly one destination is
+	// selected sidebar-wide (A10). On an area-LANDING route the area row is the
+	// selection; on a CHILD route a child row inside that area is. `landing`
+	// flags whether the area row itself should carry aria-current.
+	it.each([
+		{
+			pathname: "/dashboard",
+			active: "home",
+			area: /^Cockpit$/i,
+			landing: true,
+		},
+		{
+			// operating-review is hidden from nav (CHAOS-2181 follow-up): the Plan
+			// area row carries the selection; no child row renders.
+			pathname: "/operating-review",
+			active: "operating-review",
+			area: /^Plan$/i,
+			landing: true,
+		},
+		{ pathname: "/work", active: "work", area: /^Diagnose$/i, landing: true },
+		{
+			pathname: "/metrics",
+			active: "metrics",
+			area: /^Diagnose$/i,
+			landing: false,
+		},
+		{
+			pathname: "/people",
+			active: "people",
+			area: /^Diagnose$/i,
+			landing: false,
+		},
+		{
+			pathname: "/complexity",
+			active: "complexity",
+			area: /^Diagnose$/i,
+			landing: false,
+		},
+		{
+			pathname: "/bottleneck",
+			active: "bottleneck",
+			area: /^Diagnose$/i,
+			landing: false,
+		},
+		{
+			pathname: "/landscape",
+			active: "landscape",
+			area: /^Diagnose$/i,
+			landing: false,
+		},
+		{
+			pathname: "/opportunities",
+			active: "opportunities",
+			area: /^Improve$/i,
+			landing: false,
+			child: /^Opportunities$/i,
+		},
+		{
+			pathname: "/plan/capacity",
+			active: "capacity",
+			area: /^Plan$/i,
+			landing: false,
+		},
+		{
+			pathname: "/ai/review-load",
+			active: "ai",
+			area: /^AI$/i,
+			landing: false,
+		},
+		{
+			pathname: "/testops",
+			active: "testops",
+			area: /^Govern$/i,
+			landing: false,
+			child: /^TestOps$/i,
+		},
+		{
+			pathname: "/testops/risk",
+			active: "risk",
+			area: /^Govern$/i,
+			landing: false,
+		},
+		{
+			pathname: "/quality",
+			active: "quality",
+			area: /^Govern$/i,
+			landing: false,
+		},
+		{
+			pathname: "/security",
+			active: "security",
+			area: /^Govern$/i,
+			landing: false,
+		},
+		{
+			pathname: "/risk/compounding",
+			active: "risk-compounding",
+			area: /^Govern$/i,
+			landing: false,
+		},
+		{
+			pathname: "/reports",
+			active: "reports",
+			area: /^Reports$/i,
+			landing: true,
+		},
+		{ pathname: "/admin", active: "admin", area: /^Admin$/i, landing: true },
+	])("resolves route $pathname to its owning area with exactly one selection", ({
+		pathname,
+		active,
+		area,
+		landing,
+		child,
+	}) => {
+		navigationMock.pathname = pathname;
+		render(<PrimaryNav filters={makeFilter()} active={active} />);
 
-            // The owning area row is always rendered.
-            const areaRow = screen.getByRole("link", { name: area });
-            expect(areaRow).toBeInTheDocument();
-            // The area row carries aria-current only on its own landing route.
-            if (landing) {
-                expect(areaRow).toHaveAttribute("aria-current", "page");
-            } else {
-                expect(areaRow).not.toHaveAttribute("aria-current");
-            }
-            if (child) {
-                expect(screen.getByRole("link", { name: child })).toHaveAttribute(
-                    "aria-current",
-                    "page",
-                );
-            }
-            // A10: exactly one selected destination across the whole sidebar.
-            expect(currentPageLinks()).toHaveLength(1);
-        },
-    );
+		// The owning area row is always rendered.
+		const areaRow = screen.getByRole("link", { name: area });
+		expect(areaRow).toBeInTheDocument();
+		// The area row carries aria-current only on its own landing route.
+		if (landing) {
+			expect(areaRow).toHaveAttribute("aria-current", "page");
+		} else {
+			expect(areaRow).not.toHaveAttribute("aria-current");
+		}
+		if (child) {
+			expect(screen.getByRole("link", { name: child })).toHaveAttribute(
+				"aria-current",
+				"page",
+			);
+		}
+		// A10: exactly one selected destination across the whole sidebar.
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-    it("uses the longest pathname match and ignores a stale active prop", () => {
-        // /testops/risk belongs to Govern; the stale active="people" (Diagnose) must lose.
-        navigationMock.pathname = "/testops/risk";
-        render(<PrimaryNav filters={makeFilter()} active="people" />);
+	it("uses the longest pathname match and ignores a stale active prop", () => {
+		// /testops/risk belongs to Govern; the stale active="people" (Diagnose) must lose.
+		navigationMock.pathname = "/testops/risk";
+		render(<PrimaryNav filters={makeFilter()} active="people" />);
 
-        // Govern is the active area (its Delivery Risk child is the selection).
-        expect(screen.getByTestId("nav-children-govern")).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /^Delivery Risk$/i })).toHaveAttribute(
-            "aria-current",
-            "page",
-        );
-        // Diagnose lost: not selected and not expanded.
-        expect(screen.getByRole("link", { name: /^Diagnose$/i })).not.toHaveAttribute(
-            "aria-current",
-        );
-        expect(screen.queryByTestId("nav-children-diagnose")).toBeNull();
-        expect(currentPageLinks()).toHaveLength(1);
-    });
+		// Govern is the active area (its Delivery Risk child is the selection).
+		expect(screen.getByTestId("nav-children-govern")).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: /^Delivery Risk$/i }),
+		).toHaveAttribute("aria-current", "page");
+		// Diagnose lost: not selected and not expanded.
+		expect(
+			screen.getByRole("link", { name: /^Diagnose$/i }),
+		).not.toHaveAttribute("aria-current");
+		expect(screen.queryByTestId("nav-children-diagnose")).toBeNull();
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-    it("falls back to the active prop's area when no pathname prefix matches", () => {
-        // Evidence/detail routes (e.g. /prs/[id]) are not owned by any area prefix.
-        navigationMock.pathname = "/prs/123";
-        render(<PrimaryNav filters={makeFilter()} active="people" />);
+	it("falls back to the active prop's area when no pathname prefix matches", () => {
+		// Evidence/detail routes (e.g. /prs/[id]) are not owned by any area prefix.
+		navigationMock.pathname = "/prs/123";
+		render(<PrimaryNav filters={makeFilter()} active="people" />);
 
-        expect(screen.getByRole("link", { name: /^Diagnose$/i })).toHaveAttribute(
-            "aria-current",
-            "page",
-        );
-        expect(currentPageLinks()).toHaveLength(1);
-    });
+		expect(screen.getByRole("link", { name: /^Diagnose$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-    it("pathname /testops → TestOps cluster child active with one selection (W1)", () => {
-        navigationMock.pathname = "/testops";
-        render(<PrimaryNav filters={makeFilter()} active="testops" />);
+	it("pathname /testops → TestOps cluster child active with one selection (W1)", () => {
+		navigationMock.pathname = "/testops";
+		render(<PrimaryNav filters={makeFilter()} active="testops" />);
 
-        expect(screen.getByRole("link", { name: /^Govern$/i })).not.toHaveAttribute("aria-current");
-        expect(screen.getByRole("link", { name: /^TestOps$/i })).toHaveAttribute(
-            "aria-current",
-            "page",
-        );
-        expect(screen.getByRole("link", { name: /^Overview$/i })).not.toHaveAttribute(
-            "aria-current",
-        );
-        // A10: exactly one current-page link.
-        expect(currentPageLinks()).toHaveLength(1);
-    });
+		expect(screen.getByRole("link", { name: /^Govern$/i })).not.toHaveAttribute(
+			"aria-current",
+		);
+		expect(screen.getByRole("link", { name: /^TestOps$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(
+			screen.getByRole("link", { name: /^Overview$/i }),
+		).not.toHaveAttribute("aria-current");
+		// A10: exactly one current-page link.
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-    it("pathname /testops/pipelines → TestOps cluster child active, not Pipelines or Tests rows (W2)", () => {
-        navigationMock.pathname = "/testops/pipelines";
-        render(<PrimaryNav filters={makeFilter()} active="pipelines" />);
+	it("pathname /testops/pipelines → TestOps cluster child active, not Pipelines or Tests rows (W2)", () => {
+		navigationMock.pathname = "/testops/pipelines";
+		render(<PrimaryNav filters={makeFilter()} active="pipelines" />);
 
-        expect(screen.getByRole("link", { name: /^TestOps$/i })).toHaveAttribute(
-            "aria-current",
-            "page",
-        );
-        expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
-        expect(screen.queryByRole("link", { name: /^Tests$/i })).toBeNull();
-        expect(screen.getByRole("link", { name: /^Overview$/i })).not.toHaveAttribute(
-            "aria-current",
-        );
-        // A10: exactly one current-page link.
-        expect(currentPageLinks()).toHaveLength(1);
-    });
+		expect(screen.getByRole("link", { name: /^TestOps$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Tests$/i })).toBeNull();
+		expect(
+			screen.getByRole("link", { name: /^Overview$/i }),
+		).not.toHaveAttribute("aria-current");
+		// A10: exactly one current-page link.
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 });
 
 describe("PrimaryNav — utility-area gate (owner directive)", () => {
-    // Utility-placement areas (Reports, Admin) must render as plain rows with NO
-    // child expansion even when active. Only main-placement areas expand.
+	// Utility-placement areas (Reports, Admin) must render as plain rows with NO
+	// child expansion even when active. Only main-placement areas expand.
 
-    it("Reports area renders NO child rows when active at /reports", () => {
-        navigationMock.pathname = "/reports";
-        render(<PrimaryNav filters={makeFilter()} active="reports" />);
+	it("Reports area renders NO child rows when active at /reports", () => {
+		navigationMock.pathname = "/reports";
+		render(<PrimaryNav filters={makeFilter()} active="reports" />);
 
-        // Reports row is rendered and marked current (it's the area landing).
-        expect(screen.getByRole("link", { name: /^Reports$/i })).toHaveAttribute(
-            "aria-current",
-            "page",
-        );
-        // NO child container rendered for Reports.
-        expect(screen.queryByTestId("nav-children-reports")).toBeNull();
-        // Report Center (a navVisible child) must NOT appear in the sidebar.
-        expect(screen.queryByRole("link", { name: /^Report Center$/i })).toBeNull();
-        // Preview rows also absent (they were already suppressed, still absent).
-        expect(screen.queryByRole("link", { name: /^Weekly Review$/i })).toBeNull();
-        // A10: exactly one current-page link.
-        expect(currentPageLinks()).toHaveLength(1);
-    });
+		// Reports row is rendered and marked current (it's the area landing).
+		expect(screen.getByRole("link", { name: /^Reports$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		// NO child container rendered for Reports.
+		expect(screen.queryByTestId("nav-children-reports")).toBeNull();
+		// Report Center (a navVisible child) must NOT appear in the sidebar.
+		expect(screen.queryByRole("link", { name: /^Report Center$/i })).toBeNull();
+		// Preview rows also absent (they were already suppressed, still absent).
+		expect(screen.queryByRole("link", { name: /^Weekly Review$/i })).toBeNull();
+		// A10: exactly one current-page link.
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 
-    it("Admin area renders NO child rows when active at /admin/settings", () => {
-        navigationMock.pathname = "/admin/settings";
-        render(<PrimaryNav filters={makeFilter()} active="settings" />);
+	it("Admin area renders NO child rows when active at /admin/settings", () => {
+		navigationMock.pathname = "/admin/settings";
+		render(<PrimaryNav filters={makeFilter()} active="settings" />);
 
-        // Admin row is active (but the child Settings would have been current if expanded).
-        // Under the utility gate, no children render at all.
-        expect(screen.queryByTestId("nav-children-admin")).toBeNull();
-        expect(screen.queryByRole("link", { name: /^Settings$/i })).toBeNull();
-        expect(screen.queryByRole("link", { name: /^Connections$/i })).toBeNull();
-        // The Admin area row itself is the sole current-page link (no child selection).
-        expect(screen.getByRole("link", { name: /^Admin$/i })).toHaveAttribute(
-            "aria-current",
-            "page",
-        );
-        expect(currentPageLinks()).toHaveLength(1);
-    });
+		// Admin row is active (but the child Settings would have been current if expanded).
+		// Under the utility gate, no children render at all.
+		expect(screen.queryByTestId("nav-children-admin")).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Settings$/i })).toBeNull();
+		expect(screen.queryByRole("link", { name: /^Connections$/i })).toBeNull();
+		// The Admin area row itself is the sole current-page link (no child selection).
+		expect(screen.getByRole("link", { name: /^Admin$/i })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(currentPageLinks()).toHaveLength(1);
+	});
 });

--- a/src/components/navigation/PrimaryNav.test.tsx
+++ b/src/components/navigation/PrimaryNav.test.tsx
@@ -8,473 +8,446 @@ import type { MetricFilter } from "@/lib/filters/types";
 const navigationMock = vi.hoisted(() => ({ pathname: "/dashboard" }));
 
 vi.mock("next/navigation", () => ({
-	usePathname: () => navigationMock.pathname,
-	useRouter: () => ({ refresh: vi.fn() }),
+    usePathname: () => navigationMock.pathname,
+    useRouter: () => ({ refresh: vi.fn() }),
 }));
 
 vi.mock("next-auth/react", () => ({
-	useSession: () => ({
-		data: { user: { org_id: "org-1" } },
-		update: vi.fn(),
-	}),
+    useSession: () => ({
+        data: { user: { org_id: "org-1" } },
+        update: vi.fn(),
+    }),
 }));
 
 function makeFilter(): MetricFilter {
-	return {
-		scope: { level: "repo", ids: ["my-repo"] },
-		time: {
-			range_days: 30,
-			compare_days: 0,
-			start_date: undefined,
-			end_date: undefined,
-		},
-		who: {},
-		what: {},
-		why: {},
-		how: {},
-	};
+    return {
+        scope: { level: "repo", ids: ["my-repo"] },
+        time: {
+            range_days: 30,
+            compare_days: 0,
+            start_date: undefined,
+            end_date: undefined,
+        },
+        who: {},
+        what: {},
+        why: {},
+        how: {},
+    };
 }
 
 beforeEach(() => {
-	navigationMock.pathname = "/dashboard";
+    navigationMock.pathname = "/dashboard";
 });
 
 function currentPageLinks() {
-	return screen
-		.getAllByRole("link")
-		.filter((link) => link.getAttribute("aria-current") === "page");
+    return screen
+        .getAllByRole("link")
+        .filter((link) => link.getAttribute("aria-current") === "page");
 }
 
 describe("PrimaryNav — two-level decision-area surface (CHAOS-2079)", () => {
-	it("always renders the eight area rows", () => {
-		render(<PrimaryNav filters={makeFilter()} active="home" />);
+    it("always renders the eight area rows", () => {
+        render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-		for (const name of [
-			/^Cockpit$/i,
-			/^Diagnose$/i,
-			/^Plan$/i,
-			/^Improve$/i,
-			/^Govern$/i,
-			/^AI$/i,
-			/^Reports$/i,
-			/^Admin$/i,
-		]) {
-			expect(screen.getByRole("link", { name })).toBeInTheDocument();
-		}
-	});
+        for (const name of [
+            /^Cockpit$/i,
+            /^Diagnose$/i,
+            /^Plan$/i,
+            /^Improve$/i,
+            /^Govern$/i,
+            /^AI$/i,
+            /^Reports$/i,
+            /^Admin$/i,
+        ]) {
+            expect(screen.getByRole("link", { name })).toBeInTheDocument();
+        }
+    });
 
-	it("on a childless area (Cockpit) renders only the eight area rows", () => {
-		// Cockpit has no expandable children, so the sidebar shows exactly the areas.
-		navigationMock.pathname = "/dashboard";
-		render(<PrimaryNav filters={makeFilter()} active="home" />);
+    it("on a childless area (Cockpit) renders only the eight area rows", () => {
+        // Cockpit has no expandable children, so the sidebar shows exactly the areas.
+        navigationMock.pathname = "/dashboard";
+        render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-		const linkNames = screen
-			.getAllByRole("link")
-			.map((link) => (link.textContent ?? "").replace(/\s+/g, " ").trim());
+        const linkNames = screen
+            .getAllByRole("link")
+            .map((link) => (link.textContent ?? "").replace(/\s+/g, " ").trim());
 
-		expect(linkNames).toEqual([
-			"Cockpit",
-			"Diagnose",
-			"Plan",
-			"Improve",
-			"Govern",
-			"AI",
-			"Reports",
-			"Admin",
-		]);
-	});
+        expect(linkNames).toEqual([
+            "Cockpit",
+            "Diagnose",
+            "Plan",
+            "Improve",
+            "Govern",
+            "AI",
+            "Reports",
+            "Admin",
+        ]);
+    });
 
-	it("renders no expand/collapse buttons — rows are links, not toggles", () => {
-		render(<PrimaryNav filters={makeFilter()} active="home" />);
-		expect(screen.queryAllByRole("button")).toHaveLength(0);
-	});
+    it("renders no expand/collapse buttons — rows are links, not toggles", () => {
+        render(<PrimaryNav filters={makeFilter()} active="home" />);
+        expect(screen.queryAllByRole("button")).toHaveLength(0);
+    });
 
-	it("expands ONLY the active area's children; inactive areas stay collapsed", () => {
-		navigationMock.pathname = "/work";
-		render(<PrimaryNav filters={makeFilter()} active="work" />);
+    it("expands ONLY the active area's children; inactive areas stay collapsed", () => {
+        navigationMock.pathname = "/work";
+        render(<PrimaryNav filters={makeFilter()} active="work" />);
 
-		// Diagnose is active → its children render as indented rows.
-		expect(screen.getByTestId("nav-children-diagnose")).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: /^Flow$/i })).toBeInTheDocument();
-		expect(
-			screen.getByRole("link", { name: /^Bottlenecks$/i }),
-		).toBeInTheDocument();
+        // Diagnose is active → its children render as indented rows.
+        expect(screen.getByTestId("nav-children-diagnose")).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Flow$/i })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Bottlenecks$/i })).toBeInTheDocument();
 
-		// Govern is NOT active → none of its children appear.
-		expect(screen.queryByTestId("nav-children-govern")).toBeNull();
-		expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
-		expect(screen.queryByRole("link", { name: /^Security$/i })).toBeNull();
-	});
+        // Govern is NOT active → none of its children appear.
+        expect(screen.queryByTestId("nav-children-govern")).toBeNull();
+        expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
+        expect(screen.queryByRole("link", { name: /^Security$/i })).toBeNull();
+    });
 
-	it("never renders preview (navVisible:false) children — verified via Improve", () => {
-		navigationMock.pathname = "/opportunities";
-		render(<PrimaryNav filters={makeFilter()} active="opportunities" />);
+    it("never renders preview (navVisible:false) children — verified via Improve", () => {
+        navigationMock.pathname = "/opportunities";
+        render(<PrimaryNav filters={makeFilter()} active="opportunities" />);
 
-		expect(
-			screen.getByRole("link", { name: /^Opportunities$/i }),
-		).toBeInTheDocument();
-		expect(screen.queryByRole("link", { name: /^Experiments$/i })).toBeNull();
-		expect(screen.queryByRole("link", { name: /^Automations$/i })).toBeNull();
-	});
+        expect(screen.getByRole("link", { name: /^Opportunities$/i })).toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: /^Experiments$/i })).toBeNull();
+        expect(screen.queryByRole("link", { name: /^Automations$/i })).toBeNull();
+    });
 
-	it("renders real AI children and hides preview-only AI routes", () => {
-		navigationMock.pathname = "/ai/review-load";
-		render(<PrimaryNav filters={makeFilter()} active="ai" />);
+    it("renders real AI children and hides preview-only AI routes", () => {
+        navigationMock.pathname = "/ai/review-load";
+        render(<PrimaryNav filters={makeFilter()} active="ai" />);
 
-		expect(
-			screen.getByRole("link", { name: /^Overview$/i }),
-		).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: /^Impact$/i })).toBeInTheDocument();
-		expect(
-			screen.getByRole("link", { name: /^Review Load$/i }),
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole("link", { name: /^Governance Risk$/i }),
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole("link", { name: /^Automations$/i }),
-		).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Overview$/i })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Impact$/i })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Review Load$/i })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Governance Risk$/i })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Automations$/i })).toBeInTheDocument();
 
-		for (const tab of [/^Attribution$/i, /^Test Gaps$/i, /^Evidence$/i]) {
-			expect(screen.queryByRole("link", { name: tab })).toBeNull();
-		}
-	});
+        for (const tab of [/^Attribution$/i, /^Test Gaps$/i, /^Evidence$/i]) {
+            expect(screen.queryByRole("link", { name: tab })).toBeNull();
+        }
+    });
 
-	it("renders TestOps as the single Govern cluster row instead of separate Tests/Pipelines/Coverage rows", () => {
-		navigationMock.pathname = "/testops/tests";
-		render(<PrimaryNav filters={makeFilter()} active="tests" />);
+    it("renders TestOps as the single Govern cluster row instead of separate Tests/Pipelines/Coverage rows", () => {
+        navigationMock.pathname = "/testops/tests";
+        render(<PrimaryNav filters={makeFilter()} active="tests" />);
 
-		expect(
-			screen.queryByRole("link", { name: /Tests · Quality · Coverage/i }),
-		).toBeNull();
-		expect(screen.getAllByRole("link", { name: /^TestOps$/i })).toHaveLength(1);
-		expect(screen.queryByRole("link", { name: /^Tests$/i })).toBeNull();
-		expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
-		expect(screen.queryByRole("link", { name: /^Coverage$/i })).toBeNull();
-		expect(
-			screen.getByRole("link", { name: /^Quality$/i }),
-		).toBeInTheDocument();
-	});
+        expect(screen.queryByRole("link", { name: /Tests · Quality · Coverage/i })).toBeNull();
+        expect(screen.getAllByRole("link", { name: /^TestOps$/i })).toHaveLength(1);
+        expect(screen.queryByRole("link", { name: /^Tests$/i })).toBeNull();
+        expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
+        expect(screen.queryByRole("link", { name: /^Coverage$/i })).toBeNull();
+        expect(screen.getByRole("link", { name: /^Quality$/i })).toBeInTheDocument();
+    });
 
-	it("links each area to its landing route", () => {
-		render(<PrimaryNav filters={makeFilter()} active="home" />);
+    it("links each area to its landing route", () => {
+        render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-		const expectations: Array<[RegExp, string]> = [
-			[/^Cockpit$/i, "/dashboard"],
-			[/^Diagnose$/i, "/diagnose"],
-			[/^Plan$/i, "/plan"],
-			[/^Improve$/i, "/improve"],
-			[/^Govern$/i, "/govern"],
-			[/^AI$/i, "/ai"],
-			[/^Reports$/i, "/reports"],
-			[/^Admin$/i, "/admin"],
-		];
+        const expectations: Array<[RegExp, string]> = [
+            [/^Cockpit$/i, "/dashboard"],
+            [/^Diagnose$/i, "/diagnose"],
+            [/^Plan$/i, "/plan"],
+            [/^Improve$/i, "/improve"],
+            [/^Govern$/i, "/govern"],
+            [/^AI$/i, "/ai"],
+            [/^Reports$/i, "/reports"],
+            [/^Admin$/i, "/admin"],
+        ];
 
-		for (const [name, href] of expectations) {
-			expect(screen.getByRole("link", { name })).toHaveAttribute(
-				"href",
-				expect.stringContaining(href),
-			);
-		}
-	});
+        for (const [name, href] of expectations) {
+            expect(screen.getByRole("link", { name })).toHaveAttribute(
+                "href",
+                expect.stringContaining(href),
+            );
+        }
+    });
 });
 
 describe("PrimaryNav — active child highlight (A10: one selected, distinct hover)", () => {
-	it.each([
-		{ pathname: "/metrics", active: "metrics", child: /^Flow$/i },
-		{ pathname: "/ai/review-load", active: "ai", child: /^Review Load$/i },
-		{
-			pathname: "/plan/capacity",
-			active: "capacity",
-			child: /^Capacity Forecast$/i,
-		},
-		{ pathname: "/testops/coverage", active: "coverage", child: /^TestOps$/i },
-		{ pathname: "/quality", active: "quality", child: /^Quality$/i },
-		{ pathname: "/testops/tests", active: "tests", child: /^TestOps$/i },
-	])("marks exactly the child $child current for $pathname", ({
-		pathname,
-		active,
-		child,
-	}) => {
-		navigationMock.pathname = pathname;
-		render(<PrimaryNav filters={makeFilter()} active={active} />);
+    it.each([
+        { pathname: "/metrics", active: "metrics", child: /^Flow$/i },
+        { pathname: "/ai/review-load", active: "ai", child: /^Review Load$/i },
+        {
+            pathname: "/plan/capacity",
+            active: "capacity",
+            child: /^Capacity Forecast$/i,
+        },
+        { pathname: "/testops/coverage", active: "coverage", child: /^TestOps$/i },
+        { pathname: "/quality", active: "quality", child: /^Quality$/i },
+        { pathname: "/testops/tests", active: "tests", child: /^TestOps$/i },
+    ])("marks exactly the child $child current for $pathname", ({ pathname, active, child }) => {
+        navigationMock.pathname = pathname;
+        render(<PrimaryNav filters={makeFilter()} active={active} />);
 
-		expect(screen.getByRole("link", { name: child })).toHaveAttribute(
-			"aria-current",
-			"page",
-		);
-		// A10: exactly one selected destination across the whole sidebar.
-		expect(currentPageLinks()).toHaveLength(1);
-	});
+        expect(screen.getByRole("link", { name: child })).toHaveAttribute("aria-current", "page");
+        // A10: exactly one selected destination across the whole sidebar.
+        expect(currentPageLinks()).toHaveLength(1);
+    });
 
-	it("highlights the area row (not a child) on the area landing route", () => {
-		// /dashboard → Cockpit (no children); the area row itself is current.
-		navigationMock.pathname = "/dashboard";
-		render(<PrimaryNav filters={makeFilter()} active="home" />);
+    it("highlights the area row (not a child) on the area landing route", () => {
+        // /dashboard → Cockpit (no children); the area row itself is current.
+        navigationMock.pathname = "/dashboard";
+        render(<PrimaryNav filters={makeFilter()} active="home" />);
 
-		expect(screen.getByRole("link", { name: /^Cockpit$/i })).toHaveAttribute(
-			"aria-current",
-			"page",
-		);
-		expect(currentPageLinks()).toHaveLength(1);
-	});
+        expect(screen.getByRole("link", { name: /^Cockpit$/i })).toHaveAttribute(
+            "aria-current",
+            "page",
+        );
+        expect(currentPageLinks()).toHaveLength(1);
+    });
 
-	it("does not mark the area row current when one of its children is active", () => {
-		// On /metrics the active destination is the Flow CHILD, so the Diagnose
-		// AREA row must NOT also carry aria-current (no double-selection, A10).
-		navigationMock.pathname = "/metrics";
-		render(<PrimaryNav filters={makeFilter()} active="metrics" />);
+    it("does not mark the area row current when one of its children is active", () => {
+        // On /metrics the active destination is the Flow CHILD, so the Diagnose
+        // AREA row must NOT also carry aria-current (no double-selection, A10).
+        navigationMock.pathname = "/metrics";
+        render(<PrimaryNav filters={makeFilter()} active="metrics" />);
 
-		expect(
-			screen.getByRole("link", { name: /^Diagnose$/i }),
-		).not.toHaveAttribute("aria-current");
-		expect(screen.getByRole("link", { name: /^Flow$/i })).toHaveAttribute(
-			"aria-current",
-			"page",
-		);
-	});
+        expect(screen.getByRole("link", { name: /^Diagnose$/i })).not.toHaveAttribute(
+            "aria-current",
+        );
+        expect(screen.getByRole("link", { name: /^Flow$/i })).toHaveAttribute(
+            "aria-current",
+            "page",
+        );
+    });
 });
 
 describe("PrimaryNav — active-area resolution (A10: one selected at a time)", () => {
-	// Each row resolves to its owning area, and exactly one destination is
-	// selected sidebar-wide (A10). On an area-LANDING route the area row is the
-	// selection; on a CHILD route a child row inside that area is. `landing`
-	// flags whether the area row itself should carry aria-current.
-	it.each([
-		{
-			pathname: "/dashboard",
-			active: "home",
-			area: /^Cockpit$/i,
-			landing: true,
-		},
-		{
-			// operating-review is hidden from nav (CHAOS-2181 follow-up): the Plan
-			// area row carries the selection; no child row renders.
-			pathname: "/operating-review",
-			active: "operating-review",
-			area: /^Plan$/i,
-			landing: true,
-		},
-		{ pathname: "/work", active: "work", area: /^Diagnose$/i, landing: true },
-		{
-			pathname: "/metrics",
-			active: "metrics",
-			area: /^Diagnose$/i,
-			landing: false,
-		},
-		{
-			pathname: "/people",
-			active: "people",
-			area: /^Diagnose$/i,
-			landing: false,
-		},
-		{
-			pathname: "/complexity",
-			active: "complexity",
-			area: /^Diagnose$/i,
-			landing: false,
-		},
-		{
-			pathname: "/bottleneck",
-			active: "bottleneck",
-			area: /^Diagnose$/i,
-			landing: false,
-		},
-		{
-			pathname: "/landscape",
-			active: "landscape",
-			area: /^Diagnose$/i,
-			landing: false,
-		},
-		{
-			pathname: "/opportunities",
-			active: "opportunities",
-			area: /^Improve$/i,
-			landing: false,
-			child: /^Opportunities$/i,
-		},
-		{
-			pathname: "/plan/capacity",
-			active: "capacity",
-			area: /^Plan$/i,
-			landing: false,
-		},
-		{
-			pathname: "/ai/review-load",
-			active: "ai",
-			area: /^AI$/i,
-			landing: false,
-		},
-		{
-			pathname: "/testops",
-			active: "testops",
-			area: /^Govern$/i,
-			landing: false,
-			child: /^TestOps$/i,
-		},
-		{
-			pathname: "/testops/risk",
-			active: "risk",
-			area: /^Govern$/i,
-			landing: false,
-		},
-		{
-			pathname: "/quality",
-			active: "quality",
-			area: /^Govern$/i,
-			landing: false,
-		},
-		{
-			pathname: "/security",
-			active: "security",
-			area: /^Govern$/i,
-			landing: false,
-		},
-		{
-			pathname: "/risk/compounding",
-			active: "risk-compounding",
-			area: /^Govern$/i,
-			landing: false,
-		},
-		{
-			pathname: "/reports",
-			active: "reports",
-			area: /^Reports$/i,
-			landing: true,
-		},
-		{ pathname: "/admin", active: "admin", area: /^Admin$/i, landing: true },
-	])("resolves route $pathname to its owning area with exactly one selection", ({
-		pathname,
-		active,
-		area,
-		landing,
-		child,
-	}) => {
-		navigationMock.pathname = pathname;
-		render(<PrimaryNav filters={makeFilter()} active={active} />);
+    // Each row resolves to its owning area, and exactly one destination is
+    // selected sidebar-wide (A10). On an area-LANDING route the area row is the
+    // selection; on a CHILD route a child row inside that area is. `landing`
+    // flags whether the area row itself should carry aria-current.
+    it.each([
+        {
+            pathname: "/dashboard",
+            active: "home",
+            area: /^Cockpit$/i,
+            landing: true,
+        },
+        {
+            // operating-review is hidden from nav (CHAOS-2181 follow-up): the Plan
+            // area row carries the selection; no child row renders.
+            pathname: "/operating-review",
+            active: "operating-review",
+            area: /^Plan$/i,
+            landing: true,
+        },
+        { pathname: "/work", active: "work", area: /^Diagnose$/i, landing: true },
+        {
+            pathname: "/metrics",
+            active: "metrics",
+            area: /^Diagnose$/i,
+            landing: false,
+        },
+        {
+            pathname: "/people",
+            active: "people",
+            area: /^Diagnose$/i,
+            landing: false,
+        },
+        {
+            pathname: "/complexity",
+            active: "complexity",
+            area: /^Diagnose$/i,
+            landing: false,
+        },
+        {
+            pathname: "/bottleneck",
+            active: "bottleneck",
+            area: /^Diagnose$/i,
+            landing: false,
+        },
+        {
+            pathname: "/landscape",
+            active: "landscape",
+            area: /^Diagnose$/i,
+            landing: false,
+        },
+        {
+            pathname: "/opportunities",
+            active: "opportunities",
+            area: /^Improve$/i,
+            landing: false,
+            child: /^Opportunities$/i,
+        },
+        {
+            pathname: "/plan/capacity",
+            active: "capacity",
+            area: /^Plan$/i,
+            landing: false,
+        },
+        {
+            pathname: "/ai/review-load",
+            active: "ai",
+            area: /^AI$/i,
+            landing: false,
+        },
+        {
+            pathname: "/testops",
+            active: "testops",
+            area: /^Govern$/i,
+            landing: false,
+            child: /^TestOps$/i,
+        },
+        {
+            pathname: "/testops/risk",
+            active: "risk",
+            area: /^Govern$/i,
+            landing: false,
+        },
+        {
+            pathname: "/quality",
+            active: "quality",
+            area: /^Govern$/i,
+            landing: false,
+        },
+        {
+            pathname: "/security",
+            active: "security",
+            area: /^Govern$/i,
+            landing: false,
+        },
+        {
+            pathname: "/risk/compounding",
+            active: "risk-compounding",
+            area: /^Govern$/i,
+            landing: false,
+        },
+        {
+            pathname: "/reports",
+            active: "reports",
+            area: /^Reports$/i,
+            landing: true,
+        },
+        { pathname: "/admin", active: "admin", area: /^Admin$/i, landing: true },
+    ])(
+        "resolves route $pathname to its owning area with exactly one selection",
+        ({ pathname, active, area, landing, child }) => {
+            navigationMock.pathname = pathname;
+            render(<PrimaryNav filters={makeFilter()} active={active} />);
 
-		// The owning area row is always rendered.
-		const areaRow = screen.getByRole("link", { name: area });
-		expect(areaRow).toBeInTheDocument();
-		// The area row carries aria-current only on its own landing route.
-		if (landing) {
-			expect(areaRow).toHaveAttribute("aria-current", "page");
-		} else {
-			expect(areaRow).not.toHaveAttribute("aria-current");
-		}
-		if (child) {
-			expect(screen.getByRole("link", { name: child })).toHaveAttribute(
-				"aria-current",
-				"page",
-			);
-		}
-		// A10: exactly one selected destination across the whole sidebar.
-		expect(currentPageLinks()).toHaveLength(1);
-	});
+            // The owning area row is always rendered.
+            const areaRow = screen.getByRole("link", { name: area });
+            expect(areaRow).toBeInTheDocument();
+            // The area row carries aria-current only on its own landing route.
+            if (landing) {
+                expect(areaRow).toHaveAttribute("aria-current", "page");
+            } else {
+                expect(areaRow).not.toHaveAttribute("aria-current");
+            }
+            if (child) {
+                expect(screen.getByRole("link", { name: child })).toHaveAttribute(
+                    "aria-current",
+                    "page",
+                );
+            }
+            // A10: exactly one selected destination across the whole sidebar.
+            expect(currentPageLinks()).toHaveLength(1);
+        },
+    );
 
-	it("uses the longest pathname match and ignores a stale active prop", () => {
-		// /testops/risk belongs to Govern; the stale active="people" (Diagnose) must lose.
-		navigationMock.pathname = "/testops/risk";
-		render(<PrimaryNav filters={makeFilter()} active="people" />);
+    it("uses the longest pathname match and ignores a stale active prop", () => {
+        // /testops/risk belongs to Govern; the stale active="people" (Diagnose) must lose.
+        navigationMock.pathname = "/testops/risk";
+        render(<PrimaryNav filters={makeFilter()} active="people" />);
 
-		// Govern is the active area (its Delivery Risk child is the selection).
-		expect(screen.getByTestId("nav-children-govern")).toBeInTheDocument();
-		expect(
-			screen.getByRole("link", { name: /^Delivery Risk$/i }),
-		).toHaveAttribute("aria-current", "page");
-		// Diagnose lost: not selected and not expanded.
-		expect(
-			screen.getByRole("link", { name: /^Diagnose$/i }),
-		).not.toHaveAttribute("aria-current");
-		expect(screen.queryByTestId("nav-children-diagnose")).toBeNull();
-		expect(currentPageLinks()).toHaveLength(1);
-	});
+        // Govern is the active area (its Delivery Risk child is the selection).
+        expect(screen.getByTestId("nav-children-govern")).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Delivery Risk$/i })).toHaveAttribute(
+            "aria-current",
+            "page",
+        );
+        // Diagnose lost: not selected and not expanded.
+        expect(screen.getByRole("link", { name: /^Diagnose$/i })).not.toHaveAttribute(
+            "aria-current",
+        );
+        expect(screen.queryByTestId("nav-children-diagnose")).toBeNull();
+        expect(currentPageLinks()).toHaveLength(1);
+    });
 
-	it("falls back to the active prop's area when no pathname prefix matches", () => {
-		// Evidence/detail routes (e.g. /prs/[id]) are not owned by any area prefix.
-		navigationMock.pathname = "/prs/123";
-		render(<PrimaryNav filters={makeFilter()} active="people" />);
+    it("falls back to the active prop's area when no pathname prefix matches", () => {
+        // Evidence/detail routes (e.g. /prs/[id]) are not owned by any area prefix.
+        navigationMock.pathname = "/prs/123";
+        render(<PrimaryNav filters={makeFilter()} active="people" />);
 
-		expect(screen.getByRole("link", { name: /^Diagnose$/i })).toHaveAttribute(
-			"aria-current",
-			"page",
-		);
-		expect(currentPageLinks()).toHaveLength(1);
-	});
+        expect(screen.getByRole("link", { name: /^Diagnose$/i })).toHaveAttribute(
+            "aria-current",
+            "page",
+        );
+        expect(currentPageLinks()).toHaveLength(1);
+    });
 
-	it("pathname /testops → TestOps cluster child active with one selection (W1)", () => {
-		navigationMock.pathname = "/testops";
-		render(<PrimaryNav filters={makeFilter()} active="testops" />);
+    it("pathname /testops → TestOps cluster child active with one selection (W1)", () => {
+        navigationMock.pathname = "/testops";
+        render(<PrimaryNav filters={makeFilter()} active="testops" />);
 
-		expect(screen.getByRole("link", { name: /^Govern$/i })).not.toHaveAttribute(
-			"aria-current",
-		);
-		expect(screen.getByRole("link", { name: /^TestOps$/i })).toHaveAttribute(
-			"aria-current",
-			"page",
-		);
-		expect(
-			screen.getByRole("link", { name: /^Overview$/i }),
-		).not.toHaveAttribute("aria-current");
-		// A10: exactly one current-page link.
-		expect(currentPageLinks()).toHaveLength(1);
-	});
+        expect(screen.getByRole("link", { name: /^Govern$/i })).not.toHaveAttribute("aria-current");
+        expect(screen.getByRole("link", { name: /^TestOps$/i })).toHaveAttribute(
+            "aria-current",
+            "page",
+        );
+        expect(screen.getByRole("link", { name: /^Overview$/i })).not.toHaveAttribute(
+            "aria-current",
+        );
+        // A10: exactly one current-page link.
+        expect(currentPageLinks()).toHaveLength(1);
+    });
 
-	it("pathname /testops/pipelines → TestOps cluster child active, not Pipelines or Tests rows (W2)", () => {
-		navigationMock.pathname = "/testops/pipelines";
-		render(<PrimaryNav filters={makeFilter()} active="pipelines" />);
+    it("pathname /testops/pipelines → TestOps cluster child active, not Pipelines or Tests rows (W2)", () => {
+        navigationMock.pathname = "/testops/pipelines";
+        render(<PrimaryNav filters={makeFilter()} active="pipelines" />);
 
-		expect(screen.getByRole("link", { name: /^TestOps$/i })).toHaveAttribute(
-			"aria-current",
-			"page",
-		);
-		expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
-		expect(screen.queryByRole("link", { name: /^Tests$/i })).toBeNull();
-		expect(
-			screen.getByRole("link", { name: /^Overview$/i }),
-		).not.toHaveAttribute("aria-current");
-		// A10: exactly one current-page link.
-		expect(currentPageLinks()).toHaveLength(1);
-	});
+        expect(screen.getByRole("link", { name: /^TestOps$/i })).toHaveAttribute(
+            "aria-current",
+            "page",
+        );
+        expect(screen.queryByRole("link", { name: /^Pipelines$/i })).toBeNull();
+        expect(screen.queryByRole("link", { name: /^Tests$/i })).toBeNull();
+        expect(screen.getByRole("link", { name: /^Overview$/i })).not.toHaveAttribute(
+            "aria-current",
+        );
+        // A10: exactly one current-page link.
+        expect(currentPageLinks()).toHaveLength(1);
+    });
 });
 
 describe("PrimaryNav — utility-area gate (owner directive)", () => {
-	// Utility-placement areas (Reports, Admin) must render as plain rows with NO
-	// child expansion even when active. Only main-placement areas expand.
+    // Utility-placement areas (Reports, Admin) must render as plain rows with NO
+    // child expansion even when active. Only main-placement areas expand.
 
-	it("Reports area renders NO child rows when active at /reports", () => {
-		navigationMock.pathname = "/reports";
-		render(<PrimaryNav filters={makeFilter()} active="reports" />);
+    it("Reports area renders NO child rows when active at /reports", () => {
+        navigationMock.pathname = "/reports";
+        render(<PrimaryNav filters={makeFilter()} active="reports" />);
 
-		// Reports row is rendered and marked current (it's the area landing).
-		expect(screen.getByRole("link", { name: /^Reports$/i })).toHaveAttribute(
-			"aria-current",
-			"page",
-		);
-		// NO child container rendered for Reports.
-		expect(screen.queryByTestId("nav-children-reports")).toBeNull();
-		// Report Center (a navVisible child) must NOT appear in the sidebar.
-		expect(screen.queryByRole("link", { name: /^Report Center$/i })).toBeNull();
-		// Preview rows also absent (they were already suppressed, still absent).
-		expect(screen.queryByRole("link", { name: /^Weekly Review$/i })).toBeNull();
-		// A10: exactly one current-page link.
-		expect(currentPageLinks()).toHaveLength(1);
-	});
+        // Reports row is rendered and marked current (it's the area landing).
+        expect(screen.getByRole("link", { name: /^Reports$/i })).toHaveAttribute(
+            "aria-current",
+            "page",
+        );
+        // NO child container rendered for Reports.
+        expect(screen.queryByTestId("nav-children-reports")).toBeNull();
+        // Report Center (a navVisible child) must NOT appear in the sidebar.
+        expect(screen.queryByRole("link", { name: /^Report Center$/i })).toBeNull();
+        // Preview rows also absent (they were already suppressed, still absent).
+        expect(screen.queryByRole("link", { name: /^Weekly Review$/i })).toBeNull();
+        // A10: exactly one current-page link.
+        expect(currentPageLinks()).toHaveLength(1);
+    });
 
-	it("Admin area renders NO child rows when active at /admin/settings", () => {
-		navigationMock.pathname = "/admin/settings";
-		render(<PrimaryNav filters={makeFilter()} active="settings" />);
+    it("Admin area renders NO child rows when active at /admin/settings", () => {
+        navigationMock.pathname = "/admin/settings";
+        render(<PrimaryNav filters={makeFilter()} active="settings" />);
 
-		// Admin row is active (but the child Settings would have been current if expanded).
-		// Under the utility gate, no children render at all.
-		expect(screen.queryByTestId("nav-children-admin")).toBeNull();
-		expect(screen.queryByRole("link", { name: /^Settings$/i })).toBeNull();
-		expect(screen.queryByRole("link", { name: /^Connections$/i })).toBeNull();
-		// The Admin area row itself is the sole current-page link (no child selection).
-		expect(screen.getByRole("link", { name: /^Admin$/i })).toHaveAttribute(
-			"aria-current",
-			"page",
-		);
-		expect(currentPageLinks()).toHaveLength(1);
-	});
+        // Admin row is active (but the child Settings would have been current if expanded).
+        // Under the utility gate, no children render at all.
+        expect(screen.queryByTestId("nav-children-admin")).toBeNull();
+        expect(screen.queryByRole("link", { name: /^Settings$/i })).toBeNull();
+        expect(screen.queryByRole("link", { name: /^Connections$/i })).toBeNull();
+        // The Admin area row itself is the sole current-page link (no child selection).
+        expect(screen.getByRole("link", { name: /^Admin$/i })).toHaveAttribute(
+            "aria-current",
+            "page",
+        );
+        expect(currentPageLinks()).toHaveLength(1);
+    });
 });

--- a/src/lib/navigation/__tests__/areas.test.ts
+++ b/src/lib/navigation/__tests__/areas.test.ts
@@ -3,368 +3,327 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 import {
-	navAreas,
-	getAreaById,
-	selectedAreaIdForPathname,
-	selectedChildForPathname,
-	navTrailForPathname,
-	navTitleForPathname,
-	type NavAreaId,
+    navAreas,
+    getAreaById,
+    selectedAreaIdForPathname,
+    selectedChildForPathname,
+    navTrailForPathname,
+    navTitleForPathname,
+    type NavAreaId,
 } from "../areas";
 
 const basePath = (href: string) => href.split("?")[0].split("#")[0];
 
 const areaById = (id: NavAreaId) => {
-	const area = getAreaById(id);
-	if (!area) throw new Error(`missing area ${id}`);
-	return area;
+    const area = getAreaById(id);
+    if (!area) throw new Error(`missing area ${id}`);
+    return area;
 };
 
 const routePageExists = (routePath: string) => {
-	const segments = basePath(routePath).split("/").filter(Boolean);
-	return [
-		join(process.cwd(), "src/app/(app)", ...segments, "page.tsx"),
-		join(process.cwd(), "src/app", ...segments, "page.tsx"),
-	].some((candidate) => existsSync(candidate));
+    const segments = basePath(routePath).split("/").filter(Boolean);
+    return [
+        join(process.cwd(), "src/app/(app)", ...segments, "page.tsx"),
+        join(process.cwd(), "src/app", ...segments, "page.tsx"),
+    ].some((candidate) => existsSync(candidate));
 };
 
 describe("navAreas — locked 8-area decision surface", () => {
-	it("declares exactly eight areas in canonical order", () => {
-		expect(navAreas.map((a) => a.id)).toEqual([
-			"cockpit",
-			"diagnose",
-			"plan",
-			"improve",
-			"govern",
-			"ai",
-			"reports",
-			"admin",
-		]);
-	});
+    it("declares exactly eight areas in canonical order", () => {
+        expect(navAreas.map((a) => a.id)).toEqual([
+            "cockpit",
+            "diagnose",
+            "plan",
+            "improve",
+            "govern",
+            "ai",
+            "reports",
+            "admin",
+        ]);
+    });
 
-	it("keeps the main spine to six areas and the utility tray to two", () => {
-		expect(
-			navAreas.filter((a) => a.placement === "main").map((a) => a.id),
-		).toEqual(["cockpit", "diagnose", "plan", "improve", "govern", "ai"]);
-		expect(
-			navAreas.filter((a) => a.placement === "utility").map((a) => a.id),
-		).toEqual(["reports", "admin"]);
-	});
+    it("keeps the main spine to six areas and the utility tray to two", () => {
+        expect(navAreas.filter((a) => a.placement === "main").map((a) => a.id)).toEqual([
+            "cockpit",
+            "diagnose",
+            "plan",
+            "improve",
+            "govern",
+            "ai",
+        ]);
+        expect(navAreas.filter((a) => a.placement === "utility").map((a) => a.id)).toEqual([
+            "reports",
+            "admin",
+        ]);
+    });
 });
 
 describe("navArea.children — locked child navigation", () => {
-	it("matches CHAOS-2079 locked child labels verbatim", () => {
-		expect(
-			Object.fromEntries(
-				navAreas.map((area) => [
-					area.label,
-					area.children.map((child) => child.label),
-				]),
-			),
-		).toEqual({
-			Cockpit: [],
-			Diagnose: [
-				"Overview",
-				"Flow",
-				"Investment",
-				"Landscape",
-				"Work Graph",
-				"Complexity",
-				"Cognitive Load",
-				"Bottlenecks",
-				"People",
-				"Code",
-			],
-			Plan: ["Overview", "Capacity Forecast", "Operating Review"],
-			Improve: ["Overview", "Opportunities", "Experiments", "Automations"],
-			Govern: [
-				"Overview",
-				"TestOps",
-				"Quality",
-				"Delivery Risk",
-				"Incident Correlation",
-				"Security",
-				"Feature Flags",
-				"Compounding Risk",
-			],
-			// CHAOS-2197: Test Gaps + Evidence are tabs inside Governance Risk
-			// (decision recorded on the ticket); their child rows are retired.
-			AI: [
-				"Overview",
-				"Impact",
-				"Attribution",
-				"Review Load",
-				"Governance Risk",
-				"Automations",
-			],
-			Reports: [
-				"Report Center",
-				"Weekly Review",
-				"Executive Summary",
-				"Export History",
-			],
-			Admin: [
-				"Organization",
-				"Connections",
-				"Data Confidence",
-				"Settings",
-				"Billing",
-			],
-		});
-	});
+    it("matches CHAOS-2079 locked child labels verbatim", () => {
+        expect(
+            Object.fromEntries(
+                navAreas.map((area) => [area.label, area.children.map((child) => child.label)]),
+            ),
+        ).toEqual({
+            Cockpit: [],
+            Diagnose: [
+                "Overview",
+                "Flow",
+                "Investment",
+                "Landscape",
+                "Work Graph",
+                "Complexity",
+                "Cognitive Load",
+                "Bottlenecks",
+                "People",
+                "Code",
+            ],
+            Plan: ["Overview", "Capacity Forecast", "Operating Review"],
+            Improve: ["Overview", "Opportunities", "Experiments", "Automations"],
+            Govern: [
+                "Overview",
+                "TestOps",
+                "Quality",
+                "Delivery Risk",
+                "Incident Correlation",
+                "Security",
+                "Feature Flags",
+                "Compounding Risk",
+            ],
+            // CHAOS-2197: Test Gaps + Evidence are tabs inside Governance Risk
+            // (decision recorded on the ticket); their child rows are retired.
+            AI: [
+                "Overview",
+                "Impact",
+                "Attribution",
+                "Review Load",
+                "Governance Risk",
+                "Automations",
+            ],
+            Reports: ["Report Center", "Weekly Review", "Executive Summary", "Export History"],
+            Admin: ["Organization", "Connections", "Data Confidence", "Settings", "Billing"],
+        });
+    });
 
-	it("has unique child ids across all areas", () => {
-		const ids = navAreas.flatMap((a) => a.children.map((c) => c.id));
-		expect(new Set(ids).size).toBe(ids.length);
-	});
+    it("has unique child ids across all areas", () => {
+        const ids = navAreas.flatMap((a) => a.children.map((c) => c.id));
+        expect(new Set(ids).size).toBe(ids.length);
+    });
 
-	it("marks every hidden child as preview-only", () => {
-		for (const child of navAreas.flatMap((a) => a.children)) {
-			if (!child.navVisible) expect(child.preview).toBe(true);
-		}
-	});
+    it("marks every hidden child as preview-only", () => {
+        for (const child of navAreas.flatMap((a) => a.children)) {
+            if (!child.navVisible) expect(child.preview).toBe(true);
+        }
+    });
 
-	it("does not expose a navVisible child without a real app page", () => {
-		for (const area of navAreas) {
-			for (const child of area.children.filter((c) => c.navVisible)) {
-				expect(
-					routePageExists(child.path),
-					`${area.id}:${child.label} -> ${child.path}`,
-				).toBe(true);
-			}
-		}
-	});
+    it("does not expose a navVisible child without a real app page", () => {
+        for (const area of navAreas) {
+            for (const child of area.children.filter((c) => c.navVisible)) {
+                expect(
+                    routePageExists(child.path),
+                    `${area.id}:${child.label} -> ${child.path}`,
+                ).toBe(true);
+            }
+        }
+    });
 });
 
 describe("selectedAreaIdForPathname", () => {
-	const cases: Array<{ pathname: string; expected: NavAreaId }> = [
-		{ pathname: "/dashboard", expected: "cockpit" },
-		{ pathname: "/diagnose", expected: "diagnose" },
-		{ pathname: "/diagnose/work-graph", expected: "diagnose" },
-		{ pathname: "/metrics", expected: "diagnose" },
-		{ pathname: "/investment", expected: "diagnose" },
-		{ pathname: "/people/abc", expected: "diagnose" },
-		{ pathname: "/landscape", expected: "diagnose" },
-		{ pathname: "/plan", expected: "plan" },
-		{ pathname: "/plan/delivery-forecast", expected: "plan" },
-		{ pathname: "/capacity-planning", expected: "plan" },
-		{ pathname: "/operating-review", expected: "plan" },
-		{ pathname: "/opportunities", expected: "improve" },
-		{ pathname: "/ai/impact", expected: "ai" },
-		{ pathname: "/ai/review-load", expected: "ai" },
-		{ pathname: "/govern", expected: "govern" },
-		{ pathname: "/testops", expected: "govern" },
-		{ pathname: "/testops/risk", expected: "govern" },
-		{ pathname: "/quality", expected: "govern" },
-		{ pathname: "/security/repos/123", expected: "govern" },
-		{ pathname: "/risk/compounding", expected: "govern" },
-		{ pathname: "/feature-flags", expected: "govern" },
-		{ pathname: "/reports/new", expected: "reports" },
-		{ pathname: "/admin/users", expected: "admin" },
-		{ pathname: "/settings", expected: "admin" },
-	];
+    const cases: Array<{ pathname: string; expected: NavAreaId }> = [
+        { pathname: "/dashboard", expected: "cockpit" },
+        { pathname: "/diagnose", expected: "diagnose" },
+        { pathname: "/diagnose/work-graph", expected: "diagnose" },
+        { pathname: "/metrics", expected: "diagnose" },
+        { pathname: "/investment", expected: "diagnose" },
+        { pathname: "/people/abc", expected: "diagnose" },
+        { pathname: "/landscape", expected: "diagnose" },
+        { pathname: "/plan", expected: "plan" },
+        { pathname: "/plan/delivery-forecast", expected: "plan" },
+        { pathname: "/capacity-planning", expected: "plan" },
+        { pathname: "/operating-review", expected: "plan" },
+        { pathname: "/opportunities", expected: "improve" },
+        { pathname: "/ai/impact", expected: "ai" },
+        { pathname: "/ai/review-load", expected: "ai" },
+        { pathname: "/govern", expected: "govern" },
+        { pathname: "/testops", expected: "govern" },
+        { pathname: "/testops/risk", expected: "govern" },
+        { pathname: "/quality", expected: "govern" },
+        { pathname: "/security/repos/123", expected: "govern" },
+        { pathname: "/risk/compounding", expected: "govern" },
+        { pathname: "/feature-flags", expected: "govern" },
+        { pathname: "/reports/new", expected: "reports" },
+        { pathname: "/admin/users", expected: "admin" },
+        { pathname: "/settings", expected: "admin" },
+    ];
 
-	it.each(cases)("resolves $pathname to $expected", ({
-		pathname,
-		expected,
-	}) => {
-		expect(selectedAreaIdForPathname(navAreas, pathname)).toBe(expected);
-	});
+    it.each(cases)("resolves $pathname to $expected", ({ pathname, expected }) => {
+        expect(selectedAreaIdForPathname(navAreas, pathname)).toBe(expected);
+    });
 
-	it("prefers the longest prefix and ignores a stale fallback", () => {
-		expect(selectedAreaIdForPathname(navAreas, "/testops/risk", "people")).toBe(
-			"govern",
-		);
-	});
+    it("prefers the longest prefix and ignores a stale fallback", () => {
+        expect(selectedAreaIdForPathname(navAreas, "/testops/risk", "people")).toBe("govern");
+    });
 
-	it("falls back to the area owning the active id when no path matches", () => {
-		expect(selectedAreaIdForPathname(navAreas, "/prs/123", "people")).toBe(
-			"diagnose",
-		);
-		expect(selectedAreaIdForPathname(navAreas, "/issues/9", "security")).toBe(
-			"govern",
-		);
-	});
+    it("falls back to the area owning the active id when no path matches", () => {
+        expect(selectedAreaIdForPathname(navAreas, "/prs/123", "people")).toBe("diagnose");
+        expect(selectedAreaIdForPathname(navAreas, "/issues/9", "security")).toBe("govern");
+    });
 
-	it("returns undefined when neither path nor fallback resolves", () => {
-		expect(selectedAreaIdForPathname(navAreas, "/prs/123")).toBeUndefined();
-		expect(
-			selectedAreaIdForPathname(navAreas, "/prs/123", "nonexistent"),
-		).toBeUndefined();
-	});
+    it("returns undefined when neither path nor fallback resolves", () => {
+        expect(selectedAreaIdForPathname(navAreas, "/prs/123")).toBeUndefined();
+        expect(selectedAreaIdForPathname(navAreas, "/prs/123", "nonexistent")).toBeUndefined();
+    });
 
-	it("does not match a sibling prefix by string-prefix accident", () => {
-		expect(selectedAreaIdForPathname(navAreas, "/capacity-planning")).toBe(
-			"plan",
-		);
-	});
+    it("does not match a sibling prefix by string-prefix accident", () => {
+        expect(selectedAreaIdForPathname(navAreas, "/capacity-planning")).toBe("plan");
+    });
 });
 
 describe("getAreaById", () => {
-	it("returns the matching area", () => {
-		expect(getAreaById("govern")?.label).toBe("Govern");
-	});
+    it("returns the matching area", () => {
+        expect(getAreaById("govern")?.label).toBe("Govern");
+    });
 });
 
 describe("selectedChildForPathname — active child (A10: exactly one)", () => {
-	const cases: Array<{
-		areaId: NavAreaId;
-		pathname: string;
-		childId: string | undefined;
-	}> = [
-		{ areaId: "cockpit", pathname: "/dashboard", childId: undefined },
-		{ areaId: "diagnose", pathname: "/diagnose", childId: "diagnose-overview" },
-		{
-			areaId: "diagnose",
-			pathname: "/diagnose/work-graph",
-			childId: "work-graph",
-		},
-		{ areaId: "diagnose", pathname: "/metrics", childId: "flow" },
-		{ areaId: "diagnose", pathname: "/investment", childId: "investment" },
-		{ areaId: "diagnose", pathname: "/landscape", childId: "landscape" },
-		{
-			areaId: "plan",
-			pathname: "/plan",
-			childId: "plan-overview",
-		},
-		{
-			areaId: "plan",
-			pathname: "/plan/delivery-forecast",
-			childId: "plan-overview",
-		},
-		{
-			areaId: "plan",
-			pathname: "/plan/capacity",
-			childId: "capacity",
-		},
-		// NOTE: operating-review is hidden (navVisible: false, CHAOS-2181
-		// follow-up) and therefore intentionally absent from selection cases.
-		{
-			areaId: "improve",
-			pathname: "/opportunities",
-			childId: "opportunities",
-		},
-		{ areaId: "ai", pathname: "/ai", childId: "ai-overview" },
-		{ areaId: "ai", pathname: "/ai/impact", childId: "ai-impact" },
-		{ areaId: "ai", pathname: "/ai/review-load", childId: "ai-review-load" },
-		{ areaId: "govern", pathname: "/govern", childId: "govern-overview" },
-		{ areaId: "govern", pathname: "/testops", childId: "testops" },
-		{ areaId: "govern", pathname: "/testops/pipelines", childId: "testops" },
-		{ areaId: "govern", pathname: "/testops/coverage", childId: "testops" },
-		{ areaId: "govern", pathname: "/quality", childId: "quality" },
-		{ areaId: "govern", pathname: "/testops/tests", childId: "testops" },
-		{ areaId: "govern", pathname: "/testops/risk", childId: "risk" },
-		{ areaId: "reports", pathname: "/reports", childId: "report-center" },
-		{ areaId: "admin", pathname: "/admin", childId: "organization" },
-		{ areaId: "admin", pathname: "/admin/sync", childId: "connections" },
-		{ areaId: "admin", pathname: "/data-health", childId: "data-confidence" },
-		{ areaId: "admin", pathname: "/settings", childId: "settings" },
-	];
+    const cases: Array<{
+        areaId: NavAreaId;
+        pathname: string;
+        childId: string | undefined;
+    }> = [
+        { areaId: "cockpit", pathname: "/dashboard", childId: undefined },
+        { areaId: "diagnose", pathname: "/diagnose", childId: "diagnose-overview" },
+        {
+            areaId: "diagnose",
+            pathname: "/diagnose/work-graph",
+            childId: "work-graph",
+        },
+        { areaId: "diagnose", pathname: "/metrics", childId: "flow" },
+        { areaId: "diagnose", pathname: "/investment", childId: "investment" },
+        { areaId: "diagnose", pathname: "/landscape", childId: "landscape" },
+        {
+            areaId: "plan",
+            pathname: "/plan",
+            childId: "plan-overview",
+        },
+        {
+            areaId: "plan",
+            pathname: "/plan/delivery-forecast",
+            childId: "plan-overview",
+        },
+        {
+            areaId: "plan",
+            pathname: "/plan/capacity",
+            childId: "capacity",
+        },
+        // NOTE: operating-review is hidden (navVisible: false, CHAOS-2181
+        // follow-up) and therefore intentionally absent from selection cases.
+        {
+            areaId: "improve",
+            pathname: "/opportunities",
+            childId: "opportunities",
+        },
+        { areaId: "ai", pathname: "/ai", childId: "ai-overview" },
+        { areaId: "ai", pathname: "/ai/impact", childId: "ai-impact" },
+        { areaId: "ai", pathname: "/ai/review-load", childId: "ai-review-load" },
+        { areaId: "govern", pathname: "/govern", childId: "govern-overview" },
+        { areaId: "govern", pathname: "/testops", childId: "testops" },
+        { areaId: "govern", pathname: "/testops/pipelines", childId: "testops" },
+        { areaId: "govern", pathname: "/testops/coverage", childId: "testops" },
+        { areaId: "govern", pathname: "/quality", childId: "quality" },
+        { areaId: "govern", pathname: "/testops/tests", childId: "testops" },
+        { areaId: "govern", pathname: "/testops/risk", childId: "risk" },
+        { areaId: "reports", pathname: "/reports", childId: "report-center" },
+        { areaId: "admin", pathname: "/admin", childId: "organization" },
+        { areaId: "admin", pathname: "/admin/sync", childId: "connections" },
+        { areaId: "admin", pathname: "/data-health", childId: "data-confidence" },
+        { areaId: "admin", pathname: "/settings", childId: "settings" },
+    ];
 
-	it.each(cases)("$pathname → child $childId", ({
-		areaId,
-		pathname,
-		childId,
-	}) => {
-		expect(selectedChildForPathname(areaById(areaId), pathname)?.id).toBe(
-			childId,
-		);
-	});
+    it.each(cases)("$pathname → child $childId", ({ areaId, pathname, childId }) => {
+        expect(selectedChildForPathname(areaById(areaId), pathname)?.id).toBe(childId);
+    });
 
-	it("resolves TestOps tab subroutes to the single cluster sidebar row", () => {
-		expect(
-			selectedChildForPathname(areaById("govern"), "/testops/pipelines")?.id,
-		).toBe("testops");
-		expect(
-			selectedChildForPathname(areaById("govern"), "/testops/tests")?.id,
-		).toBe("testops");
-		expect(
-			selectedChildForPathname(areaById("govern"), "/testops/coverage")?.id,
-		).toBe("testops");
+    it("resolves TestOps tab subroutes to the single cluster sidebar row", () => {
+        expect(selectedChildForPathname(areaById("govern"), "/testops/pipelines")?.id).toBe(
+            "testops",
+        );
+        expect(selectedChildForPathname(areaById("govern"), "/testops/tests")?.id).toBe("testops");
+        expect(selectedChildForPathname(areaById("govern"), "/testops/coverage")?.id).toBe(
+            "testops",
+        );
 
-		const testOps = areaById("govern").children.find(
-			(child) => child.id === "testops",
-		);
-		expect(testOps?.label).toBe("TestOps");
-		expect(testOps?.isCluster).toBe(true);
-		expect(testOps?.ownedPaths).toEqual([
-			"/testops",
-			"/testops/pipelines",
-			"/testops/tests",
-			"/testops/coverage",
-		]);
-	});
+        const testOps = areaById("govern").children.find((child) => child.id === "testops");
+        expect(testOps?.label).toBe("TestOps");
+        expect(testOps?.isCluster).toBe(true);
+        expect(testOps?.ownedPaths).toEqual([
+            "/testops",
+            "/testops/pipelines",
+            "/testops/tests",
+            "/testops/coverage",
+        ]);
+    });
 
-	it("never selects a preview (navVisible:false) child", () => {
-		const previewPaths = navAreas.flatMap((area) =>
-			area.children
-				.filter((child) => !child.navVisible)
-				.map((child) => [area.id, child.path] as const),
-		);
-		for (const [areaId, path] of previewPaths) {
-			expect(
-				selectedChildForPathname(areaById(areaId), path)?.navVisible,
-			).not.toBe(false);
-		}
-	});
+    it("never selects a preview (navVisible:false) child", () => {
+        const previewPaths = navAreas.flatMap((area) =>
+            area.children
+                .filter((child) => !child.navVisible)
+                .map((child) => [area.id, child.path] as const),
+        );
+        for (const [areaId, path] of previewPaths) {
+            expect(selectedChildForPathname(areaById(areaId), path)?.navVisible).not.toBe(false);
+        }
+    });
 
-	it("links Flow sidebar rows to the Flow metrics tab while keeping /metrics active", () => {
-		const flowChild = areaById("diagnose").children.find(
-			(child) => child.id === "flow",
-		);
-		expect(flowChild?.path).toBe("/metrics?tab=flow");
-		expect(selectedChildForPathname(areaById("diagnose"), "/metrics")?.id).toBe(
-			"flow",
-		);
-	});
+    it("links Flow sidebar rows to the Flow metrics tab while keeping /metrics active", () => {
+        const flowChild = areaById("diagnose").children.find((child) => child.id === "flow");
+        expect(flowChild?.path).toBe("/metrics?tab=flow");
+        expect(selectedChildForPathname(areaById("diagnose"), "/metrics")?.id).toBe("flow");
+    });
 
-	it("returns undefined for an owned area route with no matching child", () => {
-		expect(
-			selectedChildForPathname(areaById("admin"), "/admin/users"),
-		).toBeUndefined();
-	});
+    it("returns undefined for an owned area route with no matching child", () => {
+        expect(selectedChildForPathname(areaById("admin"), "/admin/users")).toBeUndefined();
+    });
 });
 
 describe("navTitleForPathname / navTrailForPathname (A6: labels agree)", () => {
-	it("titles child pages with the child sidebar label", () => {
-		expect(navTitleForPathname("/diagnose")).toBe("Overview");
-		expect(navTitleForPathname("/diagnose/work-graph")).toBe("Work Graph");
-		expect(navTitleForPathname("/metrics")).toBe("Flow");
-		expect(navTitleForPathname("/landscape")).toBe("Landscape");
-		expect(navTitleForPathname("/plan")).toBe("Overview");
-		expect(navTitleForPathname("/plan/delivery-forecast")).toBe("Overview");
-		expect(navTitleForPathname("/plan/capacity")).toBe("Capacity Forecast");
-		// operating-review is hidden (navVisible: false) — title falls back to the area label.
-		expect(navTitleForPathname("/operating-review")).toBe("Plan");
-		expect(navTitleForPathname("/improve")).toBe("Overview");
-		expect(navTitleForPathname("/opportunities")).toBe("Opportunities");
-		expect(navTitleForPathname("/ai/impact")).toBe("Impact");
-		expect(navTitleForPathname("/ai/review-load")).toBe("Review Load");
-		expect(navTitleForPathname("/govern")).toBe("Overview");
-		expect(navTitleForPathname("/testops")).toBe("TestOps");
-		expect(navTitleForPathname("/testops/tests")).toBe("TestOps");
-		expect(navTitleForPathname("/quality")).toBe("Quality");
-		expect(navTitleForPathname("/settings")).toBe("Settings");
-	});
+    it("titles child pages with the child sidebar label", () => {
+        expect(navTitleForPathname("/diagnose")).toBe("Overview");
+        expect(navTitleForPathname("/diagnose/work-graph")).toBe("Work Graph");
+        expect(navTitleForPathname("/metrics")).toBe("Flow");
+        expect(navTitleForPathname("/landscape")).toBe("Landscape");
+        expect(navTitleForPathname("/plan")).toBe("Overview");
+        expect(navTitleForPathname("/plan/delivery-forecast")).toBe("Overview");
+        expect(navTitleForPathname("/plan/capacity")).toBe("Capacity Forecast");
+        // operating-review is hidden (navVisible: false) — title falls back to the area label.
+        expect(navTitleForPathname("/operating-review")).toBe("Plan");
+        expect(navTitleForPathname("/improve")).toBe("Overview");
+        expect(navTitleForPathname("/opportunities")).toBe("Opportunities");
+        expect(navTitleForPathname("/ai/impact")).toBe("Impact");
+        expect(navTitleForPathname("/ai/review-load")).toBe("Review Load");
+        expect(navTitleForPathname("/govern")).toBe("Overview");
+        expect(navTitleForPathname("/testops")).toBe("TestOps");
+        expect(navTitleForPathname("/testops/tests")).toBe("TestOps");
+        expect(navTitleForPathname("/quality")).toBe("Quality");
+        expect(navTitleForPathname("/settings")).toBe("Settings");
+    });
 
-	it("keeps Cockpit as a single area crumb because it has no children", () => {
-		expect(navTrailForPathname("/dashboard")).toEqual([{ label: "Cockpit" }]);
-		expect(navTitleForPathname("/dashboard")).toBe("Cockpit");
-	});
+    it("keeps Cockpit as a single area crumb because it has no children", () => {
+        expect(navTrailForPathname("/dashboard")).toEqual([{ label: "Cockpit" }]);
+        expect(navTitleForPathname("/dashboard")).toBe("Cockpit");
+    });
 
-	it("builds an Area → Child trail whose last crumb label === the child label", () => {
-		const trail = navTrailForPathname("/admin/sync");
-		expect(trail.map((c) => c.label)).toEqual(["Admin", "Connections"]);
-		expect(trail[0]?.href).toBe(areaById("admin").href);
-		expect(trail[trail.length - 1]?.href).toBeUndefined();
-		const child = areaById("admin").children.find(
-			(c) => c.id === "connections",
-		);
-		expect(trail[trail.length - 1]?.label).toBe(child?.label);
-	});
+    it("builds an Area → Child trail whose last crumb label === the child label", () => {
+        const trail = navTrailForPathname("/admin/sync");
+        expect(trail.map((c) => c.label)).toEqual(["Admin", "Connections"]);
+        expect(trail[0]?.href).toBe(areaById("admin").href);
+        expect(trail[trail.length - 1]?.href).toBeUndefined();
+        const child = areaById("admin").children.find((c) => c.id === "connections");
+        expect(trail[trail.length - 1]?.label).toBe(child?.label);
+    });
 
-	it("returns an empty trail/title for routes no area owns", () => {
-		expect(navTrailForPathname("/prs/123")).toEqual([]);
-		expect(navTitleForPathname("/prs/123")).toBe("");
-	});
+    it("returns an empty trail/title for routes no area owns", () => {
+        expect(navTrailForPathname("/prs/123")).toEqual([]);
+        expect(navTitleForPathname("/prs/123")).toBe("");
+    });
 });

--- a/src/lib/navigation/__tests__/areas.test.ts
+++ b/src/lib/navigation/__tests__/areas.test.ts
@@ -3,329 +3,368 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 import {
-    navAreas,
-    getAreaById,
-    selectedAreaIdForPathname,
-    selectedChildForPathname,
-    navTrailForPathname,
-    navTitleForPathname,
-    type NavAreaId,
+	navAreas,
+	getAreaById,
+	selectedAreaIdForPathname,
+	selectedChildForPathname,
+	navTrailForPathname,
+	navTitleForPathname,
+	type NavAreaId,
 } from "../areas";
 
 const basePath = (href: string) => href.split("?")[0].split("#")[0];
 
 const areaById = (id: NavAreaId) => {
-    const area = getAreaById(id);
-    if (!area) throw new Error(`missing area ${id}`);
-    return area;
+	const area = getAreaById(id);
+	if (!area) throw new Error(`missing area ${id}`);
+	return area;
 };
 
 const routePageExists = (routePath: string) => {
-    const segments = basePath(routePath).split("/").filter(Boolean);
-    return [
-        join(process.cwd(), "src/app/(app)", ...segments, "page.tsx"),
-        join(process.cwd(), "src/app", ...segments, "page.tsx"),
-    ].some((candidate) => existsSync(candidate));
+	const segments = basePath(routePath).split("/").filter(Boolean);
+	return [
+		join(process.cwd(), "src/app/(app)", ...segments, "page.tsx"),
+		join(process.cwd(), "src/app", ...segments, "page.tsx"),
+	].some((candidate) => existsSync(candidate));
 };
 
 describe("navAreas — locked 8-area decision surface", () => {
-    it("declares exactly eight areas in canonical order", () => {
-        expect(navAreas.map((a) => a.id)).toEqual([
-            "cockpit",
-            "diagnose",
-            "plan",
-            "improve",
-            "govern",
-            "ai",
-            "reports",
-            "admin",
-        ]);
-    });
+	it("declares exactly eight areas in canonical order", () => {
+		expect(navAreas.map((a) => a.id)).toEqual([
+			"cockpit",
+			"diagnose",
+			"plan",
+			"improve",
+			"govern",
+			"ai",
+			"reports",
+			"admin",
+		]);
+	});
 
-    it("keeps the main spine to six areas and the utility tray to two", () => {
-        expect(navAreas.filter((a) => a.placement === "main").map((a) => a.id)).toEqual([
-            "cockpit",
-            "diagnose",
-            "plan",
-            "improve",
-            "govern",
-            "ai",
-        ]);
-        expect(navAreas.filter((a) => a.placement === "utility").map((a) => a.id)).toEqual([
-            "reports",
-            "admin",
-        ]);
-    });
+	it("keeps the main spine to six areas and the utility tray to two", () => {
+		expect(
+			navAreas.filter((a) => a.placement === "main").map((a) => a.id),
+		).toEqual(["cockpit", "diagnose", "plan", "improve", "govern", "ai"]);
+		expect(
+			navAreas.filter((a) => a.placement === "utility").map((a) => a.id),
+		).toEqual(["reports", "admin"]);
+	});
 });
 
 describe("navArea.children — locked child navigation", () => {
-    it("matches CHAOS-2079 locked child labels verbatim", () => {
-        expect(
-            Object.fromEntries(
-                navAreas.map((area) => [area.label, area.children.map((child) => child.label)]),
-            ),
-        ).toEqual({
-            Cockpit: [],
-            Diagnose: [
-                "Overview",
-                "Flow",
-                "Investment",
-                "Landscape",
-                "Work Graph",
-                "Complexity",
-                "Cognitive Load",
-                "Bottlenecks",
-                "People",
-                "Code",
-            ],
-            Plan: ["Overview", "Capacity Forecast", "Operating Review"],
-            Improve: ["Overview", "Opportunities", "Experiments", "Automations"],
-            Govern: [
-                "Overview",
-                "TestOps",
-                "Quality",
-                "Delivery Risk",
-                "Incident Correlation",
-                "Security",
-                "Feature Flags",
-                "Compounding Risk",
-            ],
-            // CHAOS-2197: Test Gaps + Evidence are tabs inside Governance Risk
-            // (decision recorded on the ticket); their child rows are retired.
-            AI: [
-                "Overview",
-                "Impact",
-                "Attribution",
-                "Review Load",
-                "Governance Risk",
-                "Automations",
-            ],
-            Reports: ["Report Center", "Weekly Review", "Executive Summary", "Export History"],
-            Admin: ["Organization", "Connections", "Data Confidence", "Settings", "Billing"],
-        });
-    });
+	it("matches CHAOS-2079 locked child labels verbatim", () => {
+		expect(
+			Object.fromEntries(
+				navAreas.map((area) => [
+					area.label,
+					area.children.map((child) => child.label),
+				]),
+			),
+		).toEqual({
+			Cockpit: [],
+			Diagnose: [
+				"Overview",
+				"Flow",
+				"Investment",
+				"Landscape",
+				"Work Graph",
+				"Complexity",
+				"Cognitive Load",
+				"Bottlenecks",
+				"People",
+				"Code",
+			],
+			Plan: ["Overview", "Capacity Forecast", "Operating Review"],
+			Improve: ["Overview", "Opportunities", "Experiments", "Automations"],
+			Govern: [
+				"Overview",
+				"TestOps",
+				"Quality",
+				"Delivery Risk",
+				"Incident Correlation",
+				"Security",
+				"Feature Flags",
+				"Compounding Risk",
+			],
+			// CHAOS-2197: Test Gaps + Evidence are tabs inside Governance Risk
+			// (decision recorded on the ticket); their child rows are retired.
+			AI: [
+				"Overview",
+				"Impact",
+				"Attribution",
+				"Review Load",
+				"Governance Risk",
+				"Automations",
+			],
+			Reports: [
+				"Report Center",
+				"Weekly Review",
+				"Executive Summary",
+				"Export History",
+			],
+			Admin: [
+				"Organization",
+				"Connections",
+				"Data Confidence",
+				"Settings",
+				"Billing",
+			],
+		});
+	});
 
-    it("has unique child ids across all areas", () => {
-        const ids = navAreas.flatMap((a) => a.children.map((c) => c.id));
-        expect(new Set(ids).size).toBe(ids.length);
-    });
+	it("has unique child ids across all areas", () => {
+		const ids = navAreas.flatMap((a) => a.children.map((c) => c.id));
+		expect(new Set(ids).size).toBe(ids.length);
+	});
 
-    it("marks every hidden child as preview-only", () => {
-        for (const child of navAreas.flatMap((a) => a.children)) {
-            if (!child.navVisible) expect(child.preview).toBe(true);
-        }
-    });
+	it("marks every hidden child as preview-only", () => {
+		for (const child of navAreas.flatMap((a) => a.children)) {
+			if (!child.navVisible) expect(child.preview).toBe(true);
+		}
+	});
 
-    it("does not expose a navVisible child without a real app page", () => {
-        for (const area of navAreas) {
-            for (const child of area.children.filter((c) => c.navVisible)) {
-                expect(
-                    routePageExists(child.path),
-                    `${area.id}:${child.label} -> ${child.path}`,
-                ).toBe(true);
-            }
-        }
-    });
+	it("does not expose a navVisible child without a real app page", () => {
+		for (const area of navAreas) {
+			for (const child of area.children.filter((c) => c.navVisible)) {
+				expect(
+					routePageExists(child.path),
+					`${area.id}:${child.label} -> ${child.path}`,
+				).toBe(true);
+			}
+		}
+	});
 });
 
 describe("selectedAreaIdForPathname", () => {
-    const cases: Array<{ pathname: string; expected: NavAreaId }> = [
-        { pathname: "/dashboard", expected: "cockpit" },
-        { pathname: "/diagnose", expected: "diagnose" },
-        { pathname: "/diagnose/work-graph", expected: "diagnose" },
-        { pathname: "/metrics", expected: "diagnose" },
-        { pathname: "/investment", expected: "diagnose" },
-        { pathname: "/people/abc", expected: "diagnose" },
-        { pathname: "/landscape", expected: "diagnose" },
-        { pathname: "/plan", expected: "plan" },
-        { pathname: "/plan/delivery-forecast", expected: "plan" },
-        { pathname: "/capacity-planning", expected: "plan" },
-        { pathname: "/operating-review", expected: "plan" },
-        { pathname: "/opportunities", expected: "improve" },
-        { pathname: "/ai/impact", expected: "ai" },
-        { pathname: "/ai/review-load", expected: "ai" },
-        { pathname: "/govern", expected: "govern" },
-        { pathname: "/testops", expected: "govern" },
-        { pathname: "/testops/risk", expected: "govern" },
-        { pathname: "/quality", expected: "govern" },
-        { pathname: "/security/repos/123", expected: "govern" },
-        { pathname: "/risk/compounding", expected: "govern" },
-        { pathname: "/feature-flags", expected: "govern" },
-        { pathname: "/reports/new", expected: "reports" },
-        { pathname: "/admin/users", expected: "admin" },
-        { pathname: "/settings", expected: "admin" },
-    ];
+	const cases: Array<{ pathname: string; expected: NavAreaId }> = [
+		{ pathname: "/dashboard", expected: "cockpit" },
+		{ pathname: "/diagnose", expected: "diagnose" },
+		{ pathname: "/diagnose/work-graph", expected: "diagnose" },
+		{ pathname: "/metrics", expected: "diagnose" },
+		{ pathname: "/investment", expected: "diagnose" },
+		{ pathname: "/people/abc", expected: "diagnose" },
+		{ pathname: "/landscape", expected: "diagnose" },
+		{ pathname: "/plan", expected: "plan" },
+		{ pathname: "/plan/delivery-forecast", expected: "plan" },
+		{ pathname: "/capacity-planning", expected: "plan" },
+		{ pathname: "/operating-review", expected: "plan" },
+		{ pathname: "/opportunities", expected: "improve" },
+		{ pathname: "/ai/impact", expected: "ai" },
+		{ pathname: "/ai/review-load", expected: "ai" },
+		{ pathname: "/govern", expected: "govern" },
+		{ pathname: "/testops", expected: "govern" },
+		{ pathname: "/testops/risk", expected: "govern" },
+		{ pathname: "/quality", expected: "govern" },
+		{ pathname: "/security/repos/123", expected: "govern" },
+		{ pathname: "/risk/compounding", expected: "govern" },
+		{ pathname: "/feature-flags", expected: "govern" },
+		{ pathname: "/reports/new", expected: "reports" },
+		{ pathname: "/admin/users", expected: "admin" },
+		{ pathname: "/settings", expected: "admin" },
+	];
 
-    it.each(cases)("resolves $pathname to $expected", ({ pathname, expected }) => {
-        expect(selectedAreaIdForPathname(navAreas, pathname)).toBe(expected);
-    });
+	it.each(cases)("resolves $pathname to $expected", ({
+		pathname,
+		expected,
+	}) => {
+		expect(selectedAreaIdForPathname(navAreas, pathname)).toBe(expected);
+	});
 
-    it("prefers the longest prefix and ignores a stale fallback", () => {
-        expect(selectedAreaIdForPathname(navAreas, "/testops/risk", "people")).toBe("govern");
-    });
+	it("prefers the longest prefix and ignores a stale fallback", () => {
+		expect(selectedAreaIdForPathname(navAreas, "/testops/risk", "people")).toBe(
+			"govern",
+		);
+	});
 
-    it("falls back to the area owning the active id when no path matches", () => {
-        expect(selectedAreaIdForPathname(navAreas, "/prs/123", "people")).toBe("diagnose");
-        expect(selectedAreaIdForPathname(navAreas, "/issues/9", "security")).toBe("govern");
-    });
+	it("falls back to the area owning the active id when no path matches", () => {
+		expect(selectedAreaIdForPathname(navAreas, "/prs/123", "people")).toBe(
+			"diagnose",
+		);
+		expect(selectedAreaIdForPathname(navAreas, "/issues/9", "security")).toBe(
+			"govern",
+		);
+	});
 
-    it("returns undefined when neither path nor fallback resolves", () => {
-        expect(selectedAreaIdForPathname(navAreas, "/prs/123")).toBeUndefined();
-        expect(selectedAreaIdForPathname(navAreas, "/prs/123", "nonexistent")).toBeUndefined();
-    });
+	it("returns undefined when neither path nor fallback resolves", () => {
+		expect(selectedAreaIdForPathname(navAreas, "/prs/123")).toBeUndefined();
+		expect(
+			selectedAreaIdForPathname(navAreas, "/prs/123", "nonexistent"),
+		).toBeUndefined();
+	});
 
-    it("does not match a sibling prefix by string-prefix accident", () => {
-        expect(selectedAreaIdForPathname(navAreas, "/capacity-planning")).toBe("plan");
-    });
+	it("does not match a sibling prefix by string-prefix accident", () => {
+		expect(selectedAreaIdForPathname(navAreas, "/capacity-planning")).toBe(
+			"plan",
+		);
+	});
 });
 
 describe("getAreaById", () => {
-    it("returns the matching area", () => {
-        expect(getAreaById("govern")?.label).toBe("Govern");
-    });
+	it("returns the matching area", () => {
+		expect(getAreaById("govern")?.label).toBe("Govern");
+	});
 });
 
 describe("selectedChildForPathname — active child (A10: exactly one)", () => {
-    const cases: Array<{
-        areaId: NavAreaId;
-        pathname: string;
-        childId: string | undefined;
-    }> = [
-        { areaId: "cockpit", pathname: "/dashboard", childId: undefined },
-        { areaId: "diagnose", pathname: "/diagnose", childId: "diagnose-overview" },
-        {
-            areaId: "diagnose",
-            pathname: "/diagnose/work-graph",
-            childId: "work-graph",
-        },
-        { areaId: "diagnose", pathname: "/metrics", childId: "flow" },
-        { areaId: "diagnose", pathname: "/investment", childId: "investment" },
-        { areaId: "diagnose", pathname: "/landscape", childId: "landscape" },
-        {
-            areaId: "plan",
-            pathname: "/plan",
-            childId: "plan-overview",
-        },
-        {
-            areaId: "plan",
-            pathname: "/plan/delivery-forecast",
-            childId: "plan-overview",
-        },
-        {
-            areaId: "plan",
-            pathname: "/plan/capacity",
-            childId: "capacity",
-        },
-        {
-            areaId: "plan",
-            pathname: "/operating-review",
-            childId: "operating-review",
-        },
-        {
-            areaId: "improve",
-            pathname: "/opportunities",
-            childId: "opportunities",
-        },
-        { areaId: "ai", pathname: "/ai", childId: "ai-overview" },
-        { areaId: "ai", pathname: "/ai/impact", childId: "ai-impact" },
-        { areaId: "ai", pathname: "/ai/review-load", childId: "ai-review-load" },
-        { areaId: "govern", pathname: "/govern", childId: "govern-overview" },
-        { areaId: "govern", pathname: "/testops", childId: "testops" },
-        { areaId: "govern", pathname: "/testops/pipelines", childId: "testops" },
-        { areaId: "govern", pathname: "/testops/coverage", childId: "testops" },
-        { areaId: "govern", pathname: "/quality", childId: "quality" },
-        { areaId: "govern", pathname: "/testops/tests", childId: "testops" },
-        { areaId: "govern", pathname: "/testops/risk", childId: "risk" },
-        { areaId: "reports", pathname: "/reports", childId: "report-center" },
-        { areaId: "admin", pathname: "/admin", childId: "organization" },
-        { areaId: "admin", pathname: "/admin/sync", childId: "connections" },
-        { areaId: "admin", pathname: "/data-health", childId: "data-confidence" },
-        { areaId: "admin", pathname: "/settings", childId: "settings" },
-    ];
+	const cases: Array<{
+		areaId: NavAreaId;
+		pathname: string;
+		childId: string | undefined;
+	}> = [
+		{ areaId: "cockpit", pathname: "/dashboard", childId: undefined },
+		{ areaId: "diagnose", pathname: "/diagnose", childId: "diagnose-overview" },
+		{
+			areaId: "diagnose",
+			pathname: "/diagnose/work-graph",
+			childId: "work-graph",
+		},
+		{ areaId: "diagnose", pathname: "/metrics", childId: "flow" },
+		{ areaId: "diagnose", pathname: "/investment", childId: "investment" },
+		{ areaId: "diagnose", pathname: "/landscape", childId: "landscape" },
+		{
+			areaId: "plan",
+			pathname: "/plan",
+			childId: "plan-overview",
+		},
+		{
+			areaId: "plan",
+			pathname: "/plan/delivery-forecast",
+			childId: "plan-overview",
+		},
+		{
+			areaId: "plan",
+			pathname: "/plan/capacity",
+			childId: "capacity",
+		},
+		// NOTE: operating-review is hidden (navVisible: false, CHAOS-2181
+		// follow-up) and therefore intentionally absent from selection cases.
+		{
+			areaId: "improve",
+			pathname: "/opportunities",
+			childId: "opportunities",
+		},
+		{ areaId: "ai", pathname: "/ai", childId: "ai-overview" },
+		{ areaId: "ai", pathname: "/ai/impact", childId: "ai-impact" },
+		{ areaId: "ai", pathname: "/ai/review-load", childId: "ai-review-load" },
+		{ areaId: "govern", pathname: "/govern", childId: "govern-overview" },
+		{ areaId: "govern", pathname: "/testops", childId: "testops" },
+		{ areaId: "govern", pathname: "/testops/pipelines", childId: "testops" },
+		{ areaId: "govern", pathname: "/testops/coverage", childId: "testops" },
+		{ areaId: "govern", pathname: "/quality", childId: "quality" },
+		{ areaId: "govern", pathname: "/testops/tests", childId: "testops" },
+		{ areaId: "govern", pathname: "/testops/risk", childId: "risk" },
+		{ areaId: "reports", pathname: "/reports", childId: "report-center" },
+		{ areaId: "admin", pathname: "/admin", childId: "organization" },
+		{ areaId: "admin", pathname: "/admin/sync", childId: "connections" },
+		{ areaId: "admin", pathname: "/data-health", childId: "data-confidence" },
+		{ areaId: "admin", pathname: "/settings", childId: "settings" },
+	];
 
-    it.each(cases)("$pathname → child $childId", ({ areaId, pathname, childId }) => {
-        expect(selectedChildForPathname(areaById(areaId), pathname)?.id).toBe(childId);
-    });
+	it.each(cases)("$pathname → child $childId", ({
+		areaId,
+		pathname,
+		childId,
+	}) => {
+		expect(selectedChildForPathname(areaById(areaId), pathname)?.id).toBe(
+			childId,
+		);
+	});
 
-    it("resolves TestOps tab subroutes to the single cluster sidebar row", () => {
-        expect(selectedChildForPathname(areaById("govern"), "/testops/pipelines")?.id).toBe(
-            "testops",
-        );
-        expect(selectedChildForPathname(areaById("govern"), "/testops/tests")?.id).toBe("testops");
-        expect(selectedChildForPathname(areaById("govern"), "/testops/coverage")?.id).toBe(
-            "testops",
-        );
+	it("resolves TestOps tab subroutes to the single cluster sidebar row", () => {
+		expect(
+			selectedChildForPathname(areaById("govern"), "/testops/pipelines")?.id,
+		).toBe("testops");
+		expect(
+			selectedChildForPathname(areaById("govern"), "/testops/tests")?.id,
+		).toBe("testops");
+		expect(
+			selectedChildForPathname(areaById("govern"), "/testops/coverage")?.id,
+		).toBe("testops");
 
-        const testOps = areaById("govern").children.find((child) => child.id === "testops");
-        expect(testOps?.label).toBe("TestOps");
-        expect(testOps?.isCluster).toBe(true);
-        expect(testOps?.ownedPaths).toEqual([
-            "/testops",
-            "/testops/pipelines",
-            "/testops/tests",
-            "/testops/coverage",
-        ]);
-    });
+		const testOps = areaById("govern").children.find(
+			(child) => child.id === "testops",
+		);
+		expect(testOps?.label).toBe("TestOps");
+		expect(testOps?.isCluster).toBe(true);
+		expect(testOps?.ownedPaths).toEqual([
+			"/testops",
+			"/testops/pipelines",
+			"/testops/tests",
+			"/testops/coverage",
+		]);
+	});
 
-    it("never selects a preview (navVisible:false) child", () => {
-        const previewPaths = navAreas.flatMap((area) =>
-            area.children
-                .filter((child) => !child.navVisible)
-                .map((child) => [area.id, child.path] as const),
-        );
-        for (const [areaId, path] of previewPaths) {
-            expect(selectedChildForPathname(areaById(areaId), path)?.navVisible).not.toBe(false);
-        }
-    });
+	it("never selects a preview (navVisible:false) child", () => {
+		const previewPaths = navAreas.flatMap((area) =>
+			area.children
+				.filter((child) => !child.navVisible)
+				.map((child) => [area.id, child.path] as const),
+		);
+		for (const [areaId, path] of previewPaths) {
+			expect(
+				selectedChildForPathname(areaById(areaId), path)?.navVisible,
+			).not.toBe(false);
+		}
+	});
 
-    it("links Flow sidebar rows to the Flow metrics tab while keeping /metrics active", () => {
-        const flowChild = areaById("diagnose").children.find((child) => child.id === "flow");
-        expect(flowChild?.path).toBe("/metrics?tab=flow");
-        expect(selectedChildForPathname(areaById("diagnose"), "/metrics")?.id).toBe("flow");
-    });
+	it("links Flow sidebar rows to the Flow metrics tab while keeping /metrics active", () => {
+		const flowChild = areaById("diagnose").children.find(
+			(child) => child.id === "flow",
+		);
+		expect(flowChild?.path).toBe("/metrics?tab=flow");
+		expect(selectedChildForPathname(areaById("diagnose"), "/metrics")?.id).toBe(
+			"flow",
+		);
+	});
 
-    it("returns undefined for an owned area route with no matching child", () => {
-        expect(selectedChildForPathname(areaById("admin"), "/admin/users")).toBeUndefined();
-    });
+	it("returns undefined for an owned area route with no matching child", () => {
+		expect(
+			selectedChildForPathname(areaById("admin"), "/admin/users"),
+		).toBeUndefined();
+	});
 });
 
 describe("navTitleForPathname / navTrailForPathname (A6: labels agree)", () => {
-    it("titles child pages with the child sidebar label", () => {
-        expect(navTitleForPathname("/diagnose")).toBe("Overview");
-        expect(navTitleForPathname("/diagnose/work-graph")).toBe("Work Graph");
-        expect(navTitleForPathname("/metrics")).toBe("Flow");
-        expect(navTitleForPathname("/landscape")).toBe("Landscape");
-        expect(navTitleForPathname("/plan")).toBe("Overview");
-        expect(navTitleForPathname("/plan/delivery-forecast")).toBe("Overview");
-        expect(navTitleForPathname("/plan/capacity")).toBe("Capacity Forecast");
-        expect(navTitleForPathname("/operating-review")).toBe("Operating Review");
-        expect(navTitleForPathname("/improve")).toBe("Overview");
-        expect(navTitleForPathname("/opportunities")).toBe("Opportunities");
-        expect(navTitleForPathname("/ai/impact")).toBe("Impact");
-        expect(navTitleForPathname("/ai/review-load")).toBe("Review Load");
-        expect(navTitleForPathname("/govern")).toBe("Overview");
-        expect(navTitleForPathname("/testops")).toBe("TestOps");
-        expect(navTitleForPathname("/testops/tests")).toBe("TestOps");
-        expect(navTitleForPathname("/quality")).toBe("Quality");
-        expect(navTitleForPathname("/settings")).toBe("Settings");
-    });
+	it("titles child pages with the child sidebar label", () => {
+		expect(navTitleForPathname("/diagnose")).toBe("Overview");
+		expect(navTitleForPathname("/diagnose/work-graph")).toBe("Work Graph");
+		expect(navTitleForPathname("/metrics")).toBe("Flow");
+		expect(navTitleForPathname("/landscape")).toBe("Landscape");
+		expect(navTitleForPathname("/plan")).toBe("Overview");
+		expect(navTitleForPathname("/plan/delivery-forecast")).toBe("Overview");
+		expect(navTitleForPathname("/plan/capacity")).toBe("Capacity Forecast");
+		// operating-review is hidden (navVisible: false) — title falls back to the area label.
+		expect(navTitleForPathname("/operating-review")).toBe("Plan");
+		expect(navTitleForPathname("/improve")).toBe("Overview");
+		expect(navTitleForPathname("/opportunities")).toBe("Opportunities");
+		expect(navTitleForPathname("/ai/impact")).toBe("Impact");
+		expect(navTitleForPathname("/ai/review-load")).toBe("Review Load");
+		expect(navTitleForPathname("/govern")).toBe("Overview");
+		expect(navTitleForPathname("/testops")).toBe("TestOps");
+		expect(navTitleForPathname("/testops/tests")).toBe("TestOps");
+		expect(navTitleForPathname("/quality")).toBe("Quality");
+		expect(navTitleForPathname("/settings")).toBe("Settings");
+	});
 
-    it("keeps Cockpit as a single area crumb because it has no children", () => {
-        expect(navTrailForPathname("/dashboard")).toEqual([{ label: "Cockpit" }]);
-        expect(navTitleForPathname("/dashboard")).toBe("Cockpit");
-    });
+	it("keeps Cockpit as a single area crumb because it has no children", () => {
+		expect(navTrailForPathname("/dashboard")).toEqual([{ label: "Cockpit" }]);
+		expect(navTitleForPathname("/dashboard")).toBe("Cockpit");
+	});
 
-    it("builds an Area → Child trail whose last crumb label === the child label", () => {
-        const trail = navTrailForPathname("/admin/sync");
-        expect(trail.map((c) => c.label)).toEqual(["Admin", "Connections"]);
-        expect(trail[0]?.href).toBe(areaById("admin").href);
-        expect(trail[trail.length - 1]?.href).toBeUndefined();
-        const child = areaById("admin").children.find((c) => c.id === "connections");
-        expect(trail[trail.length - 1]?.label).toBe(child?.label);
-    });
+	it("builds an Area → Child trail whose last crumb label === the child label", () => {
+		const trail = navTrailForPathname("/admin/sync");
+		expect(trail.map((c) => c.label)).toEqual(["Admin", "Connections"]);
+		expect(trail[0]?.href).toBe(areaById("admin").href);
+		expect(trail[trail.length - 1]?.href).toBeUndefined();
+		const child = areaById("admin").children.find(
+			(c) => c.id === "connections",
+		);
+		expect(trail[trail.length - 1]?.label).toBe(child?.label);
+	});
 
-    it("returns an empty trail/title for routes no area owns", () => {
-        expect(navTrailForPathname("/prs/123")).toEqual([]);
-        expect(navTitleForPathname("/prs/123")).toBe("");
-    });
+	it("returns an empty trail/title for routes no area owns", () => {
+		expect(navTrailForPathname("/prs/123")).toEqual([]);
+		expect(navTitleForPathname("/prs/123")).toBe("");
+	});
 });

--- a/src/lib/navigation/__tests__/phase2-breadcrumb-areahub.test.ts
+++ b/src/lib/navigation/__tests__/phase2-breadcrumb-areahub.test.ts
@@ -1,55 +1,47 @@
 import { describe, it, expect } from "vitest";
-import {
-	navTrailForPathname,
-	navTitleForPathname,
-	getAreaById,
-} from "../areas";
+import { navTrailForPathname, navTitleForPathname, getAreaById } from "../areas";
 
 describe("navTrailForPathname — operating-review (hidden Plan child, CHAOS-2181 follow-up)", () => {
-	it("returns the Plan area crumb only while Operating Review is hidden", () => {
-		const trail = navTrailForPathname("/operating-review");
-		expect(trail).toHaveLength(1);
-		expect(trail[0]?.label).toBe("Plan");
-		expect(trail[0]?.href).toBeUndefined();
-	});
+    it("returns the Plan area crumb only while Operating Review is hidden", () => {
+        const trail = navTrailForPathname("/operating-review");
+        expect(trail).toHaveLength(1);
+        expect(trail[0]?.label).toBe("Plan");
+        expect(trail[0]?.href).toBeUndefined();
+    });
 
-	it("Operating Review is hidden from nav (navVisible: false, preview: true)", () => {
-		const child = getAreaById("plan")?.children.find(
-			(c) => c.id === "operating-review",
-		);
-		expect(child?.navVisible).toBe(false);
-		expect(child?.preview).toBe(true);
-	});
+    it("Operating Review is hidden from nav (navVisible: false, preview: true)", () => {
+        const child = getAreaById("plan")?.children.find((c) => c.id === "operating-review");
+        expect(child?.navVisible).toBe(false);
+        expect(child?.preview).toBe(true);
+    });
 
-	it("area crumb label matches the Plan area label verbatim (A6)", () => {
-		const trail = navTrailForPathname("/operating-review");
-		expect(trail[0]?.label).toBe(getAreaById("plan")?.label);
-	});
+    it("area crumb label matches the Plan area label verbatim (A6)", () => {
+        const trail = navTrailForPathname("/operating-review");
+        expect(trail[0]?.label).toBe(getAreaById("plan")?.label);
+    });
 
-	it("title for /operating-review falls back to the area label while hidden", () => {
-		expect(navTitleForPathname("/operating-review")).toBe("Plan");
-	});
+    it("title for /operating-review falls back to the area label while hidden", () => {
+        expect(navTitleForPathname("/operating-review")).toBe("Plan");
+    });
 });
 
 describe("navTrailForPathname — AI child pages", () => {
-	const tabPaths = ["/ai/review-load", "/ai/automations", "/ai/risk"];
+    const tabPaths = ["/ai/review-load", "/ai/automations", "/ai/risk"];
 
-	it.each(tabPaths)("%s trail starts with AI area crumb", (pathname) => {
-		const trail = navTrailForPathname(pathname);
-		expect(trail.length).toBeGreaterThanOrEqual(1);
-		expect(trail[0]?.label).toBe("AI");
-		expect(trail[0]?.href).toBe(getAreaById("ai")?.href);
-	});
+    it.each(tabPaths)("%s trail starts with AI area crumb", (pathname) => {
+        const trail = navTrailForPathname(pathname);
+        expect(trail.length).toBeGreaterThanOrEqual(1);
+        expect(trail[0]?.label).toBe("AI");
+        expect(trail[0]?.href).toBe(getAreaById("ai")?.href);
+    });
 
-	it.each(
-		tabPaths,
-	)("%s trail second crumb is the AI child label", (pathname) => {
-		const trail = navTrailForPathname(pathname);
-		expect(trail[1]?.label).toBe(navTitleForPathname(pathname));
-	});
+    it.each(tabPaths)("%s trail second crumb is the AI child label", (pathname) => {
+        const trail = navTrailForPathname(pathname);
+        expect(trail[1]?.label).toBe(navTitleForPathname(pathname));
+    });
 
-	it.each(tabPaths)("%s trail does NOT start with 'Home'", (pathname) => {
-		const trail = navTrailForPathname(pathname);
-		expect(trail[0]?.label).not.toBe("Home");
-	});
+    it.each(tabPaths)("%s trail does NOT start with 'Home'", (pathname) => {
+        const trail = navTrailForPathname(pathname);
+        expect(trail[0]?.label).not.toBe("Home");
+    });
 });

--- a/src/lib/navigation/__tests__/phase2-breadcrumb-areahub.test.ts
+++ b/src/lib/navigation/__tests__/phase2-breadcrumb-areahub.test.ts
@@ -1,49 +1,55 @@
 import { describe, it, expect } from "vitest";
-import { navTrailForPathname, navTitleForPathname, getAreaById } from "../areas";
+import {
+	navTrailForPathname,
+	navTitleForPathname,
+	getAreaById,
+} from "../areas";
 
-describe("navTrailForPathname — operating-review (promoted Plan child)", () => {
-    it("returns a two-crumb trail [Plan → Operating Review] after promotion", () => {
-        const trail = navTrailForPathname("/operating-review");
-        expect(trail).toHaveLength(2);
-        expect(trail[0]?.label).toBe("Plan");
-        expect(trail[0]?.href).toBe(getAreaById("plan")?.href);
-        expect(trail[1]?.label).toBe("Operating Review");
-        expect(trail[1]?.href).toBeUndefined();
-    });
+describe("navTrailForPathname — operating-review (hidden Plan child, CHAOS-2181 follow-up)", () => {
+	it("returns the Plan area crumb only while Operating Review is hidden", () => {
+		const trail = navTrailForPathname("/operating-review");
+		expect(trail).toHaveLength(1);
+		expect(trail[0]?.label).toBe("Plan");
+		expect(trail[0]?.href).toBeUndefined();
+	});
 
-    it("Operating Review is now navVisible and not preview", () => {
-        const child = getAreaById("plan")?.children.find((c) => c.id === "operating-review");
-        expect(child?.navVisible).toBe(true);
-        expect(child?.preview).toBeUndefined();
-    });
+	it("Operating Review is hidden from nav (navVisible: false, preview: true)", () => {
+		const child = getAreaById("plan")?.children.find(
+			(c) => c.id === "operating-review",
+		);
+		expect(child?.navVisible).toBe(false);
+		expect(child?.preview).toBe(true);
+	});
 
-    it("area crumb label matches the Plan area label verbatim (A6)", () => {
-        const trail = navTrailForPathname("/operating-review");
-        expect(trail[0]?.label).toBe(getAreaById("plan")?.label);
-    });
+	it("area crumb label matches the Plan area label verbatim (A6)", () => {
+		const trail = navTrailForPathname("/operating-review");
+		expect(trail[0]?.label).toBe(getAreaById("plan")?.label);
+	});
 
-    it("title for /operating-review is the child label after promotion", () => {
-        expect(navTitleForPathname("/operating-review")).toBe("Operating Review");
-    });
+	it("title for /operating-review falls back to the area label while hidden", () => {
+		expect(navTitleForPathname("/operating-review")).toBe("Plan");
+	});
 });
 
 describe("navTrailForPathname — AI child pages", () => {
-    const tabPaths = ["/ai/review-load", "/ai/automations", "/ai/risk"];
+	const tabPaths = ["/ai/review-load", "/ai/automations", "/ai/risk"];
 
-    it.each(tabPaths)("%s trail starts with AI area crumb", (pathname) => {
-        const trail = navTrailForPathname(pathname);
-        expect(trail.length).toBeGreaterThanOrEqual(1);
-        expect(trail[0]?.label).toBe("AI");
-        expect(trail[0]?.href).toBe(getAreaById("ai")?.href);
-    });
+	it.each(tabPaths)("%s trail starts with AI area crumb", (pathname) => {
+		const trail = navTrailForPathname(pathname);
+		expect(trail.length).toBeGreaterThanOrEqual(1);
+		expect(trail[0]?.label).toBe("AI");
+		expect(trail[0]?.href).toBe(getAreaById("ai")?.href);
+	});
 
-    it.each(tabPaths)("%s trail second crumb is the AI child label", (pathname) => {
-        const trail = navTrailForPathname(pathname);
-        expect(trail[1]?.label).toBe(navTitleForPathname(pathname));
-    });
+	it.each(
+		tabPaths,
+	)("%s trail second crumb is the AI child label", (pathname) => {
+		const trail = navTrailForPathname(pathname);
+		expect(trail[1]?.label).toBe(navTitleForPathname(pathname));
+	});
 
-    it.each(tabPaths)("%s trail does NOT start with 'Home'", (pathname) => {
-        const trail = navTrailForPathname(pathname);
-        expect(trail[0]?.label).not.toBe("Home");
-    });
+	it.each(tabPaths)("%s trail does NOT start with 'Home'", (pathname) => {
+		const trail = navTrailForPathname(pathname);
+		expect(trail[0]?.label).not.toBe("Home");
+	});
 });

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -25,38 +25,38 @@
 import type { Crumb } from "@/components/Breadcrumbs";
 
 export type NavAreaId =
-	| "cockpit"
-	| "diagnose"
-	| "plan"
-	| "improve"
-	| "govern"
-	| "ai"
-	| "reports"
-	| "admin";
+    | "cockpit"
+    | "diagnose"
+    | "plan"
+    | "improve"
+    | "govern"
+    | "ai"
+    | "reports"
+    | "admin";
 
 export type NavAreaHubItem = {
-	id: string;
-	label: string;
-	href: string;
-	description?: string;
-	// ── Signal-card descriptors (CHAOS-2074) ───────────────────────────────────
-	// Static metadata the area resolver pairs with a fetched value to build an
-	// `AreaSignal`. Kept here (the single nav source of truth) so the sidebar,
-	// landing hub, and signal resolvers can never drift. The *value* + *state* are
-	// resolved at request time by the area resolver (see `@/lib/areaSignals`);
-	// these fields only describe HOW a sub-area surfaces as a card.
-	/**
-	 * Optional sub-group header within a dense area. Govern groups into
-	 * "Quality" / "Risk"; flat areas (Diagnose, Improve) leave this undefined.
-	 */
-	cluster?: string;
-	/** Short metric name shown on the card (e.g. "Line coverage", "Open criticals"). */
-	metricLabel?: string;
-	/**
-	 * R4 low-value single surface (e.g. Feature Flags): render visually secondary
-	 * within its cluster rather than at equal billing.
-	 */
-	demoted?: boolean;
+    id: string;
+    label: string;
+    href: string;
+    description?: string;
+    // ── Signal-card descriptors (CHAOS-2074) ───────────────────────────────────
+    // Static metadata the area resolver pairs with a fetched value to build an
+    // `AreaSignal`. Kept here (the single nav source of truth) so the sidebar,
+    // landing hub, and signal resolvers can never drift. The *value* + *state* are
+    // resolved at request time by the area resolver (see `@/lib/areaSignals`);
+    // these fields only describe HOW a sub-area surfaces as a card.
+    /**
+     * Optional sub-group header within a dense area. Govern groups into
+     * "Quality" / "Risk"; flat areas (Diagnose, Improve) leave this undefined.
+     */
+    cluster?: string;
+    /** Short metric name shown on the card (e.g. "Line coverage", "Open criticals"). */
+    metricLabel?: string;
+    /**
+     * R4 low-value single surface (e.g. Feature Flags): render visually secondary
+     * within its cluster rather than at equal billing.
+     */
+    demoted?: boolean;
 };
 
 /**
@@ -71,660 +71,660 @@ export type NavAreaHubItem = {
  * `navVisible`; phantom/not-yet-built routes are `preview` and never rendered.
  */
 export type NavChildRoute = {
-	id: string;
-	label: string;
-	/** The child's canonical route — the sidebar row links here. */
-	path: string;
-	/** Rendered in the sidebar only when true. Preview routes stay false. */
-	navVisible: boolean;
-	/** Phantom/not-yet-built route held for reference; never rendered. */
-	preview?: boolean;
-	/**
-	 * Routes whose active state resolves to THIS child (longest match wins among
-	 * a single area's navVisible children). Defaults to `[path]`. A cluster child
-	 * lists every route it fronts (e.g. `/testops/tests`, `/quality`).
-	 */
-	ownedPaths?: string[];
-	exact?: boolean;
-	/** R4 low-value surface — render visually secondary within the list. */
-	demoted?: boolean;
-	/**
-	 * True when this single row fronts several destinations behind one in-page
-	 * tab strip (Phase 2). The sidebar shows ONE row; the tab strip lives on the
-	 * page, not in the sidebar.
-	 */
-	isCluster?: boolean;
+    id: string;
+    label: string;
+    /** The child's canonical route — the sidebar row links here. */
+    path: string;
+    /** Rendered in the sidebar only when true. Preview routes stay false. */
+    navVisible: boolean;
+    /** Phantom/not-yet-built route held for reference; never rendered. */
+    preview?: boolean;
+    /**
+     * Routes whose active state resolves to THIS child (longest match wins among
+     * a single area's navVisible children). Defaults to `[path]`. A cluster child
+     * lists every route it fronts (e.g. `/testops/tests`, `/quality`).
+     */
+    ownedPaths?: string[];
+    exact?: boolean;
+    /** R4 low-value surface — render visually secondary within the list. */
+    demoted?: boolean;
+    /**
+     * True when this single row fronts several destinations behind one in-page
+     * tab strip (Phase 2). The sidebar shows ONE row; the tab strip lives on the
+     * page, not in the sidebar.
+     */
+    isCluster?: boolean;
 };
 
 export type NavArea = {
-	id: NavAreaId;
-	label: string;
-	/** The area's landing route — what the sidebar row links to. */
-	href: string;
-	placement: "main" | "utility";
-	/**
-	 * Route prefixes this area owns, used for active-state resolution. A pathname
-	 * is matched against every area's prefixes; the longest matching prefix wins
-	 * (so `/testops/risk` resolves to Govern, `/risk/compounding` to Govern, etc).
-	 */
-	ownedPathPrefixes: string[];
-	/**
-	 * Legacy per-page `active="…"` ids (the pre-collapse leaf ids). Used only as a
-	 * fallback when no pathname prefix matches, so existing `<PrimaryNav active=…>`
-	 * call sites keep highlighting the correct area without editing every page.
-	 */
-	legacyActiveIds: string[];
-	/**
-	 * Leaf destinations reachable from this area's landing page via `AreaHub`.
-	 * Empty for areas whose only destination is the landing route itself.
-	 */
-	hubItems: NavAreaHubItem[];
-	/**
-	 * The two-level sidebar route tree (CHAOS-2075): the destinations the active
-	 * area expands to as indented rows. DISTINCT from `hubItems` — see
-	 * {@link NavChildRoute}. Empty when the area's only destination is its landing
-	 * route (e.g. Cockpit).
-	 */
-	children: NavChildRoute[];
+    id: NavAreaId;
+    label: string;
+    /** The area's landing route — what the sidebar row links to. */
+    href: string;
+    placement: "main" | "utility";
+    /**
+     * Route prefixes this area owns, used for active-state resolution. A pathname
+     * is matched against every area's prefixes; the longest matching prefix wins
+     * (so `/testops/risk` resolves to Govern, `/risk/compounding` to Govern, etc).
+     */
+    ownedPathPrefixes: string[];
+    /**
+     * Legacy per-page `active="…"` ids (the pre-collapse leaf ids). Used only as a
+     * fallback when no pathname prefix matches, so existing `<PrimaryNav active=…>`
+     * call sites keep highlighting the correct area without editing every page.
+     */
+    legacyActiveIds: string[];
+    /**
+     * Leaf destinations reachable from this area's landing page via `AreaHub`.
+     * Empty for areas whose only destination is the landing route itself.
+     */
+    hubItems: NavAreaHubItem[];
+    /**
+     * The two-level sidebar route tree (CHAOS-2075): the destinations the active
+     * area expands to as indented rows. DISTINCT from `hubItems` — see
+     * {@link NavChildRoute}. Empty when the area's only destination is its landing
+     * route (e.g. Cockpit).
+     */
+    children: NavChildRoute[];
 };
 
 export const navAreas: readonly NavArea[] = [
-	// ── Main spine ──────────────────────────────────────────────────────────────
-	{
-		id: "cockpit",
-		label: "Cockpit",
-		href: "/dashboard",
-		placement: "main",
-		ownedPathPrefixes: ["/dashboard"],
-		legacyActiveIds: ["home", "cockpit"],
-		hubItems: [],
-		// Cockpit's only destination is its landing route — no expandable children.
-		children: [],
-	},
-	{
-		id: "diagnose",
-		label: "Diagnose",
-		href: "/diagnose",
-		placement: "main",
-		ownedPathPrefixes: [
-			"/diagnose",
-			"/metrics",
-			"/team-flow",
-			"/investment",
-			"/people",
-			"/code",
-			"/landscape",
-			"/complexity",
-			"/cognitive-load",
-			"/bottleneck",
-		],
-		legacyActiveIds: [
-			"work",
-			"flow",
-			"investment",
-			"people",
-			"code",
-			"landscape",
-			"complexity",
-			"cognitive-load",
-			"bottleneck",
-			"diagnose",
-		],
-		// CHAOS-2074: Diagnose is FLAT (no clusters). Descriptors placed here; Phase
-		// 2 wires the resolver fetching (see `@/lib/areaSignals/getAreaSignals`).
-		hubItems: [
-			{
-				id: "flow",
-				label: "Flow",
-				href: "/metrics?tab=flow",
-				description: "Flow trends and delivery movement.",
-				metricLabel: "Deploy frequency",
-			},
-			{
-				id: "investment",
-				label: "Investment",
-				href: "/investment",
-				description: "Effort and attention allocation.",
-				metricLabel: "Planned allocation",
-			},
-			{
-				id: "code",
-				label: "Code",
-				href: "/code",
-				description: "Code health and ownership.",
-				metricLabel: "Code churn",
-			},
-			{
-				id: "landscape",
-				label: "Landscape",
-				href: "/landscape",
-				description: "System landscape overview.",
-				metricLabel: "Bus factor",
-			},
-			{
-				id: "complexity",
-				label: "Complexity",
-				href: "/complexity",
-				description: "Complexity trend and hotspots.",
-				metricLabel: "Avg complexity",
-			},
-			{
-				id: "cognitive-load",
-				label: "Cognitive Load",
-				href: "/cognitive-load",
-				description: "Focus and context-switch pressure.",
-				// Wired via the cognitiveLoad GraphQL resolver (CHAOS-2077):
-				// headline = avg PR interruption load over the window.
-				metricLabel: "Interruption load",
-			},
-			{
-				id: "bottleneck",
-				label: "Bottlenecks",
-				href: "/bottleneck",
-				description: "Flow bottleneck detection.",
-				metricLabel: "WIP saturation",
-			},
-		],
-		children: [
-			{
-				id: "diagnose-overview",
-				label: "Overview",
-				path: "/diagnose",
-				navVisible: true,
-			},
-			{
-				id: "flow",
-				label: "Flow",
-				path: "/metrics?tab=flow",
-				navVisible: true,
-				ownedPaths: ["/metrics"],
-			},
-			{
-				id: "investment",
-				label: "Investment",
-				path: "/investment",
-				navVisible: true,
-			},
-			{
-				id: "landscape",
-				label: "Landscape",
-				path: "/landscape",
-				navVisible: true,
-			},
-			{
-				id: "work-graph",
-				label: "Work Graph",
-				path: "/diagnose/work-graph",
-				navVisible: true,
-			},
-			{
-				id: "complexity",
-				label: "Complexity",
-				path: "/complexity",
-				navVisible: true,
-			},
-			{
-				id: "cognitive-load",
-				label: "Cognitive Load",
-				path: "/cognitive-load",
-				navVisible: true,
-			},
-			{
-				id: "bottleneck",
-				label: "Bottlenecks",
-				path: "/bottleneck",
-				navVisible: true,
-			},
-			{ id: "people", label: "People", path: "/people", navVisible: true },
-			{ id: "code", label: "Code", path: "/code", navVisible: true },
-		],
-	},
-	{
-		id: "plan",
-		label: "Plan",
-		href: "/plan",
-		placement: "main",
-		ownedPathPrefixes: ["/plan", "/capacity-planning", "/operating-review"],
-		legacyActiveIds: [
-			"capacity-planning",
-			"delivery-forecast",
-			"capacity",
-			"operating-review",
-			"plan",
-		],
-		hubItems: [
-			{
-				id: "capacity",
-				label: "Capacity Forecast",
-				href: "/plan/capacity",
-				description: "Monte Carlo throughput forecasting.",
-				metricLabel: "Forecast window",
-			},
-			{
-				id: "operating-review",
-				label: "Operating Review",
-				href: "/operating-review",
-				description:
-					"Monday-ready weekly agenda: delivery, bottlenecks, risk, reliability, and investment.",
-				metricLabel: "Weekly signals",
-			},
-		],
-		children: [
-			{
-				id: "plan-overview",
-				label: "Overview",
-				path: "/plan",
-				navVisible: true,
-			},
-			{
-				id: "capacity",
-				label: "Capacity Forecast",
-				path: "/plan/capacity",
-				navVisible: true,
-			},
-			{
-				id: "operating-review",
-				label: "Operating Review",
-				path: "/operating-review",
-				// Hidden from nav pending a hard rethink of the Operating Review
-				// surface (CHAOS-2181 follow-up). The route stays reachable by URL;
-				// `preview: true` per the IA invariant for navVisible:false children.
-				navVisible: false,
-				preview: true,
-			},
-		],
-	},
-	{
-		id: "improve",
-		label: "Improve",
-		href: "/improve",
-		placement: "main",
-		ownedPathPrefixes: ["/opportunities", "/improve"],
-		legacyActiveIds: ["opportunities", "experiments", "automations", "improve"],
-		hubItems: [
-			{
-				id: "opportunities",
-				label: "Opportunities",
-				href: "/opportunities",
-				description: "Evidence-linked improvement opportunities.",
-				metricLabel: "Opportunities data",
-			},
-			{
-				id: "experiments",
-				label: "Experiments",
-				href: "/improve/experiments",
-				description: "Run and track improvement experiments.",
-				metricLabel: "Experiments data",
-			},
-			{
-				id: "improve-automations",
-				label: "Automations",
-				href: "/improve/automations",
-				description: "Automated improvement workflows.",
-				metricLabel: "Automations data",
-			},
-		],
-		children: [
-			{
-				id: "improve-overview",
-				label: "Overview",
-				path: "/improve",
-				navVisible: true,
-			},
-			{
-				id: "opportunities",
-				label: "Opportunities",
-				path: "/opportunities",
-				navVisible: true,
-			},
-			{
-				id: "experiments",
-				label: "Experiments",
-				path: "/improve/experiments",
-				navVisible: false,
-				preview: true,
-			},
-			{
-				id: "improve-automations",
-				label: "Automations",
-				path: "/improve/automations",
-				navVisible: false,
-				preview: true,
-			},
-		],
-	},
-	{
-		id: "govern",
-		label: "Govern",
-		href: "/govern",
-		placement: "main",
-		ownedPathPrefixes: [
-			"/govern",
-			"/testops",
-			"/quality",
-			"/security",
-			"/feature-flags",
-			"/incident-correlation",
-			"/risk",
-		],
-		legacyActiveIds: [
-			"testops",
-			"pipelines",
-			"tests",
-			"quality",
-			"coverage",
-			"risk",
-			"incident-correlation",
-			"security",
-			"feature-flags",
-			"risk-compounding",
-			"govern",
-		],
-		// CHAOS-2074: Govern is sub-grouped into "Quality" and "Risk" clusters,
-		// each internally severity-sorted by the resolver (getGovernSignals).
-		hubItems: [
-			// ── Cluster: Quality ──────────────────────────────────────────────────
-			{
-				id: "testops",
-				label: "TestOps",
-				href: "/testops",
-				description: "Pipeline, test, and coverage health.",
-				cluster: "Quality",
-				metricLabel: "Worst TestOps signal",
-			},
-			{
-				id: "quality",
-				label: "Quality",
-				href: "/quality",
-				description: "Reliability and rework.",
-				cluster: "Quality",
-				metricLabel: "Change failure rate",
-			},
-			// ── Cluster: Risk ─────────────────────────────────────────────────────
-			{
-				id: "security",
-				label: "Security",
-				href: "/security",
-				description: "Security posture.",
-				cluster: "Risk",
-				metricLabel: "Open criticals",
-			},
-			{
-				id: "risk",
-				label: "Delivery Risk",
-				href: "/testops/risk",
-				description: "Delivery risk drag.",
-				cluster: "Risk",
-				metricLabel: "Release confidence",
-			},
-			{
-				id: "incident-correlation",
-				label: "Incident Correlation",
-				href: "/incident-correlation",
-				description: "Incidents correlated to changes.",
-				cluster: "Risk",
-				metricLabel: "Change failure rate",
-			},
-			{
-				id: "risk-compounding",
-				label: "Compounding Risk",
-				href: "/risk/compounding",
-				description: "Compounding risk signals.",
-				cluster: "Risk",
-				metricLabel: "Worst risk score",
-			},
-			{
-				id: "feature-flags",
-				label: "Feature Flags",
-				href: "/feature-flags",
-				description: "Flag lifecycle and debt.",
-				cluster: "Risk",
-				metricLabel: "Active flags",
-				// R4: low-value single surface — render secondary, not equal billing.
-				demoted: true,
-			},
-		],
-		children: [
-			{
-				id: "govern-overview",
-				label: "Overview",
-				path: "/govern",
-				navVisible: true,
-			},
-			{
-				id: "testops",
-				label: "TestOps",
-				path: "/testops",
-				navVisible: true,
-				ownedPaths: [
-					"/testops",
-					"/testops/pipelines",
-					"/testops/tests",
-					"/testops/coverage",
-				],
-				isCluster: true,
-			},
-			{
-				id: "quality",
-				label: "Quality",
-				path: "/quality",
-				navVisible: true,
-			},
-			{
-				id: "risk",
-				label: "Delivery Risk",
-				path: "/testops/risk",
-				navVisible: true,
-			},
-			{
-				id: "incident-correlation",
-				label: "Incident Correlation",
-				path: "/incident-correlation",
-				navVisible: true,
-			},
-			{
-				id: "security",
-				label: "Security",
-				path: "/security",
-				navVisible: true,
-			},
-			{
-				id: "feature-flags",
-				label: "Feature Flags",
-				path: "/feature-flags",
-				navVisible: true,
-				// R4 low-value surface — rendered visually secondary in the list.
-				demoted: true,
-			},
-			{
-				id: "risk-compounding",
-				label: "Compounding Risk",
-				path: "/risk/compounding",
-				navVisible: true,
-			},
-		],
-	},
-	{
-		id: "ai",
-		label: "AI",
-		href: "/ai",
-		placement: "main",
-		ownedPathPrefixes: ["/ai"],
-		legacyActiveIds: ["ai", "ai-workflows"],
-		// CHAOS-2198: AI is sub-grouped into "Signal" (monitoring metrics) and
-		// "Action" (opportunity / recommendation surfaces), severity-sorted by
-		// the resolver (getAISignals). Mirrors the Govern cluster pattern.
-		hubItems: [
-			// ── Cluster: Signal ──────────────────────────────────────────────────
-			{
-				id: "ai-impact",
-				label: "Impact",
-				href: "/ai/impact",
-				description: "AI-assisted delivery and review impact.",
-				cluster: "Signal",
-				metricLabel: "AI impact",
-			},
-			{
-				id: "ai-review-load",
-				label: "Review Load",
-				href: "/ai/review-load",
-				description: "AI-associated review pressure.",
-				cluster: "Signal",
-				metricLabel: "Review pressure",
-			},
-			{
-				id: "ai-governance-risk",
-				label: "Governance Risk",
-				href: "/ai/risk",
-				description: "Quality and governance signals for AI-associated work.",
-				cluster: "Signal",
-				metricLabel: "Governance risk",
-			},
-			// ── Cluster: Action ──────────────────────────────────────────────────
-			{
-				id: "ai-automations",
-				label: "Automations",
-				href: "/ai/automations",
-				description: "Responsible automation opportunities.",
-				cluster: "Action",
-				metricLabel: "Automation candidates",
-			},
-		],
-		children: [
-			{ id: "ai-overview", label: "Overview", path: "/ai", navVisible: true },
-			{
-				id: "ai-impact",
-				label: "Impact",
-				path: "/ai/impact",
-				navVisible: true,
-			},
-			{
-				id: "ai-attribution",
-				label: "Attribution",
-				path: "/ai/attribution",
-				navVisible: false,
-				preview: true,
-			},
-			{
-				id: "ai-review-load",
-				label: "Review Load",
-				path: "/ai/review-load",
-				navVisible: true,
-			},
-			{
-				id: "ai-governance-risk",
-				label: "Governance Risk",
-				path: "/ai/risk",
-				// CHAOS-2197: Test Gaps + Evidence are in-page tabs here; their
-				// retired standalone routes redirect and resolve to this child.
-				ownedPaths: ["/ai/risk", "/ai/test-gaps", "/ai/evidence"],
-				navVisible: true,
-			},
-			{
-				id: "ai-automations",
-				label: "Automations",
-				path: "/ai/automations",
-				navVisible: true,
-			},
-		],
-	},
-	// ── Utility tray ────────────────────────────────────────────────────────────
-	{
-		id: "reports",
-		label: "Reports",
-		href: "/reports",
-		placement: "utility",
-		ownedPathPrefixes: ["/reports"],
-		legacyActiveIds: ["reports"],
-		hubItems: [],
-		// Report Center is the only built destination. Weekly Review / Executive
-		// Summary / Export History are PREVIEW (phantom routes held for reference);
-		// they are never rendered and never resolved until their pages exist — DO
-		// NOT create stub pages for them (CHAOS-2075).
-		children: [
-			{
-				id: "report-center",
-				label: "Report Center",
-				path: "/reports",
-				navVisible: true,
-				exact: true,
-			},
-			{
-				id: "weekly-review",
-				label: "Weekly Review",
-				path: "/reports/weekly",
-				navVisible: false,
-				preview: true,
-			},
-			{
-				id: "executive-summary",
-				label: "Executive Summary",
-				path: "/reports/executive",
-				navVisible: false,
-				preview: true,
-			},
-			{
-				id: "export-history",
-				label: "Export History",
-				path: "/reports/exports",
-				navVisible: false,
-				preview: true,
-			},
-		],
-	},
-	{
-		id: "admin",
-		label: "Admin",
-		href: "/admin",
-		placement: "utility",
-		// `/data-health` (Data Confidence) is an Admin destination outside `/admin`.
-		ownedPathPrefixes: ["/admin", "/settings", "/data-health"],
-		legacyActiveIds: ["admin", "settings", "data-health"],
-		hubItems: [],
-		children: [
-			{
-				id: "organization",
-				label: "Organization",
-				path: "/admin",
-				navVisible: true,
-				exact: true,
-			},
-			{
-				id: "connections",
-				label: "Connections",
-				path: "/admin/sync",
-				navVisible: true,
-			},
-			{
-				id: "data-confidence",
-				label: "Data Confidence",
-				path: "/data-health",
-				navVisible: true,
-			},
-			{
-				id: "settings",
-				label: "Settings",
-				path: "/settings",
-				navVisible: true,
-			},
-			{
-				id: "billing",
-				label: "Billing",
-				path: "/admin/billing",
-				navVisible: false,
-				preview: true,
-			},
-		],
-	},
+    // ── Main spine ──────────────────────────────────────────────────────────────
+    {
+        id: "cockpit",
+        label: "Cockpit",
+        href: "/dashboard",
+        placement: "main",
+        ownedPathPrefixes: ["/dashboard"],
+        legacyActiveIds: ["home", "cockpit"],
+        hubItems: [],
+        // Cockpit's only destination is its landing route — no expandable children.
+        children: [],
+    },
+    {
+        id: "diagnose",
+        label: "Diagnose",
+        href: "/diagnose",
+        placement: "main",
+        ownedPathPrefixes: [
+            "/diagnose",
+            "/metrics",
+            "/team-flow",
+            "/investment",
+            "/people",
+            "/code",
+            "/landscape",
+            "/complexity",
+            "/cognitive-load",
+            "/bottleneck",
+        ],
+        legacyActiveIds: [
+            "work",
+            "flow",
+            "investment",
+            "people",
+            "code",
+            "landscape",
+            "complexity",
+            "cognitive-load",
+            "bottleneck",
+            "diagnose",
+        ],
+        // CHAOS-2074: Diagnose is FLAT (no clusters). Descriptors placed here; Phase
+        // 2 wires the resolver fetching (see `@/lib/areaSignals/getAreaSignals`).
+        hubItems: [
+            {
+                id: "flow",
+                label: "Flow",
+                href: "/metrics?tab=flow",
+                description: "Flow trends and delivery movement.",
+                metricLabel: "Deploy frequency",
+            },
+            {
+                id: "investment",
+                label: "Investment",
+                href: "/investment",
+                description: "Effort and attention allocation.",
+                metricLabel: "Planned allocation",
+            },
+            {
+                id: "code",
+                label: "Code",
+                href: "/code",
+                description: "Code health and ownership.",
+                metricLabel: "Code churn",
+            },
+            {
+                id: "landscape",
+                label: "Landscape",
+                href: "/landscape",
+                description: "System landscape overview.",
+                metricLabel: "Bus factor",
+            },
+            {
+                id: "complexity",
+                label: "Complexity",
+                href: "/complexity",
+                description: "Complexity trend and hotspots.",
+                metricLabel: "Avg complexity",
+            },
+            {
+                id: "cognitive-load",
+                label: "Cognitive Load",
+                href: "/cognitive-load",
+                description: "Focus and context-switch pressure.",
+                // Wired via the cognitiveLoad GraphQL resolver (CHAOS-2077):
+                // headline = avg PR interruption load over the window.
+                metricLabel: "Interruption load",
+            },
+            {
+                id: "bottleneck",
+                label: "Bottlenecks",
+                href: "/bottleneck",
+                description: "Flow bottleneck detection.",
+                metricLabel: "WIP saturation",
+            },
+        ],
+        children: [
+            {
+                id: "diagnose-overview",
+                label: "Overview",
+                path: "/diagnose",
+                navVisible: true,
+            },
+            {
+                id: "flow",
+                label: "Flow",
+                path: "/metrics?tab=flow",
+                navVisible: true,
+                ownedPaths: ["/metrics"],
+            },
+            {
+                id: "investment",
+                label: "Investment",
+                path: "/investment",
+                navVisible: true,
+            },
+            {
+                id: "landscape",
+                label: "Landscape",
+                path: "/landscape",
+                navVisible: true,
+            },
+            {
+                id: "work-graph",
+                label: "Work Graph",
+                path: "/diagnose/work-graph",
+                navVisible: true,
+            },
+            {
+                id: "complexity",
+                label: "Complexity",
+                path: "/complexity",
+                navVisible: true,
+            },
+            {
+                id: "cognitive-load",
+                label: "Cognitive Load",
+                path: "/cognitive-load",
+                navVisible: true,
+            },
+            {
+                id: "bottleneck",
+                label: "Bottlenecks",
+                path: "/bottleneck",
+                navVisible: true,
+            },
+            { id: "people", label: "People", path: "/people", navVisible: true },
+            { id: "code", label: "Code", path: "/code", navVisible: true },
+        ],
+    },
+    {
+        id: "plan",
+        label: "Plan",
+        href: "/plan",
+        placement: "main",
+        ownedPathPrefixes: ["/plan", "/capacity-planning", "/operating-review"],
+        legacyActiveIds: [
+            "capacity-planning",
+            "delivery-forecast",
+            "capacity",
+            "operating-review",
+            "plan",
+        ],
+        hubItems: [
+            {
+                id: "capacity",
+                label: "Capacity Forecast",
+                href: "/plan/capacity",
+                description: "Monte Carlo throughput forecasting.",
+                metricLabel: "Forecast window",
+            },
+            {
+                id: "operating-review",
+                label: "Operating Review",
+                href: "/operating-review",
+                description:
+                    "Monday-ready weekly agenda: delivery, bottlenecks, risk, reliability, and investment.",
+                metricLabel: "Weekly signals",
+            },
+        ],
+        children: [
+            {
+                id: "plan-overview",
+                label: "Overview",
+                path: "/plan",
+                navVisible: true,
+            },
+            {
+                id: "capacity",
+                label: "Capacity Forecast",
+                path: "/plan/capacity",
+                navVisible: true,
+            },
+            {
+                id: "operating-review",
+                label: "Operating Review",
+                path: "/operating-review",
+                // Hidden from nav pending a hard rethink of the Operating Review
+                // surface (CHAOS-2181 follow-up). The route stays reachable by URL;
+                // `preview: true` per the IA invariant for navVisible:false children.
+                navVisible: false,
+                preview: true,
+            },
+        ],
+    },
+    {
+        id: "improve",
+        label: "Improve",
+        href: "/improve",
+        placement: "main",
+        ownedPathPrefixes: ["/opportunities", "/improve"],
+        legacyActiveIds: ["opportunities", "experiments", "automations", "improve"],
+        hubItems: [
+            {
+                id: "opportunities",
+                label: "Opportunities",
+                href: "/opportunities",
+                description: "Evidence-linked improvement opportunities.",
+                metricLabel: "Opportunities data",
+            },
+            {
+                id: "experiments",
+                label: "Experiments",
+                href: "/improve/experiments",
+                description: "Run and track improvement experiments.",
+                metricLabel: "Experiments data",
+            },
+            {
+                id: "improve-automations",
+                label: "Automations",
+                href: "/improve/automations",
+                description: "Automated improvement workflows.",
+                metricLabel: "Automations data",
+            },
+        ],
+        children: [
+            {
+                id: "improve-overview",
+                label: "Overview",
+                path: "/improve",
+                navVisible: true,
+            },
+            {
+                id: "opportunities",
+                label: "Opportunities",
+                path: "/opportunities",
+                navVisible: true,
+            },
+            {
+                id: "experiments",
+                label: "Experiments",
+                path: "/improve/experiments",
+                navVisible: false,
+                preview: true,
+            },
+            {
+                id: "improve-automations",
+                label: "Automations",
+                path: "/improve/automations",
+                navVisible: false,
+                preview: true,
+            },
+        ],
+    },
+    {
+        id: "govern",
+        label: "Govern",
+        href: "/govern",
+        placement: "main",
+        ownedPathPrefixes: [
+            "/govern",
+            "/testops",
+            "/quality",
+            "/security",
+            "/feature-flags",
+            "/incident-correlation",
+            "/risk",
+        ],
+        legacyActiveIds: [
+            "testops",
+            "pipelines",
+            "tests",
+            "quality",
+            "coverage",
+            "risk",
+            "incident-correlation",
+            "security",
+            "feature-flags",
+            "risk-compounding",
+            "govern",
+        ],
+        // CHAOS-2074: Govern is sub-grouped into "Quality" and "Risk" clusters,
+        // each internally severity-sorted by the resolver (getGovernSignals).
+        hubItems: [
+            // ── Cluster: Quality ──────────────────────────────────────────────────
+            {
+                id: "testops",
+                label: "TestOps",
+                href: "/testops",
+                description: "Pipeline, test, and coverage health.",
+                cluster: "Quality",
+                metricLabel: "Worst TestOps signal",
+            },
+            {
+                id: "quality",
+                label: "Quality",
+                href: "/quality",
+                description: "Reliability and rework.",
+                cluster: "Quality",
+                metricLabel: "Change failure rate",
+            },
+            // ── Cluster: Risk ─────────────────────────────────────────────────────
+            {
+                id: "security",
+                label: "Security",
+                href: "/security",
+                description: "Security posture.",
+                cluster: "Risk",
+                metricLabel: "Open criticals",
+            },
+            {
+                id: "risk",
+                label: "Delivery Risk",
+                href: "/testops/risk",
+                description: "Delivery risk drag.",
+                cluster: "Risk",
+                metricLabel: "Release confidence",
+            },
+            {
+                id: "incident-correlation",
+                label: "Incident Correlation",
+                href: "/incident-correlation",
+                description: "Incidents correlated to changes.",
+                cluster: "Risk",
+                metricLabel: "Change failure rate",
+            },
+            {
+                id: "risk-compounding",
+                label: "Compounding Risk",
+                href: "/risk/compounding",
+                description: "Compounding risk signals.",
+                cluster: "Risk",
+                metricLabel: "Worst risk score",
+            },
+            {
+                id: "feature-flags",
+                label: "Feature Flags",
+                href: "/feature-flags",
+                description: "Flag lifecycle and debt.",
+                cluster: "Risk",
+                metricLabel: "Active flags",
+                // R4: low-value single surface — render secondary, not equal billing.
+                demoted: true,
+            },
+        ],
+        children: [
+            {
+                id: "govern-overview",
+                label: "Overview",
+                path: "/govern",
+                navVisible: true,
+            },
+            {
+                id: "testops",
+                label: "TestOps",
+                path: "/testops",
+                navVisible: true,
+                ownedPaths: [
+                    "/testops",
+                    "/testops/pipelines",
+                    "/testops/tests",
+                    "/testops/coverage",
+                ],
+                isCluster: true,
+            },
+            {
+                id: "quality",
+                label: "Quality",
+                path: "/quality",
+                navVisible: true,
+            },
+            {
+                id: "risk",
+                label: "Delivery Risk",
+                path: "/testops/risk",
+                navVisible: true,
+            },
+            {
+                id: "incident-correlation",
+                label: "Incident Correlation",
+                path: "/incident-correlation",
+                navVisible: true,
+            },
+            {
+                id: "security",
+                label: "Security",
+                path: "/security",
+                navVisible: true,
+            },
+            {
+                id: "feature-flags",
+                label: "Feature Flags",
+                path: "/feature-flags",
+                navVisible: true,
+                // R4 low-value surface — rendered visually secondary in the list.
+                demoted: true,
+            },
+            {
+                id: "risk-compounding",
+                label: "Compounding Risk",
+                path: "/risk/compounding",
+                navVisible: true,
+            },
+        ],
+    },
+    {
+        id: "ai",
+        label: "AI",
+        href: "/ai",
+        placement: "main",
+        ownedPathPrefixes: ["/ai"],
+        legacyActiveIds: ["ai", "ai-workflows"],
+        // CHAOS-2198: AI is sub-grouped into "Signal" (monitoring metrics) and
+        // "Action" (opportunity / recommendation surfaces), severity-sorted by
+        // the resolver (getAISignals). Mirrors the Govern cluster pattern.
+        hubItems: [
+            // ── Cluster: Signal ──────────────────────────────────────────────────
+            {
+                id: "ai-impact",
+                label: "Impact",
+                href: "/ai/impact",
+                description: "AI-assisted delivery and review impact.",
+                cluster: "Signal",
+                metricLabel: "AI impact",
+            },
+            {
+                id: "ai-review-load",
+                label: "Review Load",
+                href: "/ai/review-load",
+                description: "AI-associated review pressure.",
+                cluster: "Signal",
+                metricLabel: "Review pressure",
+            },
+            {
+                id: "ai-governance-risk",
+                label: "Governance Risk",
+                href: "/ai/risk",
+                description: "Quality and governance signals for AI-associated work.",
+                cluster: "Signal",
+                metricLabel: "Governance risk",
+            },
+            // ── Cluster: Action ──────────────────────────────────────────────────
+            {
+                id: "ai-automations",
+                label: "Automations",
+                href: "/ai/automations",
+                description: "Responsible automation opportunities.",
+                cluster: "Action",
+                metricLabel: "Automation candidates",
+            },
+        ],
+        children: [
+            { id: "ai-overview", label: "Overview", path: "/ai", navVisible: true },
+            {
+                id: "ai-impact",
+                label: "Impact",
+                path: "/ai/impact",
+                navVisible: true,
+            },
+            {
+                id: "ai-attribution",
+                label: "Attribution",
+                path: "/ai/attribution",
+                navVisible: false,
+                preview: true,
+            },
+            {
+                id: "ai-review-load",
+                label: "Review Load",
+                path: "/ai/review-load",
+                navVisible: true,
+            },
+            {
+                id: "ai-governance-risk",
+                label: "Governance Risk",
+                path: "/ai/risk",
+                // CHAOS-2197: Test Gaps + Evidence are in-page tabs here; their
+                // retired standalone routes redirect and resolve to this child.
+                ownedPaths: ["/ai/risk", "/ai/test-gaps", "/ai/evidence"],
+                navVisible: true,
+            },
+            {
+                id: "ai-automations",
+                label: "Automations",
+                path: "/ai/automations",
+                navVisible: true,
+            },
+        ],
+    },
+    // ── Utility tray ────────────────────────────────────────────────────────────
+    {
+        id: "reports",
+        label: "Reports",
+        href: "/reports",
+        placement: "utility",
+        ownedPathPrefixes: ["/reports"],
+        legacyActiveIds: ["reports"],
+        hubItems: [],
+        // Report Center is the only built destination. Weekly Review / Executive
+        // Summary / Export History are PREVIEW (phantom routes held for reference);
+        // they are never rendered and never resolved until their pages exist — DO
+        // NOT create stub pages for them (CHAOS-2075).
+        children: [
+            {
+                id: "report-center",
+                label: "Report Center",
+                path: "/reports",
+                navVisible: true,
+                exact: true,
+            },
+            {
+                id: "weekly-review",
+                label: "Weekly Review",
+                path: "/reports/weekly",
+                navVisible: false,
+                preview: true,
+            },
+            {
+                id: "executive-summary",
+                label: "Executive Summary",
+                path: "/reports/executive",
+                navVisible: false,
+                preview: true,
+            },
+            {
+                id: "export-history",
+                label: "Export History",
+                path: "/reports/exports",
+                navVisible: false,
+                preview: true,
+            },
+        ],
+    },
+    {
+        id: "admin",
+        label: "Admin",
+        href: "/admin",
+        placement: "utility",
+        // `/data-health` (Data Confidence) is an Admin destination outside `/admin`.
+        ownedPathPrefixes: ["/admin", "/settings", "/data-health"],
+        legacyActiveIds: ["admin", "settings", "data-health"],
+        hubItems: [],
+        children: [
+            {
+                id: "organization",
+                label: "Organization",
+                path: "/admin",
+                navVisible: true,
+                exact: true,
+            },
+            {
+                id: "connections",
+                label: "Connections",
+                path: "/admin/sync",
+                navVisible: true,
+            },
+            {
+                id: "data-confidence",
+                label: "Data Confidence",
+                path: "/data-health",
+                navVisible: true,
+            },
+            {
+                id: "settings",
+                label: "Settings",
+                path: "/settings",
+                navVisible: true,
+            },
+            {
+                id: "billing",
+                label: "Billing",
+                path: "/admin/billing",
+                navVisible: false,
+                preview: true,
+            },
+        ],
+    },
 ] as const;
 
 export function getAreaById(id: NavAreaId): NavArea | undefined {
-	return navAreas.find((area) => area.id === id);
+    return navAreas.find((area) => area.id === id);
 }
 
 /** True when `pathname` is exactly `prefix` or a descendant of it. */
 function pathMatchesPrefix(pathname: string, prefix: string): boolean {
-	return pathname === prefix || pathname.startsWith(`${prefix}/`);
+    return pathname === prefix || pathname.startsWith(`${prefix}/`);
 }
 
 /**
@@ -733,40 +733,35 @@ function pathMatchesPrefix(pathname: string, prefix: string): boolean {
  * matches the pathname, fall back to the legacy `active` prop id.
  */
 export function selectedAreaIdForPathname(
-	areas: readonly NavArea[],
-	pathname: string,
-	fallbackActive?: string,
+    areas: readonly NavArea[],
+    pathname: string,
+    fallbackActive?: string,
 ): NavAreaId | undefined {
-	let selected: { id: NavAreaId; score: number } | undefined;
+    let selected: { id: NavAreaId; score: number } | undefined;
 
-	for (const area of areas) {
-		for (const prefix of area.ownedPathPrefixes) {
-			if (
-				pathMatchesPrefix(pathname, prefix) &&
-				prefix.length > (selected?.score ?? -1)
-			) {
-				selected = { id: area.id, score: prefix.length };
-			}
-		}
-	}
+    for (const area of areas) {
+        for (const prefix of area.ownedPathPrefixes) {
+            if (pathMatchesPrefix(pathname, prefix) && prefix.length > (selected?.score ?? -1)) {
+                selected = { id: area.id, score: prefix.length };
+            }
+        }
+    }
 
-	if (selected) return selected.id;
+    if (selected) return selected.id;
 
-	if (fallbackActive) {
-		const fallbackArea = areas.find(
-			(area) =>
-				area.id === fallbackActive ||
-				area.legacyActiveIds.includes(fallbackActive),
-		);
-		if (fallbackArea) return fallbackArea.id;
-	}
+    if (fallbackActive) {
+        const fallbackArea = areas.find(
+            (area) => area.id === fallbackActive || area.legacyActiveIds.includes(fallbackActive),
+        );
+        if (fallbackArea) return fallbackArea.id;
+    }
 
-	return undefined;
+    return undefined;
 }
 
 /** The routes a child claims for active-state. Defaults to `[child.path]`. */
 function ownedPathsFor(child: NavChildRoute): readonly string[] {
-	return child.ownedPaths ?? [child.path];
+    return child.ownedPaths ?? [child.path];
 }
 
 /**
@@ -779,24 +774,22 @@ function ownedPathsFor(child: NavChildRoute): readonly string[] {
  * (the area row is selected, but no child is).
  */
 export function selectedChildForPathname(
-	area: NavArea,
-	pathname: string,
+    area: NavArea,
+    pathname: string,
 ): NavChildRoute | undefined {
-	let selected: { child: NavChildRoute; score: number } | undefined;
+    let selected: { child: NavChildRoute; score: number } | undefined;
 
-	for (const child of area.children) {
-		if (!child.navVisible) continue;
-		for (const owned of ownedPathsFor(child)) {
-			const matches = child.exact
-				? pathname === owned
-				: pathMatchesPrefix(pathname, owned);
-			if (matches && owned.length > (selected?.score ?? -1)) {
-				selected = { child, score: owned.length };
-			}
-		}
-	}
+    for (const child of area.children) {
+        if (!child.navVisible) continue;
+        for (const owned of ownedPathsFor(child)) {
+            const matches = child.exact ? pathname === owned : pathMatchesPrefix(pathname, owned);
+            if (matches && owned.length > (selected?.score ?? -1)) {
+                selected = { child, score: owned.length };
+            }
+        }
+    }
 
-	return selected?.child;
+    return selected?.child;
 }
 
 /**
@@ -805,13 +798,13 @@ export function selectedChildForPathname(
  * helpers so route metadata can never drift from the sidebar (rule A6).
  */
 function resolveAreaAndChild(
-	pathname: string,
+    pathname: string,
 ): { area: NavArea; child?: NavChildRoute } | undefined {
-	const areaId = selectedAreaIdForPathname(navAreas, pathname);
-	if (!areaId) return undefined;
-	const area = getAreaById(areaId);
-	if (!area) return undefined;
-	return { area, child: selectedChildForPathname(area, pathname) };
+    const areaId = selectedAreaIdForPathname(navAreas, pathname);
+    if (!areaId) return undefined;
+    const area = getAreaById(areaId);
+    if (!area) return undefined;
+    return { area, child: selectedChildForPathname(area, pathname) };
 }
 
 /**
@@ -823,15 +816,15 @@ function resolveAreaAndChild(
  * Returns `[]` for routes no area owns (callers fall back to bespoke crumbs).
  */
 export function navTrailForPathname(pathname: string): Crumb[] {
-	const resolved = resolveAreaAndChild(pathname);
-	if (!resolved) return [];
-	const { area, child } = resolved;
+    const resolved = resolveAreaAndChild(pathname);
+    if (!resolved) return [];
+    const { area, child } = resolved;
 
-	if (!child) {
-		return [{ label: area.label }];
-	}
+    if (!child) {
+        return [{ label: area.label }];
+    }
 
-	return [{ label: area.label, href: area.href }, { label: child.label }];
+    return [{ label: area.label, href: area.href }, { label: child.label }];
 }
 
 /**
@@ -840,14 +833,14 @@ export function navTrailForPathname(pathname: string): Crumb[] {
  * empty string for routes no area owns so callers can supply their own.
  */
 export function navTitleForPathname(pathname: string): string {
-	const resolved = resolveAreaAndChild(pathname);
-	if (!resolved) return "";
-	const { area, child } = resolved;
-	if (child) return child.label;
-	return area.label;
+    const resolved = resolveAreaAndChild(pathname);
+    if (!resolved) return "";
+    const { area, child } = resolved;
+    if (child) return child.label;
+    return area.label;
 }
 
 /** Strip query/hash so route comparisons use the bare path. */
 export function basePath(href: string): string {
-	return href.split("?")[0].split("#")[0];
+    return href.split("?")[0].split("#")[0];
 }

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -25,38 +25,38 @@
 import type { Crumb } from "@/components/Breadcrumbs";
 
 export type NavAreaId =
-    | "cockpit"
-    | "diagnose"
-    | "plan"
-    | "improve"
-    | "govern"
-    | "ai"
-    | "reports"
-    | "admin";
+	| "cockpit"
+	| "diagnose"
+	| "plan"
+	| "improve"
+	| "govern"
+	| "ai"
+	| "reports"
+	| "admin";
 
 export type NavAreaHubItem = {
-    id: string;
-    label: string;
-    href: string;
-    description?: string;
-    // ── Signal-card descriptors (CHAOS-2074) ───────────────────────────────────
-    // Static metadata the area resolver pairs with a fetched value to build an
-    // `AreaSignal`. Kept here (the single nav source of truth) so the sidebar,
-    // landing hub, and signal resolvers can never drift. The *value* + *state* are
-    // resolved at request time by the area resolver (see `@/lib/areaSignals`);
-    // these fields only describe HOW a sub-area surfaces as a card.
-    /**
-     * Optional sub-group header within a dense area. Govern groups into
-     * "Quality" / "Risk"; flat areas (Diagnose, Improve) leave this undefined.
-     */
-    cluster?: string;
-    /** Short metric name shown on the card (e.g. "Line coverage", "Open criticals"). */
-    metricLabel?: string;
-    /**
-     * R4 low-value single surface (e.g. Feature Flags): render visually secondary
-     * within its cluster rather than at equal billing.
-     */
-    demoted?: boolean;
+	id: string;
+	label: string;
+	href: string;
+	description?: string;
+	// ── Signal-card descriptors (CHAOS-2074) ───────────────────────────────────
+	// Static metadata the area resolver pairs with a fetched value to build an
+	// `AreaSignal`. Kept here (the single nav source of truth) so the sidebar,
+	// landing hub, and signal resolvers can never drift. The *value* + *state* are
+	// resolved at request time by the area resolver (see `@/lib/areaSignals`);
+	// these fields only describe HOW a sub-area surfaces as a card.
+	/**
+	 * Optional sub-group header within a dense area. Govern groups into
+	 * "Quality" / "Risk"; flat areas (Diagnose, Improve) leave this undefined.
+	 */
+	cluster?: string;
+	/** Short metric name shown on the card (e.g. "Line coverage", "Open criticals"). */
+	metricLabel?: string;
+	/**
+	 * R4 low-value single surface (e.g. Feature Flags): render visually secondary
+	 * within its cluster rather than at equal billing.
+	 */
+	demoted?: boolean;
 };
 
 /**
@@ -71,656 +71,660 @@ export type NavAreaHubItem = {
  * `navVisible`; phantom/not-yet-built routes are `preview` and never rendered.
  */
 export type NavChildRoute = {
-    id: string;
-    label: string;
-    /** The child's canonical route — the sidebar row links here. */
-    path: string;
-    /** Rendered in the sidebar only when true. Preview routes stay false. */
-    navVisible: boolean;
-    /** Phantom/not-yet-built route held for reference; never rendered. */
-    preview?: boolean;
-    /**
-     * Routes whose active state resolves to THIS child (longest match wins among
-     * a single area's navVisible children). Defaults to `[path]`. A cluster child
-     * lists every route it fronts (e.g. `/testops/tests`, `/quality`).
-     */
-    ownedPaths?: string[];
-    exact?: boolean;
-    /** R4 low-value surface — render visually secondary within the list. */
-    demoted?: boolean;
-    /**
-     * True when this single row fronts several destinations behind one in-page
-     * tab strip (Phase 2). The sidebar shows ONE row; the tab strip lives on the
-     * page, not in the sidebar.
-     */
-    isCluster?: boolean;
+	id: string;
+	label: string;
+	/** The child's canonical route — the sidebar row links here. */
+	path: string;
+	/** Rendered in the sidebar only when true. Preview routes stay false. */
+	navVisible: boolean;
+	/** Phantom/not-yet-built route held for reference; never rendered. */
+	preview?: boolean;
+	/**
+	 * Routes whose active state resolves to THIS child (longest match wins among
+	 * a single area's navVisible children). Defaults to `[path]`. A cluster child
+	 * lists every route it fronts (e.g. `/testops/tests`, `/quality`).
+	 */
+	ownedPaths?: string[];
+	exact?: boolean;
+	/** R4 low-value surface — render visually secondary within the list. */
+	demoted?: boolean;
+	/**
+	 * True when this single row fronts several destinations behind one in-page
+	 * tab strip (Phase 2). The sidebar shows ONE row; the tab strip lives on the
+	 * page, not in the sidebar.
+	 */
+	isCluster?: boolean;
 };
 
 export type NavArea = {
-    id: NavAreaId;
-    label: string;
-    /** The area's landing route — what the sidebar row links to. */
-    href: string;
-    placement: "main" | "utility";
-    /**
-     * Route prefixes this area owns, used for active-state resolution. A pathname
-     * is matched against every area's prefixes; the longest matching prefix wins
-     * (so `/testops/risk` resolves to Govern, `/risk/compounding` to Govern, etc).
-     */
-    ownedPathPrefixes: string[];
-    /**
-     * Legacy per-page `active="…"` ids (the pre-collapse leaf ids). Used only as a
-     * fallback when no pathname prefix matches, so existing `<PrimaryNav active=…>`
-     * call sites keep highlighting the correct area without editing every page.
-     */
-    legacyActiveIds: string[];
-    /**
-     * Leaf destinations reachable from this area's landing page via `AreaHub`.
-     * Empty for areas whose only destination is the landing route itself.
-     */
-    hubItems: NavAreaHubItem[];
-    /**
-     * The two-level sidebar route tree (CHAOS-2075): the destinations the active
-     * area expands to as indented rows. DISTINCT from `hubItems` — see
-     * {@link NavChildRoute}. Empty when the area's only destination is its landing
-     * route (e.g. Cockpit).
-     */
-    children: NavChildRoute[];
+	id: NavAreaId;
+	label: string;
+	/** The area's landing route — what the sidebar row links to. */
+	href: string;
+	placement: "main" | "utility";
+	/**
+	 * Route prefixes this area owns, used for active-state resolution. A pathname
+	 * is matched against every area's prefixes; the longest matching prefix wins
+	 * (so `/testops/risk` resolves to Govern, `/risk/compounding` to Govern, etc).
+	 */
+	ownedPathPrefixes: string[];
+	/**
+	 * Legacy per-page `active="…"` ids (the pre-collapse leaf ids). Used only as a
+	 * fallback when no pathname prefix matches, so existing `<PrimaryNav active=…>`
+	 * call sites keep highlighting the correct area without editing every page.
+	 */
+	legacyActiveIds: string[];
+	/**
+	 * Leaf destinations reachable from this area's landing page via `AreaHub`.
+	 * Empty for areas whose only destination is the landing route itself.
+	 */
+	hubItems: NavAreaHubItem[];
+	/**
+	 * The two-level sidebar route tree (CHAOS-2075): the destinations the active
+	 * area expands to as indented rows. DISTINCT from `hubItems` — see
+	 * {@link NavChildRoute}. Empty when the area's only destination is its landing
+	 * route (e.g. Cockpit).
+	 */
+	children: NavChildRoute[];
 };
 
 export const navAreas: readonly NavArea[] = [
-    // ── Main spine ──────────────────────────────────────────────────────────────
-    {
-        id: "cockpit",
-        label: "Cockpit",
-        href: "/dashboard",
-        placement: "main",
-        ownedPathPrefixes: ["/dashboard"],
-        legacyActiveIds: ["home", "cockpit"],
-        hubItems: [],
-        // Cockpit's only destination is its landing route — no expandable children.
-        children: [],
-    },
-    {
-        id: "diagnose",
-        label: "Diagnose",
-        href: "/diagnose",
-        placement: "main",
-        ownedPathPrefixes: [
-            "/diagnose",
-            "/metrics",
-            "/team-flow",
-            "/investment",
-            "/people",
-            "/code",
-            "/landscape",
-            "/complexity",
-            "/cognitive-load",
-            "/bottleneck",
-        ],
-        legacyActiveIds: [
-            "work",
-            "flow",
-            "investment",
-            "people",
-            "code",
-            "landscape",
-            "complexity",
-            "cognitive-load",
-            "bottleneck",
-            "diagnose",
-        ],
-        // CHAOS-2074: Diagnose is FLAT (no clusters). Descriptors placed here; Phase
-        // 2 wires the resolver fetching (see `@/lib/areaSignals/getAreaSignals`).
-        hubItems: [
-            {
-                id: "flow",
-                label: "Flow",
-                href: "/metrics?tab=flow",
-                description: "Flow trends and delivery movement.",
-                metricLabel: "Deploy frequency",
-            },
-            {
-                id: "investment",
-                label: "Investment",
-                href: "/investment",
-                description: "Effort and attention allocation.",
-                metricLabel: "Planned allocation",
-            },
-            {
-                id: "code",
-                label: "Code",
-                href: "/code",
-                description: "Code health and ownership.",
-                metricLabel: "Code churn",
-            },
-            {
-                id: "landscape",
-                label: "Landscape",
-                href: "/landscape",
-                description: "System landscape overview.",
-                metricLabel: "Bus factor",
-            },
-            {
-                id: "complexity",
-                label: "Complexity",
-                href: "/complexity",
-                description: "Complexity trend and hotspots.",
-                metricLabel: "Avg complexity",
-            },
-            {
-                id: "cognitive-load",
-                label: "Cognitive Load",
-                href: "/cognitive-load",
-                description: "Focus and context-switch pressure.",
-                // Wired via the cognitiveLoad GraphQL resolver (CHAOS-2077):
-                // headline = avg PR interruption load over the window.
-                metricLabel: "Interruption load",
-            },
-            {
-                id: "bottleneck",
-                label: "Bottlenecks",
-                href: "/bottleneck",
-                description: "Flow bottleneck detection.",
-                metricLabel: "WIP saturation",
-            },
-        ],
-        children: [
-            {
-                id: "diagnose-overview",
-                label: "Overview",
-                path: "/diagnose",
-                navVisible: true,
-            },
-            {
-                id: "flow",
-                label: "Flow",
-                path: "/metrics?tab=flow",
-                navVisible: true,
-                ownedPaths: ["/metrics"],
-            },
-            {
-                id: "investment",
-                label: "Investment",
-                path: "/investment",
-                navVisible: true,
-            },
-            {
-                id: "landscape",
-                label: "Landscape",
-                path: "/landscape",
-                navVisible: true,
-            },
-            {
-                id: "work-graph",
-                label: "Work Graph",
-                path: "/diagnose/work-graph",
-                navVisible: true,
-            },
-            {
-                id: "complexity",
-                label: "Complexity",
-                path: "/complexity",
-                navVisible: true,
-            },
-            {
-                id: "cognitive-load",
-                label: "Cognitive Load",
-                path: "/cognitive-load",
-                navVisible: true,
-            },
-            {
-                id: "bottleneck",
-                label: "Bottlenecks",
-                path: "/bottleneck",
-                navVisible: true,
-            },
-            { id: "people", label: "People", path: "/people", navVisible: true },
-            { id: "code", label: "Code", path: "/code", navVisible: true },
-        ],
-    },
-    {
-        id: "plan",
-        label: "Plan",
-        href: "/plan",
-        placement: "main",
-        ownedPathPrefixes: ["/plan", "/capacity-planning", "/operating-review"],
-        legacyActiveIds: [
-            "capacity-planning",
-            "delivery-forecast",
-            "capacity",
-            "operating-review",
-            "plan",
-        ],
-        hubItems: [
-            {
-                id: "capacity",
-                label: "Capacity Forecast",
-                href: "/plan/capacity",
-                description: "Monte Carlo throughput forecasting.",
-                metricLabel: "Forecast window",
-            },
-            {
-                id: "operating-review",
-                label: "Operating Review",
-                href: "/operating-review",
-                description:
-                    "Monday-ready weekly agenda: delivery, bottlenecks, risk, reliability, and investment.",
-                metricLabel: "Weekly signals",
-            },
-        ],
-        children: [
-            {
-                id: "plan-overview",
-                label: "Overview",
-                path: "/plan",
-                navVisible: true,
-            },
-            {
-                id: "capacity",
-                label: "Capacity Forecast",
-                path: "/plan/capacity",
-                navVisible: true,
-            },
-            {
-                id: "operating-review",
-                label: "Operating Review",
-                path: "/operating-review",
-                navVisible: true,
-            },
-        ],
-    },
-    {
-        id: "improve",
-        label: "Improve",
-        href: "/improve",
-        placement: "main",
-        ownedPathPrefixes: ["/opportunities", "/improve"],
-        legacyActiveIds: ["opportunities", "experiments", "automations", "improve"],
-        hubItems: [
-            {
-                id: "opportunities",
-                label: "Opportunities",
-                href: "/opportunities",
-                description: "Evidence-linked improvement opportunities.",
-                metricLabel: "Opportunities data",
-            },
-            {
-                id: "experiments",
-                label: "Experiments",
-                href: "/improve/experiments",
-                description: "Run and track improvement experiments.",
-                metricLabel: "Experiments data",
-            },
-            {
-                id: "improve-automations",
-                label: "Automations",
-                href: "/improve/automations",
-                description: "Automated improvement workflows.",
-                metricLabel: "Automations data",
-            },
-        ],
-        children: [
-            {
-                id: "improve-overview",
-                label: "Overview",
-                path: "/improve",
-                navVisible: true,
-            },
-            {
-                id: "opportunities",
-                label: "Opportunities",
-                path: "/opportunities",
-                navVisible: true,
-            },
-            {
-                id: "experiments",
-                label: "Experiments",
-                path: "/improve/experiments",
-                navVisible: false,
-                preview: true,
-            },
-            {
-                id: "improve-automations",
-                label: "Automations",
-                path: "/improve/automations",
-                navVisible: false,
-                preview: true,
-            },
-        ],
-    },
-    {
-        id: "govern",
-        label: "Govern",
-        href: "/govern",
-        placement: "main",
-        ownedPathPrefixes: [
-            "/govern",
-            "/testops",
-            "/quality",
-            "/security",
-            "/feature-flags",
-            "/incident-correlation",
-            "/risk",
-        ],
-        legacyActiveIds: [
-            "testops",
-            "pipelines",
-            "tests",
-            "quality",
-            "coverage",
-            "risk",
-            "incident-correlation",
-            "security",
-            "feature-flags",
-            "risk-compounding",
-            "govern",
-        ],
-        // CHAOS-2074: Govern is sub-grouped into "Quality" and "Risk" clusters,
-        // each internally severity-sorted by the resolver (getGovernSignals).
-        hubItems: [
-            // ── Cluster: Quality ──────────────────────────────────────────────────
-            {
-                id: "testops",
-                label: "TestOps",
-                href: "/testops",
-                description: "Pipeline, test, and coverage health.",
-                cluster: "Quality",
-                metricLabel: "Worst TestOps signal",
-            },
-            {
-                id: "quality",
-                label: "Quality",
-                href: "/quality",
-                description: "Reliability and rework.",
-                cluster: "Quality",
-                metricLabel: "Change failure rate",
-            },
-            // ── Cluster: Risk ─────────────────────────────────────────────────────
-            {
-                id: "security",
-                label: "Security",
-                href: "/security",
-                description: "Security posture.",
-                cluster: "Risk",
-                metricLabel: "Open criticals",
-            },
-            {
-                id: "risk",
-                label: "Delivery Risk",
-                href: "/testops/risk",
-                description: "Delivery risk drag.",
-                cluster: "Risk",
-                metricLabel: "Release confidence",
-            },
-            {
-                id: "incident-correlation",
-                label: "Incident Correlation",
-                href: "/incident-correlation",
-                description: "Incidents correlated to changes.",
-                cluster: "Risk",
-                metricLabel: "Change failure rate",
-            },
-            {
-                id: "risk-compounding",
-                label: "Compounding Risk",
-                href: "/risk/compounding",
-                description: "Compounding risk signals.",
-                cluster: "Risk",
-                metricLabel: "Worst risk score",
-            },
-            {
-                id: "feature-flags",
-                label: "Feature Flags",
-                href: "/feature-flags",
-                description: "Flag lifecycle and debt.",
-                cluster: "Risk",
-                metricLabel: "Active flags",
-                // R4: low-value single surface — render secondary, not equal billing.
-                demoted: true,
-            },
-        ],
-        children: [
-            {
-                id: "govern-overview",
-                label: "Overview",
-                path: "/govern",
-                navVisible: true,
-            },
-            {
-                id: "testops",
-                label: "TestOps",
-                path: "/testops",
-                navVisible: true,
-                ownedPaths: [
-                    "/testops",
-                    "/testops/pipelines",
-                    "/testops/tests",
-                    "/testops/coverage",
-                ],
-                isCluster: true,
-            },
-            {
-                id: "quality",
-                label: "Quality",
-                path: "/quality",
-                navVisible: true,
-            },
-            {
-                id: "risk",
-                label: "Delivery Risk",
-                path: "/testops/risk",
-                navVisible: true,
-            },
-            {
-                id: "incident-correlation",
-                label: "Incident Correlation",
-                path: "/incident-correlation",
-                navVisible: true,
-            },
-            {
-                id: "security",
-                label: "Security",
-                path: "/security",
-                navVisible: true,
-            },
-            {
-                id: "feature-flags",
-                label: "Feature Flags",
-                path: "/feature-flags",
-                navVisible: true,
-                // R4 low-value surface — rendered visually secondary in the list.
-                demoted: true,
-            },
-            {
-                id: "risk-compounding",
-                label: "Compounding Risk",
-                path: "/risk/compounding",
-                navVisible: true,
-            },
-        ],
-    },
-    {
-        id: "ai",
-        label: "AI",
-        href: "/ai",
-        placement: "main",
-        ownedPathPrefixes: ["/ai"],
-        legacyActiveIds: ["ai", "ai-workflows"],
-        // CHAOS-2198: AI is sub-grouped into "Signal" (monitoring metrics) and
-        // "Action" (opportunity / recommendation surfaces), severity-sorted by
-        // the resolver (getAISignals). Mirrors the Govern cluster pattern.
-        hubItems: [
-            // ── Cluster: Signal ──────────────────────────────────────────────────
-            {
-                id: "ai-impact",
-                label: "Impact",
-                href: "/ai/impact",
-                description: "AI-assisted delivery and review impact.",
-                cluster: "Signal",
-                metricLabel: "AI impact",
-            },
-            {
-                id: "ai-review-load",
-                label: "Review Load",
-                href: "/ai/review-load",
-                description: "AI-associated review pressure.",
-                cluster: "Signal",
-                metricLabel: "Review pressure",
-            },
-            {
-                id: "ai-governance-risk",
-                label: "Governance Risk",
-                href: "/ai/risk",
-                description: "Quality and governance signals for AI-associated work.",
-                cluster: "Signal",
-                metricLabel: "Governance risk",
-            },
-            // ── Cluster: Action ──────────────────────────────────────────────────
-            {
-                id: "ai-automations",
-                label: "Automations",
-                href: "/ai/automations",
-                description: "Responsible automation opportunities.",
-                cluster: "Action",
-                metricLabel: "Automation candidates",
-            },
-        ],
-        children: [
-            { id: "ai-overview", label: "Overview", path: "/ai", navVisible: true },
-            {
-                id: "ai-impact",
-                label: "Impact",
-                path: "/ai/impact",
-                navVisible: true,
-            },
-            {
-                id: "ai-attribution",
-                label: "Attribution",
-                path: "/ai/attribution",
-                navVisible: false,
-                preview: true,
-            },
-            {
-                id: "ai-review-load",
-                label: "Review Load",
-                path: "/ai/review-load",
-                navVisible: true,
-            },
-            {
-                id: "ai-governance-risk",
-                label: "Governance Risk",
-                path: "/ai/risk",
-                // CHAOS-2197: Test Gaps + Evidence are in-page tabs here; their
-                // retired standalone routes redirect and resolve to this child.
-                ownedPaths: ["/ai/risk", "/ai/test-gaps", "/ai/evidence"],
-                navVisible: true,
-            },
-            {
-                id: "ai-automations",
-                label: "Automations",
-                path: "/ai/automations",
-                navVisible: true,
-            },
-        ],
-    },
-    // ── Utility tray ────────────────────────────────────────────────────────────
-    {
-        id: "reports",
-        label: "Reports",
-        href: "/reports",
-        placement: "utility",
-        ownedPathPrefixes: ["/reports"],
-        legacyActiveIds: ["reports"],
-        hubItems: [],
-        // Report Center is the only built destination. Weekly Review / Executive
-        // Summary / Export History are PREVIEW (phantom routes held for reference);
-        // they are never rendered and never resolved until their pages exist — DO
-        // NOT create stub pages for them (CHAOS-2075).
-        children: [
-            {
-                id: "report-center",
-                label: "Report Center",
-                path: "/reports",
-                navVisible: true,
-                exact: true,
-            },
-            {
-                id: "weekly-review",
-                label: "Weekly Review",
-                path: "/reports/weekly",
-                navVisible: false,
-                preview: true,
-            },
-            {
-                id: "executive-summary",
-                label: "Executive Summary",
-                path: "/reports/executive",
-                navVisible: false,
-                preview: true,
-            },
-            {
-                id: "export-history",
-                label: "Export History",
-                path: "/reports/exports",
-                navVisible: false,
-                preview: true,
-            },
-        ],
-    },
-    {
-        id: "admin",
-        label: "Admin",
-        href: "/admin",
-        placement: "utility",
-        // `/data-health` (Data Confidence) is an Admin destination outside `/admin`.
-        ownedPathPrefixes: ["/admin", "/settings", "/data-health"],
-        legacyActiveIds: ["admin", "settings", "data-health"],
-        hubItems: [],
-        children: [
-            {
-                id: "organization",
-                label: "Organization",
-                path: "/admin",
-                navVisible: true,
-                exact: true,
-            },
-            {
-                id: "connections",
-                label: "Connections",
-                path: "/admin/sync",
-                navVisible: true,
-            },
-            {
-                id: "data-confidence",
-                label: "Data Confidence",
-                path: "/data-health",
-                navVisible: true,
-            },
-            {
-                id: "settings",
-                label: "Settings",
-                path: "/settings",
-                navVisible: true,
-            },
-            {
-                id: "billing",
-                label: "Billing",
-                path: "/admin/billing",
-                navVisible: false,
-                preview: true,
-            },
-        ],
-    },
+	// ── Main spine ──────────────────────────────────────────────────────────────
+	{
+		id: "cockpit",
+		label: "Cockpit",
+		href: "/dashboard",
+		placement: "main",
+		ownedPathPrefixes: ["/dashboard"],
+		legacyActiveIds: ["home", "cockpit"],
+		hubItems: [],
+		// Cockpit's only destination is its landing route — no expandable children.
+		children: [],
+	},
+	{
+		id: "diagnose",
+		label: "Diagnose",
+		href: "/diagnose",
+		placement: "main",
+		ownedPathPrefixes: [
+			"/diagnose",
+			"/metrics",
+			"/team-flow",
+			"/investment",
+			"/people",
+			"/code",
+			"/landscape",
+			"/complexity",
+			"/cognitive-load",
+			"/bottleneck",
+		],
+		legacyActiveIds: [
+			"work",
+			"flow",
+			"investment",
+			"people",
+			"code",
+			"landscape",
+			"complexity",
+			"cognitive-load",
+			"bottleneck",
+			"diagnose",
+		],
+		// CHAOS-2074: Diagnose is FLAT (no clusters). Descriptors placed here; Phase
+		// 2 wires the resolver fetching (see `@/lib/areaSignals/getAreaSignals`).
+		hubItems: [
+			{
+				id: "flow",
+				label: "Flow",
+				href: "/metrics?tab=flow",
+				description: "Flow trends and delivery movement.",
+				metricLabel: "Deploy frequency",
+			},
+			{
+				id: "investment",
+				label: "Investment",
+				href: "/investment",
+				description: "Effort and attention allocation.",
+				metricLabel: "Planned allocation",
+			},
+			{
+				id: "code",
+				label: "Code",
+				href: "/code",
+				description: "Code health and ownership.",
+				metricLabel: "Code churn",
+			},
+			{
+				id: "landscape",
+				label: "Landscape",
+				href: "/landscape",
+				description: "System landscape overview.",
+				metricLabel: "Bus factor",
+			},
+			{
+				id: "complexity",
+				label: "Complexity",
+				href: "/complexity",
+				description: "Complexity trend and hotspots.",
+				metricLabel: "Avg complexity",
+			},
+			{
+				id: "cognitive-load",
+				label: "Cognitive Load",
+				href: "/cognitive-load",
+				description: "Focus and context-switch pressure.",
+				// Wired via the cognitiveLoad GraphQL resolver (CHAOS-2077):
+				// headline = avg PR interruption load over the window.
+				metricLabel: "Interruption load",
+			},
+			{
+				id: "bottleneck",
+				label: "Bottlenecks",
+				href: "/bottleneck",
+				description: "Flow bottleneck detection.",
+				metricLabel: "WIP saturation",
+			},
+		],
+		children: [
+			{
+				id: "diagnose-overview",
+				label: "Overview",
+				path: "/diagnose",
+				navVisible: true,
+			},
+			{
+				id: "flow",
+				label: "Flow",
+				path: "/metrics?tab=flow",
+				navVisible: true,
+				ownedPaths: ["/metrics"],
+			},
+			{
+				id: "investment",
+				label: "Investment",
+				path: "/investment",
+				navVisible: true,
+			},
+			{
+				id: "landscape",
+				label: "Landscape",
+				path: "/landscape",
+				navVisible: true,
+			},
+			{
+				id: "work-graph",
+				label: "Work Graph",
+				path: "/diagnose/work-graph",
+				navVisible: true,
+			},
+			{
+				id: "complexity",
+				label: "Complexity",
+				path: "/complexity",
+				navVisible: true,
+			},
+			{
+				id: "cognitive-load",
+				label: "Cognitive Load",
+				path: "/cognitive-load",
+				navVisible: true,
+			},
+			{
+				id: "bottleneck",
+				label: "Bottlenecks",
+				path: "/bottleneck",
+				navVisible: true,
+			},
+			{ id: "people", label: "People", path: "/people", navVisible: true },
+			{ id: "code", label: "Code", path: "/code", navVisible: true },
+		],
+	},
+	{
+		id: "plan",
+		label: "Plan",
+		href: "/plan",
+		placement: "main",
+		ownedPathPrefixes: ["/plan", "/capacity-planning", "/operating-review"],
+		legacyActiveIds: [
+			"capacity-planning",
+			"delivery-forecast",
+			"capacity",
+			"operating-review",
+			"plan",
+		],
+		hubItems: [
+			{
+				id: "capacity",
+				label: "Capacity Forecast",
+				href: "/plan/capacity",
+				description: "Monte Carlo throughput forecasting.",
+				metricLabel: "Forecast window",
+			},
+			{
+				id: "operating-review",
+				label: "Operating Review",
+				href: "/operating-review",
+				description:
+					"Monday-ready weekly agenda: delivery, bottlenecks, risk, reliability, and investment.",
+				metricLabel: "Weekly signals",
+			},
+		],
+		children: [
+			{
+				id: "plan-overview",
+				label: "Overview",
+				path: "/plan",
+				navVisible: true,
+			},
+			{
+				id: "capacity",
+				label: "Capacity Forecast",
+				path: "/plan/capacity",
+				navVisible: true,
+			},
+			{
+				id: "operating-review",
+				label: "Operating Review",
+				path: "/operating-review",
+				// Hidden from nav pending a hard rethink of the Operating Review
+				// surface (CHAOS-2181 follow-up). The route stays reachable by URL;
+				// `preview: true` per the IA invariant for navVisible:false children.
+				navVisible: false,
+				preview: true,
+			},
+		],
+	},
+	{
+		id: "improve",
+		label: "Improve",
+		href: "/improve",
+		placement: "main",
+		ownedPathPrefixes: ["/opportunities", "/improve"],
+		legacyActiveIds: ["opportunities", "experiments", "automations", "improve"],
+		hubItems: [
+			{
+				id: "opportunities",
+				label: "Opportunities",
+				href: "/opportunities",
+				description: "Evidence-linked improvement opportunities.",
+				metricLabel: "Opportunities data",
+			},
+			{
+				id: "experiments",
+				label: "Experiments",
+				href: "/improve/experiments",
+				description: "Run and track improvement experiments.",
+				metricLabel: "Experiments data",
+			},
+			{
+				id: "improve-automations",
+				label: "Automations",
+				href: "/improve/automations",
+				description: "Automated improvement workflows.",
+				metricLabel: "Automations data",
+			},
+		],
+		children: [
+			{
+				id: "improve-overview",
+				label: "Overview",
+				path: "/improve",
+				navVisible: true,
+			},
+			{
+				id: "opportunities",
+				label: "Opportunities",
+				path: "/opportunities",
+				navVisible: true,
+			},
+			{
+				id: "experiments",
+				label: "Experiments",
+				path: "/improve/experiments",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "improve-automations",
+				label: "Automations",
+				path: "/improve/automations",
+				navVisible: false,
+				preview: true,
+			},
+		],
+	},
+	{
+		id: "govern",
+		label: "Govern",
+		href: "/govern",
+		placement: "main",
+		ownedPathPrefixes: [
+			"/govern",
+			"/testops",
+			"/quality",
+			"/security",
+			"/feature-flags",
+			"/incident-correlation",
+			"/risk",
+		],
+		legacyActiveIds: [
+			"testops",
+			"pipelines",
+			"tests",
+			"quality",
+			"coverage",
+			"risk",
+			"incident-correlation",
+			"security",
+			"feature-flags",
+			"risk-compounding",
+			"govern",
+		],
+		// CHAOS-2074: Govern is sub-grouped into "Quality" and "Risk" clusters,
+		// each internally severity-sorted by the resolver (getGovernSignals).
+		hubItems: [
+			// ── Cluster: Quality ──────────────────────────────────────────────────
+			{
+				id: "testops",
+				label: "TestOps",
+				href: "/testops",
+				description: "Pipeline, test, and coverage health.",
+				cluster: "Quality",
+				metricLabel: "Worst TestOps signal",
+			},
+			{
+				id: "quality",
+				label: "Quality",
+				href: "/quality",
+				description: "Reliability and rework.",
+				cluster: "Quality",
+				metricLabel: "Change failure rate",
+			},
+			// ── Cluster: Risk ─────────────────────────────────────────────────────
+			{
+				id: "security",
+				label: "Security",
+				href: "/security",
+				description: "Security posture.",
+				cluster: "Risk",
+				metricLabel: "Open criticals",
+			},
+			{
+				id: "risk",
+				label: "Delivery Risk",
+				href: "/testops/risk",
+				description: "Delivery risk drag.",
+				cluster: "Risk",
+				metricLabel: "Release confidence",
+			},
+			{
+				id: "incident-correlation",
+				label: "Incident Correlation",
+				href: "/incident-correlation",
+				description: "Incidents correlated to changes.",
+				cluster: "Risk",
+				metricLabel: "Change failure rate",
+			},
+			{
+				id: "risk-compounding",
+				label: "Compounding Risk",
+				href: "/risk/compounding",
+				description: "Compounding risk signals.",
+				cluster: "Risk",
+				metricLabel: "Worst risk score",
+			},
+			{
+				id: "feature-flags",
+				label: "Feature Flags",
+				href: "/feature-flags",
+				description: "Flag lifecycle and debt.",
+				cluster: "Risk",
+				metricLabel: "Active flags",
+				// R4: low-value single surface — render secondary, not equal billing.
+				demoted: true,
+			},
+		],
+		children: [
+			{
+				id: "govern-overview",
+				label: "Overview",
+				path: "/govern",
+				navVisible: true,
+			},
+			{
+				id: "testops",
+				label: "TestOps",
+				path: "/testops",
+				navVisible: true,
+				ownedPaths: [
+					"/testops",
+					"/testops/pipelines",
+					"/testops/tests",
+					"/testops/coverage",
+				],
+				isCluster: true,
+			},
+			{
+				id: "quality",
+				label: "Quality",
+				path: "/quality",
+				navVisible: true,
+			},
+			{
+				id: "risk",
+				label: "Delivery Risk",
+				path: "/testops/risk",
+				navVisible: true,
+			},
+			{
+				id: "incident-correlation",
+				label: "Incident Correlation",
+				path: "/incident-correlation",
+				navVisible: true,
+			},
+			{
+				id: "security",
+				label: "Security",
+				path: "/security",
+				navVisible: true,
+			},
+			{
+				id: "feature-flags",
+				label: "Feature Flags",
+				path: "/feature-flags",
+				navVisible: true,
+				// R4 low-value surface — rendered visually secondary in the list.
+				demoted: true,
+			},
+			{
+				id: "risk-compounding",
+				label: "Compounding Risk",
+				path: "/risk/compounding",
+				navVisible: true,
+			},
+		],
+	},
+	{
+		id: "ai",
+		label: "AI",
+		href: "/ai",
+		placement: "main",
+		ownedPathPrefixes: ["/ai"],
+		legacyActiveIds: ["ai", "ai-workflows"],
+		// CHAOS-2198: AI is sub-grouped into "Signal" (monitoring metrics) and
+		// "Action" (opportunity / recommendation surfaces), severity-sorted by
+		// the resolver (getAISignals). Mirrors the Govern cluster pattern.
+		hubItems: [
+			// ── Cluster: Signal ──────────────────────────────────────────────────
+			{
+				id: "ai-impact",
+				label: "Impact",
+				href: "/ai/impact",
+				description: "AI-assisted delivery and review impact.",
+				cluster: "Signal",
+				metricLabel: "AI impact",
+			},
+			{
+				id: "ai-review-load",
+				label: "Review Load",
+				href: "/ai/review-load",
+				description: "AI-associated review pressure.",
+				cluster: "Signal",
+				metricLabel: "Review pressure",
+			},
+			{
+				id: "ai-governance-risk",
+				label: "Governance Risk",
+				href: "/ai/risk",
+				description: "Quality and governance signals for AI-associated work.",
+				cluster: "Signal",
+				metricLabel: "Governance risk",
+			},
+			// ── Cluster: Action ──────────────────────────────────────────────────
+			{
+				id: "ai-automations",
+				label: "Automations",
+				href: "/ai/automations",
+				description: "Responsible automation opportunities.",
+				cluster: "Action",
+				metricLabel: "Automation candidates",
+			},
+		],
+		children: [
+			{ id: "ai-overview", label: "Overview", path: "/ai", navVisible: true },
+			{
+				id: "ai-impact",
+				label: "Impact",
+				path: "/ai/impact",
+				navVisible: true,
+			},
+			{
+				id: "ai-attribution",
+				label: "Attribution",
+				path: "/ai/attribution",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "ai-review-load",
+				label: "Review Load",
+				path: "/ai/review-load",
+				navVisible: true,
+			},
+			{
+				id: "ai-governance-risk",
+				label: "Governance Risk",
+				path: "/ai/risk",
+				// CHAOS-2197: Test Gaps + Evidence are in-page tabs here; their
+				// retired standalone routes redirect and resolve to this child.
+				ownedPaths: ["/ai/risk", "/ai/test-gaps", "/ai/evidence"],
+				navVisible: true,
+			},
+			{
+				id: "ai-automations",
+				label: "Automations",
+				path: "/ai/automations",
+				navVisible: true,
+			},
+		],
+	},
+	// ── Utility tray ────────────────────────────────────────────────────────────
+	{
+		id: "reports",
+		label: "Reports",
+		href: "/reports",
+		placement: "utility",
+		ownedPathPrefixes: ["/reports"],
+		legacyActiveIds: ["reports"],
+		hubItems: [],
+		// Report Center is the only built destination. Weekly Review / Executive
+		// Summary / Export History are PREVIEW (phantom routes held for reference);
+		// they are never rendered and never resolved until their pages exist — DO
+		// NOT create stub pages for them (CHAOS-2075).
+		children: [
+			{
+				id: "report-center",
+				label: "Report Center",
+				path: "/reports",
+				navVisible: true,
+				exact: true,
+			},
+			{
+				id: "weekly-review",
+				label: "Weekly Review",
+				path: "/reports/weekly",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "executive-summary",
+				label: "Executive Summary",
+				path: "/reports/executive",
+				navVisible: false,
+				preview: true,
+			},
+			{
+				id: "export-history",
+				label: "Export History",
+				path: "/reports/exports",
+				navVisible: false,
+				preview: true,
+			},
+		],
+	},
+	{
+		id: "admin",
+		label: "Admin",
+		href: "/admin",
+		placement: "utility",
+		// `/data-health` (Data Confidence) is an Admin destination outside `/admin`.
+		ownedPathPrefixes: ["/admin", "/settings", "/data-health"],
+		legacyActiveIds: ["admin", "settings", "data-health"],
+		hubItems: [],
+		children: [
+			{
+				id: "organization",
+				label: "Organization",
+				path: "/admin",
+				navVisible: true,
+				exact: true,
+			},
+			{
+				id: "connections",
+				label: "Connections",
+				path: "/admin/sync",
+				navVisible: true,
+			},
+			{
+				id: "data-confidence",
+				label: "Data Confidence",
+				path: "/data-health",
+				navVisible: true,
+			},
+			{
+				id: "settings",
+				label: "Settings",
+				path: "/settings",
+				navVisible: true,
+			},
+			{
+				id: "billing",
+				label: "Billing",
+				path: "/admin/billing",
+				navVisible: false,
+				preview: true,
+			},
+		],
+	},
 ] as const;
 
 export function getAreaById(id: NavAreaId): NavArea | undefined {
-    return navAreas.find((area) => area.id === id);
+	return navAreas.find((area) => area.id === id);
 }
 
 /** True when `pathname` is exactly `prefix` or a descendant of it. */
 function pathMatchesPrefix(pathname: string, prefix: string): boolean {
-    return pathname === prefix || pathname.startsWith(`${prefix}/`);
+	return pathname === prefix || pathname.startsWith(`${prefix}/`);
 }
 
 /**
@@ -729,35 +733,40 @@ function pathMatchesPrefix(pathname: string, prefix: string): boolean {
  * matches the pathname, fall back to the legacy `active` prop id.
  */
 export function selectedAreaIdForPathname(
-    areas: readonly NavArea[],
-    pathname: string,
-    fallbackActive?: string,
+	areas: readonly NavArea[],
+	pathname: string,
+	fallbackActive?: string,
 ): NavAreaId | undefined {
-    let selected: { id: NavAreaId; score: number } | undefined;
+	let selected: { id: NavAreaId; score: number } | undefined;
 
-    for (const area of areas) {
-        for (const prefix of area.ownedPathPrefixes) {
-            if (pathMatchesPrefix(pathname, prefix) && prefix.length > (selected?.score ?? -1)) {
-                selected = { id: area.id, score: prefix.length };
-            }
-        }
-    }
+	for (const area of areas) {
+		for (const prefix of area.ownedPathPrefixes) {
+			if (
+				pathMatchesPrefix(pathname, prefix) &&
+				prefix.length > (selected?.score ?? -1)
+			) {
+				selected = { id: area.id, score: prefix.length };
+			}
+		}
+	}
 
-    if (selected) return selected.id;
+	if (selected) return selected.id;
 
-    if (fallbackActive) {
-        const fallbackArea = areas.find(
-            (area) => area.id === fallbackActive || area.legacyActiveIds.includes(fallbackActive),
-        );
-        if (fallbackArea) return fallbackArea.id;
-    }
+	if (fallbackActive) {
+		const fallbackArea = areas.find(
+			(area) =>
+				area.id === fallbackActive ||
+				area.legacyActiveIds.includes(fallbackActive),
+		);
+		if (fallbackArea) return fallbackArea.id;
+	}
 
-    return undefined;
+	return undefined;
 }
 
 /** The routes a child claims for active-state. Defaults to `[child.path]`. */
 function ownedPathsFor(child: NavChildRoute): readonly string[] {
-    return child.ownedPaths ?? [child.path];
+	return child.ownedPaths ?? [child.path];
 }
 
 /**
@@ -770,22 +779,24 @@ function ownedPathsFor(child: NavChildRoute): readonly string[] {
  * (the area row is selected, but no child is).
  */
 export function selectedChildForPathname(
-    area: NavArea,
-    pathname: string,
+	area: NavArea,
+	pathname: string,
 ): NavChildRoute | undefined {
-    let selected: { child: NavChildRoute; score: number } | undefined;
+	let selected: { child: NavChildRoute; score: number } | undefined;
 
-    for (const child of area.children) {
-        if (!child.navVisible) continue;
-        for (const owned of ownedPathsFor(child)) {
-            const matches = child.exact ? pathname === owned : pathMatchesPrefix(pathname, owned);
-            if (matches && owned.length > (selected?.score ?? -1)) {
-                selected = { child, score: owned.length };
-            }
-        }
-    }
+	for (const child of area.children) {
+		if (!child.navVisible) continue;
+		for (const owned of ownedPathsFor(child)) {
+			const matches = child.exact
+				? pathname === owned
+				: pathMatchesPrefix(pathname, owned);
+			if (matches && owned.length > (selected?.score ?? -1)) {
+				selected = { child, score: owned.length };
+			}
+		}
+	}
 
-    return selected?.child;
+	return selected?.child;
 }
 
 /**
@@ -794,13 +805,13 @@ export function selectedChildForPathname(
  * helpers so route metadata can never drift from the sidebar (rule A6).
  */
 function resolveAreaAndChild(
-    pathname: string,
+	pathname: string,
 ): { area: NavArea; child?: NavChildRoute } | undefined {
-    const areaId = selectedAreaIdForPathname(navAreas, pathname);
-    if (!areaId) return undefined;
-    const area = getAreaById(areaId);
-    if (!area) return undefined;
-    return { area, child: selectedChildForPathname(area, pathname) };
+	const areaId = selectedAreaIdForPathname(navAreas, pathname);
+	if (!areaId) return undefined;
+	const area = getAreaById(areaId);
+	if (!area) return undefined;
+	return { area, child: selectedChildForPathname(area, pathname) };
 }
 
 /**
@@ -812,15 +823,15 @@ function resolveAreaAndChild(
  * Returns `[]` for routes no area owns (callers fall back to bespoke crumbs).
  */
 export function navTrailForPathname(pathname: string): Crumb[] {
-    const resolved = resolveAreaAndChild(pathname);
-    if (!resolved) return [];
-    const { area, child } = resolved;
+	const resolved = resolveAreaAndChild(pathname);
+	if (!resolved) return [];
+	const { area, child } = resolved;
 
-    if (!child) {
-        return [{ label: area.label }];
-    }
+	if (!child) {
+		return [{ label: area.label }];
+	}
 
-    return [{ label: area.label, href: area.href }, { label: child.label }];
+	return [{ label: area.label, href: area.href }, { label: child.label }];
 }
 
 /**
@@ -829,14 +840,14 @@ export function navTrailForPathname(pathname: string): Crumb[] {
  * empty string for routes no area owns so callers can supply their own.
  */
 export function navTitleForPathname(pathname: string): string {
-    const resolved = resolveAreaAndChild(pathname);
-    if (!resolved) return "";
-    const { area, child } = resolved;
-    if (child) return child.label;
-    return area.label;
+	const resolved = resolveAreaAndChild(pathname);
+	if (!resolved) return "";
+	const { area, child } = resolved;
+	if (child) return child.label;
+	return area.label;
 }
 
 /** Strip query/hash so route comparisons use the bare path. */
 export function basePath(href: string): string {
-    return href.split("?")[0].split("#")[0];
+	return href.split("?")[0].split("#")[0];
 }

--- a/tests/nav-reachability.spec.ts
+++ b/tests/nav-reachability.spec.ts
@@ -1,79 +1,86 @@
-import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import {
+	expect,
+	test,
+	type APIRequestContext,
+	type Page,
+} from "@playwright/test";
 
 import { clickUntilUrl, waitForHydration } from "./helpers/nav";
 
 const primaryAreas = [
-    { label: "Cockpit", path: "/dashboard" },
-    { label: "Diagnose", path: "/diagnose" },
-    { label: "Plan", path: "/plan" },
-    { label: "Improve", path: "/improve" },
-    { label: "Govern", path: "/govern" },
-    { label: "AI", path: "/ai" },
-    { label: "Reports", path: "/reports" },
-    { label: "Admin", path: "/admin" },
+	{ label: "Cockpit", path: "/dashboard" },
+	{ label: "Diagnose", path: "/diagnose" },
+	{ label: "Plan", path: "/plan" },
+	{ label: "Improve", path: "/improve" },
+	{ label: "Govern", path: "/govern" },
+	{ label: "AI", path: "/ai" },
+	{ label: "Reports", path: "/reports" },
+	{ label: "Admin", path: "/admin" },
 ] as const;
 
 // Leaf labels that must NOT appear as flat sidebar rows anymore.
-// NOTE: "Operating Review" was here when it was a hidden preview. It has been
-// promoted to a visible Plan child (CHAOS-2181) and therefore removed from this list.
+// NOTE: "Operating Review" was promoted to a visible Plan child (CHAOS-2181),
+// then hidden again pending a hard rethink (CHAOS-2181 follow-up). The route
+// stays reachable by URL; the nav row must not render.
 const collapsedLeafLabels = [
-    "Flow",
-    "Investment",
-    "Landscape",
-    "People",
-    "Code",
-    "Complexity",
-    "Cognitive Load",
-    "Bottlenecks",
-    "Delivery Forecast",
-    "Pipelines",
-    "Tests",
-    "Quality",
-    "Coverage",
-    "Delivery Risk",
-    "Incident Correlation",
-    "Security",
-    "Feature Flags",
-    "Compounding Risk",
-    "Report Center",
+	"Operating Review",
+	"Flow",
+	"Investment",
+	"Landscape",
+	"People",
+	"Code",
+	"Complexity",
+	"Cognitive Load",
+	"Bottlenecks",
+	"Delivery Forecast",
+	"Pipelines",
+	"Tests",
+	"Quality",
+	"Coverage",
+	"Delivery Risk",
+	"Incident Correlation",
+	"Security",
+	"Feature Flags",
+	"Compounding Risk",
+	"Report Center",
 ] as const;
 
 const reachableRoutes = [
-    "/dashboard",
-    "/plan",
-    "/plan/delivery-forecast",
-    "/plan/capacity",
-    "/operating-review",
-    "/diagnose",
-    "/metrics",
-    "/people",
-    "/code",
-    "/landscape",
-    "/complexity",
-    "/cognitive-load",
-    "/bottleneck",
-    "/improve",
-    "/opportunities",
-    "/ai",
-    "/ai/impact",
-    "/ai/attribution",
-    "/ai/review-load",
-    "/ai/test-gaps",
-    "/ai/risk",
-    "/ai/evidence",
-    "/ai/automations",
-    "/testops",
-    "/testops/pipelines",
-    "/testops/tests",
-    "/testops/coverage",
-    "/testops/risk",
-    "/quality",
-    "/security",
-    "/feature-flags",
-    "/incident-correlation",
-    "/risk/compounding",
-    "/reports",
-    "/admin",
+	"/dashboard",
+	"/plan",
+	"/plan/delivery-forecast",
+	"/plan/capacity",
+	"/operating-review",
+	"/diagnose",
+	"/metrics",
+	"/people",
+	"/code",
+	"/landscape",
+	"/complexity",
+	"/cognitive-load",
+	"/bottleneck",
+	"/improve",
+	"/opportunities",
+	"/ai",
+	"/ai/impact",
+	"/ai/attribution",
+	"/ai/review-load",
+	"/ai/test-gaps",
+	"/ai/risk",
+	"/ai/evidence",
+	"/ai/automations",
+	"/testops",
+	"/testops/pipelines",
+	"/testops/tests",
+	"/testops/coverage",
+	"/testops/risk",
+	"/quality",
+	"/security",
+	"/feature-flags",
+	"/incident-correlation",
+	"/risk/compounding",
+	"/reports",
+	"/admin",
 ] as const;
 
 /**
@@ -84,243 +91,251 @@ const reachableRoutes = [
  * route reachable / not a 404". Retries absorb transient dev-server aborts under load.
  */
 async function expectReachable(request: APIRequestContext, path: string) {
-    await expect(async () => {
-        const response = await request.get(path);
-        const status = response.status();
-        expect(status, `${path} returned ${status}`).not.toBe(404);
-        expect(status, `${path} returned ${status}`).toBeLessThan(500);
-    }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
+	await expect(async () => {
+		const response = await request.get(path);
+		const status = response.status();
+		expect(status, `${path} returned ${status}`).not.toBe(404);
+		expect(status, `${path} returned ${status}`).toBeLessThan(500);
+	}).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
 }
 
-async function expectSingleSelectedArea(page: Page, path: string, selectedLabel: string) {
-    await expect(async () => {
-        await page.goto(path, { waitUntil: "domcontentloaded" });
+async function expectSingleSelectedArea(
+	page: Page,
+	path: string,
+	selectedLabel: string,
+) {
+	await expect(async () => {
+		await page.goto(path, { waitUntil: "domcontentloaded" });
 
-        // CHAOS-2075 two-level nav: aria-current marks the current-page link (a child
-        // leaf on a leaf route, the area row on a landing), so the active AREA is marked
-        // with data-active instead. Assert exactly one area is active and it's the
-        // expected one — rendered from usePathname(), independent of the ?f= append.
-        const selectedArea = page.locator('aside a[data-active="true"]');
-        await expect(selectedArea).toHaveCount(1, { timeout: 15000 });
-        await expect(selectedArea).toHaveText(selectedLabel);
-    }).toPass({ timeout: 45000, intervals: [500, 1000, 2000] });
+		// CHAOS-2075 two-level nav: aria-current marks the current-page link (a child
+		// leaf on a leaf route, the area row on a landing), so the active AREA is marked
+		// with data-active instead. Assert exactly one area is active and it's the
+		// expected one — rendered from usePathname(), independent of the ?f= append.
+		const selectedArea = page.locator('aside a[data-active="true"]');
+		await expect(selectedArea).toHaveCount(1, { timeout: 15000 });
+		await expect(selectedArea).toHaveText(selectedLabel);
+	}).toPass({ timeout: 45000, intervals: [500, 1000, 2000] });
 }
 
 test.describe("primary navigation reachability", () => {
-    test("sidebar surfaces exactly the decision areas as links, no flat leaf rows", async ({
-        page,
-    }) => {
-        await page.goto("/dashboard");
-        await waitForHydration(page);
+	test("sidebar surfaces exactly the decision areas as links, no flat leaf rows", async ({
+		page,
+	}) => {
+		await page.goto("/dashboard");
+		await waitForHydration(page);
 
-        const aside = page.locator("aside");
+		const aside = page.locator("aside");
 
-        for (const area of primaryAreas) {
-            await expect(
-                aside.getByRole("link", { name: area.label, exact: true }),
-            ).toHaveAttribute("href", new RegExp(`${area.path}(?:[?#].*)?`));
-        }
+		for (const area of primaryAreas) {
+			await expect(
+				aside.getByRole("link", { name: area.label, exact: true }),
+			).toHaveAttribute("href", new RegExp(`${area.path}(?:[?#].*)?`));
+		}
 
-        // Leaf destinations are no longer enumerated flat in the sidebar.
-        for (const leaf of collapsedLeafLabels) {
-            await expect(aside.getByRole("link", { name: leaf, exact: true })).toHaveCount(0);
-        }
-    });
+		// Leaf destinations are no longer enumerated flat in the sidebar.
+		for (const leaf of collapsedLeafLabels) {
+			await expect(
+				aside.getByRole("link", { name: leaf, exact: true }),
+			).toHaveCount(0);
+		}
+	});
 
-    test("reaches Plan as a top-level area and routes its visible subviews", async ({
-        page,
-        request,
-    }) => {
-        await page.goto("/dashboard");
-        await waitForHydration(page);
+	test("reaches Plan as a top-level area and routes its visible subviews", async ({
+		page,
+		request,
+	}) => {
+		await page.goto("/dashboard");
+		await waitForHydration(page);
 
-        const sidebar = page.locator("aside");
+		const sidebar = page.locator("aside");
 
-        await clickUntilUrl(
-            page,
-            sidebar.getByRole("link", { name: "Plan", exact: true }),
-            /\/plan(?:[?#].*)?$/,
-        );
+		await clickUntilUrl(
+			page,
+			sidebar.getByRole("link", { name: "Plan", exact: true }),
+			/\/plan(?:[?#].*)?$/,
+		);
 
-        const planChildren = page.getByTestId("nav-children-plan");
-        await expect(planChildren).toBeVisible({ timeout: 15000 });
+		const planChildren = page.getByTestId("nav-children-plan");
+		await expect(planChildren).toBeVisible({ timeout: 15000 });
 
-        for (const child of [
-            { label: "Overview", url: /\/plan(?:[?#].*)?$/, path: "/plan" },
-            {
-                label: "Capacity Forecast",
-                url: /\/plan\/capacity(?:[?#].*)?$/,
-                path: "/plan/capacity",
-            },
-            {
-                label: "Operating Review",
-                url: /\/operating-review(?:[?#].*)?$/,
-                path: "/operating-review",
-            },
-        ]) {
-            await clickUntilUrl(
-                page,
-                planChildren.getByRole("link", { name: child.label, exact: true }),
-                child.url,
-            );
-            await expectReachable(request, child.path);
-        }
-    });
+		for (const child of [
+			{ label: "Overview", url: /\/plan(?:[?#].*)?$/, path: "/plan" },
+			{
+				label: "Capacity Forecast",
+				url: /\/plan\/capacity(?:[?#].*)?$/,
+				path: "/plan/capacity",
+			},
+			// "Operating Review" is hidden from nav (navVisible: false) pending
+			// a rethink — see collapsedLeafLabels above. Route stays reachable
+			// by URL (asserted via reachableRoutes).
+		]) {
+			await clickUntilUrl(
+				page,
+				planChildren.getByRole("link", { name: child.label, exact: true }),
+				child.url,
+			);
+			await expectReachable(request, child.path);
+		}
+	});
 
-    test("reaches Diagnose as a top-level area and routes its visible subviews", async ({
-        page,
-    }) => {
-        await page.goto("/dashboard");
-        await waitForHydration(page);
+	test("reaches Diagnose as a top-level area and routes its visible subviews", async ({
+		page,
+	}) => {
+		await page.goto("/dashboard");
+		await waitForHydration(page);
 
-        const sidebar = page.locator("aside");
+		const sidebar = page.locator("aside");
 
-        await clickUntilUrl(
-            page,
-            sidebar.getByRole("link", { name: "Diagnose", exact: true }),
-            /\/diagnose(?:[?#].*)?$/,
-        );
+		await clickUntilUrl(
+			page,
+			sidebar.getByRole("link", { name: "Diagnose", exact: true }),
+			/\/diagnose(?:[?#].*)?$/,
+		);
 
-        const diagnoseChildren = page.getByTestId("nav-children-diagnose");
-        await expect(diagnoseChildren).toBeVisible({ timeout: 15000 });
+		const diagnoseChildren = page.getByTestId("nav-children-diagnose");
+		await expect(diagnoseChildren).toBeVisible({ timeout: 15000 });
 
-        const children = [
-            { label: "Overview", url: /\/diagnose(?:[?#].*)?$/, path: "/diagnose" },
-            { label: "Flow", url: /\/metrics(?:[?#].*)?$/, path: "/metrics" },
-            {
-                label: "Investment",
-                url: /\/investment(?:[?#].*)?$/,
-                path: "/investment",
-            },
-            {
-                label: "Landscape",
-                url: /\/landscape(?:[?#].*)?$/,
-                path: "/landscape",
-            },
-            {
-                label: "Work Graph",
-                url: /\/diagnose\/work-graph(?:[?#].*)?$/,
-                path: "/diagnose/work-graph",
-            },
-            { label: "People", url: /\/people(?:[?#].*)?$/, path: "/people" },
-            { label: "Code", url: /\/code(?:[?#].*)?$/, path: "/code" },
-            {
-                label: "Complexity",
-                url: /\/complexity(?:[?#].*)?$/,
-                path: "/complexity",
-            },
-            {
-                label: "Cognitive Load",
-                url: /\/cognitive-load(?:[?#].*)?$/,
-                path: "/cognitive-load",
-            },
-            {
-                label: "Bottlenecks",
-                url: /\/bottleneck(?:[?#].*)?$/,
-                path: "/bottleneck",
-            },
-        ];
+		const children = [
+			{ label: "Overview", url: /\/diagnose(?:[?#].*)?$/, path: "/diagnose" },
+			{ label: "Flow", url: /\/metrics(?:[?#].*)?$/, path: "/metrics" },
+			{
+				label: "Investment",
+				url: /\/investment(?:[?#].*)?$/,
+				path: "/investment",
+			},
+			{
+				label: "Landscape",
+				url: /\/landscape(?:[?#].*)?$/,
+				path: "/landscape",
+			},
+			{
+				label: "Work Graph",
+				url: /\/diagnose\/work-graph(?:[?#].*)?$/,
+				path: "/diagnose/work-graph",
+			},
+			{ label: "People", url: /\/people(?:[?#].*)?$/, path: "/people" },
+			{ label: "Code", url: /\/code(?:[?#].*)?$/, path: "/code" },
+			{
+				label: "Complexity",
+				url: /\/complexity(?:[?#].*)?$/,
+				path: "/complexity",
+			},
+			{
+				label: "Cognitive Load",
+				url: /\/cognitive-load(?:[?#].*)?$/,
+				path: "/cognitive-load",
+			},
+			{
+				label: "Bottlenecks",
+				url: /\/bottleneck(?:[?#].*)?$/,
+				path: "/bottleneck",
+			},
+		];
 
-        // Every Diagnose child renders with the correct destination href. This is a
-        // cheap DOM assertion on purpose: browser-navigating all ~10 chart-heavy
-        // children in series wedged the dev server under CI's constrained runners
-        // (net::ERR_ABORTED / "[WebServer] Error: aborted"), failing every retry.
-        // Full SSR reachability of every route is covered by the dedicated
-        // "every former leaf destination still resolves" test below.
-        for (const child of children) {
-            await expect(
-                diagnoseChildren.getByRole("link", { name: child.label, exact: true }),
-            ).toHaveAttribute("href", new RegExp(`${child.path}(?:[?#].*)?`));
-        }
+		// Every Diagnose child renders with the correct destination href. This is a
+		// cheap DOM assertion on purpose: browser-navigating all ~10 chart-heavy
+		// children in series wedged the dev server under CI's constrained runners
+		// (net::ERR_ABORTED / "[WebServer] Error: aborted"), failing every retry.
+		// Full SSR reachability of every route is covered by the dedicated
+		// "every former leaf destination still resolves" test below.
+		for (const child of children) {
+			await expect(
+				diagnoseChildren.getByRole("link", { name: child.label, exact: true }),
+			).toHaveAttribute("href", new RegExp(`${child.path}(?:[?#].*)?`));
+		}
 
-        // Click-verify a representative subset actually routes: the overview landing,
-        // a chart leaf, and the People leaf whose nav regressed in CHAOS-2158.
-        for (const child of [children[0], children[1], children[5]]) {
-            await clickUntilUrl(
-                page,
-                diagnoseChildren.getByRole("link", { name: child.label, exact: true }),
-                child.url,
-            );
-        }
-    });
+		// Click-verify a representative subset actually routes: the overview landing,
+		// a chart leaf, and the People leaf whose nav regressed in CHAOS-2158.
+		for (const child of [children[0], children[1], children[5]]) {
+			await clickUntilUrl(
+				page,
+				diagnoseChildren.getByRole("link", { name: child.label, exact: true }),
+				child.url,
+			);
+		}
+	});
 
-    test("every former leaf destination still resolves without 404", async ({ request }) => {
-        // ~30 sequential SSR reachability fetches; Turbopack cold-compiles each route
-        // on first hit under suite load, which overruns the default 30s test budget.
-        test.setTimeout(120_000);
-        for (const route of reachableRoutes) {
-            await expectReachable(request, route);
-        }
-    });
+	test("every former leaf destination still resolves without 404", async ({
+		request,
+	}) => {
+		// ~30 sequential SSR reachability fetches; Turbopack cold-compiles each route
+		// on first hit under suite load, which overruns the default 30s test budget.
+		test.setTimeout(120_000);
+		for (const route of reachableRoutes) {
+			await expectReachable(request, route);
+		}
+	});
 
-    test("reaches AI as a top-level area and routes its visible subviews", async ({
-        page,
-        request,
-    }) => {
-        await page.goto("/dashboard");
-        await waitForHydration(page);
+	test("reaches AI as a top-level area and routes its visible subviews", async ({
+		page,
+		request,
+	}) => {
+		await page.goto("/dashboard");
+		await waitForHydration(page);
 
-        const sidebar = page.locator("aside");
+		const sidebar = page.locator("aside");
 
-        // The AI area row is a top-level sibling of Diagnose/Improve/Govern and links
-        // to the /ai workspace.
-        await clickUntilUrl(
-            page,
-            sidebar.getByRole("link", { name: "AI", exact: true }),
-            /\/ai(?:[?#].*)?$/,
-        );
+		// The AI area row is a top-level sibling of Diagnose/Improve/Govern and links
+		// to the /ai workspace.
+		await clickUntilUrl(
+			page,
+			sidebar.getByRole("link", { name: "AI", exact: true }),
+			/\/ai(?:[?#].*)?$/,
+		);
 
-        // The active AI area expands to exactly its navVisible children (areas.ts).
-        const aiChildren = page.getByTestId("nav-children-ai");
-        await expect(aiChildren).toBeVisible({ timeout: 15000 });
+		// The active AI area expands to exactly its navVisible children (areas.ts).
+		const aiChildren = page.getByTestId("nav-children-ai");
+		await expect(aiChildren).toBeVisible({ timeout: 15000 });
 
-        for (const child of [
-            { label: "Overview", url: /\/ai(?:[?#].*)?$/, path: "/ai" },
-            {
-                label: "Impact",
-                url: /\/ai\/impact(?:[?#].*)?$/,
-                path: "/ai/impact",
-            },
-            {
-                label: "Review Load",
-                url: /\/ai\/review-load(?:[?#].*)?$/,
-                path: "/ai/review-load",
-            },
-            {
-                label: "Governance Risk",
-                url: /\/ai\/risk(?:[?#].*)?$/,
-                path: "/ai/risk",
-            },
-            {
-                label: "Automations",
-                url: /\/ai\/automations(?:[?#].*)?$/,
-                path: "/ai/automations",
-            },
-        ]) {
-            await clickUntilUrl(
-                page,
-                aiChildren.getByRole("link", { name: child.label, exact: true }),
-                child.url,
-            );
-            await expectReachable(request, child.path);
-        }
-    });
+		for (const child of [
+			{ label: "Overview", url: /\/ai(?:[?#].*)?$/, path: "/ai" },
+			{
+				label: "Impact",
+				url: /\/ai\/impact(?:[?#].*)?$/,
+				path: "/ai/impact",
+			},
+			{
+				label: "Review Load",
+				url: /\/ai\/review-load(?:[?#].*)?$/,
+				path: "/ai/review-load",
+			},
+			{
+				label: "Governance Risk",
+				url: /\/ai\/risk(?:[?#].*)?$/,
+				path: "/ai/risk",
+			},
+			{
+				label: "Automations",
+				url: /\/ai\/automations(?:[?#].*)?$/,
+				path: "/ai/automations",
+			},
+		]) {
+			await clickUntilUrl(
+				page,
+				aiChildren.getByRole("link", { name: child.label, exact: true }),
+				child.url,
+			);
+			await expectReachable(request, child.path);
+		}
+	});
 
-    test("marks exactly one area as selected for representative leaf routes", async ({ page }) => {
-        test.setTimeout(120_000);
+	test("marks exactly one area as selected for representative leaf routes", async ({
+		page,
+	}) => {
+		test.setTimeout(120_000);
 
-        for (const route of [
-            { path: "/metrics?tab=dora", selectedLabel: "Diagnose" },
-            { path: "/landscape", selectedLabel: "Diagnose" },
-            { path: "/testops/coverage", selectedLabel: "Govern" },
-            { path: "/testops/risk", selectedLabel: "Govern" },
-            { path: "/bottleneck", selectedLabel: "Diagnose" },
-            { path: "/risk/compounding", selectedLabel: "Govern" },
-            { path: "/plan/delivery-forecast", selectedLabel: "Plan" },
-            { path: "/plan/capacity", selectedLabel: "Plan" },
-            { path: "/operating-review", selectedLabel: "Plan" },
-        ]) {
-            await expectSingleSelectedArea(page, route.path, route.selectedLabel);
-        }
-    });
+		for (const route of [
+			{ path: "/metrics?tab=dora", selectedLabel: "Diagnose" },
+			{ path: "/landscape", selectedLabel: "Diagnose" },
+			{ path: "/testops/coverage", selectedLabel: "Govern" },
+			{ path: "/testops/risk", selectedLabel: "Govern" },
+			{ path: "/bottleneck", selectedLabel: "Diagnose" },
+			{ path: "/risk/compounding", selectedLabel: "Govern" },
+			{ path: "/plan/delivery-forecast", selectedLabel: "Plan" },
+			{ path: "/plan/capacity", selectedLabel: "Plan" },
+			{ path: "/operating-review", selectedLabel: "Plan" },
+		]) {
+			await expectSingleSelectedArea(page, route.path, route.selectedLabel);
+		}
+	});
 });

--- a/tests/nav-reachability.spec.ts
+++ b/tests/nav-reachability.spec.ts
@@ -1,21 +1,16 @@
-import {
-	expect,
-	test,
-	type APIRequestContext,
-	type Page,
-} from "@playwright/test";
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
 
 import { clickUntilUrl, waitForHydration } from "./helpers/nav";
 
 const primaryAreas = [
-	{ label: "Cockpit", path: "/dashboard" },
-	{ label: "Diagnose", path: "/diagnose" },
-	{ label: "Plan", path: "/plan" },
-	{ label: "Improve", path: "/improve" },
-	{ label: "Govern", path: "/govern" },
-	{ label: "AI", path: "/ai" },
-	{ label: "Reports", path: "/reports" },
-	{ label: "Admin", path: "/admin" },
+    { label: "Cockpit", path: "/dashboard" },
+    { label: "Diagnose", path: "/diagnose" },
+    { label: "Plan", path: "/plan" },
+    { label: "Improve", path: "/improve" },
+    { label: "Govern", path: "/govern" },
+    { label: "AI", path: "/ai" },
+    { label: "Reports", path: "/reports" },
+    { label: "Admin", path: "/admin" },
 ] as const;
 
 // Leaf labels that must NOT appear as flat sidebar rows anymore.
@@ -23,64 +18,64 @@ const primaryAreas = [
 // then hidden again pending a hard rethink (CHAOS-2181 follow-up). The route
 // stays reachable by URL; the nav row must not render.
 const collapsedLeafLabels = [
-	"Operating Review",
-	"Flow",
-	"Investment",
-	"Landscape",
-	"People",
-	"Code",
-	"Complexity",
-	"Cognitive Load",
-	"Bottlenecks",
-	"Delivery Forecast",
-	"Pipelines",
-	"Tests",
-	"Quality",
-	"Coverage",
-	"Delivery Risk",
-	"Incident Correlation",
-	"Security",
-	"Feature Flags",
-	"Compounding Risk",
-	"Report Center",
+    "Operating Review",
+    "Flow",
+    "Investment",
+    "Landscape",
+    "People",
+    "Code",
+    "Complexity",
+    "Cognitive Load",
+    "Bottlenecks",
+    "Delivery Forecast",
+    "Pipelines",
+    "Tests",
+    "Quality",
+    "Coverage",
+    "Delivery Risk",
+    "Incident Correlation",
+    "Security",
+    "Feature Flags",
+    "Compounding Risk",
+    "Report Center",
 ] as const;
 
 const reachableRoutes = [
-	"/dashboard",
-	"/plan",
-	"/plan/delivery-forecast",
-	"/plan/capacity",
-	"/operating-review",
-	"/diagnose",
-	"/metrics",
-	"/people",
-	"/code",
-	"/landscape",
-	"/complexity",
-	"/cognitive-load",
-	"/bottleneck",
-	"/improve",
-	"/opportunities",
-	"/ai",
-	"/ai/impact",
-	"/ai/attribution",
-	"/ai/review-load",
-	"/ai/test-gaps",
-	"/ai/risk",
-	"/ai/evidence",
-	"/ai/automations",
-	"/testops",
-	"/testops/pipelines",
-	"/testops/tests",
-	"/testops/coverage",
-	"/testops/risk",
-	"/quality",
-	"/security",
-	"/feature-flags",
-	"/incident-correlation",
-	"/risk/compounding",
-	"/reports",
-	"/admin",
+    "/dashboard",
+    "/plan",
+    "/plan/delivery-forecast",
+    "/plan/capacity",
+    "/operating-review",
+    "/diagnose",
+    "/metrics",
+    "/people",
+    "/code",
+    "/landscape",
+    "/complexity",
+    "/cognitive-load",
+    "/bottleneck",
+    "/improve",
+    "/opportunities",
+    "/ai",
+    "/ai/impact",
+    "/ai/attribution",
+    "/ai/review-load",
+    "/ai/test-gaps",
+    "/ai/risk",
+    "/ai/evidence",
+    "/ai/automations",
+    "/testops",
+    "/testops/pipelines",
+    "/testops/tests",
+    "/testops/coverage",
+    "/testops/risk",
+    "/quality",
+    "/security",
+    "/feature-flags",
+    "/incident-correlation",
+    "/risk/compounding",
+    "/reports",
+    "/admin",
 ] as const;
 
 /**
@@ -91,251 +86,241 @@ const reachableRoutes = [
  * route reachable / not a 404". Retries absorb transient dev-server aborts under load.
  */
 async function expectReachable(request: APIRequestContext, path: string) {
-	await expect(async () => {
-		const response = await request.get(path);
-		const status = response.status();
-		expect(status, `${path} returned ${status}`).not.toBe(404);
-		expect(status, `${path} returned ${status}`).toBeLessThan(500);
-	}).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
+    await expect(async () => {
+        const response = await request.get(path);
+        const status = response.status();
+        expect(status, `${path} returned ${status}`).not.toBe(404);
+        expect(status, `${path} returned ${status}`).toBeLessThan(500);
+    }).toPass({ timeout: 30000, intervals: [500, 1000, 2000] });
 }
 
-async function expectSingleSelectedArea(
-	page: Page,
-	path: string,
-	selectedLabel: string,
-) {
-	await expect(async () => {
-		await page.goto(path, { waitUntil: "domcontentloaded" });
+async function expectSingleSelectedArea(page: Page, path: string, selectedLabel: string) {
+    await expect(async () => {
+        await page.goto(path, { waitUntil: "domcontentloaded" });
 
-		// CHAOS-2075 two-level nav: aria-current marks the current-page link (a child
-		// leaf on a leaf route, the area row on a landing), so the active AREA is marked
-		// with data-active instead. Assert exactly one area is active and it's the
-		// expected one — rendered from usePathname(), independent of the ?f= append.
-		const selectedArea = page.locator('aside a[data-active="true"]');
-		await expect(selectedArea).toHaveCount(1, { timeout: 15000 });
-		await expect(selectedArea).toHaveText(selectedLabel);
-	}).toPass({ timeout: 45000, intervals: [500, 1000, 2000] });
+        // CHAOS-2075 two-level nav: aria-current marks the current-page link (a child
+        // leaf on a leaf route, the area row on a landing), so the active AREA is marked
+        // with data-active instead. Assert exactly one area is active and it's the
+        // expected one — rendered from usePathname(), independent of the ?f= append.
+        const selectedArea = page.locator('aside a[data-active="true"]');
+        await expect(selectedArea).toHaveCount(1, { timeout: 15000 });
+        await expect(selectedArea).toHaveText(selectedLabel);
+    }).toPass({ timeout: 45000, intervals: [500, 1000, 2000] });
 }
 
 test.describe("primary navigation reachability", () => {
-	test("sidebar surfaces exactly the decision areas as links, no flat leaf rows", async ({
-		page,
-	}) => {
-		await page.goto("/dashboard");
-		await waitForHydration(page);
+    test("sidebar surfaces exactly the decision areas as links, no flat leaf rows", async ({
+        page,
+    }) => {
+        await page.goto("/dashboard");
+        await waitForHydration(page);
 
-		const aside = page.locator("aside");
+        const aside = page.locator("aside");
 
-		for (const area of primaryAreas) {
-			await expect(
-				aside.getByRole("link", { name: area.label, exact: true }),
-			).toHaveAttribute("href", new RegExp(`${area.path}(?:[?#].*)?`));
-		}
+        for (const area of primaryAreas) {
+            await expect(
+                aside.getByRole("link", { name: area.label, exact: true }),
+            ).toHaveAttribute("href", new RegExp(`${area.path}(?:[?#].*)?`));
+        }
 
-		// Leaf destinations are no longer enumerated flat in the sidebar.
-		for (const leaf of collapsedLeafLabels) {
-			await expect(
-				aside.getByRole("link", { name: leaf, exact: true }),
-			).toHaveCount(0);
-		}
-	});
+        // Leaf destinations are no longer enumerated flat in the sidebar.
+        for (const leaf of collapsedLeafLabels) {
+            await expect(aside.getByRole("link", { name: leaf, exact: true })).toHaveCount(0);
+        }
+    });
 
-	test("reaches Plan as a top-level area and routes its visible subviews", async ({
-		page,
-		request,
-	}) => {
-		await page.goto("/dashboard");
-		await waitForHydration(page);
+    test("reaches Plan as a top-level area and routes its visible subviews", async ({
+        page,
+        request,
+    }) => {
+        await page.goto("/dashboard");
+        await waitForHydration(page);
 
-		const sidebar = page.locator("aside");
+        const sidebar = page.locator("aside");
 
-		await clickUntilUrl(
-			page,
-			sidebar.getByRole("link", { name: "Plan", exact: true }),
-			/\/plan(?:[?#].*)?$/,
-		);
+        await clickUntilUrl(
+            page,
+            sidebar.getByRole("link", { name: "Plan", exact: true }),
+            /\/plan(?:[?#].*)?$/,
+        );
 
-		const planChildren = page.getByTestId("nav-children-plan");
-		await expect(planChildren).toBeVisible({ timeout: 15000 });
+        const planChildren = page.getByTestId("nav-children-plan");
+        await expect(planChildren).toBeVisible({ timeout: 15000 });
 
-		for (const child of [
-			{ label: "Overview", url: /\/plan(?:[?#].*)?$/, path: "/plan" },
-			{
-				label: "Capacity Forecast",
-				url: /\/plan\/capacity(?:[?#].*)?$/,
-				path: "/plan/capacity",
-			},
-			// "Operating Review" is hidden from nav (navVisible: false) pending
-			// a rethink — see collapsedLeafLabels above. Route stays reachable
-			// by URL (asserted via reachableRoutes).
-		]) {
-			await clickUntilUrl(
-				page,
-				planChildren.getByRole("link", { name: child.label, exact: true }),
-				child.url,
-			);
-			await expectReachable(request, child.path);
-		}
-	});
+        for (const child of [
+            { label: "Overview", url: /\/plan(?:[?#].*)?$/, path: "/plan" },
+            {
+                label: "Capacity Forecast",
+                url: /\/plan\/capacity(?:[?#].*)?$/,
+                path: "/plan/capacity",
+            },
+            // "Operating Review" is hidden from nav (navVisible: false) pending
+            // a rethink — see collapsedLeafLabels above. Route stays reachable
+            // by URL (asserted via reachableRoutes).
+        ]) {
+            await clickUntilUrl(
+                page,
+                planChildren.getByRole("link", { name: child.label, exact: true }),
+                child.url,
+            );
+            await expectReachable(request, child.path);
+        }
+    });
 
-	test("reaches Diagnose as a top-level area and routes its visible subviews", async ({
-		page,
-	}) => {
-		await page.goto("/dashboard");
-		await waitForHydration(page);
+    test("reaches Diagnose as a top-level area and routes its visible subviews", async ({
+        page,
+    }) => {
+        await page.goto("/dashboard");
+        await waitForHydration(page);
 
-		const sidebar = page.locator("aside");
+        const sidebar = page.locator("aside");
 
-		await clickUntilUrl(
-			page,
-			sidebar.getByRole("link", { name: "Diagnose", exact: true }),
-			/\/diagnose(?:[?#].*)?$/,
-		);
+        await clickUntilUrl(
+            page,
+            sidebar.getByRole("link", { name: "Diagnose", exact: true }),
+            /\/diagnose(?:[?#].*)?$/,
+        );
 
-		const diagnoseChildren = page.getByTestId("nav-children-diagnose");
-		await expect(diagnoseChildren).toBeVisible({ timeout: 15000 });
+        const diagnoseChildren = page.getByTestId("nav-children-diagnose");
+        await expect(diagnoseChildren).toBeVisible({ timeout: 15000 });
 
-		const children = [
-			{ label: "Overview", url: /\/diagnose(?:[?#].*)?$/, path: "/diagnose" },
-			{ label: "Flow", url: /\/metrics(?:[?#].*)?$/, path: "/metrics" },
-			{
-				label: "Investment",
-				url: /\/investment(?:[?#].*)?$/,
-				path: "/investment",
-			},
-			{
-				label: "Landscape",
-				url: /\/landscape(?:[?#].*)?$/,
-				path: "/landscape",
-			},
-			{
-				label: "Work Graph",
-				url: /\/diagnose\/work-graph(?:[?#].*)?$/,
-				path: "/diagnose/work-graph",
-			},
-			{ label: "People", url: /\/people(?:[?#].*)?$/, path: "/people" },
-			{ label: "Code", url: /\/code(?:[?#].*)?$/, path: "/code" },
-			{
-				label: "Complexity",
-				url: /\/complexity(?:[?#].*)?$/,
-				path: "/complexity",
-			},
-			{
-				label: "Cognitive Load",
-				url: /\/cognitive-load(?:[?#].*)?$/,
-				path: "/cognitive-load",
-			},
-			{
-				label: "Bottlenecks",
-				url: /\/bottleneck(?:[?#].*)?$/,
-				path: "/bottleneck",
-			},
-		];
+        const children = [
+            { label: "Overview", url: /\/diagnose(?:[?#].*)?$/, path: "/diagnose" },
+            { label: "Flow", url: /\/metrics(?:[?#].*)?$/, path: "/metrics" },
+            {
+                label: "Investment",
+                url: /\/investment(?:[?#].*)?$/,
+                path: "/investment",
+            },
+            {
+                label: "Landscape",
+                url: /\/landscape(?:[?#].*)?$/,
+                path: "/landscape",
+            },
+            {
+                label: "Work Graph",
+                url: /\/diagnose\/work-graph(?:[?#].*)?$/,
+                path: "/diagnose/work-graph",
+            },
+            { label: "People", url: /\/people(?:[?#].*)?$/, path: "/people" },
+            { label: "Code", url: /\/code(?:[?#].*)?$/, path: "/code" },
+            {
+                label: "Complexity",
+                url: /\/complexity(?:[?#].*)?$/,
+                path: "/complexity",
+            },
+            {
+                label: "Cognitive Load",
+                url: /\/cognitive-load(?:[?#].*)?$/,
+                path: "/cognitive-load",
+            },
+            {
+                label: "Bottlenecks",
+                url: /\/bottleneck(?:[?#].*)?$/,
+                path: "/bottleneck",
+            },
+        ];
 
-		// Every Diagnose child renders with the correct destination href. This is a
-		// cheap DOM assertion on purpose: browser-navigating all ~10 chart-heavy
-		// children in series wedged the dev server under CI's constrained runners
-		// (net::ERR_ABORTED / "[WebServer] Error: aborted"), failing every retry.
-		// Full SSR reachability of every route is covered by the dedicated
-		// "every former leaf destination still resolves" test below.
-		for (const child of children) {
-			await expect(
-				diagnoseChildren.getByRole("link", { name: child.label, exact: true }),
-			).toHaveAttribute("href", new RegExp(`${child.path}(?:[?#].*)?`));
-		}
+        // Every Diagnose child renders with the correct destination href. This is a
+        // cheap DOM assertion on purpose: browser-navigating all ~10 chart-heavy
+        // children in series wedged the dev server under CI's constrained runners
+        // (net::ERR_ABORTED / "[WebServer] Error: aborted"), failing every retry.
+        // Full SSR reachability of every route is covered by the dedicated
+        // "every former leaf destination still resolves" test below.
+        for (const child of children) {
+            await expect(
+                diagnoseChildren.getByRole("link", { name: child.label, exact: true }),
+            ).toHaveAttribute("href", new RegExp(`${child.path}(?:[?#].*)?`));
+        }
 
-		// Click-verify a representative subset actually routes: the overview landing,
-		// a chart leaf, and the People leaf whose nav regressed in CHAOS-2158.
-		for (const child of [children[0], children[1], children[5]]) {
-			await clickUntilUrl(
-				page,
-				diagnoseChildren.getByRole("link", { name: child.label, exact: true }),
-				child.url,
-			);
-		}
-	});
+        // Click-verify a representative subset actually routes: the overview landing,
+        // a chart leaf, and the People leaf whose nav regressed in CHAOS-2158.
+        for (const child of [children[0], children[1], children[5]]) {
+            await clickUntilUrl(
+                page,
+                diagnoseChildren.getByRole("link", { name: child.label, exact: true }),
+                child.url,
+            );
+        }
+    });
 
-	test("every former leaf destination still resolves without 404", async ({
-		request,
-	}) => {
-		// ~30 sequential SSR reachability fetches; Turbopack cold-compiles each route
-		// on first hit under suite load, which overruns the default 30s test budget.
-		test.setTimeout(120_000);
-		for (const route of reachableRoutes) {
-			await expectReachable(request, route);
-		}
-	});
+    test("every former leaf destination still resolves without 404", async ({ request }) => {
+        // ~30 sequential SSR reachability fetches; Turbopack cold-compiles each route
+        // on first hit under suite load, which overruns the default 30s test budget.
+        test.setTimeout(120_000);
+        for (const route of reachableRoutes) {
+            await expectReachable(request, route);
+        }
+    });
 
-	test("reaches AI as a top-level area and routes its visible subviews", async ({
-		page,
-		request,
-	}) => {
-		await page.goto("/dashboard");
-		await waitForHydration(page);
+    test("reaches AI as a top-level area and routes its visible subviews", async ({
+        page,
+        request,
+    }) => {
+        await page.goto("/dashboard");
+        await waitForHydration(page);
 
-		const sidebar = page.locator("aside");
+        const sidebar = page.locator("aside");
 
-		// The AI area row is a top-level sibling of Diagnose/Improve/Govern and links
-		// to the /ai workspace.
-		await clickUntilUrl(
-			page,
-			sidebar.getByRole("link", { name: "AI", exact: true }),
-			/\/ai(?:[?#].*)?$/,
-		);
+        // The AI area row is a top-level sibling of Diagnose/Improve/Govern and links
+        // to the /ai workspace.
+        await clickUntilUrl(
+            page,
+            sidebar.getByRole("link", { name: "AI", exact: true }),
+            /\/ai(?:[?#].*)?$/,
+        );
 
-		// The active AI area expands to exactly its navVisible children (areas.ts).
-		const aiChildren = page.getByTestId("nav-children-ai");
-		await expect(aiChildren).toBeVisible({ timeout: 15000 });
+        // The active AI area expands to exactly its navVisible children (areas.ts).
+        const aiChildren = page.getByTestId("nav-children-ai");
+        await expect(aiChildren).toBeVisible({ timeout: 15000 });
 
-		for (const child of [
-			{ label: "Overview", url: /\/ai(?:[?#].*)?$/, path: "/ai" },
-			{
-				label: "Impact",
-				url: /\/ai\/impact(?:[?#].*)?$/,
-				path: "/ai/impact",
-			},
-			{
-				label: "Review Load",
-				url: /\/ai\/review-load(?:[?#].*)?$/,
-				path: "/ai/review-load",
-			},
-			{
-				label: "Governance Risk",
-				url: /\/ai\/risk(?:[?#].*)?$/,
-				path: "/ai/risk",
-			},
-			{
-				label: "Automations",
-				url: /\/ai\/automations(?:[?#].*)?$/,
-				path: "/ai/automations",
-			},
-		]) {
-			await clickUntilUrl(
-				page,
-				aiChildren.getByRole("link", { name: child.label, exact: true }),
-				child.url,
-			);
-			await expectReachable(request, child.path);
-		}
-	});
+        for (const child of [
+            { label: "Overview", url: /\/ai(?:[?#].*)?$/, path: "/ai" },
+            {
+                label: "Impact",
+                url: /\/ai\/impact(?:[?#].*)?$/,
+                path: "/ai/impact",
+            },
+            {
+                label: "Review Load",
+                url: /\/ai\/review-load(?:[?#].*)?$/,
+                path: "/ai/review-load",
+            },
+            {
+                label: "Governance Risk",
+                url: /\/ai\/risk(?:[?#].*)?$/,
+                path: "/ai/risk",
+            },
+            {
+                label: "Automations",
+                url: /\/ai\/automations(?:[?#].*)?$/,
+                path: "/ai/automations",
+            },
+        ]) {
+            await clickUntilUrl(
+                page,
+                aiChildren.getByRole("link", { name: child.label, exact: true }),
+                child.url,
+            );
+            await expectReachable(request, child.path);
+        }
+    });
 
-	test("marks exactly one area as selected for representative leaf routes", async ({
-		page,
-	}) => {
-		test.setTimeout(120_000);
+    test("marks exactly one area as selected for representative leaf routes", async ({ page }) => {
+        test.setTimeout(120_000);
 
-		for (const route of [
-			{ path: "/metrics?tab=dora", selectedLabel: "Diagnose" },
-			{ path: "/landscape", selectedLabel: "Diagnose" },
-			{ path: "/testops/coverage", selectedLabel: "Govern" },
-			{ path: "/testops/risk", selectedLabel: "Govern" },
-			{ path: "/bottleneck", selectedLabel: "Diagnose" },
-			{ path: "/risk/compounding", selectedLabel: "Govern" },
-			{ path: "/plan/delivery-forecast", selectedLabel: "Plan" },
-			{ path: "/plan/capacity", selectedLabel: "Plan" },
-			{ path: "/operating-review", selectedLabel: "Plan" },
-		]) {
-			await expectSingleSelectedArea(page, route.path, route.selectedLabel);
-		}
-	});
+        for (const route of [
+            { path: "/metrics?tab=dora", selectedLabel: "Diagnose" },
+            { path: "/landscape", selectedLabel: "Diagnose" },
+            { path: "/testops/coverage", selectedLabel: "Govern" },
+            { path: "/testops/risk", selectedLabel: "Govern" },
+            { path: "/bottleneck", selectedLabel: "Diagnose" },
+            { path: "/risk/compounding", selectedLabel: "Govern" },
+            { path: "/plan/delivery-forecast", selectedLabel: "Plan" },
+            { path: "/plan/capacity", selectedLabel: "Plan" },
+            { path: "/operating-review", selectedLabel: "Plan" },
+        ]) {
+            await expectSingleSelectedArea(page, route.path, route.selectedLabel);
+        }
+    });
 });


### PR DESCRIPTION
## Summary

Hides **Operating Review** from the Plan nav pending a hard rethink of the surface (follow-up tracked in Linear). Decision: the current page is a dense agenda wall that needs a redesign, not incremental polish.

- Plan child `operating-review`: `navVisible: false, preview: true` (per the IA invariant for hidden children)
- The `/operating-review` route stays reachable by direct URL (asserted in `nav-reachability.spec.ts` `reachableRoutes`)
- Breadcrumb/title for the hidden route fall back to the Plan area label (same behavior as its pre-promotion hidden-preview state)
- Tests updated: `areas.test.ts`, `phase2-breadcrumb-areahub.test.ts`, `PrimaryNav.test.tsx`, `nav-reachability.spec.ts` ("Operating Review" restored to `collapsedLeafLabels`)

## Testing

- `vitest` navigation suites: 241 passed
- Playwright `nav-reachability.spec.ts` + `operating-review.spec.ts`: 11 passed

SCREENSHOT-WAIVER: nav-only removal; hidden row has no rendered output beyond its absence

Refs CHAOS-2181
