### PR TITLE
fix(admin): match entitlement feature keys to backend registry (CHAOS-2244)

### DIFF
--- a/src/app/(app)/admin/retention/page.tsx
+++ b/src/app/(app)/admin/retention/page.tsx
@@ -138,7 +138,7 @@ export default function RetentionPolicyPage() {
     };
 
     return (
-        <UpgradeGate feature="retention_policies" requiredTier="enterprise">
+        <UpgradeGate feature="custom_retention" requiredTier="enterprise">
             <div>
                 <AdminHeader
                     title="Data Retention"

--- a/src/components/admin/AdminSidebar.test.tsx
+++ b/src/components/admin/AdminSidebar.test.tsx
@@ -65,7 +65,7 @@ describe("AdminSidebar", () => {
                 features={{
                     audit_log: true,
                     ip_allowlist: false,
-                    retention_policies: true,
+                    custom_retention: true,
                 }}
             />,
         );

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -44,7 +44,7 @@ const navItems: NavItem[] = [
         label: "Retention",
         href: "/admin/retention",
         description: "Compliance",
-        featureKey: "retention_policies",
+        featureKey: "custom_retention",
     },
 ];
 

--- a/src/components/admin/sync/SyncConfigForm.test.tsx
+++ b/src/components/admin/sync/SyncConfigForm.test.tsx
@@ -368,7 +368,7 @@ describe("SyncConfigForm", () => {
             expect(screen.getByRole("button", { name: "Create One Now" })).toBeInTheDocument();
         });
 
-        it("schedule picker hidden behind UpgradeGate for non-enterprise", () => {
+        it("schedule picker hidden behind UpgradeGate below team tier", () => {
             mockUseAdminTier.mockReturnValue({
                 tier: "community",
                 features: {},
@@ -377,16 +377,16 @@ describe("SyncConfigForm", () => {
             });
             render(<SyncConfigForm credentials={mockCredentials} />);
 
-            expect(screen.getByText("Enterprise Plan Feature")).toBeInTheDocument();
+            expect(screen.getByText("Team Plan Feature")).toBeInTheDocument();
             expect(
                 screen.queryByRole("radio", { name: "Manual only (no schedule)" }),
             ).not.toBeInTheDocument();
         });
 
-        it("shows schedule picker for enterprise tier", () => {
+        it("shows schedule picker for team tier", () => {
             mockUseAdminTier.mockReturnValue({
-                tier: "enterprise",
-                features: { custom_scheduling: true },
+                tier: "team",
+                features: { scheduled_jobs: true },
                 limits: {},
                 minSyncIntervalHours: 0.25,
             });

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -478,7 +478,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                     </label>
                 </div>
 
-                <UpgradeGate feature="custom_scheduling" requiredTier="enterprise">
+                <UpgradeGate feature="scheduled_jobs" requiredTier="team">
                     <SchedulePicker
                         value={formData.schedule_cron}
                         timezone={formData.timezone}

--- a/src/lib/__tests__/access-matrix.test.ts
+++ b/src/lib/__tests__/access-matrix.test.ts
@@ -393,7 +393,7 @@ describe("tier feature gating — sidebar and UpgradeGate logic", () => {
             label: "Retention",
             href: "/admin/retention",
             description: "Compliance",
-            featureKey: "retention_policies",
+            featureKey: "custom_retention",
         },
     ];
 
@@ -413,14 +413,14 @@ describe("tier feature gating — sidebar and UpgradeGate logic", () => {
         return features[feature] === true;
     }
 
-    const ENTERPRISE_FEATURE_KEYS = ["audit_log", "ip_allowlist", "retention_policies"];
+    const ENTERPRISE_FEATURE_KEYS = ["audit_log", "ip_allowlist", "custom_retention"];
 
     describe("community tier (no enterprise features)", () => {
         const communityFeatures: Record<string, boolean> = {
             basic_analytics: true,
             audit_log: false,
             ip_allowlist: false,
-            retention_policies: false,
+            custom_retention: false,
         };
 
         it("hides all enterprise nav items from sidebar", () => {
@@ -453,7 +453,7 @@ describe("tier feature gating — sidebar and UpgradeGate logic", () => {
             team_dashboard: true,
             audit_log: true,
             ip_allowlist: false,
-            retention_policies: false,
+            custom_retention: false,
         };
 
         it("shows audit_log in sidebar but hides ip_allowlist and retention", () => {
@@ -476,7 +476,7 @@ describe("tier feature gating — sidebar and UpgradeGate logic", () => {
             team_dashboard: true,
             audit_log: true,
             ip_allowlist: true,
-            retention_policies: true,
+            custom_retention: true,
         };
 
         it("shows all enterprise nav items in sidebar", () => {
@@ -512,7 +512,7 @@ describe("tier feature gating — sidebar and UpgradeGate logic", () => {
         const enterpriseFeatures: Record<string, boolean> = {
             audit_log: true,
             ip_allowlist: true,
-            retention_policies: true,
+            custom_retention: true,
         };
 
         it("hides Organization item for superuser", () => {
@@ -539,7 +539,7 @@ describe("tier feature gating — sidebar and UpgradeGate logic", () => {
             const visible = filterSidebarItems(true, {
                 audit_log: false,
                 ip_allowlist: false,
-                retention_policies: false,
+                custom_retention: false,
             });
             const visibleIds = visible.map((i) => i.id);
             expect(visibleIds).not.toContain("audit");
@@ -598,11 +598,11 @@ describe("impersonation — RBAC and tier gating under impersonated sessions", (
             const communityFeatures = {
                 audit_log: false,
                 ip_allowlist: false,
-                retention_policies: false,
+                custom_retention: false,
             };
             expect(communityFeatures.audit_log).toBe(false);
             expect(communityFeatures.ip_allowlist).toBe(false);
-            expect(communityFeatures.retention_policies).toBe(false);
+            expect(communityFeatures.custom_retention).toBe(false);
         });
     });
 
@@ -630,7 +630,7 @@ describe("impersonation — RBAC and tier gating under impersonated sessions", (
             const enterpriseFeatures = {
                 audit_log: true,
                 ip_allowlist: true,
-                retention_policies: true,
+                custom_retention: true,
             };
             expect(enterpriseFeatures.audit_log).toBe(true);
             expect(enterpriseFeatures.ip_allowlist).toBe(true);


### PR DESCRIPTION
## Summary

Frontend entitlement gates referenced feature keys that **do not exist** in the backend registry (`ops/src/dev_health_ops/licensing/registry.py`), so `UpgradeGate` never matched `features[feature] === true` and entitled orgs still saw the upsell instead of the real UI.

Backend registry defines `scheduled_jobs` (Team+) and `custom_retention` (Enterprise) — **not** `custom_scheduling` or `retention_policies`.

## Changes (frontend-only)

- **`SyncConfigForm.tsx`**: scheduling gate `feature="custom_scheduling" requiredTier="enterprise"` → `feature="scheduled_jobs" requiredTier="team"` (scheduled_jobs is Team+ in the registry).
- **`AdminSidebar.tsx`**: retention nav `featureKey: "retention_policies"` → `"custom_retention"`.
- **`retention/page.tsx`**: gate `feature="retention_policies"` → `"custom_retention"` (tier stays `enterprise`, matching the registry).
- **Tests updated** to the real keys + resulting gate label: `SyncConfigForm.test.tsx` (incl. "Team Plan Feature" gate text), `AdminSidebar.test.tsx`, `access-matrix.test.ts`.

`UpgradeGate.tsx` logic (`if (features[feature] === true) return children;`) is correct and unchanged.

A repo-wide grep confirms **zero** remaining usages of `custom_scheduling` / `retention_policies` under `src/`.

## Verification

- `vitest` (touched files): **91 passed** (SyncConfigForm 19, AdminSidebar 3, access-matrix 69)
- `tsc --noEmit`: clean
- `eslint`: clean
- `prettier --check`: clean

## Visual evidence

Captured against the local stack with the canonical enterprise-tier account (`admin@devhealth.example`), which is entitled to both `scheduled_jobs` and `custom_retention`. Both gated surfaces now render the **real UI** (no upsell):

**Sync config — scheduling section (`/admin/sync/new`)**

![chaos-2244-sync-scheduling-after.png](https://github.com/user-attachments/assets/38fcfa0d-d411-4804-b4b4-33156b00ff79)

**Data Retention page (`/admin/retention`)**

![chaos-2244-retention-after.png](https://github.com/user-attachments/assets/0564591f-9425-4c80-853e-23aebcc1461e)

Closes CHAOS-2244
