### PR TITLE
fix(charts): align team exchange chord controls with theme tokens

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,5 @@ trim_trailing_whitespace = false
 
 [.{editorconfig,*.yml,*.yaml}]
 indent_style = space
-indent_size = 2
+indent_size = 4
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,6 @@ playwright-report/
 #
 **/.worktree**
 **/.pnpm**
-
+**/.claude*
 # Use pnpm-lock.yaml as the canonical lockfile; npm lockfile is rejected.
 package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,7 +12,8 @@ playwright-report
 test-results
 artifacts
 output
-
+**/.claude**
+**/.**
 # Generated files
 *.generated.*
 **/__generated__/

--- a/src/components/charts/ChordChartControls.tsx
+++ b/src/components/charts/ChordChartControls.tsx
@@ -3,296 +3,310 @@ import type { ReadonlyURLSearchParams } from "next/navigation";
 import type { ChordDirection, ChordGroupingDimension } from "@/lib/types";
 
 export type ChordControlsValue = {
-    direction: ChordDirection;
-    grouping: ChordGroupingDimension;
-    topN: number;
-    showSelfLinks: boolean;
-    showOther: boolean;
+	direction: ChordDirection;
+	grouping: ChordGroupingDimension;
+	topN: number;
+	showSelfLinks: boolean;
+	showOther: boolean;
 };
 
 export type ChordChartControlsProps = {
-    value: ChordControlsValue;
-    onChange: (next: ChordControlsValue) => void;
-    otherAvailable?: boolean;
-    className?: string;
+	value: ChordControlsValue;
+	onChange: (next: ChordControlsValue) => void;
+	otherAvailable?: boolean;
+	className?: string;
 };
 
 export const CHORD_CONTROLS_DEFAULTS: ChordControlsValue = {
-    direction: "bilateral",
-    grouping: "team",
-    topN: 8,
-    showSelfLinks: false,
-    showOther: true,
+	direction: "bilateral",
+	grouping: "team",
+	topN: 8,
+	showSelfLinks: false,
+	showOther: true,
 };
 
 export function parseChordControlsFromSearchParams(
-    sp: URLSearchParams | ReadonlyURLSearchParams,
+	sp: URLSearchParams | ReadonlyURLSearchParams,
 ): ChordControlsValue {
-    const dir = sp.get("chord.dir");
-    const group = sp.get("chord.group");
-    const n = sp.get("chord.n");
-    const self = sp.get("chord.self");
-    const other = sp.get("chord.other");
+	const dir = sp.get("chord.dir");
+	const group = sp.get("chord.group");
+	const n = sp.get("chord.n");
+	const self = sp.get("chord.self");
+	const other = sp.get("chord.other");
 
-    const direction = (
-        ["bilateral", "in", "out", "net"].includes(dir as string)
-            ? dir
-            : CHORD_CONTROLS_DEFAULTS.direction
-    ) as ChordDirection;
+	const direction = (
+		["bilateral", "in", "out", "net"].includes(dir as string)
+			? dir
+			: CHORD_CONTROLS_DEFAULTS.direction
+	) as ChordDirection;
 
-    const grouping = (
-        ["team", "repo", "work_type"].includes(group as string)
-            ? group
-            : CHORD_CONTROLS_DEFAULTS.grouping
-    ) as ChordGroupingDimension;
+	const grouping = (
+		["team", "repo", "work_type"].includes(group as string)
+			? group
+			: CHORD_CONTROLS_DEFAULTS.grouping
+	) as ChordGroupingDimension;
 
-    let topN = CHORD_CONTROLS_DEFAULTS.topN;
-    if (n) {
-        const parsedN = parseInt(n, 10);
-        if (!isNaN(parsedN)) {
-            // Clamp to [3, 16]
-            topN = Math.max(3, Math.min(16, parsedN));
-        }
-    }
+	let topN = CHORD_CONTROLS_DEFAULTS.topN;
+	if (n) {
+		const parsedN = parseInt(n, 10);
+		if (!isNaN(parsedN)) {
+			// Clamp to [3, 16]
+			topN = Math.max(3, Math.min(16, parsedN));
+		}
+	}
 
-    const showSelfLinks = self ? self === "true" : CHORD_CONTROLS_DEFAULTS.showSelfLinks;
-    const showOther = other ? other === "true" : CHORD_CONTROLS_DEFAULTS.showOther;
+	const showSelfLinks = self
+		? self === "true"
+		: CHORD_CONTROLS_DEFAULTS.showSelfLinks;
+	const showOther = other
+		? other === "true"
+		: CHORD_CONTROLS_DEFAULTS.showOther;
 
-    return { direction, grouping, topN, showSelfLinks, showOther };
+	return { direction, grouping, topN, showSelfLinks, showOther };
 }
 
 export function serializeChordControlsToSearchParams(
-    value: ChordControlsValue,
-    sp: URLSearchParams,
+	value: ChordControlsValue,
+	sp: URLSearchParams,
 ): URLSearchParams {
-    if (value.direction !== CHORD_CONTROLS_DEFAULTS.direction) {
-        sp.set("chord.dir", value.direction);
-    } else {
-        sp.delete("chord.dir");
-    }
+	if (value.direction !== CHORD_CONTROLS_DEFAULTS.direction) {
+		sp.set("chord.dir", value.direction);
+	} else {
+		sp.delete("chord.dir");
+	}
 
-    if (value.grouping !== CHORD_CONTROLS_DEFAULTS.grouping) {
-        sp.set("chord.group", value.grouping);
-    } else {
-        sp.delete("chord.group");
-    }
+	if (value.grouping !== CHORD_CONTROLS_DEFAULTS.grouping) {
+		sp.set("chord.group", value.grouping);
+	} else {
+		sp.delete("chord.group");
+	}
 
-    if (value.topN !== CHORD_CONTROLS_DEFAULTS.topN) {
-        sp.set("chord.n", value.topN.toString());
-    } else {
-        sp.delete("chord.n");
-    }
+	if (value.topN !== CHORD_CONTROLS_DEFAULTS.topN) {
+		sp.set("chord.n", value.topN.toString());
+	} else {
+		sp.delete("chord.n");
+	}
 
-    if (value.showSelfLinks !== CHORD_CONTROLS_DEFAULTS.showSelfLinks) {
-        sp.set("chord.self", value.showSelfLinks.toString());
-    } else {
-        sp.delete("chord.self");
-    }
+	if (value.showSelfLinks !== CHORD_CONTROLS_DEFAULTS.showSelfLinks) {
+		sp.set("chord.self", value.showSelfLinks.toString());
+	} else {
+		sp.delete("chord.self");
+	}
 
-    if (value.showOther !== CHORD_CONTROLS_DEFAULTS.showOther) {
-        sp.set("chord.other", value.showOther.toString());
-    } else {
-        sp.delete("chord.other");
-    }
+	if (value.showOther !== CHORD_CONTROLS_DEFAULTS.showOther) {
+		sp.set("chord.other", value.showOther.toString());
+	} else {
+		sp.delete("chord.other");
+	}
 
-    return sp;
+	return sp;
 }
 
 const DIRECTIONS: { value: ChordDirection; label: string }[] = [
-    { value: "bilateral", label: "Bilateral" },
-    { value: "in", label: "Inflow" },
-    { value: "out", label: "Outflow" },
-    { value: "net", label: "Net" },
+	{ value: "bilateral", label: "Bilateral" },
+	{ value: "in", label: "Inflow" },
+	{ value: "out", label: "Outflow" },
+	{ value: "net", label: "Net" },
 ];
 
 export function ChordChartControls({
-    value,
-    onChange,
-    otherAvailable = true,
-    className = "",
+	value,
+	onChange,
+	otherAvailable = true,
+	className = "",
 }: ChordChartControlsProps) {
-    const [topNInput, setTopNInput] = useState(value.topN.toString());
-    const [prevTopN, setPrevTopN] = useState(value.topN);
+	const [topNInput, setTopNInput] = useState(value.topN.toString());
+	const [prevTopN, setPrevTopN] = useState(value.topN);
 
-    if (value.topN !== prevTopN) {
-        setPrevTopN(value.topN);
-        setTopNInput(value.topN.toString());
-    }
+	if (value.topN !== prevTopN) {
+		setPrevTopN(value.topN);
+		setTopNInput(value.topN.toString());
+	}
 
-    const handleDirectionKeyDown = (e: KeyboardEvent<HTMLButtonElement>, index: number) => {
-        let nextIndex: number;
-        if (e.key === "ArrowRight" || e.key === "ArrowDown") {
-            nextIndex = (index + 1) % DIRECTIONS.length;
-        } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
-            nextIndex = (index - 1 + DIRECTIONS.length) % DIRECTIONS.length;
-        } else {
-            return;
-        }
-        e.preventDefault();
-        const nextValue = DIRECTIONS[nextIndex].value;
-        onChange({ ...value, direction: nextValue });
-        // Focus the next button
-        const buttons = document.querySelectorAll('[role="radio"]');
-        if (buttons[nextIndex]) {
-            (buttons[nextIndex] as HTMLButtonElement).focus();
-        }
-    };
+	const handleDirectionKeyDown = (
+		e: KeyboardEvent<HTMLButtonElement>,
+		index: number,
+	) => {
+		let nextIndex: number;
+		if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+			nextIndex = (index + 1) % DIRECTIONS.length;
+		} else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+			nextIndex = (index - 1 + DIRECTIONS.length) % DIRECTIONS.length;
+		} else {
+			return;
+		}
+		e.preventDefault();
+		const nextValue = DIRECTIONS[nextIndex].value;
+		onChange({ ...value, direction: nextValue });
+		// Focus the next button
+		const buttons = document.querySelectorAll('[role="radio"]');
+		if (buttons[nextIndex]) {
+			(buttons[nextIndex] as HTMLButtonElement).focus();
+		}
+	};
 
