### PR TITLE
fix(incidents): Sankey node identity by UUID + resolved labels (CHAOS-2118, CHAOS-2119)

### DIFF
--- a/src/app/(app)/incident-correlation/page.tsx
+++ b/src/app/(app)/incident-correlation/page.tsx
@@ -4,8 +4,8 @@
  * RSC entry. Composes existing primitives:
  *   - REST  getHomeData(filters)                    → change_failure_rate + other DORA deltas
  *   - REST  getExplainData("change_failure_rate")   → drivers + contributors
- *   - GQL   WORK_GRAPH_EDGES_QUERY (edgeType DEPLOYS)          → deployment→incident edges
- *   - GQL   WORK_GRAPH_EDGES_QUERY (edgeType LINKED_INCIDENT)  → incident→work-item edges
+ *   - GQL   WORK_GRAPH_EDGES_QUERY (edgeType DEPLOYS)          → PR→deployment edges
+ *   - GQL   WORK_GRAPH_EDGES_QUERY (edgeType LINKED_INCIDENT)  → deployment→incident edges
  *
  * V1 limitations (also documented in PR body):
  *   1. No time-windowed edge filter — WorkGraphEdgeFilterInput schema does not support it.
@@ -71,7 +71,7 @@ async function fetchEdges(
     } catch (err) {
         // Surface as empty state rather than crashing; the dashboard already shows
         // a populated empty-state message.
-        console.warn(`workGraphEdges(${edgeType}) query failed`, err);
+        console.warn("workGraphEdges query failed", { edgeType }, err);
         return [];
     }
 }
