### PR TITLE
feat(charts): standardize trend-chart interpretation via ChartFrame (CHAOS-2038)

### DIFF
--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -11,7 +11,7 @@ import { BackLink } from "@/components/shared/BackLink";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
 import { fetchCoverageMetrics } from "@/lib/testops/fetchers";
-import { TESTOPS_MEASURES } from "@/lib/testops/constants";
+import { COVERAGE_LINE_TARGET_PCT, TESTOPS_MEASURES } from "@/lib/testops/constants";
 import {
 	TimeseriesResult,
 	TimeseriesBucket,
@@ -206,9 +206,10 @@ export default async function CoveragePage({
 						<ChartFrame
 							title="Line Coverage Trend"
 							interpretation="Line coverage appears over time so drops are visible before they become release risk."
+							direction={TESTOPS_MEASURES.COVERAGE_LINE_PCT.goodDirection}
 							threshold={{
 								label: "Target baseline",
-								value: "80%",
+								value: `${COVERAGE_LINE_TARGET_PCT}%`,
 								tone: "info",
 							}}
 							isEmpty={timeseriesData.length === 0}
@@ -216,7 +217,14 @@ export default async function CoveragePage({
 							stateDescription="Coverage history appears here once CI coverage data is connected for this scope."
 						>
 							<div className="h-64">
-								<TimeseriesChart data={timeseriesData} valueFormat="percent" />
+								<TimeseriesChart
+									data={timeseriesData}
+									valueFormat="percent"
+									baseline={{
+										value: COVERAGE_LINE_TARGET_PCT,
+										label: "Target baseline",
+									}}
+								/>
 							</div>
 						</ChartFrame>
 						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">

--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -205,6 +205,7 @@ export default async function CoveragePage({
 					<section className="grid gap-6 lg:grid-cols-2">
 						<ChartFrame
 							title="Line Coverage Trend"
+							headingLevel="h2"
 							interpretation="Line coverage appears over time so drops are visible before they become release risk."
 							direction={TESTOPS_MEASURES.COVERAGE_LINE_PCT.goodDirection}
 							threshold={{

--- a/src/app/(app)/testops/pipelines/page.tsx
+++ b/src/app/(app)/testops/pipelines/page.tsx
@@ -4,6 +4,7 @@ import { MetricCard } from "@/components/metrics/MetricCard";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { DataState } from "@/components/ui/DataState";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { ChartFrame } from "@/components/charts/ChartFrame";
 import { TimeseriesChart } from "@/components/charts/TimeseriesChart";
 import { HeatmapChart } from "@/components/charts/HeatmapChart";
 import { checkApiHealth } from "@/lib/api/system";
@@ -189,14 +190,18 @@ export default async function PipelinesPage({ searchParams }: PipelinesPageProps
                     </p>
 
                     <section className="grid gap-6 lg:grid-cols-2">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
-                            <h2 className="font-(--font-display) text-xl mb-4">
-                                Success Rate Trend
-                            </h2>
+                        <ChartFrame
+                            title="Success Rate Trend"
+                            interpretation="Share of completed pipeline runs that succeed, day by day — a sustained dip flags CI instability before it blocks delivery."
+                            direction={TESTOPS_MEASURES.PIPELINE_SUCCESS_RATE.goodDirection}
+                            isEmpty={timeseriesData.length === 0}
+                            stateTitle="Pipeline trend not populated"
+                            stateDescription="Success-rate history appears here once pipeline runs are ingested for this scope."
+                        >
                             <div className="h-64">
-                                <TimeseriesChart data={timeseriesData} />
+                                <TimeseriesChart data={timeseriesData} valueFormat="percent" />
                             </div>
-                        </div>
+                        </ChartFrame>
                         <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
                             <h2 className="font-(--font-display) text-xl mb-4">Failure Patterns</h2>
                             {failurePatterns.isEmpty ? (

--- a/src/app/(app)/testops/pipelines/page.tsx
+++ b/src/app/(app)/testops/pipelines/page.tsx
@@ -192,8 +192,11 @@ export default async function PipelinesPage({ searchParams }: PipelinesPageProps
                     <section className="grid gap-6 lg:grid-cols-2">
                         <ChartFrame
                             title="Success Rate Trend"
+                            headingLevel="h2"
                             interpretation="Share of completed pipeline runs that succeed, day by day — a sustained dip flags CI instability before it blocks delivery."
                             direction={TESTOPS_MEASURES.PIPELINE_SUCCESS_RATE.goodDirection}
+                            isError={Boolean(testOpsData.fetchFailed)}
+                            stateMessage="Pipeline analytics could not be loaded. The trend will reappear once the data service recovers."
                             isEmpty={timeseriesData.length === 0}
                             stateTitle="Pipeline trend not populated"
                             stateDescription="Success-rate history appears here once pipeline runs are ingested for this scope."

--- a/src/components/charts/ChartFrame.test.tsx
+++ b/src/components/charts/ChartFrame.test.tsx
@@ -93,6 +93,48 @@ describe("ChartFrame", () => {
         expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
     });
 
+    it("renders a directionality pill from the direction prop", () => {
+        render(
+            <ChartFrame
+                title="Success Rate Trend"
+                interpretation="Share of completed runs that succeed."
+                direction="up"
+            >
+                <div data-testid="chart-child">chart body</div>
+            </ChartFrame>,
+        );
+
+        expect(screen.getByText("Higher is better")).toBeInTheDocument();
+        expect(screen.getByTestId("chart-child")).toBeInTheDocument();
+    });
+
+    it("renders 'Lower is better' for a down direction alongside other annotations", () => {
+        render(
+            <ChartFrame
+                title="Failure Rate Trend"
+                interpretation="Share of completed runs that fail."
+                direction="down"
+                threshold={{ label: "Target baseline", value: "80%" }}
+            >
+                <div data-testid="chart-child">chart body</div>
+            </ChartFrame>,
+        );
+
+        expect(screen.getByText("Lower is better")).toBeInTheDocument();
+        expect(screen.getByText("Target baseline")).toBeInTheDocument();
+        expect(screen.getByText("80%")).toBeInTheDocument();
+    });
+
+    it("renders no annotation row when direction, threshold and band are absent", () => {
+        const { container } = render(
+            <ChartFrame title="Bare Trend" interpretation="No annotations.">
+                <div data-testid="chart-child">chart body</div>
+            </ChartFrame>,
+        );
+
+        expect(container.querySelector("[data-annotation]")).toBeNull();
+    });
+
     it("renders descriptor annotations whose value is zero", () => {
         render(
             <ChartFrame

--- a/src/components/charts/ChartFrame.test.tsx
+++ b/src/components/charts/ChartFrame.test.tsx
@@ -93,6 +93,30 @@ describe("ChartFrame", () => {
         expect(screen.queryByTestId("chart-child")).not.toBeInTheDocument();
     });
 
+    it("renders the title as an h2 when headingLevel is set (default stays h3)", () => {
+        const { rerender } = render(
+            <ChartFrame title="Success Rate Trend" interpretation="Outline check.">
+                <div>chart body</div>
+            </ChartFrame>,
+        );
+        expect(
+            screen.getByRole("heading", { name: "Success Rate Trend", level: 3 }),
+        ).toBeInTheDocument();
+
+        rerender(
+            <ChartFrame
+                title="Success Rate Trend"
+                interpretation="Outline check."
+                headingLevel="h2"
+            >
+                <div>chart body</div>
+            </ChartFrame>,
+        );
+        expect(
+            screen.getByRole("heading", { name: "Success Rate Trend", level: 2 }),
+        ).toBeInTheDocument();
+    });
+
     it("renders a directionality pill from the direction prop", () => {
         render(
             <ChartFrame

--- a/src/components/charts/ChartFrame.tsx
+++ b/src/components/charts/ChartFrame.tsx
@@ -23,6 +23,12 @@ type ChartFrameProps = {
     title: ReactNode;
     interpretation: ReactNode;
     children: ReactNode;
+    /**
+     * Heading element for the title. Defaults to h3; pass "h2" when the frame
+     * sits directly under a page h1 or beside sibling h2 cards so the document
+     * outline doesn't skip a level.
+     */
+    headingLevel?: "h2" | "h3";
     direction?: ChartDirection;
     threshold?: ChartFrameAnnotation;
     band?: ChartFrameAnnotation;
@@ -103,6 +109,7 @@ export function ChartFrame({
     title,
     interpretation,
     children,
+    headingLevel,
     direction,
     threshold,
     band,
@@ -121,6 +128,7 @@ export function ChartFrame({
     const dataState = resolveDataState({ state, isLoading, isError, isEmpty });
     const hasAnnotations =
         direction != null || annotationPresent(threshold) || annotationPresent(band);
+    const Heading = headingLevel ?? "h3";
 
     return (
         <section
@@ -129,9 +137,9 @@ export function ChartFrame({
         >
             <div className="flex flex-wrap items-start justify-between gap-4">
                 <div className="min-w-0 space-y-1">
-                    <h3 className="font-(--font-display) text-base font-semibold text-foreground">
+                    <Heading className="font-(--font-display) text-base font-semibold text-foreground">
                         {title}
-                    </h3>
+                    </Heading>
                     <div className="text-sm text-(--ink-muted)">{interpretation}</div>
                 </div>
                 {hasAnnotations && (

--- a/src/components/charts/ChartFrame.tsx
+++ b/src/components/charts/ChartFrame.tsx
@@ -12,10 +12,18 @@ type ChartFrameAnnotationDescriptor = {
 
 type ChartFrameAnnotation = ReactNode | ChartFrameAnnotationDescriptor;
 
+export type ChartDirection = "up" | "down";
+
+const directionLabel: Record<ChartDirection, string> = {
+    up: "Higher is better",
+    down: "Lower is better",
+};
+
 type ChartFrameProps = {
     title: ReactNode;
     interpretation: ReactNode;
     children: ReactNode;
+    direction?: ChartDirection;
     threshold?: ChartFrameAnnotation;
     band?: ChartFrameAnnotation;
     state?: DataStateVariant;
@@ -95,6 +103,7 @@ export function ChartFrame({
     title,
     interpretation,
     children,
+    direction,
     threshold,
     band,
     state,
@@ -110,7 +119,8 @@ export function ChartFrame({
     "data-testid": testId,
 }: ChartFrameProps) {
     const dataState = resolveDataState({ state, isLoading, isError, isEmpty });
-    const hasAnnotations = annotationPresent(threshold) || annotationPresent(band);
+    const hasAnnotations =
+        direction != null || annotationPresent(threshold) || annotationPresent(band);
 
     return (
         <section
@@ -126,6 +136,11 @@ export function ChartFrame({
                 </div>
                 {hasAnnotations && (
                     <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+                        {direction != null &&
+                            renderAnnotation(
+                                { label: directionLabel[direction] },
+                                "Chart direction",
+                            )}
                         {renderAnnotation(threshold, "Chart threshold")}
                         {renderAnnotation(band, "Chart band")}
                     </div>

--- a/src/components/charts/TimeseriesChart.test.tsx
+++ b/src/components/charts/TimeseriesChart.test.tsx
@@ -1,7 +1,35 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "@/test/utils";
 
 import { orderTimeseriesPoints } from "./timeseriesData";
-import { buildBaselineMarkLine } from "./TimeseriesChart";
+import { buildBaselineMarkLine, TimeseriesChart } from "./TimeseriesChart";
+
+const chartTheme = {
+    text: "#111827",
+    grid: "#e5e7eb",
+    muted: "#6b7280",
+    background: "#ffffff",
+    stroke: "#d1d5db",
+    accent1: "#2563eb",
+    accent2: "#7c3aed",
+    accent3: "#ef4444",
+};
+
+const { chartSpy } = vi.hoisted(() => ({
+    chartSpy: vi.fn(),
+}));
+
+vi.mock("./chartTheme", () => ({
+    useChartTheme: () => chartTheme,
+    useChartColors: () => [],
+}));
+
+vi.mock("./Chart", () => ({
+    Chart: (props: unknown) => {
+        chartSpy(props);
+        return <div data-testid="timeseries-chart" />;
+    },
+}));
 
 describe("orderTimeseriesPoints", () => {
     it("orders by the full ISO day, not the display label, across a year boundary", () => {
@@ -53,5 +81,63 @@ describe("buildBaselineMarkLine", () => {
     it("hides the label when none is given", () => {
         const markLine = buildBaselineMarkLine({ value: 80 }, color);
         expect(markLine?.label).toMatchObject({ show: false });
+    });
+});
+
+describe("TimeseriesChart render path", () => {
+    beforeEach(() => {
+        chartSpy.mockClear();
+    });
+
+    type CapturedOption = {
+        series: Array<{
+            data: number[];
+            markLine?: { data: Array<{ yAxis: number }> };
+        }>;
+    };
+
+    const capturedOption = (): CapturedOption => {
+        expect(chartSpy).toHaveBeenCalledTimes(1);
+        return (chartSpy.mock.calls[0][0] as { option: CapturedOption }).option;
+    };
+
+    it("plots the baseline on the same 0–100 scale as percent series values (CHAOS-2163 gap class)", () => {
+        // Coverage-page path: backend percent values arrive already on 0–100.
+        // The 80% target must land inside the series range, not at 0.8.
+        render(
+            <TimeseriesChart
+                data={[
+                    { day: "2026-06-01", value: 72 },
+                    { day: "2026-06-02", value: 85 },
+                    { day: "2026-06-03", value: 91 },
+                ]}
+                valueFormat="percent"
+                baseline={{ value: 80, label: "Target baseline" }}
+            />,
+        );
+
+        const option = capturedOption();
+        const series = option.series[0];
+        // Series data passes through unscaled (0–100, not 0–1)…
+        expect(series.data).toEqual([72, 85, 91]);
+        // …and the baseline sits on the same scale, between min and max.
+        const baselineY = series.markLine?.data[0]?.yAxis;
+        expect(baselineY).toBe(80);
+        expect(baselineY).toBeGreaterThan(Math.min(...series.data));
+        expect(baselineY).toBeLessThan(Math.max(...series.data));
+    });
+
+    it("omits markLine entirely when no baseline is given", () => {
+        render(
+            <TimeseriesChart
+                data={[
+                    { day: "2026-06-01", value: 72 },
+                    { day: "2026-06-02", value: 85 },
+                ]}
+            />,
+        );
+
+        const series = capturedOption().series[0];
+        expect(series.markLine).toBeUndefined();
     });
 });

--- a/src/components/charts/TimeseriesChart.test.tsx
+++ b/src/components/charts/TimeseriesChart.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { orderTimeseriesPoints } from "./timeseriesData";
+import { buildBaselineMarkLine } from "./TimeseriesChart";
 
 describe("orderTimeseriesPoints", () => {
     it("orders by the full ISO day, not the display label, across a year boundary", () => {
@@ -24,5 +25,33 @@ describe("orderTimeseriesPoints", () => {
             { day: "2026-06-01", value: 2 },
         ]);
         expect(categories).toEqual(["2026-06-01", "2026-06-02"]);
+    });
+});
+
+describe("buildBaselineMarkLine", () => {
+    const color = "#49454f";
+
+    it("returns undefined when no baseline is provided", () => {
+        expect(buildBaselineMarkLine(undefined, color)).toBeUndefined();
+    });
+
+    it("returns undefined for a non-finite baseline value", () => {
+        expect(buildBaselineMarkLine({ value: Number.NaN }, color)).toBeUndefined();
+    });
+
+    it("builds a silent dashed markLine pinned to the baseline value", () => {
+        const markLine = buildBaselineMarkLine({ value: 80, label: "Target baseline" }, color);
+        expect(markLine).toMatchObject({
+            silent: true,
+            symbol: "none",
+            lineStyle: { type: "dashed", color },
+            data: [{ yAxis: 80 }],
+        });
+        expect(markLine?.label).toMatchObject({ show: true, formatter: "Target baseline" });
+    });
+
+    it("hides the label when none is given", () => {
+        const markLine = buildBaselineMarkLine({ value: 80 }, color);
+        expect(markLine?.label).toMatchObject({ show: false });
     });
 });

--- a/src/components/charts/TimeseriesChart.tsx
+++ b/src/components/charts/TimeseriesChart.tsx
@@ -12,6 +12,11 @@ import { echarts } from "@/lib/echartsInit";
 
 echarts.use([LineChart]);
 
+export type TimeseriesBaseline = {
+    value: number;
+    label?: string;
+};
+
 type TimeseriesChartProps = {
     data: TimeseriesPoint[];
     height?: number | string;
@@ -19,7 +24,26 @@ type TimeseriesChartProps = {
     className?: string;
     style?: CSSProperties;
     valueFormat?: ChartValueFormat;
+    baseline?: TimeseriesBaseline;
 };
+
+export function buildBaselineMarkLine(baseline: TimeseriesBaseline | undefined, color: string) {
+    if (!baseline || !Number.isFinite(baseline.value)) {
+        return undefined;
+    }
+    return {
+        silent: true,
+        symbol: "none",
+        lineStyle: { type: "dashed" as const, color, width: 1 },
+        label: {
+            show: Boolean(baseline.label),
+            formatter: baseline.label ?? "",
+            position: "insideEndTop" as const,
+            color,
+        },
+        data: [{ yAxis: baseline.value }],
+    };
+}
 
 type NumericChartParam = {
     name?: string;
@@ -34,9 +58,11 @@ export function TimeseriesChart({
     className,
     style,
     valueFormat = "number",
+    baseline,
 }: TimeseriesChartProps) {
     const chartTheme = useChartTheme();
     const { categories, values } = orderTimeseriesPoints(data);
+    const baselineMarkLine = buildBaselineMarkLine(baseline, chartTheme.muted);
 
     const mergedStyle: CSSProperties = {
         height,
@@ -93,6 +119,7 @@ export function TimeseriesChart({
                         symbolSize: 6,
                         lineStyle: { width: 2 },
                         areaStyle: { opacity: 0.12 },
+                        ...(baselineMarkLine ? { markLine: baselineMarkLine } : {}),
                     },
                 ],
             }}

--- a/src/lib/testops/constants.ts
+++ b/src/lib/testops/constants.ts
@@ -96,3 +96,9 @@ export const TESTOPS_MEASURES: Record<string, TestOpsMeasureDef> = {
         goodDirection: "up",
     },
 };
+
+// Product-level target already shipped as the "Target baseline" annotation on
+// the Coverage page; centralized so the pill and the on-chart baseline can't
+// drift apart. No equivalent documented target exists for pipeline measures —
+// do not invent one (CHAOS-2038).
+export const COVERAGE_LINE_TARGET_PCT = 80;

--- a/src/lib/testops/fetchers.ts
+++ b/src/lib/testops/fetchers.ts
@@ -101,6 +101,7 @@ export async function fetchTestOpsData(
             pipelines: EMPTY_ANALYTICS,
             tests: EMPTY_ANALYTICS,
             coverage: EMPTY_ANALYTICS,
+            fetchFailed: true,
         };
     }
 }

--- a/src/lib/testops/types.ts
+++ b/src/lib/testops/types.ts
@@ -4,4 +4,10 @@ export type TestOpsData = {
     pipelines: AnalyticsResult;
     tests: AnalyticsResult;
     coverage: AnalyticsResult;
+    /**
+     * True when the GraphQL fetch threw and the empty results above are a
+     * degraded fallback, not a genuine absence of data. Lets pages render an
+     * error state instead of a misleading "not yet ingested" empty state.
+     */
+    fetchFailed?: boolean;
 };


### PR DESCRIPTION
## Summary
Standardizes interpretation on bare trend charts per CHAOS-2038, reusing the existing `ChartFrame` convention (already adopted by Cognitive Load and Coverage) instead of inventing a new overlay framework.

- **ChartFrame**: new `direction?: "up" | "down"` prop renders a **Higher/Lower is better** pill, sourced from the existing `goodDirection` measure definitions in `TESTOPS_MEASURES` — no new judgment data.
- **TimeseriesChart**: optional `baseline` prop draws a silent dashed ECharts markLine, so a documented target appears on the chart itself, not only as a header pill. Exported pure helper `buildBaselineMarkLine` is unit-tested.
- **Pipelines → Success Rate Trend** (named in the issue): was a bare `div + h2 + chart`; now wrapped in `ChartFrame` with an interpretation line, directionality pill, percent axis formatting, and an empty `DataState` (previously rendered blank axes with no data).
- **Coverage → Line Coverage Trend**: the already-shipped 80% "Target baseline" is centralized as `COVERAGE_LINE_TARGET_PCT` and now drawn on the chart as a baseline; directionality pill added.

## Deliberate non-changes
- **No threshold invented for pipeline measures** — no documented target exists anywhere in repo or backend for pipeline success rate; per the no-fabrication rule the chart shows directionality + interpretation only. Filing a product decision for a real SLO target is follow-up.
- Other `TimeseriesChart` consumers (ProductTelemetry, AIImpact, people metric drill-down, incident correlation) already carry surrounding interpretation or are themselves drill-down/evidence surfaces; left for a follow-up sweep if desired.

## Testing
- `ci/run_tests.sh format` ✓, `quality` ✓ (0 errors), `unit` ✓ (1998/1998)
- New tests: ChartFrame direction pill (3), buildBaselineMarkLine (4)
- Playwright `tests/nav-reachability.spec.ts` (visits /testops/pipelines and /testops/coverage) ✓ 7/7

Closes CHAOS-2038