-    const handleTopNBlur = () => {
-        const parsed = parseInt(topNInput, 10);
-        if (isNaN(parsed)) {
-            setTopNInput(value.topN.toString());
-            return;
-        }
-        const clamped = Math.max(3, Math.min(16, parsed));
-        setTopNInput(clamped.toString());
-        if (clamped !== value.topN) {
-            onChange({ ...value, topN: clamped });
-        }
-    };
+	const handleTopNBlur = () => {
+		const parsed = parseInt(topNInput, 10);
+		if (isNaN(parsed)) {
+			setTopNInput(value.topN.toString());
+			return;
+		}
+		const clamped = Math.max(3, Math.min(16, parsed));
+		setTopNInput(clamped.toString());
+		if (clamped !== value.topN) {
+			onChange({ ...value, topN: clamped });
+		}
+	};
 
-    return (
-        <div className={`flex flex-wrap gap-4 items-end ${className}`}>
-            {/* Direction Segmented Control */}
-            <div className="flex flex-col gap-1.5">
-                <label
-                    className="text-sm font-medium text-slate-700 dark:text-slate-300"
-                    id="chord-dir-label"
-                >
-                    Flow
-                </label>
-                <div
-                    role="radiogroup"
-                    aria-labelledby="chord-dir-label"
-                    className="flex p-1 bg-slate-100 dark:bg-slate-800 rounded-lg"
-                >
-                    {DIRECTIONS.map((dir, i) => {
-                        const isActive = value.direction === dir.value;
-                        return (
-                            <button
-                                key={dir.value}
-                                role="radio"
-                                aria-checked={isActive}
-                                tabIndex={isActive ? 0 : -1}
-                                onClick={() => onChange({ ...value, direction: dir.value })}
-                                onKeyDown={(e) => handleDirectionKeyDown(e, i)}
-                                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
-                                    isActive
-                                        ? "bg-white dark:bg-slate-700 text-slate-900 dark:text-white shadow-sm"
-                                        : "text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white"
-                                }`}
-                            >
-                                {dir.label}
-                            </button>
-                        );
-                    })}
-                </div>
-            </div>
+	return (
+		<div className={`flex flex-wrap gap-4 items-end ${className}`}>
+			{/* Direction Segmented Control */}
+			<div className="flex flex-col gap-1.5">
+				<label
+					className="text-sm font-medium text-(--ink-muted)"
+					id="chord-dir-label"
+				>
+					Flow
+				</label>
+				<div
+					role="radiogroup"
+					aria-labelledby="chord-dir-label"
+					className="flex p-1 bg-(--card-stroke)/30 rounded-lg"
+				>
+					{DIRECTIONS.map((dir, i) => {
+						const isActive = value.direction === dir.value;
+						return (
+							<button
+								key={dir.value}
+								role="radio"
+								aria-checked={isActive}
+								tabIndex={isActive ? 0 : -1}
+								onClick={() => onChange({ ...value, direction: dir.value })}
+								onKeyDown={(e) => handleDirectionKeyDown(e, i)}
+								className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+									isActive
+										? "bg-(--card) text-(--foreground) shadow-sm"
+										: "text-(--ink-muted) hover:text-(--foreground)"
+								}`}
+							>
+								{dir.label}
+							</button>
+						);
+					})}
+				</div>
+			</div>
 