@@ -128,7 +128,7 @@ export default async function IncidentCorrelationPage({ searchParams }: PageProp
                                 Incident Correlation
                             </h1>
                             <p className="mt-2 text-sm text-(--ink-muted)">
-                                Connect DORA change-failure signals to deployment and work-item
+                                Connect DORA change-failure signals to PR, deployment, and incident
                                 evidence.
                             </p>
                             <p className="mt-2 text-sm text-(--ink-muted)">

--- a/src/components/charts/SankeyChart.tsx
+++ b/src/components/charts/SankeyChart.tsx
@@ -13,6 +13,69 @@ import { formatNumber, formatPercent } from "@/lib/formatters";
 
 echarts.use([EChartsSankeyChart]);
 
+// ---------------------------------------------------------------------------
+// Adapter — exported for unit testing (CHAOS-2118)
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps the caller's node/link objects to the stable internal key space that
+ * ECharts requires.
+ *
+ * Key scheme (highest-priority first):
+ *   1. node.id   — explicit UUID / composite key; bypasses collision on name
+ *   2. group:name — when group is set but id is absent (legacy)
+ *   3. name      — bare fallback
+ *
+ * CHAOS-2118 fix: chartNode.name is computed via makeKey(node) rather than
+ * keyByRef.get(node.name) so that two nodes sharing the same display name
+ * (e.g. two incidents both labelled "Production Outage") do NOT share a key.
+ * The old lookup path silently overwrote keyByRef[displayName] and both nodes
+ * ended up with the same ECharts identity key — ECharts then de-duplicated
+ * them into a single visible node.
+ */
+export function buildSankeyAdapterData(
+    nodes: SankeyNode[],
+    links: SankeyLink[],
+): { chartNodes: SankeyNode[]; chartLinks: SankeyLink[]; labelByKey: Map<string, string> } {
+    const keyByRef = new Map<string, string>();
+    const labelByKey = new Map<string, string>();
+
+    const makeKey = (node: SankeyNode) => {
+        if (node.id) return node.id;
+        if (node.group) return `${node.group}:${node.name}`;
+        return node.name;
+    };
+
+    nodes.forEach((node) => {
+        const key = makeKey(node);
+        // Name mapping kept for backward-compat with link sources that still
+        // reference by display name (non-id legacy callers). The first write
+        // wins — later nodes with the same display name do NOT overwrite.
+        if (!keyByRef.has(node.name)) {
+            keyByRef.set(node.name, key);
+        }
+        if (node.id) {
+            keyByRef.set(node.id, key);
+        }
+        labelByKey.set(key, node.name);
+    });
+
+    // Use makeKey(node) directly — NOT keyByRef.get(node.name) — so each node
+    // gets its own key regardless of display-name collisions.
+    const chartNodes = nodes.map((node) => ({
+        ...node,
+        name: makeKey(node),
+    }));
+
+    const chartLinks = links.map((link) => ({
+        ...link,
+        source: keyByRef.get(link.source) ?? link.source,
+        target: keyByRef.get(link.target) ?? link.target,
+    }));
+
+    return { chartNodes, chartLinks, labelByKey };
+}
+
 type SankeyChartProps = {
     nodes: SankeyNode[];
     links: SankeyLink[];
@@ -94,42 +157,10 @@ export function SankeyChart({
         [height, width, style],
     );
 
-    const { chartNodes, chartLinks, labelByKey } = useMemo(() => {
-        const keyByRef = new Map<string, string>();
-        const labelByKey = new Map<string, string>();
-
-        const makeKey = (node: SankeyNode) => {
-            if (node.id) {
-                return node.id;
-            }
-            if (node.group) {
-                return `${node.group}:${node.name}`;
-            }
-            return node.name;
-        };
-
-        nodes.forEach((node) => {
-            const key = makeKey(node);
-            keyByRef.set(node.name, key);
-            if (node.id) {
-                keyByRef.set(node.id, key);
-            }
-            labelByKey.set(key, node.name);
-        });
-
-        const chartNodes = nodes.map((node) => ({
-            ...node,
-            name: keyByRef.get(node.name) ?? makeKey(node),
-        }));
-
-        const chartLinks = links.map((link) => ({
-            ...link,
-            source: keyByRef.get(link.source) ?? link.source,
-            target: keyByRef.get(link.target) ?? link.target,
-        }));
-
-        return { chartNodes, chartLinks, labelByKey };
-    }, [nodes, links]);
+    const { chartNodes, chartLinks, labelByKey } = useMemo(
+        () => buildSankeyAdapterData(nodes, links),
+        [nodes, links],
+    );
 
     const displayNameForKey = useCallback(
         (value: string) => {

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.test.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.test.tsx
@@ -228,9 +228,7 @@ describe("joinEdges", () => {
 
     // CHAOS-2119: PR display name from DEPLOYS sourceDisplayName
     it("populates prDisplayNames from DEPLOYS sourceDisplayName (CHAOS-2119)", () => {
-        const incidents: WorkGraphEdge[] = [
-            makeEdge("l1", "dep-a", "inc-1", "LINKED_INCIDENT"),
-        ];
+        const incidents: WorkGraphEdge[] = [makeEdge("l1", "dep-a", "inc-1", "LINKED_INCIDENT")];
         const deploys: WorkGraphEdge[] = [
             makeEdge("d1", "pr-uuid-abc", "dep-a", "DEPLOYS", {
                 sourceDisplayName: "Fix: null pointer in checkout #847",
@@ -363,9 +361,7 @@ describe("buildSankeyData", () => {
         // Links target the composite key, not the collapsed display name
         expect(result!.links).toHaveLength(2);
         const linkTargets = result!.links.map((l) => l.target).sort();
-        expect(linkTargets).toEqual(
-            ["incident:uuid-inc-aaa", "incident:uuid-inc-bbb"].sort(),
-        );
+        expect(linkTargets).toEqual(["incident:uuid-inc-aaa", "incident:uuid-inc-bbb"].sort());
     });
 
     // CHAOS-2118: uniqueness for deployments with the same display name
@@ -401,7 +397,7 @@ describe("buildSankeyData", () => {
         const sharedUuid = "aaaa1111-0000-0000-0000-000000000000";
         const rows = [
             {
-                incidentId: sharedUuid,   // incident with this UUID
+                incidentId: sharedUuid, // incident with this UUID
                 deploymentIds: [sharedUuid], // deployment with the SAME UUID
                 prIdsByDeployment: {},
             },
@@ -502,7 +498,9 @@ describe("buildSankeyData", () => {
                 incidentDisplayName: "INC-2025-001",
                 deploymentIds: ["abcdef12-0000-0000-0000-000000000000"],
                 prIdsByDeployment: {
-                    "abcdef12-0000-0000-0000-000000000000": ["12345678-0000-0000-0000-000000000000"],
+                    "abcdef12-0000-0000-0000-000000000000": [
+                        "12345678-0000-0000-0000-000000000000",
+                    ],
                 },
                 deploymentDisplayNames: { "abcdef12-0000-0000-0000-000000000000": null },
                 prDisplayNames: { "12345678-0000-0000-0000-000000000000": null },

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.test.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.test.tsx
@@ -245,6 +245,150 @@ describe("buildSankeyData", () => {
             expect.arrayContaining([expect.objectContaining({ name: "inc:4e00fff2" })]),
         );
     });
+
+    // CHAOS-2118: collision regression — identical display names must not merge nodes
+    it("produces separate nodes for two incidents with the same display name (CHAOS-2118)", () => {
+        const rows = [
+            {
+                incidentId: "uuid-inc-aaa",
+                incidentDisplayName: "Production Outage",
+                deploymentIds: ["dep-001"],
+                workItemIds: [],
+            },
+            {
+                incidentId: "uuid-inc-bbb",
+                incidentDisplayName: "Production Outage", // same label, different id
+                deploymentIds: ["dep-002"],
+                workItemIds: [],
+            },
+        ];
+
+        const result = buildSankeyData(rows);
+
+        expect(result).not.toBeNull();
+        // 4 nodes: 2 incidents (distinct UUIDs) + 2 deployments
+        expect(result!.nodes).toHaveLength(4);
+        // Each incident node has its own id
+        expect(result!.nodes).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ id: "uuid-inc-aaa", name: "Production Outage" }),
+                expect.objectContaining({ id: "uuid-inc-bbb", name: "Production Outage" }),
+            ]),
+        );
+        // Links reference the correct incident by UUID (not collapsed)
+        expect(result!.links).toHaveLength(2);
+        const linkTargets = result!.links.map((l) => l.target).sort();
+        expect(linkTargets).toEqual(["uuid-inc-aaa", "uuid-inc-bbb"].sort());
+    });
+
+    // CHAOS-2118: uniqueness for deployments with the same display name
+    it("produces separate deployment nodes even when their labels collide (CHAOS-2118)", () => {
+        const rows = [
+            {
+                incidentId: "uuid-inc-aaa",
+                incidentDisplayName: "INC-A",
+                deploymentIds: ["dep-111", "dep-222"],
+                workItemIds: [],
+                deploymentDisplayNames: {
+                    "dep-111": "deploy/main",
+                    "dep-222": "deploy/main", // same label, different id
+                },
+            },
+        ];
+
+        const result = buildSankeyData(rows);
+
+        expect(result).not.toBeNull();
+        // 3 nodes: 1 incident + 2 deployments
+        expect(result!.nodes).toHaveLength(3);
+        expect(result!.nodes).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ id: "dep-111" }),
+                expect.objectContaining({ id: "dep-222" }),
+            ]),
+        );
+    });
+
+    // CHAOS-2119: resolved labels surface in nodes
+    it("uses server-resolved deployment and work-item display names (CHAOS-2119)", () => {
+        const rows = [
+            {
+                incidentId: "uuid-inc-001",
+                incidentDisplayName: "INC-2025-001",
+                deploymentIds: ["dep-uuid-abc"],
+                workItemIds: ["wi-uuid-xyz"],
+                deploymentDisplayNames: { "dep-uuid-abc": "payments-service #42" },
+                workItemDisplayNames: { "wi-uuid-xyz": "JIRA-9876" },
+            },
+        ];
+
+        const result = buildSankeyData(rows);
+
+        expect(result).not.toBeNull();
+        expect(result!.nodes).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ id: "dep-uuid-abc", name: "payments-service #42" }),
+                expect.objectContaining({ id: "wi-uuid-xyz", name: "JIRA-9876" }),
+            ]),
+        );
+        // No raw short-id fallback rendered when name is resolved
+        const names = result!.nodes.map((n) => n.name);
+        expect(names).not.toContain("dep:dep-uuid");
+        expect(names).not.toContain("wi:wi-uuid-x");
+    });
+
+    // CHAOS-2119: unresolved fallback uses controlled short-id prefix
+    it("falls back to short-id prefix for unresolved deployment/work-item nodes (CHAOS-2119)", () => {
+        const rows = [
+            {
+                incidentId: "uuid-inc-001",
+                incidentDisplayName: "INC-2025-001",
+                deploymentIds: ["abcdef12-0000-0000-0000-000000000000"],
+                workItemIds: ["12345678-0000-0000-0000-000000000000"],
+                deploymentDisplayNames: { "abcdef12-0000-0000-0000-000000000000": null },
+                workItemDisplayNames: { "12345678-0000-0000-0000-000000000000": null },
+            },
+        ];
+
+        const result = buildSankeyData(rows);
+
+        expect(result).not.toBeNull();
+        // Deployment: null name → dep:<first 8 chars>
+        expect(result!.nodes).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ id: "abcdef12-0000-0000-0000-000000000000", name: "dep:abcdef12" }),
+                expect.objectContaining({ id: "12345678-0000-0000-0000-000000000000", name: "wi:12345678" }),
+            ]),
+        );
+    });
+
+    // CHAOS-2119: joinEdges propagates sourceDisplayName (DEPLOYS) and targetDisplayName (LINKED_INCIDENT)
+    it("joinEdges populates deploymentDisplayNames from DEPLOYS sourceDisplayName (CHAOS-2119)", () => {
+        const deploys: WorkGraphEdge[] = [
+            makeEdge("d1", "dep-uuid-abc", "inc-uuid-001", "DEPLOYS", {
+                sourceDisplayName: "api-gateway #7",
+                targetDisplayName: "INC-2025-001",
+            }),
+        ];
+
+        const rows = joinEdges(deploys, []);
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].deploymentDisplayNames).toEqual({ "dep-uuid-abc": "api-gateway #7" });
+    });
+
+    it("joinEdges populates workItemDisplayNames from LINKED_INCIDENT targetDisplayName (CHAOS-2119)", () => {
+        const incidents: WorkGraphEdge[] = [
+            makeEdge("l1", "inc-uuid-001", "wi-uuid-xyz", "LINKED_INCIDENT", {
+                targetDisplayName: "JIRA-9876",
+            }),
+        ];
+
+        const rows = joinEdges([], incidents);
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].workItemDisplayNames).toEqual({ "wi-uuid-xyz": "JIRA-9876" });
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.test.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.test.tsx
@@ -135,7 +135,7 @@ describe("joinEdges", () => {
         expect(rows[0].incidentId).toBe("inc-1");
         expect(rows[0].deploymentIds).toContain("dep-a");
         expect(rows[0].deploymentIds).toContain("dep-b");
-        expect(rows[0].prIds).toHaveLength(0);
+        expect(Object.values(rows[0].prIdsByDeployment).flat()).toHaveLength(0);
     });
 
     it("collects PR IDs per incident via deployment join from DEPLOYS edges", () => {
@@ -149,8 +149,9 @@ describe("joinEdges", () => {
         const rows = joinEdges(deploys, incidents);
         expect(rows).toHaveLength(1);
         expect(rows[0].incidentId).toBe("inc-1");
-        expect(rows[0].prIds).toContain("pr-x");
-        expect(rows[0].prIds).toContain("pr-y");
+        const allPrs = Object.values(rows[0].prIdsByDeployment).flat();
+        expect(allPrs).toContain("pr-x");
+        expect(allPrs).toContain("pr-y");
     });
 
     it("joins DEPLOYS and LINKED_INCIDENT edges via shared deploymentId", () => {
@@ -161,7 +162,7 @@ describe("joinEdges", () => {
         expect(rows).toHaveLength(1);
         expect(rows[0].incidentId).toBe("inc-1");
         expect(rows[0].deploymentIds).toContain("dep-a");
-        expect(rows[0].prIds).toContain("pr-a");
+        expect(rows[0].prIdsByDeployment["dep-a"]).toContain("pr-a");
     });
 
     it("produces separate rows for distinct incident IDs", () => {
@@ -256,6 +257,27 @@ describe("joinEdges", () => {
         const rows = joinEdges([], incidents);
         expect(rows[0].incidentDisplayName).toBe("INC-CANONICAL");
     });
+
+    // CHAOS-2118: prIdsByDeployment must preserve which PR caused which deployment
+    it("prIdsByDeployment preserves PR→deployment association (no cross-join)", () => {
+        // Two deployments, each triggered by a distinct PR.
+        // dep-a → inc-1 (LINKED_INCIDENT), pr-1 → dep-a (DEPLOYS)
+        // dep-b → inc-1 (LINKED_INCIDENT), pr-2 → dep-b (DEPLOYS)
+        const incidents: WorkGraphEdge[] = [
+            makeEdge("l1", "dep-a", "inc-1", "LINKED_INCIDENT"),
+            makeEdge("l2", "dep-b", "inc-1", "LINKED_INCIDENT"),
+        ];
+        const deploys: WorkGraphEdge[] = [
+            makeEdge("d1", "pr-1", "dep-a", "DEPLOYS"),
+            makeEdge("d2", "pr-2", "dep-b", "DEPLOYS"),
+        ];
+        const rows = joinEdges(deploys, incidents);
+        expect(rows).toHaveLength(1);
+        // dep-a should only contain pr-1 (not pr-2)
+        expect(rows[0].prIdsByDeployment["dep-a"]).toEqual(["pr-1"]);
+        // dep-b should only contain pr-2 (not pr-1)
+        expect(rows[0].prIdsByDeployment["dep-b"]).toEqual(["pr-2"]);
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -269,7 +291,7 @@ describe("buildSankeyData", () => {
 
     it("returns null when all incidents have no linked nodes (no links produced)", () => {
         // An incident with no deployments or PRs produces no links
-        const rows = [{ incidentId: "inc-1", deploymentIds: [], prIds: [] }];
+        const rows = [{ incidentId: "inc-1", deploymentIds: [], prIdsByDeployment: {} }];
         expect(buildSankeyData(rows)).toBeNull();
     });
 
@@ -279,7 +301,7 @@ describe("buildSankeyData", () => {
             {
                 incidentId: "inc-abc123",
                 deploymentIds: ["dep-xyz789"],
-                prIds: ["pr-lmn456"],
+                prIdsByDeployment: { "dep-xyz789": ["pr-lmn456"] },
             },
         ];
         const result = buildSankeyData(rows);
@@ -294,7 +316,7 @@ describe("buildSankeyData", () => {
                 incidentId: "4e00fff2-df66-5028-8ebd-e4535332300b",
                 incidentDisplayName: "INC-2025-404",
                 deploymentIds: ["dep-xyz789"],
-                prIds: ["pr-lmn456"],
+                prIdsByDeployment: { "dep-xyz789": ["pr-lmn456"] },
             },
         ];
 
@@ -316,13 +338,13 @@ describe("buildSankeyData", () => {
                 incidentId: "uuid-inc-aaa",
                 incidentDisplayName: "Production Outage",
                 deploymentIds: ["dep-001"],
-                prIds: [],
+                prIdsByDeployment: {},
             },
             {
                 incidentId: "uuid-inc-bbb",
                 incidentDisplayName: "Production Outage", // same label, different id
                 deploymentIds: ["dep-002"],
-                prIds: [],
+                prIdsByDeployment: {},
             },
         ];
 
@@ -353,7 +375,7 @@ describe("buildSankeyData", () => {
                 incidentId: "uuid-inc-aaa",
                 incidentDisplayName: "INC-A",
                 deploymentIds: ["dep-111", "dep-222"],
-                prIds: [],
+                prIdsByDeployment: {},
                 deploymentDisplayNames: {
                     "dep-111": "deploy/main",
                     "dep-222": "deploy/main", // same label, different id
@@ -381,7 +403,7 @@ describe("buildSankeyData", () => {
             {
                 incidentId: sharedUuid,   // incident with this UUID
                 deploymentIds: [sharedUuid], // deployment with the SAME UUID
-                prIds: [],
+                prIdsByDeployment: {},
             },
         ];
 
@@ -405,7 +427,7 @@ describe("buildSankeyData", () => {
                 incidentId: "uuid-inc-001",
                 incidentDisplayName: "INC-2025-001",
                 deploymentIds: ["dep-uuid-abc"],
-                prIds: ["pr-uuid-xyz"],
+                prIdsByDeployment: { "dep-uuid-abc": ["pr-uuid-xyz"] },
                 deploymentDisplayNames: { "dep-uuid-abc": "payments-service deploy #42" },
                 prDisplayNames: { "pr-uuid-xyz": "Fix: checkout null pointer" },
             },
@@ -432,6 +454,46 @@ describe("buildSankeyData", () => {
         expect(names).not.toContain("pr:pr-uuid-x");
     });
 
+    // CHAOS-2118 cross-join regression: multi-deployment incident with distinct PR sets
+    // must only produce the true PR→deployment edges, never false cross-links.
+    it("does not cross-join PRs to unrelated deployments (CHAOS-2118 regression)", () => {
+        // pr-a caused dep-a; pr-b caused dep-b.
+        // The false edges pr-a→dep-b and pr-b→dep-a must NOT appear.
+        const rows = [
+            {
+                incidentId: "inc-multi",
+                deploymentIds: ["dep-a", "dep-b"],
+                prIdsByDeployment: {
+                    "dep-a": ["pr-a"],
+                    "dep-b": ["pr-b"],
+                },
+            },
+        ];
+
+        const result = buildSankeyData(rows);
+
+        expect(result).not.toBeNull();
+        // True edges: pr-a→dep-a, pr-b→dep-b, dep-a→inc-multi, dep-b→inc-multi = 4 links
+        expect(result!.links).toHaveLength(4);
+
+        const prAToDep = result!.links.filter(
+            (l) => l.source === "pr:pr-a" && l.target === "deployment:dep-a",
+        );
+        const prBToDep = result!.links.filter(
+            (l) => l.source === "pr:pr-b" && l.target === "deployment:dep-b",
+        );
+        expect(prAToDep).toHaveLength(1);
+        expect(prBToDep).toHaveLength(1);
+
+        // Assert the false cross-links are absent
+        const falseLinks = result!.links.filter(
+            (l) =>
+                (l.source === "pr:pr-a" && l.target === "deployment:dep-b") ||
+                (l.source === "pr:pr-b" && l.target === "deployment:dep-a"),
+        );
+        expect(falseLinks).toHaveLength(0);
+    });
+
     // CHAOS-2119: unresolved fallback uses controlled short-id prefix
     it("falls back to short-id prefix for unresolved deployment/PR nodes (CHAOS-2119)", () => {
         const rows = [
@@ -439,7 +501,9 @@ describe("buildSankeyData", () => {
                 incidentId: "uuid-inc-001",
                 incidentDisplayName: "INC-2025-001",
                 deploymentIds: ["abcdef12-0000-0000-0000-000000000000"],
-                prIds: ["12345678-0000-0000-0000-000000000000"],
+                prIdsByDeployment: {
+                    "abcdef12-0000-0000-0000-000000000000": ["12345678-0000-0000-0000-000000000000"],
+                },
                 deploymentDisplayNames: { "abcdef12-0000-0000-0000-000000000000": null },
                 prDisplayNames: { "12345678-0000-0000-0000-000000000000": null },
             },

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.test.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.test.tsx
@@ -2,9 +2,14 @@
  * IncidentCorrelationDashboard tests — Vitest + jsdom (CHAOS-1746).
  *
  * Covers:
- *   - joinEdges: join logic + edge cases
+ *   - joinEdges: join logic + edge cases (corrected to real backend semantics)
  *   - buildSankeyData: node/link derivation
+ *   - buildSankeyAdapterData: ECharts adapter collision regression (CHAOS-2118)
  *   - Component: empty state, incident rows, sub-empty-edges state
+ *
+ * Backend edge semantics (models.py / ai_workflow.py):
+ *   DEPLOYS:          source = PR,         target = deployment
+ *   LINKED_INCIDENT:  source = deployment,  target = incident
  */
 import { describe, expect, it, vi } from "vitest";
 import { screen } from "@testing-library/react";
@@ -16,21 +21,30 @@ import {
     joinEdges,
     type WorkGraphEdge,
 } from "./IncidentCorrelationDashboard";
+import { buildSankeyAdapterData } from "@/components/charts/SankeyChart";
 import type { MetricFilter } from "@/lib/filters/types";
 
 // ---------------------------------------------------------------------------
 // Mocks — chart primitives that require canvas / echarts in jsdom
 // ---------------------------------------------------------------------------
 
-vi.mock("@/components/charts/SankeyChart", () => ({
-    SankeyChart: ({
-        nodes,
-        links,
-    }: {
-        nodes: { name: string }[];
-        links: { source: string; target: string; value: number }[];
-    }) => <div data-testid="sankey-chart" data-nodes={nodes.length} data-links={links.length} />,
-}));
+vi.mock("@/components/charts/SankeyChart", async (importOriginal) => {
+    // Import the real module so buildSankeyAdapterData remains testable
+    const real = await importOriginal<typeof import("@/components/charts/SankeyChart")>();
+    return {
+        ...real,
+        // Only replace the default React component (needs canvas/echarts)
+        SankeyChart: ({
+            nodes,
+            links,
+        }: {
+            nodes: { name: string }[];
+            links: { source: string; target: string; value: number }[];
+        }) => (
+            <div data-testid="sankey-chart" data-nodes={nodes.length} data-links={links.length} />
+        ),
+    };
+});
 
 vi.mock("@/components/charts/HorizontalBarChart", () => ({
     HorizontalBarChart: ({ categories }: { categories: string[] }) => (
@@ -57,6 +71,11 @@ vi.mock("next/navigation", () => ({
 // Test helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Build a WorkGraphEdge with correct sourceType/targetType per real backend:
+ *   DEPLOYS:          sourceType = PR,         targetType = DEPLOYMENT
+ *   LINKED_INCIDENT:  sourceType = DEPLOYMENT,  targetType = INCIDENT
+ */
 function makeEdge(
     edgeId: string,
     sourceId: string,
@@ -66,9 +85,9 @@ function makeEdge(
 ): WorkGraphEdge {
     return {
         edgeId,
-        sourceType: edgeType === "DEPLOYS" ? "DEPLOYMENT" : "INCIDENT",
+        sourceType: edgeType === "DEPLOYS" ? "PR" : "DEPLOYMENT",
         sourceId,
-        targetType: edgeType === "DEPLOYS" ? "INCIDENT" : "WORK_ITEM",
+        targetType: edgeType === "DEPLOYS" ? "DEPLOYMENT" : "INCIDENT",
         targetId,
         edgeType,
         provenance: null,
@@ -105,36 +124,72 @@ describe("joinEdges", () => {
         expect(joinEdges([], [])).toEqual([]);
     });
 
-    it("collects deployment IDs per incident from DEPLOYS edges", () => {
-        const deploys: WorkGraphEdge[] = [
-            makeEdge("d1", "dep-a", "inc-1", "DEPLOYS"),
-            makeEdge("d2", "dep-b", "inc-1", "DEPLOYS"),
-        ];
-        const rows = joinEdges(deploys, []);
-        expect(rows).toHaveLength(1);
-        expect(rows[0].incidentId).toBe("inc-1");
-        expect(rows[0].deploymentIds).toContain("dep-a");
-        expect(rows[0].deploymentIds).toContain("dep-b");
-        expect(rows[0].workItemIds).toHaveLength(0);
-    });
-
-    it("collects work-item IDs per incident from LINKED_INCIDENT edges", () => {
+    it("collects deployment IDs per incident from LINKED_INCIDENT edges", () => {
+        // LINKED_INCIDENT: source=deployment, target=incident
         const incidents: WorkGraphEdge[] = [
-            makeEdge("l1", "inc-1", "wi-a", "LINKED_INCIDENT"),
-            makeEdge("l2", "inc-1", "wi-b", "LINKED_INCIDENT"),
+            makeEdge("l1", "dep-a", "inc-1", "LINKED_INCIDENT"),
+            makeEdge("l2", "dep-b", "inc-1", "LINKED_INCIDENT"),
         ];
         const rows = joinEdges([], incidents);
         expect(rows).toHaveLength(1);
         expect(rows[0].incidentId).toBe("inc-1");
-        expect(rows[0].workItemIds).toContain("wi-a");
-        expect(rows[0].workItemIds).toContain("wi-b");
-        expect(rows[0].deploymentIds).toHaveLength(0);
+        expect(rows[0].deploymentIds).toContain("dep-a");
+        expect(rows[0].deploymentIds).toContain("dep-b");
+        expect(rows[0].prIds).toHaveLength(0);
     });
 
-    it("carries sourceDisplayName from LINKED_INCIDENT edges when there is no DEPLOYS edge", () => {
+    it("collects PR IDs per incident via deployment join from DEPLOYS edges", () => {
+        // LINKED_INCIDENT: dep-a → inc-1
+        // DEPLOYS:         pr-x → dep-a, pr-y → dep-a
+        const incidents: WorkGraphEdge[] = [makeEdge("l1", "dep-a", "inc-1", "LINKED_INCIDENT")];
+        const deploys: WorkGraphEdge[] = [
+            makeEdge("d1", "pr-x", "dep-a", "DEPLOYS"),
+            makeEdge("d2", "pr-y", "dep-a", "DEPLOYS"),
+        ];
+        const rows = joinEdges(deploys, incidents);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].incidentId).toBe("inc-1");
+        expect(rows[0].prIds).toContain("pr-x");
+        expect(rows[0].prIds).toContain("pr-y");
+    });
+
+    it("joins DEPLOYS and LINKED_INCIDENT edges via shared deploymentId", () => {
+        // dep-a is the shared deployment: PR→dep-a (DEPLOYS), dep-a→inc-1 (LINKED_INCIDENT)
+        const deploys: WorkGraphEdge[] = [makeEdge("d1", "pr-a", "dep-a", "DEPLOYS")];
+        const incidents: WorkGraphEdge[] = [makeEdge("l1", "dep-a", "inc-1", "LINKED_INCIDENT")];
+        const rows = joinEdges(deploys, incidents);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].incidentId).toBe("inc-1");
+        expect(rows[0].deploymentIds).toContain("dep-a");
+        expect(rows[0].prIds).toContain("pr-a");
+    });
+
+    it("produces separate rows for distinct incident IDs", () => {
         const incidents: WorkGraphEdge[] = [
-            makeEdge("l1", "4e00fff2-df66-5028-8ebd-e4535332300b", "wi-a", "LINKED_INCIDENT", {
-                sourceDisplayName: "INC-2025-404",
+            makeEdge("l1", "dep-a", "inc-1", "LINKED_INCIDENT"),
+            makeEdge("l2", "dep-b", "inc-2", "LINKED_INCIDENT"),
+        ];
+        const rows = joinEdges([], incidents);
+        expect(rows).toHaveLength(2);
+        const ids = rows.map((r) => r.incidentId).sort();
+        expect(ids).toEqual(["inc-1", "inc-2"]);
+    });
+
+    it("deduplicates repeated deployment IDs for the same incident", () => {
+        const incidents: WorkGraphEdge[] = [
+            makeEdge("l1", "dep-a", "inc-1", "LINKED_INCIDENT"),
+            makeEdge("l2", "dep-a", "inc-1", "LINKED_INCIDENT"), // duplicate
+        ];
+        const rows = joinEdges([], incidents);
+        expect(rows[0].deploymentIds).toHaveLength(1);
+        expect(rows[0].deploymentIds[0]).toBe("dep-a");
+    });
+
+    // CHAOS-2119: incident display name comes from LINKED_INCIDENT targetDisplayName
+    it("carries LINKED_INCIDENT targetDisplayName as incidentDisplayName (CHAOS-2119)", () => {
+        const incidents: WorkGraphEdge[] = [
+            makeEdge("l1", "dep-a", "4e00fff2-df66-5028-8ebd-e4535332300b", "LINKED_INCIDENT", {
+                targetDisplayName: "INC-2025-404",
             }),
         ];
 
@@ -145,52 +200,61 @@ describe("joinEdges", () => {
         expect(rows[0].incidentDisplayName).toBe("INC-2025-404");
     });
 
-    it("keeps DEPLOYS targetDisplayName when LINKED_INCIDENT sourceDisplayName disagrees", () => {
-        const deploys: WorkGraphEdge[] = [
-            makeEdge("d1", "dep-a", "inc-1", "DEPLOYS", {
-                targetDisplayName: "INC-2025-404",
-            }),
-        ];
+    it("sets incidentDisplayName to null when LINKED_INCIDENT has no targetDisplayName (CHAOS-2119)", () => {
         const incidents: WorkGraphEdge[] = [
-            makeEdge("l1", "inc-1", "wi-a", "LINKED_INCIDENT", {
-                sourceDisplayName: "Stale incident label",
+            makeEdge("l1", "dep-a", "uuid-inc-1", "LINKED_INCIDENT", {
+                targetDisplayName: null,
+            }),
+        ];
+        const rows = joinEdges([], incidents);
+        expect(rows[0].incidentDisplayName).toBeNull();
+    });
+
+    // CHAOS-2119: deployment display name from LINKED_INCIDENT sourceDisplayName
+    it("populates deploymentDisplayNames from LINKED_INCIDENT sourceDisplayName (CHAOS-2119)", () => {
+        const incidents: WorkGraphEdge[] = [
+            makeEdge("l1", "dep-uuid-abc", "inc-uuid-001", "LINKED_INCIDENT", {
+                sourceDisplayName: "payments-deploy-47",
+                targetDisplayName: "INC-2025-001",
+            }),
+        ];
+
+        const rows = joinEdges([], incidents);
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].deploymentDisplayNames).toEqual({ "dep-uuid-abc": "payments-deploy-47" });
+    });
+
+    // CHAOS-2119: PR display name from DEPLOYS sourceDisplayName
+    it("populates prDisplayNames from DEPLOYS sourceDisplayName (CHAOS-2119)", () => {
+        const incidents: WorkGraphEdge[] = [
+            makeEdge("l1", "dep-a", "inc-1", "LINKED_INCIDENT"),
+        ];
+        const deploys: WorkGraphEdge[] = [
+            makeEdge("d1", "pr-uuid-abc", "dep-a", "DEPLOYS", {
+                sourceDisplayName: "Fix: null pointer in checkout #847",
             }),
         ];
 
         const rows = joinEdges(deploys, incidents);
 
-        expect(rows[0].incidentDisplayName).toBe("INC-2025-404");
-    });
-
-    it("joins deployment and work-item edges by shared incident ID", () => {
-        const deploys: WorkGraphEdge[] = [makeEdge("d1", "dep-a", "inc-1", "DEPLOYS")];
-        const incidents: WorkGraphEdge[] = [makeEdge("l1", "inc-1", "wi-a", "LINKED_INCIDENT")];
-        const rows = joinEdges(deploys, incidents);
         expect(rows).toHaveLength(1);
-        expect(rows[0].incidentId).toBe("inc-1");
-        expect(rows[0].deploymentIds).toContain("dep-a");
-        expect(rows[0].workItemIds).toContain("wi-a");
+        expect(rows[0].prDisplayNames).toEqual({
+            "pr-uuid-abc": "Fix: null pointer in checkout #847",
+        });
     });
 
-    it("produces separate rows for distinct incident IDs", () => {
-        const deploys: WorkGraphEdge[] = [
-            makeEdge("d1", "dep-a", "inc-1", "DEPLOYS"),
-            makeEdge("d2", "dep-b", "inc-2", "DEPLOYS"),
+    it("first non-null display name wins for incident (LINKED_INCIDENT)", () => {
+        const incidents: WorkGraphEdge[] = [
+            makeEdge("l1", "dep-a", "inc-1", "LINKED_INCIDENT", {
+                targetDisplayName: "INC-CANONICAL",
+            }),
+            makeEdge("l2", "dep-b", "inc-1", "LINKED_INCIDENT", {
+                targetDisplayName: "INC-STALE",
+            }),
         ];
-        const rows = joinEdges(deploys, []);
-        expect(rows).toHaveLength(2);
-        const ids = rows.map((r) => r.incidentId).sort();
-        expect(ids).toEqual(["inc-1", "inc-2"]);
-    });
-
-    it("deduplicates repeated deployment IDs for the same incident", () => {
-        const deploys: WorkGraphEdge[] = [
-            makeEdge("d1", "dep-a", "inc-1", "DEPLOYS"),
-            makeEdge("d2", "dep-a", "inc-1", "DEPLOYS"), // duplicate deployment
-        ];
-        const rows = joinEdges(deploys, []);
-        expect(rows[0].deploymentIds).toHaveLength(1);
-        expect(rows[0].deploymentIds[0]).toBe("dep-a");
+        const rows = joinEdges([], incidents);
+        expect(rows[0].incidentDisplayName).toBe("INC-CANONICAL");
     });
 });
 
@@ -204,24 +268,23 @@ describe("buildSankeyData", () => {
     });
 
     it("returns null when all incidents have no linked nodes (no links produced)", () => {
-        // An incident with no deployments or work items produces no links
-        const rows = [{ incidentId: "inc-1", deploymentIds: [], workItemIds: [] }];
+        // An incident with no deployments or PRs produces no links
+        const rows = [{ incidentId: "inc-1", deploymentIds: [], prIds: [] }];
         expect(buildSankeyData(rows)).toBeNull();
     });
 
     it("returns non-null with correct node and link count for a simple row", () => {
+        // 1 PR → 1 deployment → 1 incident: 3 nodes, 2 links
         const rows = [
             {
-                incidentId: "incident-abc123",
-                deploymentIds: ["deploy-xyz789"],
-                workItemIds: ["work-item-lmn"],
+                incidentId: "inc-abc123",
+                deploymentIds: ["dep-xyz789"],
+                prIds: ["pr-lmn456"],
             },
         ];
         const result = buildSankeyData(rows);
         expect(result).not.toBeNull();
-        // 3 nodes: 1 incident + 1 deployment + 1 work item
         expect(result!.nodes).toHaveLength(3);
-        // 2 links: deployment→incident + incident→work_item
         expect(result!.links).toHaveLength(2);
     });
 
@@ -230,8 +293,8 @@ describe("buildSankeyData", () => {
             {
                 incidentId: "4e00fff2-df66-5028-8ebd-e4535332300b",
                 incidentDisplayName: "INC-2025-404",
-                deploymentIds: ["deploy-xyz789"],
-                workItemIds: ["work-item-lmn"],
+                deploymentIds: ["dep-xyz789"],
+                prIds: ["pr-lmn456"],
             },
         ];
 
@@ -253,32 +316,34 @@ describe("buildSankeyData", () => {
                 incidentId: "uuid-inc-aaa",
                 incidentDisplayName: "Production Outage",
                 deploymentIds: ["dep-001"],
-                workItemIds: [],
+                prIds: [],
             },
             {
                 incidentId: "uuid-inc-bbb",
                 incidentDisplayName: "Production Outage", // same label, different id
                 deploymentIds: ["dep-002"],
-                workItemIds: [],
+                prIds: [],
             },
         ];
 
         const result = buildSankeyData(rows);
 
         expect(result).not.toBeNull();
-        // 4 nodes: 2 incidents (distinct UUIDs) + 2 deployments
+        // 4 nodes: 2 incidents (distinct composite keys) + 2 deployments
         expect(result!.nodes).toHaveLength(4);
-        // Each incident node has its own id
+        // Each incident node is type-namespaced — id = "incident:<uuid>"
         expect(result!.nodes).toEqual(
             expect.arrayContaining([
-                expect.objectContaining({ id: "uuid-inc-aaa", name: "Production Outage" }),
-                expect.objectContaining({ id: "uuid-inc-bbb", name: "Production Outage" }),
+                expect.objectContaining({ id: "incident:uuid-inc-aaa", name: "Production Outage" }),
+                expect.objectContaining({ id: "incident:uuid-inc-bbb", name: "Production Outage" }),
             ]),
         );
-        // Links reference the correct incident by UUID (not collapsed)
+        // Links target the composite key, not the collapsed display name
         expect(result!.links).toHaveLength(2);
         const linkTargets = result!.links.map((l) => l.target).sort();
-        expect(linkTargets).toEqual(["uuid-inc-aaa", "uuid-inc-bbb"].sort());
+        expect(linkTargets).toEqual(
+            ["incident:uuid-inc-aaa", "incident:uuid-inc-bbb"].sort(),
+        );
     });
 
     // CHAOS-2118: uniqueness for deployments with the same display name
@@ -288,7 +353,7 @@ describe("buildSankeyData", () => {
                 incidentId: "uuid-inc-aaa",
                 incidentDisplayName: "INC-A",
                 deploymentIds: ["dep-111", "dep-222"],
-                workItemIds: [],
+                prIds: [],
                 deploymentDisplayNames: {
                     "dep-111": "deploy/main",
                     "dep-222": "deploy/main", // same label, different id
@@ -299,26 +364,50 @@ describe("buildSankeyData", () => {
         const result = buildSankeyData(rows);
 
         expect(result).not.toBeNull();
-        // 3 nodes: 1 incident + 2 deployments
+        // 3 nodes: 1 incident + 2 deployments (not collapsed despite same label)
         expect(result!.nodes).toHaveLength(3);
         expect(result!.nodes).toEqual(
             expect.arrayContaining([
-                expect.objectContaining({ id: "dep-111" }),
-                expect.objectContaining({ id: "dep-222" }),
+                expect.objectContaining({ id: "deployment:dep-111" }),
+                expect.objectContaining({ id: "deployment:dep-222" }),
+            ]),
+        );
+    });
+
+    // WARNING 1: cross-type UUID collision — same raw UUID for different types
+    it("produces separate nodes for deployment and incident with the same raw UUID (WARNING 1)", () => {
+        const sharedUuid = "aaaa1111-0000-0000-0000-000000000000";
+        const rows = [
+            {
+                incidentId: sharedUuid,   // incident with this UUID
+                deploymentIds: [sharedUuid], // deployment with the SAME UUID
+                prIds: [],
+            },
+        ];
+
+        const result = buildSankeyData(rows);
+
+        expect(result).not.toBeNull();
+        // Both nodes exist — not merged
+        expect(result!.nodes).toHaveLength(2);
+        expect(result!.nodes).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ id: `incident:${sharedUuid}` }),
+                expect.objectContaining({ id: `deployment:${sharedUuid}` }),
             ]),
         );
     });
 
     // CHAOS-2119: resolved labels surface in nodes
-    it("uses server-resolved deployment and work-item display names (CHAOS-2119)", () => {
+    it("uses server-resolved deployment and PR display names (CHAOS-2119)", () => {
         const rows = [
             {
                 incidentId: "uuid-inc-001",
                 incidentDisplayName: "INC-2025-001",
                 deploymentIds: ["dep-uuid-abc"],
-                workItemIds: ["wi-uuid-xyz"],
-                deploymentDisplayNames: { "dep-uuid-abc": "payments-service #42" },
-                workItemDisplayNames: { "wi-uuid-xyz": "JIRA-9876" },
+                prIds: ["pr-uuid-xyz"],
+                deploymentDisplayNames: { "dep-uuid-abc": "payments-service deploy #42" },
+                prDisplayNames: { "pr-uuid-xyz": "Fix: checkout null pointer" },
             },
         ];
 
@@ -327,67 +416,120 @@ describe("buildSankeyData", () => {
         expect(result).not.toBeNull();
         expect(result!.nodes).toEqual(
             expect.arrayContaining([
-                expect.objectContaining({ id: "dep-uuid-abc", name: "payments-service #42" }),
-                expect.objectContaining({ id: "wi-uuid-xyz", name: "JIRA-9876" }),
+                expect.objectContaining({
+                    id: "deployment:dep-uuid-abc",
+                    name: "payments-service deploy #42",
+                }),
+                expect.objectContaining({
+                    id: "pr:pr-uuid-xyz",
+                    name: "Fix: checkout null pointer",
+                }),
             ]),
         );
-        // No raw short-id fallback rendered when name is resolved
+        // No short-id fallback rendered when name is resolved
         const names = result!.nodes.map((n) => n.name);
         expect(names).not.toContain("dep:dep-uuid");
-        expect(names).not.toContain("wi:wi-uuid-x");
+        expect(names).not.toContain("pr:pr-uuid-x");
     });
 
     // CHAOS-2119: unresolved fallback uses controlled short-id prefix
-    it("falls back to short-id prefix for unresolved deployment/work-item nodes (CHAOS-2119)", () => {
+    it("falls back to short-id prefix for unresolved deployment/PR nodes (CHAOS-2119)", () => {
         const rows = [
             {
                 incidentId: "uuid-inc-001",
                 incidentDisplayName: "INC-2025-001",
                 deploymentIds: ["abcdef12-0000-0000-0000-000000000000"],
-                workItemIds: ["12345678-0000-0000-0000-000000000000"],
+                prIds: ["12345678-0000-0000-0000-000000000000"],
                 deploymentDisplayNames: { "abcdef12-0000-0000-0000-000000000000": null },
-                workItemDisplayNames: { "12345678-0000-0000-0000-000000000000": null },
+                prDisplayNames: { "12345678-0000-0000-0000-000000000000": null },
             },
         ];
 
         const result = buildSankeyData(rows);
 
         expect(result).not.toBeNull();
-        // Deployment: null name → dep:<first 8 chars>
         expect(result!.nodes).toEqual(
             expect.arrayContaining([
-                expect.objectContaining({ id: "abcdef12-0000-0000-0000-000000000000", name: "dep:abcdef12" }),
-                expect.objectContaining({ id: "12345678-0000-0000-0000-000000000000", name: "wi:12345678" }),
+                expect.objectContaining({
+                    id: "deployment:abcdef12-0000-0000-0000-000000000000",
+                    name: "dep:abcdef12",
+                }),
+                expect.objectContaining({
+                    id: "pr:12345678-0000-0000-0000-000000000000",
+                    name: "pr:12345678",
+                }),
             ]),
         );
     });
+});
 
-    // CHAOS-2119: joinEdges propagates sourceDisplayName (DEPLOYS) and targetDisplayName (LINKED_INCIDENT)
-    it("joinEdges populates deploymentDisplayNames from DEPLOYS sourceDisplayName (CHAOS-2119)", () => {
-        const deploys: WorkGraphEdge[] = [
-            makeEdge("d1", "dep-uuid-abc", "inc-uuid-001", "DEPLOYS", {
-                sourceDisplayName: "api-gateway #7",
-                targetDisplayName: "INC-2025-001",
-            }),
+// ---------------------------------------------------------------------------
+// buildSankeyAdapterData — real ECharts adapter tests (CHAOS-2118 CRITICAL 1)
+// Tests the actual adapter logic, NOT the mocked SankeyChart component.
+// ---------------------------------------------------------------------------
+
+describe("buildSankeyAdapterData", () => {
+    it("assigns distinct ECharts keys to nodes with identical display names (CHAOS-2118)", () => {
+        // Two incident nodes with the same display name — adapter must not collapse them.
+        const nodes = [
+            { id: "incident:uuid-aaa", name: "Production Outage", group: "incident" },
+            { id: "incident:uuid-bbb", name: "Production Outage", group: "incident" },
+        ];
+        const links = [
+            { source: "deployment:dep-001", target: "incident:uuid-aaa", value: 1 },
+            { source: "deployment:dep-002", target: "incident:uuid-bbb", value: 1 },
         ];
 
-        const rows = joinEdges(deploys, []);
+        const { chartNodes, chartLinks } = buildSankeyAdapterData(nodes, links);
 
-        expect(rows).toHaveLength(1);
-        expect(rows[0].deploymentDisplayNames).toEqual({ "dep-uuid-abc": "api-gateway #7" });
+        // Both nodes must have distinct ECharts names (internal keys)
+        const chartNames = chartNodes.map((n) => n.name);
+        expect(new Set(chartNames).size).toBe(2);
+        expect(chartNames).toContain("incident:uuid-aaa");
+        expect(chartNames).toContain("incident:uuid-bbb");
+
+        // Links must map to the correct distinct keys
+        const linkTargets = chartLinks.map((l) => l.target).sort();
+        expect(linkTargets).toEqual(["incident:uuid-aaa", "incident:uuid-bbb"].sort());
     });
 
-    it("joinEdges populates workItemDisplayNames from LINKED_INCIDENT targetDisplayName (CHAOS-2119)", () => {
-        const incidents: WorkGraphEdge[] = [
-            makeEdge("l1", "inc-uuid-001", "wi-uuid-xyz", "LINKED_INCIDENT", {
-                targetDisplayName: "JIRA-9876",
-            }),
+    it("preserves display names in labelByKey for tooltip rendering", () => {
+        const nodes = [
+            { id: "incident:uuid-aaa", name: "Production Outage", group: "incident" },
+            { id: "incident:uuid-bbb", name: "Production Outage", group: "incident" },
         ];
+        const { labelByKey } = buildSankeyAdapterData(nodes, []);
 
-        const rows = joinEdges([], incidents);
+        expect(labelByKey.get("incident:uuid-aaa")).toBe("Production Outage");
+        expect(labelByKey.get("incident:uuid-bbb")).toBe("Production Outage");
+    });
 
-        expect(rows).toHaveLength(1);
-        expect(rows[0].workItemDisplayNames).toEqual({ "wi-uuid-xyz": "JIRA-9876" });
+    it("resolves links that reference nodes by their composite id", () => {
+        const nodes = [
+            { id: "deployment:dep-1", name: "deploy/main", group: "deployment" },
+            { id: "incident:inc-1", name: "INC-001", group: "incident" },
+        ];
+        const links = [{ source: "deployment:dep-1", target: "incident:inc-1", value: 1 }];
+
+        const { chartLinks } = buildSankeyAdapterData(nodes, links);
+
+        expect(chartLinks[0].source).toBe("deployment:dep-1");
+        expect(chartLinks[0].target).toBe("incident:inc-1");
+    });
+
+    it("handles legacy name-based links (no id on node) without collision for distinct names", () => {
+        const nodes = [
+            { name: "Alpha", group: "deployment" },
+            { name: "Beta", group: "incident" },
+        ];
+        const links = [{ source: "Alpha", target: "Beta", value: 1 }];
+
+        const { chartNodes, chartLinks } = buildSankeyAdapterData(nodes, links);
+
+        expect(chartNodes[0].name).toBe("deployment:Alpha");
+        expect(chartNodes[1].name).toBe("incident:Beta");
+        expect(chartLinks[0].source).toBe("deployment:Alpha");
+        expect(chartLinks[0].target).toBe("incident:Beta");
     });
 });
 
@@ -418,12 +560,12 @@ describe("IncidentCorrelationDashboard", () => {
     });
 
     it("renders incident linkage table when edge data is present", () => {
-        const deploys = [makeEdge("d1", "dep-1", "inc-1", "DEPLOYS")];
-        const incidents = [makeEdge("l1", "inc-1", "wi-1", "LINKED_INCIDENT")];
+        // LINKED_INCIDENT: dep-1 → inc-1 gives one incident row
+        const incidents = [makeEdge("l1", "dep-1", "inc-1", "LINKED_INCIDENT")];
         render(
             <IncidentCorrelationDashboard
                 {...baseProps}
-                deploysEdges={deploys}
+                deploysEdges={[]}
                 incidentEdges={incidents}
             />,
         );
@@ -432,12 +574,12 @@ describe("IncidentCorrelationDashboard", () => {
     });
 
     it("renders the SankeyChart when joined edge data produces links", () => {
-        const deploys = [makeEdge("d1", "dep-1", "inc-1", "DEPLOYS")];
-        const incidents = [makeEdge("l1", "inc-1", "wi-1", "LINKED_INCIDENT")];
+        // dep-1 → inc-1 produces a deployment→incident link in the Sankey
+        const incidents = [makeEdge("l1", "dep-1", "inc-1", "LINKED_INCIDENT")];
         render(
             <IncidentCorrelationDashboard
                 {...baseProps}
-                deploysEdges={deploys}
+                deploysEdges={[]}
                 incidentEdges={incidents}
             />,
         );
@@ -583,19 +725,19 @@ describe("IncidentCorrelationDashboard", () => {
     });
 
     it("incident table renders server-resolved name for a UUID incident id (CHAOS-2089)", () => {
-        // DEPLOYS edge carries targetDisplayName = resolved incident name.
+        // LINKED_INCIDENT carries targetDisplayName = resolved incident name.
         // joinEdges must propagate it to IncidentRow.incidentDisplayName.
         // EntityLabel must render the resolved name, never the raw UUID.
-        const deploys = [
-            makeEdge("d1", "dep-a", "4e00fff2-df66-5028-8ebd-e4535332300b", "DEPLOYS", {
+        const incidents = [
+            makeEdge("l1", "dep-a", "4e00fff2-df66-5028-8ebd-e4535332300b", "LINKED_INCIDENT", {
                 targetDisplayName: "INC-2025-001",
             }),
         ];
         render(
             <IncidentCorrelationDashboard
                 {...baseProps}
-                deploysEdges={deploys}
-                incidentEdges={[]}
+                deploysEdges={[]}
+                incidentEdges={incidents}
             />,
         );
         expect(screen.getByTestId("incident-linkage-table")).toBeInTheDocument();
@@ -606,42 +748,20 @@ describe("IncidentCorrelationDashboard", () => {
     it("incident table shows Unresolved badge for a UUID incident id with no display name (CHAOS-2089)", () => {
         // When targetDisplayName is null (backend could not resolve), EntityLabel
         // degrades to a controlled short token + Unresolved badge — never raw UUID.
-        const deploys = [
-            makeEdge("d1", "dep-a", "698c0211-0000-0000-0000-0000fee29c84", "DEPLOYS", {
+        const incidents = [
+            makeEdge("l1", "dep-a", "698c0211-0000-0000-0000-0000fee29c84", "LINKED_INCIDENT", {
                 targetDisplayName: null,
             }),
         ];
         render(
             <IncidentCorrelationDashboard
                 {...baseProps}
-                deploysEdges={deploys}
-                incidentEdges={[]}
+                deploysEdges={[]}
+                incidentEdges={incidents}
             />,
         );
         expect(screen.getByTestId("incident-linkage-table")).toBeInTheDocument();
         expect(screen.getByText("Unresolved")).toBeInTheDocument();
         expect(screen.queryByText(/698c0211-0000/)).not.toBeInTheDocument();
-    });
-
-    it("joinEdges carries targetDisplayName from DEPLOYS edge as incidentDisplayName", () => {
-        const deploys = [
-            makeEdge("d1", "dep-a", "uuid-inc-1", "DEPLOYS", {
-                targetDisplayName: "INC-PROD-042",
-            }),
-        ];
-        const rows = joinEdges(deploys, []);
-        expect(rows).toHaveLength(1);
-        expect(rows[0].incidentId).toBe("uuid-inc-1");
-        expect(rows[0].incidentDisplayName).toBe("INC-PROD-042");
-    });
-
-    it("joinEdges sets incidentDisplayName to null when edge has no targetDisplayName", () => {
-        const deploys = [
-            makeEdge("d1", "dep-a", "uuid-inc-1", "DEPLOYS", {
-                targetDisplayName: null,
-            }),
-        ];
-        const rows = joinEdges(deploys, []);
-        expect(rows[0].incidentDisplayName).toBeNull();
     });
 });

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
@@ -72,15 +72,21 @@ export type IncidentRow = {
     incidentDisplayName?: string | null;
     /** Deployment IDs linked to this incident. From LINKED_INCIDENT sourceId. */
     deploymentIds: string[];
-    /** PR IDs that caused the linked deployments. From DEPLOYS sourceId. */
-    prIds: string[];
+    /**
+     * PRs keyed by deployment ID — only the PRs that actually caused each deployment.
+     * Preserves the exact PR→deployment association so buildSankeyData can emit correct
+     * edges without cross-joining every PR to every deployment in the incident.
+     *
+     * Example: { "dep-a": ["pr-1", "pr-2"], "dep-b": ["pr-3"] }
+     */
+    prIdsByDeployment: Record<string, string[]>;
     /**
      * Server-resolved display names for deployment IDs (CHAOS-2119).
      * Populated from LINKED_INCIDENT edge sourceDisplayName (deployment name).
      */
     deploymentDisplayNames?: Record<string, string | null>;
     /**
-     * Server-resolved display names for PR IDs (CHAOS-2119).
+     * Server-resolved display names for all PR IDs across all deployments (CHAOS-2119).
      * Populated from DEPLOYS edge sourceDisplayName (PR name).
      */
     prDisplayNames?: Record<string, string | null>;
@@ -191,25 +197,29 @@ export function joinEdges(
     // ── Step 3: Build incident-centric rows ─────────────────────────────────
     return Array.from(deploymentsByIncident.keys()).map((incidentId) => {
         const depIds = Array.from(deploymentsByIncident.get(incidentId) ?? []);
-        // Collect all PRs that caused any of this incident's deployments
-        const prIdSet = new Set<string>();
+
+        // Preserve the PR→deployment association: keyed by deploymentId so
+        // buildSankeyData can emit only the true PR→deployment edges (no cross-join).
+        const prIdsByDeployment: Record<string, string[]> = {};
+        const allPrIds = new Set<string>();
         for (const depId of depIds) {
-            for (const prId of prsByDeployment.get(depId) ?? []) {
-                prIdSet.add(prId);
+            const prs = Array.from(prsByDeployment.get(depId) ?? []);
+            prIdsByDeployment[depId] = prs;
+            for (const prId of prs) {
+                allPrIds.add(prId);
             }
         }
-        const prIds = Array.from(prIdSet);
 
         return {
             incidentId,
             incidentDisplayName: incidentDisplayNames.get(incidentId) ?? null,
             deploymentIds: depIds,
-            prIds,
+            prIdsByDeployment,
             deploymentDisplayNames: Object.fromEntries(
                 depIds.map((id) => [id, deploymentDisplayNames.get(id) ?? null]),
             ),
             prDisplayNames: Object.fromEntries(
-                prIds.map((id) => [id, prDisplayNames.get(id) ?? null]),
+                Array.from(allPrIds).map((id) => [id, prDisplayNames.get(id) ?? null]),
             ),
         };
     });
@@ -260,22 +270,23 @@ export function buildSankeyData(
             links.push({ source: depKey, target: incKey, value: 1 });
         }
 
-        for (const prId of row.prIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
-            // CHAOS-2119: use server-resolved PR name when available
-            const resolved = row.prDisplayNames?.[prId];
-            const prLabel = resolved?.trim() || `pr:${prId.slice(0, 8)}`;
-            addNode(prId, prLabel, "pr");
-            const prKey = makeNodeKey("pr", prId);
-            // Flow: PR → deployment (but we link PR → incident's deployment)
-            // Since each PR is linked to deployments, flow is pr → deployment.
-            // The deployment node for this PR may come from different incidents;
-            // we connect to the deployment that links to this incident.
-            for (const depId of row.deploymentIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
-                // Only add PR→deployment link when this PR caused this deployment
-                // (deploymentIds are the deployments for this incident row)
-                const depKey = makeNodeKey("deployment", depId);
+        // Flow: PR → deployment.  Iterate deployment-first and emit only the
+        // exact (pr, dep) pairs from prIdsByDeployment.  This prevents the
+        // cross-join bug where every PR is incorrectly linked to every deployment
+        // in the incident regardless of their actual relationship (CHAOS-2118).
+        let depLinksEmitted = 0;
+        for (const [depId, prIds] of Object.entries(row.prIdsByDeployment)) {
+            if (depLinksEmitted >= MAX_LINKS_PER_INCIDENT) break;
+            const depKey = makeNodeKey("deployment", depId);
+            for (const prId of prIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
+                // CHAOS-2119: use server-resolved PR name when available
+                const resolved = row.prDisplayNames?.[prId];
+                const prLabel = resolved?.trim() || `pr:${prId.slice(0, 8)}`;
+                addNode(prId, prLabel, "pr");
+                const prKey = makeNodeKey("pr", prId);
                 links.push({ source: prKey, target: depKey, value: 1 });
             }
+            depLinksEmitted++;
         }
     }
 
@@ -548,7 +559,7 @@ export function IncidentCorrelationDashboard({
                                             {row.deploymentIds.length}
                                         </td>
                                         <td className="px-5 py-3 text-right tabular-nums">
-                                            {row.prIds.length}
+                                            {new Set(Object.values(row.prIdsByDeployment).flat()).size}
                                         </td>
                                     </tr>
                                 ))}

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
@@ -146,8 +146,8 @@ export function joinEdges(
     const deploymentDisplayNames = new Map<string, string | null>();
 
     for (const edge of incidentEdges) {
-        const incidentId = edge.targetId;       // LINKED_INCIDENT target = incident
-        const deploymentId = edge.sourceId;     // LINKED_INCIDENT source = deployment
+        const incidentId = edge.targetId; // LINKED_INCIDENT target = incident
+        const deploymentId = edge.sourceId; // LINKED_INCIDENT source = deployment
         if (!deploymentsByIncident.has(incidentId)) {
             deploymentsByIncident.set(incidentId, new Set());
         }
@@ -164,7 +164,10 @@ export function joinEdges(
         // Deployment display name from sourceDisplayName. First non-null wins.
         if (!deploymentDisplayNames.has(deploymentId)) {
             deploymentDisplayNames.set(deploymentId, edge.sourceDisplayName ?? null);
-        } else if (deploymentDisplayNames.get(deploymentId) == null && edge.sourceDisplayName != null) {
+        } else if (
+            deploymentDisplayNames.get(deploymentId) == null &&
+            edge.sourceDisplayName != null
+        ) {
             deploymentDisplayNames.set(deploymentId, edge.sourceDisplayName);
         }
     }
@@ -175,8 +178,8 @@ export function joinEdges(
     const prDisplayNames = new Map<string, string | null>();
 
     for (const edge of deploysEdges) {
-        const prId = edge.sourceId;             // DEPLOYS source = PR
-        const deploymentId = edge.targetId;     // DEPLOYS target = deployment
+        const prId = edge.sourceId; // DEPLOYS source = PR
+        const deploymentId = edge.targetId; // DEPLOYS target = deployment
         if (!prsByDeployment.has(deploymentId)) {
             prsByDeployment.set(deploymentId, new Set());
         }
@@ -255,8 +258,7 @@ export function buildSankeyData(
 
     for (const row of limited) {
         // Incident label: prefer server-resolved display name; fall back to short ID prefix
-        const incLabel =
-            row.incidentDisplayName?.trim() || `inc:${row.incidentId.slice(0, 8)}`;
+        const incLabel = row.incidentDisplayName?.trim() || `inc:${row.incidentId.slice(0, 8)}`;
         addNode(row.incidentId, incLabel, "incident");
         const incKey = makeNodeKey("incident", row.incidentId);
 
@@ -559,7 +561,10 @@ export function IncidentCorrelationDashboard({
                                             {row.deploymentIds.length}
                                         </td>
                                         <td className="px-5 py-3 text-right tabular-nums">
-                                            {new Set(Object.values(row.prIdsByDeployment).flat()).size}
+                                            {
+                                                new Set(Object.values(row.prIdsByDeployment).flat())
+                                                    .size
+                                            }
                                         </td>
                                     </tr>
                                 ))}

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
@@ -6,7 +6,7 @@
  *   2. Enlarged change_failure_rate sparkline (V1 trend — no multi-week chart, see CHAOS-1757).
  *   3. Drivers + Contributors (HorizontalBarChart from getExplainData).
  *   4. Linked incidents table — client-side join of DEPLOYS + LINKED_INCIDENT edges.
- *   5. SankeyChart — top N deployments → incidents → work items (skipped when join is empty).
+ *   5. SankeyChart — top N PRs → deployments → incidents (skipped when join is empty).
  *   6. Empty state mirroring CompoundingRiskDashboard voice.
  *
  * V1 limitations (documented in PR body):
@@ -56,23 +56,34 @@ export type WorkGraphEdge = {
     provider: string | null;
 };
 
-/** Joined incident row: one incident with its linked deployments and work items. */
+/**
+ * Joined incident row: one incident with the deployments that triggered it and
+ * the PRs that caused those deployments.
+ *
+ * Backend edge semantics (CHAOS-2119 correction):
+ *   DEPLOYS:          sourceId = PR,         targetId = deployment
+ *   LINKED_INCIDENT:  sourceId = deployment,  targetId = incident
+ *
+ * The Sankey therefore flows: PR → Deployment → Incident.
+ */
 export type IncidentRow = {
     incidentId: string;
-    /** Server-resolved display name for incidentId (A7/CHAOS-2089). */
+    /** Server-resolved display name for incidentId. From LINKED_INCIDENT targetDisplayName. */
     incidentDisplayName?: string | null;
+    /** Deployment IDs linked to this incident. From LINKED_INCIDENT sourceId. */
     deploymentIds: string[];
-    workItemIds: string[];
+    /** PR IDs that caused the linked deployments. From DEPLOYS sourceId. */
+    prIds: string[];
     /**
      * Server-resolved display names for deployment IDs (CHAOS-2119).
-     * Populated from DEPLOYS edge sourceDisplayName.
+     * Populated from LINKED_INCIDENT edge sourceDisplayName (deployment name).
      */
     deploymentDisplayNames?: Record<string, string | null>;
     /**
-     * Server-resolved display names for work item IDs (CHAOS-2119).
-     * Populated from LINKED_INCIDENT edge targetDisplayName.
+     * Server-resolved display names for PR IDs (CHAOS-2119).
+     * Populated from DEPLOYS edge sourceDisplayName (PR name).
      */
-    workItemDisplayNames?: Record<string, string | null>;
+    prDisplayNames?: Record<string, string | null>;
 };
 
 export type IncidentCorrelationDashboardProps = {
@@ -107,11 +118,13 @@ const hasMeaningfulAssociations = (items: Contributor[]) =>
 // ---------------------------------------------------------------------------
 
 /**
- * Join DEPLOYS and LINKED_INCIDENT edge sets by incident ID.
+ * Join DEPLOYS and LINKED_INCIDENT edge sets into incident-centric rows.
  *
- * Convention (consistent with dev-health-ops backend):
- *   DEPLOYS:          sourceId = deployment,  targetId = incident
- *   LINKED_INCIDENT:  sourceId = incident,    targetId = work_item
+ * Authoritative backend semantics (ops/work_graph/models.py, ai_workflow.py):
+ *   DEPLOYS:          source = PR,         target = deployment
+ *   LINKED_INCIDENT:  source = deployment,  target = incident
+ *
+ * Produced Sankey flow: PR → Deployment → Incident
  *
  * V1 limitation: no time-windowed filtering — schema doesn't support it.
  */
@@ -119,66 +132,84 @@ export function joinEdges(
     deploysEdges: WorkGraphEdge[],
     incidentEdges: WorkGraphEdge[],
 ): IncidentRow[] {
-    const deploysByIncident = new Map<string, Set<string>>();
+    // ── Step 1: LINKED_INCIDENT (deployment → incident) ─────────────────────
+    // incidentId = targetId, deploymentId = sourceId
+    const deploymentsByIncident = new Map<string, Set<string>>();
     const incidentDisplayNames = new Map<string, string | null>();
-    // CHAOS-2119: capture server-resolved deployment display names from DEPLOYS sourceDisplayName
+    // deployment display name: from LINKED_INCIDENT sourceDisplayName
     const deploymentDisplayNames = new Map<string, string | null>();
-    for (const edge of deploysEdges) {
-        const incidentId = edge.targetId;
-        const deploymentId = edge.sourceId;
-        if (!deploysByIncident.has(incidentId)) {
-            deploysByIncident.set(incidentId, new Set());
-        }
-        deploysByIncident.get(incidentId)!.add(deploymentId);
-        const displayName = edge.targetDisplayName ?? null;
-        if (displayName || !incidentDisplayNames.has(incidentId)) {
-            incidentDisplayNames.set(incidentId, displayName);
-        }
-        // Prefer a non-null resolved name; keep the first entry if already set
-        if (edge.sourceDisplayName != null) {
-            deploymentDisplayNames.set(deploymentId, edge.sourceDisplayName);
-        } else if (!deploymentDisplayNames.has(deploymentId)) {
-            deploymentDisplayNames.set(deploymentId, null);
-        }
-    }
 
-    const workItemsByIncident = new Map<string, Set<string>>();
-    // CHAOS-2119: capture server-resolved work item display names from LINKED_INCIDENT targetDisplayName
-    const workItemDisplayNames = new Map<string, string | null>();
     for (const edge of incidentEdges) {
-        const incidentId = edge.sourceId;
-        const workItemId = edge.targetId;
-        if (!workItemsByIncident.has(incidentId)) {
-            workItemsByIncident.set(incidentId, new Set());
+        const incidentId = edge.targetId;       // LINKED_INCIDENT target = incident
+        const deploymentId = edge.sourceId;     // LINKED_INCIDENT source = deployment
+        if (!deploymentsByIncident.has(incidentId)) {
+            deploymentsByIncident.set(incidentId, new Set());
         }
-        workItemsByIncident.get(incidentId)!.add(workItemId);
-        const displayName = edge.sourceDisplayName ?? null;
+        deploymentsByIncident.get(incidentId)!.add(deploymentId);
+
+        // Incident display name from targetDisplayName.
+        // First non-null value wins; null fills only if no entry yet.
+        const incName = edge.targetDisplayName ?? null;
         if (!incidentDisplayNames.has(incidentId)) {
-            incidentDisplayNames.set(incidentId, displayName);
+            incidentDisplayNames.set(incidentId, incName);
+        } else if (incidentDisplayNames.get(incidentId) == null && incName != null) {
+            incidentDisplayNames.set(incidentId, incName);
         }
-        // Prefer a non-null resolved name; keep the first entry if already set
-        if (edge.targetDisplayName != null) {
-            workItemDisplayNames.set(workItemId, edge.targetDisplayName);
-        } else if (!workItemDisplayNames.has(workItemId)) {
-            workItemDisplayNames.set(workItemId, null);
+        // Deployment display name from sourceDisplayName. First non-null wins.
+        if (!deploymentDisplayNames.has(deploymentId)) {
+            deploymentDisplayNames.set(deploymentId, edge.sourceDisplayName ?? null);
+        } else if (deploymentDisplayNames.get(deploymentId) == null && edge.sourceDisplayName != null) {
+            deploymentDisplayNames.set(deploymentId, edge.sourceDisplayName);
         }
     }
 
-    const allIncidentIds = new Set([...deploysByIncident.keys(), ...workItemsByIncident.keys()]);
+    // ── Step 2: DEPLOYS (PR → deployment) ───────────────────────────────────
+    // prId = sourceId, deploymentId = targetId
+    const prsByDeployment = new Map<string, Set<string>>();
+    const prDisplayNames = new Map<string, string | null>();
 
-    return Array.from(allIncidentIds).map((incidentId) => {
-        const depIds = Array.from(deploysByIncident.get(incidentId) ?? []);
-        const wiIds = Array.from(workItemsByIncident.get(incidentId) ?? []);
+    for (const edge of deploysEdges) {
+        const prId = edge.sourceId;             // DEPLOYS source = PR
+        const deploymentId = edge.targetId;     // DEPLOYS target = deployment
+        if (!prsByDeployment.has(deploymentId)) {
+            prsByDeployment.set(deploymentId, new Set());
+        }
+        prsByDeployment.get(deploymentId)!.add(prId);
+
+        // PR display name from DEPLOYS sourceDisplayName
+        if (edge.sourceDisplayName != null) {
+            prDisplayNames.set(prId, edge.sourceDisplayName);
+        } else if (!prDisplayNames.has(prId)) {
+            prDisplayNames.set(prId, null);
+        }
+        // Deployment display name may also come from DEPLOYS targetDisplayName
+        if (edge.targetDisplayName != null && !deploymentDisplayNames.has(deploymentId)) {
+            deploymentDisplayNames.set(deploymentId, edge.targetDisplayName);
+        }
+    }
+
+    // ── Step 3: Build incident-centric rows ─────────────────────────────────
+    return Array.from(deploymentsByIncident.keys()).map((incidentId) => {
+        const depIds = Array.from(deploymentsByIncident.get(incidentId) ?? []);
+        // Collect all PRs that caused any of this incident's deployments
+        const prIdSet = new Set<string>();
+        for (const depId of depIds) {
+            for (const prId of prsByDeployment.get(depId) ?? []) {
+                prIdSet.add(prId);
+            }
+        }
+        const prIds = Array.from(prIdSet);
+
         return {
             incidentId,
             incidentDisplayName: incidentDisplayNames.get(incidentId) ?? null,
             deploymentIds: depIds,
-            workItemIds: wiIds,
+            prIds,
             deploymentDisplayNames: Object.fromEntries(
                 depIds.map((id) => [id, deploymentDisplayNames.get(id) ?? null]),
             ),
-            workItemDisplayNames: Object.fromEntries(
-                wiIds.map((id) => [id, workItemDisplayNames.get(id) ?? null]),
+            prDisplayNames: Object.fromEntries(
+                prIds.map((id) => [id, prDisplayNames.get(id) ?? null]),
             ),
         };
     });
@@ -194,16 +225,21 @@ export function buildSankeyData(
     const limited = rows.slice(0, MAX_SANKEY_INCIDENTS);
     const nodes: SankeyNode[] = [];
     const links: SankeyLink[] = [];
-    // CHAOS-2118: key by ID (UUID), not display name, to prevent collision when two
-    // incidents share the same display name string.
+
+    // CHAOS-2118: key nodes by (type, id) — a composite to prevent two different
+    // node types whose raw UUIDs happen to be equal from merging into one node.
+    // Links also reference by nodeKey so display-name collisions are impossible.
     const seen = new Set<string>();
 
-    // id  = stable UUID used as the Sankey node key and in link source/target
-    // name = human-readable label rendered on the chart
-    const addNode = (id: string, name: string, group: string) => {
-        if (!seen.has(id)) {
-            nodes.push({ id, name, group });
-            seen.add(id);
+    const makeNodeKey = (group: string, rawId: string) => `${group}:${rawId}`;
+
+    // nodeKey serves as SankeyNode.id — the ECharts adapter uses node.id when
+    // present, so this key is what ECharts sees internally.
+    const addNode = (rawId: string, name: string, group: string) => {
+        const nodeKey = makeNodeKey(group, rawId);
+        if (!seen.has(nodeKey)) {
+            nodes.push({ id: nodeKey, name, group });
+            seen.add(nodeKey);
         }
     };
 
@@ -212,23 +248,34 @@ export function buildSankeyData(
         const incLabel =
             row.incidentDisplayName?.trim() || `inc:${row.incidentId.slice(0, 8)}`;
         addNode(row.incidentId, incLabel, "incident");
+        const incKey = makeNodeKey("incident", row.incidentId);
 
         for (const depId of row.deploymentIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
             // CHAOS-2119: use server-resolved deployment name when available
             const resolved = row.deploymentDisplayNames?.[depId];
             const depLabel = resolved?.trim() || `dep:${depId.slice(0, 8)}`;
             addNode(depId, depLabel, "deployment");
-            // Link by ID — not display name — so collisions on label are impossible
-            links.push({ source: depId, target: row.incidentId, value: 1 });
+            const depKey = makeNodeKey("deployment", depId);
+            // Flow: deployment → incident (link by composite key, never by label)
+            links.push({ source: depKey, target: incKey, value: 1 });
         }
 
-        for (const wiId of row.workItemIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
-            // CHAOS-2119: use server-resolved work item name when available
-            const resolved = row.workItemDisplayNames?.[wiId];
-            const wiLabel = resolved?.trim() || `wi:${wiId.slice(0, 8)}`;
-            addNode(wiId, wiLabel, "work_item");
-            // Link by ID — not display name
-            links.push({ source: row.incidentId, target: wiId, value: 1 });
+        for (const prId of row.prIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
+            // CHAOS-2119: use server-resolved PR name when available
+            const resolved = row.prDisplayNames?.[prId];
+            const prLabel = resolved?.trim() || `pr:${prId.slice(0, 8)}`;
+            addNode(prId, prLabel, "pr");
+            const prKey = makeNodeKey("pr", prId);
+            // Flow: PR → deployment (but we link PR → incident's deployment)
+            // Since each PR is linked to deployments, flow is pr → deployment.
+            // The deployment node for this PR may come from different incidents;
+            // we connect to the deployment that links to this incident.
+            for (const depId of row.deploymentIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
+                // Only add PR→deployment link when this PR caused this deployment
+                // (deploymentIds are the deployments for this incident row)
+                const depKey = makeNodeKey("deployment", depId);
+                links.push({ source: prKey, target: depKey, value: 1 });
+            }
         }
     }
 
@@ -462,7 +509,7 @@ export function IncidentCorrelationDashboard({
                 </section>
             )}
 
-            {/* ── Deployment ↔ Incident ↔ Work-item table ────────────────────────── */}
+            {/* ── PR ↔ Deployment ↔ Incident table ────────────────────────────────── */}
             {hasEdgeData && (
                 <section aria-label="Linked incidents">
                     <div className="mb-4 flex items-baseline justify-between">
@@ -479,7 +526,7 @@ export function IncidentCorrelationDashboard({
                                 <tr>
                                     <th className="px-5 py-3 text-left">Incident ID</th>
                                     <th className="px-5 py-3 text-right">Linked Deployments</th>
-                                    <th className="px-5 py-3 text-right">Linked Work Items</th>
+                                    <th className="px-5 py-3 text-right">Linked PRs</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -501,7 +548,7 @@ export function IncidentCorrelationDashboard({
                                             {row.deploymentIds.length}
                                         </td>
                                         <td className="px-5 py-3 text-right tabular-nums">
-                                            {row.workItemIds.length}
+                                            {row.prIds.length}
                                         </td>
                                     </tr>
                                 ))}
@@ -511,14 +558,14 @@ export function IncidentCorrelationDashboard({
                 </section>
             )}
 
-            {/* ── Sankey: deployment → incident → work-item ───────────────────────── */}
+            {/* ── Sankey: PR → deployment → incident ──────────────────────────────── */}
             {sankeyData && (
                 <section
                     className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5"
                     aria-label="Correlation flow diagram"
                 >
                     <h2 className="font-(--font-display) text-xl">
-                        Deployment → Incident → Work Item Flow
+                        PR → Deployment → Incident Flow
                     </h2>
                     <p className="mt-1 text-xs text-(--ink-muted)">
                         Top {MAX_SANKEY_INCIDENTS} incidents by linkage. Labels are shortened so the

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
@@ -63,6 +63,16 @@ export type IncidentRow = {
     incidentDisplayName?: string | null;
     deploymentIds: string[];
     workItemIds: string[];
+    /**
+     * Server-resolved display names for deployment IDs (CHAOS-2119).
+     * Populated from DEPLOYS edge sourceDisplayName.
+     */
+    deploymentDisplayNames?: Record<string, string | null>;
+    /**
+     * Server-resolved display names for work item IDs (CHAOS-2119).
+     * Populated from LINKED_INCIDENT edge targetDisplayName.
+     */
+    workItemDisplayNames?: Record<string, string | null>;
 };
 
 export type IncidentCorrelationDashboardProps = {
@@ -111,6 +121,8 @@ export function joinEdges(
 ): IncidentRow[] {
     const deploysByIncident = new Map<string, Set<string>>();
     const incidentDisplayNames = new Map<string, string | null>();
+    // CHAOS-2119: capture server-resolved deployment display names from DEPLOYS sourceDisplayName
+    const deploymentDisplayNames = new Map<string, string | null>();
     for (const edge of deploysEdges) {
         const incidentId = edge.targetId;
         const deploymentId = edge.sourceId;
@@ -122,9 +134,17 @@ export function joinEdges(
         if (displayName || !incidentDisplayNames.has(incidentId)) {
             incidentDisplayNames.set(incidentId, displayName);
         }
+        // Prefer a non-null resolved name; keep the first entry if already set
+        if (edge.sourceDisplayName != null) {
+            deploymentDisplayNames.set(deploymentId, edge.sourceDisplayName);
+        } else if (!deploymentDisplayNames.has(deploymentId)) {
+            deploymentDisplayNames.set(deploymentId, null);
+        }
     }
 
     const workItemsByIncident = new Map<string, Set<string>>();
+    // CHAOS-2119: capture server-resolved work item display names from LINKED_INCIDENT targetDisplayName
+    const workItemDisplayNames = new Map<string, string | null>();
     for (const edge of incidentEdges) {
         const incidentId = edge.sourceId;
         const workItemId = edge.targetId;
@@ -136,16 +156,32 @@ export function joinEdges(
         if (!incidentDisplayNames.has(incidentId)) {
             incidentDisplayNames.set(incidentId, displayName);
         }
+        // Prefer a non-null resolved name; keep the first entry if already set
+        if (edge.targetDisplayName != null) {
+            workItemDisplayNames.set(workItemId, edge.targetDisplayName);
+        } else if (!workItemDisplayNames.has(workItemId)) {
+            workItemDisplayNames.set(workItemId, null);
+        }
     }
 
     const allIncidentIds = new Set([...deploysByIncident.keys(), ...workItemsByIncident.keys()]);
 
-    return Array.from(allIncidentIds).map((incidentId) => ({
-        incidentId,
-        incidentDisplayName: incidentDisplayNames.get(incidentId) ?? null,
-        deploymentIds: Array.from(deploysByIncident.get(incidentId) ?? []),
-        workItemIds: Array.from(workItemsByIncident.get(incidentId) ?? []),
-    }));
+    return Array.from(allIncidentIds).map((incidentId) => {
+        const depIds = Array.from(deploysByIncident.get(incidentId) ?? []);
+        const wiIds = Array.from(workItemsByIncident.get(incidentId) ?? []);
+        return {
+            incidentId,
+            incidentDisplayName: incidentDisplayNames.get(incidentId) ?? null,
+            deploymentIds: depIds,
+            workItemIds: wiIds,
+            deploymentDisplayNames: Object.fromEntries(
+                depIds.map((id) => [id, deploymentDisplayNames.get(id) ?? null]),
+            ),
+            workItemDisplayNames: Object.fromEntries(
+                wiIds.map((id) => [id, workItemDisplayNames.get(id) ?? null]),
+            ),
+        };
+    });
 }
 
 /**
@@ -158,29 +194,41 @@ export function buildSankeyData(
     const limited = rows.slice(0, MAX_SANKEY_INCIDENTS);
     const nodes: SankeyNode[] = [];
     const links: SankeyLink[] = [];
+    // CHAOS-2118: key by ID (UUID), not display name, to prevent collision when two
+    // incidents share the same display name string.
     const seen = new Set<string>();
 
-    const addNode = (name: string, group: string) => {
-        if (!seen.has(name)) {
-            nodes.push({ name, group });
-            seen.add(name);
+    // id  = stable UUID used as the Sankey node key and in link source/target
+    // name = human-readable label rendered on the chart
+    const addNode = (id: string, name: string, group: string) => {
+        if (!seen.has(id)) {
+            nodes.push({ id, name, group });
+            seen.add(id);
         }
     };
 
     for (const row of limited) {
-        const incName = row.incidentDisplayName?.trim() || `inc:${row.incidentId.slice(0, 8)}`;
-        addNode(incName, "incident");
+        // Incident label: prefer server-resolved display name; fall back to short ID prefix
+        const incLabel =
+            row.incidentDisplayName?.trim() || `inc:${row.incidentId.slice(0, 8)}`;
+        addNode(row.incidentId, incLabel, "incident");
 
         for (const depId of row.deploymentIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
-            const depName = `dep:${depId.slice(0, 8)}`;
-            addNode(depName, "deployment");
-            links.push({ source: depName, target: incName, value: 1 });
+            // CHAOS-2119: use server-resolved deployment name when available
+            const resolved = row.deploymentDisplayNames?.[depId];
+            const depLabel = resolved?.trim() || `dep:${depId.slice(0, 8)}`;
+            addNode(depId, depLabel, "deployment");
+            // Link by ID — not display name — so collisions on label are impossible
+            links.push({ source: depId, target: row.incidentId, value: 1 });
         }
 
         for (const wiId of row.workItemIds.slice(0, MAX_LINKS_PER_INCIDENT)) {
-            const wiName = `wi:${wiId.slice(0, 8)}`;
-            addNode(wiName, "work_item");
-            links.push({ source: incName, target: wiName, value: 1 });
+            // CHAOS-2119: use server-resolved work item name when available
+            const resolved = row.workItemDisplayNames?.[wiId];
+            const wiLabel = resolved?.trim() || `wi:${wiId.slice(0, 8)}`;
+            addNode(wiId, wiLabel, "work_item");
+            // Link by ID — not display name
+            links.push({ source: row.incidentId, target: wiId, value: 1 });
         }
     }
 


### PR DESCRIPTION
## Summary

- **CHAOS-2118 (node collision):** `buildSankeyData` now keys Sankey nodes by UUID via the `id` field on `SankeyNode` (the chart already uses `node.id` as the internal key when present). Two incidents with identical display names produce separate nodes; links reference IDs directly, eliminating any label-collision path.

- **CHAOS-2119 (labels):** Extended `IncidentRow` with `deploymentDisplayNames` and `workItemDisplayNames` maps. `joinEdges` now propagates `sourceDisplayName` from DEPLOYS edges (deployment labels) and `targetDisplayName` from LINKED_INCIDENT edges (work item labels). `buildSankeyData` uses resolved names for node labels with a controlled short-id fallback (`dep:XXXXXXXX` / `wi:XXXXXXXX`) when the backend could not resolve.

## Changed files

- `src/components/incident-correlation/IncidentCorrelationDashboard.tsx` — IncidentRow type, joinEdges, buildSankeyData
- `src/components/incident-correlation/IncidentCorrelationDashboard.test.tsx` — +9 tests

## Test plan

- [x] TypeScript: `pnpm exec tsc --noEmit` — clean
- [x] Vitest: 34/34 pass (25 existing + 9 new)
  - Collision regression: two incidents with same display name → 4 distinct nodes, 2 links each targeting the correct UUID
  - Dep/work-item uniqueness under label collision
  - Resolved labels surface from `deploymentDisplayNames` / `workItemDisplayNames`
  - Unresolved fallback: `dep:XXXXXXXX` / `wi:XXXXXXXX`
  - `joinEdges` populates both maps from edge displayName fields