### PR TITLE
feat(improve): Experiments sub-area — page, nav, signals (CHAOS-2219)

### DIFF
--- a/src/app/(app)/improve/experiments/page.tsx
+++ b/src/app/(app)/improve/experiments/page.tsx
@@ -69,7 +69,7 @@ export default async function ExperimentsPage({ searchParams }: ExperimentsPageP
 
     const [health, experimentsResult] = await Promise.all([
         checkApiHealth(),
-        getExperimentsViaGraphQL(orgId),
+        getExperimentsViaGraphQL(orgId, filters),
     ]);
 
     if (!health.ok && !isTestMode) {

--- a/src/app/(app)/improve/experiments/page.tsx
+++ b/src/app/(app)/improve/experiments/page.tsx
@@ -1,0 +1,138 @@
+/**
+ * /improve/experiments — Experiments sub-area (CHAOS-2219).
+ *
+ * v1: renders experiments derived at query-time from opportunity
+ * suggested_experiments.  Each card shows the hypothesis, source metric,
+ * and status badge.  Empty state uses DataState with the canonical
+ * "detector-enabled-no-findings" variant rather than fabricated content.
+ *
+ * Penpot contract: Hypothesis · Owner · Metric · Stop condition.
+ * v1 fields Owner and Stop condition are empty for derived experiments and
+ * rendered as "—" placeholders so the layout is stable for v2 promotion.
+ */
+
+import { DataState } from "@/components/ui/DataState";
+import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
+import { PrimaryNav } from "@/components/navigation/PrimaryNav";
+import { BackLink } from "@/components/shared/BackLink";
+import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { checkApiHealth } from "@/lib/api/system";
+import { requireSession } from "@/lib/auth";
+import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
+import { withFilterParam } from "@/lib/filters/url";
+import { getExperimentsViaGraphQL } from "@/lib/graphql/improveFetchers";
+import type { Experiment } from "@/lib/graphql/types";
+import { getServerEnv } from "@/lib/config";
+
+type ExperimentsPageProps = {
+    searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+function ExperimentCard({ experiment }: { experiment: Experiment }) {
+    return (
+        <article
+            className="flex flex-col gap-3 rounded-3xl border border-(--card-stroke) bg-card p-6"
+            data-testid="experiment-card"
+        >
+            <header className="flex items-start justify-between gap-4">
+                <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+                    {experiment.metric || "Experiment"}
+                </p>
+                <span className="shrink-0 rounded-full bg-(--card-80) px-2 py-0.5 text-[10px] uppercase tracking-[0.15em] text-(--ink-muted)">
+                    {experiment.status}
+                </span>
+            </header>
+            <p className="font-(--font-display) text-base leading-snug">{experiment.hypothesis}</p>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-(--ink-muted)">
+                <dt className="font-medium uppercase tracking-[0.12em]">Owner</dt>
+                <dd>{experiment.owner || "—"}</dd>
+                <dt className="font-medium uppercase tracking-[0.12em]">Stop condition</dt>
+                <dd className="col-span-1">{experiment.stopCondition || "—"}</dd>
+            </dl>
+        </article>
+    );
+}
+
+export default async function ExperimentsPage({ searchParams }: ExperimentsPageProps) {
+    const session = await requireSession();
+    const params = (await searchParams) ?? {};
+    const encodedFilter = Array.isArray(params.f) ? params.f[0] : params.f;
+    const roleParam = Array.isArray(params.role) ? params.role[0] : params.role;
+    const activeRole = typeof roleParam === "string" ? roleParam : undefined;
+    const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
+
+    const env = getServerEnv();
+    const isTestMode =
+        env.DEV_HEALTH_TEST_MODE === "true" || env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
+
+    const orgId = session.user?.org_id ?? "demo-org";
+
+    const [health, experimentsResult] = await Promise.all([
+        checkApiHealth(),
+        getExperimentsViaGraphQL(orgId),
+    ]);
+
+    if (!health.ok && !isTestMode) {
+        return <ServiceUnavailable />;
+    }
+
+    const experiments = experimentsResult?.items ?? [];
+    const hasData = experimentsResult !== null;
+
+    return (
+        <div className="min-h-screen bg-background text-foreground">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+                <PrimaryNav filters={filters} active="experiments" role={activeRole} />
+                <main className="flex min-w-0 flex-1 flex-col gap-8">
+                    <header className="flex flex-col gap-4">
+                        <BackLink href={withFilterParam("/improve", filters, activeRole)} />
+                        <div>
+                            <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+                                Improve
+                            </p>
+                            <h1 className="mt-2 font-(--font-display) text-3xl">Experiments</h1>
+                            <p className="mt-2 text-sm text-(--ink-muted)">
+                                Process experiments derived from improvement opportunities — each
+                                with a hypothesis, owner, metric, and stop condition.
+                            </p>
+                        </div>
+                    </header>
+
+                    <GlobalContextBar filters={filters} />
+
+                    {!hasData && (
+                        <DataState
+                            variant="detector-unavailable"
+                            title="Experiments unavailable"
+                            description="Could not load experiment suggestions for the current window. Connect a data source or retry."
+                            className="py-12"
+                            data-testid="experiments-unavailable"
+                        />
+                    )}
+
+                    {hasData && experiments.length === 0 && (
+                        <DataState
+                            variant="detector-enabled-no-findings"
+                            title="No experiments in this window"
+                            description="There are no open improvement opportunities to derive experiments from right now. Experiments appear here once the opportunities detector surfaces candidates."
+                            className="py-12"
+                            data-testid="experiments-empty"
+                        />
+                    )}
+
+                    {hasData && experiments.length > 0 && (
+                        <section
+                            className="grid gap-6 md:grid-cols-2"
+                            aria-label="Experiments"
+                            data-testid="experiments-list"
+                        >
+                            {experiments.map((experiment) => (
+                                <ExperimentCard key={experiment.id} experiment={experiment} />
+                            ))}
+                        </section>
+                    )}
+                </main>
+            </div>
+        </div>
+    );
+}

--- a/src/components/navigation/PrimaryNav.test.tsx
+++ b/src/components/navigation/PrimaryNav.test.tsx
@@ -104,12 +104,14 @@ describe("PrimaryNav — two-level decision-area surface (CHAOS-2079)", () => {
         expect(screen.queryByRole("link", { name: /^Security$/i })).toBeNull();
     });
 
-    it("never renders preview (navVisible:false) children — verified via Improve", () => {
+    it("renders navVisible children and hides preview (navVisible:false) children — verified via Improve", () => {
         navigationMock.pathname = "/opportunities";
         render(<PrimaryNav filters={makeFilter()} active="opportunities" />);
 
+        // Opportunities and Experiments are navVisible:true → rendered.
         expect(screen.getByRole("link", { name: /^Opportunities$/i })).toBeInTheDocument();
-        expect(screen.queryByRole("link", { name: /^Experiments$/i })).toBeNull();
+        expect(screen.getByRole("link", { name: /^Experiments$/i })).toBeInTheDocument();
+        // Automations is still navVisible:false (preview) → not rendered.
         expect(screen.queryByRole("link", { name: /^Automations$/i })).toBeNull();
     });
 

--- a/src/lib/areaSignals/__tests__/improve.test.ts
+++ b/src/lib/areaSignals/__tests__/improve.test.ts
@@ -263,18 +263,43 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
         });
     });
 
-    // ── Preview sub-areas (Experiments / Automations) ─────────────────────────────
+    // ── Experiments (CHAOS-2219) ──────────────────────────────────────────────────
 
-    it("emits honest UNAVAILABLE + preview for Experiments (no backend / no route)", async () => {
+    it("emits a neutral count for Experiments derived from opportunity suggestions", async () => {
+        // Default mock: 2 opportunity cards, each with 0 suggested_experiments → count = 0.
         const signals = byId(await getImproveSignals(defaultMetricFilter));
 
         expect(signals.experiments).toMatchObject({
             id: "experiments",
             label: "Experiments",
             href: "/improve/experiments",
+            state: "neutral",
+            metricLabel: "Suggested next steps",
+        });
+        // Value contains the count and "suggested"; preview is NOT set.
+        expect(signals.experiments.value).toContain("suggested");
+        expect(signals.experiments.preview).not.toBe(true);
+    });
+
+    it("counts suggested_experiments across all opportunity cards", async () => {
+        mockGetOpportunities.mockResolvedValue({
+            items: [
+                { ...opportunityItem(), suggested_experiments: ["Exp A", "Exp B"] },
+                { ...opportunityItem(), suggested_experiments: ["Exp C"] },
+            ],
+        } as never);
+
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.experiments.value).toBe("3 suggested");
+    });
+
+    it("degrades Experiments to UNAVAILABLE when the opportunities fetch fails", async () => {
+        mockGetOpportunities.mockRejectedValue(new Error("backend down"));
+
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.experiments).toMatchObject({
             state: "unavailable",
             value: "",
-            preview: true,
         });
     });
 
@@ -294,6 +319,11 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
     it("does NOT mark the real Opportunities card as preview (stays clickable)", async () => {
         const signals = byId(await getImproveSignals(defaultMetricFilter));
         expect(signals.opportunities.preview).not.toBe(true);
+    });
+
+    it("does NOT mark the Experiments card as preview (route exists, stays clickable)", async () => {
+        const signals = byId(await getImproveSignals(defaultMetricFilter));
+        expect(signals.experiments.preview).not.toBe(true);
     });
 
     // ── Shape / ordering / wiring ─────────────────────────────────────────────────
@@ -344,8 +374,9 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
 
     it("degrades the 3 sub-areas to UNAVAILABLE (no top signal) when BOTH sources fail", async () => {
         // The genuine "not connected" path: both REST fetches throw → safe()
-        // swallows to undefined → opportunities unavailable, no deltas to rank, and
-        // Experiments/Automations stay preview. This is the honest-empty Overview.
+        // swallows to undefined → opportunities unavailable, no deltas to rank.
+        // Experiments also degrades to UNAVAILABLE (no preview — route exists).
+        // Automations stays preview (route does not yet exist).
         mockGetOpportunities.mockRejectedValue(new Error("opps down"));
         mockGetHomeData.mockRejectedValue(new Error("home down"));
 
@@ -357,7 +388,9 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
             expect(signal.value).toBe("");
         }
         const byIdMap = byId(signals);
-        expect(byIdMap.experiments.preview).toBe(true);
+        // Experiments has a real route now — UNAVAILABLE but NOT preview.
+        expect(byIdMap.experiments.preview).not.toBe(true);
+        // Automations still has no route — stays preview.
         expect(byIdMap["improve-automations"].preview).toBe(true);
         expect(byIdMap.opportunities.preview).not.toBe(true);
     });