-            {/* Grouping Select */}
-            <div className="flex flex-col gap-1.5">
-                <label
-                    htmlFor="chord-grouping"
-                    className="text-sm font-medium text-slate-700 dark:text-slate-300"
-                >
-                    Group by
-                </label>
-                <select
-                    id="chord-grouping"
-                    value={value.grouping}
-                    onChange={(e) =>
-                        onChange({ ...value, grouping: e.target.value as ChordGroupingDimension })
-                    }
-                    className="h-9 px-3 py-1.5 text-sm bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                    <option value="team">Team</option>
-                    <option value="repo">Repository</option>
-                    <option value="work_type">Work type</option>
-                </select>
-            </div>
+			{/* Grouping Select */}
+			<div className="flex flex-col gap-1.5">
+				<label
+					htmlFor="chord-grouping"
+					className="text-sm font-medium text-(--ink-muted)"
+				>
+					Group by
+				</label>
+				<select
+					id="chord-grouping"
+					value={value.grouping}
+					onChange={(e) =>
+						onChange({
+							...value,
+							grouping: e.target.value as ChordGroupingDimension,
+						})
+					}
+					className="h-9 px-3 py-1.5 text-sm text-(--foreground) bg-(--card) border border-(--card-stroke) rounded-lg focus:outline-none focus:ring-2 focus:ring-(--accent)"
+				>
+					<option value="team">Team</option>
+					<option value="repo">Repository</option>
+					<option value="work_type">Work type</option>
+				</select>
+			</div>
 
