### PR TITLE
fix(explore): absorb Evidence-detail into Diagnose chrome (CHAOS-2096)

### DIFF
--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -204,6 +204,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
         <div className="min-h-screen bg-background text-foreground">
             <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} role={activeRole} active="diagnose" />
+                {/* Fallback: prefix match wins; this is intentional belt-and-braces */}
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-start justify-between gap-4">
                         <div>

--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -203,12 +203,12 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
     return (
         <div className="min-h-screen bg-background text-foreground">
             <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
-                <PrimaryNav filters={filters} role={activeRole} />
+                <PrimaryNav filters={filters} role={activeRole} active="diagnose" />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
                     <header className="flex flex-wrap items-start justify-between gap-4">
                         <div>
                             <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                                Explore
+                                Diagnose
                             </p>
                             <h1 className="mt-2 font-(--font-display) text-3xl">{metricLabel}</h1>
                             <p className="mt-2 text-sm text-(--ink-muted)">

--- a/src/lib/navigation/__tests__/areas.test.ts
+++ b/src/lib/navigation/__tests__/areas.test.ts
@@ -137,6 +137,7 @@ describe("selectedAreaIdForPathname", () => {
         { pathname: "/investment", expected: "diagnose" },
         { pathname: "/people/abc", expected: "diagnose" },
         { pathname: "/landscape", expected: "diagnose" },
+        { pathname: "/explore", expected: "diagnose" },
         { pathname: "/plan", expected: "plan" },
         { pathname: "/plan/delivery-forecast", expected: "plan" },
         { pathname: "/capacity-planning", expected: "plan" },

--- a/src/lib/navigation/__tests__/areas.test.ts
+++ b/src/lib/navigation/__tests__/areas.test.ts
@@ -328,3 +328,22 @@ describe("navTitleForPathname / navTrailForPathname (A6: labels agree)", () => {
         expect(navTitleForPathname("/prs/123")).toBe("");
     });
 });
+
+describe("navTitleForPathname / navTrailForPathname — /explore (CHAOS-2096)", () => {
+    it("titles /explore as 'Diagnose'", () => {
+        expect(navTitleForPathname("/explore")).toBe("Diagnose");
+    });
+
+    it("builds /explore trail with Diagnose area only", () => {
+        const trail = navTrailForPathname("/explore");
+        expect(trail.map((c) => c.label)).toEqual(["Diagnose"]);
+    });
+
+    it("only Diagnose area claims /explore prefix (no conflicts)", () => {
+        const exploreOwners = navAreas.filter((area) =>
+            area.ownedPathPrefixes.some((prefix) => prefix === "/explore"),
+        );
+        expect(exploreOwners).toHaveLength(1);
+        expect(exploreOwners[0]?.id).toBe("diagnose");
+    });
+});

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -157,6 +157,7 @@ export const navAreas: readonly NavArea[] = [
             "/complexity",
             "/cognitive-load",
             "/bottleneck",
+            "/explore",
         ],
         legacyActiveIds: [
             "work",


### PR DESCRIPTION
## Summary

Absorbs the /explore Evidence-detail page into Diagnose chrome by:
- Adding '/explore' to Diagnose ownedPathPrefixes for navigation resolution
- Changing the page eyebrow text from "Explore" to "Diagnose"  
- Passing active="diagnose" to PrimaryNav to highlight correct sidebar area
- Updated navigation areas test to verify /explore routes to diagnose area

**Linear Issue:** CHAOS-2096
**Status:** All unit tests + typecheck pass

## Changed Files
- src/lib/navigation/areas.ts — added "/explore" path prefix
- src/app/(app)/explore/page.tsx — eyebrow text + active prop + comment
- src/lib/navigation/__tests__/areas.test.ts — test cases for /explore navigation resolution + metadata

## Notes
- CTA copy unchanged: "Back to Explore", "Open in Explore View" strings intentionally preserved (existing navigation paradigm)
- active="diagnose" prop is intentional fallback; prefix match wins but prop serves as belt-and-braces documentation
- navTitleForPathname("/explore") now returns "Diagnose" (covered by new test assertions)

## Adversarial Review Fixes
- ✅ S1: Added comment explaining active prop is intentional fallback
- ✅ S2: Broadened test to assert navTitleForPathname, navTrailForPathname, no prefix conflicts
- ✅ W2: Verified navTitleForPathname semantic drift and added test coverage