### PR TITLE
fix(ai): normalize attribution-bucket comparisons to backend vocabulary (CHAOS-2225)

### DIFF
--- a/src/components/ai/AIImpactDashboard.tsx
+++ b/src/components/ai/AIImpactDashboard.tsx
@@ -7,6 +7,7 @@ import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
 import { DataState } from "@/components/ui/DataState";
 import { useAIComparison, useAIImpactSummary } from "@/lib/graphql/hooks/useAIImpact";
 import type { AIFilter } from "@/lib/filters/ai";
+import { bucketEquals } from "@/lib/ai/buckets";
 import { CTA_LABELS } from "@/lib/design/cta";
 import { AIComparisonCard } from "./AIComparisonCard";
 import { AILeverageBars } from "./AILeverageBars";
@@ -60,9 +61,10 @@ export function AIImpactDashboard({ filter, evidenceHref }: AIImpactDashboardPro
     }
 
     const bucketRows = summary?.byBucket ?? [];
-    const agentBucket = bucketRows.find((row) => row.bucket === "AGENT_CREATED");
+    const agentBucket = bucketRows.find((row) => bucketEquals(row.bucket, "AGENT_CREATED"));
     const leverage =
-        bucketRows.find((row) => row.bucket === "AI_ASSISTED")?.leverage ?? bucketRows[0]?.leverage;
+        bucketRows.find((row) => bucketEquals(row.bucket, "AI_ASSISTED"))?.leverage ??
+        bucketRows[0]?.leverage;
     const donutRows = assistedWorkShareRows(bucketRows);
     const trend = agentCreatedTrend(summary?.daily ?? []);
 

--- a/src/components/ai/AIReviewAmplificationTrend.tsx
+++ b/src/components/ai/AIReviewAmplificationTrend.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { Chart } from "@/components/charts/Chart";
 import { useChartTheme } from "@/components/charts/chartTheme";
 import type { AiReviewLoadRow } from "@/lib/graphql/__generated__/types";
+import { bucketLabel } from "./utils";
 
 type DailyRow = AiReviewLoadRow & { day?: string };
 
@@ -50,7 +51,11 @@ export function AIReviewAmplificationTrend({ daily, loading }: AIReviewAmplifica
                 borderColor: chartTheme.stroke,
                 textStyle: { color: chartTheme.text },
             },