-            {/* Top-N Stepper */}
-            <div className="flex flex-col gap-1.5">
-                <label
-                    htmlFor="chord-topn"
-                    className="text-sm font-medium text-slate-700 dark:text-slate-300"
-                >
-                    Entities
-                </label>
-                <div className="flex items-center border border-slate-200 dark:border-slate-700 rounded-lg bg-white dark:bg-slate-900 overflow-hidden h-9">
-                    <button
-                        type="button"
-                        aria-label="Decrease entities"
-                        onClick={() => {
-                            const next = Math.max(3, value.topN - 1);
-                            setTopNInput(next.toString());
-                            onChange({ ...value, topN: next });
-                        }}
-                        disabled={value.topN <= 3}
-                        className="px-2.5 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 h-full"
-                    >
-                        -
-                    </button>
-                    <input
-                        id="chord-topn"
-                        type="number"
-                        min={3}
-                        max={16}
-                        step={1}
-                        value={topNInput}
-                        onChange={(e) => setTopNInput(e.target.value)}
-                        onBlur={handleTopNBlur}
-                        onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                                handleTopNBlur();
-                            }
-                        }}
-                        className="w-12 text-center text-sm bg-transparent focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                    />
-                    <button
-                        type="button"
-                        aria-label="Increase entities"
-                        onClick={() => {
-                            const next = Math.min(16, value.topN + 1);
-                            setTopNInput(next.toString());
-                            onChange({ ...value, topN: next });
-                        }}
-                        disabled={value.topN >= 16}
-                        className="px-2.5 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:opacity-50 h-full"
-                    >
-                        +
-                    </button>
-                </div>
-            </div>
+			{/* Top-N Stepper */}
+			<div className="flex flex-col gap-1.5">
+				<label
+					htmlFor="chord-topn"
+					className="text-sm font-medium text-(--ink-muted)"
+				>
+					Entities
+				</label>
+				<div className="flex items-center border border-(--card-stroke) rounded-lg bg-(--card) overflow-hidden h-9">
+					<button
+						type="button"
+						aria-label="Decrease entities"
+						onClick={() => {
+							const next = Math.max(3, value.topN - 1);
+							setTopNInput(next.toString());
+							onChange({ ...value, topN: next });
+						}}
+						disabled={value.topN <= 3}
+						className="px-2.5 text-(--ink-muted) hover:bg-(--card-stroke)/30 disabled:opacity-50 h-full"
+					>
+						-
+					</button>
+					<input
+						id="chord-topn"
+						type="number"
+						min={3}
+						max={16}
+						step={1}
+						value={topNInput}
+						onChange={(e) => setTopNInput(e.target.value)}
+						onBlur={handleTopNBlur}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								handleTopNBlur();
+							}
+						}}
+						className="w-12 text-center text-sm text-(--foreground) bg-transparent focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+					/>
+					<button
+						type="button"
+						aria-label="Increase entities"
+						onClick={() => {
+							const next = Math.min(16, value.topN + 1);
+							setTopNInput(next.toString());
+							onChange({ ...value, topN: next });
+						}}
+						disabled={value.topN >= 16}
+						className="px-2.5 text-(--ink-muted) hover:bg-(--card-stroke)/30 disabled:opacity-50 h-full"
+					>
+						+
+					</button>
+				</div>
+			</div>
 
-            {/* Checkboxes */}
-            <div className="flex items-center gap-4 h-9">
-                <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 cursor-pointer">
-                    <input
-                        type="checkbox"
-                        checked={value.showSelfLinks}
-                        onChange={(e) => onChange({ ...value, showSelfLinks: e.target.checked })}
-                        className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                    />
-                    Include self-links
-                </label>
+			{/* Checkboxes */}
+			<div className="flex items-center gap-4 h-9">
+				<label className="flex items-center gap-2 text-sm text-(--ink-muted) cursor-pointer">
+					<input
+						type="checkbox"
+						checked={value.showSelfLinks}
+						onChange={(e) =>
+							onChange({ ...value, showSelfLinks: e.target.checked })
+						}
+						className="rounded border-(--card-stroke) accent-(--accent) focus:ring-(--accent)"
+					/>
+					Include self-links
+				</label>
 
-                <label
-                    className={`flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 ${
-                        !otherAvailable ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
-                    }`}
-                    aria-disabled={!otherAvailable}
-                >
-                    <input
-                        type="checkbox"
-                        checked={value.showOther}
-                        onChange={(e) => onChange({ ...value, showOther: e.target.checked })}
-                        disabled={!otherAvailable}
-                        className="rounded border-slate-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50"
-                    />
-                    Show &apos;Other&apos; bucket
-                </label>
-            </div>
-        </div>
-    );
+				<label
+					className={`flex items-center gap-2 text-sm text-(--ink-muted) ${
+						!otherAvailable ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+					}`}
+					aria-disabled={!otherAvailable}
+				>
+					<input
+						type="checkbox"
+						checked={value.showOther}
+						onChange={(e) =>
+							onChange({ ...value, showOther: e.target.checked })
+						}
+						disabled={!otherAvailable}
+						className="rounded border-(--card-stroke) accent-(--accent) focus:ring-(--accent) disabled:opacity-50"
+					/>
+					Show &apos;Other&apos; bucket
+				</label>
+			</div>
+		</div>
+	);
 }