--- a/src/lib/areaSignals/improve.ts
+++ b/src/lib/areaSignals/improve.ts
@@ -30,9 +30,10 @@
 //     "neutral" whenever the fetch SUCCEEDS (a count is informational, not a
 //     severity), including a healthy zero ("0 open"). Only a FAILED fetch
 //     (safe() → undefined) degrades to "unavailable" (genuine "not connected").
-//   - Experiments: UNAVAILABLE + preview (route /improve/experiments has no page
-//     yet → card is rendered non-clickable so it can't 404).
-//   - Automations: UNAVAILABLE + preview (route /improve/automations, same).
+//   - Experiments: REAL — count derived from opportunitiesData.items[*].suggested_experiments
+//     (no extra fetch; same data the Opportunities card already reads).  State is
+//     "neutral" on a successful fetch (even zero), "unavailable" only on failure.
+//   - Automations: UNAVAILABLE + preview (route /improve/automations, no page yet).
 
 import { getHomeData, getOpportunities } from "@/lib/api/home";
 import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
@@ -207,12 +208,23 @@ export async function getImproveSignals(
         push("opportunities", { ...UNAVAILABLE, metricLabel: "Opportunities" });
     }
 
-    // ── Experiments — UNAVAILABLE + preview (no backend / no route yet) ──────────
-    push("experiments", {
-        ...UNAVAILABLE,
-        preview: true,
-        metricLabel: "Experiments",
-    });
+    // ── Experiments — REAL (count derived from opportunity suggested_experiments) ──
+    // Experiments are derived from the same opportunities payload already fetched
+    // above (no extra API call).  A successful fetch with zero experiments is still
+    // "neutral" — healthy zero; only a failed fetch degrades to "unavailable".
+    if (opportunitiesData) {
+        const experimentCount = (opportunitiesData.items ?? []).reduce(
+            (sum, card) => sum + (card.suggested_experiments?.length ?? 0),
+            0,
+        );
+        push("experiments", {
+            state: "neutral",
+            value: `${formatNumber(experimentCount)} suggested`,
+            metricLabel: "Suggested next steps",
+        });
+    } else {
+        push("experiments", { ...UNAVAILABLE, metricLabel: "Experiments" });
+    }
 
     // ── Automations — UNAVAILABLE + preview (no backend / no route yet) ──────────
     push("improve-automations", {

--- a/src/lib/graphql/improveFetchers.ts
+++ b/src/lib/graphql/improveFetchers.ts
@@ -6,24 +6,31 @@
  * data was available.
  */
 
+import type { MetricFilter } from "@/lib/filters/types";
 import { EXPERIMENTS_QUERY } from "./queries";
+import { translateMetricFilterToGraphQL } from "./investmentFetchers";
 import { graphqlFetch } from "./urqlClient";
-import type { ExperimentsQueryResponse, ExperimentsResult, FilterInput } from "./types";
+import type { ExperimentsQueryResponse, ExperimentsResult } from "./types";
 
 /**
  * Fetch derived experiments for the Improve / Experiments page.
+ *
+ * Accepts the standard MetricFilter (from URL params / filterFromQueryParams)
+ * and translates it to GraphQL FilterInput before sending — normalising
+ * scope.level from lowercase ("org", "team") to GraphQL uppercase ("ORG", "TEAM").
  *
  * Returns null if the GraphQL query fails — callers should render a DataState
  * variant rather than throwing.
  */
 export async function getExperimentsViaGraphQL(
     orgId: string,
-    filters?: FilterInput | null,
+    filters?: MetricFilter | null,
 ): Promise<ExperimentsResult | null> {
     try {
+        const graphqlFilters = filters ? translateMetricFilterToGraphQL(filters) : null;
         const response = await graphqlFetch<ExperimentsQueryResponse>(
             EXPERIMENTS_QUERY,
-            { orgId, filters: filters ?? null },
+            { orgId, filters: graphqlFilters },
             { orgId },
         );
         return response.experiments;

--- a/src/lib/graphql/improveFetchers.ts
+++ b/src/lib/graphql/improveFetchers.ts
@@ -1,0 +1,33 @@
+/**
+ * GraphQL fetchers for the Improve area — Experiments sub-area (CHAOS-2219).
+ *
+ * v1: experiments are derived from OpportunityCard.suggested_experiments at
+ * query-time; ``derivedFromOpportunities`` signals whether live opportunity
+ * data was available.
+ */
+
+import { EXPERIMENTS_QUERY } from "./queries";
+import { graphqlFetch } from "./urqlClient";
+import type { ExperimentsQueryResponse, ExperimentsResult, FilterInput } from "./types";
+
+/**
+ * Fetch derived experiments for the Improve / Experiments page.
+ *
+ * Returns null if the GraphQL query fails — callers should render a DataState
+ * variant rather than throwing.
+ */
+export async function getExperimentsViaGraphQL(
+    orgId: string,
+    filters?: FilterInput | null,
+): Promise<ExperimentsResult | null> {
+    try {
+        const response = await graphqlFetch<ExperimentsQueryResponse>(
+            EXPERIMENTS_QUERY,
+            { orgId, filters: filters ?? null },
+            { orgId },
+        );
+        return response.experiments;
+    } catch {
+        return null;
+    }
+}

--- a/src/lib/graphql/investmentFetchers.ts
+++ b/src/lib/graphql/investmentFetchers.ts
@@ -64,8 +64,13 @@ function buildDateRange(filters: MetricFilter): {
 
 /**
  * Translate internal MetricFilter to GraphQL FilterInput.
+ *
+ * Exported for reuse by other GraphQL fetchers (e.g. improveFetchers).
+ * Key invariant: MetricFilter scope.level is lowercase ("org", "team") while
+ * the GraphQL ScopeLevelInput enum is uppercase ("ORG", "TEAM") — this
+ * function normalises the case via .toUpperCase().
  */
-function translateMetricFilterToGraphQL(filters: MetricFilter): FilterInput {
+export function translateMetricFilterToGraphQL(filters: MetricFilter): FilterInput {
     return {
         scope: {
             level: filters.scope.level.toUpperCase() as ScopeLevelInput,

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -914,3 +914,27 @@ query ReviewEdges($input: ReviewEdgesInput!) {
   }
 }
 `;
+
+// ==== Improve — Experiments Query (CHAOS-2219) ====
+
+// Derived experiments promoted from OpportunityCard.suggested_experiments.
+// v1: status is always "suggested"; no persistence table — computed at query-time.
+export const EXPERIMENTS_QUERY = `
+query Experiments($orgId: String!, $filters: FilterInput) {
+  experiments(orgId: $orgId, filters: $filters) {
+    items {
+      id
+      opportunityId
+      hypothesis
+      metric
+      owner
+      stopCondition
+      status
+      startDate
+      stopDate
+      outcome
+    }
+    derivedFromOpportunities
+  }
+}
+`;

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -593,3 +593,40 @@ export interface AIWorkflowDrilldownResult {
 export interface AIWorkflowDrilldownQueryResponse {
     aiWorkflowDrilldown: AIWorkflowDrilldownResult;
 }
+
+// ==== Improve — Experiments Types (CHAOS-2219) ====
+
+export type ExperimentStatus = "suggested" | "active" | "completed" | "abandoned";
+
+/**
+ * A process experiment derived from or promoted from an opportunity.
+ *
+ * v1: all experiments are derived (status="suggested") from
+ * OpportunityCard.suggested_experiments at query-time; no persistence table
+ * is used.  Fields for owned/tracked experiments (owner, stopCondition,
+ * startDate, stopDate, outcome) are included in the schema for v2 promotion.
+ *
+ * Field names match the GraphQL camelCase response format.
+ */
+export interface Experiment {
+    id: string;
+    opportunityId: string;
+    hypothesis: string;
+    metric: string;
+    owner: string;
+    stopCondition: string;
+    status: ExperimentStatus;
+    startDate: string | null;
+    stopDate: string | null;
+    outcome: string | null;
+}
+
+export interface ExperimentsResult {
+    items: Experiment[];
+    /** True when experiments were derived from live opportunity data. */
+    derivedFromOpportunities: boolean;
+}
+
+export interface ExperimentsQueryResponse {
+    experiments: ExperimentsResult;
+}

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -382,8 +382,7 @@ export const navAreas: readonly NavArea[] = [
                 id: "experiments",
                 label: "Experiments",
                 path: "/improve/experiments",
-                navVisible: false,
-                preview: true,
+                navVisible: true,
             },
             {
                 id: "improve-automations",

--- a/tests/improve-overview.spec.ts
+++ b/tests/improve-overview.spec.ts
@@ -70,20 +70,26 @@ test.describe("Improve Overview landing", () => {
         await expect(oppCard).toHaveAttribute("href", /\/opportunities/);
     });
 
-    test("keeps Experiments + Automations as non-clickable preview chips", async ({ page }) => {
+    test("Automations stays a non-clickable preview chip; Experiments is now a live link (CHAOS-2219)", async ({
+        page,
+    }) => {
         await page.goto("/improve", { waitUntil: "domcontentloaded" });
 
         const grid = page.getByTestId("area-overview-grid");
         await expect(grid).toBeVisible();
 
-        for (const label of ["Experiments", "Automations"]) {
-            const card = grid.locator("[data-signal-id]", { hasText: label });
-            await expect(card).toHaveAttribute("data-preview", "true");
-            await expect(card).toHaveAttribute("aria-disabled", "true");
-        }
-        // Preview chips are never links (dead route can't 404).
-        await expect(grid.getByRole("link", { name: "Experiments" })).toHaveCount(0);
+        // Automations: still a preview chip — route not yet shipped.
+        const automationsCard = grid.locator("[data-signal-id]", { hasText: "Automations" });
+        await expect(automationsCard).toHaveAttribute("data-preview", "true");
+        await expect(automationsCard).toHaveAttribute("aria-disabled", "true");
         await expect(grid.getByRole("link", { name: "Automations" })).toHaveCount(0);
+
+        // Experiments: promoted to a live area (CHAOS-2219) — must be a navigable link,
+        // NOT a disabled preview chip.
+        const experimentsCard = grid.locator("[data-signal-id]", { hasText: "Experiments" });
+        await expect(experimentsCard).not.toHaveAttribute("data-preview", "true");
+        await expect(experimentsCard).not.toHaveAttribute("aria-disabled", "true");
+        await expect(grid.getByRole("link", { name: "Experiments" })).toHaveCount(1);
     });
 
     test("marks Improve as the single selected area on /improve", async ({ page }) => {


### PR DESCRIPTION
## Summary

- **`/improve/experiments` page** — renders experiments derived from GraphQL `experiments` query; DataState `detector-enabled-no-findings` / `detector-unavailable` for empty/error states; never fabricates data
- **Filter passthrough**: page forwards `filters` (MetricFilter from URL searchParams) to `getExperimentsViaGraphQL` — hub signal and page now use the same window/scope
- **Nav**: flip `experiments` entry to `navVisible: true` (route now exists, not a phantom)
- **Signals**: replace `UNAVAILABLE + preview` for Experiments with a real neutral count derived from `opportunitiesData.items[*].suggested_experiments` (no extra API call)
- **GraphQL layer**: `EXPERIMENTS_QUERY` + `improveFetchers.ts` (accepts `MetricFilter`, translates to GraphQL `FilterInput` via `translateMetricFilterToGraphQL`) + `Experiment`/`ExperimentsResult` types in `types.ts` (camelCase, matching GraphQL response)
- **`translateMetricFilterToGraphQL`** exported from `investmentFetchers.ts` for reuse — normalises scope.level from lowercase ("org", "team") to GraphQL uppercase ("ORG", "TEAM")
- **Tests**: 26/26 in `improve.test.ts`, 40/40 in `PrimaryNav.test.tsx` — updated to assert real state (not preview)

## Persistence decision (ops side)

v1 uses a **derived resolver** in ops — no `experiments` table. See ops PR [#829](https://github.com/full-chaos/dev-health-ops/pull/829).

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm vitest run src/lib/areaSignals/__tests__/improve.test.ts` — 26 passed
- [x] `pnpm vitest run src/components/navigation/PrimaryNav.test.tsx` — 40 passed
- [x] `pnpm vitest run` — 1975 tests, 3 pre-existing rate-limit failures unrelated to this PR (confirmed pre-existing on unmodified main)
- [x] `pnpm prettier --write` — all changed files formatted

SCREENSHOT-WAIVER: `/improve/experiments` renders against the ops GraphQL backend (PR #829); visual verification deferred until ops is deployed.

Closes CHAOS-2219