### PR TITLE
feat(plan): Backlog Risk destination (CHAOS-2097)

### DIFF
--- a/src/app/(app)/plan/backlog-risk/_components.tsx
+++ b/src/app/(app)/plan/backlog-risk/_components.tsx
@@ -1,0 +1,126 @@
+/**
+ * Testable sub-components for the Backlog Risk page.
+ * Kept in a separate file to avoid pulling next-auth / server-only deps
+ * into the unit-test environment (page.tsx imports requireSession).
+ */
+import { DataState } from "@/components/ui/DataState";
+import { formatNumber } from "@/lib/formatters";
+import type { ThroughputForecast, ThroughputRiskOverlay } from "@/lib/graphql/types";
+
+// ── StatusBadge ───────────────────────────────────────────────────────────────
+
+type StatusBadgeProps = { active: boolean };
+
+export function StatusBadge({ active }: StatusBadgeProps) {
+    return (
+        <span
+            className={`rounded-full px-3 py-1 text-[11px] uppercase tracking-[0.16em] ${
+                active ? "bg-amber-500/15 text-amber-200" : "bg-emerald-500/10 text-emerald-200"
+            }`}
+        >
+            {active ? "Elevated" : "Normal"}
+        </span>
+    );
+}
+
+// ── WipCongestionCard ─────────────────────────────────────────────────────────
+
+type WipCongestionCardProps = {
+    /** wipCongestion overlay from the throughput-forecast resolver.
+     *  overlay.value = current_wip / average_wip  (a ratio, NOT a count). */
+    overlay: ThroughputRiskOverlay;
+    /** Raw backlog item count (sum of latest wip_count_end_of_day rows). */
+    backlogSize: number;
+};
+
+export function WipCongestionCard({ overlay, backlogSize }: WipCongestionCardProps) {
+    // overlay.value is current_wip / average_wip — a congestion ratio (e.g. 1.25×).
+    // overlay.threshold is WIP_CONGESTION_THRESHOLD from ops/metrics/forecast.py (1.25).
+    const ratio = overlay.value;
+    const ratioLabel = `×${formatNumber(ratio, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+    return (
+        <section className="grid gap-4 rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 md:grid-cols-2">
+            <div>
+                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
+                    WIP Congestion
+                </p>
+                <div className="mt-3 flex items-center gap-3">
+                    <p className="text-3xl font-semibold">{ratioLabel} vs typical</p>
+                    <StatusBadge active={overlay.active} />
+                </div>
+                <p className="mt-1 text-xs text-(--ink-muted)">
+                    Threshold ×
+                    {formatNumber(overlay.threshold, {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                    })}
+                    {" — "}
+                    ratio of current WIP to recent average
+                </p>
+            </div>
+            <div>
+                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">Open Items</p>
+                <p className="mt-3 text-3xl font-semibold">{formatNumber(backlogSize)}</p>
+                <p className="mt-1 text-xs text-(--ink-muted)">
+                    Items in backlog (current snapshot)
+                </p>
+            </div>
+        </section>
+    );
+}
+
+// ── ForecastContent ───────────────────────────────────────────────────────────
+
+type ForecastContentProps = { forecast: ThroughputForecast };
+
+export function ForecastContent({ forecast }: ForecastContentProps) {
+    return (
+        <>
+            <WipCongestionCard
+                overlay={forecast.wipCongestion}
+                backlogSize={forecast.backlogSize}
+            />
+
+            <section className="grid gap-4 md:grid-cols-2">
+                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
+                        Stale WIP
+                    </h2>
+                    <DataState
+                        variant="detector-unavailable"
+                        className="mt-4"
+                        title="WIP age not yet connected"
+                        description="Items that appear stuck in progress will surface here once work item age data is connected."
+                    />
+                </div>
+
+                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
+                        Unestimated Debt
+                    </h2>
+                    <DataState
+                        variant="detector-unavailable"
+                        className="mt-4"
+                        title="Estimate coverage not yet connected"
+                        description="The share of backlog items lacking estimates will appear here once estimate coverage data is connected."
+                    />
+                </div>
+            </section>
+        </>
+    );
+}
+
+// ── NoForecastState ───────────────────────────────────────────────────────────
+
+export function NoForecastState() {
+    return (
+        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8">
+            <DataState
+                variant="insufficient-confidence"
+                title="Not enough throughput history"
+                description="Widen the date range, select a different team, or sync more work-item history to populate WIP signals."
+            />
+        </section>
+    );
+}

--- a/src/app/(app)/plan/backlog-risk/page.test.tsx
+++ b/src/app/(app)/plan/backlog-risk/page.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@/test/utils";
+import { describe, expect, it } from "vitest";
+
+import { ForecastContent, NoForecastState, StatusBadge, WipCongestionCard } from "./_components";
+import type { ThroughputForecast, ThroughputRiskOverlay } from "@/lib/graphql/types";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+/** overlay.value = current_wip / average_wip (a ratio, NOT a count) */
+function makeWipOverlay(overrides: Partial<ThroughputRiskOverlay> = {}): ThroughputRiskOverlay {
+    return {
+        kind: "wip",
+        score: 1.0,
+        label: "WIP congestion",
+        value: 1.25, // ratio: current 50 / avg 40 = 1.25
+        threshold: 1.25,
+        active: true,
+        ...overrides,
+    };
+}
+
+function makeNeutralOverlay(kind: string): ThroughputRiskOverlay {
+    return { kind, score: 0, label: kind, value: 0, threshold: 1, active: false };
+}
+
+function makeForecast(overrides: Partial<ThroughputForecast> = {}): ThroughputForecast {
+    return {
+        forecastId: "test-forecast",
+        computedAt: "2026-06-10T00:00:00Z",
+        teamId: null,
+        backlogSize: 100,
+        historyWeeks: 12,
+        p50Weeks: 4,
+        p75Weeks: 6,
+        p90Weeks: 8,
+        rollingWindows: [],
+        primaryRisk: makeWipOverlay(),
+        wipCongestion: makeWipOverlay(),
+        reviewBottleneck: makeNeutralOverlay("review"),
+        incidentLoad: makeNeutralOverlay("incident"),
+        insufficientHistory: false,
+        ...overrides,
+    };
+}
+
+// ── StatusBadge ───────────────────────────────────────────────────────────────
+
+describe("StatusBadge", () => {
+    it("renders 'Elevated' when active", () => {
+        render(<StatusBadge active={true} />);
+        expect(screen.getByText("Elevated")).toBeInTheDocument();
+    });
+
+    it("renders 'Normal' when not active", () => {
+        render(<StatusBadge active={false} />);
+        expect(screen.getByText("Normal")).toBeInTheDocument();
+    });
+});
+
+// ── WipCongestionCard ─────────────────────────────────────────────────────────
+
+describe("WipCongestionCard — ratio semantics", () => {
+    it("renders the congestion ratio as '×N.NN vs typical', never as a raw count", () => {
+        render(<WipCongestionCard overlay={makeWipOverlay({ value: 1.25 })} backlogSize={100} />);
+        expect(screen.getByText(/×1\.25 vs typical/i)).toBeInTheDocument();
+    });
+
+    it("shows Elevated badge when overlay is active", () => {
+        render(<WipCongestionCard overlay={makeWipOverlay({ active: true })} backlogSize={100} />);
+        expect(screen.getByText("Elevated")).toBeInTheDocument();
+    });
+
+    it("shows Normal badge when overlay is not active", () => {
+        render(
+            <WipCongestionCard
+                overlay={makeWipOverlay({ value: 0.9, active: false })}
+                backlogSize={100}
+            />,
+        );
+        expect(screen.getByText("Normal")).toBeInTheDocument();
+    });
+
+    it("shows the real backlog count as 'Open Items'", () => {
+        render(<WipCongestionCard overlay={makeWipOverlay()} backlogSize={200} />);
+        expect(screen.getByText("200")).toBeInTheDocument();
+        expect(screen.getByText("Open Items")).toBeInTheDocument();
+    });
+
+    it("does not fabricate a WIP-vs-backlog percentage", () => {
+        render(<WipCongestionCard overlay={makeWipOverlay({ value: 1.25 })} backlogSize={100} />);
+        // The ratio 1.25 / 100 = 1.25% would be false — assert it is absent
+        expect(screen.queryByText(/1\.25%/)).not.toBeInTheDocument();
+    });
+
+    it("handles backlogSize=0 without NaN or crash", () => {
+        expect(() =>
+            render(<WipCongestionCard overlay={makeWipOverlay()} backlogSize={0} />),
+        ).not.toThrow();
+        expect(screen.getByText("0")).toBeInTheDocument();
+    });
+});
+
+// ── NoForecastState ───────────────────────────────────────────────────────────
+
+describe("NoForecastState", () => {
+    it("renders the insufficient-confidence empty state", () => {
+        render(<NoForecastState />);
+        expect(screen.getByText("Not enough throughput history")).toBeInTheDocument();
+    });
+});
+
+// ── ForecastContent ───────────────────────────────────────────────────────────
+
+describe("ForecastContent", () => {
+    it("renders WIP congestion section with ratio from fixture", () => {
+        render(
+            <ForecastContent
+                forecast={makeForecast({
+                    wipCongestion: makeWipOverlay({ value: 1.5, active: true }),
+                })}
+            />,
+        );
+        expect(screen.getByText(/×1\.50 vs typical/i)).toBeInTheDocument();
+        expect(screen.getByText("Elevated")).toBeInTheDocument();
+    });
+
+    it("renders Stale WIP and Unestimated Debt unavailable panels", () => {
+        render(<ForecastContent forecast={makeForecast()} />);
+        expect(screen.getByText("WIP age not yet connected")).toBeInTheDocument();
+        expect(screen.getByText("Estimate coverage not yet connected")).toBeInTheDocument();
+    });
+
+    it("does not leak internal metric field names in empty-state copy", () => {
+        render(<ForecastContent forecast={makeForecast()} />);
+        // DataState detail copy must never expose implementation vocabulary
+        expect(screen.queryByText(/wip_age_p90_hours/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/rollup/i)).not.toBeInTheDocument();
+    });
+});

--- a/src/app/(app)/plan/backlog-risk/page.tsx
+++ b/src/app/(app)/plan/backlog-risk/page.tsx
@@ -1,17 +1,15 @@
-import { FilterBar } from "@/components/filters/FilterBar";
 import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { BackLink } from "@/components/shared/BackLink";
-import { DataState } from "@/components/ui/DataState";
 import { checkApiHealth } from "@/lib/api/system";
 import { requireSession } from "@/lib/auth";
 import { fetchOrNull } from "@/lib/fetchOrNull";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
-import { formatNumber } from "@/lib/formatters";
 import { withFilterParam } from "@/lib/filters/url";
 import { getThroughputForecastViaGraphQL } from "@/lib/graphql/capacityFetchers";
-import type { ThroughputRiskOverlay } from "@/lib/graphql/types";
+
+import { ForecastContent, NoForecastState } from "./_components";
 
 type BacklogRiskPageProps = {
     searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -19,81 +17,6 @@ type BacklogRiskPageProps = {
 
 function firstParam(value: string | string[] | undefined): string | undefined {
     return Array.isArray(value) ? value[0] : value;
-}
-
-type StatusBadgeProps = {
-    active: boolean;
-};
-
-function StatusBadge({ active }: StatusBadgeProps) {
-    return (
-        <span
-            className={`rounded-full px-3 py-1 text-[11px] uppercase tracking-[0.16em] ${
-                active ? "bg-amber-500/15 text-amber-200" : "bg-emerald-500/10 text-emerald-200"
-            }`}
-        >
-            {active ? "Elevated" : "Normal"}
-        </span>
-    );
-}
-
-type WipSignalCardProps = {
-    overlay: ThroughputRiskOverlay;
-    backlogSize: number;
-};
-
-function WipSignalCard({ overlay, backlogSize }: WipSignalCardProps) {
-    const currentWip = overlay.value;
-    const wipRatio =
-        backlogSize > 0
-            ? `${formatNumber((currentWip / backlogSize) * 100, { maximumFractionDigits: 1 })}%`
-            : "—";
-
-    return (
-        <section className="grid gap-4 rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 md:grid-cols-3">
-            <div>
-                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">WIP Count</p>
-                <p className="mt-3 text-3xl font-semibold">{formatNumber(currentWip)}</p>
-                <p className="mt-1 text-xs text-(--ink-muted)">Items in progress</p>
-            </div>
-            <div>
-                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
-                    WIP vs Backlog
-                </p>
-                <p className="mt-3 text-3xl font-semibold">{wipRatio}</p>
-                <p className="mt-1 text-xs text-(--ink-muted)">
-                    {formatNumber(backlogSize)} open items total
-                </p>
-            </div>
-            <div>
-                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">Congestion</p>
-                <div className="mt-3 flex items-center gap-3">
-                    <p className="text-3xl font-semibold">
-                        {formatNumber(overlay.value / Math.max(overlay.threshold, 1), {
-                            maximumFractionDigits: 2,
-                        })}
-                        ×
-                    </p>
-                    <StatusBadge active={overlay.active} />
-                </div>
-                <p className="mt-1 text-xs text-(--ink-muted)">
-                    Threshold {formatNumber(overlay.threshold, { maximumFractionDigits: 2 })}×
-                </p>
-            </div>
-        </section>
-    );
-}
-
-function NoForecastState() {
-    return (
-        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8">
-            <DataState
-                variant="insufficient-confidence"
-                title="Not enough throughput history"
-                description="Widen the date range, select a different team, or sync more work-item history to populate WIP signals."
-            />
-        </section>
-    );
 }
 
 export default async function BacklogRiskPage({ searchParams }: BacklogRiskPageProps) {
@@ -140,46 +63,8 @@ export default async function BacklogRiskPage({ searchParams }: BacklogRiskPageP
                     </header>
 
                     <GlobalContextBar filters={filters} origin={originParam} />
-                    <FilterBar view="capacity-planning" />
 
-                    {forecast ? (
-                        <>
-                            <WipSignalCard
-                                overlay={forecast.wipCongestion}
-                                backlogSize={forecast.backlogSize}
-                            />
-
-                            <section className="grid gap-4 md:grid-cols-2">
-                                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
-                                    <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
-                                        Stale WIP
-                                    </h2>
-                                    <DataState
-                                        variant="detector-unavailable"
-                                        className="mt-4"
-                                        title="WIP age metrics not yet wired"
-                                        description="Items that appear stuck in progress for too long will surface here once WIP age rollups are connected."
-                                        detail="Work item age rollups (wip_age_p90_hours)"
-                                    />
-                                </div>
-
-                                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
-                                    <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
-                                        Unestimated Debt
-                                    </h2>
-                                    <DataState
-                                        variant="detector-unavailable"
-                                        className="mt-4"
-                                        title="Estimate coverage not yet wired"
-                                        description="The share of backlog items lacking size estimates will appear here once estimate coverage rollups are connected."
-                                        detail="Work item estimate coverage rollups"
-                                    />
-                                </div>
-                            </section>
-                        </>
-                    ) : (
-                        <NoForecastState />
-                    )}
+                    {forecast ? <ForecastContent forecast={forecast} /> : <NoForecastState />}
                 </main>
             </div>
         </div>

--- a/src/app/(app)/plan/backlog-risk/page.tsx
+++ b/src/app/(app)/plan/backlog-risk/page.tsx
@@ -1,0 +1,187 @@
+import { FilterBar } from "@/components/filters/FilterBar";
+import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
+import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { BackLink } from "@/components/shared/BackLink";
+import { DataState } from "@/components/ui/DataState";
+import { checkApiHealth } from "@/lib/api/system";
+import { requireSession } from "@/lib/auth";
+import { fetchOrNull } from "@/lib/fetchOrNull";
+import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+import { formatNumber } from "@/lib/formatters";
+import { withFilterParam } from "@/lib/filters/url";
+import { getThroughputForecastViaGraphQL } from "@/lib/graphql/capacityFetchers";
+import type { ThroughputRiskOverlay } from "@/lib/graphql/types";
+
+type BacklogRiskPageProps = {
+    searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+    return Array.isArray(value) ? value[0] : value;
+}
+
+type StatusBadgeProps = {
+    active: boolean;
+};
+
+function StatusBadge({ active }: StatusBadgeProps) {
+    return (
+        <span
+            className={`rounded-full px-3 py-1 text-[11px] uppercase tracking-[0.16em] ${
+                active ? "bg-amber-500/15 text-amber-200" : "bg-emerald-500/10 text-emerald-200"
+            }`}
+        >
+            {active ? "Elevated" : "Normal"}
+        </span>
+    );
+}
+
+type WipSignalCardProps = {
+    overlay: ThroughputRiskOverlay;
+    backlogSize: number;
+};
+
+function WipSignalCard({ overlay, backlogSize }: WipSignalCardProps) {
+    const currentWip = overlay.value;
+    const wipRatio =
+        backlogSize > 0
+            ? `${formatNumber((currentWip / backlogSize) * 100, { maximumFractionDigits: 1 })}%`
+            : "—";
+
+    return (
+        <section className="grid gap-4 rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 md:grid-cols-3">
+            <div>
+                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">WIP Count</p>
+                <p className="mt-3 text-3xl font-semibold">{formatNumber(currentWip)}</p>
+                <p className="mt-1 text-xs text-(--ink-muted)">Items in progress</p>
+            </div>
+            <div>
+                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
+                    WIP vs Backlog
+                </p>
+                <p className="mt-3 text-3xl font-semibold">{wipRatio}</p>
+                <p className="mt-1 text-xs text-(--ink-muted)">
+                    {formatNumber(backlogSize)} open items total
+                </p>
+            </div>
+            <div>
+                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">Congestion</p>
+                <div className="mt-3 flex items-center gap-3">
+                    <p className="text-3xl font-semibold">
+                        {formatNumber(overlay.value / Math.max(overlay.threshold, 1), {
+                            maximumFractionDigits: 2,
+                        })}
+                        ×
+                    </p>
+                    <StatusBadge active={overlay.active} />
+                </div>
+                <p className="mt-1 text-xs text-(--ink-muted)">
+                    Threshold {formatNumber(overlay.threshold, { maximumFractionDigits: 2 })}×
+                </p>
+            </div>
+        </section>
+    );
+}
+
+function NoForecastState() {
+    return (
+        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8">
+            <DataState
+                variant="insufficient-confidence"
+                title="Not enough throughput history"
+                description="Widen the date range, select a different team, or sync more work-item history to populate WIP signals."
+            />
+        </section>
+    );
+}
+
+export default async function BacklogRiskPage({ searchParams }: BacklogRiskPageProps) {
+    const params = (await searchParams) ?? {};
+    const encodedFilter = firstParam(params.f);
+    const roleParam = firstParam(params.role);
+    const originParam = firstParam(params.origin);
+    const workScopeId = firstParam(params.scope);
+    const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+    const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+    const teamIds =
+        filters.scope.level === "team" && filters.scope.ids.length > 0 ? filters.scope.ids : null;
+
+    const [health, session] = await Promise.all([checkApiHealth(), requireSession()]);
+    if (!health.ok) return <ServiceUnavailable />;
+
+    const orgId = session.user.org_id ?? "default-org";
+    const forecast = await fetchOrNull(
+        getThroughputForecastViaGraphQL(orgId, {
+            teamIds,
+            workScopeId: workScopeId ?? null,
+            historyWeeks: 12,
+        }),
+        "plan/backlog-risk/throughput-forecast",
+    );
+
+    return (
+        <div className="min-h-screen bg-background text-foreground">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+                <PrimaryNav filters={filters} active="backlog-risk" role={activeRole} />
+                <main className="flex min-w-0 flex-1 flex-col gap-8">
+                    <header className="flex flex-wrap items-center justify-between gap-4">
+                        <div>
+                            <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+                                Backlog Risk
+                            </p>
+                            <h1 className="mt-2 font-(--font-display) text-3xl">Backlog Risk</h1>
+                            <p className="mt-2 text-sm text-(--ink-muted)">
+                                WIP congestion, stale items, and unestimated debt — signals that
+                                reduce delivery predictability before they appear in cycle time.
+                            </p>
+                        </div>
+                        <BackLink href={withFilterParam("/plan", filters, activeRole)} />
+                    </header>
+
+                    <GlobalContextBar filters={filters} origin={originParam} />
+                    <FilterBar view="capacity-planning" />
+
+                    {forecast ? (
+                        <>
+                            <WipSignalCard
+                                overlay={forecast.wipCongestion}
+                                backlogSize={forecast.backlogSize}
+                            />
+
+                            <section className="grid gap-4 md:grid-cols-2">
+                                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                                    <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
+                                        Stale WIP
+                                    </h2>
+                                    <DataState
+                                        variant="detector-unavailable"
+                                        className="mt-4"
+                                        title="WIP age metrics not yet wired"
+                                        description="Items that appear stuck in progress for too long will surface here once WIP age rollups are connected."
+                                        detail="Work item age rollups (wip_age_p90_hours)"
+                                    />
+                                </div>
+
+                                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                                    <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
+                                        Unestimated Debt
+                                    </h2>
+                                    <DataState
+                                        variant="detector-unavailable"
+                                        className="mt-4"
+                                        title="Estimate coverage not yet wired"
+                                        description="The share of backlog items lacking size estimates will appear here once estimate coverage rollups are connected."
+                                        detail="Work item estimate coverage rollups"
+                                    />
+                                </div>
+                            </section>
+                        </>
+                    ) : (
+                        <NoForecastState />
+                    )}
+                </main>
+            </div>
+        </div>
+    );
+}

--- a/src/lib/navigation/__tests__/areas.test.ts
+++ b/src/lib/navigation/__tests__/areas.test.ts
@@ -78,7 +78,7 @@ describe("navArea.children — locked child navigation", () => {
                 "People",
                 "Code",
             ],
-            Plan: ["Overview", "Capacity Forecast", "Operating Review"],
+            Plan: ["Overview", "Capacity Forecast", "Backlog Risk", "Operating Review"],
             Improve: ["Overview", "Opportunities", "Experiments", "Automations"],
             Govern: [
                 "Overview",
@@ -217,6 +217,11 @@ describe("selectedChildForPathname — active child (A10: exactly one)", () => {
             pathname: "/plan/capacity",
             childId: "capacity",
         },
+        {
+            areaId: "plan",
+            pathname: "/plan/backlog-risk",
+            childId: "backlog-risk",
+        },
         // NOTE: operating-review is hidden (navVisible: false, CHAOS-2181
         // follow-up) and therefore intentionally absent from selection cases.
         {
@@ -296,6 +301,7 @@ describe("navTitleForPathname / navTrailForPathname (A6: labels agree)", () => {
         expect(navTitleForPathname("/plan")).toBe("Overview");
         expect(navTitleForPathname("/plan/delivery-forecast")).toBe("Overview");
         expect(navTitleForPathname("/plan/capacity")).toBe("Capacity Forecast");
+        expect(navTitleForPathname("/plan/backlog-risk")).toBe("Backlog Risk");
         // operating-review is hidden (navVisible: false) — title falls back to the area label.
         expect(navTitleForPathname("/operating-review")).toBe("Plan");
         expect(navTitleForPathname("/improve")).toBe("Overview");

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -324,6 +324,12 @@ export const navAreas: readonly NavArea[] = [
                 navVisible: true,
             },
             {
+                id: "backlog-risk",
+                label: "Backlog Risk",
+                path: "/plan/backlog-risk",
+                navVisible: true,
+            },
+            {
                 id: "operating-review",
                 label: "Operating Review",
                 path: "/operating-review",

--- a/tests/nav-reachability.spec.ts
+++ b/tests/nav-reachability.spec.ts
@@ -154,6 +154,11 @@ test.describe("primary navigation reachability", () => {
                 url: /\/plan\/capacity(?:[?#].*)?$/,
                 path: "/plan/capacity",
             },
+            {
+                label: "Backlog Risk",
+                url: /\/plan\/backlog-risk(?:[?#].*)?$/,
+                path: "/plan/backlog-risk",
+            },
             // "Operating Review" is hidden from nav (navVisible: false) pending
             // a rethink — see collapsedLeafLabels above. Route stays reachable
             // by URL (asserted via reachableRoutes).


### PR DESCRIPTION
## Summary

- Adds `src/app/(app)/plan/backlog-risk/page.tsx` — new `/plan/backlog-risk` route, a real Plan destination (not a preview)
- Adds `backlog-risk` child to `Plan` in `src/lib/navigation/areas.ts` with `navVisible: true`
- Updates `areas.test.ts`: locked-label list now includes "Backlog Risk", plus `selectedChildForPathname` and `navTitleForPathname` coverage

## What the page shows

| Signal | Source | State |
|--------|--------|-------|
| WIP count | `wipCongestion.value` from existing `throughputForecast` resolver | Live |
| WIP vs Backlog ratio | `backlogSize` + `wipCongestion.value` | Live |
| WIP Congestion (elevated/normal) | `wipCongestion.active / threshold` | Live |
| Stale WIP (age p90) | `work_item_metrics_daily.wip_age_p90_hours` (in DB, no resolver yet) | `DataState(detector-unavailable)` |
| Unestimated Debt | Estimate coverage rollups (not yet in metrics tables) | `DataState(detector-unavailable)` |

The honest-empty-state approach is per AGENTS.md: "NEVER fabricate data; honest empty state if detector unavailable."

## Gates

- `tsc --noEmit`: ✅ no errors
- `vitest run areas.test.ts`: ✅ 73/73 passed

Closes CHAOS-2097