--- a/src/components/charts/ChordChartControls.tsx
+++ b/src/components/charts/ChordChartControls.tsx
@@ -3,310 +3,290 @@ import type { ReadonlyURLSearchParams } from "next/navigation";
 import type { ChordDirection, ChordGroupingDimension } from "@/lib/types";
 
 export type ChordControlsValue = {
-	direction: ChordDirection;
-	grouping: ChordGroupingDimension;
-	topN: number;
-	showSelfLinks: boolean;
-	showOther: boolean;
+    direction: ChordDirection;
+    grouping: ChordGroupingDimension;
+    topN: number;
+    showSelfLinks: boolean;
+    showOther: boolean;
 };
 
 export type ChordChartControlsProps = {
-	value: ChordControlsValue;
-	onChange: (next: ChordControlsValue) => void;
-	otherAvailable?: boolean;
-	className?: string;
+    value: ChordControlsValue;
+    onChange: (next: ChordControlsValue) => void;
+    otherAvailable?: boolean;
+    className?: string;
 };
 
 export const CHORD_CONTROLS_DEFAULTS: ChordControlsValue = {
-	direction: "bilateral",
-	grouping: "team",
-	topN: 8,
-	showSelfLinks: false,
-	showOther: true,
+    direction: "bilateral",
+    grouping: "team",
+    topN: 8,
+    showSelfLinks: false,
+    showOther: true,
 };
 
 export function parseChordControlsFromSearchParams(
-	sp: URLSearchParams | ReadonlyURLSearchParams,
+    sp: URLSearchParams | ReadonlyURLSearchParams,
 ): ChordControlsValue {
-	const dir = sp.get("chord.dir");
-	const group = sp.get("chord.group");
-	const n = sp.get("chord.n");
-	const self = sp.get("chord.self");
-	const other = sp.get("chord.other");
+    const dir = sp.get("chord.dir");
+    const group = sp.get("chord.group");
+    const n = sp.get("chord.n");
+    const self = sp.get("chord.self");
+    const other = sp.get("chord.other");
 
-	const direction = (
-		["bilateral", "in", "out", "net"].includes(dir as string)
-			? dir
-			: CHORD_CONTROLS_DEFAULTS.direction
-	) as ChordDirection;
+    const direction = (
+        ["bilateral", "in", "out", "net"].includes(dir as string)
+            ? dir
+            : CHORD_CONTROLS_DEFAULTS.direction
+    ) as ChordDirection;
 
-	const grouping = (
-		["team", "repo", "work_type"].includes(group as string)
-			? group
-			: CHORD_CONTROLS_DEFAULTS.grouping
-	) as ChordGroupingDimension;
+    const grouping = (
+        ["team", "repo", "work_type"].includes(group as string)
+            ? group
+            : CHORD_CONTROLS_DEFAULTS.grouping
+    ) as ChordGroupingDimension;
 
-	let topN = CHORD_CONTROLS_DEFAULTS.topN;
-	if (n) {
-		const parsedN = parseInt(n, 10);
-		if (!isNaN(parsedN)) {
-			// Clamp to [3, 16]
-			topN = Math.max(3, Math.min(16, parsedN));
-		}
-	}
+    let topN = CHORD_CONTROLS_DEFAULTS.topN;
+    if (n) {
+        const parsedN = parseInt(n, 10);
+        if (!isNaN(parsedN)) {
+            // Clamp to [3, 16]
+            topN = Math.max(3, Math.min(16, parsedN));
+        }
+    }
 
-	const showSelfLinks = self
-		? self === "true"
-		: CHORD_CONTROLS_DEFAULTS.showSelfLinks;
-	const showOther = other
-		? other === "true"
-		: CHORD_CONTROLS_DEFAULTS.showOther;
+    const showSelfLinks = self ? self === "true" : CHORD_CONTROLS_DEFAULTS.showSelfLinks;
+    const showOther = other ? other === "true" : CHORD_CONTROLS_DEFAULTS.showOther;
 
-	return { direction, grouping, topN, showSelfLinks, showOther };
+    return { direction, grouping, topN, showSelfLinks, showOther };
 }
 
 export function serializeChordControlsToSearchParams(
-	value: ChordControlsValue,
-	sp: URLSearchParams,
+    value: ChordControlsValue,
+    sp: URLSearchParams,
 ): URLSearchParams {
-	if (value.direction !== CHORD_CONTROLS_DEFAULTS.direction) {
-		sp.set("chord.dir", value.direction);
-	} else {
-		sp.delete("chord.dir");
-	}
+    if (value.direction !== CHORD_CONTROLS_DEFAULTS.direction) {
+        sp.set("chord.dir", value.direction);
+    } else {
+        sp.delete("chord.dir");
+    }
 
-	if (value.grouping !== CHORD_CONTROLS_DEFAULTS.grouping) {
-		sp.set("chord.group", value.grouping);
-	} else {
-		sp.delete("chord.group");
-	}
+    if (value.grouping !== CHORD_CONTROLS_DEFAULTS.grouping) {
+        sp.set("chord.group", value.grouping);
+    } else {
+        sp.delete("chord.group");
+    }
 
-	if (value.topN !== CHORD_CONTROLS_DEFAULTS.topN) {
-		sp.set("chord.n", value.topN.toString());
-	} else {
-		sp.delete("chord.n");
-	}
+    if (value.topN !== CHORD_CONTROLS_DEFAULTS.topN) {
+        sp.set("chord.n", value.topN.toString());
+    } else {
+        sp.delete("chord.n");
+    }
 
-	if (value.showSelfLinks !== CHORD_CONTROLS_DEFAULTS.showSelfLinks) {
-		sp.set("chord.self", value.showSelfLinks.toString());
-	} else {
-		sp.delete("chord.self");
-	}
+    if (value.showSelfLinks !== CHORD_CONTROLS_DEFAULTS.showSelfLinks) {
+        sp.set("chord.self", value.showSelfLinks.toString());
+    } else {
+        sp.delete("chord.self");
+    }
 
-	if (value.showOther !== CHORD_CONTROLS_DEFAULTS.showOther) {
-		sp.set("chord.other", value.showOther.toString());
-	} else {
-		sp.delete("chord.other");
-	}
+    if (value.showOther !== CHORD_CONTROLS_DEFAULTS.showOther) {
+        sp.set("chord.other", value.showOther.toString());
+    } else {
+        sp.delete("chord.other");
+    }
 
-	return sp;
+    return sp;
 }
 
 const DIRECTIONS: { value: ChordDirection; label: string }[] = [
-	{ value: "bilateral", label: "Bilateral" },
-	{ value: "in", label: "Inflow" },
-	{ value: "out", label: "Outflow" },
-	{ value: "net", label: "Net" },
+    { value: "bilateral", label: "Bilateral" },
+    { value: "in", label: "Inflow" },
+    { value: "out", label: "Outflow" },
+    { value: "net", label: "Net" },
 ];
 
 export function ChordChartControls({
-	value,
-	onChange,
-	otherAvailable = true,
-	className = "",
+    value,
+    onChange,
+    otherAvailable = true,
+    className = "",
 }: ChordChartControlsProps) {
-	const [topNInput, setTopNInput] = useState(value.topN.toString());
-	const [prevTopN, setPrevTopN] = useState(value.topN);
+    const [topNInput, setTopNInput] = useState(value.topN.toString());
+    const [prevTopN, setPrevTopN] = useState(value.topN);
 
-	if (value.topN !== prevTopN) {
-		setPrevTopN(value.topN);
-		setTopNInput(value.topN.toString());
-	}
+    if (value.topN !== prevTopN) {
+        setPrevTopN(value.topN);
+        setTopNInput(value.topN.toString());
+    }
 
-	const handleDirectionKeyDown = (
-		e: KeyboardEvent<HTMLButtonElement>,
-		index: number,
-	) => {
-		let nextIndex: number;
-		if (e.key === "ArrowRight" || e.key === "ArrowDown") {
-			nextIndex = (index + 1) % DIRECTIONS.length;
-		} else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
-			nextIndex = (index - 1 + DIRECTIONS.length) % DIRECTIONS.length;
-		} else {
-			return;
-		}
-		e.preventDefault();
-		const nextValue = DIRECTIONS[nextIndex].value;
-		onChange({ ...value, direction: nextValue });
-		// Focus the next button
-		const buttons = document.querySelectorAll('[role="radio"]');
-		if (buttons[nextIndex]) {
-			(buttons[nextIndex] as HTMLButtonElement).focus();
-		}
-	};
+    const handleDirectionKeyDown = (e: KeyboardEvent<HTMLButtonElement>, index: number) => {
+        let nextIndex: number;
+        if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+            nextIndex = (index + 1) % DIRECTIONS.length;
+        } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+            nextIndex = (index - 1 + DIRECTIONS.length) % DIRECTIONS.length;
+        } else {
+            return;
+        }
+        e.preventDefault();
+        const nextValue = DIRECTIONS[nextIndex].value;
+        onChange({ ...value, direction: nextValue });
+        // Focus the next button
+        const buttons = document.querySelectorAll('[role="radio"]');
+        if (buttons[nextIndex]) {
+            (buttons[nextIndex] as HTMLButtonElement).focus();
+        }
+    };
 
