### PR TITLE
feat(tokens): lock V1 token foundation in globals.css (CHAOS-2107)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -47,6 +47,12 @@ Use tokens only. **No hardcoded hex or px in components**, if a value is missing
 - **C5 Charts**, one palette + conventions: sequential scale for heatmaps that **must map data variance** (Churn heatmap renders uniform cyan today), categorical palette for series, consistent axis/gridline/tooltip styling, **styled tooltips** (Pipelines shows a blank white tooltip box), and a `ChartFrame` wrapper exposing title / interpretation / threshold slots.
 - **C6 Density & alignment**, consistent KPI card layout, card heights, and sparkline treatment across TestOps / Work / Coverage.
 
+### Locked decisions (CHAOS-2107, V1 token foundation)
+
+- **D1 — accent = orange (resolved).** The canonical palette is `fullchaos-infinity-knot-redux` (the app default in `src/app/layout.tsx`); its `--accent` (`#f47b20` dark / `#e04520` light) is the product realization of the Penpot `#F97316` accent. Blue-accent palettes (`fullchaos`, `echarts`, `material`) remain opt-in variants; they inherit the same semantic role tokens, so restyles must reference roles, never a literal orange.
+- **D2 — radius scale locked (resolved).** One scale only: `--radius-sm` 6 / `--radius-md` 10 / `--radius-lg` 16 / `--radius-pill` 999. The Penpot card radius of 24 snaps to `--radius-lg` (16); no `xl` token is added.
+- **Token inventory (defined in `src/app/globals.css`, all palettes):** color roles `--surface`, `--surface-raised`, `--border` (dark runs dimmer than `--card-stroke` per CHAOS-2067; bright strokes reserved for `--card-stroke-active`), `--text-primary`, `--text-secondary`, `--text-muted`, status `--positive` / `--caution` / `--negative` / `--info`, `--accent-ai`; typography utilities `text-display` 32/40, `text-h1` 24/32, `text-h2` 18/26, `text-h3` 15/22, `text-body` 14/22, `text-label-caps` 11/16 (+0.08em tracking); spacing `--space-card` 24 / `--space-card-sm` 16 on the 4px base scale; radius + elevation (`--elevation-card`, `--elevation-drawer`) as above.
+
 ## Part D: CTA vocabulary registry (typed constants)
 
 Approved (add new ones here before use): `Open evidence`, `Inspect associations`, `Open artifact`, `Present in view`, `Export report`, `Apply filters`, `Reset filters`, `Copy`; navigation `Back to Cockpit`, `Back to {area}`.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -580,12 +580,44 @@
     );
 }
 
