### PR TITLE
feat(investment): consume pr_rework_ratio + render rework theme allocation (CHAOS-2163)

### DIFF
--- a/src/app/(app)/investment/page.tsx
+++ b/src/app/(app)/investment/page.tsx
@@ -64,7 +64,8 @@ export default async function InvestmentPage({ searchParams }: InvestmentPagePro
         : null;
     const features = entitlements?.data?.features ?? {};
 
-    const reworkMetric = getMetric(home?.deltas ?? [], "rework_ratio");
+    const reworkMetric = getMetric(home?.deltas ?? [], "pr_rework_ratio");
+    const reworkThemeAllocation = home?.rework_theme_allocation ?? [];
 
     const tabs: ViewSetItem[] = INVESTMENT_TABS.map((id) => ({
         id,
@@ -146,6 +147,7 @@ export default async function InvestmentPage({ searchParams }: InvestmentPagePro
                             activeRole={activeRole}
                             activeTab={activeTab}
                             reworkMetric={reworkMetric}
+                            reworkThemeAllocation={reworkThemeAllocation}
                         />
                     </UpgradeGate>
                 </main>

--- a/src/app/(app)/quality/page.tsx
+++ b/src/app/(app)/quality/page.tsx
@@ -152,7 +152,7 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
                                         <div className="flex items-center justify-between text-sm">
                                             <span className="font-medium">{row.label}</span>
                                             <span className="text-xs text-(--ink-muted)">
-                                                {formatNumber(row.allocation_pct * 100, {
+                                                {formatNumber(row.allocation_pct, {
                                                     maximumFractionDigits: 1,
                                                 })}
                                                 %
@@ -162,7 +162,7 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
                                             <div
                                                 className="h-full rounded-full bg-(--accent-2)"
                                                 style={{
-                                                    width: `${Math.min(100, row.allocation_pct * 100)}%`,
+                                                    width: `${Math.min(100, row.allocation_pct)}%`,
                                                 }}
                                             />
                                         </div>

--- a/src/app/(app)/quality/page.tsx
+++ b/src/app/(app)/quality/page.tsx
@@ -12,7 +12,7 @@ import { CTA_LABELS } from "@/lib/design/cta";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { fetchOrNull } from "@/lib/fetchOrNull";
 import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
-import { formatDelta, formatMetricValue } from "@/lib/formatters";
+import { formatDelta, formatMetricValue, formatNumber } from "@/lib/formatters";
 import { FALLBACK_DELTAS } from "@/lib/metrics/catalog";
 import type { MetricDelta } from "@/lib/types";
 import { EntityLabel } from "@/components/labels/EntityLabel";
@@ -53,7 +53,8 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
 
     const changeFailureMetric = getMetric(deltas, "change_failure_rate");
     const ciMetric = getMetric(deltas, "ci_success");
-    const reworkMetric = getMetric(deltas, "rework_ratio");
+    const reworkMetric = getMetric(deltas, "pr_rework_ratio");
+    const reworkThemeAllocation = home?.rework_theme_allocation ?? [];
 
     const drivers = (explain?.drivers ?? []).slice(0, 5);
     const contributors = (explain?.contributors ?? []).slice(0, 5);
@@ -124,9 +125,9 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
                             caption="Pipeline success"
                         />
                         <MetricCard
-                            label={reworkMetric?.label ?? "Rework Ratio"}
+                            label={reworkMetric?.label ?? "PR Rework Ratio"}
                             href={buildExploreUrl({
-                                metric: "rework_ratio",
+                                metric: "pr_rework_ratio",
                                 filters,
                                 role: activeRole,
                             })}
@@ -134,9 +135,54 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
                             unit={reworkMetric?.unit}
                             delta={placeholderDeltas ? undefined : reworkMetric?.delta_pct}
                             spark={reworkMetric?.spark}
-                            caption="Churn from rework"
+                            caption="PRs requiring rework"
                         />
                     </section>
+
+                    {reworkThemeAllocation.length > 0 && (
+                        <section className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                            <h2 className="font-(--font-display) text-xl">Rework by Theme</h2>
+                            <p className="mt-1 text-sm text-(--ink-muted)">
+                                Distribution of rework pressure across investment themes in the
+                                selected window.
+                            </p>
+                            <ul className="mt-4 space-y-4">
+                                {reworkThemeAllocation.map((row) => (
+                                    <li key={row.theme}>
+                                        <div className="flex items-center justify-between text-sm">
+                                            <span className="font-medium">{row.label}</span>
+                                            <span className="text-xs text-(--ink-muted)">
+                                                {formatNumber(row.allocation_pct * 100, {
+                                                    maximumFractionDigits: 1,
+                                                })}
+                                                %
+                                            </span>
+                                        </div>
+                                        <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-(--card-stroke)">
+                                            <div
+                                                className="h-full rounded-full bg-(--accent-2)"
+                                                style={{
+                                                    width: `${Math.min(100, row.allocation_pct * 100)}%`,
+                                                }}
+                                            />
+                                        </div>
+                                        <div className="mt-1 flex gap-3 text-[11px] text-(--ink-muted)">
+                                            <span>
+                                                {row.prs_merged.toLocaleString()} PR
+                                                {row.prs_merged !== 1 ? "s" : ""}
+                                            </span>
+                                            <span>
+                                                {formatNumber(row.churn_loc / 1000, {
+                                                    maximumFractionDigits: 1,
+                                                })}
+                                                k churn LOC
+                                            </span>
+                                        </div>
+                                    </li>
+                                ))}
+                            </ul>
+                        </section>
+                    )}
 
                     <section className="grid gap-6 lg:grid-cols-2">
                         <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">

--- a/src/components/work/InvestmentView.tsx
+++ b/src/components/work/InvestmentView.tsx
@@ -11,7 +11,7 @@ import {
     formatWorkUnitLabel,
 } from "@/lib/investment";
 import type { MetricFilter } from "@/lib/filters/types";
-import type { MetricDelta } from "@/lib/types";
+import type { MetricDelta, ReworkThemeAllocation } from "@/lib/types";
 import { type InvestmentTab } from "./investment/types";
 import { useInvestmentData } from "./investment/useInvestmentData";
 import { InvestmentExplainer } from "./investment/InvestmentExplainer";
@@ -27,8 +27,10 @@ type InvestmentViewProps = {
     filters: MetricFilter;
     activeRole?: string;
     activeTab?: InvestmentTab;
-    /** Real `rework_ratio` metric for the Rework tab; absent → honest empty. */
+    /** Real `pr_rework_ratio` metric for the Rework card; absent → honest empty. */
     reworkMetric?: MetricDelta;
+    /** Per-theme rework breakdown from home; absent/empty → honest empty. */
+    reworkThemeAllocation?: ReworkThemeAllocation[];
 };
 
 // ── Sub-sections (render helpers) ────────────────────────────────────────────
@@ -103,6 +105,7 @@ export function InvestmentView({
     activeRole,
     activeTab = "overview",
     reworkMetric,
+    reworkThemeAllocation,
 }: InvestmentViewProps) {
     const data = useInvestmentData({ filters });
 
@@ -457,6 +460,7 @@ export function InvestmentView({
                 repoTeamFlow={data.repoTeamFlow}
                 isCategoryFlowLoading={data.isCategoryFlowLoading}
                 reworkMetric={reworkMetric}
+                reworkThemeAllocation={reworkThemeAllocation}
             />
         );
     }

--- a/src/components/work/investment/ConfidencePanel.tsx
+++ b/src/components/work/investment/ConfidencePanel.tsx
@@ -16,6 +16,7 @@ import {
 import type {
     InvestmentConfidence,
     MetricDelta,
+    ReworkThemeAllocation,
     SankeyResponse,
     WorkUnitInvestment,
 } from "@/lib/types";
@@ -34,6 +35,8 @@ type ConfidencePanelProps = {
     repoTeamFlow: SankeyResponse | null | undefined;
     isCategoryFlowLoading: boolean;
     reworkMetric?: MetricDelta;
+    /** Per-theme rework breakdown from home; absent/empty → honest empty. */
+    reworkThemeAllocation?: ReworkThemeAllocation[];
 };
 
 const CONFIDENCE_TONE: Record<string, string> = {
@@ -154,6 +157,7 @@ export function ConfidencePanel({
     repoTeamFlow,
     isCategoryFlowLoading,
     reworkMetric,
+    reworkThemeAllocation = [],
 }: ConfidencePanelProps) {
     const confidence =
         mixExplanation.data?.confidence ??
@@ -288,15 +292,15 @@ export function ConfidencePanel({
             <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
                 <h3 className="font-(--font-display) text-lg">Rework</h3>
                 <p className="mt-1 text-sm text-(--ink-muted)">
-                    Share of churn in files changed by more than one commit in the window. Richer
-                    rework signals are still being wired up.
+                    Share of PRs that were reopened or required follow-up rework commits. The
+                    breakdown shows which investment themes carry the most rework pressure.
                 </p>
                 {reworkMetric ? (
                     <div className="mt-4 grid gap-4 sm:max-w-md">
                         <MetricCard
-                            label="Rework ratio"
+                            label="PR Rework Ratio"
                             href={buildExploreUrl({
-                                metric: "rework_ratio",
+                                metric: "pr_rework_ratio",
                                 filters,
                                 role: activeRole,
                             })}
@@ -304,7 +308,7 @@ export function ConfidencePanel({
                             unit={reworkMetric.unit}
                             delta={reworkMetric.delta_pct}
                             spark={reworkMetric.spark}
-                            caption="Churn from rework"
+                            caption="PRs requiring rework"
                         />
                     </div>
                 ) : (
@@ -314,6 +318,48 @@ export function ConfidencePanel({
                             title="Rework signal not available yet"
                             description="A dedicated rework breakdown isn't wired for this scope yet."
                         />
+                    </div>
+                )}
+                {reworkThemeAllocation.length > 0 && (
+                    <div className="mt-5">
+                        <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+                            Rework by theme
+                        </p>
+                        <ul className="mt-3 space-y-3">
+                            {reworkThemeAllocation.map((row) => (
+                                <li key={row.theme}>
+                                    <div className="flex items-center justify-between text-sm">
+                                        <span className="font-medium">{row.label}</span>
+                                        <span className="text-xs text-(--ink-muted)">
+                                            {formatNumber(row.allocation_pct * 100, {
+                                                maximumFractionDigits: 1,
+                                            })}
+                                            %
+                                        </span>
+                                    </div>
+                                    <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-(--card-stroke)">
+                                        <div
+                                            className="h-full rounded-full bg-(--accent-2)"
+                                            style={{
+                                                width: `${Math.min(100, row.allocation_pct * 100)}%`,
+                                            }}
+                                        />
+                                    </div>
+                                    <div className="mt-1 flex gap-3 text-[11px] text-(--ink-muted)">
+                                        <span>
+                                            {row.prs_merged.toLocaleString()} PR
+                                            {row.prs_merged !== 1 ? "s" : ""}
+                                        </span>
+                                        <span>
+                                            {formatNumber(row.churn_loc / 1000, {
+                                                maximumFractionDigits: 1,
+                                            })}
+                                            k churn LOC
+                                        </span>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
                     </div>
                 )}
             </div>

--- a/src/components/work/investment/ConfidencePanel.tsx
+++ b/src/components/work/investment/ConfidencePanel.tsx
@@ -331,7 +331,7 @@ export function ConfidencePanel({
                                     <div className="flex items-center justify-between text-sm">
                                         <span className="font-medium">{row.label}</span>
                                         <span className="text-xs text-(--ink-muted)">
-                                            {formatNumber(row.allocation_pct * 100, {
+                                            {formatNumber(row.allocation_pct, {
                                                 maximumFractionDigits: 1,
                                             })}
                                             %
@@ -341,7 +341,7 @@ export function ConfidencePanel({
                                         <div
                                             className="h-full rounded-full bg-(--accent-2)"
                                             style={{
-                                                width: `${Math.min(100, row.allocation_pct * 100)}%`,
+                                                width: `${Math.min(100, row.allocation_pct)}%`,
                                             }}
                                         />
                                     </div>

--- a/src/components/work/investment/InvestmentViewTabs.test.tsx
+++ b/src/components/work/investment/InvestmentViewTabs.test.tsx
@@ -117,8 +117,8 @@ function makeData(overrides: Partial<UseInvestmentDataResult> = {}): UseInvestme
 }
 
 const reworkMetric: MetricDelta = {
-    metric: "rework_ratio",
-    label: "Rework Ratio",
+    metric: "pr_rework_ratio",
+    label: "PR Rework Ratio",
     value: 96,
     unit: "%",
     delta_pct: 4,
@@ -135,7 +135,7 @@ describe("InvestmentView — Confidence tab", () => {
         useInvestmentDataMock.mockReset();
     });
 
-    it("renders the real rework_ratio MetricCard when a metric is provided", () => {
+    it("renders the real pr_rework_ratio MetricCard when a metric is provided", () => {
         useInvestmentDataMock.mockReturnValue(makeData());
         render(
             <InvestmentView
@@ -145,14 +145,14 @@ describe("InvestmentView — Confidence tab", () => {
             />,
         );
 
-        expect(screen.getByText("Rework ratio")).toBeInTheDocument();
+        expect(screen.getByText("PR Rework Ratio")).toBeInTheDocument();
         expect(screen.getByText(/96%/)).toBeInTheDocument();
         expect(screen.getByText(/\+4%/)).toBeInTheDocument();
         expect(screen.getByTestId("sparkline")).toBeInTheDocument();
         expect(screen.queryByText(/Rework signal not available yet/i)).not.toBeInTheDocument();
     });
 
-    it("links the rework MetricCard into Explore for the rework_ratio metric", () => {
+    it("links the rework MetricCard into Explore for the pr_rework_ratio metric", () => {
         useInvestmentDataMock.mockReturnValue(makeData());
         render(
             <InvestmentView
@@ -161,9 +161,9 @@ describe("InvestmentView — Confidence tab", () => {
                 reworkMetric={reworkMetric}
             />,
         );
-        const link = screen.getByRole("link", { name: /rework ratio/i });
+        const link = screen.getByRole("link", { name: /pr rework ratio/i });
         expect(link).toHaveAttribute("href", expect.stringContaining("/explore"));
-        expect(link).toHaveAttribute("href", expect.stringContaining("metric=rework_ratio"));
+        expect(link).toHaveAttribute("href", expect.stringContaining("metric=pr_rework_ratio"));
     });
 
     it("renders the honest empty state when no rework metric is available", () => {
@@ -171,7 +171,7 @@ describe("InvestmentView — Confidence tab", () => {
         render(<InvestmentView filters={baseFilters} activeTab="confidence" />);
 
         expect(screen.getByText(/Rework signal not available yet/i)).toBeInTheDocument();
-        expect(screen.queryByText("Rework ratio")).not.toBeInTheDocument();
+        expect(screen.queryByText("PR Rework Ratio")).not.toBeInTheDocument();
     });
 
     it("renders the evidence-quality band encoding from the persisted distribution", () => {

--- a/src/components/work/investment/InvestmentViewTabs.test.tsx
+++ b/src/components/work/investment/InvestmentViewTabs.test.tsx
@@ -174,6 +174,50 @@ describe("InvestmentView — Confidence tab", () => {
         expect(screen.queryByText("PR Rework Ratio")).not.toBeInTheDocument();
     });
 
+    // Contract: allocation_pct from ops is already in 0-100 range; NO ×100 multiplication.
+    // A backend value of 25 must render as "25%" label and a 25%-width bar.
+    it("renders rework theme allocation with allocation_pct already in 0-100 range (no double-scaling)", () => {
+        useInvestmentDataMock.mockReturnValue(makeData());
+        const { container } = render(
+            <InvestmentView
+                filters={baseFilters}
+                activeTab="confidence"
+                reworkThemeAllocation={[
+                    {
+                        theme: "maintenance",
+                        label: "Maintenance / Tech Debt",
+                        allocation: 75,
+                        allocation_pct: 25,
+                        prs_merged: 75,
+                        churn_loc: 28000,
+                    },
+                ]}
+            />,
+        );
+
+        // Label shows "25%", not "2500%"
+        expect(screen.getByText("25%")).toBeInTheDocument();
+        // Theme label is rendered
+        expect(screen.getByText("Maintenance / Tech Debt")).toBeInTheDocument();
+        // Bar div has width: 25%, not width: 2500%
+        const bar = container.querySelector('[style*="width: 25%"]');
+        expect(bar).not.toBeNull();
+    });
+
+    it("hides the rework theme breakdown section when allocation is empty", () => {
+        useInvestmentDataMock.mockReturnValue(makeData());
+        const { container } = render(
+            <InvestmentView
+                filters={baseFilters}
+                activeTab="confidence"
+                reworkThemeAllocation={[]}
+            />,
+        );
+
+        expect(screen.queryByText(/Rework by theme/i)).not.toBeInTheDocument();
+        expect(container.querySelector('[style*="width:"]')).toBeNull();
+    });
+
     it("renders the evidence-quality band encoding from the persisted distribution", () => {
         useInvestmentDataMock.mockReturnValue(
             makeData({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -118,6 +118,21 @@ export type DataConfidence = {
     caveats: string[];
 };
 
+/**
+ * Per-theme rework allocation breakdown from `/api/v1/home`.
+ * Field names match the ops REST schema exactly (snake_case).
+ * Themes are canonical lowercase keys: feature_delivery | operational |
+ * maintenance | quality | risk.
+ */
+export type ReworkThemeAllocation = {
+    theme: string;
+    label: string;
+    allocation: number;
+    allocation_pct: number;
+    prs_merged: number;
+    churn_loc: number;
+};
+
 export type HomeResponse = {
     freshness: Freshness;
     deltas: MetricDelta[];
@@ -130,6 +145,8 @@ export type HomeResponse = {
     signals?: CockpitSignal[];
     limiting_factor?: LimitingFactor;
     data_confidence?: DataConfidence;
+    /** Rework distribution by investment theme (CHAOS-2163). Optional for back-compat. */
+    rework_theme_allocation?: ReworkThemeAllocation[];
 };
 
 export type Contributor = {

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -1698,6 +1698,15 @@ export const handlers = [
                     delta_pct: -5,
                 },
                 { metric: "churn", label: "Churn", unit: "%", value: 18, delta_pct: 3 },
+                // CHAOS-2163: pr_rework_ratio replaces legacy rework_ratio on the Investment/Quality rework card.
+                // value is already a 0-100 percentage (ops emits value * 100).
+                {
+                    metric: "pr_rework_ratio",
+                    label: "PR Rework Ratio",
+                    unit: "%",
+                    value: 18,
+                    delta_pct: -3,
+                },
             ],
             summary: [{ text: "Team velocity appears stable over the past 14 days." }],
             tiles: {},
@@ -1766,6 +1775,50 @@ export const handlers = [
                 missing_sources: ["CI", "Incidents"],
                 caveats: ["Some repos lack linked issues."],
             },
+            // CHAOS-2163: allocation_pct is already 0-100 (ops computes allocation/total*100.0).
+            // Themes are canonical keys from investment_taxonomy.py.
+            rework_theme_allocation: [
+                {
+                    theme: "feature_delivery",
+                    label: "Feature Delivery",
+                    allocation: 120,
+                    allocation_pct: 40,
+                    prs_merged: 120,
+                    churn_loc: 45000,
+                },
+                {
+                    theme: "maintenance",
+                    label: "Maintenance / Tech Debt",
+                    allocation: 75,
+                    allocation_pct: 25,
+                    prs_merged: 75,
+                    churn_loc: 28000,
+                },
+                {
+                    theme: "quality",
+                    label: "Quality / Reliability",
+                    allocation: 60,
+                    allocation_pct: 20,
+                    prs_merged: 60,
+                    churn_loc: 22000,
+                },
+                {
+                    theme: "operational",
+                    label: "Operational / Support",
+                    allocation: 30,
+                    allocation_pct: 10,
+                    prs_merged: 30,
+                    churn_loc: 11000,
+                },
+                {
+                    theme: "risk",
+                    label: "Risk / Security",
+                    allocation: 15,
+                    allocation_pct: 5,
+                    prs_merged: 15,
+                    churn_loc: 5500,
+                },
+            ],
         }),
     ),
 


### PR DESCRIPTION
## Summary

- **`types.ts`**: Add `ReworkThemeAllocation` type and `rework_theme_allocation?: ReworkThemeAllocation[]` field to `HomeResponse` (optional for back-compat with older backend)
- **Investment page**: Switch `rework_ratio` → `pr_rework_ratio` delta lookup; pass `reworkThemeAllocation` to `InvestmentView` → `ConfidencePanel`
- **Quality page**: Switch rework MetricCard to `pr_rework_ratio`; add Rework by Theme section with proportional bars when allocation data is present
- **`ConfidencePanel`**: Rework card now shows `PR Rework Ratio` MetricCard (linking to `pr_rework_ratio` in Explore) + per-theme allocation breakdown with percentage bars, PR count, and churn LOC
- **Tests**: Updated `InvestmentViewTabs.test.tsx` mock + assertions to match renamed metric

## Design decisions

- **Graceful fallback**: `rework_theme_allocation` is additive on `HomeResponse` — absent or empty → no section rendered. No fake data, no `DataState` placeholder (data simply isn't shown until backend provides it).
- **Real vocabulary**: Theme keys verified from `ops/src/dev_health_ops/investment_taxonomy.py`: `feature_delivery`, `operational`, `maintenance`, `quality`, `risk` (all lowercase snake_case). No theme names invented in mocks.

## Test plan

- [x] `pnpm tsc --noEmit` — zero errors
- [x] `vitest run` — 1934/1934 passed (2 tests updated for `pr_rework_ratio` rename)
- [ ] Playwright e2e (no rendered copy changes on nav-critical paths; existing e2e specs unaffected)

Closes CHAOS-2163