-	const handleTopNBlur = () => {
-		const parsed = parseInt(topNInput, 10);
-		if (isNaN(parsed)) {
-			setTopNInput(value.topN.toString());
-			return;
-		}
-		const clamped = Math.max(3, Math.min(16, parsed));
-		setTopNInput(clamped.toString());
-		if (clamped !== value.topN) {
-			onChange({ ...value, topN: clamped });
-		}
-	};
+    const handleTopNBlur = () => {
+        const parsed = parseInt(topNInput, 10);
+        if (isNaN(parsed)) {
+            setTopNInput(value.topN.toString());
+            return;
+        }
+        const clamped = Math.max(3, Math.min(16, parsed));
+        setTopNInput(clamped.toString());
+        if (clamped !== value.topN) {
+            onChange({ ...value, topN: clamped });
+        }
+    };
 
-	return (
-		<div className={`flex flex-wrap gap-4 items-end ${className}`}>
-			{/* Direction Segmented Control */}
-			<div className="flex flex-col gap-1.5">
-				<label
-					className="text-sm font-medium text-(--ink-muted)"
-					id="chord-dir-label"
-				>
-					Flow
-				</label>
-				<div
-					role="radiogroup"
-					aria-labelledby="chord-dir-label"
-					className="flex p-1 bg-(--card-stroke)/30 rounded-lg"
-				>
-					{DIRECTIONS.map((dir, i) => {
-						const isActive = value.direction === dir.value;
-						return (
-							<button
-								key={dir.value}
-								role="radio"
-								aria-checked={isActive}
-								tabIndex={isActive ? 0 : -1}
-								onClick={() => onChange({ ...value, direction: dir.value })}
-								onKeyDown={(e) => handleDirectionKeyDown(e, i)}
-								className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
-									isActive
-										? "bg-(--card) text-(--foreground) shadow-sm"
-										: "text-(--ink-muted) hover:text-(--foreground)"
-								}`}
-							>
-								{dir.label}
-							</button>
-						);
-					})}
-				</div>
-			</div>
+    return (
+        <div className={`flex flex-wrap gap-4 items-end ${className}`}>
+            {/* Direction Segmented Control */}
+            <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium text-(--ink-muted)" id="chord-dir-label">
+                    Flow
+                </label>
+                <div
+                    role="radiogroup"
+                    aria-labelledby="chord-dir-label"
+                    className="flex p-1 bg-(--card-stroke)/30 rounded-lg"
+                >
+                    {DIRECTIONS.map((dir, i) => {
+                        const isActive = value.direction === dir.value;
+                        return (
+                            <button
+                                key={dir.value}
+                                role="radio"
+                                aria-checked={isActive}
+                                tabIndex={isActive ? 0 : -1}
+                                onClick={() => onChange({ ...value, direction: dir.value })}
+                                onKeyDown={(e) => handleDirectionKeyDown(e, i)}
+                                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                                    isActive
+                                        ? "bg-(--card) text-(--foreground) shadow-sm"
+                                        : "text-(--ink-muted) hover:text-(--foreground)"
+                                }`}
+                            >
+                                {dir.label}
+                            </button>
+                        );
+                    })}
+                </div>
+            </div>
 