+/* ============================================================
+ * SEMANTIC TOKEN FOUNDATION (Framework Part C — CHAOS-2107)
+ *
+ * Cross-palette role tokens. Derived via alias/color-mix from
+ * the per-palette primitives above; redeclare per-palette only
+ * when a palette genuinely diverges.
+ *
+ * Locked decisions (recorded in docs/design-system.md Part C):
+ *   D1 accent = orange — canonical palette is
+ *      fullchaos-infinity-knot-redux (app default); its accent
+ *      realizes Penpot #F97316. Blue-accent palettes are
+ *      opt-in variants.
+ *   D2 radius scale stays sm 6 / md 10 / lg 16 / pill 999;
+ *      Penpot card 24 snaps to --radius-lg. No xl token.
+ *
+ * Spacing (C3): 4px base scale — 4/8/12/16/24/32/48 via
+ * Tailwind spacing utilities; card padding standardizes on
+ * --space-card (24) / --space-card-sm (16).
+ * ============================================================ */
 :root,
 :root[data-theme="light"],
 :root[data-palette][data-theme="light"] {
+    /* C2 color roles */
+    --surface: var(--card);
+    --surface-raised: color-mix(in srgb, var(--card) 97%, var(--foreground));
+    --border: var(--card-stroke);
+    --text-primary: var(--foreground);
+    --text-secondary: color-mix(in srgb, var(--foreground) 72%, var(--ink-muted));
+    --text-muted: var(--ink-muted);
     --positive: #16a34a;
     --caution: #f59e0b;
+    --negative: #dc2626;
     --info: #2563eb;
+    --accent-ai: #7c3aed;
+    /* C3 spacing */
+    --space-card: 24px;
+    --space-card-sm: 16px;
+    /* C4 radius & elevation — prefer surface + hairline over stacked bright outlines */
     --radius-sm: 6px;
     --radius-md: 10px;
     --radius-lg: 16px;
@@ -597,9 +629,15 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
+        --surface-raised: color-mix(in srgb, var(--card) 92%, var(--foreground));
+        /* CHAOS-2067: dark borders run dimmer than --card-stroke; bright
+           strokes are reserved for --card-stroke-active states */
+        --border: color-mix(in srgb, var(--card-stroke) 65%, var(--background));
         --positive: #34d399;
         --caution: #fbbf24;
+        --negative: #f87171;
         --info: #60a5fa;
+        --accent-ai: #a78bfa;
         --elevation-card: 0 22px 58px -40px rgb(0 0 0 / 0.65);
         --elevation-drawer: 0 32px 90px -42px rgb(0 0 0 / 0.75);
         --card-stroke-active: color-mix(in srgb, var(--accent) 45%, var(--card-stroke));
@@ -608,9 +646,15 @@
 
 :root[data-theme="dark"],
 :root[data-palette][data-theme="dark"] {
+    --surface-raised: color-mix(in srgb, var(--card) 92%, var(--foreground));
+    /* CHAOS-2067: dark borders run dimmer than --card-stroke; bright
+       strokes are reserved for --card-stroke-active states */
+    --border: color-mix(in srgb, var(--card-stroke) 65%, var(--background));
     --positive: #34d399;
     --caution: #fbbf24;
+    --negative: #f87171;
     --info: #60a5fa;
+    --accent-ai: #a78bfa;
     --elevation-card: 0 22px 58px -40px rgb(0 0 0 / 0.65);
     --elevation-drawer: 0 32px 90px -42px rgb(0 0 0 / 0.75);
     --card-stroke-active: color-mix(in srgb, var(--accent) 45%, var(--card-stroke));
@@ -627,17 +671,45 @@
     --color-card-stroke-active: var(--card-stroke-active);
     --color-foreground: var(--foreground);
     --color-ink-muted: var(--ink-muted);
+    --color-surface: var(--surface);
+    --color-surface-raised: var(--surface-raised);
+    --color-border-subtle: var(--border);
+    --color-ink-secondary: var(--text-secondary);
     --color-accent: var(--accent);
     --color-accent-2: var(--accent-2);
     --color-accent-3: var(--accent-3);
+    --color-accent-ai: var(--accent-ai);
     --color-accent-negative: var(--accent-negative);
     --color-positive: var(--positive);
     --color-caution: var(--caution);
+    --color-negative: var(--negative);
     --color-info: var(--info);
     --color-app-gradient: var(--app-gradient);
     --font-sans: var(--font-body);
     --font-display: var(--font-display);
     --font-mono: var(--font-mono);
+}
+
+/* ============================================================
+ * TYPOGRAPHY SCALE (C1 — locked)
+ * Generates text-display / text-h1 / text-h2 / text-h3 /
+ * text-body / text-label-caps utilities. Page title = h1;
+ * section header = h2; uppercase descriptors = label-caps.
+ * ============================================================ */
+@theme {
+    --text-display: 32px;
+    --text-display--line-height: 40px;
+    --text-h1: 24px;
+    --text-h1--line-height: 32px;
+    --text-h2: 18px;
+    --text-h2--line-height: 26px;
+    --text-h3: 15px;
+    --text-h3--line-height: 22px;
+    --text-body: 14px;
+    --text-body--line-height: 22px;
+    --text-label-caps: 11px;
+    --text-label-caps--line-height: 16px;
+    --text-label-caps--letter-spacing: 0.08em;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary
Locks the Framework Part C token foundation in `src/app/globals.css` so every later restyle (CHAOS-2108 V2 primitives → CHAOS-2113 V7 enforcement, plus CHAOS-2067/2109/2111) has tokens to use. Token-only and additive — nothing consumes the new tokens yet, so there is no visual change.

Linear: [CHAOS-2107](https://linear.app/fullchaos/issue/CHAOS-2107/v1-lock-the-token-foundation-in-globalscss-color-roles-typography)

## What's added (cross-palette foundation blocks — apply to all palettes)
- **C2 color roles:** `--surface`, `--surface-raised`, `--border`, `--text-primary`, `--text-secondary`, `--text-muted`, status `--negative` (light `#dc2626` / dark `#f87171`), `--accent-ai` (violet). `--positive/--caution/--info` already existed and are unchanged.
- **CHAOS-2067 prep:** dark-mode `--border` is defined dimmer than `--card-stroke` (`color-mix` 65% toward background); bright strokes stay reserved for `--card-stroke-active`. Nothing consumes `--border` yet — the sweep is CHAOS-2067's scope.
- **C1 typography:** locked scale as Tailwind v4 utilities — `text-display` 32/40, `text-h1` 24/32, `text-h2` 18/26, `text-h3` 15/22, `text-body` 14/22, `text-label-caps` 11/16 + 0.08em tracking. Fonts already conform (Inter `--font-body`, JetBrains Mono `--font-mono`).
- **C3 spacing:** `--space-card` 24 / `--space-card-sm` 16; 4px base scale confirmed via Tailwind spacing.
- **C4:** radius scale + `--elevation-card/--elevation-drawer` already existed; unchanged.
- **Tailwind bridge:** `--color-surface`, `--color-surface-raised`, `--color-border-subtle`, `--color-ink-secondary`, `--color-negative`, `--color-accent-ai`.

## Decisions (recorded in docs/design-system.md Part C)
- **D1 resolved — accent = orange.** The issue predates the IA restructure: the app default palette is now `fullchaos-infinity-knot-redux` (layout.tsx), whose accent (`#f47b20`/`#e04520`) realizes Penpot `#F97316`. Canonical palette designated; blue-accent palettes stay opt-in variants. No live accent change.
- **D2 resolved — no xl radius.** Penpot card 24 snaps to `--radius-lg` 16; the one-scale rule (C4) holds.

## Notes
- Fixes a latent bug: `SyncConfigForm.tsx` already referenced `var(--text-primary)`/`var(--text-secondary)` which were undefined (styles silently inherited); they now resolve to real role tokens.
- `pnpm design-lint`: scan counters 0; eslint half reports **327 pre-existing** `no-hardcoded-style` errors in component files — identical count on main (zero new). That debt is the V2/V7 burn-down (CHAOS-2108/2113); CI runs this check as advisory today.

## Gates
- `ci/run_tests.sh format` ✓
- `ci/run_tests.sh quality` (tsc) ✓
- `ci/run_tests.sh unit` ✓ — 215 files, 1991 tests
- prettier --write on touched files (no diff)

TEST-WAIVER: token-only CSS custom-property additions in globals.css; no JS/TS logic changed. Zero-visual-change verified by adversarial review (no pre-existing consumers of new token names; SyncConfigForm delta intended). Existing 1991-test unit suite passes unchanged.