### PR TITLE
style(primitives): restyle shared Part E primitives to V1 tokens (CHAOS-2108)

### DIFF
--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -3,6 +3,7 @@ import { LineagePopover } from "@/app/(app)/data-health/_components/LineagePopov
 
 import { SparklineChart } from "@/components/charts/SparklineChart";
 import { MetricDelta } from "@/components/shared/MetricDelta";
+import { CARD_SURFACE } from "@/lib/design/card";
 import { formatMetricValue } from "@/lib/formatters";
 import type { SparkPoint } from "@/lib/types";
 
@@ -44,8 +45,8 @@ export function MetricCard({
     const sparkLabels = spark?.map((point) => point.ts) ?? [];
     // Only a real destination earns the clickable affordance + "Open evidence" cue.
     const captionText = caption ?? (href ? "Open evidence" : null);
-    const cardClassName = `group rounded-3xl border border-(--card-stroke) bg-card p-4 ${
-        href ? "transition hover:-translate-y-1 hover:shadow-lg" : ""
+    const cardClassName = `group ${CARD_SURFACE} p-4 ${
+        href ? "transition hover:-translate-y-1 hover:border-(--card-stroke-active)" : ""
     } ${className ?? ""}`;
 
     const body = (
@@ -78,7 +79,7 @@ export function MetricCard({
                     ) : (
                         <div
                             title="Not enough data points to plot a trend yet"
-                            className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-2 text-center text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)"
+                            className="flex h-full items-center justify-center rounded-(--radius-md) border border-dashed border-(--border) bg-(--card-70) px-2 text-center text-label-caps uppercase text-(--text-muted)"
                         >
                             No trend yet
                         </div>

--- a/src/components/shared/BackLink.test.tsx
+++ b/src/components/shared/BackLink.test.tsx
@@ -41,7 +41,7 @@ describe("BackLink", () => {
     it("is not styled as a filter pill (quiet inline link, no pill background)", () => {
         render(<BackLink href="/" />);
         const link = screen.getByRole("link", { name: /back to cockpit/i });
-        expect(link.className).not.toContain("rounded-full");
-        expect(link.className).toContain("text-(--ink-muted)");
+        expect(link.className).not.toContain("rounded-(--radius-pill)");
+        expect(link.className).toContain("text-(--text-muted)");
     });
 });

--- a/src/components/shared/BackLink.tsx
+++ b/src/components/shared/BackLink.tsx
@@ -37,7 +37,7 @@ export function BackLink({ href, label, area, className }: BackLinkProps) {
     return (
         <Link
             href={href}
-            className={`group inline-flex items-center gap-1.5 text-xs uppercase tracking-[0.2em] text-(--ink-muted) transition-colors hover:text-foreground ${className ?? ""}`.trim()}
+            className={`group inline-flex items-center gap-1.5 text-label-caps uppercase text-(--text-muted) transition-colors hover:text-(--text-primary) ${className ?? ""}`.trim()}
         >
             <span aria-hidden="true" className="transition-transform group-hover:-translate-x-0.5">
                 &larr;

--- a/src/components/shared/Button.test.tsx
+++ b/src/components/shared/Button.test.tsx
@@ -20,9 +20,11 @@ describe("Button", () => {
     it("applies variant + size classes through buttonClassName", () => {
         const primary = buttonClassName("primary", "md");
         expect(primary).toContain("bg-(--accent-2)");
-        expect(primary).toContain("rounded-full");
+        expect(primary).toContain("rounded-(--radius-pill)");
+        expect(primary).toContain("text-label-caps");
         const ghostSm = buttonClassName("ghost", "sm");
         expect(ghostSm).toContain("border-transparent");
-        expect(ghostSm).toContain("text-[10px]");
+        expect(ghostSm).toContain("px-3");
+        expect(ghostSm).toContain("text-(--text-muted)");
     });
 });

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -4,18 +4,19 @@ export type ButtonVariant = "primary" | "secondary" | "ghost";
 export type ButtonSize = "sm" | "md";
 
 const BASE =
-    "inline-flex items-center justify-center gap-1.5 rounded-full font-medium uppercase tracking-[0.2em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-not-allowed disabled:opacity-50";
+    "inline-flex items-center justify-center gap-1.5 rounded-(--radius-pill) text-label-caps font-medium uppercase transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-not-allowed disabled:opacity-50";
 
 const SIZES: Record<ButtonSize, string> = {
-    sm: "px-3 py-1.5 text-[10px]",
-    md: "px-4 py-2 text-xs",
+    sm: "px-3 py-1.5",
+    md: "px-4 py-2",
 };
 
 const VARIANTS: Record<ButtonVariant, string> = {
+    /* No on-accent role token exists yet; text-white is the interim contrast color. */
     primary: "border border-(--accent-2) bg-(--accent-2) text-white hover:bg-(--accent-2)/90",
     secondary:
-        "border border-(--card-stroke) bg-(--card-70) text-foreground hover:border-(--ink-muted)",
-    ghost: "border border-transparent text-(--ink-muted) hover:text-foreground hover:bg-(--card-80)",
+        "border border-(--border) bg-(--card-70) text-(--text-primary) hover:border-(--card-stroke-active)",
+    ghost: "border border-transparent text-(--text-muted) hover:text-(--text-primary) hover:bg-(--card-80)",
 };
 
 /**

--- a/src/components/shared/FilterPills.tsx
+++ b/src/components/shared/FilterPills.tsx
@@ -23,10 +23,10 @@ type FilterPillsProps<TId extends string = string> = {
 
 const ACTIVE = "border-(--accent) bg-(--accent)/15 text-(--accent)";
 const INACTIVE =
-    "border-(--card-stroke) bg-(--card-80) text-(--ink-muted) hover:border-(--accent)/40 hover:text-foreground";
+    "border-(--border) bg-(--card-80) text-(--text-muted) hover:border-(--accent)/40 hover:text-(--text-primary)";
 
 const PILL =
-    "inline-flex items-center gap-1.5 rounded-(--radius-pill) border px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.15em] transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--accent)";
+    "inline-flex items-center gap-1.5 rounded-(--radius-pill) border px-3 py-1.5 text-label-caps font-medium uppercase transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--accent)";
 
 /**
  * Segmented selection primitive (framework A3).
@@ -55,7 +55,7 @@ export function FilterPills<TId extends string = string>({
             data-testid={testId}
         >
             {leadingLabel ? (
-                <span className="text-xs uppercase tracking-[0.25em] text-(--ink-muted)">
+                <span className="text-label-caps uppercase text-(--text-muted)">
                     {leadingLabel}
                 </span>
             ) : null}

--- a/src/components/shared/ModeTabs.tsx
+++ b/src/components/shared/ModeTabs.tsx
@@ -18,14 +18,14 @@ type ModeTabsProps<TId extends string = string> = {
 };
 
 const CONTAINER =
-    "flex items-center gap-1 overflow-x-auto whitespace-nowrap border-b border-(--card-stroke) px-1 scrollbar-hide";
+    "flex items-center gap-1 overflow-x-auto whitespace-nowrap border-b border-(--border) px-1 scrollbar-hide";
 
 const TAB_BASE =
-    "-mb-px flex items-center gap-1.5 border-b-2 px-3.5 py-3 text-[10px] uppercase tracking-[0.18em] transition-all";
+    "-mb-px flex items-center gap-1.5 border-b-2 px-3.5 py-3 text-label-caps uppercase transition-all";
 
-const TAB_ACTIVE = "border-(--accent) text-foreground font-semibold";
+const TAB_ACTIVE = "border-(--accent) text-(--text-primary) font-semibold";
 const TAB_INACTIVE =
-    "border-transparent text-(--ink-muted) hover:border-(--card-stroke) hover:text-foreground";
+    "border-transparent text-(--text-muted) hover:border-(--border) hover:text-(--text-primary)";
 
 /**
  * Shared route-tab strip primitive (framework A2).

--- a/src/lib/design/__tests__/card.test.ts
+++ b/src/lib/design/__tests__/card.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+
+import { CARD_SURFACE, cardClassName } from "../card";
+
+describe("card primitive (framework C4)", () => {
+    it("uses only V1 tokens for the card shell", () => {
+        expect(CARD_SURFACE).toContain("rounded-(--radius-lg)");
+        expect(CARD_SURFACE).toContain("border-(--border)");
+        expect(CARD_SURFACE).toContain("bg-(--surface)");
+        expect(CARD_SURFACE).toContain("shadow-(--elevation-card)");
+        // Legacy bright stroke must not creep back in (CHAOS-2067).
+        expect(CARD_SURFACE).not.toContain("card-stroke)");
+    });
+
+    it("composes call-site classes after the shell", () => {
+        expect(cardClassName("p-4")).toBe(`${CARD_SURFACE} p-4`);
+        expect(cardClassName()).toBe(CARD_SURFACE);
+    });
+});

--- a/src/lib/design/card.ts
+++ b/src/lib/design/card.ts
@@ -1,0 +1,15 @@
+/**
+ * Canonical card surface (framework C4) — the one sanctioned card treatment:
+ * surface fill, hairline `--border` stroke, `--radius-lg`, `--elevation-card`.
+ *
+ * Compose with layout/padding utilities at the call site (`p-4`,
+ * `p-(--space-card)`, …). Interactive emphasis (hover/active) should move the
+ * stroke to `--card-stroke-active`, never to a brighter static border
+ * (CHAOS-2067).
+ */
+export const CARD_SURFACE =
+    "rounded-(--radius-lg) border border-(--border) bg-(--surface) shadow-(--elevation-card)";
+
+export function cardClassName(className = ""): string {
+    return `${CARD_SURFACE} ${className}`.trim();
+}


### PR DESCRIPTION
Implements [CHAOS-2108](https://linear.app/fullchaos/issue/CHAOS-2108) — V2 of the restyle chain (follows #661 V1 tokens).

## What
- **ModeTabs**: container/inactive borders → `--border`; tab labels → `text-label-caps` (was 10px/0.18em); text roles → `--text-primary`/`--text-muted`. Active stays accent underline.
- **FilterPills**: pill labels + leading label → `text-label-caps`; inactive border → `--border`, text → `--text-muted`. Active accent treatment unchanged; radius was already `--radius-pill`.
- **Button**: `rounded-full` → `rounded-(--radius-pill)`; label type unified on `text-label-caps` (sizes now differ by padding only); secondary border → `--border` with `--card-stroke-active` hover; ghost text roles → tokens. **No on-accent token exists** — primary keeps `text-white` (flagged for the token backlog).
- **Card**: new canonical C4 shell `CARD_SURFACE` / `cardClassName()` in `src/lib/design/card.ts` (surface / `--border` / `--radius-lg` / `--elevation-card`); adopted in MetricCard (radius 24→16 per D2, link-hover now `--card-stroke-active` instead of `shadow-lg`, dashed sparkline placeholder de-hardcoded).
- **BackLink**: quiet-link type → `text-label-caps` + text role tokens.

## Deliberate visual deltas (C1/C4 snaps — reviewers please eyeball)
- Caps labels converge on 11px / 0.08em tracking (tabs were 10px/0.18em, BackLink 12px/0.2em, Button md 12px) — denser tracking, slightly different sizes.
- Dark mode: restyled container/inactive borders run dimmer (`--border` = 65% mix per CHAOS-2067); bright strokes now only on interactive emphasis.
- MetricCard: corner radius 24→16, gains `--elevation-card` shadow, hover emphasis moved from shadow-lift to accent stroke.

## Lint/gates
- design-lint `no-hardcoded-style` on touched files: ModeTabs/FilterPills/Button/BackLink 0→0 (already clean; legacy-var migration is the substance), MetricCard 1→0.
- format ✓ · quality (tsc+eslint) ✓ · unit 2009/2009 ✓ · Playwright `nav-reachability` 7/7 ✓
- Component tests updated to assert the new token classes (+2 tests for the card shell).

Per-primitive Penpot screenshot comparison deferred to the V7 visual-baseline pass (CHAOS-2113), same as V1.