-			{/* Grouping Select */}
-			<div className="flex flex-col gap-1.5">
-				<label
-					htmlFor="chord-grouping"
-					className="text-sm font-medium text-(--ink-muted)"
-				>
-					Group by
-				</label>
-				<select
-					id="chord-grouping"
-					value={value.grouping}
-					onChange={(e) =>
-						onChange({
-							...value,
-							grouping: e.target.value as ChordGroupingDimension,
-						})
-					}
-					className="h-9 px-3 py-1.5 text-sm text-(--foreground) bg-(--card) border border-(--card-stroke) rounded-lg focus:outline-none focus:ring-2 focus:ring-(--accent)"
-				>
-					<option value="team">Team</option>
-					<option value="repo">Repository</option>
-					<option value="work_type">Work type</option>
-				</select>
-			</div>
+            {/* Grouping Select */}
+            <div className="flex flex-col gap-1.5">
+                <label htmlFor="chord-grouping" className="text-sm font-medium text-(--ink-muted)">
+                    Group by
+                </label>
+                <select
+                    id="chord-grouping"
+                    value={value.grouping}
+                    onChange={(e) =>
+                        onChange({
+                            ...value,
+                            grouping: e.target.value as ChordGroupingDimension,
+                        })
+                    }
+                    className="h-9 px-3 py-1.5 text-sm text-(--foreground) bg-(--card) border border-(--card-stroke) rounded-lg focus:outline-none focus:ring-2 focus:ring-(--accent)"
+                >
+                    <option value="team">Team</option>
+                    <option value="repo">Repository</option>
+                    <option value="work_type">Work type</option>
+                </select>
+            </div>
 
-			{/* Top-N Stepper */}
-			<div className="flex flex-col gap-1.5">
-				<label
-					htmlFor="chord-topn"
-					className="text-sm font-medium text-(--ink-muted)"
-				>
-					Entities
-				</label>
-				<div className="flex items-center border border-(--card-stroke) rounded-lg bg-(--card) overflow-hidden h-9">
-					<button
-						type="button"
-						aria-label="Decrease entities"
-						onClick={() => {
-							const next = Math.max(3, value.topN - 1);
-							setTopNInput(next.toString());
-							onChange({ ...value, topN: next });
-						}}
-						disabled={value.topN <= 3}
-						className="px-2.5 text-(--ink-muted) hover:bg-(--card-stroke)/30 disabled:opacity-50 h-full"
-					>
-						-
-					</button>
-					<input
-						id="chord-topn"
-						type="number"
-						min={3}
-						max={16}
-						step={1}
-						value={topNInput}
-						onChange={(e) => setTopNInput(e.target.value)}
-						onBlur={handleTopNBlur}
-						onKeyDown={(e) => {
-							if (e.key === "Enter") {
-								handleTopNBlur();
-							}
-						}}
-						className="w-12 text-center text-sm text-(--foreground) bg-transparent focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-					/>
-					<button
-						type="button"
-						aria-label="Increase entities"
-						onClick={() => {
-							const next = Math.min(16, value.topN + 1);
-							setTopNInput(next.toString());
-							onChange({ ...value, topN: next });
-						}}
-						disabled={value.topN >= 16}
-						className="px-2.5 text-(--ink-muted) hover:bg-(--card-stroke)/30 disabled:opacity-50 h-full"
-					>
-						+
-					</button>
-				</div>
-			</div>
+            {/* Top-N Stepper */}
+            <div className="flex flex-col gap-1.5">
+                <label htmlFor="chord-topn" className="text-sm font-medium text-(--ink-muted)">
+                    Entities
+                </label>
+                <div className="flex items-center border border-(--card-stroke) rounded-lg bg-(--card) overflow-hidden h-9">
+                    <button
+                        type="button"
+                        aria-label="Decrease entities"
+                        onClick={() => {
+                            const next = Math.max(3, value.topN - 1);
+                            setTopNInput(next.toString());
+                            onChange({ ...value, topN: next });
+                        }}
+                        disabled={value.topN <= 3}
+                        className="px-2.5 text-(--ink-muted) hover:bg-(--card-stroke)/30 disabled:opacity-50 h-full"
+                    >
+                        -
+                    </button>
+                    <input
+                        id="chord-topn"
+                        type="number"
+                        min={3}
+                        max={16}
+                        step={1}
+                        value={topNInput}
+                        onChange={(e) => setTopNInput(e.target.value)}
+                        onBlur={handleTopNBlur}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                                handleTopNBlur();
+                            }
+                        }}
+                        className="w-12 text-center text-sm text-(--foreground) bg-transparent focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                    />
+                    <button
+                        type="button"
+                        aria-label="Increase entities"
+                        onClick={() => {
+                            const next = Math.min(16, value.topN + 1);
+                            setTopNInput(next.toString());
+                            onChange({ ...value, topN: next });
+                        }}
+                        disabled={value.topN >= 16}
+                        className="px-2.5 text-(--ink-muted) hover:bg-(--card-stroke)/30 disabled:opacity-50 h-full"
+                    >
+                        +
+                    </button>
+                </div>
+            </div>
 