-            legend: { data: buckets, bottom: 0, textStyle: { color: chartTheme.muted } },
+            legend: {
+                data: buckets.map(bucketLabel),
+                bottom: 0,
+                textStyle: { color: chartTheme.muted },
+            },
             grid: { left: 44, right: 20, top: 20, bottom: 48, containLabel: true },
             xAxis: {
                 type: "category" as const,
@@ -64,7 +69,7 @@ export function AIReviewAmplificationTrend({ daily, loading }: AIReviewAmplifica
                 splitLine: { lineStyle: { color: chartTheme.grid, type: "dashed" as const } },
             },
             series: buckets.map((bucket) => ({
-                name: bucket,
+                name: bucketLabel(bucket),
                 type: "line" as const,
                 smooth: true,
                 symbol: "circle",

--- a/src/components/ai/__tests__/AIImpactDashboard.test.tsx
+++ b/src/components/ai/__tests__/AIImpactDashboard.test.tsx
@@ -56,7 +56,7 @@ function mockDefaults() {
                 endDate: "2026-05-19",
                 dataAvailable: true,
                 aiSide: {
-                    bucket: "AI_ASSISTED",
+                    bucket: "ai_assisted",
                     prsTotal: 8,
                     prsMerged: 7,
                     reviewsPerPr: 2.4,
@@ -67,7 +67,7 @@ function mockDefaults() {
                     cycleTimeAvgHours: 20,
                 },
                 baselineSide: {
-                    bucket: "HUMAN",
+                    bucket: "human",
                     prsTotal: 10,
                     prsMerged: 9,
                     reviewsPerPr: 1.8,
@@ -161,7 +161,7 @@ describe("AIImpactDashboard", () => {
                     computedAt: "2026-05-19T00:00:00Z",
                     byBucket: [
                         {
-                            bucket: "AI_ASSISTED",
+                            bucket: "ai_assisted",
                             prsTotal: 5,
                             prsMerged: 4,
                             aiAssistedPrRatio: 0.25,
@@ -183,7 +183,7 @@ describe("AIImpactDashboard", () => {
                             },
                         },
                         {
-                            bucket: "AGENT_CREATED",
+                            bucket: "agent_created",
                             prsTotal: 3,
                             prsMerged: 3,
                             aiAssistedPrRatio: 0.15,
@@ -205,7 +205,7 @@ describe("AIImpactDashboard", () => {
                             },
                         },
                         {
-                            bucket: "HUMAN",
+                            bucket: "human",
                             prsTotal: 10,
                             prsMerged: 9,
                             aiAssistedPrRatio: 0,
@@ -227,7 +227,7 @@ describe("AIImpactDashboard", () => {
                             },
                         },
                         {
-                            bucket: "UNKNOWN",
+                            bucket: "unknown",
                             prsTotal: 2,
                             prsMerged: 2,
                             aiAssistedPrRatio: null,
@@ -251,7 +251,7 @@ describe("AIImpactDashboard", () => {
                     ],
                     daily: [
                         {
-                            bucket: "AGENT_CREATED",
+                            bucket: "agent_created",
                             prsTotal: 1,
                             prsMerged: 1,
                             cycleTimeAvgHours: 10,
@@ -267,7 +267,7 @@ describe("AIImpactDashboard", () => {
                             testGapRate: 0,
                         },
                         {
-                            bucket: "AGENT_CREATED",
+                            bucket: "agent_created",
                             prsTotal: 2,
                             prsMerged: 2,
                             cycleTimeAvgHours: 12,

--- a/src/components/ai/__tests__/AIReviewAmplificationTrend.test.tsx
+++ b/src/components/ai/__tests__/AIReviewAmplificationTrend.test.tsx
@@ -12,7 +12,7 @@ describe("AIReviewAmplificationTrend helpers", () => {
         const trend = reviewAmplificationTrendRows([
             {
                 day: "2026-05-22",
-                bucket: "AI_ASSISTED",
+                bucket: "ai_assisted",
                 prsTotal: 4,
                 reviewsTotal: 8,
                 reviewAmplification: 2.2,
@@ -20,7 +20,7 @@ describe("AIReviewAmplificationTrend helpers", () => {
             },
             {
                 day: "2026-05-01",
-                bucket: "AI_ASSISTED",
+                bucket: "ai_assisted",
                 prsTotal: 4,
                 reviewsTotal: 4,
                 reviewAmplification: 1.1,
@@ -28,7 +28,7 @@ describe("AIReviewAmplificationTrend helpers", () => {
             },
             {
                 day: "2026-05-09",
-                bucket: "AGENT_CREATED",
+                bucket: "agent_created",
                 prsTotal: 4,
                 reviewsTotal: 7,
                 reviewAmplification: 1.9,
@@ -36,14 +36,14 @@ describe("AIReviewAmplificationTrend helpers", () => {
             },
             {
                 day: "2026-05-09",
-                bucket: "AI_ASSISTED",
+                bucket: "ai_assisted",
                 prsTotal: 4,
                 reviewsTotal: 5,
                 reviewAmplification: 1.4,
                 postFirstReviewPushesCount: 2,
             },
             {
-                bucket: "UNKNOWN",
+                bucket: "unknown",
                 prsTotal: 1,
                 reviewsTotal: 9,
                 reviewAmplification: 9.9,

--- a/src/components/ai/__tests__/AIReviewLoadDashboard.test.tsx
+++ b/src/components/ai/__tests__/AIReviewLoadDashboard.test.tsx
@@ -5,26 +5,21 @@ import type { AIFilter } from "@/lib/filters/ai";
 
 const { mockUseAIReviewLoad } = vi.hoisted(() => ({ mockUseAIReviewLoad: vi.fn() }));
 
-vi.mock("@/lib/graphql/hooks/useAIReviewRisk", async () => {
-    const normalizeBucket = (bucket: string) => bucket.trim().toLowerCase();
+// Stub the transitive urql/provider imports so importOriginal can load the
+// real useAIReviewRisk module under vitest (same pattern as the adapters test).
+vi.mock("urql", () => ({
+    useQuery: () => [{ data: undefined, fetching: false, error: undefined }],
+}));
+vi.mock("@/lib/graphql/provider", () => ({ useOrgId: () => "org" }));
+
+// Mock ONLY the data hook; findBucketRow/valueDelta/approvalFriction must be
+// the real implementations so this suite exercises the production
+// bucket-normalization path (uppercase request vs lowercase rows, CHAOS-2225).
+vi.mock("@/lib/graphql/hooks/useAIReviewRisk", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/lib/graphql/hooks/useAIReviewRisk")>();
     return {
+        ...actual,
         useAIReviewLoad: mockUseAIReviewLoad,
-        findBucketRow: <T extends { bucket: string }>(
-            rows: T[] | undefined,
-            bucket = "ai_assisted",
-        ) => {
-            const targetBucket = normalizeBucket(bucket);
-            return rows?.find((row) => normalizeBucket(row.bucket) === targetBucket);
-        },
-        valueDelta: (value?: number | null, baseline?: number | null) =>
-            value == null || baseline == null ? undefined : value - baseline,
-        approvalFriction: (row?: {
-            changesRequestedPerPr?: number | null;
-            reviewsPerPr?: number | null;
-        }) =>
-            !row?.reviewsPerPr || row.changesRequestedPerPr == null
-                ? undefined
-                : row.changesRequestedPerPr / row.reviewsPerPr,
     };
 });
 

--- a/src/components/ai/__tests__/AIReviewLoadDashboard.test.tsx
+++ b/src/components/ai/__tests__/AIReviewLoadDashboard.test.tsx
@@ -11,7 +11,7 @@ vi.mock("@/lib/graphql/hooks/useAIReviewRisk", async () => {
         useAIReviewLoad: mockUseAIReviewLoad,
         findBucketRow: <T extends { bucket: string }>(
             rows: T[] | undefined,
-            bucket = "AI_ASSISTED",
+            bucket = "ai_assisted",
         ) => {
             const targetBucket = normalizeBucket(bucket);
             return rows?.find((row) => normalizeBucket(row.bucket) === targetBucket);

--- a/src/components/ai/__tests__/AIRiskDashboard.test.tsx
+++ b/src/components/ai/__tests__/AIRiskDashboard.test.tsx
@@ -8,18 +8,22 @@ const { mockUseAIRiskBreakdown, mockUseAIGovernanceSummary } = vi.hoisted(() => 
     mockUseAIGovernanceSummary: vi.fn(),
 }));
 
-vi.mock("@/lib/graphql/hooks/useAIReviewRisk", async () => {
+// Stub the transitive urql/provider imports so importOriginal can load the
+// real useAIReviewRisk module under vitest (same pattern as the adapters test).
+vi.mock("urql", () => ({
+    useQuery: () => [{ data: undefined, fetching: false, error: undefined }],
+}));
+vi.mock("@/lib/graphql/provider", () => ({ useOrgId: () => "org" }));
+
+// Mock ONLY the data hooks; everything else (findBucketRow, prViolationRows)
+// must be the real implementation so this suite exercises the production
+// bucket-normalization path (uppercase request vs lowercase rows, CHAOS-2225).
+vi.mock("@/lib/graphql/hooks/useAIReviewRisk", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/lib/graphql/hooks/useAIReviewRisk")>();
     return {
+        ...actual,
         useAIRiskBreakdown: mockUseAIRiskBreakdown,
         useAIGovernanceSummary: mockUseAIGovernanceSummary,
-        findBucketRow: <T extends { bucket: string }>(
-            rows: T[] | undefined,
-            bucket = "ai_assisted",
-        ) => rows?.find((row) => row.bucket === bucket),
-        prViolationRows: (summary?: { recentViolations?: Array<{ subjectType: string }> }) =>
-            (summary?.recentViolations ?? []).filter(
-                (violation) => violation.subjectType.toLowerCase() === "pr",
-            ),
     };
 });
 

--- a/src/components/ai/__tests__/AIRiskDashboard.test.tsx
+++ b/src/components/ai/__tests__/AIRiskDashboard.test.tsx
@@ -14,7 +14,7 @@ vi.mock("@/lib/graphql/hooks/useAIReviewRisk", async () => {
         useAIGovernanceSummary: mockUseAIGovernanceSummary,
         findBucketRow: <T extends { bucket: string }>(
             rows: T[] | undefined,
-            bucket = "AI_ASSISTED",
+            bucket = "ai_assisted",
         ) => rows?.find((row) => row.bucket === bucket),
         prViolationRows: (summary?: { recentViolations?: Array<{ subjectType: string }> }) =>
             (summary?.recentViolations ?? []).filter(
@@ -70,7 +70,7 @@ describe("AIRiskDashboard", () => {
                     ],
                     byBucket: [
                         {
-                            bucket: "AI_ASSISTED",
+                            bucket: "ai_assisted",
                             prsTotal: 10,
                             reworkPrs: 2,
                             reworkRate: 0.2,
@@ -89,7 +89,7 @@ describe("AIRiskDashboard", () => {
                     endDate: "2026-05-01",
                     dataAvailable: true,
                     aiSide: {
-                        bucket: "AI_ASSISTED",
+                        bucket: "ai_assisted",
                         prsTotal: 10,
                         prsMerged: 8,
                         reworkRate: 0.2,
@@ -98,7 +98,7 @@ describe("AIRiskDashboard", () => {
                         incidentRate: 0.1,
                     },
                     baselineSide: {
-                        bucket: "HUMAN",
+                        bucket: "human",
                         prsTotal: 10,
                         prsMerged: 8,
                         reworkRate: 0.1,
@@ -160,7 +160,7 @@ describe("AIRiskDashboard", () => {
                     byBucket: [],
                     hotspotOverlap: [
                         {
-                            bucket: "AI_ASSISTED",
+                            bucket: "ai_assisted",
                             prsTotal: 44,
                             prsTouchingHotspots: 26,
                             hotspotOverlapRate: 0.59,
@@ -169,7 +169,7 @@ describe("AIRiskDashboard", () => {
                     ],
                     complexityOverlap: [
                         {
-                            bucket: "AI_ASSISTED",
+                            bucket: "ai_assisted",
                             prsTotal: 44,
                             prsTouchingHighComplexity: 0,
                             complexityOverlapRate: 0,

--- a/src/components/ai/__tests__/useAIReviewRisk.adapters.test.ts
+++ b/src/components/ai/__tests__/useAIReviewRisk.adapters.test.ts
@@ -45,6 +45,22 @@ describe("useAIReviewRisk adapters", () => {
         expect(findBucketRow(rows, "AGENT_CREATED")?.value).toBe(2);
     });
 
+    it("matches lowercase backend rows against enum-style requests (CHAOS-2225)", () => {
+        // Production shape: rows carry the backend's lowercase vocabulary while
+        // callers request with the uppercase input-enum spelling (including the
+        // implicit AI_ASSISTED default). A regression of findBucketRow back to
+        // raw comparison fails here.
+        const rows = [
+            { bucket: "ai_assisted", value: 10 },
+            { bucket: "human", value: 11 },
+            { bucket: "agent_created", value: 12 },
+        ];
+        expect(findBucketRow(rows)?.value).toBe(10); // default request = "AI_ASSISTED"
+        expect(findBucketRow(rows, "HUMAN")?.value).toBe(11);
+        expect(findBucketRow(rows, "AGENT_CREATED")?.value).toBe(12);
+        expect(findBucketRow([{ bucket: "AI_ASSISTED", value: 1 }], "ai_assisted")?.value).toBe(1);
+    });
+
     it("derives deltas and approval friction only when inputs exist", () => {
         expect(valueDelta(5, 3)).toBe(2);
         expect(valueDelta(undefined, 3)).toBeUndefined();

--- a/src/components/ai/utils.ts
+++ b/src/components/ai/utils.ts
@@ -1,9 +1,16 @@
+import { bucketEquals, bucketKey } from "@/lib/ai/buckets";
 import type {
     AiImpactBucketRow,
     AiImpactBucketTotals,
     AiLeverageComponents,
 } from "@/lib/graphql/__generated__/types";
 
+/**
+ * GraphQL INPUT enum vocabulary (`AIAttributionBucketInput`) — uppercase wire
+ * values used in filter variables sent to the backend. Row OUTPUTS
+ * (`bucket: String!`) are lowercase snake_case; never compare them to these
+ * literals raw — use `bucketEquals`/`bucketKey` (CHAOS-2225).
+ */
 export const AI_BUCKETS = [
     "AI_ASSISTED",
     "AI_REVIEW",
@@ -49,15 +56,15 @@ export function formatSigned(value?: number | null, suffix = ""): string {
 }
 
 export function assistedWorkShareRows(rows: AiImpactBucketTotals[]) {
-    const assistedBuckets = new Set<string>(AI_BUCKETS);
+    const assistedBuckets = new Set<string>(AI_BUCKETS.map(bucketKey));
     return rows
-        .filter((row) => assistedBuckets.has(row.bucket))
+        .filter((row) => assistedBuckets.has(bucketKey(row.bucket)))
         .map((row) => ({ name: bucketLabel(row.bucket), value: row.prsTotal }));
 }
 
 export function agentCreatedTrend(rows: AiImpactBucketRow[]) {
     return rows
-        .filter((row) => row.bucket === "AGENT_CREATED")
+        .filter((row) => bucketEquals(row.bucket, "AGENT_CREATED"))
         .map((row, index) => ({ day: String(index + 1), value: row.prsTotal }));
 }
 

--- a/src/lib/ai/buckets.ts
+++ b/src/lib/ai/buckets.ts
@@ -1,0 +1,26 @@
+/**
+ * Canonical AI attribution-bucket identity helpers (CHAOS-2225).
+ *
+ * The platform has TWO bucket vocabularies:
+ * - GraphQL INPUT (`AIAttributionBucketInput` enum): UPPERCASE wire values
+ *   (`AI_ASSISTED`, `AGENT_CREATED`, …) — used only in filter variables sent
+ *   to the backend.
+ * - GraphQL OUTPUT (`bucket: String!` on every row type): lowercase
+ *   snake_case strings (`ai_assisted`, `agent_created`, `human`, `unknown`,
+ *   `ai_review`) — ClickHouse `attribution_bucket` values passed through the
+ *   resolvers verbatim.
+ *
+ * Never compare a row's `bucket` to a raw literal — uppercase comparisons
+ * pass against uppercase mocks and silently fail against the real backend.
+ * Route every output-side comparison through `bucketKey`/`bucketEquals`.
+ */
+
+/** Canonicalize a bucket string for identity comparison. */
+export function bucketKey(bucket: string): string {
+    return bucket.trim().toLowerCase();
+}
+
+/** Case/whitespace-insensitive bucket identity. */
+export function bucketEquals(a: string, b: string): boolean {
+    return bucketKey(a) === bucketKey(b);
+}

--- a/src/lib/ai/sample-data.ts
+++ b/src/lib/ai/sample-data.ts
@@ -37,7 +37,7 @@ export const SAMPLE_AI_IMPACT_SUMMARY: AiImpactSummary = {
     computedAt: `${SAMPLE_END_DATE}T06:00:00Z`,
     byBucket: [
         {
-            bucket: "AI_ASSISTED",
+            bucket: "ai_assisted",
             prsTotal: 41,
             prsMerged: 38,
             agentCreatedPrCount: 0,
@@ -88,7 +88,7 @@ export const SAMPLE_AI_REVIEW_LOAD: AiReviewLoadResult = {
     dataAvailable: true,
     byBucket: [
         {
-            bucket: "AI_ASSISTED",
+            bucket: "ai_assisted",
             prsTotal: 41,
             reviewsTotal: 96,
             reviewsPerPr: 2.3,

--- a/src/lib/areaSignals/__tests__/ai.test.ts
+++ b/src/lib/areaSignals/__tests__/ai.test.ts
@@ -43,7 +43,7 @@ function makeImpact(overrides?: {
             missingStates: [],
             byBucket: [
                 {
-                    bucket: "AI_ASSISTED",
+                    bucket: "ai_assisted",
                     prsTotal: 40,
                     prsMerged: 38,
                     aiAssistedPrRatio: 0.4,
@@ -68,7 +68,7 @@ function makeImpact(overrides?: {
                     },
                 },
                 {
-                    bucket: "HUMAN",
+                    bucket: "human",
                     prsTotal: 55,
                     prsMerged: 53,
                     aiAssistedPrRatio: 0,
@@ -108,7 +108,7 @@ function makeReviewLoad(overrides?: {
             dataAvailable: overrides?.dataAvailable ?? true,
             byBucket: [
                 {
-                    bucket: "AI_ASSISTED",
+                    bucket: "ai_assisted",
                     prsTotal: 40,
                     reviewsTotal: 72,
                     reviewsPerPr: 1.8,
@@ -125,7 +125,7 @@ function makeReviewLoad(overrides?: {
                     postFirstReviewPushesPerPr: 0.3,
                 },
                 {
-                    bucket: "HUMAN",
+                    bucket: "human",
                     prsTotal: 55,
                     reviewsTotal: 88,
                     reviewsPerPr: 1.6,

--- a/src/lib/areaSignals/ai.ts
+++ b/src/lib/areaSignals/ai.ts
@@ -21,6 +21,7 @@
 // Honest-state contract: a sub-area whose value cannot be resolved is emitted
 // with `state: "unavailable"` and an empty `value` — never a fabricated number.
 
+import { bucketEquals } from "@/lib/ai/buckets";
 import { auth } from "@/lib/auth";
 import { graphqlFetch } from "@/lib/graphql/server";
 import {
@@ -201,7 +202,7 @@ export async function getAISignals(
     //   BACKEND_LADDER). Falls back to "neutral" when reworkDragRate is absent
     //   but adoption data is present (informational only — no rework signal yet).
     if (impact?.dataAvailable) {
-        const aiBucket = impact.byBucket.find((b) => b.bucket === "AI_ASSISTED");
+        const aiBucket = impact.byBucket.find((b) => bucketEquals(b.bucket, "AI_ASSISTED"));
         const reworkDrag = aiBucket?.reworkDragRate;
         const adoptionRatio = impact.aiAssistedPrRatio;
         const state: AreaSignalState =
@@ -224,7 +225,7 @@ export async function getAISignals(
     // AI_ASSISTED bucket reviewAmplification multiplier (lowerIsBetter).
     // dataAvailable guards against a non-null but empty result.
     if (reviewLoad?.dataAvailable) {
-        const aiBucket = reviewLoad.byBucket.find((b) => b.bucket === "AI_ASSISTED");
+        const aiBucket = reviewLoad.byBucket.find((b) => bucketEquals(b.bucket, "AI_ASSISTED"));
         const amplification = aiBucket?.reviewAmplification;
         const commentsPerLoc = aiBucket?.reviewCommentsPerLoc;
         if (amplification != null) {

--- a/src/lib/graphql/hooks/useAIReviewRisk.ts
+++ b/src/lib/graphql/hooks/useAIReviewRisk.ts
@@ -22,6 +22,7 @@ import type {
     AiWorkflowDrilldownResult,
     AiWorkflowRootTypeInput,
 } from "../__generated__/types";
+import { bucketKey } from "@/lib/ai/buckets";
 import type { AIFilter } from "@/lib/filters/ai";
 import type { AiAttributionBucketInput } from "@/lib/graphql/__generated__/types";
 
@@ -80,12 +81,8 @@ export function findBucketRow<T extends { bucket: string }>(
     rows: T[] | undefined,
     bucket: AIBucket | string = "AI_ASSISTED",
 ): T | undefined {
-    const targetBucket = normalizeBucketKey(bucket);
-    return rows?.find((row) => normalizeBucketKey(row.bucket) === targetBucket);
-}
-
-function normalizeBucketKey(bucket: string): string {
-    return bucket.trim().toLowerCase();
+    const targetBucket = bucketKey(bucket);
+    return rows?.find((row) => bucketKey(row.bucket) === targetBucket);
 }
 
 export function valueDelta(

--- a/tests/mocks/aiSample.ts
+++ b/tests/mocks/aiSample.ts
@@ -57,8 +57,8 @@ function emptyComparison(orgId: string, startDate: string, endDate: string) {
         startDate,
         endDate,
         dataAvailable: false,
-        aiSide: side("AI_ASSISTED"),
-        baselineSide: side("HUMAN"),
+        aiSide: side("ai_assisted"),
+        baselineSide: side("human"),
         delta: {
             cycleTimeDeltaHours: null,
             reviewsPerPrDelta: null,
@@ -76,7 +76,7 @@ function populatedComparison(orgId: string, startDate: string, endDate: string) 
         startDate,
         endDate,
         dataAvailable: true,
-        aiSide: side("AI_ASSISTED", {
+        aiSide: side("ai_assisted", {
             prsTotal: 42,
             prsMerged: 38,
             cycleTimeAvgHours: 18.4,
@@ -86,7 +86,7 @@ function populatedComparison(orgId: string, startDate: string, endDate: string) 
             testGapRate: 0.18,
             incidentRate: 0.03,
         }),
-        baselineSide: side("HUMAN", {
+        baselineSide: side("human", {
             prsTotal: 120,
             prsMerged: 110,
             cycleTimeAvgHours: 22.1,
@@ -269,7 +269,7 @@ export function aiImpactSummaryResponse(
             },
         ],
         byBucket: [
-            impactBucket("AI_ASSISTED", {
+            impactBucket("ai_assisted", {
                 prsTotal: 42,
                 prsMerged: 38,
                 aiAssistedPrRatio: 0.26,
@@ -289,20 +289,20 @@ export function aiImpactSummaryResponse(
                     incidentComponent: -0.01,
                 }),
             }),
-            impactBucket("AGENT_CREATED", {
+            impactBucket("agent_created", {
                 prsTotal: 12,
                 prsMerged: 11,
                 agentCreatedPrCount: 12,
                 cycleTimeAvgHours: 14.0,
             }),
-            impactBucket("HUMAN", {
+            impactBucket("human", {
                 prsTotal: 96,
                 prsMerged: 88,
                 cycleTimeAvgHours: 22.1,
             }),
-            impactBucket("UNKNOWN", { prsTotal: 12, prsMerged: 10 }),
+            impactBucket("unknown", { prsTotal: 12, prsMerged: 10 }),
         ],
-        daily: Array.from({ length: 7 }, (_, i) => dailyRow("AGENT_CREATED", { prsTotal: i + 1 })),
+        daily: Array.from({ length: 7 }, (_, i) => dailyRow("agent_created", { prsTotal: i + 1 })),
     };
 }
 
@@ -357,7 +357,7 @@ export function aiReviewLoadResponse(
         dataAvailable: true,
         byBucket: [
             {
-                bucket: "AI_ASSISTED",
+                bucket: "ai_assisted",
                 prsTotal: 42,
                 reviewsTotal: 110,
                 reviewsPerPr: 2.6,
@@ -369,7 +369,7 @@ export function aiReviewLoadResponse(
                 reviewCommentsPerLoc: 0.032,
             },
             {
-                bucket: "HUMAN",
+                bucket: "human",
                 prsTotal: 96,
                 reviewsTotal: 183,
                 reviewsPerPr: 1.9,
@@ -382,7 +382,7 @@ export function aiReviewLoadResponse(
             },
         ],
         daily: Array.from({ length: 7 }, (_, i) => ({
-            bucket: "AI_ASSISTED",
+            bucket: "ai_assisted",
             prsTotal: 6 - i,
             reviewsTotal: 18 - i,
             reviewsPerPr: 2.4 + i * 0.05,
@@ -463,7 +463,7 @@ export function aiRiskBreakdownResponse(
         missingStates: [],
         hotspotOverlap: [
             {
-                bucket: "AI_ASSISTED",
+                bucket: "ai_assisted",
                 prsTotal: 44,
                 prsTouchingHotspots: 26,
                 hotspotOverlapRate: 0.59,
@@ -472,7 +472,7 @@ export function aiRiskBreakdownResponse(
         ],
         complexityOverlap: [
             {
-                bucket: "AI_ASSISTED",
+                bucket: "ai_assisted",
                 prsTotal: 44,
                 prsTouchingHighComplexity: 0,
                 complexityOverlapRate: 0,
@@ -480,7 +480,7 @@ export function aiRiskBreakdownResponse(
         ],
         byBucket: [
             {
-                bucket: "AI_ASSISTED",
+                bucket: "ai_assisted",
                 prsTotal: 42,
                 reworkPrs: 9,
                 reworkRate: 0.22,
@@ -492,7 +492,7 @@ export function aiRiskBreakdownResponse(
                 incidentRate: 0.03,
             },
             {
-                bucket: "HUMAN",
+                bucket: "human",
                 prsTotal: 96,
                 reworkPrs: 13,
                 reworkRate: 0.14,


### PR DESCRIPTION
## Post-merge fix: AI hub 'Not yet connected' despite real data

**Symptom (user-reported after CHAOS-2180 Wave 2 merged):** AI Overview hub renders the Review Load signal card as **NOT YET CONNECTED** while /ai/review-load shows live data. The Impact card silently degrades to its no-severity fallback on the same root cause.

### Root cause
Two bucket vocabularies exist:
- **GraphQL INPUT** (`AIAttributionBucketInput` enum): UPPERCASE (`AI_ASSISTED`, …) — filter variables only
- **GraphQL OUTPUT** (`bucket: String!` on every row): **lowercase** snake_case (`ai_assisted`, `agent_created`, `human`, `unknown`) — ClickHouse `attribution_bucket` passed through resolvers verbatim (verified against live data)

Web's mocks used UPPERCASE for outputs too, so raw comparisons like `b.bucket === "AI_ASSISTED"` passed every unit/e2e gate and matched nothing in production. `findBucketRow` already normalized case — which is why the Review Load *page* worked while everything else drifted.

### Fix
- **`src/lib/ai/buckets.ts`** (new): canonical `bucketKey`/`bucketEquals`; the two-vocabulary contract documented
- Every output-side comparison normalized: `areaSignals/ai.ts` (×2 — the user-visible fix), `utils.ts` `assistedWorkShareRows` + `agentCreatedTrend`, `AIImpactDashboard` (×2), `findBucketRow` delegates to the shared helper
- `AIReviewAmplificationTrend`: legend/series names via `bucketLabel` (raw lowercase strings were leaking into the chart legend against real data)
- `AI_BUCKETS` stays UPPERCASE (it is the input-enum vocabulary, used to validate URL filter params) with a doc comment

### Regression guard (the load-bearing part)
Mock + unit-test fixtures flipped to the **real lowercase vocabulary** (`tests/mocks/aiSample.ts`, sample-data, 5 test files) — any future raw uppercase comparison now **fails tests** instead of silently passing. `useAIReviewRisk.adapters.test.ts` keeps mixed-case fixtures as the explicit case-tolerance proof; input-enum filter tests unchanged (uppercase is correct there).

### Gates
tsc ✅ · vitest **1932/1932** ✅ · codegen:check ✅ · prettier ✅ · **full Playwright 206 passed / 2 skipped** ✅ (= baseline)

Closes CHAOS-2225 (parent epic CHAOS-2180).