-			{/* Checkboxes */}
-			<div className="flex items-center gap-4 h-9">
-				<label className="flex items-center gap-2 text-sm text-(--ink-muted) cursor-pointer">
-					<input
-						type="checkbox"
-						checked={value.showSelfLinks}
-						onChange={(e) =>
-							onChange({ ...value, showSelfLinks: e.target.checked })
-						}
-						className="rounded border-(--card-stroke) accent-(--accent) focus:ring-(--accent)"
-					/>
-					Include self-links
-				</label>
+            {/* Checkboxes */}
+            <div className="flex items-center gap-4 h-9">
+                <label className="flex items-center gap-2 text-sm text-(--ink-muted) cursor-pointer">
+                    <input
+                        type="checkbox"
+                        checked={value.showSelfLinks}
+                        onChange={(e) => onChange({ ...value, showSelfLinks: e.target.checked })}
+                        className="rounded border-(--card-stroke) accent-(--accent) focus:ring-(--accent)"
+                    />
+                    Include self-links
+                </label>
 
-				<label
-					className={`flex items-center gap-2 text-sm text-(--ink-muted) ${
-						!otherAvailable ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
-					}`}
-					aria-disabled={!otherAvailable}
-				>
-					<input
-						type="checkbox"
-						checked={value.showOther}
-						onChange={(e) =>
-							onChange({ ...value, showOther: e.target.checked })
-						}
-						disabled={!otherAvailable}
-						className="rounded border-(--card-stroke) accent-(--accent) focus:ring-(--accent) disabled:opacity-50"
-					/>
-					Show &apos;Other&apos; bucket
-				</label>
-			</div>
-		</div>
-	);
+                <label
+                    className={`flex items-center gap-2 text-sm text-(--ink-muted) ${
+                        !otherAvailable ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+                    }`}
+                    aria-disabled={!otherAvailable}
+                >
+                    <input
+                        type="checkbox"
+                        checked={value.showOther}
+                        onChange={(e) => onChange({ ...value, showOther: e.target.checked })}
+                        disabled={!otherAvailable}
+                        className="rounded border-(--card-stroke) accent-(--accent) focus:ring-(--accent) disabled:opacity-50"
+                    />
+                    Show &apos;Other&apos; bucket
+                </label>
+            </div>
+        </div>
+    );
 }


### PR DESCRIPTION
## Summary

The **Team exchange chord** filter controls (Flow segmented control, Group by select, Entities stepper, checkboxes) rendered with light backgrounds on the dark app and did not follow any palette.

## Root cause

`ChordChartControls.tsx` was the only component under `src/components` still styled with hardcoded `slate`/`white`/`blue` Tailwind colors plus `dark:` variants. Two problems made it theme-blind:

1. **The `dark:` variants were dead.** There is no `@custom-variant dark` in `globals.css`, so Tailwind v4 falls back to the `prefers-color-scheme` media query — which tracks the OS setting, not the app's `data-theme` attribute. The controls therefore rendered their light base styling on the dark app.
2. **`data-palette` was ignored entirely** — hardcoded colors cannot follow any of the 6 palettes (fullchaos, material, echarts, etc.). Hence "not aligned for any theme."

## Fix

Migrated every control to the design-system CSS-variable tokens the parent `TeamExchangeChordSection` already uses (design-system Part C2 — semantic tokens, not raw hex):

| Element | Before | After |
|---|---|---|
| Labels | `text-slate-700 dark:text-slate-300` | `text-(--ink-muted)` |
| Flow track | `bg-slate-100 dark:bg-slate-800` | `bg-(--card-stroke)/30` |
| Active pill | `bg-white dark:bg-slate-700 text-slate-900 dark:text-white` | `bg-(--card) text-(--foreground)` |
| Select / stepper | `bg-white dark:bg-slate-900 border-slate-200…` | `bg-(--card) border-(--card-stroke) text-(--foreground)` |
| Focus ring | `focus:ring-blue-500` | `focus:ring-(--accent)` |
| Checkboxes | `border-slate-300 text-blue-600` | `border-(--card-stroke) accent-(--accent)` |

Controls now follow the active `data-theme` × `data-palette` like the rest of the chart card.

## Verification

- `lsp_diagnostics` clean on the changed file.
- Existing test assertion (`toHaveClass("opacity-50")`) preserved.

TEST-WAIVER: CSS-token-only change (className swaps to design-system tokens); no component logic or behavior changed. The one existing class assertion is preserved.

SCREENSHOT-WAIVER: pending — visual theming fix; before/after capture requires the local stack + Playwright login and will be attached as a follow-up before merge.