### PR TITLE
style(borders): resting card borders → --border token; bright strokes only for interactive states (CHAOS-2067)

### DIFF
--- a/src/app/(app)/admin/audit-logs/page.tsx
+++ b/src/app/(app)/admin/audit-logs/page.tsx
@@ -79,7 +79,7 @@ export default function OrgAuditLogPage() {
                                 type="button"
                                 onClick={handlePrevPage}
                                 disabled={offset === 0}
-                                className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
+                                className="rounded-lg border border-(--border) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
                                 Previous
                             </button>
@@ -90,7 +90,7 @@ export default function OrgAuditLogPage() {
                                 type="button"
                                 onClick={handleNextPage}
                                 disabled={logs.length < limit}
-                                className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
+                                className="rounded-lg border border-(--border) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
                                 Next
                             </button>

--- a/src/app/(app)/admin/identities/page.tsx
+++ b/src/app/(app)/admin/identities/page.tsx
@@ -30,7 +30,7 @@ export default async function IdentitiesPage() {
                 <input
                     type="text"
                     placeholder="Search identities..."
-                    className="w-full max-w-sm rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                    className="w-full max-w-sm rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                 />
             </div>
 

--- a/src/app/(app)/admin/ip-allowlist/page.tsx
+++ b/src/app/(app)/admin/ip-allowlist/page.tsx
@@ -108,7 +108,7 @@ export default function IPAllowlistPage() {
 
                 <div className="mb-6">
                     {showAddForm ? (
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-5">
+                        <div className="rounded-2xl border border-(--border) bg-(--card-80) p-5">
                             <div className="grid gap-4 sm:grid-cols-3">
                                 <div>
                                     <label className="mb-1 block text-xs font-medium text-(--ink-muted)">
@@ -121,7 +121,7 @@ export default function IPAllowlistPage() {
                                         onChange={(e) =>
                                             setFormData({ ...formData, ip_range: e.target.value })
                                         }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                                     />
                                 </div>
                                 <div>
@@ -138,7 +138,7 @@ export default function IPAllowlistPage() {
                                                 description: e.target.value || null,
                                             })
                                         }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                                     />
                                 </div>
                                 <div>
@@ -156,7 +156,7 @@ export default function IPAllowlistPage() {
                                                     : null,
                                             })
                                         }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                                     />
                                 </div>
                             </div>
@@ -175,7 +175,7 @@ export default function IPAllowlistPage() {
                                         setShowAddForm(false);
                                         setFormData({ ip_range: "" });
                                     }}
-                                    className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium"
+                                    className="rounded-lg border border-(--border) bg-(--card-70) px-4 py-2 text-sm font-medium"
                                 >
                                     Cancel
                                 </button>
@@ -198,10 +198,10 @@ export default function IPAllowlistPage() {
                     </div>
                 ) : (
                     <>
-                        <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+                        <div className="overflow-x-auto rounded-2xl border border-(--border) bg-(--card-80)">
                             <table className="w-full text-sm">
                                 <thead>
-                                    <tr className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+                                    <tr className="border-b border-(--border) bg-(--card-70) text-(--ink-muted)">
                                         <th className="px-4 py-3 text-left font-medium">
                                             IP Range
                                         </th>
@@ -230,7 +230,7 @@ export default function IPAllowlistPage() {
                                         entries.map((entry) => (
                                             <tr
                                                 key={entry.id}
-                                                className="border-b border-(--card-stroke) last:border-0"
+                                                className="border-b border-(--border) last:border-0"
                                             >
                                                 <td className="px-4 py-3 font-mono text-xs">
                                                     {entry.ip_range}
@@ -261,7 +261,7 @@ export default function IPAllowlistPage() {
                                                             type="button"
                                                             onClick={() => handleToggle(entry)}
                                                             disabled={togglingId === entry.id}
-                                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
+                                                            className="rounded-lg border border-(--border) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
                                                         >
                                                             {entry.is_active ? "Disable" : "Enable"}
                                                         </button>
@@ -288,7 +288,7 @@ export default function IPAllowlistPage() {
                                 type="button"
                                 onClick={() => setOffset((prev) => Math.max(0, prev - limit))}
                                 disabled={offset === 0}
-                                className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
+                                className="rounded-lg border border-(--border) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
                                 Previous
                             </button>
@@ -299,7 +299,7 @@ export default function IPAllowlistPage() {
                                 type="button"
                                 onClick={() => setOffset((prev) => prev + limit)}
                                 disabled={entries.length < limit}
-                                className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
+                                className="rounded-lg border border-(--border) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
                                 Next
                             </button>

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -15,7 +15,7 @@ export default async function AdminDashboardPage() {
             />
 
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <h3 className="font-medium text-foreground">User Management</h3>
                     <p className="mt-2 text-sm text-(--ink-muted)">
                         Manage users, roles, and permissions across the organization.
@@ -30,7 +30,7 @@ export default async function AdminDashboardPage() {
                     </div>
                 </div>
 
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <h3 className="font-medium text-foreground">Integrations</h3>
                     <p className="mt-2 text-sm text-(--ink-muted)">
                         Configure connections to GitHub, GitLab, Jira, and other tools.
@@ -45,7 +45,7 @@ export default async function AdminDashboardPage() {
                     </div>
                 </div>
 
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <h3 className="font-medium text-foreground">Sync Status</h3>
                     <p className="mt-2 text-sm text-(--ink-muted)">
                         Monitor data synchronization jobs and troubleshoot issues.

--- a/src/app/(app)/admin/retention/page.tsx
+++ b/src/app/(app)/admin/retention/page.tsx
@@ -153,7 +153,7 @@ export default function RetentionPolicyPage() {
 
                 <div className="mb-6">
                     {showAddForm ? (
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-5">
+                        <div className="rounded-2xl border border-(--border) bg-(--card-80) p-5">
                             <div className="grid gap-4 sm:grid-cols-3">
                                 <div>
                                     <label className="mb-1 block text-xs font-medium text-(--ink-muted)">
@@ -167,7 +167,7 @@ export default function RetentionPolicyPage() {
                                                 resource_type: e.target.value,
                                             })
                                         }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                                     >
                                         <option value="">Select...</option>
                                         {resourceTypes.map((rt) => (
@@ -191,7 +191,7 @@ export default function RetentionPolicyPage() {
                                                 retention_days: parseInt(e.target.value) || 90,
                                             })
                                         }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                                     />
                                 </div>
                                 <div>
@@ -208,7 +208,7 @@ export default function RetentionPolicyPage() {
                                                 description: e.target.value || null,
                                             })
                                         }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                                     />
                                 </div>
                             </div>
@@ -227,7 +227,7 @@ export default function RetentionPolicyPage() {
                                         setShowAddForm(false);
                                         setFormData({ resource_type: "", retention_days: 90 });
                                     }}
-                                    className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium"
+                                    className="rounded-lg border border-(--border) bg-(--card-70) px-4 py-2 text-sm font-medium"
                                 >
                                     Cancel
                                 </button>
@@ -250,10 +250,10 @@ export default function RetentionPolicyPage() {
                     </div>
                 ) : (
                     <>
-                        <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+                        <div className="overflow-x-auto rounded-2xl border border-(--border) bg-(--card-80)">
                             <table className="w-full text-sm">
                                 <thead>
-                                    <tr className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+                                    <tr className="border-b border-(--border) bg-(--card-70) text-(--ink-muted)">
                                         <th className="px-4 py-3 text-left font-medium">
                                             Resource Type
                                         </th>
@@ -287,7 +287,7 @@ export default function RetentionPolicyPage() {
                                         policies.map((policy) => (
                                             <tr
                                                 key={policy.id}
-                                                className="border-b border-(--card-stroke) last:border-0"
+                                                className="border-b border-(--border) last:border-0"
                                             >
                                                 <td className="px-4 py-3 font-mono text-xs">
                                                     {policy.resource_type}
@@ -323,7 +323,7 @@ export default function RetentionPolicyPage() {
                                                             type="button"
                                                             onClick={() => handleToggle(policy)}
                                                             disabled={togglingId === policy.id}
-                                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
+                                                            className="rounded-lg border border-(--border) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
                                                         >
                                                             {policy.is_active
                                                                 ? "Disable"
@@ -333,7 +333,7 @@ export default function RetentionPolicyPage() {
                                                             type="button"
                                                             onClick={() => handleDryRun(policy.id)}
                                                             disabled={executingId === policy.id}
-                                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
+                                                            className="rounded-lg border border-(--border) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
                                                         >
                                                             Dry Run
                                                         </button>
@@ -373,7 +373,7 @@ export default function RetentionPolicyPage() {
                                 type="button"
                                 onClick={() => setOffset((prev) => Math.max(0, prev - limit))}
                                 disabled={offset === 0}
-                                className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
+                                className="rounded-lg border border-(--border) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
                                 Previous
                             </button>
@@ -384,7 +384,7 @@ export default function RetentionPolicyPage() {
                                 type="button"
                                 onClick={() => setOffset((prev) => prev + limit)}
                                 disabled={policies.length < limit}
-                                className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
+                                className="rounded-lg border border-(--border) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
                                 Next
                             </button>

--- a/src/app/(app)/admin/sync/[configId]/page.tsx
+++ b/src/app/(app)/admin/sync/[configId]/page.tsx
@@ -45,7 +45,7 @@ export default async function SyncConfigDetailPage({ params }: PageProps) {
                         />
                         <Link
                             href={`/admin/sync/${config.id}/edit`}
-                            className="rounded-md border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground hover:border-(--accent) hover:text-(--accent)"
+                            className="rounded-md border border-(--border) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground hover:border-(--accent) hover:text-(--accent)"
                         >
                             Edit Config
                         </Link>
@@ -57,7 +57,7 @@ export default async function SyncConfigDetailPage({ params }: PageProps) {
             <SyncProgressBar configId={config.id} provider={config.provider} orgId={orgId} />
 
             <div className="grid gap-6 md:grid-cols-3">
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
                         Current Status
                     </h3>
@@ -66,7 +66,7 @@ export default async function SyncConfigDetailPage({ params }: PageProps) {
                     </div>
                 </div>
 
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
                         Last Sync
                     </h3>
@@ -75,7 +75,7 @@ export default async function SyncConfigDetailPage({ params }: PageProps) {
                     </p>
                 </div>
 
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
                         Active
                     </h3>

--- a/src/app/(app)/admin/sync/page.tsx
+++ b/src/app/(app)/admin/sync/page.tsx
@@ -52,7 +52,7 @@ export default async function SyncStatusPage() {
             )}
 
             {configs.length === 0 && !result.error && (
-                <div className="rounded-lg border border-(--card-stroke) bg-(--card-80) p-8 text-center text-(--ink-muted)">
+                <div className="rounded-lg border border-(--border) bg-(--card-80) p-8 text-center text-(--ink-muted)">
                     No sync configurations found. Create a new configuration to get started.
                 </div>
             )}

--- a/src/app/(app)/admin/teams/page.tsx
+++ b/src/app/(app)/admin/teams/page.tsx
@@ -43,7 +43,7 @@ export default async function TeamsPage() {
                 <input
                     type="text"
                     placeholder="Search teams..."
-                    className="w-full max-w-sm rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                    className="w-full max-w-sm rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                 />
             </div>
 

--- a/src/app/(app)/admin/users/[id]/DeleteUserButton.tsx
+++ b/src/app/(app)/admin/users/[id]/DeleteUserButton.tsx
@@ -47,7 +47,7 @@ export function DeleteUserButton({ userId, userEmail }: DeleteUserButtonProps) {
                         type="button"
                         onClick={() => setIsConfirming(false)}
                         disabled={isDeleting}
-                        className="flex-1 rounded-lg border border-(--card-stroke) px-3 py-2 text-sm font-medium text-(--ink-muted) hover:bg-(--card-70)"
+                        className="flex-1 rounded-lg border border-(--border) px-3 py-2 text-sm font-medium text-(--ink-muted) hover:bg-(--card-70)"
                     >
                         Cancel
                     </button>

--- a/src/app/(app)/admin/users/[id]/page.tsx
+++ b/src/app/(app)/admin/users/[id]/page.tsx
@@ -28,7 +28,7 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
             >
                 <Link
                     href={`/admin/users/${user.id}/edit`}
-                    className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground hover:bg-(--card-stroke)"
+                    className="rounded-lg border border-(--border) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground hover:bg-(--card-stroke)"
                 >
                     Edit User
                 </Link>
@@ -36,7 +36,7 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
 
             <div className="grid gap-6 md:grid-cols-3">
                 <div className="md:col-span-2 space-y-6">
-                    <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <div className="rounded-2xl border border-(--border) bg-(--card-80) p-6">
                         <h3 className="mb-4 text-lg font-medium">Profile Information</h3>
                         <dl className="grid gap-4 sm:grid-cols-2">
                             <div>
@@ -99,12 +99,12 @@ export default async function UserDetailPage({ params }: { params: Promise<{ id:
                 </div>
 
                 <div className="space-y-6">
-                    <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <div className="rounded-2xl border border-(--border) bg-(--card-80) p-6">
                         <h3 className="mb-4 text-lg font-medium">Quick Actions</h3>
                         <div className="space-y-3">
                             <Link
                                 href={`/admin/users/${user.id}/edit`}
-                                className="block w-full rounded-lg border border-(--card-stroke) px-4 py-2 text-sm font-medium text-(--ink-muted) hover:bg-(--card-70) hover:text-foreground text-left"
+                                className="block w-full rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--ink-muted) hover:bg-(--card-70) hover:text-foreground text-left"
                             >
                                 Edit Profile
                             </Link>

--- a/src/app/(app)/admin/users/page.tsx
+++ b/src/app/(app)/admin/users/page.tsx
@@ -35,7 +35,7 @@ export default async function UsersPage() {
                 <input
                     type="text"
                     placeholder="Search users..."
-                    className="w-full max-w-sm rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                    className="w-full max-w-sm rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                 />
             </div>
 

--- a/src/app/(app)/bottleneck/loading.tsx
+++ b/src/app/(app)/bottleneck/loading.tsx
@@ -40,7 +40,7 @@ export default function Loading() {
                         {Array.from({ length: 3 }).map((_, i) => (
                             <div
                                 key={i}
-                                className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 space-y-3"
+                                className="rounded-3xl border border-(--border) bg-(--card) p-5 space-y-3"
                             >
                                 <div className="h-3 bg-(--card-70) rounded w-20" />
                                 <div className="h-8 bg-(--card-70) rounded w-14" />

--- a/src/app/(app)/bottleneck/page.tsx
+++ b/src/app/(app)/bottleneck/page.tsx
@@ -133,7 +133,7 @@ export default async function BottleneckPage({ searchParams }: BottleneckPagePro
                         </div>
                         <Link
                             href={withFilterParam("/", filters, activeRole)}
-                            className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                            className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                         >
                             {CTA_LABELS.backToCockpit}
                         </Link>

--- a/src/app/(app)/capacity/page.tsx
+++ b/src/app/(app)/capacity/page.tsx
@@ -97,7 +97,7 @@ export default async function CapacityPage({ searchParams }: CapacityPageProps) 
 
                         <FilterBar view="capacity-planning" />
 
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-3 text-xs leading-relaxed text-(--ink-muted)">
+                        <div className="rounded-2xl border border-(--border) bg-(--card-80) p-3 text-xs leading-relaxed text-(--ink-muted)">
                             <span className="text-foreground font-semibold uppercase tracking-wider">
                                 Perspective:
                             </span>{" "}

--- a/src/app/(app)/code/page.tsx
+++ b/src/app/(app)/code/page.tsx
@@ -123,7 +123,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                         </div>
                         <Link
                             href={withFilterParam("/", filters, activeRole)}
-                            className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                            className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                         >
                             {CTA_LABELS.backToCockpit}
                         </Link>
@@ -146,7 +146,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                             spark={churnMetric?.spark}
                             caption="Churn over the active window"
                         />
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">
                                     Ownership Patterns
@@ -159,7 +159,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                                 Ownership concentration shows who carries the most-changed code in
                                 this view.
                             </p>
-                            <div className="mt-4 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+                            <div className="mt-4 rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
                                 Connect a Git provider with commit history to surface ownership
                                 concentration here.
                             </div>
@@ -198,7 +198,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                     </section>
 
                     <section className="grid gap-6 lg:grid-cols-2">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">Hotspots</h2>
                                 <Link
@@ -227,7 +227,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                                                     filters,
                                                     role: activeRole,
                                                 })}
-                                                className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+                                                className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-4 py-2"
                                             >
                                                 <span>{item.label}</span>
                                                 <span className="text-xs text-(--ink-muted)">
@@ -249,7 +249,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                             )}
                         </div>
 
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">Bus Factor</h2>
                                 <Link
@@ -269,7 +269,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                             </p>
                             {hasBusFactorEvidence ? (
                                 <div className="mt-4 space-y-4 text-sm">
-                                    <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3">
+                                    <div className="rounded-2xl border border-(--border) bg-(--card-70) px-4 py-3">
                                         <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                             Scope-wide bus factor
                                         </p>
@@ -290,7 +290,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                                             {topMaintainers.map((maintainer) => (
                                                 <div
                                                     key={maintainer.author}
-                                                    className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+                                                    className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-4 py-2"
                                                 >
                                                     <span className="truncate pr-4">
                                                         {maintainer.author}
@@ -312,7 +312,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                                                 {riskyRepos.map((repo) => (
                                                     <div
                                                         key={repo.repoId}
-                                                        className="rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3"
+                                                        className="rounded-2xl border border-(--border) bg-(--card-70) px-4 py-3"
                                                     >
                                                         <div className="flex items-center justify-between gap-3">
                                                             <span className="font-medium">
@@ -329,7 +329,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                                                                     .map((maintainer) => (
                                                                         <span
                                                                             key={`${repo.repoId}-${maintainer.author}`}
-                                                                            className="rounded-full border border-(--card-stroke) px-2 py-1 text-xs text-(--ink-muted)"
+                                                                            className="rounded-full border border-(--border) px-2 py-1 text-xs text-(--ink-muted)"
                                                                         >
                                                                             {maintainer.author} ·{" "}
                                                                             {maintainer.sharePercent.toFixed(
@@ -355,7 +355,7 @@ export default async function CodePage({ searchParams }: CodePageProps) {
                                 </div>
                             ) : (
                                 <div className="mt-4 space-y-2 text-sm">
-                                    <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-(--ink-muted)">
+                                    <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-4 py-3 text-(--ink-muted)">
                                         Connect a Git provider with commit history to surface
                                         bus-factor risk for this view.
                                     </div>

--- a/src/app/(app)/cognitive-load/page.tsx
+++ b/src/app/(app)/cognitive-load/page.tsx
@@ -291,7 +291,7 @@ export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadP
                     className="flex min-w-0 flex-1 flex-col gap-6"
                     data-testid="cognitive-load-dashboard"
                 >
-                    <section className="overflow-hidden rounded-[2rem] border border-(--card-stroke) bg-(--card-80) shadow-sm">
+                    <section className="overflow-hidden rounded-[2rem] border border-(--border) bg-(--card-80) shadow-sm">
                         <div className="grid gap-0 lg:grid-cols-[1.15fr_0.85fr]">
                             <div className="p-8">
                                 <p className="text-xs font-semibold uppercase tracking-[0.28em] text-(--ink-muted)">
@@ -306,7 +306,7 @@ export default async function CognitiveLoadPage({ searchParams }: CognitiveLoadP
                                     does not collect IDE, keystroke, prompt, or session telemetry.
                                 </p>
                             </div>
-                            <div className="border-t border-(--card-stroke) bg-(--card-60) p-8 lg:border-l lg:border-t-0">
+                            <div className="border-t border-(--border) bg-(--card-60) p-8 lg:border-l lg:border-t-0">
                                 <p className="text-xs font-semibold uppercase tracking-[0.24em] text-(--ink-muted)">
                                     Guardrail
                                 </p>

--- a/src/app/(app)/complexity/loading.tsx
+++ b/src/app/(app)/complexity/loading.tsx
@@ -37,7 +37,7 @@ export default function Loading() {
                         {Array.from({ length: 3 }).map((_, i) => (
                             <div
                                 key={i}
-                                className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 space-y-3"
+                                className="rounded-3xl border border-(--border) bg-(--card) p-5 space-y-3"
                             >
                                 <div className="h-3 bg-(--card-70) rounded w-20" />
                                 <div className="h-8 bg-(--card-70) rounded w-14" />

--- a/src/app/(app)/dashboard/loading.tsx
+++ b/src/app/(app)/dashboard/loading.tsx
@@ -19,7 +19,7 @@ export default function Loading() {
                 <NavSkeleton />
                 <main className="flex min-w-0 flex-1 flex-col gap-10">
                     {/* Header card */}
-                    <div className="rounded-[32px] border border-(--card-stroke) bg-(--card-80) p-6 animate-pulse">
+                    <div className="rounded-[32px] border border-(--border) bg-(--card-80) p-6 animate-pulse">
                         <div className="flex flex-col gap-6">
                             <div className="flex flex-wrap items-start justify-between gap-4">
                                 <div className="space-y-4">
@@ -47,7 +47,7 @@ export default function Loading() {
                     <div className="h-10 bg-(--card-70) rounded-full animate-pulse" />
 
                     {/* Monitoring views section */}
-                    <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 animate-pulse">
+                    <div className="rounded-3xl border border-(--border) bg-(--card-80) p-6 animate-pulse">
                         <div className="flex flex-wrap items-center justify-between gap-3">
                             <div className="space-y-2">
                                 <div className="h-3 bg-(--card-70) rounded w-32" />
@@ -59,7 +59,7 @@ export default function Loading() {
                             {Array.from({ length: 4 }).map((_, i) => (
                                 <div
                                     key={i}
-                                    className="rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3 space-y-2"
+                                    className="rounded-2xl border border-(--border) bg-(--card) px-4 py-3 space-y-2"
                                 >
                                     <div className="flex items-center justify-between">
                                         <div className="h-3 bg-(--card-70) rounded w-16" />
@@ -73,13 +73,13 @@ export default function Loading() {
                     </div>
 
                     {/* Cockpit / key signals area */}
-                    <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 animate-pulse space-y-4">
+                    <div className="rounded-3xl border border-(--border) bg-(--card-80) p-6 animate-pulse space-y-4">
                         <div className="h-5 bg-(--card-70) rounded w-40" />
                         <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
                             {Array.from({ length: 4 }).map((_, i) => (
                                 <div
                                     key={i}
-                                    className="rounded-2xl border border-(--card-stroke) bg-(--card) p-4 space-y-3"
+                                    className="rounded-2xl border border-(--border) bg-(--card) p-4 space-y-3"
                                 >
                                     <div className="h-3 bg-(--card-70) rounded w-20" />
                                     <div className="h-7 bg-(--card-70) rounded w-16" />

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -108,7 +108,7 @@ export default async function Home({ searchParams }: HomePageProps) {
             <div className="flex w-full flex-col gap-6 px-6 pb-20 pt-10 md:flex-row">
                 <PrimaryNav filters={filters} active="home" role={activeRole} />
                 <main className="flex min-w-0 flex-1 flex-col gap-10">
-                    <header className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.4)]">
+                    <header className="rounded-3xl border border-(--border) bg-(--card-80) p-6 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.4)]">
                         <div className="flex flex-col gap-6">
                             <div className="flex flex-wrap items-center justify-between gap-4">
                                 <div>
@@ -163,7 +163,7 @@ export default async function Home({ searchParams }: HomePageProps) {
                         prominent={aiDominant}
                     />
 
-                    <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                    <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                         <div className="flex flex-wrap items-center justify-between gap-3">
                             <div>
                                 <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
@@ -185,7 +185,7 @@ export default async function Home({ searchParams }: HomePageProps) {
                                 <Link
                                     key={view.id}
                                     href={withFilterParam(view.href, filters, activeRole)}
-                                    className="group rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3 transition hover:-translate-y-1"
+                                    className="group rounded-2xl border border-(--border) bg-(--card) px-4 py-3 transition hover:-translate-y-1"
                                 >
                                     <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                         <span>{view.label}</span>

--- a/src/app/(app)/data-health/_components/IdentityGapsTable.tsx
+++ b/src/app/(app)/data-health/_components/IdentityGapsTable.tsx
@@ -76,7 +76,7 @@ export function IdentityGapsTable() {
                     These identities have been observed in events but are not mapped to any
                     canonical user.
                 </p>
-                <div className="rounded-xl border border-(--card-stroke) bg-card overflow-hidden">
+                <div className="rounded-xl border border-(--border) bg-card overflow-hidden">
                     <DataTable
                         data={health.unmappedIdentities}
                         columns={columns}
@@ -93,7 +93,7 @@ export function IdentityGapsTable() {
                         Heuristic suggestions based on name/email similarity. Requires manual
                         confirmation.
                     </p>
-                    <div className="rounded-xl border border-(--card-stroke) bg-card divide-y divide-(--card-stroke)">
+                    <div className="rounded-xl border border-(--border) bg-card divide-y divide-(--border)">
                         {health.suggestedAliases.map((suggestion, idx) => (
                             <AliasSuggestionRow key={idx} suggestion={suggestion} />
                         ))}

--- a/src/app/(app)/data-health/_components/LineagePopover.tsx
+++ b/src/app/(app)/data-health/_components/LineagePopover.tsx
@@ -38,7 +38,7 @@ export function LineagePopover({ metricId }: { metricId: string }) {
                 />
             </svg>
 
-            <div className="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 p-3 bg-card border border-(--card-stroke) rounded-xl shadow-xl opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all pointer-events-none">
+            <div className="absolute z-10 bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 p-3 bg-card border border-(--border) rounded-xl shadow-xl opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all pointer-events-none">
                 <div className="text-xs font-semibold uppercase tracking-wider text-(--ink-muted) mb-2">
                     Metric Lineage
                 </div>
@@ -58,7 +58,7 @@ export function LineagePopover({ metricId }: { metricId: string }) {
                                 {data.dataHealth.metricLineage.sourceTables.map((t) => (
                                     <span
                                         key={t}
-                                        className="px-1.5 py-0.5 rounded-sm bg-(--card-70) border border-(--card-stroke) text-xs font-mono"
+                                        className="px-1.5 py-0.5 rounded-sm bg-(--card-70) border border-(--border) text-xs font-mono"
                                     >
                                         {t}
                                     </span>

--- a/src/app/(app)/data-health/mapping/page.tsx
+++ b/src/app/(app)/data-health/mapping/page.tsx
@@ -39,14 +39,14 @@ export default async function MappingHealthPage() {
             )}
 
             {!error && !coverageData && (
-                <div className="rounded-lg border border-(--card-stroke) bg-(--card-80) p-8 text-center text-(--ink-muted)">
+                <div className="rounded-lg border border-(--border) bg-(--card-80) p-8 text-center text-(--ink-muted)">
                     No mapping coverage data found.
                 </div>
             )}
 
             {coverageData && (
                 <div className="grid gap-6 md:grid-cols-2">
-                    <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                         <h3 className="font-semibold text-lg mb-4">Deployments Coverage</h3>
                         <p className="text-sm text-(--ink-muted) mb-4">
                             Percentage of deployments successfully mapped back to work items.
@@ -57,7 +57,7 @@ export default async function MappingHealthPage() {
                         />
                     </div>
 
-                    <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                         <h3 className="font-semibold text-lg mb-4">Work Items Coverage</h3>
                         <p className="text-sm text-(--ink-muted) mb-4">
                             Percentage of work items successfully mapped back to deployments.

--- a/src/app/(app)/data-health/page.tsx
+++ b/src/app/(app)/data-health/page.tsx
@@ -11,7 +11,7 @@ export default function DataHealthOverviewPage() {
 
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
                 <Link href="/data-health/connectors" className="block">
-                    <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6 hover:border-(--accent) transition-colors h-full">
+                    <div className="rounded-xl border border-(--border) bg-(--card-80) p-6 hover:border-(--accent) transition-colors h-full">
                         <h2 className="font-semibold text-lg mb-2">Connectors</h2>
                         <p className="text-sm text-(--ink-muted)">
                             Check synchronization freshness, errors, and status of all configured
@@ -20,7 +20,7 @@ export default function DataHealthOverviewPage() {
                     </div>
                 </Link>
                 <Link href="/data-health/identity" className="block">
-                    <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6 hover:border-(--accent) transition-colors h-full">
+                    <div className="rounded-xl border border-(--border) bg-(--card-80) p-6 hover:border-(--accent) transition-colors h-full">
                         <h2 className="font-semibold text-lg mb-2">Identity Coverage</h2>
                         <p className="text-sm text-(--ink-muted)">
                             Review unmapped authors, missing identities, and alias suggestions.
@@ -28,7 +28,7 @@ export default function DataHealthOverviewPage() {
                     </div>
                 </Link>
                 <Link href="/data-health/mapping" className="block">
-                    <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6 hover:border-(--accent) transition-colors h-full">
+                    <div className="rounded-xl border border-(--border) bg-(--card-80) p-6 hover:border-(--accent) transition-colors h-full">
                         <h2 className="font-semibold text-lg mb-2">Mapping Coverage</h2>
                         <p className="text-sm text-(--ink-muted)">
                             Review deployment to work-item mapping and overall traceability.

--- a/src/app/(app)/demo/page.tsx
+++ b/src/app/(app)/demo/page.tsx
@@ -466,7 +466,7 @@ export default function Home() {
 
                 <section className="grid gap-6 md:grid-cols-2">
                     <div
-                        className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                        className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                         data-testid="chart-sparkline"
                     >
                         <div className="mb-4 flex items-center justify-between">
@@ -479,7 +479,7 @@ export default function Home() {
                     </div>
 
                     <div
-                        className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                        className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                         data-testid="chart-vertical-bar"
                     >
                         <div className="mb-4 flex items-center justify-between">
@@ -498,7 +498,7 @@ export default function Home() {
                     </div>
 
                     <div
-                        className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                        className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                         data-testid="chart-horizontal-bar"
                     >
                         <div className="mb-4 flex items-center justify-between">
@@ -514,7 +514,7 @@ export default function Home() {
                     </div>
 
                     <div
-                        className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                        className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                         data-testid="chart-donut"
                     >
                         <div className="mb-4 flex items-center justify-between">
@@ -527,7 +527,7 @@ export default function Home() {
                     </div>
 
                     <div
-                        className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                        className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                         data-testid="chart-nested-pie-2d"
                     >
                         <div className="mb-4 flex items-center justify-between">
@@ -543,7 +543,7 @@ export default function Home() {
                     </div>
 
                     <div
-                        className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                        className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                         data-testid="chart-nested-pie-3d"
                     >
                         <div className="mb-4 flex items-center justify-between">
@@ -560,7 +560,7 @@ export default function Home() {
                 </section>
 
                 <section
-                    className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                    className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                     data-testid="chart-heatmap"
                 >
                     <div className="mb-4 flex items-center justify-between">
@@ -573,7 +573,7 @@ export default function Home() {
                 </section>
 
                 <section
-                    className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                    className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                     data-testid="chart-flame"
                 >
                     <div className="mb-4 flex items-center justify-between">
@@ -591,7 +591,7 @@ export default function Home() {
                 </section>
 
                 <section
-                    className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                    className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                     data-testid="chart-quadrant"
                 >
                     <div className="mb-4 flex items-center justify-between">
@@ -618,7 +618,7 @@ export default function Home() {
                     />
                 </section>
 
-                <section className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm">
+                <section className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm">
                     <div className="flex flex-wrap items-start justify-between gap-3">
                         <div>
                             <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
@@ -632,19 +632,19 @@ export default function Home() {
                             </p>
                         </div>
                         <div className="flex flex-wrap gap-2 text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
-                            <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1">
+                            <span className="rounded-full border border-(--border) bg-(--card-70) px-3 py-1">
                                 Developer: L. Morales
                             </span>
-                            <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1">
+                            <span className="rounded-full border border-(--border) bg-(--card-70) px-3 py-1">
                                 Comparison: off
                             </span>
-                            <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1">
+                            <span className="rounded-full border border-(--border) bg-(--card-70) px-3 py-1">
                                 Range: 30d
                             </span>
                         </div>
                     </div>
                     <div className="mt-6 grid gap-6 md:grid-cols-3">
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4">
+                        <div className="rounded-2xl border border-(--border) bg-(--card-80) p-4">
                             <div className="mb-3 flex items-center justify-between">
                                 <h3 className="text-sm font-semibold">Individual heatmap</h3>
                                 <span className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -653,7 +653,7 @@ export default function Home() {
                             </div>
                             <HeatmapChart data={icHeatmapData} height={200} />
                         </div>
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4">
+                        <div className="rounded-2xl border border-(--border) bg-(--card-80) p-4">
                             <div className="mb-3 flex items-center justify-between">
                                 <h3 className="text-sm font-semibold">Individual flame</h3>
                                 <span className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -667,7 +667,7 @@ export default function Home() {
                                 height={200}
                             />
                         </div>
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4">
+                        <div className="rounded-2xl border border-(--border) bg-(--card-80) p-4">
                             <div className="mb-3 flex items-center justify-between">
                                 <h3 className="text-sm font-semibold">Individual quadrant</h3>
                                 <span className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -685,7 +685,7 @@ export default function Home() {
                 </section>
 
                 <section
-                    className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                    className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                     data-testid="chart-sankey"
                 >
                     <div className="mb-4 flex items-center justify-between">
@@ -698,7 +698,7 @@ export default function Home() {
                 </section>
 
                 <section
-                    className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                    className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                     data-testid="chart-chord"
                 >
                     <header className="mb-4 flex items-start justify-between gap-4">
@@ -731,7 +731,7 @@ export default function Home() {
 
                     <div className="mt-6 grid gap-4 md:grid-cols-2">
                         <div
-                            className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4"
+                            className="rounded-2xl border border-(--border) bg-(--card-80) p-4"
                             data-testid="chart-chord-repo"
                         >
                             <div className="mb-3 flex items-center justify-between">
@@ -744,7 +744,7 @@ export default function Home() {
                         </div>
 
                         <div
-                            className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4"
+                            className="rounded-2xl border border-(--border) bg-(--card-80) p-4"
                             data-testid="chart-chord-work-type"
                         >
                             <div className="mb-3 flex items-center justify-between">
@@ -759,7 +759,7 @@ export default function Home() {
                 </section>
 
                 <section
-                    className="rounded-2xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                    className="rounded-2xl border border-(--border) bg-card p-5 shadow-sm"
                     data-testid="chart-work-graph"
                 >
                     <div className="mb-4 flex items-center justify-between">

--- a/src/app/(app)/deployments/[deployment_id]/page.tsx
+++ b/src/app/(app)/deployments/[deployment_id]/page.tsx
@@ -42,18 +42,18 @@ export default async function DeploymentDetailPage({ params }: DeploymentDetailP
                         </div>
                         <Link
                             href="/explore"
-                            className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                            className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                         >
                             Back to Explore
                         </Link>
                     </header>
 
                     {!flame ? (
-                        <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
+                        <div className="rounded-3xl border border-dashed border-(--border) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
                             Flame data unavailable for this deployment.
                         </div>
                     ) : (
-                        <section className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+                        <section className="rounded-3xl border border-(--border) bg-card p-6">
                             <div className="flex flex-wrap items-center justify-between gap-3">
                                 <div>
                                     <h2 className="font-(--font-display) text-xl">

--- a/src/app/(app)/explore/loading.tsx
+++ b/src/app/(app)/explore/loading.tsx
@@ -35,7 +35,7 @@ export default function Loading() {
                     <div className="h-10 bg-(--card-70) rounded-full animate-pulse" />
 
                     {/* Context strip — metric label + active filters */}
-                    <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 animate-pulse">
+                    <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5 animate-pulse">
                         <div className="flex flex-wrap items-center justify-between gap-3">
                             <div className="space-y-2">
                                 <div className="h-3 bg-(--card-70) rounded w-16" />
@@ -66,7 +66,7 @@ export default function Loading() {
                     {/* Evidence: Snapshot + Top Associations + Contributors (3-col grid) */}
                     <div className="grid gap-6 lg:grid-cols-3 animate-pulse">
                         {/* Snapshot card */}
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 space-y-3">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5 space-y-3">
                             <div className="h-3 bg-(--card-70) rounded w-20" />
                             <div className="h-9 bg-(--card-70) rounded w-24" />
                             <div className="h-4 bg-(--card-70) rounded w-40" />
@@ -74,7 +74,7 @@ export default function Loading() {
                         </div>
 
                         {/* Top Associations card */}
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 space-y-4">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5 space-y-4">
                             <div className="flex items-center justify-between">
                                 <div className="h-6 bg-(--card-70) rounded w-36" />
                                 <div className="h-3 bg-(--card-70) rounded w-24" />
@@ -88,7 +88,7 @@ export default function Loading() {
                         </div>
 
                         {/* Contributors card */}
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 space-y-4">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5 space-y-4">
                             <div className="flex items-center justify-between">
                                 <div className="h-6 bg-(--card-70) rounded w-28" />
                                 <div className="h-3 bg-(--card-70) rounded w-24" />
@@ -103,7 +103,7 @@ export default function Loading() {
                     </div>
 
                     {/* Evidence shortcuts */}
-                    <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 animate-pulse">
+                    <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5 animate-pulse">
                         <div className="h-6 bg-(--card-70) rounded w-40 mb-3" />
                         <div className="flex flex-wrap gap-3">
                             {Array.from({ length: 4 }).map((_, i) => (

--- a/src/app/(app)/explore/page.tsx
+++ b/src/app/(app)/explore/page.tsx
@@ -247,7 +247,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                     <GlobalContextBar filters={filters} />
                     <FilterBar condensed view="explore" />
 
-                    <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 text-sm">
+                    <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5 text-sm">
                         <div className="flex flex-wrap items-center justify-between gap-3">
                             <div>
                                 <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
@@ -279,7 +279,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                                     {chips.map((chip) => (
                                         <span
                                             key={chip}
-                                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
+                                            className="rounded-full border border-(--border) bg-(--card-70) px-3 py-1"
                                         >
                                             {chip}
                                         </span>
@@ -289,12 +289,12 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                         </div>
                     </section>
 
-                    <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                    <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                         <details>
                             <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                                 Debug filters
                             </summary>
-                            <pre className="mt-3 max-h-64 overflow-auto rounded-2xl border border-(--card-stroke) bg-(--card-60) px-4 py-3 text-xs text-(--ink-muted)">
+                            <pre className="mt-3 max-h-64 overflow-auto rounded-2xl border border-(--border) bg-(--card-60) px-4 py-3 text-xs text-(--ink-muted)">
                                 {JSON.stringify(filters, null, 2)}
                             </pre>
                         </details>
@@ -302,7 +302,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
 
                     {view === "explain" && (
                         <section id="evidence" className="grid gap-6 lg:grid-cols-3">
-                            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+                            <div className="rounded-3xl border border-(--border) bg-(--card) p-4">
                                 <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                                     Snapshot
                                 </p>
@@ -320,7 +320,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                                 </p>
                             </div>
 
-                            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+                            <div className="rounded-3xl border border-(--border) bg-(--card) p-4">
                                 <div className="flex items-center justify-between">
                                     <h2 className="font-(--font-display) text-xl">
                                         Top Associations
@@ -353,7 +353,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                                                         filters,
                                                         role: activeRole,
                                                     })}
-                                                    className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                                    className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-3 py-2"
                                                 >
                                                     <span>{driver.label}</span>
                                                     <span className="text-xs text-(--ink-muted)">
@@ -370,7 +370,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                                 )}
                             </div>
 
-                            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+                            <div className="rounded-3xl border border-(--border) bg-(--card) p-4">
                                 <div className="flex items-center justify-between">
                                     <h2 className="font-(--font-display) text-xl">Contributors</h2>
                                     <Link
@@ -403,7 +403,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                                                         filters,
                                                         role: activeRole,
                                                     })}
-                                                    className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                                    className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-3 py-2"
                                                 >
                                                     <span>{contributor.label}</span>
                                                     <span className="text-xs text-(--ink-muted)">
@@ -428,7 +428,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                     )}
 
                     {view === "drilldown" && (
-                        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                        <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">Evidence Table</h2>
                                 <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -442,10 +442,10 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                                 <table className="min-w-full border-collapse">
                                     <thead className="text-left text-(--ink-muted)">
                                         <tr>
-                                            <th className="border-b border-(--card-stroke) pb-2">
+                                            <th className="border-b border-(--border) pb-2">
                                                 Item
                                             </th>
-                                            <th className="border-b border-(--card-stroke) pb-2">
+                                            <th className="border-b border-(--border) pb-2">
                                                 Details
                                             </th>
                                         </tr>
@@ -472,7 +472,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                                             return (
                                                 <tr
                                                     key={`${href}-${getItemTitle(item, idx)}`}
-                                                    className="border-b border-(--card-stroke)"
+                                                    className="border-b border-(--border)"
                                                 >
                                                     <td className="py-2 pr-4 font-medium">
                                                         <a
@@ -508,7 +508,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                                                             {flameHref ? (
                                                                 <Link
                                                                     href={flameHref}
-                                                                    className="inline-flex items-center rounded-full border border-(--card-stroke) bg-(--card) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--accent-2)"
+                                                                    className="inline-flex items-center rounded-full border border-(--border) bg-(--card) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--accent-2)"
                                                                 >
                                                                     {CTA_LABELS.openArtifact}
                                                                 </Link>
@@ -525,25 +525,25 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                     )}
 
                     {view === "home" && (
-                        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                        <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                             <h2 className="font-(--font-display) text-xl">Home Snapshot</h2>
                             <p className="mt-3 text-sm text-(--ink-muted)">
                                 This endpoint powers the cockpit. Open Home for the curated summary.
                             </p>
-                            <pre className="mt-4 max-h-64 overflow-auto rounded-2xl border border-(--card-stroke) bg-(--card-60) px-4 py-3 text-xs text-(--ink-muted)">
+                            <pre className="mt-4 max-h-64 overflow-auto rounded-2xl border border-(--border) bg-(--card-60) px-4 py-3 text-xs text-(--ink-muted)">
                                 {JSON.stringify(home ?? {}, null, 2)}
                             </pre>
                         </section>
                     )}
 
                     {view === "unknown" && (
-                        <section className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
+                        <section className="rounded-3xl border border-dashed border-(--border) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
                             Unsupported endpoint. Provide a metric or a supported drilldown API.
                         </section>
                     )}
 
                     {view === "explain" && (
-                        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                        <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                             <h2 className="font-(--font-display) text-xl">Evidence shortcuts</h2>
                             <div className="mt-3 flex flex-wrap gap-3 text-sm">
                                 {Object.entries(data?.drilldown_links ?? {}).map(
@@ -555,7 +555,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
                                                 filters,
                                                 role: activeRole,
                                             })}
-                                            className="rounded-full border border-(--card-stroke) bg-(--card) px-4 py-2"
+                                            className="rounded-full border border-(--border) bg-(--card) px-4 py-2"
                                         >
                                             {label}
                                         </Link>

--- a/src/app/(app)/feature-flags/page.tsx
+++ b/src/app/(app)/feature-flags/page.tsx
@@ -98,7 +98,7 @@ export default async function FeatureFlagsPage({ searchParams }: FeatureFlagsPag
                         </div>
                         <Link
                             href={withFilterParam("/", filters, activeRole)}
-                            className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                            className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                         >
                             Back to cockpit
                         </Link>

--- a/src/app/(app)/improve/experiments/page.tsx
+++ b/src/app/(app)/improve/experiments/page.tsx
@@ -31,7 +31,7 @@ type ExperimentsPageProps = {
 function ExperimentCard({ experiment }: { experiment: Experiment }) {
     return (
         <article
-            className="flex flex-col gap-3 rounded-3xl border border-(--card-stroke) bg-card p-6"
+            className="flex flex-col gap-3 rounded-3xl border border-(--border) bg-card p-6"
             data-testid="experiment-card"
         >
             <header className="flex items-start justify-between gap-4">

--- a/src/app/(app)/incident-correlation/page.tsx
+++ b/src/app/(app)/incident-correlation/page.tsx
@@ -137,7 +137,7 @@ export default async function IncidentCorrelationPage({ searchParams }: PageProp
                         </div>
                         <Link
                             href={withFilterParam("/", filters, activeRole)}
-                            className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                            className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                         >
                             Back to cockpit
                         </Link>

--- a/src/app/(app)/investment/page.tsx
+++ b/src/app/(app)/investment/page.tsx
@@ -106,7 +106,7 @@ export default async function InvestmentPage({ searchParams }: InvestmentPagePro
                                         role: activeRole,
                                         origin: activeOrigin,
                                     })}
-                                    className="rounded-full border border-(--card-stroke) px-4 py-2"
+                                    className="rounded-full border border-(--border) px-4 py-2"
                                 >
                                     {CTA_LABELS.inspectAssociations}
                                 </Link>
@@ -124,7 +124,7 @@ export default async function InvestmentPage({ searchParams }: InvestmentPagePro
 
                         <FilterBar view="investment" />
 
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-3 text-xs leading-relaxed text-(--ink-muted)">
+                        <div className="rounded-2xl border border-(--border) bg-(--card-80) p-3 text-xs leading-relaxed text-(--ink-muted)">
                             <span className="text-foreground font-semibold uppercase tracking-wider">
                                 Perspective:
                             </span>{" "}

--- a/src/app/(app)/issues/[issue_id]/page.tsx
+++ b/src/app/(app)/issues/[issue_id]/page.tsx
@@ -56,18 +56,18 @@ export default async function IssueDetailPage({ params }: IssueDetailPageProps) 
                         </div>
                         <Link
                             href="/explore"
-                            className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                            className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                         >
                             Back to Explore
                         </Link>
                     </header>
 
                     {!flame?.entity || !flame.timeline || !flame.frames ? (
-                        <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
+                        <div className="rounded-3xl border border-dashed border-(--border) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
                             Flame data unavailable for this issue.
                         </div>
                     ) : (
-                        <section className="rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
+                        <section className="rounded-3xl border border-(--border) bg-(--card) p-6">
                             <div className="flex flex-wrap items-center justify-between gap-3">
                                 <div>
                                     <h2 className="font-(--font-display) text-xl">

--- a/src/app/(app)/landscape/page.tsx
+++ b/src/app/(app)/landscape/page.tsx
@@ -97,7 +97,7 @@ function LandscapeTable({
         );
     }
     return (
-        <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90) shadow-sm">
+        <div className="overflow-hidden rounded-2xl border border-(--border) bg-(--card-90) shadow-sm">
             <table className="w-full text-sm" data-testid={testId}>
                 <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
                     <tr>
@@ -130,7 +130,7 @@ function TabPanel({
 }) {
     return (
         <section
-            className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
+            className="rounded-[1.75rem] border border-(--border) bg-(--card-90) p-6 shadow-sm"
             data-testid={testId}
         >
             <div className="mb-4">
@@ -185,7 +185,7 @@ function TeamsView({
                     <tr
                         key={r.id}
                         data-testid="teams-row"
-                        className="border-t border-(--card-stroke)/60"
+                        className="border-t border-(--border)/60"
                     >
                         <td className="px-5 py-3 align-middle font-medium">{r.label}</td>
                         <td className="px-5 py-3 text-right tabular-nums">
@@ -252,7 +252,7 @@ function ReposView({ hotspots }: { hotspots: HotspotRow[] }) {
                     <tr
                         key={r.repoName}
                         data-testid="repos-row"
-                        className="border-t border-(--card-stroke)/60"
+                        className="border-t border-(--border)/60"
                     >
                         <td className="px-5 py-3 align-middle font-medium">{r.repoName}</td>
                         <td className="px-5 py-3 text-right tabular-nums">
@@ -301,7 +301,7 @@ function OwnershipView({ busFactor }: { busFactor: BusFactor | null }) {
                         <tr
                             key={r.repoId}
                             data-testid="ownership-row"
-                            className="border-t border-(--card-stroke)/60"
+                            className="border-t border-(--border)/60"
                         >
                             <td className="px-5 py-3 align-middle font-medium">{r.repoName}</td>
                             <td className="px-5 py-3 text-right tabular-nums">
@@ -350,7 +350,7 @@ function HotspotsView({ hotspots }: { hotspots: HotspotRow[] }) {
                         <tr
                             key={`${r.repoId}-${r.filePath}`}
                             data-testid="hotspots-row"
-                            className="border-t border-(--card-stroke)/60"
+                            className="border-t border-(--border)/60"
                         >
                             <td
                                 className="px-5 py-3 align-middle font-mono text-[0.82em]"
@@ -493,7 +493,7 @@ export default async function LandscapePage({ searchParams }: LandscapePageProps
                     />
 
                     {!canQuery && (
-                        <section className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
+                        <section className="rounded-3xl border border-dashed border-(--border) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
                             Individual landscapes are available from the individual view.
                         </section>
                     )}
@@ -511,7 +511,7 @@ export default async function LandscapePage({ searchParams }: LandscapePageProps
                                     className={`rounded-full border px-3 py-1 ${
                                         bucket === "week"
                                             ? "border-(--accent) bg-(--accent)/15 text-foreground"
-                                            : "border-(--card-stroke)"
+                                            : "border-(--border)"
                                     }`}
                                 >
                                     {CTA_LABELS.week}
@@ -525,7 +525,7 @@ export default async function LandscapePage({ searchParams }: LandscapePageProps
                                     className={`rounded-full border px-3 py-1 ${
                                         bucket === "month"
                                             ? "border-(--accent) bg-(--accent)/15 text-foreground"
-                                            : "border-(--card-stroke)"
+                                            : "border-(--border)"
                                     }`}
                                 >
                                     {CTA_LABELS.month}

--- a/src/app/(app)/metrics/loading.tsx
+++ b/src/app/(app)/metrics/loading.tsx
@@ -40,7 +40,7 @@ export default function Loading() {
                     </div>
 
                     {/* Active tab section header + metric chips */}
-                    <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 animate-pulse">
+                    <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5 animate-pulse">
                         <div className="flex flex-wrap items-center justify-between gap-3">
                             <div className="space-y-2">
                                 <div className="h-3 bg-(--card-70) rounded w-28" />
@@ -60,7 +60,7 @@ export default function Loading() {
                         {Array.from({ length: 4 }).map((_, i) => (
                             <div
                                 key={i}
-                                className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 space-y-3"
+                                className="rounded-3xl border border-(--border) bg-(--card) p-5 space-y-3"
                             >
                                 <div className="h-3 bg-(--card-70) rounded w-24" />
                                 <div className="h-8 bg-(--card-70) rounded w-16" />
@@ -75,7 +75,7 @@ export default function Loading() {
 
                     {/* Associations + Contributors side by side */}
                     <div className="grid gap-6 lg:grid-cols-2">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 animate-pulse space-y-4">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5 animate-pulse space-y-4">
                             <div className="flex items-center justify-between">
                                 <div className="h-6 bg-(--card-70) rounded w-40" />
                                 <div className="h-3 bg-(--card-70) rounded w-24" />
@@ -88,7 +88,7 @@ export default function Loading() {
                                 ))}
                             </div>
                         </div>
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 animate-pulse space-y-4">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5 animate-pulse space-y-4">
                             <div className="flex items-center justify-between">
                                 <div className="h-6 bg-(--card-70) rounded w-44" />
                                 <div className="h-3 bg-(--card-70) rounded w-24" />
@@ -104,7 +104,7 @@ export default function Loading() {
                     </div>
 
                     {/* Summary table */}
-                    <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 animate-pulse">
+                    <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5 animate-pulse">
                         <div className="flex items-center justify-between mb-4">
                             <div className="h-6 bg-(--card-70) rounded w-24" />
                             <div className="h-3 bg-(--card-70) rounded w-28" />

--- a/src/app/(app)/metrics/page.tsx
+++ b/src/app/(app)/metrics/page.tsx
@@ -186,7 +186,7 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
                         )}
                     />
 
-                    <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                    <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                         <div className="flex flex-wrap items-center justify-between gap-3">
                             <div>
                                 <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
@@ -219,7 +219,7 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
                                             filters,
                                             role: activeRole,
                                         })}
-                                        className="rounded-full border border-(--card-stroke) bg-(--card) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted) transition hover:text-foreground"
+                                        className="rounded-full border border-(--border) bg-(--card) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted) transition hover:text-foreground"
                                     >
                                         {data?.label ?? metric}
                                     </Link>
@@ -247,7 +247,7 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
                     </section>
 
                     <section className="grid gap-6 lg:grid-cols-2">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-4">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">
                                     Likely associations
@@ -282,7 +282,7 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
                                                     filters,
                                                     role: activeRole,
                                                 })}
-                                                className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+                                                className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-4 py-2"
                                             >
                                                 <EntityLabel id={driver.label} />
                                                 <span className="text-xs text-(--ink-muted)">
@@ -299,7 +299,7 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
                             )}
                         </div>
 
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-4">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">
                                     Primary contributors
@@ -336,7 +336,7 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
                                                     filters,
                                                     role: activeRole,
                                                 })}
-                                                className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+                                                className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-4 py-2"
                                             >
                                                 <EntityLabel id={contributor.label} />
                                                 <span className="text-xs text-(--ink-muted)">
@@ -359,7 +359,7 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
                         </div>
                     </section>
 
-                    <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                    <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                         <div className="flex items-center justify-between">
                             <h2 className="font-(--font-display) text-xl">Summary</h2>
                             <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -370,18 +370,10 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
                             <table className="min-w-full border-collapse text-sm">
                                 <thead className="text-left text-(--ink-muted)">
                                     <tr>
-                                        <th className="border-b border-(--card-stroke) pb-2">
-                                            Metric
-                                        </th>
-                                        <th className="border-b border-(--card-stroke) pb-2">
-                                            Current
-                                        </th>
-                                        <th className="border-b border-(--card-stroke) pb-2">
-                                            Delta
-                                        </th>
-                                        <th className="border-b border-(--card-stroke) pb-2">
-                                            Explore
-                                        </th>
+                                        <th className="border-b border-(--border) pb-2">Metric</th>
+                                        <th className="border-b border-(--border) pb-2">Current</th>
+                                        <th className="border-b border-(--border) pb-2">Delta</th>
+                                        <th className="border-b border-(--border) pb-2">Explore</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -393,10 +385,7 @@ export default async function MetricsPage({ searchParams }: MetricsPageProps) {
                                             role: activeRole,
                                         });
                                         return (
-                                            <tr
-                                                key={metric}
-                                                className="border-b border-(--card-stroke)"
-                                            >
+                                            <tr key={metric} className="border-b border-(--border)">
                                                 <td className="py-3 pr-4 font-medium">
                                                     <Link href={href} className="block">
                                                         {data?.label ?? metric}

--- a/src/app/(app)/operating-review/page.tsx
+++ b/src/app/(app)/operating-review/page.tsx
@@ -207,7 +207,7 @@ async function resolveOperatingReview(
 
 function AllTeamsBadge() {
     return (
-        <section className="rounded-2xl border border-(--card-stroke) bg-(--card-80) px-5 py-3 text-xs text-(--ink-muted)">
+        <section className="rounded-2xl border border-(--border) bg-(--card-80) px-5 py-3 text-xs text-(--ink-muted)">
             Showing the cross-team aggregate{" "}
             <span className="font-medium text-foreground">(All Teams)</span>. Pick a team from the{" "}
             <span className="font-medium text-foreground">Team</span> filter above to scope to one
@@ -218,7 +218,7 @@ function AllTeamsBadge() {
 
 function SelectedTeamsBadge({ teamIds }: { teamIds: string[] }) {
     return (
-        <section className="rounded-2xl border border-(--card-stroke) bg-(--card-80) px-5 py-3 text-xs text-(--ink-muted)">
+        <section className="rounded-2xl border border-(--border) bg-(--card-80) px-5 py-3 text-xs text-(--ink-muted)">
             Showing operating review data for{" "}
             <span className="font-medium text-foreground">
                 {teamIds.length} selected {teamIds.length === 1 ? "team" : "teams"}
@@ -237,7 +237,7 @@ function OperatingReviewAgenda({ review }: { review: OperatingReview }) {
                     <a
                         key={section.key}
                         href={`#${section.key}`}
-                        className={`rounded-2xl border bg-card p-4 transition hover:border-primary/50 ${section.key === AI_WORKFLOW_SECTION_KEY ? "border-sky-400/40 shadow-sm shadow-sky-500/10" : "border-border"}`}
+                        className={`rounded-2xl border bg-card p-4 transition hover:border-primary/50 ${section.key === AI_WORKFLOW_SECTION_KEY ? "border-(--accent-ai)/40 shadow-sm shadow-(--accent-ai)/10" : "border-border"}`}
                     >
                         <h2 className="text-base font-semibold">{section.title}</h2>
                         <p className="mt-2 text-xs text-muted-foreground">
@@ -252,7 +252,7 @@ function OperatingReviewAgenda({ review }: { review: OperatingReview }) {
                 <section
                     id={section.key}
                     key={section.key}
-                    className={`rounded-[1.75rem] border bg-card/90 p-6 shadow-sm ${section.key === AI_WORKFLOW_SECTION_KEY ? "border-sky-400/40 shadow-sky-500/10" : "border-border"}`}
+                    className={`rounded-[1.75rem] border bg-card/90 p-6 shadow-sm ${section.key === AI_WORKFLOW_SECTION_KEY ? "border-(--accent-ai)/40 shadow-(--accent-ai)/10" : "border-border"}`}
                 >
                     <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                         <div>
@@ -314,7 +314,7 @@ function OperatingReviewAgenda({ review }: { review: OperatingReview }) {
 function AIWorkflowIntelligenceCallout() {
     return (
         <div
-            className="mt-5 rounded-2xl border border-sky-400/30 bg-sky-500/5 p-4"
+            className="mt-5 rounded-2xl border border-(--accent-ai)/30 bg-(--accent-ai)/5 p-4"
             data-testid="operating-review-ai-workflow-callout"
         >
             <p className="text-sm text-muted-foreground">
@@ -324,25 +324,25 @@ function AIWorkflowIntelligenceCallout() {
             </p>
             <div className="mt-3 flex flex-wrap gap-2 text-xs font-semibold">
                 <Link
-                    className="rounded-full border border-sky-400/30 bg-background/60 px-3 py-1 text-foreground"
+                    className="rounded-full border border-(--accent-ai)/30 bg-background/60 px-3 py-1 text-foreground"
                     href="/ai"
                 >
                     {CTA_LABELS.aiImpact}
                 </Link>
                 <Link
-                    className="rounded-full border border-sky-400/30 bg-background/60 px-3 py-1 text-foreground"
+                    className="rounded-full border border-(--accent-ai)/30 bg-background/60 px-3 py-1 text-foreground"
                     href="/ai/review-load"
                 >
                     {CTA_LABELS.aiReviewLoad}
                 </Link>
                 <Link
-                    className="rounded-full border border-sky-400/30 bg-background/60 px-3 py-1 text-foreground"
+                    className="rounded-full border border-(--accent-ai)/30 bg-background/60 px-3 py-1 text-foreground"
                     href="/ai/risk"
                 >
                     {CTA_LABELS.aiRisk}
                 </Link>
                 <Link
-                    className="rounded-full border border-sky-400/30 bg-background/60 px-3 py-1 text-foreground"
+                    className="rounded-full border border-(--accent-ai)/30 bg-background/60 px-3 py-1 text-foreground"
                     href="/ai/automations"
                 >
                     {CTA_LABELS.aiAutomations}

--- a/src/app/(app)/opportunities/OpportunityCard.tsx
+++ b/src/app/(app)/opportunities/OpportunityCard.tsx
@@ -15,7 +15,7 @@ export function OpportunityCard({ card, filters, activeRole }: OpportunityCardPr
     const hasArtifacts = card.evidence_links.length > 0;
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+        <div className="rounded-3xl border border-(--border) bg-(--card-80) p-6">
             <h2 className="font-(--font-display) text-xl">{card.title}</h2>
             <p className="mt-2 text-sm text-(--ink-muted)">{card.rationale}</p>
 
@@ -29,7 +29,7 @@ export function OpportunityCard({ card, filters, activeRole }: OpportunityCardPr
                             <Link
                                 key={link}
                                 href={buildExploreUrl({ api: link, filters, role: activeRole })}
-                                className="rounded-full border border-(--card-stroke) bg-(--card) px-3 py-1"
+                                className="rounded-full border border-(--border) bg-(--card) px-3 py-1"
                             >
                                 Open artifact ↗
                             </Link>
@@ -38,7 +38,7 @@ export function OpportunityCard({ card, filters, activeRole }: OpportunityCardPr
                 ) : (
                     <p
                         aria-disabled="true"
-                        className="mt-2 inline-block rounded-full border border-dashed border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs text-(--ink-muted)"
+                        className="mt-2 inline-block rounded-full border border-dashed border-(--border) bg-(--card-70) px-3 py-1 text-xs text-(--ink-muted)"
                     >
                         No linked artifacts in this window
                     </p>
@@ -54,7 +54,7 @@ export function OpportunityCard({ card, filters, activeRole }: OpportunityCardPr
                         {card.suggested_experiments.map((experiment) => (
                             <div
                                 key={experiment}
-                                className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-3 py-2"
                             >
                                 {experiment}
                             </div>

--- a/src/app/(app)/opportunities/page.tsx
+++ b/src/app/(app)/opportunities/page.tsx
@@ -71,20 +71,20 @@ export default async function OpportunitiesPage({ searchParams }: OpportunitiesP
                             />
                         ))}
                         {data && data.items.length === 0 && (
-                            <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
+                            <div className="rounded-3xl border border-dashed border-(--border) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
                                 No open opportunities in this window — nothing is trending worse for
                                 the current scope.
                             </div>
                         )}
                         {!data && (
-                            <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
+                            <div className="rounded-3xl border border-dashed border-(--border) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
                                 Opportunity data unavailable.
                             </div>
                         )}
                     </section>
 
                     <section
-                        className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-(--card-stroke) bg-card p-5"
+                        className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-(--border) bg-card p-5"
                         aria-label="AI automation opportunities"
                         data-testid="improve-ai-automations-crosslink"
                     >

--- a/src/app/(app)/people/[person_id]/metrics/[metric]/page.tsx
+++ b/src/app/(app)/people/[person_id]/metrics/[metric]/page.tsx
@@ -214,7 +214,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                 {(person?.identities ?? []).map((identity) => (
                                     <span
                                         key={`${personId}-${identity.provider}-${identity.handle}`}
-                                        className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
+                                        className="rounded-full border border-(--border) bg-(--card-70) px-3 py-1"
                                     >
                                         {identity.provider}: {identity.handle}
                                     </span>
@@ -228,7 +228,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                     range_days,
                                     compare_days,
                                 )}
-                                className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                                className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                             >
                                 Back to individual
                             </Link>
@@ -244,7 +244,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                     <PersonRangeBar rangeDays={range_days} />
 
                     <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                        <div className="rounded-3xl border border-(--border) bg-(--card-80) p-6">
                             <h2 className="font-(--font-display) text-xl">Definition</h2>
                             <p className="mt-2 text-sm text-(--ink-muted)">
                                 {definitionSummary ??
@@ -260,7 +260,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                     {definitionEntries.map(([key, value]) => (
                                         <div
                                             key={key}
-                                            className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-card px-3 py-2"
+                                            className="flex items-center justify-between rounded-2xl border border-(--border) bg-card px-3 py-2"
                                         >
                                             <span className="uppercase tracking-[0.2em]">
                                                 {key.replace(/[_-]+/g, " ")}
@@ -276,7 +276,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                             )}
                         </div>
 
-                        <div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+                        <div className="rounded-3xl border border-(--border) bg-card p-6">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">Timeseries</h2>
                                 <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -287,7 +287,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                 {timeseries.length ? (
                                     <TimeseriesChart data={timeseries} height={240} />
                                 ) : (
-                                    <div className="flex h-[240px] items-center justify-center rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-60) text-sm text-(--ink-muted)">
+                                    <div className="flex h-[240px] items-center justify-center rounded-3xl border border-dashed border-(--border) bg-(--card-60) text-sm text-(--ink-muted)">
                                         Timeseries data unavailable.
                                     </div>
                                 )}
@@ -329,7 +329,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                             return (
                                 <div
                                     key={group.id}
-                                    className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+                                    className="rounded-3xl border border-(--border) bg-card p-5"
                                 >
                                     <div className="flex items-center justify-between">
                                         <h2 className="font-(--font-display) text-xl">
@@ -353,7 +353,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                                 }
                                             />
                                         ) : (
-                                            <div className="flex h-[220px] items-center justify-center rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-60) text-sm text-(--ink-muted)">
+                                            <div className="flex h-[220px] items-center justify-center rounded-3xl border border-dashed border-(--border) bg-(--card-60) text-sm text-(--ink-muted)">
                                                 No breakdown data.
                                             </div>
                                         )}
@@ -362,7 +362,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                         {group.items.map((item, index) => (
                                             <div
                                                 key={`${group.id}-${item.label ?? "unknown"}-${index}`}
-                                                className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                                className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-3 py-2"
                                             >
                                                 {group.isEntity ? (
                                                     <EntityLabel id={item.label} />
@@ -381,7 +381,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                     </section>
 
                     <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+                        <div className="rounded-3xl border border-(--border) bg-card p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">Associations</h2>
                                 <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -396,7 +396,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                         return (
                                             <div
                                                 key={`${driver.text}-${idx}`}
-                                                className="rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3"
+                                                className="rounded-2xl border border-(--border) bg-(--card-70) px-4 py-3"
                                             >
                                                 <p className="text-sm text-foreground">
                                                     {driver.text}
@@ -413,14 +413,14 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                         );
                                     })
                                 ) : (
-                                    <p className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-60) px-4 py-3 text-sm text-(--ink-muted)">
+                                    <p className="rounded-2xl border border-dashed border-(--border) bg-(--card-60) px-4 py-3 text-sm text-(--ink-muted)">
                                         Association statements will appear once data is ingested.
                                     </p>
                                 )}
                             </div>
                         </div>
 
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">
                                     {CTA_LABELS.evidence}
@@ -435,7 +435,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                     className={`rounded-full border px-3 py-2 ${
                                         evidenceType === "prs"
                                             ? "border-(--accent) bg-(--accent)/15 text-foreground"
-                                            : "border-(--card-stroke) text-(--ink-muted)"
+                                            : "border-(--border) text-(--ink-muted)"
                                     }`}
                                 >
                                     PRs
@@ -445,7 +445,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                     className={`rounded-full border px-3 py-2 ${
                                         evidenceType === "issues"
                                             ? "border-(--accent) bg-(--accent)/15 text-foreground"
-                                            : "border-(--card-stroke) text-(--ink-muted)"
+                                            : "border-(--border) text-(--ink-muted)"
                                     }`}
                                 >
                                     Issues
@@ -456,10 +456,10 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                     <table className="min-w-full border-collapse">
                                         <thead className="text-left text-(--ink-muted)">
                                             <tr>
-                                                <th className="border-b border-(--card-stroke) pb-2">
+                                                <th className="border-b border-(--border) pb-2">
                                                     Item
                                                 </th>
-                                                <th className="border-b border-(--card-stroke) pb-2">
+                                                <th className="border-b border-(--border) pb-2">
                                                     Details
                                                 </th>
                                             </tr>
@@ -471,7 +471,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                                 return (
                                                     <tr
                                                         key={`item-${idx}`}
-                                                        className="border-b border-(--card-stroke)"
+                                                        className="border-b border-(--border)"
                                                     >
                                                         <td className="py-2 pr-4 font-medium">
                                                             <a
@@ -502,7 +502,7 @@ export default async function PersonMetricPage({ params, searchParams }: PersonM
                                 </div>
                             )}
                             {!evidenceType && (
-                                <div className="mt-4 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-60) px-4 py-3 text-sm text-(--ink-muted)">
+                                <div className="mt-4 rounded-2xl border border-dashed border-(--border) bg-(--card-60) px-4 py-3 text-sm text-(--ink-muted)">
                                     Choose PRs or Issues to review evidence.
                                 </div>
                             )}

--- a/src/app/(app)/people/[person_id]/page.tsx
+++ b/src/app/(app)/people/[person_id]/page.tsx
@@ -155,13 +155,13 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                 {(person?.identities ?? []).map((identity) => (
                                     <span
                                         key={`${personId}-${identity.provider}-${identity.handle}`}
-                                        className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
+                                        className="rounded-full border border-(--border) bg-(--card-70) px-3 py-1"
                                     >
                                         {identity.provider}: {identity.handle}
                                     </span>
                                 ))}
                                 {person?.active === false && (
-                                    <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1">
+                                    <span className="rounded-full border border-(--border) bg-(--card-70) px-3 py-1">
                                         Inactive
                                     </span>
                                 )}
@@ -208,7 +208,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                     </section>
 
                     <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                        <div className="rounded-3xl border border-(--border) bg-(--card-80) p-6">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-2xl">Narrative</h2>
                                 <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -237,7 +237,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                         );
                                     })
                                 ) : (
-                                    <p className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-60) px-4 py-3">
+                                    <p className="rounded-2xl border border-dashed border-(--border) bg-(--card-60) px-4 py-3">
                                         Narrative insights will appear once data is ingested.
                                     </p>
                                 )}
@@ -246,7 +246,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
 
                         <div className="grid gap-4">
                             <div
-                                className={`rounded-3xl border border-(--card-stroke) p-5 text-sm ${
+                                className={`rounded-3xl border border-(--border) p-5 text-sm ${
                                     coverageLow
                                         ? "bg-amber-50/80 text-amber-900"
                                         : "bg-(--card-80) text-(--ink-muted)"
@@ -264,7 +264,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                     Attribution accuracy reflects linked accounts.
                                 </p>
                             </div>
-                            <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 text-sm text-(--ink-muted)">
+                            <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5 text-sm text-(--ink-muted)">
                                 <div className="flex items-center justify-between">
                                     <p className="text-xs uppercase tracking-[0.15em]">Freshness</p>
                                     <ClientTimestamp
@@ -278,7 +278,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                             ([key, value]) => (
                                                 <div
                                                     key={key}
-                                                    className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                                    className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-3 py-2"
                                                 >
                                                     <span className="uppercase tracking-[0.2em]">
                                                         {key}
@@ -290,7 +290,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                             ),
                                         )
                                     ) : (
-                                        <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-60) px-3 py-2">
+                                        <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-60) px-3 py-2">
                                             Freshness details pending.
                                         </div>
                                     )}
@@ -300,7 +300,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                     </section>
 
                     <section className="grid gap-6 lg:grid-cols-3">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+                        <div className="rounded-3xl border border-(--border) bg-card p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">Work mix</h2>
                                 <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -311,7 +311,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                 {workMixData.length ? (
                                     <DonutChart data={workMixData} height={260} />
                                 ) : (
-                                    <div className="flex min-h-64 items-center justify-center rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-60) text-sm text-(--ink-muted)">
+                                    <div className="flex min-h-64 items-center justify-center rounded-3xl border border-dashed border-(--border) bg-(--card-60) text-sm text-(--ink-muted)">
                                         Work mix data unavailable.
                                     </div>
                                 )}
@@ -320,7 +320,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                 {(workMix?.categories ?? []).map((category) => (
                                     <div
                                         key={category.key}
-                                        className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                        className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-3 py-2"
                                     >
                                         <span>{category.name}</span>
                                         <span className="text-xs text-(--ink-muted)">
@@ -331,7 +331,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                             </div>
                         </div>
 
-                        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+                        <div className="rounded-3xl border border-(--border) bg-card p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">Flow breakdown</h2>
                                 <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -345,7 +345,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                         values={flowStages.map((stage) => stage.value)}
                                     />
                                 ) : (
-                                    <div className="flex min-h-60 items-center justify-center rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-60) text-sm text-(--ink-muted)">
+                                    <div className="flex min-h-60 items-center justify-center rounded-3xl border border-dashed border-(--border) bg-(--card-60) text-sm text-(--ink-muted)">
                                         Flow stage detail unavailable.
                                     </div>
                                 )}
@@ -354,7 +354,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                 {flowStages.map((stage) => (
                                     <div
                                         key={stage.stage}
-                                        className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                        className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-3 py-2"
                                     >
                                         <span>{stage.stage}</span>
                                         <span className="text-xs text-(--ink-muted)">
@@ -367,7 +367,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                             </div>
                         </div>
 
-                        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+                        <div className="rounded-3xl border border-(--border) bg-card p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">Collaboration</h2>
                                 <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -379,7 +379,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                     collaborationStats.map((stat) => (
                                         <div
                                             key={`${stat.label}-${stat.value}`}
-                                            className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                            className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-3 py-2"
                                         >
                                             <span>{stat.label}</span>
                                             <span className="text-xs text-(--ink-muted)">
@@ -388,7 +388,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                         </div>
                                     ))
                                 ) : (
-                                    <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-60) px-3 py-3 text-sm text-(--ink-muted)">
+                                    <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-60) px-3 py-3 text-sm text-(--ink-muted)">
                                         Collaboration counts pending.
                                     </div>
                                 )}
@@ -396,7 +396,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                         </div>
                     </section>
 
-                    <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <section className="rounded-3xl border border-(--border) bg-(--card-80) p-6">
                         <div className="flex items-center justify-between">
                             <h2 className="font-(--font-display) text-xl">View metric</h2>
                             <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -412,7 +412,7 @@ export default async function PersonPage({ params, searchParams }: PersonPagePro
                                         range_days,
                                         compare_days,
                                     )}
-                                    className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-card px-4 py-3 text-sm"
+                                    className="flex items-center justify-between rounded-2xl border border-(--border) bg-card px-4 py-3 text-sm"
                                 >
                                     <span>{getMetricLabel(metric)}</span>
                                     <span className="text-xs uppercase tracking-[0.2em] text-(--accent-2)">

--- a/src/app/(app)/plan/backlog-risk/_components.tsx
+++ b/src/app/(app)/plan/backlog-risk/_components.tsx
@@ -40,7 +40,7 @@ export function WipCongestionCard({ overlay, backlogSize }: WipCongestionCardPro
     const ratioLabel = `×${formatNumber(ratio, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
     return (
-        <section className="grid gap-4 rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 md:grid-cols-2">
+        <section className="grid gap-4 rounded-3xl border border-(--border) bg-(--card-80) p-6 md:grid-cols-2">
             <div>
                 <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
                     WIP Congestion
@@ -83,7 +83,7 @@ export function ForecastContent({ forecast }: ForecastContentProps) {
             />
 
             <section className="grid gap-4 md:grid-cols-2">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-6">
                     <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
                         Stale WIP
                     </h2>
@@ -95,7 +95,7 @@ export function ForecastContent({ forecast }: ForecastContentProps) {
                     />
                 </div>
 
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-6">
                     <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
                         Unestimated Debt
                     </h2>
@@ -115,7 +115,7 @@ export function ForecastContent({ forecast }: ForecastContentProps) {
 
 export function NoForecastState() {
     return (
-        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8">
+        <section className="rounded-3xl border border-(--border) bg-(--card-80) p-8">
             <DataState
                 variant="insufficient-confidence"
                 title="Not enough throughput history"

--- a/src/app/(app)/plan/page.tsx
+++ b/src/app/(app)/plan/page.tsx
@@ -36,7 +36,7 @@ function riskValue(risk: ThroughputRiskOverlay) {
 
 function RiskCard({ risk }: { risk: ThroughputRiskOverlay }) {
     return (
-        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-5">
+        <div className="rounded-2xl border border-(--border) bg-(--card-80) p-5">
             <div className="flex items-center justify-between gap-3">
                 <h3 className="text-sm font-semibold">{risk.label}</h3>
                 <span
@@ -59,7 +59,7 @@ function RiskCard({ risk }: { risk: ThroughputRiskOverlay }) {
 
 function EmptyForecastState({ scopeLabel }: { scopeLabel: string }) {
     return (
-        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8">
+        <section className="rounded-3xl border border-(--border) bg-(--card-80) p-8">
             <h2 className="text-xl font-semibold">No forecast available</h2>
             <p className="mt-2 text-sm text-(--ink-muted)">
                 Scope: <span className="text-foreground">{scopeLabel}</span>
@@ -126,7 +126,7 @@ export default async function PlanPage({ searchParams }: PlanPageProps) {
 
                     {forecast ? (
                         <>
-                            <section className="grid gap-4 rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 md:grid-cols-[auto_1fr]">
+                            <section className="grid gap-4 rounded-3xl border border-(--border) bg-(--card-80) p-6 md:grid-cols-[auto_1fr]">
                                 <div>
                                     <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
                                         Delivery confidence
@@ -152,7 +152,7 @@ export default async function PlanPage({ searchParams }: PlanPageProps) {
                                 ].map(([label, weeks]) => (
                                     <div
                                         key={label as string}
-                                        className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6"
+                                        className="rounded-3xl border border-(--border) bg-(--card-80) p-6"
                                     >
                                         <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
                                             {label}
@@ -167,7 +167,7 @@ export default async function PlanPage({ searchParams }: PlanPageProps) {
                                 ))}
                             </section>
 
-                            <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                            <section className="rounded-3xl border border-(--border) bg-(--card-80) p-6">
                                 <div className="flex flex-wrap items-start justify-between gap-3">
                                     <div>
                                         <h2 className="text-xl font-semibold">
@@ -204,7 +204,7 @@ export default async function PlanPage({ searchParams }: PlanPageProps) {
                                 <RiskCard risk={forecast.incidentLoad} />
                             </section>
 
-                            <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                            <section className="rounded-3xl border border-(--border) bg-(--card-80) p-6">
                                 <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
                                     Primary risk callout
                                 </p>

--- a/src/app/(app)/prs/[pr_id]/page.tsx
+++ b/src/app/(app)/prs/[pr_id]/page.tsx
@@ -56,18 +56,18 @@ export default async function PrDetailPage({ params }: PrDetailPageProps) {
                         </div>
                         <Link
                             href="/explore"
-                            className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                            className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                         >
                             Back to Explore
                         </Link>
                     </header>
 
                     {!flame?.entity || !flame.timeline || !flame.frames ? (
-                        <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
+                        <div className="rounded-3xl border border-dashed border-(--border) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
                             Flame data unavailable for this PR.
                         </div>
                     ) : (
-                        <section className="rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
+                        <section className="rounded-3xl border border-(--border) bg-(--card) p-6">
                             <div className="flex flex-wrap items-center justify-between gap-3">
                                 <div>
                                     <h2 className="font-(--font-display) text-xl">

--- a/src/app/(app)/quality/page.tsx
+++ b/src/app/(app)/quality/page.tsx
@@ -88,7 +88,7 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
                         </div>
                         <Link
                             href={withFilterParam("/", filters, activeRole)}
-                            className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                            className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                         >
                             {CTA_LABELS.backToCockpit}
                         </Link>
@@ -140,7 +140,7 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
                     </section>
 
                     {reworkThemeAllocation.length > 0 && (
-                        <section className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                        <section className="rounded-3xl border border-(--border) bg-(--card) p-5">
                             <h2 className="font-(--font-display) text-xl">Rework by Theme</h2>
                             <p className="mt-1 text-sm text-(--ink-muted)">
                                 Distribution of rework pressure across investment themes in the
@@ -185,7 +185,7 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
                     )}
 
                     <section className="grid gap-6 lg:grid-cols-2">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">
                                     Change Failure Associations
@@ -217,7 +217,7 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
                                                     filters,
                                                     role: activeRole,
                                                 })}
-                                                className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+                                                className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-4 py-2"
                                             >
                                                 <EntityLabel
                                                     id={driver.id}
@@ -237,7 +237,7 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
                             )}
                         </div>
 
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                             <div className="flex items-center justify-between">
                                 <h2 className="font-(--font-display) text-xl">Contributors</h2>
                                 <Link
@@ -261,7 +261,7 @@ export default async function QualityPage({ searchParams }: QualityPageProps) {
                                                 filters,
                                                 role: activeRole,
                                             })}
-                                            className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+                                            className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-4 py-2"
                                         >
                                             <EntityLabel
                                                 id={contributor.id}

--- a/src/app/(app)/reports/[id]/page.tsx
+++ b/src/app/(app)/reports/[id]/page.tsx
@@ -70,7 +70,7 @@ function RenderedReportAndConfig({ report, runs }: { report: SavedReport; runs: 
     return (
         <div className="grid gap-6 lg:grid-cols-3">
             <div className="lg:col-span-2 space-y-6">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                     <h2 className="font-(--font-display) text-xl mb-4">Latest Rendered Report</h2>
                     {latestRun?.renderedMarkdown ? (
                         <MarkdownRenderer content={latestRun.renderedMarkdown} />
@@ -83,7 +83,7 @@ function RenderedReportAndConfig({ report, runs }: { report: SavedReport; runs: 
             </div>
 
             <div className="space-y-6">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                     <h2 className="font-(--font-display) text-xl mb-4">Configuration</h2>
                     <dl className="space-y-4 text-sm">
                         <div>
@@ -130,20 +130,20 @@ function RenderedReportAndConfig({ report, runs }: { report: SavedReport; runs: 
                     </dl>
                 </div>
 
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                     <h2 className="font-(--font-display) text-xl mb-4">Run History</h2>
                     {runs.length > 0 ? (
                         <div className="overflow-x-auto">
                             <table className="w-full text-left text-sm">
                                 <thead>
-                                    <tr className="border-b border-(--card-stroke) text-(--ink-muted)">
+                                    <tr className="border-b border-(--border) text-(--ink-muted)">
                                         <th className="pb-2 font-medium">Date</th>
                                         <th className="pb-2 font-medium">Status</th>
                                         <th className="pb-2 font-medium">Duration</th>
                                         <th className="pb-2 font-medium">Trigger</th>
                                     </tr>
                                 </thead>
-                                <tbody className="divide-y divide-(--card-stroke)">
+                                <tbody className="divide-y divide-(--border)">
                                     {runs.map((run) => (
                                         <tr
                                             key={run.id}
@@ -234,7 +234,7 @@ export default function SingleReportPage() {
                 <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                     <PrimaryNav filters={defaultMetricFilter} active="reports" />
                     <main className="flex min-w-0 flex-1 flex-col gap-8">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-10 text-center">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-10 text-center">
                             <p className="text-(--ink-muted)">Loading report...</p>
                         </div>
                     </main>
@@ -249,11 +249,11 @@ export default function SingleReportPage() {
                 <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                     <PrimaryNav filters={defaultMetricFilter} active="reports" />
                     <main className="flex min-w-0 flex-1 flex-col gap-8">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-10 text-center">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-10 text-center">
                             <p className="text-(--ink-muted)">Report not found.</p>
                             <Link
                                 href="/reports"
-                                className="mt-4 inline-block rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
+                                className="mt-4 inline-block rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
                             >
                                 Back to Reports
                             </Link>
@@ -413,13 +413,13 @@ export default function SingleReportPage() {
                                         type="text"
                                         value={editName}
                                         onChange={(e) => setEditName(e.target.value)}
-                                        className="w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2 font-(--font-display) text-2xl focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                        className="w-full rounded-xl border border-(--border) bg-(--card-70) px-4 py-2 font-(--font-display) text-2xl focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                                     />
                                     <textarea
                                         value={editDescription}
                                         onChange={(e) => setEditDescription(e.target.value)}
                                         rows={2}
-                                        className="w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                        className="w-full rounded-xl border border-(--border) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                                         placeholder="Description"
                                     />
                                     <div className="flex gap-2">
@@ -433,7 +433,7 @@ export default function SingleReportPage() {
                                         <button
                                             onClick={handleEditCancel}
                                             disabled={isSaving}
-                                            className="rounded-full border border-(--card-stroke) px-4 py-1.5 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
+                                            className="rounded-full border border-(--border) px-4 py-1.5 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
                                         >
                                             Cancel
                                         </button>
@@ -454,13 +454,13 @@ export default function SingleReportPage() {
                             <div className="flex items-center gap-3">
                                 <button
                                     onClick={handleEditStart}
-                                    className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
+                                    className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
                                 >
                                     Edit
                                 </button>
                                 <button
                                     onClick={handleCloneStart}
-                                    className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
+                                    className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
                                 >
                                     Clone
                                 </button>
@@ -482,14 +482,14 @@ export default function SingleReportPage() {
                     </header>
 
                     {showCloneDialog && (
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-6">
                             <h2 className="font-(--font-display) text-lg mb-3">Clone Report</h2>
                             <div className="space-y-3 max-w-md">
                                 <input
                                     type="text"
                                     value={cloneName}
                                     onChange={(e) => setCloneName(e.target.value)}
-                                    className="w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                    className="w-full rounded-xl border border-(--border) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                                     placeholder="Name for cloned report"
                                 />
                                 <div className="flex gap-2">
@@ -503,7 +503,7 @@ export default function SingleReportPage() {
                                     <button
                                         onClick={() => setShowCloneDialog(false)}
                                         disabled={isCloning}
-                                        className="rounded-full border border-(--card-stroke) px-4 py-1.5 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
+                                        className="rounded-full border border-(--border) px-4 py-1.5 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
                                     >
                                         Cancel
                                     </button>
@@ -532,7 +532,7 @@ export default function SingleReportPage() {
                                 <button
                                     onClick={() => setShowDeleteConfirm(false)}
                                     disabled={isDeleting}
-                                    className="rounded-full border border-(--card-stroke) px-4 py-1.5 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
+                                    className="rounded-full border border-(--border) px-4 py-1.5 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
                                 >
                                     Cancel
                                 </button>

--- a/src/app/(app)/reports/new/page.tsx
+++ b/src/app/(app)/reports/new/page.tsx
@@ -105,7 +105,7 @@ export default function NewReportPage() {
                         </div>
                     </header>
 
-                    <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-6 md:p-8">
+                    <div className="rounded-3xl border border-(--border) bg-(--card) p-6 md:p-8">
                         <form onSubmit={handleSubmit} className="space-y-8 max-w-2xl">
                             <div className="space-y-4">
                                 <h2 className="font-(--font-display) text-xl">Basic Details</h2>
@@ -120,7 +120,7 @@ export default function NewReportPage() {
                                         required
                                         value={name}
                                         onChange={(e) => setName(e.target.value)}
-                                        className="w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                        className="w-full rounded-xl border border-(--border) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                                         placeholder="e.g., Weekly Engineering Health"
                                     />
                                 </div>
@@ -137,7 +137,7 @@ export default function NewReportPage() {
                                         rows={3}
                                         value={description}
                                         onChange={(e) => setDescription(e.target.value)}
-                                        className="w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                        className="w-full rounded-xl border border-(--border) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                                         placeholder="What is this report for?"
                                     />
                                 </div>
@@ -158,7 +158,7 @@ export default function NewReportPage() {
                                             id="scope"
                                             value={scope}
                                             onChange={(e) => setScope(e.target.value)}
-                                            className="w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                            className="w-full rounded-xl border border-(--border) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                                         >
                                             <option value="org">Organization</option>
                                             <option value="team">Team</option>
@@ -177,7 +177,7 @@ export default function NewReportPage() {
                                             id="dateRange"
                                             value={dateRange}
                                             onChange={(e) => setDateRange(e.target.value)}
-                                            className="w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                            className="w-full rounded-xl border border-(--border) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                                         >
                                             <option value="last_7_days">Last 7 Days</option>
                                             <option value="last_30_days">Last 30 Days</option>
@@ -194,11 +194,11 @@ export default function NewReportPage() {
                                         {AVAILABLE_METRICS.map((metric) => (
                                             <label
                                                 key={metric}
-                                                className="flex items-center gap-2 rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm cursor-pointer hover:border-(--accent) transition-colors"
+                                                className="flex items-center gap-2 rounded-xl border border-(--border) bg-(--card-70) px-4 py-2 text-sm cursor-pointer hover:border-(--accent) transition-colors"
                                             >
                                                 <input
                                                     type="checkbox"
-                                                    className="rounded border-(--card-stroke) text-(--accent) focus:ring-(--accent)"
+                                                    className="rounded border-(--border) text-(--accent) focus:ring-(--accent)"
                                                     checked={selectedMetrics.has(metric)}
                                                     onChange={() => toggleMetric(metric)}
                                                 />
@@ -216,7 +216,7 @@ export default function NewReportPage() {
                                         id="schedule"
                                         value={schedule}
                                         onChange={(e) => setSchedule(e.target.value)}
-                                        className="w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                        className="w-full rounded-xl border border-(--border) bg-(--card-70) px-4 py-2 text-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                                     >
                                         <option value="none">None (Manual only)</option>
                                         <option value="weekly">Weekly</option>
@@ -231,10 +231,10 @@ export default function NewReportPage() {
                                 </div>
                             )}
 
-                            <div className="flex items-center justify-end gap-4 pt-4 border-t border-(--card-stroke)">
+                            <div className="flex items-center justify-end gap-4 pt-4 border-t border-(--border)">
                                 <Link
                                     href="/reports"
-                                    className="rounded-full border border-(--card-stroke) px-6 py-2 text-sm font-medium hover:bg-(--card-70) transition-colors"
+                                    className="rounded-full border border-(--border) px-6 py-2 text-sm font-medium hover:bg-(--card-70) transition-colors"
                                 >
                                     Cancel
                                 </Link>

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -53,13 +53,13 @@ export default async function ReportsPage({ searchParams }: ReportsPageProps) {
 
                     <section className="flex flex-col gap-4">
                         {reports.length === 0 ? (
-                            <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-10 text-center">
+                            <div className="rounded-3xl border border-(--border) bg-(--card) p-10 text-center">
                                 <p className="text-(--ink-muted)">
                                     No saved reports yet. Create your first report to get started.
                                 </p>
                                 <Link
                                     href="/reports/new"
-                                    className="mt-4 inline-block rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
+                                    className="mt-4 inline-block rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em] hover:bg-(--card-70) transition-colors"
                                 >
                                     {CTA_LABELS.createReport}
                                 </Link>
@@ -70,7 +70,7 @@ export default async function ReportsPage({ searchParams }: ReportsPageProps) {
                                     <Link
                                         key={report.id}
                                         href={`/reports/${report.id}`}
-                                        className="group flex flex-col justify-between rounded-3xl border border-(--card-stroke) bg-(--card) p-5 hover:border-(--accent) transition-colors"
+                                        className="group flex flex-col justify-between rounded-3xl border border-(--border) bg-(--card) p-5 hover:border-(--accent) transition-colors"
                                     >
                                         <div>
                                             <div className="flex items-start justify-between gap-2">

--- a/src/app/(app)/security/error.tsx
+++ b/src/app/(app)/security/error.tsx
@@ -17,7 +17,7 @@ export default function SecurityError({
                 action={
                     <button
                         onClick={reset}
-                        className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em] transition hover:bg-(--card-80)"
+                        className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em] transition hover:bg-(--card-80)"
                     >
                         Try again
                     </button>

--- a/src/app/(app)/security/loading.tsx
+++ b/src/app/(app)/security/loading.tsx
@@ -6,7 +6,7 @@ export default function SecurityLoading() {
             <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 {/* Nav skeleton */}
                 <div className="w-full md:max-w-[220px] md:shrink-0">
-                    <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-4">
+                    <div className="rounded-3xl border border-(--border) bg-(--card-80) p-4">
                         <SkeletonLine height="h-4" width="w-3/4" />
                         <SkeletonLine height="h-6" width="w-1/2" />
                         <div className="mt-4 space-y-2">
@@ -30,7 +30,7 @@ export default function SecurityLoading() {
                         {Array.from({ length: 4 }).map((_, i) => (
                             <div
                                 key={i}
-                                className="flex flex-col gap-2 rounded-2xl border border-(--card-stroke) bg-card px-5 py-4"
+                                className="flex flex-col gap-2 rounded-2xl border border-(--border) bg-card px-5 py-4"
                             >
                                 <SkeletonLine height="h-3" width="w-1/2" />
                                 <SkeletonLine height="h-8" width="w-1/3" />
@@ -40,25 +40,25 @@ export default function SecurityLoading() {
 
                     {/* Charts skeleton */}
                     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                        <div className="rounded-2xl border border-(--card-stroke) bg-card p-4">
+                        <div className="rounded-2xl border border-(--border) bg-card p-4">
                             <SkeletonLine height="h-48" />
                         </div>
-                        <div className="rounded-2xl border border-(--card-stroke) bg-card p-4">
+                        <div className="rounded-2xl border border-(--border) bg-card p-4">
                             <SkeletonLine height="h-48" />
                         </div>
                     </div>
 
                     {/* Trend chart skeleton */}
-                    <div className="rounded-2xl border border-(--card-stroke) bg-card p-4">
+                    <div className="rounded-2xl border border-(--border) bg-card p-4">
                         <SkeletonLine height="h-64" />
                     </div>
 
                     {/* Table skeleton */}
-                    <div className="rounded-2xl border border-(--card-stroke) bg-card">
+                    <div className="rounded-2xl border border-(--border) bg-card">
                         <div className="p-4">
                             <SkeletonLine height="h-10" />
                         </div>
-                        <div className="divide-y divide-(--card-stroke)">
+                        <div className="divide-y divide-(--border)">
                             {Array.from({ length: 8 }).map((_, i) => (
                                 <div key={i} className="flex gap-3 px-3 py-3">
                                     <SkeletonLine height="h-5" width="w-16" />

--- a/src/app/(app)/superadmin/audit/page.tsx
+++ b/src/app/(app)/superadmin/audit/page.tsx
@@ -75,7 +75,7 @@ export default function AuditLogPage() {
                             type="button"
                             onClick={handlePrevPage}
                             disabled={offset === 0}
-                            className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
+                            className="rounded-lg border border-(--border) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                         >
                             Previous
                         </button>
@@ -86,7 +86,7 @@ export default function AuditLogPage() {
                             type="button"
                             onClick={handleNextPage}
                             disabled={logs.length < limit}
-                            className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
+                            className="rounded-lg border border-(--border) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                         >
                             Next
                         </button>

--- a/src/app/(app)/superadmin/orgs/[id]/page.tsx
+++ b/src/app/(app)/superadmin/orgs/[id]/page.tsx
@@ -36,7 +36,7 @@ export default async function OrgDetailPage({ params }: PageProps) {
                 {membersError ? (
                     <div className="text-red-500">Error loading members: {membersError}</div>
                 ) : (
-                    <div className="overflow-x-auto rounded-lg border border-(--card-stroke)">
+                    <div className="overflow-x-auto rounded-lg border border-(--border)">
                         <table className="w-full text-left text-sm">
                             <thead className="bg-(--card-70) text-(--ink-muted)">
                                 <tr>
@@ -45,7 +45,7 @@ export default async function OrgDetailPage({ params }: PageProps) {
                                     <th className="px-4 py-3 font-medium">Joined</th>
                                 </tr>
                             </thead>
-                            <tbody className="divide-y divide-(--card-stroke)">
+                            <tbody className="divide-y divide-(--border)">
                                 {members?.map((member) => (
                                     <tr key={member.id}>
                                         <td className="px-4 py-3 font-mono text-xs">

--- a/src/app/(app)/superadmin/page.tsx
+++ b/src/app/(app)/superadmin/page.tsx
@@ -33,7 +33,7 @@ export default async function SuperadminDashboard() {
             {/* Key Metrics Grid */}
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
                 {/* Organizations */}
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <div className="text-sm font-medium text-(--ink-muted)">
                         Total Organizations
                     </div>
@@ -46,7 +46,7 @@ export default async function SuperadminDashboard() {
                 </div>
 
                 {/* Users */}
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <div className="text-sm font-medium text-(--ink-muted)">Total Users</div>
                     <div className="mt-2 text-3xl font-bold text-foreground">
                         {stats.total_users}
@@ -57,7 +57,7 @@ export default async function SuperadminDashboard() {
                 </div>
 
                 {/* Superusers */}
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <div className="text-sm font-medium text-(--ink-muted)">Superusers</div>
                     <div className="mt-2 text-3xl font-bold text-purple-500">
                         {stats.superuser_count}
@@ -66,7 +66,7 @@ export default async function SuperadminDashboard() {
                 </div>
 
                 {/* Memberships */}
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <div className="text-sm font-medium text-(--ink-muted)">Total Memberships</div>
                     <div className="mt-2 text-3xl font-bold text-foreground">
                         {stats.total_memberships}
@@ -77,7 +77,7 @@ export default async function SuperadminDashboard() {
 
             <div className="grid gap-6 lg:grid-cols-2">
                 {/* Tier Distribution */}
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <h3 className="mb-4 text-lg font-semibold text-foreground">
                         Tier Distribution
                     </h3>
@@ -100,7 +100,7 @@ export default async function SuperadminDashboard() {
                 </div>
 
                 {/* Sync Health */}
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
                     <h3 className="mb-4 text-lg font-semibold text-foreground">Sync Health</h3>
 
                     <div className="grid gap-4 sm:grid-cols-2">

--- a/src/app/(app)/superadmin/product-telemetry/[orgId]/page.tsx
+++ b/src/app/(app)/superadmin/product-telemetry/[orgId]/page.tsx
@@ -47,7 +47,7 @@ export default async function ProductTelemetryOrgDashboardPage({
         <div className="space-y-6">
             <Link
                 href={backHref}
-                className="inline-flex w-fit items-center rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em] text-(--ink-muted) transition-colors hover:border-(--ink-muted) hover:text-foreground"
+                className="inline-flex w-fit items-center rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em] text-(--ink-muted) transition-colors hover:border-(--ink-muted) hover:text-foreground"
             >
                 ← Back to all orgs
             </Link>

--- a/src/app/(app)/superadmin/settings/page.tsx
+++ b/src/app/(app)/superadmin/settings/page.tsx
@@ -41,7 +41,7 @@ export default async function SettingsPage() {
                         {settings.length === 0 ? (
                             <div className="text-sm text-(--ink-muted)">No settings found.</div>
                         ) : (
-                            <div className="overflow-x-auto rounded-lg border border-(--card-stroke)">
+                            <div className="overflow-x-auto rounded-lg border border-(--border)">
                                 <table className="w-full text-left text-sm">
                                     <thead className="bg-(--card-70) text-(--ink-muted)">
                                         <tr>
@@ -50,7 +50,7 @@ export default async function SettingsPage() {
                                             <th className="px-4 py-3 font-medium">Description</th>
                                         </tr>
                                     </thead>
-                                    <tbody className="divide-y divide-(--card-stroke)">
+                                    <tbody className="divide-y divide-(--border)">
                                         {settings.map((setting) => (
                                             <tr key={setting.key}>
                                                 <td className="px-4 py-3 font-mono text-xs">
@@ -73,7 +73,7 @@ export default async function SettingsPage() {
                     </SettingsSection>
                 ))}
 
-                <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-center">
+                <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) p-6 text-center">
                     <p className="text-sm text-(--ink-muted)">
                         To edit these settings, please use the{" "}
                         <Link href="/admin/settings" className="text-(--accent) hover:underline">

--- a/src/app/(app)/superadmin/users/page.tsx
+++ b/src/app/(app)/superadmin/users/page.tsx
@@ -38,11 +38,11 @@ export default async function UsersPage({ searchParams }: UsersPageProps) {
                             type="search"
                             defaultValue={query}
                             placeholder="Search users..."
-                            className="w-64 rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                            className="w-64 rounded-xl border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                         />
                         <button
                             type="submit"
-                            className="inline-flex items-center rounded-xl border border-(--card-stroke) px-3 py-2 text-sm font-medium text-foreground hover:bg-(--card-70)"
+                            className="inline-flex items-center rounded-xl border border-(--border) px-3 py-2 text-sm font-medium text-foreground hover:bg-(--card-70)"
                         >
                             Search
                         </button>

--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -228,7 +228,7 @@ export default async function CoveragePage({
 								/>
 							</div>
 						</ChartFrame>
-						<div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+						<div className="rounded-3xl border border-(--border) bg-(--card) p-5">
 							<h2 className="font-(--font-display) text-xl mb-4">
 								Coverage by Repository
 							</h2>

--- a/src/app/(app)/testops/page.tsx
+++ b/src/app/(app)/testops/page.tsx
@@ -133,7 +133,7 @@ export default async function TestOpsPage({ searchParams }: TestOpsPageProps) {
                     <GlobalContextBar filters={filters} />
                     <FilterBar view="testops" />
 
-                    <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                    <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                         <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                             TestOps summary
                         </p>

--- a/src/app/(app)/testops/pipelines/page.tsx
+++ b/src/app/(app)/testops/pipelines/page.tsx
@@ -205,7 +205,7 @@ export default async function PipelinesPage({ searchParams }: PipelinesPageProps
                                 <TimeseriesChart data={timeseriesData} valueFormat="percent" />
                             </div>
                         </ChartFrame>
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                             <h2 className="font-(--font-display) text-xl mb-4">Failure Patterns</h2>
                             {failurePatterns.isEmpty ? (
                                 <DataState

--- a/src/app/(app)/testops/risk/page.tsx
+++ b/src/app/(app)/testops/risk/page.tsx
@@ -166,7 +166,7 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
                         </div>
                         <Link
                             href={withFilterParam("/", filters, activeRole)}
-                            className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                            className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                         >
                             {CTA_LABELS.backToCockpit}
                         </Link>
@@ -211,13 +211,13 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
                     </section>
 
                     <section className="grid gap-6 lg:grid-cols-2">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                             <h2 className="font-(--font-display) text-xl mb-4">Risk Trend</h2>
                             <div className="h-64">
                                 <TimeseriesChart data={timeseriesData} valueFormat="percent" />
                             </div>
                         </div>
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                             <h2 className="font-(--font-display) text-xl mb-4">
                                 Quality Drag Breakdown
                             </h2>
@@ -231,7 +231,7 @@ export default async function RiskPage({ searchParams }: RiskPageProps) {
                         </div>
                     </section>
 
-                    <section className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                    <section className="rounded-3xl border border-(--border) bg-(--card) p-5">
                         <h2 className="font-(--font-display) text-xl mb-4">
                             Risk vs Throughput (by Repo)
                         </h2>

--- a/src/app/(app)/testops/tests/page.tsx
+++ b/src/app/(app)/testops/tests/page.tsx
@@ -188,13 +188,13 @@ export default async function TestsPage({ searchParams }: TestsPageProps) {
                     </section>
 
                     <section className="grid gap-6 lg:grid-cols-2">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                             <h2 className="font-(--font-display) text-xl mb-4">Pass Rate Trend</h2>
                             <div className="h-64">
                                 <TimeseriesChart data={timeseriesData} />
                             </div>
                         </div>
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                        <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                             <h2 className="font-(--font-display) text-xl mb-4">
                                 Flaky Test Patterns
                             </h2>

--- a/src/app/(app)/work/loading.tsx
+++ b/src/app/(app)/work/loading.tsx
@@ -56,7 +56,7 @@ export default function Loading() {
                         {Array.from({ length: 4 }).map((_, i) => (
                             <div
                                 key={i}
-                                className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 space-y-3"
+                                className="rounded-3xl border border-(--border) bg-(--card) p-5 space-y-3"
                             >
                                 <div className="h-3 bg-(--card-70) rounded w-20" />
                                 <div className="h-8 bg-(--card-70) rounded w-14" />

--- a/src/app/(auth)/auth/forgot-password/page.tsx
+++ b/src/app/(auth)/auth/forgot-password/page.tsx
@@ -18,7 +18,7 @@ export default function ForgotPasswordPage() {
                     </p>
                 </div>
 
-                <div className="mt-8 bg-[var(--card)] py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-[var(--card-stroke)]">
+                <div className="mt-8 bg-[var(--card)] py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-[var(--border)]">
                     <ForgotPasswordForm />
                 </div>
             </div>

--- a/src/app/(auth)/auth/onboard/page.tsx
+++ b/src/app/(auth)/auth/onboard/page.tsx
@@ -30,7 +30,7 @@ export default async function OnboardPage({ searchParams }: { searchParams: Sear
                         Create your organization to get started
                     </p>
                 </div>
-                <div className="mt-8 bg-[var(--card)] py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-[var(--card-stroke)]">
+                <div className="mt-8 bg-[var(--card)] py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-[var(--border)]">
                     <OnboardForm plan={plan} trialIntent={trialIntent} />
                 </div>
             </div>

--- a/src/app/(auth)/auth/reset-password/page.tsx
+++ b/src/app/(auth)/auth/reset-password/page.tsx
@@ -21,7 +21,7 @@ export default async function ResetPasswordPage({ searchParams }: { searchParams
                     </h2>
                 </div>
 
-                <div className="mt-8 bg-[var(--card)] py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-[var(--card-stroke)]">
+                <div className="mt-8 bg-[var(--card)] py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-[var(--border)]">
                     {!token ? (
                         <div className="space-y-6">
                             <div className="p-4 text-sm text-red-400 bg-red-950/50 rounded-md border border-red-800 text-center">

--- a/src/app/(auth)/auth/verify/page.tsx
+++ b/src/app/(auth)/auth/verify/page.tsx
@@ -46,7 +46,7 @@ export default async function VerifyEmailPage({ searchParams }: { searchParams: 
                         Email Verification
                     </h2>
                 </div>
-                <div className="mt-8 bg-[var(--card)] py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-[var(--card-stroke)]">
+                <div className="mt-8 bg-[var(--card)] py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-[var(--border)]">
                     {success ? (
                         <div className="space-y-6">
                             <div className="p-4 text-sm text-green-400 bg-green-950/50 rounded-md border border-green-800 text-center">

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -34,7 +34,7 @@ export default function AuthLayout({
                         </div>
                     </Link>
                     <div className="flex items-center gap-1.5">
-                        <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
+                        <span className="rounded-full border border-(--border) bg-(--card-70) px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
                             OSS
                         </span>
                         <BetaBadge />

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -196,7 +196,7 @@ export default function MarketingPage() {
                         </Link>
                         <Link
                             href="https://github.com/full-chaos/dev-health-ops"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             View on GitHub
                         </Link>
@@ -205,8 +205,8 @@ export default function MarketingPage() {
 
                 {/* Mock dashboard preview */}
                 <div className="mx-auto mt-16 max-w-5xl">
-                    <div className="overflow-hidden rounded-3xl border border-(--card-stroke) bg-(--card-80) shadow-[0_20px_60px_-40px_rgba(0,0,0,0.4)]">
-                        <div className="border-b border-(--card-stroke) px-4 py-3">
+                    <div className="overflow-hidden rounded-3xl border border-(--border) bg-(--card-80) shadow-[0_20px_60px_-40px_rgba(0,0,0,0.4)]">
+                        <div className="border-b border-(--border) px-4 py-3">
                             <div className="flex items-center gap-2">
                                 <div className="size-3 rounded-full bg-(--card-stroke)" />
                                 <div className="size-3 rounded-full bg-(--card-stroke)" />
@@ -220,7 +220,7 @@ export default function MarketingPage() {
                             {["DORA", "Flow", "Quality"].map((tab) => (
                                 <div
                                     key={tab}
-                                    className="rounded-2xl border border-(--card-stroke) bg-(--card) p-4"
+                                    className="rounded-2xl border border-(--border) bg-(--card) p-4"
                                 >
                                     <p className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
                                         {tab}
@@ -262,7 +262,7 @@ export default function MarketingPage() {
                     {FEATURES.map((feature) => (
                         <div
                             key={feature.label}
-                            className="group rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 transition hover:-translate-y-1"
+                            className="group rounded-3xl border border-(--border) bg-(--card-80) p-6 transition hover:-translate-y-1"
                         >
                             <div className="flex items-center gap-3">
                                 <div className="flex size-9 items-center justify-center rounded-xl bg-(--accent)/10 text-(--accent)">
@@ -283,7 +283,7 @@ export default function MarketingPage() {
 
             {/* How it works */}
             <section id="how-it-works" className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 sm:p-12">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         How it works
                     </p>
@@ -333,7 +333,7 @@ export default function MarketingPage() {
                     {PERSONAS.map((persona) => (
                         <div
                             key={persona.tag}
-                            className="group rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 transition hover:-translate-y-1"
+                            className="group rounded-3xl border border-(--border) bg-(--card-80) p-6 transition hover:-translate-y-1"
                         >
                             <div className="flex items-center justify-between">
                                 <span className="rounded-full bg-(--accent)/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-(--accent)">
@@ -354,7 +354,7 @@ export default function MarketingPage() {
 
             {/* CTA */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 text-center sm:p-12">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         Open source
                     </p>
@@ -375,7 +375,7 @@ export default function MarketingPage() {
                         </Link>
                         <Link
                             href="https://github.com/full-chaos/dev-health-ops"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             Star on GitHub
                         </Link>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -34,7 +34,7 @@ export default function Error({ error, reset }: ErrorProps) {
                 </p>
                 <button
                     onClick={reset}
-                    className="rounded-full border border-(--card-stroke) px-6 py-2.5 text-xs uppercase tracking-[0.2em] hover:border-(--accent) transition"
+                    className="rounded-full border border-(--border) px-6 py-2.5 text-xs uppercase tracking-[0.2em] hover:border-(--accent) transition"
                 >
                     Try again
                 </button>

--- a/src/app/marketing/about/page.tsx
+++ b/src/app/marketing/about/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function AboutPage() {
     return (
         <section className="mx-auto max-w-5xl px-6 pb-24 pt-16 sm:pt-24">
-            <div className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-8 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.45)] sm:p-12">
+            <div className="rounded-[2rem] border border-(--border) bg-(--card-80) p-8 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.45)] sm:p-12">
                 <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                     About Dev Health
                 </p>

--- a/src/app/marketing/cto-architecture/page.tsx
+++ b/src/app/marketing/cto-architecture/page.tsx
@@ -162,7 +162,7 @@ export default function CTOArchitecturePage() {
                         </Link>
                         <Link
                             href="/marketing/pricing"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             See pricing
                         </Link>
@@ -190,7 +190,7 @@ export default function CTOArchitecturePage() {
                                         {surface.icon}
                                     </div>
                                     {surface.comingSoon && (
-                                        <span className="rounded-full border border-(--card-stroke) bg-(--card) px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
+                                        <span className="rounded-full border border-(--border) bg-(--card) px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
                                             Coming soon
                                         </span>
                                     )}
@@ -207,7 +207,7 @@ export default function CTOArchitecturePage() {
                             return (
                                 <div
                                     key={surface.title}
-                                    className="block rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 opacity-90"
+                                    className="block rounded-3xl border border-(--border) bg-(--card-80) p-6 opacity-90"
                                     aria-disabled="true"
                                 >
                                     {cardInner}
@@ -218,7 +218,7 @@ export default function CTOArchitecturePage() {
                             <Link
                                 key={surface.title}
                                 href={surface.href}
-                                className="group block rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 transition hover:-translate-y-1"
+                                className="group block rounded-3xl border border-(--border) bg-(--card-80) p-6 transition hover:-translate-y-1"
                             >
                                 {cardInner}
                             </Link>
@@ -229,7 +229,7 @@ export default function CTOArchitecturePage() {
 
             {/* No surveillance, just signal — canonical section, identical across all buyer pages */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 sm:p-12">
                     <div className="mx-auto max-w-3xl text-center">
                         <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                             Our posture
@@ -274,7 +274,7 @@ export default function CTOArchitecturePage() {
                         ].map((pillar) => (
                             <li
                                 key={pillar.id}
-                                className="rounded-2xl border border-(--card-stroke) bg-(--card) p-5"
+                                className="rounded-2xl border border-(--border) bg-(--card) p-5"
                             >
                                 <p className="font-(--font-display) text-base">{pillar.title}</p>
                                 <p className="mt-2 text-sm leading-relaxed text-(--ink-muted)">
@@ -292,7 +292,7 @@ export default function CTOArchitecturePage() {
 
             {/* CTA */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 text-center sm:p-12">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         Open source
                     </p>
@@ -313,7 +313,7 @@ export default function CTOArchitecturePage() {
                         </Link>
                         <Link
                             href="https://github.com/full-chaos/dev-health-ops"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             Star on GitHub
                         </Link>

--- a/src/app/marketing/engineering-manager/page.tsx
+++ b/src/app/marketing/engineering-manager/page.tsx
@@ -167,7 +167,7 @@ export default function EngineeringManagerPage() {
                         </Link>
                         <Link
                             href="/marketing/pricing"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             See pricing
                         </Link>
@@ -200,7 +200,7 @@ export default function EngineeringManagerPage() {
                                         </p>
                                     </div>
                                     {feature.comingSoon && (
-                                        <span className="rounded-full border border-(--card-stroke) bg-(--card) px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
+                                        <span className="rounded-full border border-(--border) bg-(--card) px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
                                             Coming soon
                                         </span>
                                     )}
@@ -217,7 +217,7 @@ export default function EngineeringManagerPage() {
                             return (
                                 <div
                                     key={feature.label}
-                                    className="block rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 opacity-90"
+                                    className="block rounded-3xl border border-(--border) bg-(--card-80) p-6 opacity-90"
                                     aria-disabled="true"
                                 >
                                     {cardInner}
@@ -228,7 +228,7 @@ export default function EngineeringManagerPage() {
                             <Link
                                 key={feature.label}
                                 href={feature.href}
-                                className="group block rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 transition hover:-translate-y-1 hover:border-(--accent)/50"
+                                className="group block rounded-3xl border border-(--border) bg-(--card-80) p-6 transition hover:-translate-y-1 hover:border-(--accent)/50"
                             >
                                 {cardInner}
                             </Link>
@@ -239,7 +239,7 @@ export default function EngineeringManagerPage() {
 
             {/* No surveillance, just signal — canonical section, identical across all buyer pages */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 sm:p-12">
                     <div className="mx-auto max-w-3xl text-center">
                         <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                             Our posture
@@ -284,7 +284,7 @@ export default function EngineeringManagerPage() {
                         ].map((pillar) => (
                             <li
                                 key={pillar.id}
-                                className="rounded-2xl border border-(--card-stroke) bg-(--card) p-5"
+                                className="rounded-2xl border border-(--border) bg-(--card) p-5"
                             >
                                 <p className="font-(--font-display) text-base">{pillar.title}</p>
                                 <p className="mt-2 text-sm leading-relaxed text-(--ink-muted)">
@@ -302,7 +302,7 @@ export default function EngineeringManagerPage() {
 
             {/* Final CTA */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 text-center sm:p-12">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         Open source
                     </p>
@@ -323,7 +323,7 @@ export default function EngineeringManagerPage() {
                         </Link>
                         <Link
                             href="https://github.com/full-chaos/dev-health-ops"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             Star on GitHub
                         </Link>

--- a/src/app/marketing/page.tsx
+++ b/src/app/marketing/page.tsx
@@ -76,7 +76,7 @@ export default function MarketingHubPage() {
                         <Link
                             key={buyer.slug}
                             href={`/marketing/${buyer.slug}`}
-                            className="group block rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 transition hover:-translate-y-1 hover:border-(--accent)/50"
+                            className="group block rounded-3xl border border-(--border) bg-(--card-80) p-8 transition hover:-translate-y-1 hover:border-(--accent)/50"
                         >
                             <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
                                 {buyer.eyebrow}
@@ -101,7 +101,7 @@ export default function MarketingHubPage() {
 
             {/* No surveillance pillar (compact form, links to full buyer pages) */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 text-center sm:p-12">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         Our posture
                     </p>
@@ -120,7 +120,7 @@ export default function MarketingHubPage() {
 
             {/* CTA */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 text-center sm:p-12">
                     <h2 className="font-(--font-display) text-3xl sm:text-4xl">
                         Ready to see where your effort is going?
                     </h2>
@@ -138,7 +138,7 @@ export default function MarketingHubPage() {
                         </Link>
                         <Link
                             href="/marketing/pricing"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             See pricing
                         </Link>

--- a/src/app/marketing/platform-devex/page.tsx
+++ b/src/app/marketing/platform-devex/page.tsx
@@ -160,7 +160,7 @@ export default function PlatformDevexPage() {
                         </Link>
                         <Link
                             href="/marketing/pricing"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             See pricing
                         </Link>
@@ -184,7 +184,7 @@ export default function PlatformDevexPage() {
                                         </p>
                                     </div>
                                     {surface.comingSoon && (
-                                        <span className="rounded-full border border-(--card-stroke) bg-(--card) px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
+                                        <span className="rounded-full border border-(--border) bg-(--card) px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
                                             Coming soon
                                         </span>
                                     )}
@@ -201,7 +201,7 @@ export default function PlatformDevexPage() {
                             return (
                                 <div
                                     key={surface.label}
-                                    className="block rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 opacity-90"
+                                    className="block rounded-3xl border border-(--border) bg-(--card-80) p-6 opacity-90"
                                     aria-disabled="true"
                                 >
                                     {cardInner}
@@ -212,7 +212,7 @@ export default function PlatformDevexPage() {
                             <Link
                                 key={surface.label}
                                 href={surface.href}
-                                className="group block rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 transition hover:-translate-y-1"
+                                className="group block rounded-3xl border border-(--border) bg-(--card-80) p-6 transition hover:-translate-y-1"
                             >
                                 {cardInner}
                             </Link>
@@ -223,7 +223,7 @@ export default function PlatformDevexPage() {
 
             {/* No surveillance, just signal — canonical section, identical across all buyer pages */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 sm:p-12">
                     <div className="mx-auto max-w-3xl text-center">
                         <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                             Our posture
@@ -268,7 +268,7 @@ export default function PlatformDevexPage() {
                         ].map((pillar) => (
                             <li
                                 key={pillar.id}
-                                className="rounded-2xl border border-(--card-stroke) bg-(--card) p-5"
+                                className="rounded-2xl border border-(--border) bg-(--card) p-5"
                             >
                                 <p className="font-(--font-display) text-base">{pillar.title}</p>
                                 <p className="mt-2 text-sm leading-relaxed text-(--ink-muted)">
@@ -286,7 +286,7 @@ export default function PlatformDevexPage() {
 
             {/* Final CTA */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 text-center sm:p-12">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         Open source
                     </p>
@@ -309,7 +309,7 @@ export default function PlatformDevexPage() {
                             href="https://github.com/full-chaos/dev-health-ops"
                             target="_blank"
                             rel="noopener"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             Star on GitHub
                         </a>

--- a/src/app/marketing/pricing/page.tsx
+++ b/src/app/marketing/pricing/page.tsx
@@ -287,7 +287,7 @@ export default async function PricingPage() {
                             className={`rounded-3xl border p-6 transition ${
                                 tier.highlighted
                                     ? "relative border-(--accent) bg-(--card-80) shadow-[0_8px_40px_-12px_rgba(103,80,164,0.3)] sm:-mt-4 sm:p-8"
-                                    : "border-(--card-stroke) bg-(--card-80)"
+                                    : "border-(--border) bg-(--card-80)"
                             }`}
                         >
                             {tier.highlighted && (
@@ -342,7 +342,7 @@ export default async function PricingPage() {
                                         className={`block w-full rounded-full py-3 text-center text-sm font-medium transition ${
                                             tier.highlighted
                                                 ? "bg-(--accent) text-white hover:opacity-90"
-                                                : "border border-(--card-stroke) bg-(--card-70) hover:border-foreground/30"
+                                                : "border border-(--border) bg-(--card-70) hover:border-foreground/30"
                                         }`}
                                     >
                                         {tier.cta}
@@ -353,7 +353,7 @@ export default async function PricingPage() {
                                         className={`block w-full rounded-full py-3 text-center text-sm font-medium transition ${
                                             tier.highlighted
                                                 ? "bg-(--accent) text-white hover:opacity-90"
-                                                : "border border-(--card-stroke) bg-(--card-70) hover:border-foreground/30"
+                                                : "border border-(--border) bg-(--card-70) hover:border-foreground/30"
                                         }`}
                                     >
                                         {tier.cta}
@@ -367,7 +367,7 @@ export default async function PricingPage() {
 
             {/* Comparison Table */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 sm:p-12">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         Compare plans
                     </p>
@@ -378,7 +378,7 @@ export default async function PricingPage() {
                     <div className="mt-10 overflow-x-auto">
                         <table className="w-full text-sm">
                             <thead>
-                                <tr className="border-b border-(--card-stroke)">
+                                <tr className="border-b border-(--border)">
                                     <th className="pb-4 pr-4 text-left text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                                         Feature
                                     </th>
@@ -395,10 +395,7 @@ export default async function PricingPage() {
                             </thead>
                             <tbody>
                                 {COMPARISON.map((row) => (
-                                    <tr
-                                        key={row.feature}
-                                        className="border-b border-(--card-stroke)/50"
-                                    >
+                                    <tr key={row.feature} className="border-b border-(--border)/50">
                                         <td className="py-4 pr-4 text-sm">{row.feature}</td>
                                         <td className="py-4 px-4 text-center">
                                             <span className="inline-flex justify-center">
@@ -425,7 +422,7 @@ export default async function PricingPage() {
 
             {/* CTA */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 text-center sm:p-12">
                     <h2 className="font-(--font-display) text-3xl sm:text-4xl">
                         Ready to understand your engineering effort?
                     </h2>
@@ -442,7 +439,7 @@ export default async function PricingPage() {
                         </Link>
                         <a
                             href="mailto:support@fullchaos.studio"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             Talk to sales
                         </a>

--- a/src/app/marketing/vp-engineering/page.tsx
+++ b/src/app/marketing/vp-engineering/page.tsx
@@ -165,7 +165,7 @@ export default function VPEngineeringPage() {
                         </Link>
                         <Link
                             href="/marketing/pricing"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             See pricing
                         </Link>
@@ -197,7 +197,7 @@ export default function VPEngineeringPage() {
                                         </p>
                                     </div>
                                     {surface.comingSoon && (
-                                        <span className="rounded-full border border-(--card-stroke) bg-(--card) px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
+                                        <span className="rounded-full border border-(--border) bg-(--card) px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
                                             Coming soon
                                         </span>
                                     )}
@@ -214,7 +214,7 @@ export default function VPEngineeringPage() {
                             return (
                                 <div
                                     key={surface.label}
-                                    className="block rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 opacity-90"
+                                    className="block rounded-3xl border border-(--border) bg-(--card-80) p-6 opacity-90"
                                     aria-disabled="true"
                                 >
                                     {cardInner}
@@ -225,7 +225,7 @@ export default function VPEngineeringPage() {
                             <Link
                                 key={surface.label}
                                 href={surface.href}
-                                className="group block rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 transition hover:-translate-y-1"
+                                className="group block rounded-3xl border border-(--border) bg-(--card-80) p-6 transition hover:-translate-y-1"
                             >
                                 {cardInner}
                             </Link>
@@ -236,7 +236,7 @@ export default function VPEngineeringPage() {
 
             {/* No surveillance, just signal — canonical section, identical across all buyer pages */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 sm:p-12">
                     <div className="mx-auto max-w-3xl text-center">
                         <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                             Our posture
@@ -281,7 +281,7 @@ export default function VPEngineeringPage() {
                         ].map((pillar) => (
                             <li
                                 key={pillar.id}
-                                className="rounded-2xl border border-(--card-stroke) bg-(--card) p-5"
+                                className="rounded-2xl border border-(--border) bg-(--card) p-5"
                             >
                                 <p className="font-(--font-display) text-base">{pillar.title}</p>
                                 <p className="mt-2 text-sm leading-relaxed text-(--ink-muted)">
@@ -299,7 +299,7 @@ export default function VPEngineeringPage() {
 
             {/* CTA */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-8 text-center sm:p-12">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         Open source
                     </p>
@@ -322,7 +322,7 @@ export default function VPEngineeringPage() {
                             href="https://github.com/full-chaos/dev-health-ops"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                            className="rounded-full border border-(--border) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             Star on GitHub
                         </Link>

--- a/src/components/NoSurveillanceContract.tsx
+++ b/src/components/NoSurveillanceContract.tsx
@@ -20,7 +20,7 @@ type NoSurveillanceContractProps = {
 export function NoSurveillanceContract({ compact = false }: NoSurveillanceContractProps) {
     return (
         <section
-            className={`rounded-3xl border border-(--card-stroke) bg-(--card-80) ${
+            className={`rounded-3xl border border-(--border) bg-(--card-80) ${
                 compact ? "p-5" : "p-6"
             }`}
             data-testid="no-surveillance-contract"
@@ -39,7 +39,7 @@ export function NoSurveillanceContract({ compact = false }: NoSurveillanceContra
                 {CONTRACT_ITEMS.map((item) => (
                     <article
                         key={item.title}
-                        className="rounded-2xl border border-(--card-stroke) bg-card px-4 py-3"
+                        className="rounded-2xl border border-(--border) bg-card px-4 py-3"
                     >
                         <h3 className="text-sm font-semibold text-(--foreground)">{item.title}</h3>
                         <p className="mt-2 text-xs leading-5 text-(--ink-muted)">{item.body}</p>

--- a/src/components/RoleSelectorWrapper.tsx
+++ b/src/components/RoleSelectorWrapper.tsx
@@ -21,7 +21,7 @@ export function RoleSelectorWithSuspense({ className }: { className?: string }) 
                         {["IC", "EM", "PM", "Leadership"].map((label) => (
                             <span
                                 key={label}
-                                className="rounded-full border border-(--card-stroke) bg-(--card-80) px-3 py-1.5 text-xs font-medium uppercase tracking-[0.15em] text-(--ink-muted)"
+                                className="rounded-full border border-(--border) bg-(--card-80) px-3 py-1.5 text-xs font-medium uppercase tracking-[0.15em] text-(--ink-muted)"
                             >
                                 {label}
                             </span>

--- a/src/components/ServiceUnavailable.tsx
+++ b/src/components/ServiceUnavailable.tsx
@@ -12,7 +12,7 @@ export function ServiceUnavailable() {
                 <p className="text-sm text-(--ink-muted)">
                     The API status check failed. The API must be available to load this view.
                 </p>
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 text-sm text-(--ink-muted)">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-6 text-sm text-(--ink-muted)">
                     <p>Quick checks:</p>
                     <ul className="mt-2 list-disc space-y-1 pl-4">
                         <li>API at {config.api.baseUrl}</li>
@@ -20,7 +20,7 @@ export function ServiceUnavailable() {
                 </div>
                 <Link
                     href="/dashboard"
-                    className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+                    className="rounded-full border border-(--border) px-4 py-2 text-xs uppercase tracking-[0.2em]"
                 >
                     Retry
                 </Link>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -141,7 +141,7 @@ export function ThemeToggle() {
 
     return (
         <div
-            className={`group inline-flex items-center gap-2 rounded-full border border-(--card-stroke) bg-(--card-80) p-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted) shadow-[0_12px_30px_-20px_rgba(0,0,0,0.45)] transition-all duration-300 ${
+            className={`group inline-flex items-center gap-2 rounded-full border border-(--border) bg-(--card-80) p-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted) shadow-[0_12px_30px_-20px_rgba(0,0,0,0.45)] transition-all duration-300 ${
                 isCollapsed ? "w-10 overflow-hidden" : "px-3 py-2"
             }`}
         >
@@ -166,7 +166,7 @@ export function ThemeToggle() {
                         type="button"
                         onClick={handleToggle}
                         aria-label="Toggle light/dark"
-                        className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-foreground transition hover:-translate-y-0.5"
+                        className="rounded-full border border-(--border) bg-(--card-70) px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-foreground transition hover:-translate-y-0.5"
                     >
                         {theme === "dark" ? "Dark" : "Light"}
                     </button>

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -69,7 +69,7 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
     return (
         <aside className="w-full md:max-w-[220px] md:shrink-0">
             <div className="md:sticky md:top-6">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                     <div>
                         <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                             Full Chaos Dev Health Ops
@@ -123,7 +123,7 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                             </Link>
                         )}
                     </nav>
-                    <div className="mt-5 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-3 py-3 text-xs text-(--ink-muted)">
+                    <div className="mt-5 rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-3 py-3 text-xs text-(--ink-muted)">
                         Return to{" "}
                         <Link href="/dashboard" className="underline hover:text-foreground">
                             main app

--- a/src/components/admin/billing/AuditDetailPanel.tsx
+++ b/src/components/admin/billing/AuditDetailPanel.tsx
@@ -39,10 +39,10 @@ function StateDiff({
     }
 
     return (
-        <div className="overflow-auto rounded-xl border border-(--card-stroke) bg-(--card-70)">
+        <div className="overflow-auto rounded-xl border border-(--border) bg-(--card-70)">
             <table className="w-full text-left text-xs">
                 <thead>
-                    <tr className="border-b border-(--card-stroke)">
+                    <tr className="border-b border-(--border)">
                         <th className="p-2 font-medium">Field</th>
                         <th className="p-2 font-medium">Local</th>
                         <th className="p-2 font-medium">Stripe</th>
@@ -59,7 +59,7 @@ function StateDiff({
                         return (
                             <tr
                                 key={key}
-                                className={`border-b border-(--card-stroke)/60 ${matches ? "" : "bg-(--accent)/10"}`}
+                                className={`border-b border-(--border)/60 ${matches ? "" : "bg-(--accent)/10"}`}
                             >
                                 <td className="p-2 font-medium">{key}</td>
                                 <td
@@ -87,14 +87,14 @@ export function AuditDetailPanel({ entry, onResolveAction }: AuditDetailPanelPro
 
     if (!entry) {
         return (
-            <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4 text-sm text-(--ink-muted)">
+            <div className="rounded-2xl border border-(--border) bg-(--card-80) p-4 text-sm text-(--ink-muted)">
                 Select an audit entry to inspect local vs Stripe state.
             </div>
         );
     }
 
     return (
-        <div className="space-y-3 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4">
+        <div className="space-y-3 rounded-2xl border border-(--border) bg-(--card-80) p-4">
             <p className="text-sm font-medium">{entry.description}</p>
             <StateDiff local={entry.local_state} stripe={entry.stripe_state} />
             <form
@@ -114,7 +114,7 @@ export function AuditDetailPanel({ entry, onResolveAction }: AuditDetailPanelPro
                     value={resolution}
                     onChange={(event) => setResolution(event.target.value)}
                     placeholder="resolution details"
-                    className="w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm"
+                    className="w-full rounded-xl border border-(--border) bg-(--card-70) px-3 py-2 text-sm"
                 />
                 <button
                     type="submit"

--- a/src/components/admin/billing/InvoiceDetailModal.tsx
+++ b/src/components/admin/billing/InvoiceDetailModal.tsx
@@ -26,8 +26,8 @@ export function InvoiceDetailModal({ invoice, isOpen, onClose }: InvoiceDetailMo
             role="dialog"
             aria-modal="true"
         >
-            <div className="max-h-[85vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--background) shadow-2xl">
-                <div className="flex items-center justify-between border-b border-(--card-stroke) px-6 py-4">
+            <div className="max-h-[85vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-(--border) bg-(--background) shadow-2xl">
+                <div className="flex items-center justify-between border-b border-(--border) px-6 py-4">
                     <div>
                         <h3 className="font-(--font-display) text-xl text-foreground">
                             Invoice Details
@@ -37,13 +37,13 @@ export function InvoiceDetailModal({ invoice, isOpen, onClose }: InvoiceDetailMo
                     <button
                         type="button"
                         onClick={onClose}
-                        className="rounded-md border border-(--card-stroke) px-3 py-1.5 text-sm hover:bg-(--card-70)"
+                        className="rounded-md border border-(--border) px-3 py-1.5 text-sm hover:bg-(--card-70)"
                     >
                         Close
                     </button>
                 </div>
 
-                <div className="grid gap-4 border-b border-(--card-stroke) bg-(--card-80) px-6 py-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
+                <div className="grid gap-4 border-b border-(--border) bg-(--card-80) px-6 py-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
                     <div>
                         <p className="text-(--ink-muted)">Status</p>
                         <p className="font-medium text-foreground">{invoice.status}</p>
@@ -68,7 +68,7 @@ export function InvoiceDetailModal({ invoice, isOpen, onClose }: InvoiceDetailMo
 
                 <div className="max-h-[50vh] overflow-auto p-6">
                     <table className="w-full text-left text-sm">
-                        <thead className="border-b border-(--card-stroke) text-(--ink-muted)">
+                        <thead className="border-b border-(--border) text-(--ink-muted)">
                             <tr>
                                 <th className="px-3 py-2 font-medium">Description</th>
                                 <th className="px-3 py-2 font-medium">Qty</th>
@@ -76,7 +76,7 @@ export function InvoiceDetailModal({ invoice, isOpen, onClose }: InvoiceDetailMo
                                 <th className="px-3 py-2 font-medium text-right">Amount</th>
                             </tr>
                         </thead>
-                        <tbody className="divide-y divide-(--card-stroke)">
+                        <tbody className="divide-y divide-(--border)">
                             {invoice.line_items.map((line) => (
                                 <tr key={line.id}>
                                     <td className="px-3 py-3 text-foreground">

--- a/src/components/admin/billing/InvoiceList.tsx
+++ b/src/components/admin/billing/InvoiceList.tsx
@@ -184,7 +184,7 @@ export function InvoiceList({
                             <button
                                 type="button"
                                 onClick={() => handleOpenDetail(invoice.id)}
-                                className="rounded-md border border-(--card-stroke) px-2.5 py-1 text-xs font-medium text-foreground hover:bg-(--card-70)"
+                                className="rounded-md border border-(--border) px-2.5 py-1 text-xs font-medium text-foreground hover:bg-(--card-70)"
                             >
                                 View
                             </button>
@@ -210,7 +210,7 @@ export function InvoiceList({
         <label className="flex items-center gap-2 text-sm text-(--ink-muted)">
             <span>Status</span>
             <select
-                className="rounded-md border border-(--card-stroke) bg-(--card-80) px-2 py-1 text-sm text-foreground"
+                className="rounded-md border border-(--border) bg-(--card-80) px-2 py-1 text-sm text-foreground"
                 value={statusFilter}
                 onChange={(event) => {
                     const nextStatus = event.target.value;

--- a/src/components/admin/billing/PlanManager.tsx
+++ b/src/components/admin/billing/PlanManager.tsx
@@ -188,14 +188,14 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
 
     return (
         <div className="space-y-8">
-            <section className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+            <section className="rounded-2xl border border-(--border) bg-(--card-80) p-6">
                 <div className="mb-4 flex items-center justify-between">
                     <h2 className="font-(--font-display) text-xl">Plan Editor</h2>
                     {editingPlanId && (
                         <button
                             type="button"
                             onClick={resetForm}
-                            className="rounded-lg border border-(--card-stroke) px-3 py-1.5 text-xs uppercase tracking-widest text-(--ink-muted)"
+                            className="rounded-lg border border-(--border) px-3 py-1.5 text-xs uppercase tracking-widest text-(--ink-muted)"
                         >
                             Cancel edit
                         </button>
@@ -208,7 +208,7 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
                             setFormState((current) => ({ ...current, name: event.target.value }))
                         }
                         placeholder="Plan name"
-                        className="rounded-lg border border-(--card-stroke) bg-(--card) px-3 py-2 text-sm"
+                        className="rounded-lg border border-(--border) bg-(--card) px-3 py-2 text-sm"
                         required
                     />
                     <input
@@ -217,7 +217,7 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
                             setFormState((current) => ({ ...current, key: event.target.value }))
                         }
                         placeholder="Plan key"
-                        className="rounded-lg border border-(--card-stroke) bg-(--card) px-3 py-2 text-sm"
+                        className="rounded-lg border border-(--border) bg-(--card) px-3 py-2 text-sm"
                         required
                     />
                     <input
@@ -226,7 +226,7 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
                             setFormState((current) => ({ ...current, tier: event.target.value }))
                         }
                         placeholder="Tier"
-                        className="rounded-lg border border-(--card-stroke) bg-(--card) px-3 py-2 text-sm"
+                        className="rounded-lg border border-(--border) bg-(--card) px-3 py-2 text-sm"
                         required
                     />
                     <input
@@ -239,7 +239,7 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
                             }))
                         }
                         placeholder="Display order"
-                        className="rounded-lg border border-(--card-stroke) bg-(--card) px-3 py-2 text-sm"
+                        className="rounded-lg border border-(--border) bg-(--card) px-3 py-2 text-sm"
                     />
                     <input
                         value={formState.description}
@@ -250,7 +250,7 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
                             }))
                         }
                         placeholder="Description"
-                        className="rounded-lg border border-(--card-stroke) bg-(--card) px-3 py-2 text-sm md:col-span-2"
+                        className="rounded-lg border border-(--border) bg-(--card) px-3 py-2 text-sm md:col-span-2"
                     />
                     <input
                         value={formState.bundle_ids_csv}
@@ -261,7 +261,7 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
                             }))
                         }
                         placeholder="Bundle IDs (comma-separated)"
-                        className="rounded-lg border border-(--card-stroke) bg-(--card) px-3 py-2 text-sm md:col-span-2"
+                        className="rounded-lg border border-(--border) bg-(--card) px-3 py-2 text-sm md:col-span-2"
                     />
                     <textarea
                         value={formState.prices_json}
@@ -273,7 +273,7 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
                         }
                         placeholder='[{"interval":"monthly","amount":4900,"currency":"usd"}]'
                         rows={8}
-                        className="rounded-lg border border-(--card-stroke) bg-(--card) px-3 py-2 text-sm font-(--font-mono) md:col-span-2"
+                        className="rounded-lg border border-(--border) bg-(--card) px-3 py-2 text-sm font-(--font-mono) md:col-span-2"
                     />
                     <label className="flex items-center gap-2 text-sm text-(--ink-muted)">
                         <input
@@ -300,7 +300,7 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
                 </form>
             </section>
 
-            <section className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+            <section className="rounded-2xl border border-(--border) bg-(--card-80) p-6">
                 <div className="mb-4 flex items-center justify-between">
                     <h2 className="font-(--font-display) text-xl">Plans</h2>
                     <button
@@ -316,7 +316,7 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
                     {sortedPlans.map((plan) => (
                         <article
                             key={plan.id}
-                            className="rounded-xl border border-(--card-stroke) bg-(--card) p-4"
+                            className="rounded-xl border border-(--border) bg-(--card) p-4"
                         >
                             <div className="flex flex-wrap items-start justify-between gap-3">
                                 <div>
@@ -335,14 +335,14 @@ export function PlanManager({ initialPlans }: PlanManagerProps) {
                                             setEditingPlanId(plan.id);
                                             setFormState(mapPlanToForm(plan));
                                         }}
-                                        className="rounded-lg border border-(--card-stroke) px-3 py-1.5 text-xs uppercase tracking-widest text-(--ink-muted)"
+                                        className="rounded-lg border border-(--border) px-3 py-1.5 text-xs uppercase tracking-widest text-(--ink-muted)"
                                     >
                                         Edit
                                     </button>
                                     <button
                                         type="button"
                                         onClick={() => onSync(plan.id)}
-                                        className="rounded-lg border border-(--card-stroke) px-3 py-1.5 text-xs uppercase tracking-widest text-(--ink-muted)"
+                                        className="rounded-lg border border-(--border) px-3 py-1.5 text-xs uppercase tracking-widest text-(--ink-muted)"
                                     >
                                         Sync Stripe
                                     </button>

--- a/src/components/admin/billing/ReconciliationTrigger.tsx
+++ b/src/components/admin/billing/ReconciliationTrigger.tsx
@@ -10,7 +10,7 @@ type ReconciliationTriggerProps = {
 
 export function ReconciliationTrigger({ running, report, onRun }: ReconciliationTriggerProps) {
     return (
-        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4">
+        <div className="rounded-2xl border border-(--border) bg-(--card-80) p-4">
             <button
                 type="button"
                 onClick={() => void onRun()}

--- a/src/components/admin/billing/RefundDialog.tsx
+++ b/src/components/admin/billing/RefundDialog.tsx
@@ -120,8 +120,8 @@ export function RefundDialog({
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-            <div className="w-full max-w-xl rounded-xl border border-(--card-stroke) bg-(--card) shadow-2xl">
-                <div className="flex items-center justify-between border-b border-(--card-stroke) p-6">
+            <div className="w-full max-w-xl rounded-xl border border-(--border) bg-(--card) shadow-2xl">
+                <div className="flex items-center justify-between border-b border-(--border) p-6">
                     <h2 className="text-lg font-semibold text-(--foreground)">Issue Refund</h2>
                     <button
                         type="button"
@@ -133,7 +133,7 @@ export function RefundDialog({
                 </div>
 
                 <div className="space-y-4 p-6">
-                    <div className="rounded-md border border-(--card-stroke) bg-(--card-80) p-3 text-sm text-(--ink-muted)">
+                    <div className="rounded-md border border-(--border) bg-(--card-80) p-3 text-sm text-(--ink-muted)">
                         <p>Invoice total: ${centsToDollars(invoiceAmountCents)}</p>
                         <p>Refundable balance: ${centsToDollars(refundableAmountCents)}</p>
                     </div>
@@ -162,7 +162,7 @@ export function RefundDialog({
                                 step="0.01"
                                 value={amountInput}
                                 onChange={(event) => setAmountInput(event.target.value)}
-                                className="w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-sm"
+                                className="w-full rounded-md border border-(--border) bg-(--background) px-3 py-2 text-sm"
                             />
                         </div>
                     )}
@@ -182,7 +182,7 @@ export function RefundDialog({
                                     event.target.value as (typeof REFUND_REASONS)[number]["value"],
                                 )
                             }
-                            className="w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-sm"
+                            className="w-full rounded-md border border-(--border) bg-(--background) px-3 py-2 text-sm"
                         >
                             {REFUND_REASONS.map((option) => (
                                 <option key={option.value} value={option.value}>
@@ -204,7 +204,7 @@ export function RefundDialog({
                             value={description}
                             onChange={(event) => setDescription(event.target.value)}
                             rows={3}
-                            className="w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-sm"
+                            className="w-full rounded-md border border-(--border) bg-(--background) px-3 py-2 text-sm"
                         />
                     </div>
 
@@ -224,7 +224,7 @@ export function RefundDialog({
                                 <button
                                     type="button"
                                     onClick={() => setConfirming(false)}
-                                    className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm"
+                                    className="rounded-md border border-(--border) px-4 py-2 text-sm"
                                 >
                                     Back
                                 </button>

--- a/src/components/admin/billing/VoidConfirmDialog.tsx
+++ b/src/components/admin/billing/VoidConfirmDialog.tsx
@@ -25,7 +25,7 @@ export function VoidConfirmDialog({
             role="dialog"
             aria-modal="true"
         >
-            <div className="w-full max-w-md rounded-2xl border border-(--card-stroke) bg-(--background) p-6 shadow-2xl">
+            <div className="w-full max-w-md rounded-2xl border border-(--border) bg-(--background) p-6 shadow-2xl">
                 <h3 className="font-(--font-display) text-lg text-foreground">Void Invoice</h3>
                 <p className="mt-2 text-sm text-(--ink-muted)">
                     This will void{" "}
@@ -38,7 +38,7 @@ export function VoidConfirmDialog({
                         type="button"
                         onClick={onCancel}
                         disabled={isPending}
-                        className="rounded-md border border-(--card-stroke) px-3 py-1.5 text-sm hover:bg-(--card-70) disabled:opacity-50"
+                        className="rounded-md border border-(--border) px-3 py-1.5 text-sm hover:bg-(--card-70) disabled:opacity-50"
                     >
                         Cancel
                     </button>

--- a/src/components/admin/identities/IdentityForm.tsx
+++ b/src/components/admin/identities/IdentityForm.tsx
@@ -101,7 +101,7 @@ export function IdentityForm({
                 isLoading ? "Saving..." : isEditing ? "Update Identity" : "Create Identity"
             }
             className="max-w-2xl space-y-6"
-            contentClassName="space-y-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6"
+            contentClassName="space-y-4 rounded-2xl border border-(--border) bg-(--card-80) p-6"
             actionsClassName="flex items-center gap-4"
             actionsStart={
                 <Link
@@ -201,7 +201,7 @@ export function IdentityForm({
                                 onChange={(event) =>
                                     handleProviderChange(index, "provider", event.target.value)
                                 }
-                                className="w-1/3 rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                className="w-1/3 rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                             >
                                 {PROVIDERS.map((provider) => (
                                     <option key={provider} value={provider}>

--- a/src/components/admin/integrations/CredentialCard.tsx
+++ b/src/components/admin/integrations/CredentialCard.tsx
@@ -54,7 +54,7 @@ export function CredentialCard({
     };
 
     return (
-        <div className="flex flex-col justify-between rounded-lg border border-(--border-subtle) bg-(--surface-base) p-6 shadow-sm transition-shadow hover:shadow-md">
+        <div className="flex flex-col justify-between rounded-lg border border-(--border) bg-(--surface-base) p-6 shadow-sm transition-shadow hover:shadow-md">
             <div>
                 <div className="mb-4 flex items-center justify-between">
                     <h3 className="text-lg font-semibold text-(--ink-base)">{credential.name}</h3>
@@ -73,7 +73,7 @@ export function CredentialCard({
                     type="button"
                     onClick={handleTest}
                     disabled={isTesting || isDeleting}
-                    className="inline-flex items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-1.5 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted) disabled:opacity-50"
+                    className="inline-flex items-center justify-center rounded-md border border-(--border) bg-(--surface-base) px-3 py-1.5 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted) disabled:opacity-50"
                 >
                     {isTesting ? "Testing..." : "Test"}
                 </button>
@@ -81,7 +81,7 @@ export function CredentialCard({
                     type="button"
                     onClick={onEdit}
                     disabled={isTesting || isDeleting}
-                    className="inline-flex items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-1.5 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted) disabled:opacity-50"
+                    className="inline-flex items-center justify-center rounded-md border border-(--border) bg-(--surface-base) px-3 py-1.5 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted) disabled:opacity-50"
                 >
                     Edit
                 </button>
@@ -97,7 +97,7 @@ export function CredentialCard({
 
             {showDeleteConfirm && (
                 <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-                    <div className="w-full max-w-md rounded-xl border border-(--card-stroke) bg-(--card) p-6 shadow-2xl">
+                    <div className="w-full max-w-md rounded-xl border border-(--border) bg-(--card) p-6 shadow-2xl">
                         <h3 className="mb-4 text-lg font-semibold text-(--foreground)">
                             Delete Credential
                         </h3>
@@ -116,7 +116,7 @@ export function CredentialCard({
                                 type="button"
                                 onClick={() => setShowDeleteConfirm(false)}
                                 disabled={isDeleting}
-                                className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm hover:bg-(--card-80) disabled:opacity-50"
+                                className="rounded-md border border-(--border) px-4 py-2 text-sm hover:bg-(--card-80) disabled:opacity-50"
                             >
                                 Cancel
                             </button>

--- a/src/components/admin/integrations/EditCredentialModal.tsx
+++ b/src/components/admin/integrations/EditCredentialModal.tsx
@@ -158,8 +158,8 @@ export function EditCredentialModal({
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-            <div className="w-full max-w-xl rounded-xl border border-(--card-stroke) bg-(--card) shadow-2xl">
-                <div className="flex items-center justify-between border-b border-(--card-stroke) p-6">
+            <div className="w-full max-w-xl rounded-xl border border-(--border) bg-(--card) shadow-2xl">
+                <div className="flex items-center justify-between border-b border-(--border) p-6">
                     <h2 className="text-lg font-semibold text-(--foreground)">
                         Edit {existingCredential.name}
                     </h2>
@@ -185,7 +185,7 @@ export function EditCredentialModal({
                             type="text"
                             value={existingCredential.name}
                             disabled
-                            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-80) px-3 py-2 text-sm text-(--ink-muted) cursor-not-allowed"
+                            className="w-full rounded-lg border border-(--border) bg-(--card-80) px-3 py-2 text-sm text-(--ink-muted) cursor-not-allowed"
                         />
                     </div>
 
@@ -208,7 +208,7 @@ export function EditCredentialModal({
                                 placeholder={
                                     field.type === "password" ? "Enter new token to update..." : ""
                                 }
-                                className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                             />
                         </div>
                     ))}
@@ -225,7 +225,7 @@ export function EditCredentialModal({
                         <button
                             type="button"
                             onClick={handleClose}
-                            className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm"
+                            className="rounded-md border border-(--border) px-4 py-2 text-sm"
                         >
                             Cancel
                         </button>
@@ -233,7 +233,7 @@ export function EditCredentialModal({
                             type="button"
                             onClick={handleTestConnection}
                             disabled={isTesting || isSaving || !canRunTest}
-                            className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm hover:bg-(--card-80) disabled:opacity-50"
+                            className="rounded-md border border-(--border) px-4 py-2 text-sm hover:bg-(--card-80) disabled:opacity-50"
                         >
                             {isTesting ? "Testing..." : "Test Connection"}
                         </button>

--- a/src/components/admin/integrations/IntegrationCard.tsx
+++ b/src/components/admin/integrations/IntegrationCard.tsx
@@ -17,7 +17,7 @@ type IntegrationCardProps = {
 
 export function IntegrationCard({ provider }: IntegrationCardProps) {
     return (
-        <div className="flex flex-col justify-between rounded-lg border border-(--border-subtle) bg-(--surface-base) p-6 shadow-sm transition-shadow hover:shadow-md">
+        <div className="flex flex-col justify-between rounded-lg border border-(--border) bg-(--surface-base) p-6 shadow-sm transition-shadow hover:shadow-md">
             <div>
                 <div className="mb-4 flex items-center justify-between">
                     <div className="flex h-12 w-12 items-center justify-center rounded-md bg-(--surface-muted)">

--- a/src/components/admin/integrations/IntegrationForm.tsx
+++ b/src/components/admin/integrations/IntegrationForm.tsx
@@ -73,7 +73,7 @@ export function IntegrationForm({
     };
 
     return (
-        <div className="max-w-2xl rounded-lg border border-(--border-subtle) bg-(--surface-base) p-6 shadow-sm">
+        <div className="max-w-2xl rounded-lg border border-(--border) bg-(--surface-base) p-6 shadow-sm">
             <div className="mb-6 flex items-center justify-between">
                 <h2 className="text-xl font-semibold text-(--ink-base)">Configuration</h2>
                 <ConnectionStatus status={status} />
@@ -82,7 +82,7 @@ export function IntegrationForm({
             <form onSubmit={handleSubmit} className="space-y-6">
                 {children}
 
-                <div className="flex items-center justify-end gap-4 pt-4 border-t border-(--border-subtle)">
+                <div className="flex items-center justify-end gap-4 pt-4 border-t border-(--border)">
                     {onCancel && (
                         <button
                             type="button"

--- a/src/components/admin/integrations/ProviderCredentialsList.tsx
+++ b/src/components/admin/integrations/ProviderCredentialsList.tsx
@@ -80,7 +80,7 @@ export function ProviderCredentialsList({
             </div>
 
             {credentials.length === 0 ? (
-                <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-(--border-subtle) bg-(--surface-base) py-12 text-center">
+                <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-(--border) bg-(--surface-base) py-12 text-center">
                     <h3 className="mb-2 text-lg font-medium text-(--ink-base)">
                         No credentials saved
                     </h3>

--- a/src/components/admin/settings/BillingSettings.tsx
+++ b/src/components/admin/settings/BillingSettings.tsx
@@ -215,7 +215,7 @@ export function BillingSettings({ tier = "community" }: BillingSettingsProps) {
 
     return (
         <SettingsSection title="Billing" description="Manage your subscription and history.">
-            <div className="rounded-md border border-(--card-stroke) bg-(--background) p-4">
+            <div className="rounded-md border border-(--border) bg-(--background) p-4">
                 <div className="flex items-start justify-between gap-4">
                     <div className="space-y-2">
                         <p className="text-sm text-(--ink-muted)">Current Plan</p>
@@ -240,7 +240,7 @@ export function BillingSettings({ tier = "community" }: BillingSettingsProps) {
                                         className={`mt-4 max-w-sm rounded-lg border p-4 ${
                                             isTrialWarning
                                                 ? "border-amber-500/30 bg-amber-500/10"
-                                                : "border-(--card-stroke) bg-(--card-80)"
+                                                : "border-(--border) bg-(--card-80)"
                                         }`}
                                     >
                                         <div className="flex items-center justify-between mb-2">
@@ -301,7 +301,7 @@ export function BillingSettings({ tier = "community" }: BillingSettingsProps) {
                                     : openPlanModal
                             }
                             disabled={isPending}
-                            className="rounded-md border border-(--card-stroke) px-3 py-2 text-sm hover:bg-(--card) disabled:opacity-50"
+                            className="rounded-md border border-(--border) px-3 py-2 text-sm hover:bg-(--card) disabled:opacity-50"
                         >
                             {isFree ? "Start free trial" : "Change Plan"}
                         </button>
@@ -334,13 +334,13 @@ export function BillingSettings({ tier = "community" }: BillingSettingsProps) {
                 </div>
             </div>
 
-            <details className="mt-4 rounded-md border border-(--card-stroke) bg-(--background) p-4">
+            <details className="mt-4 rounded-md border border-(--border) bg-(--background) p-4">
                 <summary className="cursor-pointer text-sm font-semibold text-(--foreground)">
                     Subscription History ({history.length})
                 </summary>
                 <ul className="mt-3 space-y-3">
                     {history.map((item) => (
-                        <li key={item.id} className="rounded-md border border-(--card-stroke) p-3">
+                        <li key={item.id} className="rounded-md border border-(--border) p-3">
                             <div className="flex items-center justify-between gap-4 text-sm">
                                 <span className="font-medium text-(--foreground)">
                                     {item.event_type}
@@ -361,7 +361,7 @@ export function BillingSettings({ tier = "community" }: BillingSettingsProps) {
 
             {showPlanModal && (
                 <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
-                    <div className="w-full max-w-lg rounded-lg border border-(--card-stroke) bg-(--card-80) p-6 shadow-lg">
+                    <div className="w-full max-w-lg rounded-lg border border-(--border) bg-(--card-80) p-6 shadow-lg">
                         <h3 className="text-lg font-semibold text-(--foreground)">Change Plan</h3>
                         <p className="mt-1 text-sm text-(--ink-muted)">
                             Select the plan you want to switch to.
@@ -396,8 +396,8 @@ export function BillingSettings({ tier = "community" }: BillingSettingsProps) {
                                                 isSelected
                                                     ? "border-(--accent) bg-(--accent)/10 ring-1 ring-(--accent)"
                                                     : isCurrent
-                                                      ? "border-(--card-stroke) bg-(--card-70) opacity-60 cursor-not-allowed"
-                                                      : "border-(--card-stroke) hover:border-(--accent)/50"
+                                                      ? "border-(--border) bg-(--card-70) opacity-60 cursor-not-allowed"
+                                                      : "border-(--border) hover:border-(--accent)/50"
                                             }`}
                                         >
                                             <div className="flex items-center justify-between">
@@ -451,7 +451,7 @@ export function BillingSettings({ tier = "community" }: BillingSettingsProps) {
                             <button
                                 type="button"
                                 onClick={() => setShowPlanModal(false)}
-                                className="rounded-md border border-(--card-stroke) px-3 py-2 text-sm hover:bg-(--card) text-(--foreground)"
+                                className="rounded-md border border-(--border) px-3 py-2 text-sm hover:bg-(--card) text-(--foreground)"
                             >
                                 Cancel
                             </button>

--- a/src/components/admin/settings/DeletionPlanPreview.tsx
+++ b/src/components/admin/settings/DeletionPlanPreview.tsx
@@ -38,8 +38,8 @@ export function DeletionPlanPreview({
                 </div>
             </div>
 
-            <div className="overflow-hidden rounded-md border border-(--card-stroke)">
-                <table className="min-w-full divide-y divide-(--card-stroke)">
+            <div className="overflow-hidden rounded-md border border-(--border)">
+                <table className="min-w-full divide-y divide-(--border)">
                     <thead className="bg-(--card-70)">
                         <tr>
                             <th className="px-4 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider">
@@ -50,7 +50,7 @@ export function DeletionPlanPreview({
                             </th>
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-(--card-stroke) bg-(--background)">
+                    <tbody className="divide-y divide-(--border) bg-(--background)">
                         {Object.entries(plan.deletedCounts).map(([category, count]) => (
                             <tr key={category}>
                                 <td className="px-4 py-3 text-sm text-(--foreground) capitalize">
@@ -104,7 +104,7 @@ export function DeletionPlanPreview({
                 </div>
             )}
 
-            <div className="space-y-4 pt-4 border-t border-(--card-stroke)">
+            <div className="space-y-4 pt-4 border-t border-(--border)">
                 <p className="text-sm text-(--foreground)">
                     Type <strong>{expectedConfirmText}</strong> to confirm deletion:
                 </p>
@@ -121,7 +121,7 @@ export function DeletionPlanPreview({
                         type="button"
                         onClick={onCancel}
                         disabled={isPending}
-                        className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm font-medium text-(--foreground) hover:bg-(--card-70) disabled:opacity-50"
+                        className="rounded-md border border-(--border) px-4 py-2 text-sm font-medium text-(--foreground) hover:bg-(--card-70) disabled:opacity-50"
                     >
                         Cancel
                     </button>

--- a/src/components/admin/settings/GeneralSettings.tsx
+++ b/src/components/admin/settings/GeneralSettings.tsx
@@ -48,7 +48,7 @@ export function GeneralSettings({ org }: GeneralSettingsProps) {
                         name="name"
                         defaultValue={org?.name ?? ""}
                         disabled={isLoading}
-                        className="mt-1 block w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
+                        className="mt-1 block w-full rounded-md border border-(--border) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
                     />
                 </div>
                 <div>
@@ -61,7 +61,7 @@ export function GeneralSettings({ org }: GeneralSettingsProps) {
                         name="slug"
                         defaultValue={org?.slug ?? ""}
                         disabled
-                        className="mt-1 block w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-(--ink-muted) shadow-sm opacity-50 cursor-not-allowed"
+                        className="mt-1 block w-full rounded-md border border-(--border) bg-(--background) px-3 py-2 text-(--ink-muted) shadow-sm opacity-50 cursor-not-allowed"
                     />
                 </div>
                 <div>
@@ -77,7 +77,7 @@ export function GeneralSettings({ org }: GeneralSettingsProps) {
                         rows={3}
                         defaultValue={org?.description ?? ""}
                         disabled={isLoading}
-                        className="mt-1 block w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
+                        className="mt-1 block w-full rounded-md border border-(--border) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
                     />
                 </div>
                 <div className="flex justify-end">

--- a/src/components/admin/settings/SecuritySettings.tsx
+++ b/src/components/admin/settings/SecuritySettings.tsx
@@ -87,7 +87,7 @@ export function SecuritySettings() {
                         value={sessionTimeout}
                         onChange={(e) => setSessionTimeout(e.target.value)}
                         disabled={isPending || !loaded}
-                        className="mt-1 block w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
+                        className="mt-1 block w-full rounded-md border border-(--border) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
                     >
                         {SESSION_TIMEOUT_OPTIONS.map((opt) => (
                             <option key={opt.value} value={opt.value}>

--- a/src/components/admin/sync/CreateCredentialModal.tsx
+++ b/src/components/admin/sync/CreateCredentialModal.tsx
@@ -142,8 +142,8 @@ export function CreateCredentialModal({
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-            <div className="w-full max-w-xl rounded-xl border border-(--card-stroke) bg-(--card) shadow-2xl">
-                <div className="flex items-center justify-between border-b border-(--card-stroke) p-6">
+            <div className="w-full max-w-xl rounded-xl border border-(--border) bg-(--card) shadow-2xl">
+                <div className="flex items-center justify-between border-b border-(--border) p-6">
                     <h2 className="text-lg font-semibold text-(--foreground)">
                         Create {provider.charAt(0).toUpperCase() + provider.slice(1)} Credential
                     </h2>
@@ -169,7 +169,7 @@ export function CreateCredentialModal({
                             type="text"
                             value={name}
                             onChange={(event) => handleNameChange(event.target.value)}
-                            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                            className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                             placeholder="e.g., Primary token"
                         />
                     </div>
@@ -190,7 +190,7 @@ export function CreateCredentialModal({
                                     handleFieldChange(field.key, event.target.value)
                                 }
                                 required={field.required}
-                                className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                             />
                         </div>
                     ))}
@@ -207,7 +207,7 @@ export function CreateCredentialModal({
                         <button
                             type="button"
                             onClick={handleClose}
-                            className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm"
+                            className="rounded-md border border-(--border) px-4 py-2 text-sm"
                         >
                             Cancel
                         </button>
@@ -215,7 +215,7 @@ export function CreateCredentialModal({
                             type="button"
                             onClick={handleTestConnection}
                             disabled={isTesting || isSaving || !canRunTest}
-                            className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm hover:bg-(--card-80) disabled:opacity-50"
+                            className="rounded-md border border-(--border) px-4 py-2 text-sm hover:bg-(--card-80) disabled:opacity-50"
                         >
                             {isTesting ? "Testing..." : "Test Connection"}
                         </button>

--- a/src/components/admin/sync/RepoSelector.tsx
+++ b/src/components/admin/sync/RepoSelector.tsx
@@ -150,14 +150,14 @@ export function RepoSelector({
                     <button
                         type="button"
                         onClick={handleSelectAll}
-                        className="rounded-md border border-(--card-stroke) px-2 py-1 text-xs font-medium text-(--foreground) hover:bg-(--card-70)"
+                        className="rounded-md border border-(--border) px-2 py-1 text-xs font-medium text-(--foreground) hover:bg-(--card-70)"
                     >
                         Select All
                     </button>
                     <button
                         type="button"
                         onClick={handleClear}
-                        className="rounded-md border border-(--card-stroke) px-2 py-1 text-xs font-medium text-(--foreground) hover:bg-(--card-70)"
+                        className="rounded-md border border-(--border) px-2 py-1 text-xs font-medium text-(--foreground) hover:bg-(--card-70)"
                     >
                         Clear
                     </button>
@@ -170,7 +170,7 @@ export function RepoSelector({
                 placeholder="Search repositories..."
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
             />
 
             {/* Repo list */}
@@ -184,7 +184,7 @@ export function RepoSelector({
                         return (
                             <label
                                 key={repo.name}
-                                className={`flex items-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 hover:bg-(--card-60) ${
+                                className={`flex items-center gap-2 rounded-lg border border-(--border) bg-(--card-70) p-3 hover:bg-(--card-60) ${
                                     isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"
                                 }`}
                             >
@@ -193,7 +193,7 @@ export function RepoSelector({
                                     checked={isChecked}
                                     disabled={isDisabled}
                                     onChange={(e) => handleToggle(repo.name, e.target.checked)}
-                                    className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
+                                    className="h-4 w-4 rounded border-(--border) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
                                 />
                                 <div className="min-w-0 flex-1">
                                     <span className="block truncate text-sm font-medium">
@@ -208,7 +208,7 @@ export function RepoSelector({
                                 <div className="flex shrink-0 items-center gap-2 text-xs text-(--ink-muted)">
                                     {repo.language && <span>{repo.language}</span>}
                                     {repo.is_private && (
-                                        <span className="rounded-full border border-(--card-stroke) px-1.5 py-0.5 text-[10px]">
+                                        <span className="rounded-full border border-(--border) px-1.5 py-0.5 text-[10px]">
                                             private
                                         </span>
                                     )}

--- a/src/components/admin/sync/RunBackfill.tsx
+++ b/src/components/admin/sync/RunBackfill.tsx
@@ -91,7 +91,7 @@ export function RunBackfill({ configId }: RunBackfillProps) {
     const isTerminal = activeJob?.status === "completed" || activeJob?.status === "failed";
 
     return (
-        <div className="space-y-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6 mt-6">
+        <div className="space-y-4 rounded-2xl border border-(--border) bg-(--card-80) p-6 mt-6">
             <div>
                 <h3 className="text-sm font-medium">Run Historical Backfill</h3>
                 <p className="mt-1 text-xs text-(--ink-muted)">
@@ -107,7 +107,7 @@ export function RunBackfill({ configId }: RunBackfillProps) {
                         type="date"
                         value={since}
                         onChange={(e) => setSince(e.target.value)}
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
                     />
                 </div>
                 <div className="flex-1">
@@ -118,7 +118,7 @@ export function RunBackfill({ configId }: RunBackfillProps) {
                         type="date"
                         value={before}
                         onChange={(e) => setBefore(e.target.value)}
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent) disabled:opacity-50"
                     />
                 </div>
                 <button
@@ -132,7 +132,7 @@ export function RunBackfill({ configId }: RunBackfillProps) {
 
             {/* Progress section */}
             {activeJob && (
-                <div className="space-y-2 pt-2 border-t border-(--card-stroke)">
+                <div className="space-y-2 pt-2 border-t border-(--border)">
                     <div className="flex items-center justify-between text-xs">
                         <span className="text-(--ink-muted)">
                             {activeJob.status === "pending" && "Waiting to start..."}

--- a/src/components/admin/sync/SchedulePicker.tsx
+++ b/src/components/admin/sync/SchedulePicker.tsx
@@ -105,27 +105,27 @@ export function SchedulePicker({
                     return (
                         <label
                             key={modeValue}
-                            className="flex items-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 hover:bg-(--card-60)"
+                            className="flex items-center gap-2 rounded-lg border border-(--border) bg-(--card-70) p-3 hover:bg-(--card-60)"
                         >
                             <input
                                 type="radio"
                                 name="schedule-mode"
                                 checked={mode === modeValue}
                                 onChange={() => handleModeChange(modeValue)}
-                                className="h-4 w-4 border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
+                                className="h-4 w-4 border-(--border) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
                             />
                             <span className="text-sm">{preset.label}</span>
                         </label>
                     );
                 })}
 
-                <label className="flex items-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 hover:bg-(--card-60)">
+                <label className="flex items-center gap-2 rounded-lg border border-(--border) bg-(--card-70) p-3 hover:bg-(--card-60)">
                     <input
                         type="radio"
                         name="schedule-mode"
                         checked={mode === "custom"}
                         onChange={() => handleModeChange("custom")}
-                        className="h-4 w-4 border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
+                        className="h-4 w-4 border-(--border) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
                     />
                     <span className="text-sm">Custom cron expression</span>
                 </label>
@@ -148,7 +148,7 @@ export function SchedulePicker({
                             onChange(event.target.value || null, selectedTimezone);
                         }}
                         placeholder="e.g., 15 3 * * *"
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                     />
                     {minIntervalHours !== undefined && minIntervalHours > 0 && (
                         <p className="mt-1.5 text-xs text-(--ink-muted)">
@@ -175,7 +175,7 @@ export function SchedulePicker({
                     id="schedule-timezone"
                     value={selectedTimezone}
                     onChange={(event) => handleTimezoneChange(event.target.value)}
-                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                    className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                 >
                     {timezones.map((tz) => (
                         <option key={tz} value={tz}>

--- a/src/components/admin/sync/SyncConfigCard.tsx
+++ b/src/components/admin/sync/SyncConfigCard.tsx
@@ -76,7 +76,7 @@ export function SyncConfigCard({ config }: SyncConfigCardProps) {
     return (
         <Link
             href={`/admin/sync/${config.id}`}
-            className="block cursor-pointer rounded-xl border border-(--card-stroke) bg-(--card-80) p-6 transition-all hover:border-(--card-stroke-hover)"
+            className="block cursor-pointer rounded-xl border border-(--border) bg-(--card-80) p-6 transition-all hover:border-(--card-stroke-hover)"
         >
             <div className="flex items-start justify-between">
                 <div>
@@ -94,7 +94,7 @@ export function SyncConfigCard({ config }: SyncConfigCardProps) {
                 <SyncStatusBadge status={getStatus()} />
             </div>
 
-            <div className="mt-6 flex items-center justify-between border-t border-(--card-stroke) pt-4">
+            <div className="mt-6 flex items-center justify-between border-t border-(--border) pt-4">
                 <div className="text-xs text-(--ink-muted)">
                     <ClientTimestamp
                         value={config.last_sync_at}
@@ -119,7 +119,7 @@ export function SyncConfigCard({ config }: SyncConfigCardProps) {
                                 type="button"
                                 onClick={() => setShowDeleteConfirm(false)}
                                 disabled={isPending}
-                                className="rounded-md border border-(--card-stroke) bg-(--card-70) px-2 py-1 text-xs font-medium text-foreground hover:border-(--accent) hover:text-(--accent)"
+                                className="rounded-md border border-(--border) bg-(--card-70) px-2 py-1 text-xs font-medium text-foreground hover:border-(--accent) hover:text-(--accent)"
                             >
                                 Cancel
                             </button>
@@ -130,7 +130,7 @@ export function SyncConfigCard({ config }: SyncConfigCardProps) {
                                 type="button"
                                 onClick={handleToggleActive}
                                 disabled={isPending}
-                                className="rounded-md border border-(--card-stroke) bg-(--card-70) px-3 py-1.5 text-xs font-medium text-foreground hover:border-(--accent) hover:text-(--accent) disabled:opacity-50"
+                                className="rounded-md border border-(--border) bg-(--card-70) px-3 py-1.5 text-xs font-medium text-foreground hover:border-(--accent) hover:text-(--accent) disabled:opacity-50"
                             >
                                 {config.is_active ? "Pause" : "Resume"}
                             </button>

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -231,7 +231,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                           : "Create Configuration"
                 }
                 className="max-w-2xl space-y-6"
-                contentClassName="space-y-6 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6"
+                contentClassName="space-y-6 rounded-2xl border border-(--border) bg-(--card-80) p-6"
                 actionsClassName="flex items-center gap-4"
                 actionsStart={
                     <Link
@@ -290,7 +290,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                         <button
                             type="button"
                             onClick={() => setShowCredentialModal(true)}
-                            className="rounded-md border border-(--card-stroke) px-2 py-1 text-xs font-medium text-(--foreground) hover:bg-(--card-70)"
+                            className="rounded-md border border-(--border) px-2 py-1 text-xs font-medium text-(--foreground) hover:bg-(--card-70)"
                         >
                             + New
                         </button>
@@ -402,7 +402,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                         {availableTargets.map((target) => (
                             <label
                                 key={target.id}
-                                className="flex items-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 hover:bg-(--card-60)"
+                                className="flex items-center gap-2 rounded-lg border border-(--border) bg-(--card-70) p-3 hover:bg-(--card-60)"
                             >
                                 <input
                                     type="checkbox"
@@ -410,7 +410,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                                     onChange={(e) =>
                                         handleTargetChange(target.id, e.target.checked)
                                     }
-                                    className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
+                                    className="h-4 w-4 rounded border-(--border) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
                                 />
                                 <span className="text-sm">{target.label}</span>
                             </label>
@@ -451,8 +451,8 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                                         isSelected
                                             ? "border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--accent)]"
                                             : isGated
-                                              ? "cursor-not-allowed border-[var(--card-stroke)] bg-[var(--bg-secondary)] text-[var(--text-tertiary)] opacity-50"
-                                              : "border-[var(--card-stroke)] hover:border-[var(--accent)]/50"
+                                              ? "cursor-not-allowed border-[var(--border)] bg-[var(--bg-secondary)] text-[var(--text-tertiary)] opacity-50"
+                                              : "border-[var(--border)] hover:border-[var(--accent)]/50"
                                     }`}
                                 >
                                     {opt.label}
@@ -471,7 +471,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                         name="is_active"
                         checked={formData.is_active}
                         onChange={handleChange}
-                        className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
+                        className="h-4 w-4 rounded border-(--border) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
                     />
                     <label htmlFor="is_active" className="text-sm font-medium">
                         Enable automatic sync schedule

--- a/src/components/admin/sync/SyncConfigGroup.tsx
+++ b/src/components/admin/sync/SyncConfigGroup.tsx
@@ -20,7 +20,7 @@ export function SyncConfigGroup({ parent, childConfigs }: SyncConfigGroupProps) 
     const groupStatus = failedCount > 0 ? "failed" : successCount > 0 ? "success" : "never";
 
     return (
-        <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) overflow-hidden">
+        <div className="rounded-xl border border-(--border) bg-(--card-80) overflow-hidden">
             {/* Parent header — clickable to expand/collapse */}
             <button
                 type="button"
@@ -30,7 +30,7 @@ export function SyncConfigGroup({ parent, childConfigs }: SyncConfigGroupProps) 
                 <div className="space-y-1">
                     <div className="flex items-center gap-2">
                         <h3 className="font-medium text-foreground">{parent.name}</h3>
-                        <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2 py-0.5 text-xs text-(--ink-muted)">
+                        <span className="rounded-full border border-(--border) bg-(--card-70) px-2 py-0.5 text-xs text-(--ink-muted)">
                             {childConfigs.length} repo{childConfigs.length !== 1 ? "s" : ""}
                         </span>
                     </div>
@@ -70,7 +70,7 @@ export function SyncConfigGroup({ parent, childConfigs }: SyncConfigGroupProps) 
 
             {/* Children */}
             {expanded && (
-                <div className="border-t border-(--card-stroke) p-4 grid gap-4 md:grid-cols-2">
+                <div className="border-t border-(--border) p-4 grid gap-4 md:grid-cols-2">
                     {childConfigs.map((child) => (
                         <SyncConfigCard key={child.id} config={child} />
                     ))}

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -17,7 +17,7 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
 
     if (jobs.length === 0) {
         return (
-            <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-8 text-center">
+            <div className="rounded-xl border border-(--border) bg-(--card-80) p-8 text-center">
                 <p className="text-sm text-(--ink-muted)">No sync history available.</p>
             </div>
         );
@@ -39,8 +39,8 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
     };
 
     return (
-        <div className="overflow-hidden rounded-xl border border-(--card-stroke) bg-(--card-80)">
-            <table className="min-w-full divide-y divide-(--card-stroke)">
+        <div className="overflow-hidden rounded-xl border border-(--border) bg-(--card-80)">
+            <table className="min-w-full divide-y divide-(--border)">
                 <thead className="bg-(--card-bg)">
                     <tr>
                         <th
@@ -75,7 +75,7 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                         </th>
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-(--card-stroke) bg-(--card-80)">
+                <tbody className="divide-y divide-(--border) bg-(--card-80)">
                     {paginatedJobs.map((job) => {
                         const duration = job.duration_seconds
                             ? `${Math.round(job.duration_seconds)}s`
@@ -116,7 +116,7 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                 </tbody>
             </table>
 
-            <div className="flex items-center justify-between border-t border-(--card-stroke) px-6 py-4">
+            <div className="flex items-center justify-between border-t border-(--border) px-6 py-4">
                 <span className="text-sm text-(--ink-muted)">
                     Showing {offset + 1}-{Math.min(offset + limit, total)} of {total}
                 </span>
@@ -125,7 +125,7 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                         type="button"
                         onClick={() => setOffset((prev) => Math.max(0, prev - limit))}
                         disabled={offset === 0}
-                        className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium hover:bg-(--card-70) disabled:cursor-not-allowed disabled:opacity-50"
+                        className="rounded-lg border border-(--border) bg-(--card-80) px-4 py-2 text-sm font-medium hover:bg-(--card-70) disabled:cursor-not-allowed disabled:opacity-50"
                     >
                         Previous
                     </button>
@@ -133,7 +133,7 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                         type="button"
                         onClick={() => setOffset((prev) => prev + limit)}
                         disabled={offset + limit >= total}
-                        className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium hover:bg-(--card-70) disabled:cursor-not-allowed disabled:opacity-50"
+                        className="rounded-lg border border-(--border) bg-(--card-80) px-4 py-2 text-sm font-medium hover:bg-(--card-70) disabled:cursor-not-allowed disabled:opacity-50"
                     >
                         Next
                     </button>

--- a/src/components/admin/sync/SyncProgressBar.tsx
+++ b/src/components/admin/sync/SyncProgressBar.tsx
@@ -105,7 +105,7 @@ export function SyncProgressBar({ provider, orgId }: SyncProgressBarProps) {
     const stageLabel = progress.stage || progress.currentStep || `${percentage}% complete`;
 
     return (
-        <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+        <div className="rounded-xl border border-(--border) bg-(--card-80) p-6">
             <div className="mb-2 flex items-center justify-between text-sm">
                 <span className="font-medium text-foreground">
                     {progress.status === "RUNNING" ? "Syncing..." : progress.status}

--- a/src/components/admin/sync/TestConnectionButton.tsx
+++ b/src/components/admin/sync/TestConnectionButton.tsx
@@ -34,7 +34,7 @@ export function TestConnectionButton({ provider, credentialId }: TestConnectionB
             type="button"
             onClick={handleTestConnection}
             disabled={isPending || !credentialId}
-            className="inline-flex items-center gap-2 rounded-md border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground hover:border-(--accent) hover:text-(--accent) disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex items-center gap-2 rounded-md border border-(--border) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground hover:border-(--accent) hover:text-(--accent) disabled:cursor-not-allowed disabled:opacity-50"
         >
             {isPending ? (
                 <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />

--- a/src/components/admin/teams/ImportTeamsDialog.tsx
+++ b/src/components/admin/teams/ImportTeamsDialog.tsx
@@ -124,7 +124,7 @@ export function ImportTeamsDialog() {
             <button
                 type="button"
                 onClick={handleOpen}
-                className="cursor-pointer rounded-lg border border-(--card-stroke) bg-(--card) px-4 py-2 text-sm font-medium text-foreground hover:bg-(--card-80) transition-colors"
+                className="cursor-pointer rounded-lg border border-(--border) bg-(--card) px-4 py-2 text-sm font-medium text-foreground hover:bg-(--card-80) transition-colors"
             >
                 Import Teams
             </button>
@@ -133,8 +133,8 @@ export function ImportTeamsDialog() {
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-            <div className="w-full max-w-2xl rounded-xl border border-(--card-stroke) bg-(--card) shadow-2xl max-h-[90vh] flex flex-col">
-                <div className="flex items-center justify-between border-b border-(--card-stroke) p-6">
+            <div className="w-full max-w-2xl rounded-xl border border-(--border) bg-(--card) shadow-2xl max-h-[90vh] flex flex-col">
+                <div className="flex items-center justify-between border-b border-(--border) p-6">
                     <h2 className="text-xl font-semibold text-foreground">Import Teams</h2>
                     <button
                         type="button"
@@ -153,7 +153,7 @@ export function ImportTeamsDialog() {
                                     type="button"
                                     key={provider.id}
                                     onClick={() => handleDiscover(provider.id)}
-                                    className="cursor-pointer flex flex-col items-start gap-2 rounded-lg border border-(--card-stroke) bg-(--card-80) p-4 text-left hover:border-(--accent) hover:bg-(--card) transition-all"
+                                    className="cursor-pointer flex flex-col items-start gap-2 rounded-lg border border-(--border) bg-(--card-80) p-4 text-left hover:border-(--accent) hover:bg-(--card) transition-all"
                                 >
                                     <span className="font-medium text-foreground">
                                         {provider.name}
@@ -200,7 +200,7 @@ export function ImportTeamsDialog() {
                                         onChange={(e) =>
                                             setOnConflict(e.target.value as "skip" | "merge")
                                         }
-                                        className="cursor-pointer rounded border border-(--card-stroke) bg-(--card-80) px-2 py-1 text-foreground focus:border-(--accent) focus:outline-none"
+                                        className="cursor-pointer rounded border border-(--border) bg-(--card-80) px-2 py-1 text-foreground focus:border-(--accent) focus:outline-none"
                                     >
                                         <option value="skip">Skip existing</option>
                                         <option value="merge">Merge with existing</option>
@@ -208,7 +208,7 @@ export function ImportTeamsDialog() {
                                 </div>
                             </div>
 
-                            <div className="max-h-[400px] overflow-y-auto rounded-lg border border-(--card-stroke)">
+                            <div className="max-h-[400px] overflow-y-auto rounded-lg border border-(--border)">
                                 {discoveredTeams.length === 0 ? (
                                     <div className="p-8 text-center text-(--ink-muted)">
                                         No teams found.
@@ -226,7 +226,7 @@ export function ImportTeamsDialog() {
                                                             discoveredTeams.length > 0
                                                         }
                                                         onChange={toggleAll}
-                                                        className="cursor-pointer rounded border-(--card-stroke) bg-(--card) text-(--accent) focus:ring-(--accent)"
+                                                        className="cursor-pointer rounded border-(--border) bg-(--card) text-(--accent) focus:ring-(--accent)"
                                                     />
                                                 </th>
                                                 <th className="p-3 font-medium">Team</th>
@@ -234,7 +234,7 @@ export function ImportTeamsDialog() {
                                                 <th className="p-3 font-medium">Associations</th>
                                             </tr>
                                         </thead>
-                                        <tbody className="divide-y divide-(--card-stroke)">
+                                        <tbody className="divide-y divide-(--border)">
                                             {discoveredTeams.map((team) => (
                                                 <tr
                                                     key={team.provider_team_id}
@@ -253,7 +253,7 @@ export function ImportTeamsDialog() {
                                                                 toggleTeam(team.provider_team_id)
                                                             }
                                                             onClick={(e) => e.stopPropagation()}
-                                                            className="cursor-pointer rounded border-(--card-stroke) bg-(--card) text-(--accent) focus:ring-(--accent)"
+                                                            className="cursor-pointer rounded border-(--border) bg-(--card) text-(--accent) focus:ring-(--accent)"
                                                         />
                                                     </td>
                                                     <td className="p-3">
@@ -313,7 +313,7 @@ export function ImportTeamsDialog() {
                                 </p>
                             </div>
 
-                            <div className="grid grid-cols-3 gap-4 rounded-lg border border-(--card-stroke) bg-(--card-80) p-4">
+                            <div className="grid grid-cols-3 gap-4 rounded-lg border border-(--border) bg-(--card-80) p-4">
                                 <div>
                                     <div className="text-2xl font-bold text-foreground">
                                         {importResult.imported}
@@ -337,7 +337,7 @@ export function ImportTeamsDialog() {
                     )}
                 </div>
 
-                <div className="flex items-center justify-end gap-3 border-t border-(--card-stroke) p-6">
+                <div className="flex items-center justify-end gap-3 border-t border-(--border) p-6">
                     {step === "result" ? (
                         <button
                             type="button"

--- a/src/components/admin/teams/PendingChangesPanel.tsx
+++ b/src/components/admin/teams/PendingChangesPanel.tsx
@@ -105,7 +105,7 @@ export function PendingChangesPanel() {
     }
 
     return (
-        <div className="mb-6 rounded-lg border border-(--card-stroke) bg-(--card)">
+        <div className="mb-6 rounded-lg border border-(--border) bg-(--card)">
             <button
                 type="button"
                 className="flex w-full cursor-pointer items-center justify-between px-4 py-3 text-left"
@@ -121,8 +121,8 @@ export function PendingChangesPanel() {
             </button>
 
             {isOpen && (
-                <div className="border-t border-(--card-stroke)">
-                    <div className="flex items-center justify-end gap-2 px-4 py-2 border-b border-(--card-stroke) bg-(--card-80)">
+                <div className="border-t border-(--border)">
+                    <div className="flex items-center justify-end gap-2 px-4 py-2 border-b border-(--border) bg-(--card-80)">
                         <button
                             type="button"
                             onClick={() => handleBulkAction("approve")}
@@ -144,7 +144,7 @@ export function PendingChangesPanel() {
                     {changes.map((change) => (
                         <div
                             key={`${change.team_id}-${change.change_type}-${change.field ?? "all"}-${change.change_index}`}
-                            className="flex items-center justify-between border-b border-(--card-stroke) px-4 py-3 last:border-0 hover:bg-(--card-70)"
+                            className="flex items-center justify-between border-b border-(--border) px-4 py-3 last:border-0 hover:bg-(--card-70)"
                         >
                             <div className="flex flex-col gap-1">
                                 <div className="flex items-center gap-2">

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -57,7 +57,7 @@ export function TeamForm({
             isLoading={isLoading}
             submitLabel={isLoading ? "Saving…" : isEditing ? "Update Team" : "Create Team"}
             className="max-w-2xl space-y-6"
-            contentClassName="space-y-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6"
+            contentClassName="space-y-4 rounded-2xl border border-(--border) bg-(--card-80) p-6"
             actionsClassName="flex items-center gap-4"
             actionsStart={
                 <Link

--- a/src/components/admin/users/UserForm.tsx
+++ b/src/components/admin/users/UserForm.tsx
@@ -38,7 +38,7 @@ export function UserForm({
             onCancelAction={onCancel}
             isLoading={isLoading}
             submitLabel={isLoading ? "Saving..." : isEdit ? "Save Changes" : "Create User"}
-            className="space-y-6 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6"
+            className="space-y-6 rounded-2xl border border-(--border) bg-(--card-80) p-6"
             contentClassName="grid gap-6 md:grid-cols-2"
             actionsClassName="flex justify-end gap-3 pt-4"
         >
@@ -126,7 +126,7 @@ export function UserForm({
                             checked={formData.is_active}
                             onChange={handleChange}
                             disabled={isLoading}
-                            className="h-4 w-4 rounded border-(--card-stroke) text-(--accent) focus:ring-(--accent)"
+                            className="h-4 w-4 rounded border-(--border) text-(--accent) focus:ring-(--accent)"
                         />
                         <label htmlFor="is_active" className="text-sm text-foreground">
                             Active

--- a/src/components/ai/AIAttributionBadge.tsx
+++ b/src/components/ai/AIAttributionBadge.tsx
@@ -31,7 +31,7 @@ const BUCKET_TREATMENTS = {
     },
     unknown: {
         label: "Unknown attribution",
-        className: "border-(--card-stroke) bg-background/60 text-(--ink-muted)",
+        className: "border-(--border) bg-background/60 text-(--ink-muted)",
     },
 } as const;
 

--- a/src/components/ai/AIAutomationsDashboard.tsx
+++ b/src/components/ai/AIAutomationsDashboard.tsx
@@ -45,7 +45,7 @@ export function AIAutomationsDashboard({ filter }: AIAutomationsDashboardProps) 
 function AutomationsSkeleton() {
     return (
         <div
-            className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+            className="rounded-3xl border border-(--border) bg-card p-5"
             data-testid="ai-automations-loading"
         >
             <div className="h-40 animate-pulse rounded-2xl bg-(--card-80)" />

--- a/src/components/ai/AIComparisonCard.tsx
+++ b/src/components/ai/AIComparisonCard.tsx
@@ -31,7 +31,7 @@ export function AIComparisonCard({
     const spark = [baselineValue ?? 0, aiValue ?? 0];
 
     return (
-        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4">
+        <div className="rounded-2xl border border-(--border) bg-(--card-80) p-4">
             <div className="flex items-start justify-between gap-4">
                 <div>
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">

--- a/src/components/ai/AIComparisonMetricCard.tsx
+++ b/src/components/ai/AIComparisonMetricCard.tsx
@@ -44,7 +44,7 @@ export function AIComparisonMetricCard({
 
     return (
         <article
-            className="flex min-h-[188px] flex-col justify-between rounded-3xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+            className="flex min-h-[188px] flex-col justify-between rounded-3xl border border-(--border) bg-card p-5 shadow-sm"
             data-testid="ai-comparison-metric-card"
         >
             <div>
@@ -52,7 +52,7 @@ export function AIComparisonMetricCard({
                     <h3 className="font-(--font-display) text-lg">{title}</h3>
                     {tooltip && (
                         <span
-                            className="rounded-full border border-(--card-stroke) px-2 py-1 text-xs text-(--ink-muted)"
+                            className="rounded-full border border-(--border) px-2 py-1 text-xs text-(--ink-muted)"
                             title={tooltip}
                             aria-label={tooltip}
                         >

--- a/src/components/ai/AIDrilldownModal.tsx
+++ b/src/components/ai/AIDrilldownModal.tsx
@@ -22,7 +22,7 @@ export function AIDrilldownModal({ metric, filter, onClose }: AIDrilldownModalPr
             data-testid="ai-drilldown-modal"
         >
             <div
-                className="w-full max-w-3xl rounded-3xl border border-(--card-stroke) bg-card p-6 shadow-xl"
+                className="w-full max-w-3xl rounded-3xl border border-(--border) bg-card p-6 shadow-xl"
                 onClick={(event) => event.stopPropagation()}
             >
                 <div className="flex items-start justify-between gap-4">
@@ -41,7 +41,7 @@ export function AIDrilldownModal({ metric, filter, onClose }: AIDrilldownModalPr
                     <button
                         type="button"
                         onClick={onClose}
-                        className="rounded-full border border-(--card-stroke) px-3 py-1 text-xs font-semibold text-(--ink-muted) hover:text-foreground"
+                        className="rounded-full border border-(--border) px-3 py-1 text-xs font-semibold text-(--ink-muted) hover:text-foreground"
                         aria-label="Close evidence drilldown"
                     >
                         Close

--- a/src/components/ai/AIEvidenceExplorer.tsx
+++ b/src/components/ai/AIEvidenceExplorer.tsx
@@ -82,7 +82,7 @@ function PrTable({
     }
     return (
         <div
-            className="max-h-72 overflow-y-auto rounded-2xl border border-(--card-stroke)"
+            className="max-h-72 overflow-y-auto rounded-2xl border border-(--border)"
             data-testid="ai-drilldown-table"
         >
             <table className="w-full text-left text-sm">
@@ -95,7 +95,7 @@ function PrTable({
                         <th className="px-3 py-2 font-semibold">Merged</th>
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-(--card-stroke)">
+                <tbody className="divide-y divide-(--border)">
                     {rows.map((pr) => {
                         const key = prRowKey(pr);
                         const isSelected = key === selectedKey;
@@ -185,7 +185,7 @@ export function EvidencePanel({ selected }: { selected: AiAttributedPr | null })
                 {drilldown.edges.slice(0, 25).map((edge) => (
                     <li
                         key={edge.edgeId}
-                        className="rounded-2xl border border-(--card-stroke) bg-background/40 px-3 py-2 text-sm"
+                        className="rounded-2xl border border-(--border) bg-background/40 px-3 py-2 text-sm"
                     >
                         <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.12em] text-(--ink-muted)">
                             <span className="font-semibold text-foreground">{edge.edgeType}</span>
@@ -265,7 +265,7 @@ export function AIEvidenceExplorer({ filter }: AIEvidenceExplorerProps) {
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="Search title, kind, or PR number"
-                className="mt-1 w-full rounded-full border border-(--card-stroke) bg-background/60 px-4 py-2 text-sm focus:border-(--accent-positive) focus:outline-none"
+                className="mt-1 w-full rounded-full border border-(--border) bg-background/60 px-4 py-2 text-sm focus:border-(--accent-positive) focus:outline-none"
                 data-testid="ai-drilldown-search"
             />
 

--- a/src/components/ai/AIEvidencePanel.tsx
+++ b/src/components/ai/AIEvidencePanel.tsx
@@ -14,7 +14,7 @@ type AIEvidencePanelProps = {
 export function AIEvidencePanel({ filter }: AIEvidencePanelProps) {
     return (
         <section
-            className="rounded-3xl border border-(--card-stroke) bg-card p-6"
+            className="rounded-3xl border border-(--border) bg-card p-6"
             data-testid="ai-evidence-panel"
         >
             <h3 className="font-(--font-display) text-lg">Evidence by pull request</h3>

--- a/src/components/ai/AIImpactDashboard.tsx
+++ b/src/components/ai/AIImpactDashboard.tsx
@@ -71,7 +71,7 @@ export function AIImpactDashboard({ filter, evidenceHref }: AIImpactDashboardPro
     return (
         <div className="flex flex-col gap-6" data-testid="ai-impact-dashboard">
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-                <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+                <div className="rounded-3xl border border-(--border) bg-card p-5">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         AI-assisted work share
                     </p>
@@ -83,7 +83,7 @@ export function AIImpactDashboard({ filter, evidenceHref }: AIImpactDashboardPro
                         AI-assisted.
                     </p>
                 </div>
-                <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+                <div className="rounded-3xl border border-(--border) bg-card p-5">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         Agent-created work share
                     </p>
@@ -95,7 +95,7 @@ export function AIImpactDashboard({ filter, evidenceHref }: AIImpactDashboardPro
                         PRs appear agent-created.
                     </p>
                 </div>
-                <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+                <div className="rounded-3xl border border-(--border) bg-card p-5">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                         Unknown attribution
                     </p>

--- a/src/components/ai/AIImpactEvidenceList.tsx
+++ b/src/components/ai/AIImpactEvidenceList.tsx
@@ -99,7 +99,7 @@ export function AIImpactEvidenceList({ filter }: AIImpactEvidenceListProps) {
                     data-testid="ai-impact-evidence-sparse-page"
                 />
             ) : (
-                <div className="overflow-hidden rounded-3xl border border-(--card-stroke)">
+                <div className="overflow-hidden rounded-3xl border border-(--border)">
                     <table className="w-full text-left text-sm">
                         <thead className="bg-card text-xs uppercase tracking-[0.14em] text-(--ink-muted)">
                             <tr>
@@ -111,7 +111,7 @@ export function AIImpactEvidenceList({ filter }: AIImpactEvidenceListProps) {
                                 <th className="px-4 py-3 font-semibold">Merged</th>
                             </tr>
                         </thead>
-                        <tbody className="divide-y divide-(--card-stroke)">
+                        <tbody className="divide-y divide-(--border)">
                             {fetching && rows.length === 0 ? (
                                 <tr>
                                     <td
@@ -175,7 +175,7 @@ export function AIImpactEvidenceList({ filter }: AIImpactEvidenceListProps) {
                             setOffset(Math.max(0, offset - PAGE_SIZE));
                             setSelectedKey(null);
                         }}
-                        className="rounded-full border border-(--card-stroke) px-3 py-1 text-xs font-semibold disabled:opacity-40"
+                        className="rounded-full border border-(--border) px-3 py-1 text-xs font-semibold disabled:opacity-40"
                     >
                         {CTA_LABELS.previousPage}
                     </button>
@@ -186,14 +186,14 @@ export function AIImpactEvidenceList({ filter }: AIImpactEvidenceListProps) {
                             setOffset(offset + PAGE_SIZE);
                             setSelectedKey(null);
                         }}
-                        className="rounded-full border border-(--card-stroke) px-3 py-1 text-xs font-semibold disabled:opacity-40"
+                        className="rounded-full border border-(--border) px-3 py-1 text-xs font-semibold disabled:opacity-40"
                     >
                         {CTA_LABELS.nextPage}
                     </button>
                 </div>
             </div>
 
-            <section className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+            <section className="rounded-3xl border border-(--border) bg-card p-5">
                 <h3 className="font-(--font-display) text-lg">Work Graph evidence</h3>
                 <div className="mt-3">
                     <EvidencePanel selected={selected} />

--- a/src/components/ai/AIOpportunityList.tsx
+++ b/src/components/ai/AIOpportunityList.tsx
@@ -40,7 +40,7 @@ function OpportunityEvidence({ selected }: { selected: AiWorkGraphDrilldownRef |
 
     return (
         <div
-            className="mt-3 rounded-2xl border border-(--card-stroke) bg-background/50 p-3"
+            className="mt-3 rounded-2xl border border-(--border) bg-background/50 p-3"
             data-testid="ai-opportunity-workgraph-evidence"
         >
             <p className="text-xs uppercase tracking-[0.12em] text-(--ink-muted)">
@@ -69,7 +69,7 @@ export function AIOpportunityList({
 
     if (!detectorReady) {
         return (
-            <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-80) p-5 text-sm text-(--ink-muted)">
+            <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-80) p-5 text-sm text-(--ink-muted)">
                 <p className="font-medium text-foreground">
                     No automation candidates in this scope yet
                 </p>
@@ -94,7 +94,7 @@ export function AIOpportunityList({
             {recommendations.slice(0, 5).map((item) => (
                 <li
                     key={item.opportunityId}
-                    className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4"
+                    className="rounded-2xl border border-(--border) bg-(--card-80) p-4"
                 >
                     <div className="flex items-start justify-between gap-3">
                         <div>
@@ -120,7 +120,7 @@ export function AIOpportunityList({
                                         key={`${ref.rootType}:${ref.rootId}`}
                                         type="button"
                                         onClick={() => setSelectedRef(selected ? null : ref)}
-                                        className={`rounded-full border px-3 py-1 text-xs font-semibold transition-colors ${selected ? "border-(--accent-positive) bg-(--accent-positive)/10 text-foreground" : "border-(--card-stroke) bg-background/60 text-(--ink-muted) hover:text-foreground"}`}
+                                        className={`rounded-full border px-3 py-1 text-xs font-semibold transition-colors ${selected ? "border-(--accent-positive) bg-(--accent-positive)/10 text-foreground" : "border-(--border) bg-background/60 text-(--ink-muted) hover:text-foreground"}`}
                                     >
                                         Work Graph: {ref.label}
                                     </button>

--- a/src/components/ai/AIPanelCard.tsx
+++ b/src/components/ai/AIPanelCard.tsx
@@ -11,7 +11,7 @@ type AIPanelCardProps = {
 export function AIPanelCard({ title, description, evidenceHref, children }: AIPanelCardProps) {
     return (
         <section
-            className="rounded-3xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+            className="rounded-3xl border border-(--border) bg-card p-5 shadow-sm"
             data-testid={`ai-panel-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`}
         >
             <div className="flex items-start justify-between gap-4">

--- a/src/components/ai/AIReviewAmplificationTrend.tsx
+++ b/src/components/ai/AIReviewAmplificationTrend.tsx
@@ -85,7 +85,7 @@ export function AIReviewAmplificationTrend({ daily, loading }: AIReviewAmplifica
 
     return (
         <section
-            className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+            className="rounded-3xl border border-(--border) bg-card p-5"
             data-testid="ai-review-amplification-trend"
         >
             <h3 className="font-(--font-display) text-lg">Review amplification trend</h3>

--- a/src/components/ai/AIReviewLoadDashboard.tsx
+++ b/src/components/ai/AIReviewLoadDashboard.tsx
@@ -115,7 +115,7 @@ export function AIReviewLoadDashboard({ filter }: AIReviewLoadDashboardProps) {
                 />
                 {reviewLoad?.reviewerConcentration.dataAvailable ? (
                     <section
-                        className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+                        className="rounded-3xl border border-(--border) bg-card p-5"
                         data-testid="ai-reviewer-concentration"
                     >
                         <p className="text-xs font-semibold uppercase tracking-[0.16em] text-(--ink-muted)">

--- a/src/components/ai/AIRiskDashboard.tsx
+++ b/src/components/ai/AIRiskDashboard.tsx
@@ -129,7 +129,7 @@ export function AIRiskDashboard({ filter }: AIRiskDashboardProps) {
             <div className="grid gap-4 lg:grid-cols-3">
                 {hotspotRow ? (
                     <section
-                        className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+                        className="rounded-3xl border border-(--border) bg-card p-5"
                         data-testid="ai-hotspot-overlap"
                     >
                         <h3 className="font-(--font-display) text-lg">Hotspot file overlap</h3>
@@ -166,7 +166,7 @@ export function AIRiskDashboard({ filter }: AIRiskDashboardProps) {
                 )}
                 {complexityRow ? (
                     <section
-                        className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+                        className="rounded-3xl border border-(--border) bg-card p-5"
                         data-testid="ai-complexity-overlap"
                     >
                         <h3 className="font-(--font-display) text-lg">
@@ -201,7 +201,7 @@ export function AIRiskDashboard({ filter }: AIRiskDashboardProps) {
                     />
                 )}
                 <section
-                    className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+                    className="rounded-3xl border border-(--border) bg-card p-5"
                     data-testid="ai-linked-incidents"
                 >
                     <h3 className="font-(--font-display) text-lg">Linked incidents</h3>

--- a/src/components/ai/AITabPreview.tsx
+++ b/src/components/ai/AITabPreview.tsx
@@ -11,7 +11,7 @@ export function AITabPreview({ children, whereNow }: AITabPreviewProps) {
     return (
         <section
             data-testid="ai-tab-preview"
-            className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-8"
+            className="rounded-3xl border border-dashed border-(--border) bg-(--card-70) p-8"
         >
             <span className="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-[0.15em] text-amber-400">
                 Preview

--- a/src/components/ai/AITestGapsPanel.tsx
+++ b/src/components/ai/AITestGapsPanel.tsx
@@ -55,7 +55,7 @@ export function AITestGapsPanel({ filter }: AITestGapsPanelProps) {
                     loading={risk.fetching}
                 />
                 <section
-                    className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+                    className="rounded-3xl border border-(--border) bg-card p-5"
                     data-testid="ai-test-gap-baseline"
                 >
                     <h3 className="font-(--font-display) text-lg">Baseline test gap rate</h3>
@@ -72,7 +72,7 @@ export function AITestGapsPanel({ filter }: AITestGapsPanelProps) {
                     </p>
                 </section>
                 <section
-                    className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+                    className="rounded-3xl border border-(--border) bg-card p-5"
                     data-testid="ai-test-gap-prs"
                 >
                     <h3 className="font-(--font-display) text-lg">PRs with test gaps</h3>

--- a/src/components/ai/AIViolationsList.tsx
+++ b/src/components/ai/AIViolationsList.tsx
@@ -9,7 +9,7 @@ export function AIViolationsList({ violations, loading }: AIViolationsListProps)
     if (loading) {
         return (
             <section
-                className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+                className="rounded-3xl border border-(--border) bg-card p-5"
                 data-testid="ai-violations-list"
             >
                 <h3 className="font-(--font-display) text-lg">Security findings</h3>
@@ -20,7 +20,7 @@ export function AIViolationsList({ violations, loading }: AIViolationsListProps)
 
     return (
         <section
-            className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+            className="rounded-3xl border border-(--border) bg-card p-5"
             data-testid="ai-violations-list"
         >
             <div className="flex items-center justify-between gap-3">
@@ -40,7 +40,7 @@ export function AIViolationsList({ violations, loading }: AIViolationsListProps)
                     No PR-scoped governance violations appear in this range.
                 </p>
             ) : (
-                <ul className="mt-4 divide-y divide-(--card-stroke)">
+                <ul className="mt-4 divide-y divide-(--border)">
                     {violations.slice(0, 8).map((violation) => (
                         <li
                             key={`${violation.ruleId}-${violation.subjectId}-${violation.observedAt}`}

--- a/src/components/auth/AuthCard.tsx
+++ b/src/components/auth/AuthCard.tsx
@@ -12,7 +12,7 @@ type AuthCardProps = {
 
 export function AuthCard({ children, signInHref, signUpHref, providers = [] }: AuthCardProps) {
     return (
-        <div className="w-full max-w-md rounded-2xl border border-[var(--card-stroke)] bg-[var(--card)] p-6 sm:p-8 shadow-lg space-y-6">
+        <div className="w-full max-w-md rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 sm:p-8 shadow-lg space-y-6">
             <AuthTabs signInHref={signInHref} signUpHref={signUpHref} />
 
             <SocialLoginButtons providers={providers} />

--- a/src/components/auth/AuthTabs.tsx
+++ b/src/components/auth/AuthTabs.tsx
@@ -16,7 +16,7 @@ export function AuthTabs({
     const isSignIn = pathname === "/auth/signin";
 
     return (
-        <div className="flex rounded-lg border border-[var(--card-stroke)] overflow-hidden">
+        <div className="flex rounded-lg border border-[var(--border)] overflow-hidden">
             <Link
                 href={signInHref}
                 className={`flex-1 py-3 text-center font-medium text-sm transition-colors ${

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -77,7 +77,7 @@ export function ForgotPasswordForm() {
                         required
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
-                        className="w-full px-3 py-2 border rounded-md border-[var(--card-stroke)] bg-[var(--card)] text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+                        className="w-full px-3 py-2 border rounded-md border-[var(--border)] bg-[var(--card)] text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
                         disabled={isLoading}
                     />
                 </div>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -82,7 +82,7 @@ export function LoginForm({ plan, trialIntent = false }: LoginFormProps) {
     };
 
     const inputClass =
-        "w-full rounded-lg border border-[var(--card-stroke)] bg-[var(--background)] px-4 py-3 text-[var(--foreground)] placeholder:text-[var(--ink-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] transition-shadow";
+        "w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-[var(--foreground)] placeholder:text-[var(--ink-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] transition-shadow";
 
     return (
         <>
@@ -144,7 +144,7 @@ export function LoginForm({ plan, trialIntent = false }: LoginFormProps) {
                 <button
                     type="submit"
                     disabled={loading}
-                    className="w-full rounded-lg border border-[var(--card-stroke)] bg-transparent py-3 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--card-stroke)]/20 transition-colors disabled:opacity-50"
+                    className="w-full rounded-lg border border-[var(--border)] bg-transparent py-3 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--card-stroke)]/20 transition-colors disabled:opacity-50"
                 >
                     {loading ? "Signing in..." : "Sign in"}
                 </button>

--- a/src/components/auth/OnboardForm.tsx
+++ b/src/components/auth/OnboardForm.tsx
@@ -110,7 +110,7 @@ export function OnboardForm({ plan, trialIntent = false }: OnboardFormProps) {
                     type="text"
                     value={orgName}
                     onChange={(e) => setOrgName(e.target.value)}
-                    className="w-full px-3 py-2 border rounded-md border-[var(--card-stroke)] bg-[var(--card)] text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+                    className="w-full px-3 py-2 border rounded-md border-[var(--border)] bg-[var(--card)] text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
                     placeholder="My Company"
                 />
                 <p className="text-xs text-[var(--ink-muted)]">

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -106,7 +106,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
                         maxLength={128}
                         value={newPassword}
                         onChange={(e) => setNewPassword(e.target.value)}
-                        className="w-full px-3 py-2 border rounded-md border-[var(--card-stroke)] bg-[var(--card)] text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+                        className="w-full px-3 py-2 border rounded-md border-[var(--border)] bg-[var(--card)] text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
                         disabled={isLoading}
                     />
                 </div>
@@ -129,7 +129,7 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
                         maxLength={128}
                         value={confirmPassword}
                         onChange={(e) => setConfirmPassword(e.target.value)}
-                        className="w-full px-3 py-2 border rounded-md border-[var(--card-stroke)] bg-[var(--card)] text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+                        className="w-full px-3 py-2 border rounded-md border-[var(--border)] bg-[var(--card)] text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
                         disabled={isLoading}
                     />
                 </div>

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -77,7 +77,7 @@ export function SignupForm({ plan, trialIntent = false }: SignupFormProps) {
     };
 
     const inputClass =
-        "w-full rounded-lg border border-[var(--card-stroke)] bg-[var(--background)] px-4 py-3 text-[var(--foreground)] placeholder:text-[var(--ink-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] transition-shadow";
+        "w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-[var(--foreground)] placeholder:text-[var(--ink-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] transition-shadow";
 
     return (
         <form onSubmit={handleSubmit} className="space-y-5">
@@ -142,7 +142,7 @@ export function SignupForm({ plan, trialIntent = false }: SignupFormProps) {
                     type="checkbox"
                     checked={agreedToTerms}
                     onChange={(e) => setAgreedToTerms(e.target.checked)}
-                    className="mt-0.5 h-4 w-4 rounded border-[var(--card-stroke)] accent-[var(--accent)]"
+                    className="mt-0.5 h-4 w-4 rounded border-[var(--border)] accent-[var(--accent)]"
                 />
                 <span className="text-sm text-[var(--foreground)]">
                     I agree to the{" "}
@@ -159,7 +159,7 @@ export function SignupForm({ plan, trialIntent = false }: SignupFormProps) {
             <button
                 type="submit"
                 disabled={loading || !agreedToTerms}
-                className="w-full rounded-lg border border-[var(--card-stroke)] bg-transparent py-3 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--card-stroke)]/20 transition-colors disabled:opacity-50"
+                className="w-full rounded-lg border border-[var(--border)] bg-transparent py-3 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--card-stroke)]/20 transition-colors disabled:opacity-50"
             >
                 {loading ? "Creating account..." : "Create account"}
             </button>

--- a/src/components/auth/SocialLoginButtons.tsx
+++ b/src/components/auth/SocialLoginButtons.tsx
@@ -49,7 +49,7 @@ export function SocialLoginButtons({ providers = [] }: SocialLoginButtonsProps) 
     if (providers.length === 0) return null;
 
     const buttonClass =
-        "w-full rounded-lg border border-[var(--card-stroke)] bg-transparent py-3 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--card-stroke)]/20 transition-colors flex items-center justify-center gap-2";
+        "w-full rounded-lg border border-[var(--border)] bg-transparent py-3 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--card-stroke)]/20 transition-colors flex items-center justify-center gap-2";
 
     return (
         <div className="space-y-3">

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -39,7 +39,7 @@ export function UserMenu() {
             <button
                 type="button"
                 onClick={() => setIsOpen(!isOpen)}
-                className="cursor-pointer flex items-center gap-2 rounded-full border border-[var(--card-stroke)] bg-[var(--card)] px-3 py-1.5 hover:bg-[var(--card-80)] transition-colors"
+                className="cursor-pointer flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 hover:bg-[var(--card-80)] transition-colors"
             >
                 <div className="h-6 w-6 rounded-full bg-[var(--accent)] text-white flex items-center justify-center text-xs font-bold">
                     {session.user?.email?.[0]?.toUpperCase() || "U"}
@@ -50,9 +50,9 @@ export function UserMenu() {
             </button>
 
             {isOpen && (
-                <div className="absolute right-0 mt-2 w-48 origin-top-right rounded-md border border-[var(--card-stroke)] bg-[var(--card)] shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+                <div className="absolute right-0 mt-2 w-48 origin-top-right rounded-md border border-[var(--border)] bg-[var(--card)] shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
                     <div className="py-1">
-                        <div className="px-4 py-2 text-xs text-[var(--ink-muted)] border-b border-[var(--card-stroke)]">
+                        <div className="px-4 py-2 text-xs text-[var(--ink-muted)] border-b border-[var(--border)]">
                             Signed in as
                             <br />
                             <span className="font-medium text-[var(--foreground)] truncate block">
@@ -82,7 +82,7 @@ export function UserMenu() {
                         >
                             Admin Panel
                         </Link>
-                        <div className="border-t border-[var(--card-stroke)]">
+                        <div className="border-t border-[var(--border)]">
                             <button
                                 type="button"
                                 onClick={() => signOut()}

--- a/src/components/billing/UpgradeGate.tsx
+++ b/src/components/billing/UpgradeGate.tsx
@@ -31,7 +31,7 @@ export function UpgradeGate({
     const requiredTierLabel = requiredTier.charAt(0).toUpperCase() + requiredTier.slice(1);
 
     return (
-        <div className="relative min-h-[400px] w-full overflow-hidden rounded-3xl border border-(--card-stroke) bg-(--card)">
+        <div className="relative min-h-[400px] w-full overflow-hidden rounded-3xl border border-(--border) bg-(--card)">
             {/* Frosted overlay effect */}
             <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-(--card)/80 backdrop-blur-sm p-8 text-center">
                 <div className="max-w-md space-y-6">
@@ -45,14 +45,14 @@ export function UpgradeGate({
                         <p className="text-(--ink-muted)">{featureDescription}</p>
                     </div>
 
-                    <div className="rounded-xl border border-(--card-stroke) bg-(--background) p-4 text-sm">
+                    <div className="rounded-xl border border-(--border) bg-(--background) p-4 text-sm">
                         <div className="flex items-center justify-between gap-4">
                             <span className="text-(--ink-muted)">Current Plan</span>
                             <span className="font-medium text-(--foreground) capitalize">
                                 {currentTier}
                             </span>
                         </div>
-                        <div className="my-2 border-t border-(--card-stroke)" />
+                        <div className="my-2 border-t border-(--border)" />
                         <div className="flex items-center justify-between gap-4">
                             <span className="text-(--ink-muted)">Required Plan</span>
                             <span className="font-medium text-(--accent)">{requiredTierLabel}</span>

--- a/src/components/capacity/ForecastCard.tsx
+++ b/src/components/capacity/ForecastCard.tsx
@@ -21,7 +21,7 @@ function formatLowVarianceWeeks(days: number): string {
 
 function SkeletonCard() {
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-6 animate-pulse">
+        <div className="rounded-3xl border border-(--border) bg-card p-6 animate-pulse">
             <div className="h-6 bg-(--card-70) rounded w-1/3 mb-4" />
             <div className="space-y-3">
                 <div className="h-4 bg-(--card-70) rounded w-1/2" />
@@ -43,7 +43,7 @@ function ErrorCard({ error }: { error: Error }) {
 
 function EmptyCard() {
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+        <div className="rounded-3xl border border-(--border) bg-card p-6">
             <h3 className="text-lg font-semibold text-foreground mb-2">No Forecast Available</h3>
             <p className="text-sm text-(--ink-muted)">
                 Insufficient throughput history to generate a forecast. Need at least 14 days of
@@ -71,7 +71,7 @@ export function ForecastCard({ forecast, loading, error }: ForecastCardProps) {
           : "All Teams";
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+        <div className="rounded-3xl border border-(--border) bg-card p-6">
             <div className="mb-4">
                 <div className="flex items-center justify-between">
                     <h3 className="text-lg font-semibold text-foreground">Completion Forecast</h3>
@@ -90,7 +90,7 @@ export function ForecastCard({ forecast, loading, error }: ForecastCardProps) {
 
             <div className="space-y-2 mb-4">
                 {hasLowVarianceForecast ? (
-                    <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3">
+                    <div className="rounded-2xl border border-(--border) bg-(--card-70) px-4 py-3">
                         <span className="text-sm text-(--ink-muted)">Forecast range</span>
                         <div className="mt-1 flex flex-wrap items-center justify-between gap-2">
                             <span className="font-semibold text-foreground">
@@ -103,7 +103,7 @@ export function ForecastCard({ forecast, loading, error }: ForecastCardProps) {
                     </div>
                 ) : (
                     <>
-                        <div className="flex items-center justify-between py-2 border-b border-(--card-stroke)">
+                        <div className="flex items-center justify-between py-2 border-b border-(--border)">
                             <span className="text-sm text-(--ink-muted)">50% chance</span>
                             <div className="text-right">
                                 <span className="font-medium text-green-500">
@@ -117,7 +117,7 @@ export function ForecastCard({ forecast, loading, error }: ForecastCardProps) {
                             </div>
                         </div>
 
-                        <div className="flex items-center justify-between py-2 border-b border-(--card-stroke) bg-amber-500/10 -mx-2 px-2 rounded">
+                        <div className="flex items-center justify-between py-2 border-b border-(--border) bg-amber-500/10 -mx-2 px-2 rounded">
                             <span className="text-sm font-medium text-amber-400">85% chance</span>
                             <div className="text-right flex items-center">
                                 <span className="font-bold text-amber-400">
@@ -151,7 +151,7 @@ export function ForecastCard({ forecast, loading, error }: ForecastCardProps) {
                 )}
             </div>
 
-            <div className="pt-4 border-t border-(--card-stroke)">
+            <div className="pt-4 border-t border-(--border)">
                 <div className="flex items-center justify-between text-sm">
                     <span className="text-(--ink-muted)">Throughput</span>
                     <span className="text-foreground">

--- a/src/components/charts/ChartFrame.tsx
+++ b/src/components/charts/ChartFrame.tsx
@@ -46,7 +46,7 @@ type ChartFrameProps = {
 };
 
 const annotationToneClassName: Record<ChartFrameAnnotationTone, string> = {
-    default: "border-(--card-stroke) bg-(--card-80) text-(--ink-muted)",
+    default: "border-(--border) bg-(--card-80) text-(--ink-muted)",
     positive: "border-(--positive)/30 bg-(--positive)/10 text-(--positive)",
     caution: "border-(--caution)/30 bg-(--caution)/10 text-(--caution)",
     negative: "border-(--accent-negative)/30 bg-(--accent-negative)/10 text-(--accent-negative)",
@@ -132,7 +132,7 @@ export function ChartFrame({
 
     return (
         <section
-            className={`rounded-(--radius-lg) border border-(--card-stroke) bg-(--card) p-5 shadow-(--elevation-card) ${className ?? ""}`.trim()}
+            className={`rounded-(--radius-lg) border border-(--border) bg-(--card) p-5 shadow-(--elevation-card) ${className ?? ""}`.trim()}
             data-testid={testId}
         >
             <div className="flex flex-wrap items-start justify-between gap-4">

--- a/src/components/charts/ChartTypeToggle.tsx
+++ b/src/components/charts/ChartTypeToggle.tsx
@@ -27,7 +27,7 @@ export function ChartTypeToggle<T extends string = string>({
 }: ChartTypeToggleProps<T>) {
     return (
         <div
-            className={`inline-flex rounded-lg border border-(--card-stroke) bg-(--card-70) p-0.5 ${className}`}
+            className={`inline-flex rounded-lg border border-(--border) bg-(--card-70) p-0.5 ${className}`}
             role="radiogroup"
             aria-label="Chart type"
         >

--- a/src/components/charts/ChordChartControls.tsx
+++ b/src/components/charts/ChordChartControls.tsx
@@ -200,7 +200,7 @@ export function ChordChartControls({
                             grouping: e.target.value as ChordGroupingDimension,
                         })
                     }
-                    className="h-9 px-3 py-1.5 text-sm text-(--foreground) bg-(--card) border border-(--card-stroke) rounded-lg focus:outline-none focus:ring-2 focus:ring-(--accent)"
+                    className="h-9 px-3 py-1.5 text-sm text-(--foreground) bg-(--card) border border-(--border) rounded-lg focus:outline-none focus:ring-2 focus:ring-(--accent)"
                 >
                     <option value="team">Team</option>
                     <option value="repo">Repository</option>
@@ -213,7 +213,7 @@ export function ChordChartControls({
                 <label htmlFor="chord-topn" className="text-sm font-medium text-(--ink-muted)">
                     Entities
                 </label>
-                <div className="flex items-center border border-(--card-stroke) rounded-lg bg-(--card) overflow-hidden h-9">
+                <div className="flex items-center border border-(--border) rounded-lg bg-(--card) overflow-hidden h-9">
                     <button
                         type="button"
                         aria-label="Decrease entities"
@@ -266,7 +266,7 @@ export function ChordChartControls({
                         type="checkbox"
                         checked={value.showSelfLinks}
                         onChange={(e) => onChange({ ...value, showSelfLinks: e.target.checked })}
-                        className="rounded border-(--card-stroke) accent-(--accent) focus:ring-(--accent)"
+                        className="rounded border-(--border) accent-(--accent) focus:ring-(--accent)"
                     />
                     Include self-links
                 </label>
@@ -282,7 +282,7 @@ export function ChordChartControls({
                         checked={value.showOther}
                         onChange={(e) => onChange({ ...value, showOther: e.target.checked })}
                         disabled={!otherAvailable}
-                        className="rounded border-(--card-stroke) accent-(--accent) focus:ring-(--accent) disabled:opacity-50"
+                        className="rounded border-(--border) accent-(--accent) focus:ring-(--accent) disabled:opacity-50"
                     />
                     Show &apos;Other&apos; bucket
                 </label>

--- a/src/components/charts/ChordSummaryPanel.tsx
+++ b/src/components/charts/ChordSummaryPanel.tsx
@@ -30,9 +30,7 @@ export function ChordSummaryPanel({
 }: ChordSummaryPanelProps) {
     if (loading) {
         return (
-            <section
-                className={`rounded-3xl border border-(--card-stroke) bg-card p-4 ${className}`}
-            >
+            <section className={`rounded-3xl border border-(--border) bg-card p-4 ${className}`}>
                 <div className="space-y-6">
                     {loadingSections.map((section) => (
                         <div key={section} className="space-y-3">
@@ -55,9 +53,7 @@ export function ChordSummaryPanel({
 
     if (!dataset || dataset.nodes.length === 0) {
         return (
-            <section
-                className={`rounded-3xl border border-(--card-stroke) bg-card p-4 ${className}`}
-            >
+            <section className={`rounded-3xl border border-(--border) bg-card p-4 ${className}`}>
                 <EmptyState
                     title="No summary yet"
                     description="Adjust filters to reveal exchange patterns."
@@ -77,7 +73,7 @@ export function ChordSummaryPanel({
 
     return (
         <section
-            className={`rounded-3xl border border-(--card-stroke) bg-card p-4 space-y-6 ${className}`}
+            className={`rounded-3xl border border-(--border) bg-card p-4 space-y-6 ${className}`}
         >
             {/* Top Importers */}
             <div>
@@ -191,7 +187,7 @@ export function ChordSummaryPanel({
 
             {/* Overflow Row */}
             {summary.otherShare > 0 && (
-                <div className="pt-2 border-t border-(--card-stroke)">
+                <div className="pt-2 border-t border-(--border)">
                     <p className="text-xs text-(--ink-muted) text-center">
                         {formatNumber(summary.otherShare * 100, {
                             maximumFractionDigits: 1,

--- a/src/components/charts/HeatmapPanel.tsx
+++ b/src/components/charts/HeatmapPanel.tsx
@@ -219,7 +219,7 @@ export function HeatmapPanel({
 
     if (!data || !data.axes?.x?.length || !data.axes?.y?.length) {
         return (
-            <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
+            <div className="rounded-3xl border border-dashed border-(--border) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
                 {emptyState}
             </div>
         );
@@ -229,7 +229,7 @@ export function HeatmapPanel({
     const showArtifacts = !loading && artifacts.length > 0;
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+        <div className="rounded-3xl border border-(--border) bg-card p-5">
             <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
                     <h2 className="font-(--font-display) text-xl">{title}</h2>
@@ -243,7 +243,7 @@ export function HeatmapPanel({
                 {isFlat ? (
                     <div
                         data-testid="heatmap-flat-state"
-                        className="flex h-[320px] items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-6 text-center text-sm text-(--ink-muted)"
+                        className="flex h-[320px] items-center justify-center rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-6 text-center text-sm text-(--ink-muted)"
                     >
                         {flatStateLabel}
                     </div>
@@ -251,7 +251,7 @@ export function HeatmapPanel({
                     <HeatmapChart data={data} height={320} onCellSelectAction={handleCellSelect} />
                 )}
             </div>
-            <div className="mt-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4">
+            <div className="mt-4 rounded-2xl border border-(--border) bg-(--card-80) p-4">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                     <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                         {evidenceTitle}
@@ -276,7 +276,7 @@ export function HeatmapPanel({
                                 <>
                                     <div className="flex items-center justify-between gap-3">
                                         <div className="flex min-w-0 items-center gap-2">
-                                            <span className="shrink-0 rounded border border-(--card-stroke) bg-(--card-70) px-1.5 py-0.5 text-[10px] font-bold uppercase text-(--ink-muted)">
+                                            <span className="shrink-0 rounded border border-(--border) bg-(--card-70) px-1.5 py-0.5 text-[10px] font-bold uppercase text-(--ink-muted)">
                                                 {artifact.type}
                                             </span>
                                             <span className="truncate" title={artifact.title}>
@@ -308,14 +308,14 @@ export function HeatmapPanel({
                                 <Link
                                     key={artifactKey}
                                     href={artifact.link}
-                                    className="block rounded-2xl border border-(--card-stroke) bg-card px-3 py-2 transition-colors hover:border-(--accent)/40"
+                                    className="block rounded-2xl border border-(--border) bg-card px-3 py-2 transition-colors hover:border-(--accent)/40"
                                 >
                                     {body}
                                 </Link>
                             ) : (
                                 <div
                                     key={artifactKey}
-                                    className="rounded-2xl border border-(--card-stroke) bg-card px-3 py-2"
+                                    className="rounded-2xl border border-(--border) bg-card px-3 py-2"
                                 >
                                     {body}
                                 </div>

--- a/src/components/charts/HierarchicalFlameGraph.tsx
+++ b/src/components/charts/HierarchicalFlameGraph.tsx
@@ -148,7 +148,7 @@ export function HierarchicalFlameGraph({
                     disabled={!hasChildren}
                     className={`
             flex items-center w-full text-left px-2 text-xs truncate
-            border border-(--card-stroke) rounded-sm mb-0.5
+            border border-(--border) rounded-sm mb-0.5
             transition-all duration-150 text-white [text-shadow:0_1px_2px_rgba(0,0,0,0.3)]
             ${hasChildren ? "cursor-pointer hover:brightness-110" : "cursor-default"}
             ${isSearchMatch ? "ring-2 ring-(--accent-2)" : ""}
@@ -218,14 +218,14 @@ export function HierarchicalFlameGraph({
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}
                         placeholder="Search..."
-                        className="px-3 py-1 text-xs rounded-full border border-(--card-stroke) bg-card text-foreground placeholder:text-(--ink-muted) w-36"
+                        className="px-3 py-1 text-xs rounded-full border border-(--border) bg-card text-foreground placeholder:text-(--ink-muted) w-36"
                     />
                     {/* Reset */}
                     {(zoomStack.length > 0 || searchQuery) && (
                         <button
                             type="button"
                             onClick={handleReset}
-                            className="px-3 py-1 text-xs rounded-full border border-(--card-stroke) bg-card text-(--accent-2)"
+                            className="px-3 py-1 text-xs rounded-full border border-(--border) bg-card text-(--accent-2)"
                         >
                             {CTA_LABELS.reset}
                         </button>
@@ -246,7 +246,7 @@ export function HierarchicalFlameGraph({
             </div>
 
             {/* Flame Graph */}
-            <div className="flex-1 overflow-auto rounded-lg border border-(--card-stroke) bg-(--card-80) p-2 min-h-0">
+            <div className="flex-1 overflow-auto rounded-lg border border-(--border) bg-(--card-80) p-2 min-h-0">
                 {filteredChildren.length === 0 ? (
                     <div className="flex items-center justify-center h-32 text-sm text-(--ink-muted)">
                         {searchQuery ? (
@@ -267,7 +267,7 @@ export function HierarchicalFlameGraph({
             {/* Tooltip */}
             {hoveredNode && (
                 <div
-                    className="fixed z-50 px-3 py-2 text-xs rounded-lg border border-(--card-stroke) bg-card shadow-lg pointer-events-none max-w-xs"
+                    className="fixed z-50 px-3 py-2 text-xs rounded-lg border border-(--border) bg-card shadow-lg pointer-events-none max-w-xs"
                     style={{
                         left: tooltipPos.x + 12,
                         top: tooltipPos.y + 12,
@@ -285,7 +285,7 @@ export function HierarchicalFlameGraph({
                             {formatShare(hoveredNode.value, totalValue)}
                         </span>
                     </div>
-                    <div className="flex justify-between border-b border-(--card-stroke) pb-1">
+                    <div className="flex justify-between border-b border-(--border) pb-1">
                         <span className="text-(--ink-muted)">Total Elapsed</span>
                         <span className="text-foreground font-mono">
                             {formatValue(totalValue, unit)} {unit}

--- a/src/components/charts/InvestigationPanel.tsx
+++ b/src/components/charts/InvestigationPanel.tsx
@@ -126,7 +126,7 @@ export function InvestigationPanel({
 
     return (
         <div className="flex h-full flex-col bg-(--card-80) text-xs shadow-xl animate-in fade-in slide-in-from-right-4 duration-300">
-            <header className="flex items-center justify-between border-b border-(--card-stroke) p-4">
+            <header className="flex items-center justify-between border-b border-(--border) p-4">
                 <div>
                     <p className="text-[10px] uppercase tracking-widest text-(--ink-muted)">
                         Investigation
@@ -136,7 +136,7 @@ export function InvestigationPanel({
                 <button
                     type="button"
                     onClick={onCloseAction}
-                    className="rounded-full border border-(--card-stroke) p-1.5 text-[10px] uppercase tracking-widest text-(--ink-muted) hover:bg-(--card-70)"
+                    className="rounded-full border border-(--border) p-1.5 text-[10px] uppercase tracking-widest text-(--ink-muted) hover:bg-(--card-70)"
                     title="Close panel"
                 >
                     ✕
@@ -184,7 +184,7 @@ export function InvestigationPanel({
                                     className={`group flex items-center justify-between rounded-xl border px-4 py-3 transition ${
                                         isSuggested
                                             ? "border-(--accent-2) bg-(--accent-2)/5"
-                                            : "border-(--card-stroke) bg-card hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5"
+                                            : "border-(--border) bg-card hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5"
                                     }`}
                                 >
                                     <div className="flex flex-col gap-0.5 text-left">
@@ -207,7 +207,7 @@ export function InvestigationPanel({
                 </section>
             </div>
 
-            <footer className="border-t border-(--card-stroke) p-4 bg-(--card-90)">
+            <footer className="border-t border-(--border) p-4 bg-(--card-90)">
                 <p className="text-[10px] text-(--ink-muted) text-center font-medium">
                     Lens: {roleConfig.label}
                 </p>

--- a/src/components/charts/QuadrantPanel.tsx
+++ b/src/components/charts/QuadrantPanel.tsx
@@ -255,7 +255,7 @@ export function QuadrantPanel({
 
     if (!scopedData || !scopedData.points?.length) {
         return (
-            <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
+            <div className="rounded-3xl border border-dashed border-(--border) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
                 {emptyState}
             </div>
         );
@@ -317,7 +317,7 @@ export function QuadrantPanel({
     };
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+        <div className="rounded-3xl border border-(--border) bg-card p-5">
             <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
                     <h2 className="font-(--font-display) text-xl">{title}</h2>
@@ -330,7 +330,7 @@ export function QuadrantPanel({
                             ref={triggerRef}
                             type="button"
                             onClick={() => setIsGuideOpen(true)}
-                            className="flex items-center gap-2 rounded-full border border-(--card-stroke) bg-(--card-80) px-3 py-2 text-xs uppercase tracking-[0.25em] text-(--ink-muted) btn-help"
+                            className="flex items-center gap-2 rounded-full border border-(--border) bg-(--card-80) px-3 py-2 text-xs uppercase tracking-[0.25em] text-(--ink-muted) btn-help"
                         >
                             <span className="flex h-5 w-5 items-center justify-center rounded-full bg-card text-xs text-foreground">
                                 ⓘ
@@ -356,7 +356,7 @@ export function QuadrantPanel({
                               aria-modal="true"
                               aria-label={infoTitle}
                               onKeyDown={handleDialogKeyDown}
-                              className="relative z-10 w-full max-w-lg rounded-3xl border border-(--card-stroke) bg-card p-5 text-xs text-(--ink-muted) shadow-[0_30px_70px_-35px_rgba(0,0,0,0.7)]"
+                              className="relative z-10 w-full max-w-lg rounded-3xl border border-(--border) bg-card p-5 text-xs text-(--ink-muted) shadow-[0_30px_70px_-35px_rgba(0,0,0,0.7)]"
                           >
                               <div className="flex items-start justify-between gap-4">
                                   <div>
@@ -369,7 +369,7 @@ export function QuadrantPanel({
                                       ref={closeBtnRef}
                                       type="button"
                                       onClick={() => setIsGuideOpen(false)}
-                                      className="rounded-full border border-(--card-stroke) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted)"
+                                      className="rounded-full border border-(--border) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted)"
                                   >
                                       {CTA_LABELS.closePanel}
                                   </button>
@@ -402,7 +402,7 @@ export function QuadrantPanel({
             <div className="mt-3 flex flex-wrap items-start gap-3 text-xs text-(--ink-muted)">
                 {hasInterpretationOverlay ? (
                     <div className="space-y-1">
-                        <label className="inline-flex items-center gap-2 rounded-full border border-(--card-stroke) bg-(--card-80) px-3 py-2 text-xs">
+                        <label className="inline-flex items-center gap-2 rounded-full border border-(--border) bg-(--card-80) px-3 py-2 text-xs">
                             <input
                                 type="checkbox"
                                 checked={showZoneOverlay}
@@ -440,7 +440,7 @@ export function QuadrantPanel({
                             />
                         </div>
                         {showZoneLegend ? (
-                            <div className="min-w-0 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4 text-xs text-(--ink-muted)">
+                            <div className="min-w-0 rounded-2xl border border-(--border) bg-(--card-80) p-4 text-xs text-(--ink-muted)">
                                 <div className="flex items-center justify-between">
                                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                                         Zone legend
@@ -475,7 +475,7 @@ export function QuadrantPanel({
                                                 }
                                                 className={`flex w-full gap-3 rounded-xl border px-2 py-2 text-left transition ${
                                                     isActive
-                                                        ? "border-(--card-stroke) bg-(--card-70)"
+                                                        ? "border-(--border) bg-(--card-70)"
                                                         : "border-transparent"
                                                 }`}
                                             >
@@ -502,7 +502,7 @@ export function QuadrantPanel({
                     </div>
 
                     {!activeSelectedPoint && (
-                        <div className="text-xs text-(--ink-muted) bg-(--card-80) rounded-2xl p-4 border border-dashed border-(--card-stroke)">
+                        <div className="text-xs text-(--ink-muted) bg-(--card-80) rounded-2xl p-4 border border-dashed border-(--border)">
                             <p>
                                 {isPersonScope
                                     ? "Individual in view."
@@ -515,7 +515,7 @@ export function QuadrantPanel({
                                         return isPersonScope ? (
                                             <span
                                                 key={pointKey}
-                                                className="rounded-full border border-(--card-stroke) bg-card px-3 py-1 text-(--accent-2)"
+                                                className="rounded-full border border-(--border) bg-card px-3 py-1 text-(--accent-2)"
                                             >
                                                 {point.entity_label}
                                             </span>
@@ -524,7 +524,7 @@ export function QuadrantPanel({
                                                 key={pointKey}
                                                 type="button"
                                                 onClick={() => handlePointSelect(point)}
-                                                className="rounded-full border border-(--card-stroke) bg-card px-3 py-1 text-(--accent-2) hover:bg-(--accent-2)/5 transition"
+                                                className="rounded-full border border-(--border) bg-card px-3 py-1 text-(--accent-2) hover:bg-(--accent-2)/5 transition"
                                             >
                                                 {point.entity_label}
                                             </button>
@@ -541,7 +541,7 @@ export function QuadrantPanel({
                                 <Link
                                     key={`${link.href}-${link.label}`}
                                     href={link.href}
-                                    className="rounded-full border border-(--card-stroke) bg-(--card-80) px-4 py-2 uppercase tracking-[0.2em] text-(--accent-2) hover:bg-(--accent-2)/5 transition"
+                                    className="rounded-full border border-(--border) bg-(--card-80) px-4 py-2 uppercase tracking-[0.2em] text-(--accent-2) hover:bg-(--accent-2)/5 transition"
                                 >
                                     {link.label}
                                 </Link>
@@ -551,7 +551,7 @@ export function QuadrantPanel({
                 </div>
 
                 {activeSelectedPoint && scopedData && (
-                    <aside className="w-full shrink-0 overflow-hidden rounded-3xl border border-(--card-stroke) shadow-2xl lg:w-96">
+                    <aside className="w-full shrink-0 overflow-hidden rounded-3xl border border-(--border) shadow-2xl lg:w-96">
                         <InvestigationPanel
                             point={activeSelectedPoint}
                             data={scopedData}

--- a/src/components/charts/WorkGraphExplorer.tsx
+++ b/src/components/charts/WorkGraphExplorer.tsx
@@ -377,7 +377,7 @@ export function WorkGraphExplorer({
                         <label
                             key={type}
                             title={NODE_TYPE_LABELS[type]}
-                            className="flex cursor-pointer items-center gap-1.5 rounded-full border border-(--card-stroke) bg-(--card-90) px-2 py-1 text-(--ink-muted) transition-colors hover:text-foreground"
+                            className="flex cursor-pointer items-center gap-1.5 rounded-full border border-(--border) bg-(--card-90) px-2 py-1 text-(--ink-muted) transition-colors hover:text-foreground"
                         >
                             <input
                                 type="checkbox"
@@ -455,7 +455,7 @@ export function WorkGraphLegend({ collapsed = false, onToggleAction }: WorkGraph
                 <button
                     type="button"
                     onClick={onToggleAction}
-                    className="flex h-9 w-9 items-center justify-center rounded-xl border border-(--card-stroke) text-sm transition-colors hover:border-(--accent)/40 hover:text-foreground"
+                    className="flex h-9 w-9 items-center justify-center rounded-xl border border-(--border) text-sm transition-colors hover:border-(--accent)/40 hover:text-foreground"
                     aria-label="Expand legend"
                     title="Expand legend"
                 >
@@ -488,14 +488,14 @@ export function WorkGraphLegend({ collapsed = false, onToggleAction }: WorkGraph
                 <button
                     type="button"
                     onClick={onToggleAction}
-                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-(--card-stroke) text-sm transition-colors hover:border-(--accent)/40 hover:text-foreground"
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-(--border) text-sm transition-colors hover:border-(--accent)/40 hover:text-foreground"
                     aria-label="Collapse legend"
                     title="Collapse legend"
                 >
                     ▶
                 </button>
             </div>
-            <div className="mt-3 space-y-4 border-t border-(--card-stroke) pt-3">
+            <div className="mt-3 space-y-4 border-t border-(--border) pt-3">
                 <section className="space-y-2">
                     <p className="text-[10px] font-medium uppercase tracking-[0.18em]">
                         Node Types

--- a/src/components/cognitive-load/CognitiveLoadViews.tsx
+++ b/src/components/cognitive-load/CognitiveLoadViews.tsx
@@ -55,7 +55,7 @@ export function OverviewView({
 }) {
     return (
         <>
-            <section className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm">
+            <section className="rounded-[1.75rem] border border-(--border) bg-(--card-90) p-6 shadow-sm">
                 <div className="flex flex-wrap items-start justify-between gap-4">
                     <div>
                         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-(--ink-muted)">
@@ -88,7 +88,7 @@ export function OverviewView({
                 </p>
 
                 {!signals ? (
-                    <div className="mt-6 rounded-2xl border border-(--card-stroke) bg-(--card-60) p-5 text-(--ink-muted)">
+                    <div className="mt-6 rounded-2xl border border-(--border) bg-(--card-60) p-5 text-(--ink-muted)">
                         <p className="text-xs font-semibold uppercase tracking-[0.2em]">
                             No data for this window
                         </p>
@@ -105,7 +105,7 @@ export function OverviewView({
                         {signals.map((signal) => (
                             <article
                                 key={signal.label}
-                                className="rounded-3xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                                className="rounded-3xl border border-(--border) bg-card p-5 shadow-sm"
                             >
                                 <div className="flex items-start justify-between gap-3">
                                     <p className="text-xs font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -132,7 +132,7 @@ export function OverviewView({
                 )}
             </section>
 
-            <section className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm">
+            <section className="rounded-[1.75rem] border border-(--border) bg-(--card-90) p-6 shadow-sm">
                 <p className="text-xs font-semibold uppercase tracking-[0.24em] text-(--ink-muted)">
                     Aggregation contract
                 </p>

--- a/src/components/complexity/ComplexityDashboard.tsx
+++ b/src/components/complexity/ComplexityDashboard.tsx
@@ -282,7 +282,7 @@ function buildTrendOption(
 function KpiCard({ label, value, caption }: { label: string; value: ReactNode; caption: string }) {
     return (
         <article
-            className="rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-sm"
+            className="rounded-2xl border border-(--border) bg-card p-4 shadow-sm"
             data-testid="kpi-card"
         >
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
@@ -307,7 +307,7 @@ function Panel({
 }) {
     return (
         <section
-            className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
+            className="rounded-[1.75rem] border border-(--border) bg-(--card-90) p-6 shadow-sm"
             data-testid={testId}
         >
             <div className="mb-4">
@@ -330,7 +330,7 @@ function FileTable({
     testId: string;
 }) {
     return (
-        <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90) shadow-sm">
+        <div className="overflow-hidden rounded-2xl border border-(--border) bg-(--card-90) shadow-sm">
             <table className="w-full text-sm" data-testid={testId}>
                 <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
                     <tr>
@@ -567,7 +567,7 @@ function HotspotsView({ hotspotRows }: { hotspotRows: HotspotRow[] }) {
                             <tr
                                 key={`${row.repoId}-${row.filePath}`}
                                 data-testid="hotspot-row"
-                                className="border-t border-(--card-stroke)/60 hover:bg-(--card-60)/60"
+                                className="border-t border-(--border)/60 hover:bg-(--card-60)/60"
                             >
                                 <td
                                     className="px-5 py-3 align-middle font-medium font-mono text-[0.82em]"
@@ -650,7 +650,7 @@ function OwnershipRiskView({ hotspotRows }: { hotspotRows: HotspotRow[] }) {
                         <tr
                             key={`${row.repoId}-${row.filePath}`}
                             data-testid="ownership-row"
-                            className="border-t border-(--card-stroke)/60 hover:bg-(--card-60)/60"
+                            className="border-t border-(--border)/60 hover:bg-(--card-60)/60"
                         >
                             <td
                                 className="px-5 py-3 align-middle font-medium font-mono text-[0.82em]"
@@ -723,7 +723,7 @@ function ChurnView({ hotspotRows }: { hotspotRows: HotspotRow[] }) {
                         <tr
                             key={`${row.repoId}-${row.filePath}`}
                             data-testid="churn-row"
-                            className="border-t border-(--card-stroke)/60 hover:bg-(--card-60)/60"
+                            className="border-t border-(--border)/60 hover:bg-(--card-60)/60"
                         >
                             <td
                                 className="px-5 py-3 align-middle font-medium font-mono text-[0.82em]"
@@ -778,7 +778,7 @@ export function ComplexityDashboard({
     if (isEmpty) {
         return (
             <section
-                className="rounded-2xl border border-(--card-stroke) bg-card p-8 shadow-sm"
+                className="rounded-2xl border border-(--border) bg-card p-8 shadow-sm"
                 data-testid="empty-state"
             >
                 <h2 className="text-2xl font-semibold tracking-tight">

--- a/src/components/evidence/EvidenceContext.tsx
+++ b/src/components/evidence/EvidenceContext.tsx
@@ -23,11 +23,11 @@ export function EvidenceContext({ data }: EvidenceContextProps) {
             ? "border-green-400/20 bg-green-400/10 text-green-300"
             : data.trend === "down"
               ? "border-red-400/20 bg-red-400/10 text-red-300"
-              : "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)";
+              : "border-(--border) bg-(--card-70) text-(--ink-muted)";
     const trendIcon = data.trend === "up" ? "↗" : data.trend === "down" ? "↘" : "→";
 
     return (
-        <section className="space-y-3 rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4">
+        <section className="space-y-3 rounded-2xl border border-(--border) bg-(--card-90) p-4">
             <div className="flex items-center justify-between">
                 <p className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">Context</p>
                 {data.trend && (
@@ -40,7 +40,7 @@ export function EvidenceContext({ data }: EvidenceContextProps) {
                 )}
             </div>
 
-            <div className="rounded-xl border border-(--card-stroke) bg-background/35 p-3">
+            <div className="rounded-xl border border-(--border) bg-background/35 p-3">
                 <p className="text-sm leading-6 text-foreground">
                     <span className="font-semibold text-(--accent)">{roleConfig.framing}</span>{" "}
                     {data.summary || "No summary available for this metric."}

--- a/src/components/evidence/EvidenceItems.tsx
+++ b/src/components/evidence/EvidenceItems.tsx
@@ -18,12 +18,12 @@ export function EvidenceItems({ items }: EvidenceItemsProps) {
     if (!items || items.length === 0) return null;
 
     return (
-        <section className="space-y-3 rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4">
+        <section className="space-y-3 rounded-2xl border border-(--border) bg-(--card-90) p-4">
             <div className="flex items-center justify-between gap-3">
                 <p className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
                     Supporting Evidence
                 </p>
-                <span className="rounded-full border border-(--card-stroke) px-2 py-0.5 text-[10px] text-(--ink-muted)">
+                <span className="rounded-full border border-(--border) px-2 py-0.5 text-[10px] text-(--ink-muted)">
                     {items.length} artifacts
                 </span>
             </div>
@@ -34,12 +34,12 @@ export function EvidenceItems({ items }: EvidenceItemsProps) {
                         href={item.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="group block rounded-xl border border-(--card-stroke) bg-background/35 p-3 transition-all hover:border-(--accent)/40 hover:bg-(--accent)/5"
+                        className="group block rounded-xl border border-(--border) bg-background/35 p-3 transition-all hover:border-(--accent)/40 hover:bg-(--accent)/5"
                     >
                         <div className="flex items-start justify-between gap-3">
                             <div className="min-w-0 space-y-1.5">
                                 <div className="flex items-center gap-2">
-                                    <span className="rounded border border-(--card-stroke) bg-(--card-70) px-1.5 py-0.5 text-[10px] font-bold uppercase text-(--ink-muted)">
+                                    <span className="rounded border border-(--border) bg-(--card-70) px-1.5 py-0.5 text-[10px] font-bold uppercase text-(--ink-muted)">
                                         {item.type}
                                     </span>
                                     <span className="truncate font-mono text-xs text-(--ink-muted)">

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -246,8 +246,8 @@ export function EvidencePanel({
                 onClick={onCloseAction}
             />
 
-            <div className="relative z-10 flex h-full w-full flex-col rounded-l-3xl border-l border-(--card-stroke) bg-card shadow-2xl animate-in fade-in slide-in-from-right-4 duration-300 md:max-w-lg">
-                <header className="flex items-center justify-between border-b border-(--card-stroke) bg-(--card-90) p-6">
+            <div className="relative z-10 flex h-full w-full flex-col rounded-l-3xl border-l border-(--border) bg-card shadow-2xl animate-in fade-in slide-in-from-right-4 duration-300 md:max-w-lg">
+                <header className="flex items-center justify-between border-b border-(--border) bg-(--card-90) p-6">
                     <div>
                         <p className="text-xs uppercase tracking-widest text-(--ink-muted)">
                             Evidence & Context
@@ -257,7 +257,7 @@ export function EvidencePanel({
                     <button
                         type="button"
                         onClick={onCloseAction}
-                        className="rounded-full border border-(--card-stroke) p-2 text-xs uppercase tracking-widest text-(--ink-muted) transition-colors hover:bg-(--card-70) hover:text-foreground"
+                        className="rounded-full border border-(--border) p-2 text-xs uppercase tracking-widest text-(--ink-muted) transition-colors hover:bg-(--card-70) hover:text-foreground"
                         title={CTA_LABELS.closePanel}
                     >
                         ✕
@@ -277,7 +277,7 @@ export function EvidencePanel({
                             {showDevDiagnostics && errorDetail ? (
                                 <pre
                                     data-testid="evidence-error-diagnostics"
-                                    className="overflow-x-auto whitespace-pre-wrap rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4 text-xs leading-5 text-(--ink-muted)"
+                                    className="overflow-x-auto whitespace-pre-wrap rounded-2xl border border-(--border) bg-(--card-90) p-4 text-xs leading-5 text-(--ink-muted)"
                                 >
                                     {errorDetail}
                                 </pre>
@@ -290,7 +290,7 @@ export function EvidencePanel({
                             {data.evidence?.length ? (
                                 <EvidenceItems items={data.evidence} />
                             ) : (
-                                <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-90) p-4 text-sm leading-6 text-(--ink-muted)">
+                                <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-90) p-4 text-sm leading-6 text-(--ink-muted)">
                                     No contributing artifacts were returned for this metric and
                                     filter window. This is a partial-data state, not a zero signal.
                                 </div>
@@ -305,7 +305,7 @@ export function EvidencePanel({
                     )}
                 </div>
 
-                <footer className="border-t border-(--card-stroke) bg-(--card-90) p-6">
+                <footer className="border-t border-(--border) bg-(--card-90) p-6">
                     <Link
                         href={exploreUrl}
                         className="flex w-full items-center justify-center rounded-xl border border-(--accent)/20 bg-(--accent)/10 px-4 py-3 text-sm font-medium text-(--accent) transition-colors hover:bg-(--accent)/20"
@@ -322,7 +322,7 @@ function EvidenceProvenanceStrip({ provenance }: { provenance?: EvidenceProvenan
     const confidence = provenance?.identity_confidence;
 
     return (
-        <section className="grid gap-3 rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4 text-xs text-(--ink-muted)">
+        <section className="grid gap-3 rounded-2xl border border-(--border) bg-(--card-90) p-4 text-xs text-(--ink-muted)">
             <p className="text-xs uppercase tracking-[0.2em]">Quality + provenance</p>
             <div className="grid gap-2 sm:grid-cols-2">
                 <EvidenceProvenanceItem
@@ -355,7 +355,7 @@ function EvidenceProvenanceStrip({ provenance }: { provenance?: EvidenceProvenan
 
 function EvidenceProvenanceItem({ label, value }: { label: string; value: string }) {
     return (
-        <span className="rounded-xl border border-(--card-stroke) bg-background/35 px-3 py-2 leading-5">
+        <span className="rounded-xl border border-(--border) bg-background/35 px-3 py-2 leading-5">
             {label}: {value}
         </span>
     );

--- a/src/components/evidence/SuggestedActions.tsx
+++ b/src/components/evidence/SuggestedActions.tsx
@@ -14,7 +14,7 @@ export function SuggestedActions({ actions }: SuggestedActionsProps) {
     if (!actions || actions.length === 0) return null;
 
     return (
-        <section className="space-y-3 rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4">
+        <section className="space-y-3 rounded-2xl border border-(--border) bg-(--card-90) p-4">
             <p className="text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
                 Recommended next steps
             </p>

--- a/src/components/feature-flags/ConfidenceGate.tsx
+++ b/src/components/feature-flags/ConfidenceGate.tsx
@@ -31,7 +31,7 @@ export function ConfidenceGate({
 
     if (level === "suppress") {
         return (
-            <div className="flex flex-col items-center gap-3 rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) py-12 text-center">
+            <div className="flex flex-col items-center gap-3 rounded-3xl border border-dashed border-(--border) bg-(--card-70) py-12 text-center">
                 <div className="rounded-full bg-(--accent-negative)/10 p-3 text-(--accent-negative)">
                     <svg
                         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/feedback/BugReportButton.tsx
+++ b/src/components/feedback/BugReportButton.tsx
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 import type { FeedbackPayload, FeedbackResponse, FeedbackType } from "@/components/feedback/types";
 
 const inputClassName =
-    "w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground placeholder:text-(--ink-muted) focus:border-(--accent) focus:outline-none";
+    "w-full rounded-xl border border-(--border) bg-(--card-70) px-3 py-2 text-sm text-foreground placeholder:text-(--ink-muted) focus:border-(--accent) focus:outline-none";
 
 type FeedbackFormState = {
     title: string;
@@ -117,13 +117,13 @@ export function BugReportButton() {
                         onClick={closePanel}
                     />
                     <div
-                        className="fixed right-0 top-0 bottom-0 z-50 w-full max-w-md translate-x-0 border-l border-(--card-stroke) bg-(--card-80) shadow-2xl transition-transform duration-300 ease-out"
+                        className="fixed right-0 top-0 bottom-0 z-50 w-full max-w-md translate-x-0 border-l border-(--border) bg-(--card-80) shadow-2xl transition-transform duration-300 ease-out"
                         role="dialog"
                         aria-modal="true"
                         aria-labelledby="bug-report-title"
                     >
                         <div className="flex h-full flex-col">
-                            <div className="flex items-center justify-between border-b border-(--card-stroke) px-5 py-4">
+                            <div className="flex items-center justify-between border-b border-(--border) px-5 py-4">
                                 <h2
                                     id="bug-report-title"
                                     className="font-(--font-display) text-lg text-foreground"

--- a/src/components/filters/FilterBarClient.tsx
+++ b/src/components/filters/FilterBarClient.tsx
@@ -66,7 +66,7 @@ export function FilterBarClient({
             ref={barRef}
             data-testid="filter-bar"
             data-view={view ?? "default"}
-            className={`w-full rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4 backdrop-blur-sm transition-all duration-300 ease-in-out ${condensed ? "py-2" : "py-4"}`}
+            className={`w-full rounded-2xl border border-(--border) bg-(--card-70) p-4 backdrop-blur-sm transition-all duration-300 ease-in-out ${condensed ? "py-2" : "py-4"}`}
         >
             <div className="flex w-full flex-col gap-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/components/filters/FilterPill.tsx
+++ b/src/components/filters/FilterPill.tsx
@@ -9,7 +9,7 @@ type FilterPillProps = {
 
 export function FilterPill({ label, value, onClear, onClick }: FilterPillProps) {
     return (
-        <div className="flex items-center gap-1 rounded-full border border-(--card-stroke) bg-card pl-3 pr-1 py-1 text-xs transition-colors hover:border-(--accent)">
+        <div className="flex items-center gap-1 rounded-full border border-(--border) bg-card pl-3 pr-1 py-1 text-xs transition-colors hover:border-(--accent)">
             <button
                 type="button"
                 onClick={onClick}

--- a/src/components/filters/sections/HowSection.tsx
+++ b/src/components/filters/sections/HowSection.tsx
@@ -16,7 +16,7 @@ export function HowSection({
     updateFlowStage,
 }: HowSectionProps) {
     return (
-        <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+        <details className="rounded-2xl border border-(--border) bg-(--card-70) p-4">
             <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                 How
             </summary>
@@ -24,7 +24,7 @@ export function HowSection({
                 <label className="flex flex-col gap-2">
                     <span className="text-xs text-(--ink-muted)">Flow stage</span>
                     <input
-                        className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+                        className="rounded-xl border border-(--border) bg-card px-3 py-2"
                         placeholder="review, build"
                         value={toValue(flowStage)}
                         onChange={(event) => updateFlowStage(toList(event.target.value))}

--- a/src/components/filters/sections/QuickFilterMenu.tsx
+++ b/src/components/filters/sections/QuickFilterMenu.tsx
@@ -35,7 +35,7 @@ export function QuickFilterMenu({
             <button
                 type="button"
                 onClick={() => setOpenMenu(openMenu === menuKey ? null : menuKey)}
-                className={`flex items-center gap-2 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs ${
+                className={`flex items-center gap-2 rounded-full border border-(--border) bg-card px-4 py-2 text-xs ${
                     variant === "accent" && isActive ? "border-(--accent) text-(--accent)" : ""
                 }`}
                 aria-expanded={openMenu === menuKey}
@@ -45,7 +45,7 @@ export function QuickFilterMenu({
                 <span className="text-(--ink-muted)">▾</span>
             </button>
             {openMenu === menuKey && (
-                <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
+                <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--border) bg-card p-4 shadow-lg">
                     <div className="max-h-56 overflow-auto">
                         <OptionList
                             emptyLabel={emptyLabel}

--- a/src/components/filters/sections/ScopeSection.tsx
+++ b/src/components/filters/sections/ScopeSection.tsx
@@ -35,7 +35,7 @@ export function ScopeSection({
             <button
                 type="button"
                 onClick={() => setOpenMenu(openMenu === "scope" ? null : "scope")}
-                className="flex items-center gap-2 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs"
+                className="flex items-center gap-2 rounded-full border border-(--border) bg-card px-4 py-2 text-xs"
                 aria-expanded={openMenu === "scope"}
             >
                 <span className="uppercase tracking-[0.2em] text-(--ink-muted)">{scopeLabel}:</span>
@@ -43,14 +43,14 @@ export function ScopeSection({
                 <span className="text-(--ink-muted)">▾</span>
             </button>
             {openMenu === "scope" && (
-                <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
+                <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--border) bg-card p-4 shadow-lg">
                     {!scopeLock && (
                         <label className="flex flex-col gap-2 text-xs">
                             <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
                                 Scope level
                             </span>
                             <select
-                                className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2 text-sm"
+                                className="rounded-xl border border-(--border) bg-(--card-60) px-3 py-2 text-sm"
                                 value={scopeLevel}
                                 onChange={(event) =>
                                     updateFilters({

--- a/src/components/filters/sections/TimeRangeSection.tsx
+++ b/src/components/filters/sections/TimeRangeSection.tsx
@@ -26,7 +26,7 @@ export function TimeRangeSection({
     updateFilters,
 }: TimeRangeSectionProps) {
     return (
-        <div className="flex items-center rounded-full border border-(--card-stroke) bg-card p-1">
+        <div className="flex items-center rounded-full border border-(--border) bg-card p-1">
             {DATE_PRESETS.map((preset) => (
                 <button
                     key={preset.days}
@@ -41,7 +41,7 @@ export function TimeRangeSection({
                     {preset.label}
                 </button>
             ))}
-            <div className="relative ml-1 border-l border-(--card-stroke) pl-1">
+            <div className="relative ml-1 border-l border-(--border) pl-1">
                 <button
                     type="button"
                     onClick={() => setOpenMenu(openMenu === "date" ? null : "date")}
@@ -54,14 +54,14 @@ export function TimeRangeSection({
                     {isCustomDateRange ? dateValue : "Custom"}
                 </button>
                 {openMenu === "date" && (
-                    <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-lg">
+                    <div className="absolute left-0 z-50 mt-2 w-72 rounded-2xl border border-(--border) bg-card p-4 shadow-lg">
                         <div className="grid gap-3 text-xs">
                             <label className="flex flex-col gap-2">
                                 <span className="uppercase tracking-[0.2em] text-(--ink-muted)">
                                     Start date
                                 </span>
                                 <input
-                                    className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2 text-sm"
+                                    className="rounded-xl border border-(--border) bg-(--card-60) px-3 py-2 text-sm"
                                     type="date"
                                     value={formatDateInput(startDate)}
                                     onChange={(event) => {
@@ -93,7 +93,7 @@ export function TimeRangeSection({
                                     End date
                                 </span>
                                 <input
-                                    className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2 text-sm"
+                                    className="rounded-xl border border-(--border) bg-(--card-60) px-3 py-2 text-sm"
                                     type="date"
                                     value={formatDateInput(endDate)}
                                     onChange={(event) => {

--- a/src/components/filters/sections/ToolbarActions.tsx
+++ b/src/components/filters/sections/ToolbarActions.tsx
@@ -31,7 +31,7 @@ export function ToolbarActions({
                         value={peopleQuery}
                         onChange={(event) => updatePeopleQuery(event.target.value)}
                         placeholder="Name or handle"
-                        className="w-full sm:w-56 rounded-full border border-(--card-stroke) bg-card px-4 py-2 text-xs"
+                        className="w-full sm:w-56 rounded-full border border-(--border) bg-card px-4 py-2 text-xs"
                     />
                 </label>
             )}
@@ -43,7 +43,7 @@ export function ToolbarActions({
                     className={`rounded-full border px-4 py-2 text-xs uppercase tracking-[0.2em] transition-colors ${
                         showAdvanced
                             ? "border-(--accent) bg-(--accent-10) text-(--accent)"
-                            : "border-(--card-stroke) bg-(--card-70) hover:border-(--ink-muted)"
+                            : "border-(--border) bg-(--card-70) hover:border-(--ink-muted)"
                     }`}
                     aria-expanded={showAdvanced}
                 >

--- a/src/components/filters/sections/WhatSection.tsx
+++ b/src/components/filters/sections/WhatSection.tsx
@@ -16,7 +16,7 @@ export function WhatSection({
     updateRepos,
 }: WhatSectionProps) {
     return (
-        <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+        <details className="rounded-2xl border border-(--border) bg-(--card-70) p-4">
             <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                 What
             </summary>
@@ -24,7 +24,7 @@ export function WhatSection({
                 <label className="flex flex-col gap-2">
                     <span className="text-xs text-(--ink-muted)">Repos</span>
                     <input
-                        className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+                        className="rounded-xl border border-(--border) bg-card px-3 py-2"
                         placeholder="org/api, org/ui"
                         value={toValue(repos)}
                         onChange={(event) => updateRepos(toList(event.target.value))}
@@ -33,7 +33,7 @@ export function WhatSection({
                 <label className="flex flex-col gap-2">
                     <span className="text-xs text-(--ink-muted)">Artifacts</span>
                     <input
-                        className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+                        className="rounded-xl border border-(--border) bg-card px-3 py-2"
                         placeholder="pr, issue"
                         value={toValue(artifacts)}
                         onChange={(event) => updateArtifacts(toList(event.target.value))}

--- a/src/components/filters/sections/WhoSection.tsx
+++ b/src/components/filters/sections/WhoSection.tsx
@@ -16,7 +16,7 @@ export function WhoSection({
     updateRoles,
 }: WhoSectionProps) {
     return (
-        <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+        <details className="rounded-2xl border border-(--border) bg-(--card-70) p-4">
             <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                 Who
             </summary>
@@ -24,7 +24,7 @@ export function WhoSection({
                 <label className="flex flex-col gap-2">
                     <span className="text-xs text-(--ink-muted)">Developers</span>
                     <input
-                        className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2"
+                        className="rounded-xl border border-(--border) bg-(--card-60) px-3 py-2"
                         placeholder="alice, bob"
                         value={toValue(developers)}
                         onChange={(event) => updateDevelopers(toList(event.target.value))}
@@ -33,7 +33,7 @@ export function WhoSection({
                 <label className="flex flex-col gap-2">
                     <span className="text-xs text-(--ink-muted)">Roles</span>
                     <input
-                        className="rounded-xl border border-(--card-stroke) bg-(--card-60) px-3 py-2"
+                        className="rounded-xl border border-(--border) bg-(--card-60) px-3 py-2"
                         placeholder="maintainer, reviewer"
                         value={toValue(roles)}
                         onChange={(event) => updateRoles(toList(event.target.value))}

--- a/src/components/filters/sections/WhySection.tsx
+++ b/src/components/filters/sections/WhySection.tsx
@@ -16,7 +16,7 @@ export function WhySection({
     workCategory,
 }: WhySectionProps) {
     return (
-        <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+        <details className="rounded-2xl border border-(--border) bg-(--card-70) p-4">
             <summary className="cursor-pointer text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                 Why
             </summary>
@@ -24,7 +24,7 @@ export function WhySection({
                 <label className="flex flex-col gap-2">
                     <span className="text-xs text-(--ink-muted)">Work category</span>
                     <input
-                        className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+                        className="rounded-xl border border-(--border) bg-card px-3 py-2"
                         placeholder="feature, maintenance"
                         value={toValue(workCategory)}
                         onChange={(event) => updateWorkCategory(toList(event.target.value))}
@@ -33,7 +33,7 @@ export function WhySection({
                 <label className="flex flex-col gap-2">
                     <span className="text-xs text-(--ink-muted)">Issue type</span>
                     <input
-                        className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+                        className="rounded-xl border border-(--border) bg-card px-3 py-2"
                         placeholder="bug, story"
                         value={toValue(issueType)}
                         onChange={(event) => updateIssueType(toList(event.target.value))}

--- a/src/components/home/BackendBanner.tsx
+++ b/src/components/home/BackendBanner.tsx
@@ -22,7 +22,7 @@ export function BackendBanner({ meta }: BackendBannerProps) {
     }
 
     return (
-        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-xs">
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-xs">
             {meta.last_ingest_at && (
                 <>
                     <span className="text-(--ink-muted)">•</span>

--- a/src/components/home/CockpitClient.tsx
+++ b/src/components/home/CockpitClient.tsx
@@ -62,7 +62,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
 
             {/* Key Shifts — role-aware delta row (CHAOS-2094) */}
             <section
-                className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5"
+                className="rounded-3xl border border-(--border) bg-(--card-80) p-5"
                 data-testid="key-shifts-row"
             >
                 <div className="flex items-center justify-between">
@@ -96,7 +96,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                                     filters,
                                     role: activeRole,
                                 })}
-                                className="group rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3 transition hover:-translate-y-1"
+                                className="group rounded-2xl border border-(--border) bg-(--card) px-4 py-3 transition hover:-translate-y-1"
                             >
                                 <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                                     {delta.label}
@@ -122,7 +122,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
             </section>
 
             <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                     <h2 className="font-(--font-display) text-2xl">Notable shifts</h2>
                     <p className="mt-2 text-sm text-(--ink-muted)">
                         Short shifts from the selected window.
@@ -141,14 +141,14 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                             </button>
                         ))}
                         {!home?.summary?.length && (
-                            <p className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-60) px-4 py-3">
+                            <p className="rounded-2xl border border-dashed border-(--border) bg-(--card-60) px-4 py-3">
                                 Summary will appear once data is ingested.
                             </p>
                         )}
                     </div>
                 </div>
 
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                     <div className="flex items-center justify-between">
                         <h3 className="font-(--font-display) text-xl">Investigation threads</h3>
                         <Link
@@ -165,7 +165,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                                       type="button"
                                       key={key}
                                       onClick={() => openPanel(tile.title, { apiUrl: tile.link })}
-                                      className="group w-full text-left rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3 transition hover:-translate-y-1"
+                                      className="group w-full text-left rounded-2xl border border-(--border) bg-(--card) px-4 py-3 transition hover:-translate-y-1"
                                   >
                                       <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                                           {tile.title}
@@ -181,7 +181,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                             : null}
                         <Link
                             href={withFilterParam("/opportunities", filters, activeRole)}
-                            className="block rounded-2xl border border-(--card-stroke) bg-(--accent)/15 px-4 py-3"
+                            className="block rounded-2xl border border-(--border) bg-(--accent)/15 px-4 py-3"
                         >
                             <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                 Focus thread
@@ -198,7 +198,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
             </section>
 
             <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                     <div className="flex items-center justify-between">
                         <h3 className="font-(--font-display) text-xl">Limiting factor</h3>
                         <button
@@ -239,7 +239,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                                 type="button"
                                 key={`${item.label}-${idx}`}
                                 onClick={() => openPanel(item.label, { apiUrl: item.link })}
-                                className="block w-full text-left rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3 hover:bg-(--card-60) transition-colors"
+                                className="block w-full text-left rounded-2xl border border-(--border) bg-(--card-70) px-4 py-3 hover:bg-(--card-60) transition-colors"
                             >
                                 {item.label}
                             </button>
@@ -249,7 +249,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                         {(home?.constraint.experiments ?? []).map((experiment) => (
                             <span
                                 key={experiment}
-                                className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
+                                className="rounded-full border border-(--border) bg-(--card-70) px-3 py-1"
                             >
                                 {experiment}
                             </span>
@@ -257,7 +257,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                     </div>
                 </div>
 
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                     <div className="flex items-center justify-between">
                         <h3 className="font-(--font-display) text-xl">Recent events</h3>
                         <Link
@@ -273,7 +273,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                                 type="button"
                                 key={`${event.type}-${idx}`}
                                 onClick={() => openPanel(event.type, { apiUrl: event.link })}
-                                className="block w-full text-left rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3 hover:border-(--card-stroke)/80 transition-colors"
+                                className="block w-full text-left rounded-2xl border border-(--border) bg-(--card) px-4 py-3 hover:border-(--card-stroke)/80 transition-colors"
                             >
                                 <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                     <span>{event.type}</span>
@@ -283,7 +283,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                             </button>
                         ))}
                         {!home?.events?.length && (
-                            <p className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card) px-4 py-3 text-(--ink-muted)">
+                            <p className="rounded-2xl border border-dashed border-(--border) bg-(--card) px-4 py-3 text-(--ink-muted)">
                                 No major shifts detected in the current window.
                             </p>
                         )}

--- a/src/components/home/CockpitSummary.tsx
+++ b/src/components/home/CockpitSummary.tsx
@@ -78,7 +78,7 @@ export function CockpitSummary({ home, filters }: CockpitSummaryProps) {
         <section
             data-testid="cockpit-summary"
             data-status={status}
-            className={`relative overflow-hidden rounded-[32px] border border-(--card-stroke) bg-gradient-to-br ${meta.glow} to-(--card-80) p-6 shadow-[0_28px_90px_-52px_rgba(0,0,0,0.6)] sm:p-8`}
+            className={`relative overflow-hidden rounded-[32px] border border-(--border) bg-gradient-to-br ${meta.glow} to-(--card-80) p-6 shadow-[0_28px_90px_-52px_rgba(0,0,0,0.6)] sm:p-8`}
         >
             <EvidencePanel
                 isOpen={panel.isOpen}
@@ -135,7 +135,7 @@ export function CockpitSummary({ home, filters }: CockpitSummaryProps) {
                             <EntityLabel variant="text" id={topSignal.title} />
                         </h2>
                         <div className="flex items-center gap-2 text-xs">
-                            <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-0.5 font-bold uppercase tracking-[0.16em] text-(--ink-muted)">
+                            <span className="rounded-full border border-(--border) bg-(--card-70) px-2.5 py-0.5 font-bold uppercase tracking-[0.16em] text-(--ink-muted)">
                                 {topSignal.severity}
                             </span>
                             {(topSignal.scope_entity?.id ?? topSignal.affected_scope) ? (
@@ -143,7 +143,7 @@ export function CockpitSummary({ home, filters }: CockpitSummaryProps) {
                                     id={topSignal.scope_entity?.id ?? topSignal.affected_scope}
                                     displayName={topSignal.scope_entity?.display_name ?? null}
                                     data-testid="cockpit-top-change-scope"
-                                    className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-0.5 font-medium text-(--ink-muted)"
+                                    className="rounded-full border border-(--border) bg-(--card-70) px-2.5 py-0.5 font-medium text-(--ink-muted)"
                                 />
                             ) : null}
                             {topSignal.delta ? (
@@ -176,7 +176,7 @@ export function CockpitSummary({ home, filters }: CockpitSummaryProps) {
                                 metric: topSignal.metric,
                             })
                         }
-                        className="mt-4 flex w-full items-center justify-between rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2.5 text-left text-xs font-medium uppercase tracking-[0.18em] text-(--ink-muted) transition-colors hover:border-(--accent)/40 hover:bg-(--accent)/10 hover:text-(--accent)"
+                        className="mt-4 flex w-full items-center justify-between rounded-xl border border-(--border) bg-(--card-70) px-4 py-2.5 text-left text-xs font-medium uppercase tracking-[0.18em] text-(--ink-muted) transition-colors hover:border-(--accent)/40 hover:bg-(--accent)/10 hover:text-(--accent)"
                     >
                         Open evidence
                         <span aria-hidden>↗</span>

--- a/src/components/home/DataConfidenceIndicator.tsx
+++ b/src/components/home/DataConfidenceIndicator.tsx
@@ -65,7 +65,7 @@ function SourceList({ heading, sources }: { heading: string; sources: string[] }
             {sources.map((source) => (
                 <span
                     key={source}
-                    className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-0.5 text-xs text-(--ink-muted)"
+                    className="rounded-full border border-(--border) bg-(--card-70) px-2.5 py-0.5 text-xs text-(--ink-muted)"
                 >
                     {source}
                 </span>
@@ -87,7 +87,7 @@ export function DataConfidenceIndicator({ confidence, className }: DataConfidenc
             data-testid="data-confidence-indicator"
             data-level={level}
             aria-label={`Data confidence: ${meta.label}`}
-            className={`flex flex-col gap-3 rounded-3xl border border-(--card-stroke) bg-(--card-70) px-4 py-3 ${className ?? ""}`}
+            className={`flex flex-col gap-3 rounded-3xl border border-(--border) bg-(--card-70) px-4 py-3 ${className ?? ""}`}
         >
             <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex items-center gap-2">

--- a/src/components/home/InvestmentPreview.tsx
+++ b/src/components/home/InvestmentPreview.tsx
@@ -26,7 +26,7 @@ type InvestmentPreviewProps = {
 
 function LoadingState() {
     return (
-        <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) h-[320px]">
+        <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-(--border) bg-(--card-70) h-[320px]">
             <div className="mb-4 flex gap-1">
                 <span className="h-2 w-2 animate-pulse rounded-full bg-(--accent) [animation-delay:0ms]" />
                 <span className="h-2 w-2 animate-pulse rounded-full bg-(--accent) [animation-delay:150ms]" />
@@ -93,7 +93,7 @@ export function InvestmentPreview({ filters }: InvestmentPreviewProps) {
 
     if (!hasData) {
         return (
-            <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) h-[320px]">
+            <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-(--border) bg-(--card-70) h-[320px]">
                 <span className="text-sm text-(--ink-muted)">
                     Investment data not yet available for this window.
                 </span>
@@ -102,7 +102,7 @@ export function InvestmentPreview({ filters }: InvestmentPreviewProps) {
     }
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-4">
+        <div className="rounded-3xl border border-(--border) bg-card p-4">
             <InvestmentMixSunburst
                 themeDistribution={mix.theme_distribution}
                 subcategoryDistribution={mix.subcategory_distribution}

--- a/src/components/home/SignalCard.tsx
+++ b/src/components/home/SignalCard.tsx
@@ -55,7 +55,7 @@ export function SignalCard({ signal, emphasized = false, onOpenEvidence }: Signa
             className={
                 emphasized
                     ? "relative overflow-hidden rounded-3xl border border-(--accent)/30 bg-gradient-to-br from-(--card) to-(--card-80) p-6 shadow-lg ring-1 ring-(--accent)/10"
-                    : "relative overflow-hidden rounded-3xl border border-(--card-stroke) bg-(--card) p-5"
+                    : "relative overflow-hidden rounded-3xl border border-(--border) bg-(--card) p-5"
             }
         >
             {emphasized && (
@@ -113,7 +113,7 @@ export function SignalCard({ signal, emphasized = false, onOpenEvidence }: Signa
             <div className="mt-4 flex flex-wrap items-center gap-2 text-[11px]">
                 <span
                     data-testid="signal-confidence"
-                    className={`inline-flex items-center gap-1.5 rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-1 font-medium uppercase tracking-[0.12em] ${CONFIDENCE_TEXT[signal.confidence]}`}
+                    className={`inline-flex items-center gap-1.5 rounded-full border border-(--border) bg-(--card-70) px-2.5 py-1 font-medium uppercase tracking-[0.12em] ${CONFIDENCE_TEXT[signal.confidence]}`}
                 >
                     <span
                         className={`h-1.5 w-1.5 rounded-full ${CONFIDENCE_DOT[signal.confidence]}`}
@@ -122,13 +122,13 @@ export function SignalCard({ signal, emphasized = false, onOpenEvidence }: Signa
                 </span>
                 <span
                     data-testid="signal-scope"
-                    className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-1 text-(--ink-muted)"
+                    className="rounded-full border border-(--border) bg-(--card-70) px-2.5 py-1 text-(--ink-muted)"
                 >
                     {signal.affected_scope}
                 </span>
                 <span
                     data-testid="signal-evidence-count"
-                    className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-1 text-(--ink-muted)"
+                    className="rounded-full border border-(--border) bg-(--card-70) px-2.5 py-1 text-(--ink-muted)"
                 >
                     {signal.evidence_count} {signal.evidence_count === 1 ? "artifact" : "artifacts"}
                 </span>
@@ -157,7 +157,7 @@ export function SignalCard({ signal, emphasized = false, onOpenEvidence }: Signa
                 type="button"
                 data-testid="signal-open-evidence"
                 onClick={open}
-                className="mt-4 flex w-full items-center justify-between rounded-xl border border-(--card-stroke) bg-(--card-70) px-4 py-2.5 text-left text-xs font-medium uppercase tracking-[0.18em] text-(--ink-muted) transition-colors hover:border-(--accent)/40 hover:bg-(--accent)/10 hover:text-(--accent)"
+                className="mt-4 flex w-full items-center justify-between rounded-xl border border-(--border) bg-(--card-70) px-4 py-2.5 text-left text-xs font-medium uppercase tracking-[0.18em] text-(--ink-muted) transition-colors hover:border-(--accent)/40 hover:bg-(--accent)/10 hover:text-(--accent)"
             >
                 Open evidence
                 <span aria-hidden>↗</span>

--- a/src/components/home/severityTokens.ts
+++ b/src/components/home/severityTokens.ts
@@ -13,7 +13,7 @@ export const SEVERITY_BADGE: Record<SignalSeverity, string> = {
     critical: "border-red-500/30 bg-red-500/15 text-red-300",
     high: "border-amber-500/30 bg-amber-500/15 text-amber-300",
     medium: "border-(--accent-2)/30 bg-(--accent-2)/12 text-(--accent-2)",
-    low: "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)",
+    low: "border-(--border) bg-(--card-70) text-(--ink-muted)",
 };
 
 /** Severity badge labels. */
@@ -55,7 +55,7 @@ export const directionAccent = (direction: SignalDirection): string =>
 // rather than a badge). The badge map below covers only the badge-bearing states.
 
 /** Neutral / informational chip — calm, non-alarming. */
-export const NEUTRAL_BADGE = "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)";
+export const NEUTRAL_BADGE = "border-(--border) bg-(--card-70) text-(--ink-muted)";
 export const NEUTRAL_LABEL = "Info";
 
 /** Badge classes for any badge-bearing area-signal state ("unavailable" excluded). */

--- a/src/components/improve/ImproveAutomationsDashboard.tsx
+++ b/src/components/improve/ImproveAutomationsDashboard.tsx
@@ -42,7 +42,7 @@ export function ImproveAutomationsDashboard({
         <div className="flex flex-col gap-6" data-testid="improve-automations-dashboard">
             {/* ── Flow opportunity candidates ─────────────────────────────── */}
             <section
-                className="rounded-3xl border border-(--card-stroke) bg-card p-5 shadow-sm"
+                className="rounded-3xl border border-(--border) bg-card p-5 shadow-sm"
                 data-testid="improve-automations-flow-panel"
             >
                 <div className="flex items-start justify-between gap-4">
@@ -71,7 +71,7 @@ export function ImproveAutomationsDashboard({
 
             {/* ── AI-workflow cross-link ───────────────────────────────────── */}
             <section
-                className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5"
+                className="rounded-3xl border border-(--border) bg-(--card-80) p-5"
                 data-testid="improve-automations-ai-crosslink"
             >
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -87,7 +87,7 @@ export function ImproveAutomationsDashboard({
                     </div>
                     <Link
                         href={aiAutomationsHref}
-                        className="shrink-0 rounded-2xl border border-(--card-stroke) bg-background px-4 py-2 text-sm font-medium hover:bg-(--card-80) transition-colors"
+                        className="shrink-0 rounded-2xl border border-(--border) bg-background px-4 py-2 text-sm font-medium hover:bg-(--card-80) transition-colors"
                         data-testid="improve-automations-ai-link"
                     >
                         View AI automations →
@@ -101,7 +101,7 @@ export function ImproveAutomationsDashboard({
 function AutomationsSkeleton() {
     return (
         <div
-            className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+            className="rounded-3xl border border-(--border) bg-card p-5"
             data-testid="improve-automations-loading"
         >
             <div className="h-40 animate-pulse rounded-2xl bg-(--card-80)" />

--- a/src/components/improve/ImproveOpportunityList.tsx
+++ b/src/components/improve/ImproveOpportunityList.tsx
@@ -33,7 +33,7 @@ export function ImproveOpportunityList({
 }) {
     if (!detectorReady) {
         return (
-            <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-80) p-5 text-sm text-(--ink-muted)">
+            <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-80) p-5 text-sm text-(--ink-muted)">
                 <p className="font-medium text-foreground">No flow opportunities detected</p>
                 <p className="mt-2">
                     As review, cycle time, rework, WIP, throughput, churn, and change failure data
@@ -57,7 +57,7 @@ export function ImproveOpportunityList({
             {opportunities.map((item) => (
                 <li
                     key={item.opportunityId}
-                    className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4"
+                    className="rounded-2xl border border-(--border) bg-(--card-80) p-4"
                 >
                     <div className="flex items-start justify-between gap-3">
                         <div>

--- a/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
+++ b/src/components/incident-correlation/IncidentCorrelationDashboard.tsx
@@ -353,7 +353,7 @@ export function IncidentCorrelationDashboard({
     if (!hasAnyData) {
         return (
             <div
-                className="rounded-2xl border border-(--card-stroke) bg-card p-8 shadow-sm"
+                className="rounded-2xl border border-(--border) bg-card p-8 shadow-sm"
                 data-testid="empty-state"
             >
                 <h2 className="text-2xl font-semibold tracking-tight">
@@ -405,7 +405,7 @@ export function IncidentCorrelationDashboard({
                     const hasCfrTrend = hasRenderableSeries(cfrTrendData);
                     return (
                         <section
-                            className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5"
+                            className="rounded-3xl border border-(--border) bg-(--card) p-5"
                             aria-label="Change failure rate trend"
                         >
                             <div className="flex items-center justify-between">
@@ -447,7 +447,7 @@ export function IncidentCorrelationDashboard({
                     className="grid gap-6 lg:grid-cols-2"
                     aria-label="Change failure root cause"
                 >
-                    <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                    <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                         <div className="flex items-center justify-between">
                             <h2 className="font-(--font-display) text-xl">
                                 Change Failure Associations
@@ -483,7 +483,7 @@ export function IncidentCorrelationDashboard({
                         )}
                     </div>
 
-                    <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5">
+                    <div className="rounded-3xl border border-(--border) bg-(--card) p-5">
                         <div className="flex items-center justify-between">
                             <h2 className="font-(--font-display) text-xl">Contributors</h2>
                             <Link
@@ -502,7 +502,7 @@ export function IncidentCorrelationDashboard({
                                 {topContributors.map((c) => (
                                     <div
                                         key={c.id}
-                                        className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+                                        className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-4 py-2"
                                     >
                                         <EntityLabel id={c.id} displayName={c.display_name} />
                                         <span className="text-xs text-(--ink-muted)">
@@ -533,7 +533,7 @@ export function IncidentCorrelationDashboard({
                             records
                         </p>
                     </div>
-                    <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90) shadow-sm">
+                    <div className="overflow-hidden rounded-2xl border border-(--border) bg-(--card-90) shadow-sm">
                         <table className="w-full text-sm" data-testid="incident-linkage-table">
                             <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
                                 <tr>
@@ -546,7 +546,7 @@ export function IncidentCorrelationDashboard({
                                 {incidentRows.slice(0, 50).map((row) => (
                                     <tr
                                         key={row.incidentId}
-                                        className="border-t border-(--card-stroke)/60 hover:bg-(--card-60)/60"
+                                        className="border-t border-(--border)/60 hover:bg-(--card-60)/60"
                                         data-testid="incident-row"
                                         data-incident-id={row.incidentId}
                                     >
@@ -577,7 +577,7 @@ export function IncidentCorrelationDashboard({
             {/* ── Sankey: PR → deployment → incident ──────────────────────────────── */}
             {sankeyData && (
                 <section
-                    className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5"
+                    className="rounded-3xl border border-(--border) bg-(--card) p-5"
                     aria-label="Correlation flow diagram"
                 >
                     <h2 className="font-(--font-display) text-xl">
@@ -600,7 +600,7 @@ export function IncidentCorrelationDashboard({
             {/* ── Sub-empty: metrics/explain present but no edges ─────────────────── */}
             {!hasEdgeData && (doraMetrics.length > 0 || hasExplainData) && (
                 <section
-                    className="rounded-2xl border border-(--card-stroke) bg-(--card-60) p-6 text-sm text-(--ink-muted)"
+                    className="rounded-2xl border border-(--border) bg-(--card-60) p-6 text-sm text-(--ink-muted)"
                     data-testid="empty-edges-state"
                 >
                     No deployment-incident linkage found yet. Deployment and incident associations

--- a/src/components/investment/InvestmentChart.tsx
+++ b/src/components/investment/InvestmentChart.tsx
@@ -16,7 +16,7 @@ export function InvestmentChart({
     unit,
 }: InvestmentChartProps) {
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+        <div className="rounded-3xl border border-(--border) bg-card p-5">
             <InvestmentMixSunburst
                 themeDistribution={themeDistribution}
                 subcategoryDistribution={subcategoryDistribution}

--- a/src/components/labels/EntityLabel.tsx
+++ b/src/components/labels/EntityLabel.tsx
@@ -48,7 +48,7 @@ type EntityLabelProps = {
 };
 
 const BADGE_CLASS =
-    "rounded-full border border-(--card-stroke) bg-(--card-70) px-1.5 py-0.5 text-xs font-semibold uppercase tracking-[0.16em] text-(--ink-muted)";
+    "rounded-full border border-(--border) bg-(--card-70) px-1.5 py-0.5 text-xs font-semibold uppercase tracking-[0.16em] text-(--ink-muted)";
 
 export function EntityLabel({
     id,

--- a/src/components/marketing/MarketingShell.tsx
+++ b/src/components/marketing/MarketingShell.tsx
@@ -82,7 +82,7 @@ export function MarketingShell({ children }: Readonly<{ children: React.ReactNod
                         </div>
                     </Link>
                     <div className="flex items-center gap-1.5">
-                        <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
+                        <span className="rounded-full border border-(--border) bg-(--card-70) px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
                             OSS
                         </span>
                         <BetaBadge />
@@ -118,7 +118,7 @@ export function MarketingShell({ children }: Readonly<{ children: React.ReactNod
 
             <main>{children}</main>
 
-            <footer className="border-t border-(--card-stroke)">
+            <footer className="border-t border-(--border)">
                 <div className="mx-auto grid max-w-7xl gap-8 px-6 py-12 sm:grid-cols-2 lg:grid-cols-5">
                     <div>
                         <p className="text-lg font-semibold">Full Chaos Dev Health</p>
@@ -157,7 +157,7 @@ export function MarketingShell({ children }: Readonly<{ children: React.ReactNod
                         </div>
                     ))}
                 </div>
-                <div className="border-t border-(--card-stroke)">
+                <div className="border-t border-(--border)">
                     <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-6">
                         <p className="text-xs text-(--ink-muted)">
                             &copy; {new Date().getFullYear()} Full Chaos Studios. All rights

--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -51,7 +51,7 @@ export function MetricCard({
 
     const body = (
         <>
-            <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+            <div className="flex items-center justify-between text-label-caps uppercase text-(--text-muted)">
                 <div className="flex items-center">
                     <span>{label}</span>
                     {lineageMetricId && <LineagePopover metricId={lineageMetricId} />}
@@ -70,7 +70,7 @@ export function MetricCard({
                             : formatMetricValue(value, unit ?? "")}
                     </p>
                     {captionText && (
-                        <p className="mt-2 text-xs text-(--ink-muted)">{captionText}</p>
+                        <p className="mt-2 text-xs text-(--text-muted)">{captionText}</p>
                     )}
                 </div>
                 <div className="h-16 w-full">

--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -3,6 +3,7 @@ import { LineagePopover } from "@/app/(app)/data-health/_components/LineagePopov
 
 import { SparklineChart } from "@/components/charts/SparklineChart";
 import { MetricDelta } from "@/components/shared/MetricDelta";
+import { CARD_SURFACE } from "@/lib/design/card";
 import { formatMetricValue } from "@/lib/formatters";
 import type { SparkPoint } from "@/lib/types";
 
@@ -44,8 +45,8 @@ export function MetricCard({
     const sparkLabels = spark?.map((point) => point.ts) ?? [];
     // Only a real destination earns the clickable affordance + "Open evidence" cue.
     const captionText = caption ?? (href ? "Open evidence" : null);
-    const cardClassName = `group rounded-3xl border border-(--card-stroke) bg-card p-4 ${
-        href ? "transition hover:-translate-y-1 hover:shadow-lg" : ""
+    const cardClassName = `group ${CARD_SURFACE} p-4 ${
+        href ? "transition hover:-translate-y-1 hover:border-(--card-stroke-active)" : ""
     } ${className ?? ""}`;
 
     const body = (
@@ -78,7 +79,7 @@ export function MetricCard({
                     ) : (
                         <div
                             title="Not enough data points to plot a trend yet"
-                            className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-2 text-center text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)"
+                            className="flex h-full items-center justify-center rounded-(--radius-md) border border-dashed border-(--border) bg-(--card-70) px-2 text-center text-label-caps uppercase text-(--text-muted)"
                         >
                             No trend yet
                         </div>

--- a/src/components/metrics/MetricEvidenceCards.tsx
+++ b/src/components/metrics/MetricEvidenceCards.tsx
@@ -58,7 +58,7 @@ export function MetricEvidenceCards({
                     return (
                         <article
                             key={metric}
-                            className="group rounded-3xl border border-(--card-stroke) bg-card p-4 transition hover:-translate-y-1 hover:shadow-lg"
+                            className="group rounded-3xl border border-(--border) bg-card p-4 transition hover:-translate-y-1 hover:shadow-lg"
                         >
                             <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                 <span>{label}</span>
@@ -102,7 +102,7 @@ export function MetricEvidenceCards({
                                             height={64}
                                         />
                                     ) : (
-                                        <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
+                                        <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--border) bg-(--card-70) text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)">
                                             Trend
                                         </div>
                                     )}

--- a/src/components/navigation/AreaHub.tsx
+++ b/src/components/navigation/AreaHub.tsx
@@ -63,7 +63,7 @@ export function AreaHub({ areaId, signals, filters, role, title, description }: 
         <section
             aria-label={`${area.label} signals`}
             data-testid="area-hub"
-            className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5"
+            className="rounded-3xl border border-(--border) bg-(--card-80) p-5"
         >
             <div>
                 <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">

--- a/src/components/navigation/GlobalContextBarClient.tsx
+++ b/src/components/navigation/GlobalContextBarClient.tsx
@@ -167,7 +167,7 @@ export function GlobalContextBarClient({ filters, origin, orgName }: GlobalConte
             ref={barRef}
             aria-label="Global context"
             data-testid="global-context-bar"
-            className="rounded-2xl border border-(--card-stroke) bg-(--card-90)/80 px-4 py-3 text-xs backdrop-blur-sm"
+            className="rounded-2xl border border-(--border) bg-(--card-90)/80 px-4 py-3 text-xs backdrop-blur-sm"
         >
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
                 <div className="flex items-center gap-2">
@@ -180,7 +180,7 @@ export function GlobalContextBarClient({ filters, origin, orgName }: GlobalConte
                         className={`rounded-full border px-3 py-1.5 font-medium transition-colors ${
                             isOrgScope
                                 ? "border-(--accent-2) bg-(--accent-2)/15 text-foreground"
-                                : "border-(--card-stroke) bg-(--card-80) text-(--ink-muted) hover:text-foreground"
+                                : "border-(--border) bg-(--card-80) text-(--ink-muted) hover:text-foreground"
                         }`}
                     >
                         {orgLabel}
@@ -212,7 +212,7 @@ export function GlobalContextBarClient({ filters, origin, orgName }: GlobalConte
                     <span className="text-xs font-semibold uppercase tracking-[0.2em] text-(--ink-muted)">
                         Window
                     </span>
-                    <div className="flex rounded-full border border-(--card-stroke) bg-(--card-80) p-1">
+                    <div className="flex rounded-full border border-(--border) bg-(--card-80) p-1">
                         {WINDOW_OPTIONS.map((days) => {
                             const active = filters.time.range_days === days;
                             return (

--- a/src/components/navigation/OrgSwitcher.tsx
+++ b/src/components/navigation/OrgSwitcher.tsx
@@ -97,7 +97,7 @@ export function OrgSwitcher() {
     }
 
     return (
-        <div className="mt-4 rounded-2xl border border-(--card-stroke) bg-(--card-70) p-3">
+        <div className="mt-4 rounded-2xl border border-(--border) bg-(--card-70) p-3">
             <label
                 htmlFor="org-switcher"
                 className="text-[10px] uppercase tracking-widest text-(--ink-muted)"
@@ -109,7 +109,7 @@ export function OrgSwitcher() {
                 value={activeOrgId}
                 disabled={isPending || !canSwitchOrganizations}
                 onChange={(event) => switchOrg(event.target.value)}
-                className="mt-2 w-full rounded-xl border border-(--card-stroke) bg-(--background) px-3 py-2 text-sm text-foreground outline-none transition focus:border-(--accent) disabled:opacity-60"
+                className="mt-2 w-full rounded-xl border border-(--border) bg-(--background) px-3 py-2 text-sm text-foreground outline-none transition focus:border-(--accent) disabled:opacity-60"
                 aria-describedby="org-switcher-data"
             >
                 {state.organizations.map((org) => (

--- a/src/components/navigation/PrimaryNav.tsx
+++ b/src/components/navigation/PrimaryNav.tsx
@@ -98,7 +98,7 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
                     // borders. The active area owns one expanded list; A10 keeps exactly
                     // one child selected with hover/focus visually distinct.
                     <div
-                        className="mt-1 ml-3 flex flex-col gap-0.5 border-l border-(--card-stroke) pl-2"
+                        className="mt-1 ml-3 flex flex-col gap-0.5 border-l border-(--border) pl-2"
                         data-testid={`nav-children-${area.id}`}
                     >
                         {visibleChildren.map((child) => renderChild(child, activeChildId))}
@@ -111,7 +111,7 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
     return (
         <aside className="w-full md:max-w-56 md:shrink-0">
             <div className="md:sticky md:top-6">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-4">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-4">
                     <div>
                         <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                             Full Chaos Dev Health Ops
@@ -133,11 +133,11 @@ export function PrimaryNav({ filters, active, role }: PrimaryNavProps) {
                     </nav>
 
                     {/* Utility tray — visually separated from main spine */}
-                    <div className="mt-4 border-t border-(--card-stroke) pt-3 space-y-2 text-xs">
+                    <div className="mt-4 border-t border-(--border) pt-3 space-y-2 text-xs">
                         {utilityAreas.map((area) => renderArea(area))}
                     </div>
 
-                    <div className="mt-4 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-3 py-2 text-xs text-(--ink-muted)">
+                    <div className="mt-4 rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-3 py-2 text-xs text-(--ink-muted)">
                         The active area expands to its destinations; open one to drill in.
                     </div>
                 </div>

--- a/src/components/navigation/ViewSet.tsx
+++ b/src/components/navigation/ViewSet.tsx
@@ -16,7 +16,7 @@ type ViewSetProps = {
 };
 
 const TAB_CONTAINER =
-    "flex items-center gap-1 overflow-x-auto whitespace-nowrap border-b border-(--card-stroke) px-1 scrollbar-hide";
+    "flex items-center gap-1 overflow-x-auto whitespace-nowrap border-b border-(--border) px-1 scrollbar-hide";
 
 const TAB_BASE =
     "-mb-px flex items-center gap-1.5 border-b-2 px-3.5 py-3 text-[10px] uppercase tracking-[0.18em] transition-all";
@@ -25,7 +25,7 @@ const TAB_ACTIVE = "border-(--accent) text-foreground font-semibold";
 const TAB_INACTIVE =
     "border-transparent text-(--ink-muted) hover:border-(--card-stroke) hover:text-foreground";
 
-const VERTICAL_CONTAINER = "mt-1 ml-3 flex flex-col gap-0.5 border-l border-(--card-stroke) pl-2";
+const VERTICAL_CONTAINER = "mt-1 ml-3 flex flex-col gap-0.5 border-l border-(--border) pl-2";
 
 const VERTICAL_BASE =
     "group relative flex items-center rounded-xl px-3 py-1.5 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/35";

--- a/src/components/people/PeopleSearch.tsx
+++ b/src/components/people/PeopleSearch.tsx
@@ -186,7 +186,7 @@ export function PeopleSearch({ query, filters }: PeopleSearchProps) {
     }, [fetchPlans, shouldFetch]);
 
     return (
-        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+        <section className="rounded-3xl border border-(--border) bg-(--card-80) p-6">
             <div className="flex flex-wrap items-center justify-between gap-4">
                 <div>
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
@@ -200,27 +200,27 @@ export function PeopleSearch({ query, filters }: PeopleSearchProps) {
 
             <div className="mt-4 space-y-3">
                 {shouldShowResults && isLoading && (
-                    <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+                    <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
                         Searching people...
                     </div>
                 )}
                 {shouldShowResults && error && (
-                    <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+                    <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
                         {error}
                     </div>
                 )}
                 {showQueryEmpty && (
-                    <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+                    <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
                         No matches yet. Try another spelling or handle.
                     </div>
                 )}
                 {showTeamEmpty && (
-                    <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+                    <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
                         No matches for the selected team filter.
                     </div>
                 )}
                 {showFocusEmpty && (
-                    <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+                    <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
                         No matches for the selected people filter.
                     </div>
                 )}
@@ -230,12 +230,12 @@ export function PeopleSearch({ query, filters }: PeopleSearchProps) {
                     visibleResults.length > 0 &&
                     focusActive &&
                     !hasFocusMatches && (
-                        <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+                        <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
                             No matches for the selected people filter.
                         </div>
                     )}
                 {!shouldShowResults && !focusActive && (
-                    <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
+                    <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-4 py-3 text-sm text-(--ink-muted)">
                         {emptyPrompt}
                     </div>
                 )}
@@ -248,7 +248,7 @@ export function PeopleSearch({ query, filters }: PeopleSearchProps) {
                         <Link
                             key={person.person_id}
                             href={href}
-                            className={`block rounded-2xl border border-(--card-stroke) bg-card px-4 py-3 transition hover:-translate-y-1 ${
+                            className={`block rounded-2xl border border-(--border) bg-card px-4 py-3 transition hover:-translate-y-1 ${
                                 focusActive && !isFocus ? "opacity-50" : "opacity-100"
                             }`}
                         >
@@ -268,7 +268,7 @@ export function PeopleSearch({ query, filters }: PeopleSearchProps) {
                                             {(person.identities ?? []).map((identity) => (
                                                 <span
                                                     key={`${person.person_id}-${identity.provider}-${identity.handle}`}
-                                                    className="rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1"
+                                                    className="rounded-full border border-(--border) bg-(--card-70) px-3 py-1"
                                                 >
                                                     {identity.provider}: {identity.handle}
                                                 </span>

--- a/src/components/people/PersonRangeBar.tsx
+++ b/src/components/people/PersonRangeBar.tsx
@@ -55,7 +55,7 @@ export function PersonRangeBar({ rangeDays }: PersonRangeBarProps) {
     };
 
     return (
-        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-90) p-5 shadow-sm">
+        <section className="rounded-3xl border border-(--border) bg-(--card-90) p-5 shadow-sm">
             <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
@@ -71,7 +71,7 @@ export function PersonRangeBar({ rangeDays }: PersonRangeBarProps) {
                     <label className="flex flex-col gap-2 text-sm">
                         <span className="text-xs text-(--ink-muted)">Start date</span>
                         <input
-                            className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+                            className="rounded-xl border border-(--border) bg-card px-3 py-2"
                             type="date"
                             value={formatDateInput(startDate)}
                             onChange={(event) => {
@@ -91,7 +91,7 @@ export function PersonRangeBar({ rangeDays }: PersonRangeBarProps) {
                     <label className="flex flex-col gap-2 text-sm">
                         <span className="text-xs text-(--ink-muted)">End date</span>
                         <input
-                            className="rounded-xl border border-(--card-stroke) bg-card px-3 py-2"
+                            className="rounded-xl border border-(--border) bg-card px-3 py-2"
                             type="date"
                             value={formatDateInput(endDate)}
                             onChange={(event) => {
@@ -113,11 +113,11 @@ export function PersonRangeBar({ rangeDays }: PersonRangeBarProps) {
                 <div className="mt-4 grid gap-3 sm:grid-cols-2" aria-hidden="true">
                     <div className="flex flex-col gap-2">
                         <div className="h-3 w-16 rounded bg-(--card-70) animate-pulse" />
-                        <div className="h-10 rounded-xl border border-(--card-stroke) bg-(--card-70) animate-pulse" />
+                        <div className="h-10 rounded-xl border border-(--border) bg-(--card-70) animate-pulse" />
                     </div>
                     <div className="flex flex-col gap-2">
                         <div className="h-3 w-16 rounded bg-(--card-70) animate-pulse" />
-                        <div className="h-10 rounded-xl border border-(--card-stroke) bg-(--card-70) animate-pulse" />
+                        <div className="h-10 rounded-xl border border-(--border) bg-(--card-70) animate-pulse" />
                     </div>
                 </div>
             )}

--- a/src/components/product-telemetry/PlatformProductTelemetryDashboard.tsx
+++ b/src/components/product-telemetry/PlatformProductTelemetryDashboard.tsx
@@ -14,7 +14,7 @@ const formatNumber = (value: number | null | undefined) =>
 
 function StatCard({ label, value, caption }: { label: string; value: string; caption: string }) {
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+        <div className="rounded-3xl border border-(--border) bg-card p-5">
             <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">{label}</p>
             <p className="mt-3 font-(--font-display) text-3xl font-semibold text-foreground">
                 {value}
@@ -35,7 +35,7 @@ function TopOrgsTable({
 }) {
     if (rows.length === 0) {
         return (
-            <div className="rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-8 text-center text-sm text-(--ink-muted)">
+            <div className="rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-4 py-8 text-center text-sm text-(--ink-muted)">
                 No orgs reported product telemetry in this window.
             </div>
         );
@@ -52,14 +52,14 @@ function TopOrgsTable({
         <div className="overflow-x-auto">
             <table className="min-w-full text-left text-sm">
                 <thead className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
-                    <tr className="border-b border-(--card-stroke)">
+                    <tr className="border-b border-(--border)">
                         <th className="py-2 pr-4 font-medium">Organization</th>
                         <th className="py-2 pr-4 font-medium">Events</th>
                         <th className="py-2 pr-4 font-medium">Sessions</th>
                         <th className="py-2 pr-4 font-medium">Anonymous users</th>
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-(--card-stroke)">
+                <tbody className="divide-y divide-(--border)">
                     {rows.map((org) => {
                         const label =
                             org.orgName || org.orgSlug || `${org.orgIdHash.slice(0, 12)}\u2026`;
@@ -133,7 +133,7 @@ export function PlatformProductTelemetryDashboard({
                 />
             </div>
 
-            <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)]">
+            <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5 shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)]">
                 <div className="mb-4 flex items-baseline justify-between gap-4">
                     <div>
                         <h2 className="text-lg font-semibold text-foreground">Top organizations</h2>

--- a/src/components/product-telemetry/ProductTelemetryDashboard.tsx
+++ b/src/components/product-telemetry/ProductTelemetryDashboard.tsx
@@ -29,7 +29,7 @@ function SectionCard({
     children: React.ReactNode;
 }) {
     return (
-        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5 shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)]">
+        <section className="rounded-3xl border border-(--border) bg-(--card-80) p-5 shadow-[0_24px_80px_-56px_rgba(0,0,0,0.55)]">
             <div className="mb-4">
                 <h2 className="text-lg font-semibold text-foreground">{title}</h2>
                 <p className="mt-1 text-sm text-(--ink-muted)">{description}</p>
@@ -54,7 +54,7 @@ function DataTable({ headers, rows }: { headers: string[]; rows: Array<Array<str
         <div className="overflow-x-auto">
             <table className="min-w-full text-left text-sm">
                 <thead className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
-                    <tr className="border-b border-(--card-stroke)">
+                    <tr className="border-b border-(--border)">
                         {headers.map((header) => (
                             <th key={header} className="py-2 pr-4 font-medium">
                                 {header}
@@ -62,7 +62,7 @@ function DataTable({ headers, rows }: { headers: string[]; rows: Array<Array<str
                         ))}
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-(--card-stroke)">
+                <tbody className="divide-y divide-(--border)">
                     {rows.map((row) => (
                         <tr key={row.join("|")}>
                             {row.map((cell, cellIndex) => (
@@ -112,10 +112,7 @@ export function ProductTelemetryDashboard({
                     ["Feature views", formatNumber(totalFeatureViews), "Stable feature IDs viewed"],
                     ["Client errors", formatNumber(totalErrors), "Rendered by route and boundary"],
                 ].map(([label, value, caption]) => (
-                    <div
-                        key={label}
-                        className="rounded-3xl border border-(--card-stroke) bg-card p-5"
-                    >
+                    <div key={label} className="rounded-3xl border border-(--border) bg-card p-5">
                         <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
                             {label}
                         </p>
@@ -240,7 +237,7 @@ export function ProductTelemetryDashboard({
                         ].map(([label, value]) => (
                             <div
                                 key={label}
-                                className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4"
+                                className="rounded-2xl border border-(--border) bg-(--card-70) p-4"
                             >
                                 <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
                                     {label}

--- a/src/components/reports/MarkdownRenderer.tsx
+++ b/src/components/reports/MarkdownRenderer.tsx
@@ -41,7 +41,7 @@ export function MarkdownRenderer({ content }: { content: string }) {
             </div>
 
             {provenance && (
-                <div className="border-t border-(--card-stroke) pt-4">
+                <div className="border-t border-(--border) pt-4">
                     <button
                         onClick={() => setShowProvenance(!showProvenance)}
                         className="flex items-center gap-2 text-xs uppercase tracking-[0.15em] text-(--ink-muted) hover:text-foreground transition-colors"
@@ -73,7 +73,7 @@ export function MarkdownRenderer({ content }: { content: string }) {
             )}
 
             {footer && (
-                <div className="border-t border-(--card-stroke) pt-3 text-[10px] text-(--ink-muted) tracking-wide">
+                <div className="border-t border-(--border) pt-3 text-[10px] text-(--ink-muted) tracking-wide">
                     {footer}
                 </div>
             )}

--- a/src/components/risk/CompoundingRiskDashboard.tsx
+++ b/src/components/risk/CompoundingRiskDashboard.tsx
@@ -210,7 +210,7 @@ function ComponentBars({ row }: { row: CompoundingRiskRowView }) {
                 return (
                     <article
                         key={component.key}
-                        className="rounded-2xl border border-(--card-stroke) bg-card p-4 shadow-sm"
+                        className="rounded-2xl border border-(--border) bg-card p-4 shadow-sm"
                         data-testid={`component-${component.label.toLowerCase().replace(/\s+/g, "-")}`}
                     >
                         <div className="flex items-center justify-between gap-3">
@@ -246,7 +246,7 @@ function ScopeTable({
     if (rows.length === 0) {
         return (
             <p
-                className="rounded-2xl border border-(--card-stroke) bg-card p-6 text-sm text-(--ink-muted)"
+                className="rounded-2xl border border-(--border) bg-card p-6 text-sm text-(--ink-muted)"
                 data-testid="empty-state"
             >
                 No Compounding Risk data is available for this org yet. Run{" "}
@@ -257,7 +257,7 @@ function ScopeTable({
     }
 
     return (
-        <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90) shadow-sm">
+        <div className="overflow-hidden rounded-2xl border border-(--border) bg-(--card-90) shadow-sm">
             <table className="w-full text-sm" data-testid="compounding-risk-table">
                 <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
                     <tr>
@@ -287,7 +287,7 @@ function ScopeTable({
                                 data-testid="risk-row"
                                 data-scope-id={row.scopeId}
                                 data-severity={row.severity}
-                                className="border-t border-(--card-stroke)/60 hover:bg-(--card-60)/60"
+                                className="border-t border-(--border)/60 hover:bg-(--card-60)/60"
                             >
                                 <td className="px-5 py-3 align-middle font-medium">
                                     {row.scopeLabel}
@@ -357,7 +357,7 @@ export function CompoundingRiskDashboard({
         return (
             <div className="flex flex-col gap-6" data-testid="compounding-risk-dashboard">
                 <section
-                    className="rounded-2xl border border-(--card-stroke) bg-card p-8 shadow-sm"
+                    className="rounded-2xl border border-(--border) bg-card p-8 shadow-sm"
                     data-testid="all-scores-null-state"
                 >
                     <h1 className="text-3xl font-semibold tracking-tight md:text-5xl">
@@ -381,7 +381,7 @@ export function CompoundingRiskDashboard({
                     </p>
 
                     {missingInputs.length > 0 && (
-                        <div className="mt-8 rounded-2xl border border-(--card-stroke) bg-(--card-60) p-6">
+                        <div className="mt-8 rounded-2xl border border-(--border) bg-(--card-60) p-6">
                             <h3 className="text-sm font-semibold tracking-tight">
                                 Missing inputs across all {breakout}s:
                             </h3>
@@ -408,7 +408,7 @@ export function CompoundingRiskDashboard({
 
     return (
         <div className="flex flex-col gap-6" data-testid="compounding-risk-dashboard">
-            <section className="overflow-hidden rounded-[2rem] border border-(--card-stroke) bg-(--card-80) shadow-sm">
+            <section className="overflow-hidden rounded-[2rem] border border-(--border) bg-(--card-80) shadow-sm">
                 <div className="grid gap-0 lg:grid-cols-[1.15fr_0.85fr]">
                     <div className="p-8">
                         <h1 className="text-3xl font-semibold tracking-tight md:text-5xl">
@@ -427,7 +427,7 @@ export function CompoundingRiskDashboard({
                             </time>
                         </p>
                     </div>
-                    <div className="border-t border-(--card-stroke) bg-(--card-60) p-8 lg:border-l lg:border-t-0">
+                    <div className="border-t border-(--border) bg-(--card-60) p-8 lg:border-l lg:border-t-0">
                         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-(--ink-muted)">
                             Headline
                         </p>
@@ -456,7 +456,7 @@ export function CompoundingRiskDashboard({
 
             {headline && (
                 <section
-                    className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
+                    className="rounded-[1.75rem] border border-(--border) bg-(--card-90) p-6 shadow-sm"
                     data-testid="component-breakdown"
                 >
                     <div className="flex items-center justify-between gap-3">

--- a/src/components/security/KpiTile.tsx
+++ b/src/components/security/KpiTile.tsx
@@ -33,7 +33,7 @@ export function KpiTile({ label, value, delta, tone = "default", loading = false
 
     return (
         <div
-            className={`flex flex-col gap-1 rounded-2xl border border-(--card-stroke) bg-card px-5 py-4 border-l-4 ${accentClass}`}
+            className={`flex flex-col gap-1 rounded-2xl border border-(--border) bg-card px-5 py-4 border-l-4 ${accentClass}`}
         >
             <span className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
                 {label}

--- a/src/components/security/SecurityAlertQueue.tsx
+++ b/src/components/security/SecurityAlertQueue.tsx
@@ -41,7 +41,7 @@ export function SecurityAlertQueue({ filter, lockedRepoId }: SecurityAlertQueueP
                 </div>
                 {lockedRepoId && (
                     <span
-                        className="inline-flex items-center gap-1.5 rounded-full border border-(--card-stroke) bg-(--card-80) px-3 py-1 text-xs text-(--ink-muted)"
+                        className="inline-flex items-center gap-1.5 rounded-full border border-(--border) bg-(--card-80) px-3 py-1 text-xs text-(--ink-muted)"
                         data-testid="locked-repo-pill"
                     >
                         <svg
@@ -65,9 +65,9 @@ export function SecurityAlertQueue({ filter, lockedRepoId }: SecurityAlertQueueP
             </div>
 
             {/* Table */}
-            <div className="rounded-2xl border border-(--card-stroke) bg-card overflow-hidden">
+            <div className="rounded-2xl border border-(--border) bg-card overflow-hidden">
                 {fetching && allEdges.length === 0 ? (
-                    <div className="divide-y divide-(--card-stroke)">
+                    <div className="divide-y divide-(--border)">
                         {Array.from({ length: 8 }).map((_, i) => (
                             <div key={i} className="flex gap-3 px-3 py-3 animate-pulse">
                                 <div className="h-5 w-16 rounded bg-(--card-70)" />
@@ -86,7 +86,7 @@ export function SecurityAlertQueue({ filter, lockedRepoId }: SecurityAlertQueueP
                         />
                     </div>
                 ) : (
-                    <div className="divide-y divide-(--card-stroke)">
+                    <div className="divide-y divide-(--border)">
                         {allEdges.map((edge) => (
                             <SecurityAlertRow
                                 key={edge.cursor}
@@ -103,7 +103,7 @@ export function SecurityAlertQueue({ filter, lockedRepoId }: SecurityAlertQueueP
                     <button
                         onClick={() => fetchMore(pageInfo.endCursor!)}
                         disabled={fetching}
-                        className="rounded-full border border-(--card-stroke) px-6 py-2 text-xs uppercase tracking-[0.15em] transition hover:bg-(--card-80) disabled:opacity-50"
+                        className="rounded-full border border-(--border) px-6 py-2 text-xs uppercase tracking-[0.15em] transition hover:bg-(--card-80) disabled:opacity-50"
                     >
                         {fetching ? "Loading…" : "Load more"}
                     </button>

--- a/src/components/security/SecurityAlertRow.tsx
+++ b/src/components/security/SecurityAlertRow.tsx
@@ -28,7 +28,7 @@ function relativeAge(iso: string): string {
 }
 
 const ROW_BASE =
-    "grid grid-cols-[auto_auto_1fr_auto_auto_auto_auto_auto] items-center gap-x-3 border-b border-[var(--card-stroke)] px-3 py-2 text-sm hover:bg-[var(--card-70)] transition-colors";
+    "grid grid-cols-[auto_auto_1fr_auto_auto_auto_auto_auto] items-center gap-x-3 border-b border-[var(--border)] px-3 py-2 text-sm hover:bg-[var(--card-70)] transition-colors";
 
 export function SecurityAlertRow({ alert }: SecurityAlertRowProps) {
     const {

--- a/src/components/security/SecurityDashboard.tsx
+++ b/src/components/security/SecurityDashboard.tsx
@@ -103,7 +103,7 @@ export function SecurityDashboard({ filter }: SecurityDashboardProps) {
 
             {/* Row 2: Severity breakdown + Top repos */}
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                <div className="rounded-2xl border border-(--card-stroke) bg-card p-4">
+                <div className="rounded-2xl border border-(--border) bg-card p-4">
                     <p className="mb-3 text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
                         By Severity
                     </p>
@@ -114,7 +114,7 @@ export function SecurityDashboard({ filter }: SecurityDashboardProps) {
                     )}
                 </div>
                 <div
-                    className="rounded-2xl border border-(--card-stroke) bg-card p-4"
+                    className="rounded-2xl border border-(--border) bg-card p-4"
                     data-testid="top-repos-chart"
                 >
                     <p className="mb-3 text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
@@ -129,7 +129,7 @@ export function SecurityDashboard({ filter }: SecurityDashboardProps) {
             </div>
 
             {/* Row 3: Trend chart */}
-            <div className="rounded-2xl border border-(--card-stroke) bg-card p-4">
+            <div className="rounded-2xl border border-(--border) bg-card p-4">
                 <p className="mb-3 text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
                     Trend (last 30 days)
                 </p>

--- a/src/components/security/SecurityFilterBarWrapper.tsx
+++ b/src/components/security/SecurityFilterBarWrapper.tsx
@@ -139,7 +139,7 @@ export function SecurityFilterBarWrapper({ encodedFilter }: SecurityFilterBarWra
     return (
         <section
             aria-label="Security filters"
-            className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4"
+            className="rounded-2xl border border-(--border) bg-(--card-80) p-4"
             data-testid="security-filter-bar"
         >
             <div className="flex flex-col gap-3">

--- a/src/components/settings/PreferencesSettings.tsx
+++ b/src/components/settings/PreferencesSettings.tsx
@@ -134,7 +134,7 @@ export function PreferencesSettings() {
                             className={`flex-1 rounded-lg border px-4 py-3 text-sm font-medium transition ${
                                 theme === "light"
                                     ? "border-(--accent) bg-(--accent)/10 text-(--accent)"
-                                    : "border-(--card-stroke) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
+                                    : "border-(--border) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
                             }`}
                         >
                             <span className="block text-lg mb-1">☀️</span>
@@ -146,7 +146,7 @@ export function PreferencesSettings() {
                             className={`flex-1 rounded-lg border px-4 py-3 text-sm font-medium transition ${
                                 theme === "dark"
                                     ? "border-(--accent) bg-(--accent)/10 text-(--accent)"
-                                    : "border-(--card-stroke) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
+                                    : "border-(--border) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
                             }`}
                         >
                             <span className="block text-lg mb-1">🌙</span>
@@ -168,7 +168,7 @@ export function PreferencesSettings() {
                                 className={`rounded-lg border px-4 py-3 text-sm font-medium transition ${
                                     palette === p.value
                                         ? "border-(--accent) bg-(--accent)/10 text-(--accent)"
-                                        : "border-(--card-stroke) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
+                                        : "border-(--border) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
                                 }`}
                             >
                                 {p.label}
@@ -195,7 +195,7 @@ export function PreferencesSettings() {
                             className={`flex-1 rounded-lg border px-4 py-3 text-sm font-medium transition ${
                                 !telemetryOptedOut
                                     ? "border-(--accent) bg-(--accent)/10 text-(--accent)"
-                                    : "border-(--card-stroke) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
+                                    : "border-(--border) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
                             }`}
                         >
                             Enabled
@@ -207,7 +207,7 @@ export function PreferencesSettings() {
                             className={`flex-1 rounded-lg border px-4 py-3 text-sm font-medium transition ${
                                 telemetryOptedOut
                                     ? "border-(--accent) bg-(--accent)/10 text-(--accent)"
-                                    : "border-(--card-stroke) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
+                                    : "border-(--border) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
                             }`}
                         >
                             Disabled

--- a/src/components/settings/SettingsSection.tsx
+++ b/src/components/settings/SettingsSection.tsx
@@ -13,7 +13,7 @@ export function SettingsSection({ title, description, children, danger }: Settin
             className={`mb-8 rounded-lg border p-6 ${
                 danger
                     ? "border-red-200 bg-red-50/50 dark:border-red-900/50 dark:bg-red-900/10"
-                    : "border-(--card-stroke) bg-(--card)"
+                    : "border-(--border) bg-(--card)"
             }`}
         >
             <div className="mb-6">

--- a/src/components/shared/AuditLogFilters.tsx
+++ b/src/components/shared/AuditLogFilters.tsx
@@ -55,7 +55,7 @@ function AdminAuditLogFilters({ onFilter }: { onFilter: (f: AdminAuditFilter) =>
                     end_date: endDate || undefined,
                 });
             }}
-            className="mb-6 grid gap-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4 sm:grid-cols-2 lg:grid-cols-5"
+            className="mb-6 grid gap-4 rounded-2xl border border-(--border) bg-(--card-80) p-4 sm:grid-cols-2 lg:grid-cols-5"
         >
             <div>
                 <label
@@ -70,7 +70,7 @@ function AdminAuditLogFilters({ onFilter }: { onFilter: (f: AdminAuditFilter) =>
                     value={action}
                     onChange={(e) => setAction(e.target.value)}
                     placeholder="e.g. org.create"
-                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                    className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                 />
             </div>
             <div>
@@ -86,7 +86,7 @@ function AdminAuditLogFilters({ onFilter }: { onFilter: (f: AdminAuditFilter) =>
                     value={resourceType}
                     onChange={(e) => setResourceType(e.target.value)}
                     placeholder="e.g. organization"
-                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                    className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                 />
             </div>
             <div>
@@ -101,7 +101,7 @@ function AdminAuditLogFilters({ onFilter }: { onFilter: (f: AdminAuditFilter) =>
                     type="date"
                     value={startDate}
                     onChange={(e) => setStartDate(e.target.value)}
-                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                    className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                 />
             </div>
             <div>
@@ -116,7 +116,7 @@ function AdminAuditLogFilters({ onFilter }: { onFilter: (f: AdminAuditFilter) =>
                     type="date"
                     value={endDate}
                     onChange={(e) => setEndDate(e.target.value)}
-                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                    className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                 />
             </div>
             <div className="flex items-end">
@@ -144,7 +144,7 @@ function BillingAuditLogFilters({ onApply }: { onApply: (f: BillingAuditFilter) 
 
     return (
         <form
-            className="grid gap-3 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4 md:grid-cols-5"
+            className="grid gap-3 rounded-2xl border border-(--border) bg-(--card-80) p-4 md:grid-cols-5"
             onSubmit={(e) => {
                 e.preventDefault();
                 onApply({
@@ -160,18 +160,18 @@ function BillingAuditLogFilters({ onApply }: { onApply: (f: BillingAuditFilter) 
                 value={resourceType}
                 onChange={(e) => setResourceType(e.target.value)}
                 placeholder="resource type"
-                className="rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm"
+                className="rounded-xl border border-(--border) bg-(--card-70) px-3 py-2 text-sm"
             />
             <input
                 value={action}
                 onChange={(e) => setAction(e.target.value)}
                 placeholder="action"
-                className="rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm"
+                className="rounded-xl border border-(--border) bg-(--card-70) px-3 py-2 text-sm"
             />
             <select
                 value={status}
                 onChange={(e) => setStatus(e.target.value)}
-                className="rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm"
+                className="rounded-xl border border-(--border) bg-(--card-70) px-3 py-2 text-sm"
             >
                 <option value="">any status</option>
                 <option value="matched">matched</option>
@@ -182,14 +182,14 @@ function BillingAuditLogFilters({ onApply }: { onApply: (f: BillingAuditFilter) 
                 type="date"
                 value={fromDate}
                 onChange={(e) => setFromDate(e.target.value)}
-                className="rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm"
+                className="rounded-xl border border-(--border) bg-(--card-70) px-3 py-2 text-sm"
             />
             <div className="flex gap-2">
                 <input
                     type="date"
                     value={toDate}
                     onChange={(e) => setToDate(e.target.value)}
-                    className="w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm"
+                    className="w-full rounded-xl border border-(--border) bg-(--card-70) px-3 py-2 text-sm"
                 />
                 <button
                     type="submit"

--- a/src/components/shared/AuditLogTable.tsx
+++ b/src/components/shared/AuditLogTable.tsx
@@ -52,9 +52,9 @@ function BillingAuditLogTable({
     onSelect?: (id: string) => void;
 }) {
     return (
-        <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+        <div className="overflow-hidden rounded-2xl border border-(--border) bg-(--card-80)">
             <table className="w-full text-left text-sm">
-                <thead className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+                <thead className="border-b border-(--border) bg-(--card-70) text-(--ink-muted)">
                     <tr>
                         <th className="px-4 py-3 font-medium">Action</th>
                         <th className="px-4 py-3 font-medium">Resource</th>
@@ -62,7 +62,7 @@ function BillingAuditLogTable({
                         <th className="px-4 py-3 font-medium">Created</th>
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-(--card-stroke)">
+                <tbody className="divide-y divide-(--border)">
                     {entries.map((entry) => (
                         <tr
                             key={entry.id}
@@ -106,9 +106,9 @@ function BillingAuditLogTable({
 
 function AdminAuditLogTable({ entries }: { entries: AuditEntry[] }) {
     return (
-        <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+        <div className="overflow-x-auto rounded-2xl border border-(--border) bg-(--card-80)">
             <table className="w-full text-left text-sm">
-                <thead className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+                <thead className="border-b border-(--border) bg-(--card-70) text-(--ink-muted)">
                     <tr>
                         <th className="px-6 py-4 font-medium">Timestamp</th>
                         <th className="px-6 py-4 font-medium">Action</th>
@@ -118,7 +118,7 @@ function AdminAuditLogTable({ entries }: { entries: AuditEntry[] }) {
                         <th className="px-6 py-4 font-medium">Description</th>
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-(--card-stroke)">
+                <tbody className="divide-y divide-(--border)">
                     {entries.map((entry) => (
                         <tr key={entry.id} className="hover:bg-(--card-70)/50">
                             <td className="px-6 py-4 text-(--ink-muted)">

--- a/src/components/shared/BackLink.test.tsx
+++ b/src/components/shared/BackLink.test.tsx
@@ -41,7 +41,7 @@ describe("BackLink", () => {
     it("is not styled as a filter pill (quiet inline link, no pill background)", () => {
         render(<BackLink href="/" />);
         const link = screen.getByRole("link", { name: /back to cockpit/i });
-        expect(link.className).not.toContain("rounded-full");
-        expect(link.className).toContain("text-(--ink-muted)");
+        expect(link.className).not.toContain("rounded-(--radius-pill)");
+        expect(link.className).toContain("text-(--text-muted)");
     });
 });

--- a/src/components/shared/BackLink.tsx
+++ b/src/components/shared/BackLink.tsx
@@ -37,7 +37,7 @@ export function BackLink({ href, label, area, className }: BackLinkProps) {
     return (
         <Link
             href={href}
-            className={`group inline-flex items-center gap-1.5 text-xs uppercase tracking-[0.2em] text-(--ink-muted) transition-colors hover:text-foreground ${className ?? ""}`.trim()}
+            className={`group inline-flex items-center gap-1.5 text-label-caps uppercase text-(--text-muted) transition-colors hover:text-(--text-primary) ${className ?? ""}`.trim()}
         >
             <span aria-hidden="true" className="transition-transform group-hover:-translate-x-0.5">
                 &larr;

--- a/src/components/shared/BaseForm.tsx
+++ b/src/components/shared/BaseForm.tsx
@@ -3,7 +3,7 @@
 import { useState, type ChangeEvent, type ReactNode, type SyntheticEvent } from "react";
 
 export const inputClass =
-    "w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)";
+    "w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)";
 
 export function useBaseFormState<T>(initialState: T) {
     const [formData, setFormData] = useState<T>(initialState);
@@ -39,7 +39,7 @@ export function BaseForm({
     submitLabel,
     cancelLabel = "Cancel",
     className = "space-y-6",
-    contentClassName = "space-y-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6",
+    contentClassName = "space-y-4 rounded-2xl border border-(--border) bg-(--card-80) p-6",
     actionsClassName = "flex justify-end gap-3 pt-4",
     children,
     actionsStart,
@@ -54,7 +54,7 @@ export function BaseForm({
                         type="button"
                         onClick={onCancelAction}
                         disabled={isLoading}
-                        className="rounded-lg border border-(--card-stroke) px-4 py-2 text-sm font-medium text-(--ink-muted) hover:bg-(--card-70) hover:text-foreground disabled:opacity-50"
+                        className="rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--ink-muted) hover:bg-(--card-70) hover:text-foreground disabled:opacity-50"
                     >
                         {cancelLabel}
                     </button>

--- a/src/components/shared/Button.test.tsx
+++ b/src/components/shared/Button.test.tsx
@@ -20,9 +20,11 @@ describe("Button", () => {
     it("applies variant + size classes through buttonClassName", () => {
         const primary = buttonClassName("primary", "md");
         expect(primary).toContain("bg-(--accent-2)");
-        expect(primary).toContain("rounded-full");
+        expect(primary).toContain("rounded-(--radius-pill)");
+        expect(primary).toContain("text-label-caps");
         const ghostSm = buttonClassName("ghost", "sm");
         expect(ghostSm).toContain("border-transparent");
-        expect(ghostSm).toContain("text-[10px]");
+        expect(ghostSm).toContain("px-3");
+        expect(ghostSm).toContain("text-(--text-muted)");
     });
 });

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -4,18 +4,19 @@ export type ButtonVariant = "primary" | "secondary" | "ghost";
 export type ButtonSize = "sm" | "md";
 
 const BASE =
-    "inline-flex items-center justify-center gap-1.5 rounded-full font-medium uppercase tracking-[0.2em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-not-allowed disabled:opacity-50";
+    "inline-flex items-center justify-center gap-1.5 rounded-(--radius-pill) text-label-caps font-medium uppercase transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-not-allowed disabled:opacity-50";
 
 const SIZES: Record<ButtonSize, string> = {
-    sm: "px-3 py-1.5 text-[10px]",
-    md: "px-4 py-2 text-xs",
+    sm: "px-3 py-1.5",
+    md: "px-4 py-2",
 };
 
 const VARIANTS: Record<ButtonVariant, string> = {
+    /* No on-accent role token exists yet; text-white is the interim contrast color. */
     primary: "border border-(--accent-2) bg-(--accent-2) text-white hover:bg-(--accent-2)/90",
     secondary:
-        "border border-(--card-stroke) bg-(--card-70) text-foreground hover:border-(--ink-muted)",
-    ghost: "border border-transparent text-(--ink-muted) hover:text-foreground hover:bg-(--card-80)",
+        "border border-(--border) bg-(--card-70) text-(--text-primary) hover:border-(--card-stroke-active)",
+    ghost: "border border-transparent text-(--text-muted) hover:text-(--text-primary) hover:bg-(--card-80)",
 };
 
 /**

--- a/src/components/shared/DataTable.tsx
+++ b/src/components/shared/DataTable.tsx
@@ -86,11 +86,11 @@ export function DataTable<T>({
                                     value={search.value}
                                     onChange={(event) => onSearchChangeAction?.(event.target.value)}
                                     placeholder={search.placeholder ?? "Search"}
-                                    className="rounded-md border border-(--card-stroke) bg-(--card-60) px-2 py-1 text-sm text-foreground"
+                                    className="rounded-md border border-(--border) bg-(--card-60) px-2 py-1 text-sm text-foreground"
                                 />
                                 <button
                                     type="submit"
-                                    className="rounded-md border border-(--card-stroke) px-2.5 py-1 text-xs font-medium text-foreground hover:bg-(--card-70)"
+                                    className="rounded-md border border-(--border) px-2.5 py-1 text-xs font-medium text-foreground hover:bg-(--card-70)"
                                 >
                                     {search.buttonLabel ?? "Filter"}
                                 </button>
@@ -108,9 +108,9 @@ export function DataTable<T>({
                 </div>
             )}
 
-            <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+            <div className="overflow-x-auto rounded-2xl border border-(--border) bg-(--card-80)">
                 <table className="w-full text-left text-sm">
-                    <thead className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+                    <thead className="border-b border-(--border) bg-(--card-70) text-(--ink-muted)">
                         <tr>
                             {columns.map((column) => (
                                 <th
@@ -122,7 +122,7 @@ export function DataTable<T>({
                             ))}
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-(--card-stroke)">
+                    <tbody className="divide-y divide-(--border)">
                         {data.map((row) => (
                             <tr
                                 key={rowKeyAction(row)}
@@ -160,7 +160,7 @@ export function DataTable<T>({
                             onPageChangeAction(Math.max(0, pagination.offset - pagination.limit))
                         }
                         disabled={isPending || pagination.offset === 0}
-                        className="rounded-md border border-(--card-stroke) px-3 py-1.5 text-sm disabled:opacity-50"
+                        className="rounded-md border border-(--border) px-3 py-1.5 text-sm disabled:opacity-50"
                     >
                         Previous
                     </button>
@@ -168,7 +168,7 @@ export function DataTable<T>({
                         type="button"
                         onClick={() => onPageChangeAction(pagination.offset + pagination.limit)}
                         disabled={isPending || currentPage >= totalPages}
-                        className="rounded-md border border-(--card-stroke) px-3 py-1.5 text-sm disabled:opacity-50"
+                        className="rounded-md border border-(--border) px-3 py-1.5 text-sm disabled:opacity-50"
                     >
                         Next
                     </button>

--- a/src/components/shared/ErrorView.tsx
+++ b/src/components/shared/ErrorView.tsx
@@ -42,7 +42,7 @@ export function ErrorView({
                 </p>
                 <button
                     onClick={reset}
-                    className="rounded-full border border-(--card-stroke) px-6 py-2.5 text-xs uppercase tracking-[0.2em] hover:border-(--accent) transition"
+                    className="rounded-full border border-(--border) px-6 py-2.5 text-xs uppercase tracking-[0.2em] hover:border-(--accent) transition"
                 >
                     Try again
                 </button>

--- a/src/components/shared/FilterPills.tsx
+++ b/src/components/shared/FilterPills.tsx
@@ -23,10 +23,10 @@ type FilterPillsProps<TId extends string = string> = {
 
 const ACTIVE = "border-(--accent) bg-(--accent)/15 text-(--accent)";
 const INACTIVE =
-    "border-(--card-stroke) bg-(--card-80) text-(--ink-muted) hover:border-(--accent)/40 hover:text-foreground";
+    "border-(--border) bg-(--card-80) text-(--text-muted) hover:border-(--accent)/40 hover:text-(--text-primary)";
 
 const PILL =
-    "inline-flex items-center gap-1.5 rounded-(--radius-pill) border px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.15em] transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--accent)";
+    "inline-flex items-center gap-1.5 rounded-(--radius-pill) border px-3 py-1.5 text-label-caps font-medium uppercase transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--accent)";
 
 /**
  * Segmented selection primitive (framework A3).
@@ -55,7 +55,7 @@ export function FilterPills<TId extends string = string>({
             data-testid={testId}
         >
             {leadingLabel ? (
-                <span className="text-xs uppercase tracking-[0.25em] text-(--ink-muted)">
+                <span className="text-label-caps uppercase text-(--text-muted)">
                     {leadingLabel}
                 </span>
             ) : null}

--- a/src/components/shared/LegalDocument.tsx
+++ b/src/components/shared/LegalDocument.tsx
@@ -21,7 +21,7 @@ export function LegalDocument({
 }: LegalDocumentProps) {
     return (
         <section className="mx-auto max-w-4xl px-6 pb-24 pt-16 sm:pt-24">
-            <div className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-8 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.45)] sm:p-12">
+            <div className="rounded-[2rem] border border-(--border) bg-(--card-80) p-8 shadow-[0_20px_60px_-40px_rgba(0,0,0,0.45)] sm:p-12">
                 <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">{eyebrow}</p>
                 <h1 className="mt-4 font-(--font-display) text-4xl leading-tight sm:text-5xl">
                     {title}

--- a/src/components/shared/ModeTabs.tsx
+++ b/src/components/shared/ModeTabs.tsx
@@ -18,14 +18,14 @@ type ModeTabsProps<TId extends string = string> = {
 };
 
 const CONTAINER =
-    "flex items-center gap-1 overflow-x-auto whitespace-nowrap border-b border-(--card-stroke) px-1 scrollbar-hide";
+    "flex items-center gap-1 overflow-x-auto whitespace-nowrap border-b border-(--border) px-1 scrollbar-hide";
 
 const TAB_BASE =
-    "-mb-px flex items-center gap-1.5 border-b-2 px-3.5 py-3 text-[10px] uppercase tracking-[0.18em] transition-all";
+    "-mb-px flex items-center gap-1.5 border-b-2 px-3.5 py-3 text-label-caps uppercase transition-all";
 
-const TAB_ACTIVE = "border-(--accent) text-foreground font-semibold";
+const TAB_ACTIVE = "border-(--accent) text-(--text-primary) font-semibold";
 const TAB_INACTIVE =
-    "border-transparent text-(--ink-muted) hover:border-(--card-stroke) hover:text-foreground";
+    "border-transparent text-(--text-muted) hover:border-(--border) hover:text-(--text-primary)";
 
 /**
  * Shared route-tab strip primitive (framework A2).

--- a/src/components/superadmin/EntitlementsDetail.tsx
+++ b/src/components/superadmin/EntitlementsDetail.tsx
@@ -66,10 +66,10 @@ export function EntitlementsDetail({
     return (
         <div className="space-y-8">
             {/* Limits Section */}
-            <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+            <div className="rounded-2xl border border-(--border) bg-(--card-80) p-6">
                 <h3 className="mb-4 text-lg font-medium">Limits</h3>
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                    <div className="rounded-xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <div className="rounded-xl border border-(--border) bg-(--card-70) p-4">
                         <div className="text-sm text-(--ink-muted)">Licensed Users</div>
                         <div className="mt-1 text-2xl font-semibold">
                             {entitlements.licensed_users === null
@@ -77,7 +77,7 @@ export function EntitlementsDetail({
                                 : entitlements.licensed_users}
                         </div>
                     </div>
-                    <div className="rounded-xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <div className="rounded-xl border border-(--border) bg-(--card-70) p-4">
                         <div className="text-sm text-(--ink-muted)">Licensed Repos</div>
                         <div className="mt-1 text-2xl font-semibold">
                             {entitlements.licensed_repos === null
@@ -88,7 +88,7 @@ export function EntitlementsDetail({
                     {Object.entries(entitlements.limits).map(([key, value]) => (
                         <div
                             key={key}
-                            className="rounded-xl border border-(--card-stroke) bg-(--card-70) p-4"
+                            className="rounded-xl border border-(--border) bg-(--card-70) p-4"
                         >
                             <div className="text-sm text-(--ink-muted)">{key}</div>
                             <div className="mt-1 text-2xl font-semibold">
@@ -100,9 +100,9 @@ export function EntitlementsDetail({
             </div>
 
             {/* Features Section */}
-            <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+            <div className="rounded-2xl border border-(--border) bg-(--card-80) p-6">
                 <h3 className="mb-4 text-lg font-medium">Features</h3>
-                <div className="overflow-x-auto rounded-xl border border-(--card-stroke)">
+                <div className="overflow-x-auto rounded-xl border border-(--border)">
                     <table className="w-full text-left text-sm">
                         <thead className="bg-(--card-70) text-(--ink-muted)">
                             <tr>
@@ -111,7 +111,7 @@ export function EntitlementsDetail({
                                 <th className="px-4 py-3 font-medium">Source</th>
                             </tr>
                         </thead>
-                        <tbody className="divide-y divide-(--card-stroke)">
+                        <tbody className="divide-y divide-(--border)">
                             {Object.entries(entitlements.features).map(([key, enabled]) => {
                                 const isOverridden =
                                     entitlements.features_override &&
@@ -146,7 +146,7 @@ export function EntitlementsDetail({
             </div>
 
             {/* Overrides Section */}
-            <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+            <div className="rounded-2xl border border-(--border) bg-(--card-80) p-6">
                 <div className="mb-4 flex items-center justify-between">
                     <h3 className="text-lg font-medium">Feature Overrides</h3>
                     <button
@@ -161,7 +161,7 @@ export function EntitlementsDetail({
                 {isCreating && (
                     <form
                         onSubmit={handleCreateOverride}
-                        className="mb-6 rounded-xl border border-(--card-stroke) bg-(--card-70) p-4"
+                        className="mb-6 rounded-xl border border-(--border) bg-(--card-70) p-4"
                     >
                         <div className="grid gap-4 sm:grid-cols-2">
                             <div>
@@ -175,7 +175,7 @@ export function EntitlementsDetail({
                                     id="feature-select"
                                     value={selectedFeatureId}
                                     onChange={(e) => setSelectedFeatureId(e.target.value)}
-                                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-80) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                                    className="w-full rounded-lg border border-(--border) bg-(--card-80) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                                     required
                                 >
                                     <option value="">Select a feature...</option>
@@ -197,7 +197,7 @@ export function EntitlementsDetail({
                                     id="state-select"
                                     value={overrideEnabled ? "true" : "false"}
                                     onChange={(e) => setOverrideEnabled(e.target.value === "true")}
-                                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-80) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                                    className="w-full rounded-lg border border-(--border) bg-(--card-80) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                                 >
                                     <option value="true">Enabled</option>
                                     <option value="false">Disabled</option>
@@ -216,7 +216,7 @@ export function EntitlementsDetail({
                                     value={overrideReason}
                                     onChange={(e) => setOverrideReason(e.target.value)}
                                     placeholder="Why is this override being applied?"
-                                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-80) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                                    className="w-full rounded-lg border border-(--border) bg-(--card-80) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                                 />
                             </div>
                         </div>
@@ -234,7 +234,7 @@ export function EntitlementsDetail({
                 {overrides.length === 0 ? (
                     <div className="text-sm text-(--ink-muted)">No overrides active.</div>
                 ) : (
-                    <div className="overflow-x-auto rounded-xl border border-(--card-stroke)">
+                    <div className="overflow-x-auto rounded-xl border border-(--border)">
                         <table className="w-full text-left text-sm">
                             <thead className="bg-(--card-70) text-(--ink-muted)">
                                 <tr>
@@ -245,7 +245,7 @@ export function EntitlementsDetail({
                                     <th className="px-4 py-3 font-medium text-right">Actions</th>
                                 </tr>
                             </thead>
-                            <tbody className="divide-y divide-(--card-stroke)">
+                            <tbody className="divide-y divide-(--border)">
                                 {overrides.map((override) => (
                                     <tr key={override.id}>
                                         <td className="px-4 py-3 font-mono text-xs">

--- a/src/components/superadmin/LicenseTable.tsx
+++ b/src/components/superadmin/LicenseTable.tsx
@@ -19,9 +19,9 @@ function getTierBadge(tier: string) {
 
 export function LicenseTable({ orgs }: LicenseTableProps) {
     return (
-        <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+        <div className="overflow-x-auto rounded-2xl border border-(--border) bg-(--card-80)">
             <table className="w-full text-left text-sm">
-                <thead className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+                <thead className="border-b border-(--border) bg-(--card-70) text-(--ink-muted)">
                     <tr>
                         <th className="px-6 py-4 font-medium">Organization</th>
                         <th className="px-6 py-4 font-medium">Slug</th>
@@ -30,7 +30,7 @@ export function LicenseTable({ orgs }: LicenseTableProps) {
                         <th className="px-6 py-4 font-medium text-right">Actions</th>
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-(--card-stroke)">
+                <tbody className="divide-y divide-(--border)">
                     {orgs.map((org) => (
                         <tr key={org.id} className="hover:bg-(--card-70)/50">
                             <td className="px-6 py-4 font-medium text-foreground">

--- a/src/components/superadmin/OrgCreateForm.tsx
+++ b/src/components/superadmin/OrgCreateForm.tsx
@@ -62,7 +62,7 @@ export function OrgCreateForm() {
                         value={name}
                         onChange={handleNameChange}
                         required
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                         placeholder="Acme Corp"
                     />
                 </div>
@@ -76,7 +76,7 @@ export function OrgCreateForm() {
                         value={slug}
                         onChange={handleSlugChange}
                         required
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                         placeholder="acme-corp"
                     />
                 </div>
@@ -90,7 +90,7 @@ export function OrgCreateForm() {
                     id="description"
                     name="description"
                     rows={3}
-                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                    className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                     placeholder="Optional description"
                 />
             </div>
@@ -104,7 +104,7 @@ export function OrgCreateForm() {
                         id="tier"
                         name="tier"
                         defaultValue="community"
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                     >
                         <option value="community">Community</option>
                         <option value="team">Team</option>
@@ -118,7 +118,7 @@ export function OrgCreateForm() {
                     <input
                         id="owner_user_id"
                         name="owner_user_id"
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                         placeholder="UUID of initial owner"
                     />
                 </div>

--- a/src/components/superadmin/OrgDeleteSection.tsx
+++ b/src/components/superadmin/OrgDeleteSection.tsx
@@ -86,7 +86,7 @@ export function OrgDeleteSection({ orgId, orgSlug }: OrgDeleteSectionProps) {
                                 id="confirm-slug"
                                 value={confirmSlug}
                                 onChange={(e) => setConfirmSlug(e.target.value)}
-                                className="block w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+                                className="block w-full rounded-md border border-(--border) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
                                 placeholder={orgSlug}
                             />
                             <button

--- a/src/components/superadmin/OrgEditForm.tsx
+++ b/src/components/superadmin/OrgEditForm.tsx
@@ -41,7 +41,7 @@ export function OrgEditForm({ org }: OrgEditFormProps) {
                         name="name"
                         defaultValue={org.name}
                         required
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                     />
                 </div>
                 <div className="space-y-2">
@@ -52,7 +52,7 @@ export function OrgEditForm({ org }: OrgEditFormProps) {
                         id="slug"
                         defaultValue={org.slug}
                         disabled
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70)/50 px-3 py-2 text-sm text-(--ink-muted) outline-none"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70)/50 px-3 py-2 text-sm text-(--ink-muted) outline-none"
                     />
                 </div>
             </div>
@@ -66,7 +66,7 @@ export function OrgEditForm({ org }: OrgEditFormProps) {
                     name="description"
                     defaultValue={org.description || ""}
                     rows={3}
-                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                    className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                 />
             </div>
 
@@ -79,7 +79,7 @@ export function OrgEditForm({ org }: OrgEditFormProps) {
                         id="tier"
                         name="tier"
                         defaultValue={org.tier}
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                     >
                         <option value="community">Community</option>
                         <option value="team">Team</option>
@@ -92,7 +92,7 @@ export function OrgEditForm({ org }: OrgEditFormProps) {
                         id="is_active"
                         name="is_active"
                         defaultChecked={org.is_active}
-                        className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
+                        className="h-4 w-4 rounded border-(--border) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
                     />
                     <label htmlFor="is_active" className="text-sm font-medium">
                         Active

--- a/src/components/superadmin/SuperadminSidebar.tsx
+++ b/src/components/superadmin/SuperadminSidebar.tsx
@@ -54,7 +54,7 @@ export function SuperadminSidebar({ canAccessOrgAdmin = false }: { canAccessOrgA
     return (
         <aside className="w-full md:max-w-[220px] md:shrink-0">
             <div className="md:sticky md:top-6">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-5">
                     <div>
                         <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                             Full Chaos Dev Health Ops
@@ -96,7 +96,7 @@ export function SuperadminSidebar({ canAccessOrgAdmin = false }: { canAccessOrgA
                         })}
                     </nav>
                     {canAccessOrgAdmin && (
-                        <div className="mt-5 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-3 py-3 text-xs text-(--ink-muted)">
+                        <div className="mt-5 rounded-2xl border border-dashed border-(--border) bg-(--card-70) px-3 py-3 text-xs text-(--ink-muted)">
                             Return to{" "}
                             <Link href="/admin" className="underline hover:text-foreground">
                                 org admin

--- a/src/components/superadmin/UserDeleteSection.tsx
+++ b/src/components/superadmin/UserDeleteSection.tsx
@@ -67,7 +67,7 @@ export function UserDeleteSection({ userId, userEmail }: UserDeleteSectionProps)
                             id="confirm-email"
                             value={confirmEmail}
                             onChange={(e) => setConfirmEmail(e.target.value)}
-                            className="block w-full rounded-md border border-(--card-stroke) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+                            className="block w-full rounded-md border border-(--border) bg-(--background) px-3 py-2 text-(--foreground) shadow-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
                             placeholder={userEmail}
                         />
                         <button

--- a/src/components/superadmin/UserEditForm.tsx
+++ b/src/components/superadmin/UserEditForm.tsx
@@ -44,7 +44,7 @@ export function UserEditForm({ user }: UserEditFormProps) {
                         type="email"
                         defaultValue={user.email}
                         required
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                     />
                 </div>
                 <div className="space-y-2">
@@ -55,7 +55,7 @@ export function UserEditForm({ user }: UserEditFormProps) {
                         id="username"
                         name="username"
                         defaultValue={user.username || ""}
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                     />
                 </div>
             </div>
@@ -68,7 +68,7 @@ export function UserEditForm({ user }: UserEditFormProps) {
                     id="full_name"
                     name="full_name"
                     defaultValue={user.full_name || ""}
-                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                    className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                 />
             </div>
 
@@ -79,7 +79,7 @@ export function UserEditForm({ user }: UserEditFormProps) {
                         id="is_active"
                         name="is_active"
                         defaultChecked={user.is_active}
-                        className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
+                        className="h-4 w-4 rounded border-(--border) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
                     />
                     <label htmlFor="is_active" className="text-sm font-medium">
                         Active
@@ -91,7 +91,7 @@ export function UserEditForm({ user }: UserEditFormProps) {
                         id="is_verified"
                         name="is_verified"
                         defaultChecked={user.is_verified}
-                        className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
+                        className="h-4 w-4 rounded border-(--border) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
                     />
                     <label htmlFor="is_verified" className="text-sm font-medium">
                         Verified
@@ -103,7 +103,7 @@ export function UserEditForm({ user }: UserEditFormProps) {
                         id="is_superuser"
                         name="is_superuser"
                         defaultChecked={user.is_superuser}
-                        className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
+                        className="h-4 w-4 rounded border-(--border) bg-(--card-70) text-(--accent) focus:ring-(--accent)"
                     />
                     <label htmlFor="is_superuser" className="text-sm font-medium">
                         Superuser

--- a/src/components/superadmin/UserSetPasswordForm.tsx
+++ b/src/components/superadmin/UserSetPasswordForm.tsx
@@ -50,7 +50,7 @@ export function UserSetPasswordForm({ userId }: UserSetPasswordFormProps) {
                         type="password"
                         required
                         minLength={8}
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                     />
                 </div>
                 <div className="space-y-2">
@@ -63,7 +63,7 @@ export function UserSetPasswordForm({ userId }: UserSetPasswordFormProps) {
                         type="password"
                         required
                         minLength={8}
-                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
+                        className="w-full rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-sm outline-none focus:border-(--accent)"
                     />
                 </div>
             </div>

--- a/src/components/testops/PrTestOpsSummary.tsx
+++ b/src/components/testops/PrTestOpsSummary.tsx
@@ -59,7 +59,7 @@ export function PrTestOpsSummary({
         : 0;
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-5 flex flex-col gap-4">
+        <div className="rounded-3xl border border-(--border) bg-(--card) p-5 flex flex-col gap-4">
             <div className="flex items-center justify-between">
                 <div>
                     <h3 className="font-(--font-display) text-lg">TestOps Summary</h3>

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -9,7 +9,7 @@ interface EmptyStateProps {
 
 export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
     return (
-        <div className="flex flex-col items-center gap-3 rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) py-12 text-center">
+        <div className="flex flex-col items-center gap-3 rounded-3xl border border-dashed border-(--border) bg-(--card-70) py-12 text-center">
             {icon && (
                 <div className="rounded-full bg-(--accent)/10 p-3 text-(--accent)">{icon}</div>
             )}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -12,7 +12,7 @@ export function SkeletonLine({
 
 export function SkeletonCard({ lines = 3 }: { lines?: number }) {
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-6 space-y-3 animate-pulse">
+        <div className="rounded-3xl border border-(--border) bg-card p-6 space-y-3 animate-pulse">
             <div className="h-6 bg-(--card-70) rounded w-1/3" />
             {Array.from({ length: lines }, (_, i) => (
                 <div
@@ -52,9 +52,7 @@ export function SkeletonTable({ rows = 5, cols = 4 }: { rows?: number; cols?: nu
 
 export function SkeletonChart({ height = "h-64" }: { height?: string }) {
     return (
-        <div
-            className={`${height} rounded-3xl border border-(--card-stroke) bg-card p-6 animate-pulse`}
-        >
+        <div className={`${height} rounded-3xl border border-(--border) bg-card p-6 animate-pulse`}>
             <div className="h-5 bg-(--card-70) rounded w-1/4 mb-6" />
             <div className="h-full bg-(--card-70) rounded" />
         </div>

--- a/src/components/work/CapacityView.tsx
+++ b/src/components/work/CapacityView.tsx
@@ -62,7 +62,7 @@ export function CapacityView({ filters, orgId: propOrgId }: CapacityViewProps) {
                     type="button"
                     onClick={() => refetch()}
                     disabled={isLoading}
-                    className="rounded-lg border border-(--card-stroke) bg-card px-4 py-2 text-sm font-medium text-foreground hover:bg-(--card-80) disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="rounded-lg border border-(--border) bg-card px-4 py-2 text-sm font-medium text-foreground hover:bg-(--card-80) disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                     {isLoading ? "Computing..." : "Refresh Forecast"}
                 </button>
@@ -71,7 +71,7 @@ export function CapacityView({ filters, orgId: propOrgId }: CapacityViewProps) {
             <div className="grid gap-6 lg:grid-cols-[380px_1fr]">
                 <ForecastCard forecast={forecast} loading={isLoading} error={error} />
 
-                <div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+                <div className="rounded-3xl border border-(--border) bg-card p-6">
                     <h3 className="text-sm font-medium text-foreground mb-4">
                         Completion Projection
                     </h3>
@@ -100,7 +100,7 @@ export function CapacityView({ filters, orgId: propOrgId }: CapacityViewProps) {
 
             {forecast && (
                 <div className="grid gap-6 lg:grid-cols-2">
-                    <div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+                    <div className="rounded-3xl border border-(--border) bg-card p-6">
                         <h3 className="text-sm font-medium text-foreground mb-4">
                             Throughput Distribution
                         </h3>
@@ -114,7 +114,7 @@ export function CapacityView({ filters, orgId: propOrgId }: CapacityViewProps) {
                         </p>
                     </div>
 
-                    <div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+                    <div className="rounded-3xl border border-(--border) bg-card p-6">
                         <h3 className="text-sm font-medium text-foreground mb-3">
                             How to Interpret
                         </h3>

--- a/src/components/work/EvidenceView.tsx
+++ b/src/components/work/EvidenceView.tsx
@@ -21,7 +21,7 @@ export function EvidenceView({
 }: EvidenceViewProps) {
     return (
         <section className="grid gap-6 lg:grid-cols-2">
-            <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+            <div className="rounded-3xl border border-(--border) bg-card p-5">
                 <div className="flex items-center justify-between">
                     <h2 className="font-(--font-display) text-xl">WIP Associations</h2>
                     <Link
@@ -44,7 +44,7 @@ export function EvidenceView({
                                 filters,
                                 role: activeRole,
                             })}
-                            className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+                            className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-4 py-2"
                         >
                             <span>{driver.label}</span>
                             <span className="text-xs text-(--ink-muted)">
@@ -60,7 +60,7 @@ export function EvidenceView({
                 </div>
             </div>
 
-            <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+            <div className="rounded-3xl border border-(--border) bg-card p-5">
                 <div className="flex items-center justify-between">
                     <h2 className="font-(--font-display) text-xl">Blocked Associations</h2>
                 </div>
@@ -73,7 +73,7 @@ export function EvidenceView({
                                 filters,
                                 role: activeRole,
                             })}
-                            className="flex items-center justify-between rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2"
+                            className="flex items-center justify-between rounded-2xl border border-(--border) bg-(--card-70) px-4 py-2"
                         >
                             <span>{driver.label}</span>
                             <span className="text-xs text-(--ink-muted)">

--- a/src/components/work/FlameView.tsx
+++ b/src/components/work/FlameView.tsx
@@ -80,7 +80,7 @@ export function FlameView({ filters }: FlameViewProps) {
 
     return (
         <div className="flex flex-col gap-6">
-            <section className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+            <section className="rounded-3xl border border-(--border) bg-card p-6">
                 <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
                     <div>
                         <h2 className="text-xl font-(--font-display)">{modeLabels[mode]}</h2>
@@ -103,7 +103,7 @@ export function FlameView({ filters }: FlameViewProps) {
                                 className={`rounded-full border px-3 py-1.5 text-[10px] uppercase tracking-[0.2em] transition ${
                                     mode === m
                                         ? "border-(--accent-2) bg-(--accent-2) text-white"
-                                        : "border-(--card-stroke) text-(--ink-muted) hover:border-(--card-stroke)/60"
+                                        : "border-(--border) text-(--ink-muted) hover:border-(--card-stroke)/60"
                                 }`}
                             >
                                 {modeLabels[m]}
@@ -128,7 +128,7 @@ export function FlameView({ filters }: FlameViewProps) {
                         />
                     ) : (
                         !loading && (
-                            <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) text-sm text-(--ink-muted)">
+                            <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--border) bg-(--card-70) text-sm text-(--ink-muted)">
                                 No flame data available for this scope and window.
                             </div>
                         )

--- a/src/components/work/FlowView.tsx
+++ b/src/components/work/FlowView.tsx
@@ -224,7 +224,7 @@ export function FlowView({ filters, activeRole }: FlowViewProps) {
         <div className="flex flex-col gap-6">
             <Tabs activeTab={subTab} onTabChange={handleSubTabChange} />
             <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
-                <div className="rounded-3xl border border-(--card-stroke) bg-card p-6">
+                <div className="rounded-3xl border border-(--border) bg-card p-6">
                     <Toolbar
                         currentTabLabel={currentTabDef.label}
                         currentTabDescription={currentTabDef.description}

--- a/src/components/work/FlowView/Chart.tsx
+++ b/src/components/work/FlowView/Chart.tsx
@@ -79,11 +79,11 @@ export function Chart({
 
             {subTab === "investment_mix" &&
                 (investmentMixLoading ? (
-                    <div className="flex h-96 items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) text-sm text-(--ink-muted)">
+                    <div className="flex h-96 items-center justify-center rounded-2xl border border-dashed border-(--border) bg-(--card-70) text-sm text-(--ink-muted)">
                         Loading investment mix…
                     </div>
                 ) : !investmentMix ? (
-                    <div className="flex h-96 items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) text-sm text-(--ink-muted)">
+                    <div className="flex h-96 items-center justify-center rounded-2xl border border-dashed border-(--border) bg-(--card-70) text-sm text-(--ink-muted)">
                         Investment mix unavailable for this scope and window.
                     </div>
                 ) : (
@@ -104,7 +104,7 @@ export function Chart({
                                 onInvestmentMixClick(subcategoryKey, "subcategory")
                             }
                         />
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                        <div className="rounded-2xl border border-(--border) bg-(--card-70) p-4">
                             <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                 {investmentMixFocusTheme ? "Focused theme" : "How to use"}
                             </p>
@@ -175,7 +175,7 @@ export function Chart({
                     />
                 ) : (
                     !isLoading && (
-                        <div className="flex h-96 items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) text-sm text-(--ink-muted)">
+                        <div className="flex h-96 items-center justify-center rounded-2xl border border-dashed border-(--border) bg-(--card-70) text-sm text-(--ink-muted)">
                             No flow data available for this scope and window.
                         </div>
                     )

--- a/src/components/work/FlowView/InspectPanel.tsx
+++ b/src/components/work/FlowView/InspectPanel.tsx
@@ -84,7 +84,7 @@ export function InspectPanel({
 }: InspectPanelProps) {
     return (
         <div className="flex flex-col gap-4">
-            <div className="h-full min-h-96 rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
+            <div className="h-full min-h-96 rounded-3xl border border-(--border) bg-(--card-80) p-5">
                 <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
                     Inspect Flow
                 </p>
@@ -172,10 +172,10 @@ export function InspectPanel({
                             </div>
                         )}
 
-                        <div className="grid gap-3 pt-4 border-t border-(--card-stroke)">
+                        <div className="grid gap-3 pt-4 border-t border-(--border)">
                             <Link
                                 href={evidenceUrl || "#"}
-                                className="flex items-center justify-between rounded-xl border border-(--card-stroke) bg-card px-4 py-3 text-xs uppercase tracking-widest text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
+                                className="flex items-center justify-between rounded-xl border border-(--border) bg-card px-4 py-3 text-xs uppercase tracking-widest text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
                             >
                                 <span>{CTA_LABELS.openEvidence}</span>
                                 <span className="text-(--accent-2) group-hover:translate-x-0.5 transition-transform">
@@ -184,7 +184,7 @@ export function InspectPanel({
                             </Link>
                             <Link
                                 href={flameUrl || "#"}
-                                className="flex items-center justify-between rounded-xl border border-(--card-stroke) bg-card px-4 py-3 text-xs uppercase tracking-widest text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
+                                className="flex items-center justify-between rounded-xl border border-(--border) bg-card px-4 py-3 text-xs uppercase tracking-widest text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
                             >
                                 <span>{CTA_LABELS.openArtifact}</span>
                                 <span className="text-(--accent-2) group-hover:translate-x-0.5 transition-transform">
@@ -193,7 +193,7 @@ export function InspectPanel({
                             </Link>
                             <Link
                                 href={buildFlowWorkGraphUrl(selection, filters, activeRole)}
-                                className="flex items-center justify-between rounded-xl border border-(--card-stroke) bg-card px-4 py-3 text-xs uppercase tracking-widest text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
+                                className="flex items-center justify-between rounded-xl border border-(--border) bg-card px-4 py-3 text-xs uppercase tracking-widest text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
                             >
                                 <span>{CTA_LABELS.openWorkGraph}</span>
                                 <span className="text-(--accent-2) group-hover:translate-x-0.5 transition-transform">
@@ -204,7 +204,7 @@ export function InspectPanel({
                     </div>
                 )}
                 {(contextEntityLabel || contextZone) && (
-                    <div className="pt-4 mt-6 border-t border-(--card-stroke)">
+                    <div className="pt-4 mt-6 border-t border-(--border)">
                         <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                             Analysis Context
                         </p>

--- a/src/components/work/FlowView/Tabs.tsx
+++ b/src/components/work/FlowView/Tabs.tsx
@@ -98,7 +98,7 @@ export function Tabs({ activeTab, onTabChange }: TabsProps) {
                     className={`rounded-full border px-3 py-1.5 text-[10px] uppercase tracking-[0.2em] transition ${
                         activeTab === tab.id
                             ? "border-(--accent-2) bg-(--accent-2) text-white"
-                            : "border-(--card-stroke) text-(--ink-muted) hover:border-(--card-stroke)/60"
+                            : "border-(--border) text-(--ink-muted) hover:border-(--card-stroke)/60"
                     }`}
                 >
                     {tab.label}

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -310,7 +310,7 @@ export function GraphView({
             className={`grid gap-4 2xl:items-start ${isLegendCollapsed ? "2xl:grid-cols-[minmax(0,1fr)_3.25rem]" : "2xl:grid-cols-[minmax(0,1fr)_17rem]"}`}
         >
             <div className="order-1 min-w-0 space-y-4">
-                <div className="bg-card rounded-lg border border-(--card-stroke) p-4">
+                <div className="bg-card rounded-lg border border-(--border) p-4">
                     <div className="mb-4 flex items-center justify-between gap-4">
                         <div>
                             <h3 className="text-lg font-medium">{tabHeading[graphTab]}</h3>
@@ -334,7 +334,7 @@ export function GraphView({
                     </div>
 
                     {showConnectionSelector && (
-                        <div className="mb-4 rounded-2xl border border-(--card-stroke) bg-(--card-70) p-3 text-xs">
+                        <div className="mb-4 rounded-2xl border border-(--border) bg-(--card-70) p-3 text-xs">
                             <div className="grid gap-3 lg:grid-cols-[minmax(13rem,1.1fr)_minmax(11rem,0.9fr)_minmax(14rem,1.2fr)]">
                                 <label className="grid min-w-0 gap-1">
                                     <span className="uppercase tracking-[0.18em] text-(--ink-muted)">
@@ -346,7 +346,7 @@ export function GraphView({
                                             setConnectionSliceId(event.target.value);
                                             setSelectedNode(null);
                                         }}
-                                        className="min-w-0 rounded-xl border border-(--card-stroke) bg-background px-3 py-2 text-foreground"
+                                        className="min-w-0 rounded-xl border border-(--border) bg-background px-3 py-2 text-foreground"
                                     >
                                         {CONNECTION_SLICES.map((slice) => (
                                             <option key={slice.id} value={slice.id}>
@@ -365,7 +365,7 @@ export function GraphView({
                                             setTheme(event.target.value);
                                             setSubcategory("all");
                                         }}
-                                        className="min-w-0 rounded-xl border border-(--card-stroke) bg-background px-3 py-2 text-foreground"
+                                        className="min-w-0 rounded-xl border border-(--border) bg-background px-3 py-2 text-foreground"
                                     >
                                         <option value="all">All themes</option>
                                         {INVESTMENT_THEMES.map((item) => (
@@ -382,7 +382,7 @@ export function GraphView({
                                     <select
                                         value={subcategory}
                                         onChange={(event) => setSubcategory(event.target.value)}
-                                        className="min-w-0 rounded-xl border border-(--card-stroke) bg-background px-3 py-2 text-foreground"
+                                        className="min-w-0 rounded-xl border border-(--border) bg-background px-3 py-2 text-foreground"
                                     >
                                         <option value="all">All subcategories</option>
                                         {visibleSubcategories.map((item) => (
@@ -393,7 +393,7 @@ export function GraphView({
                                     </select>
                                 </label>
                             </div>
-                            <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-1 border-t border-(--card-stroke) pt-3 text-xs text-(--ink-muted)">
+                            <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-1 border-t border-(--border) pt-3 text-xs text-(--ink-muted)">
                                 <span title={activeConnectionSlice.description}>
                                     {activeConnectionSlice.description}
                                 </span>
@@ -439,7 +439,7 @@ export function GraphView({
                     ) : (
                         <div
                             data-testid="work-graph-panel"
-                            className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-background/30"
+                            className="overflow-hidden rounded-2xl border border-(--border) bg-background/30"
                         >
                             <WorkGraphExplorer
                                 edges={displayEdges}
@@ -468,7 +468,7 @@ export function GraphView({
 
             <div className="order-2 2xl:sticky 2xl:top-4">
                 <div
-                    className={`rounded-2xl border border-(--card-stroke) bg-card transition-all ${isLegendCollapsed ? "p-2" : "p-3.5"}`}
+                    className={`rounded-2xl border border-(--border) bg-card transition-all ${isLegendCollapsed ? "p-2" : "p-3.5"}`}
                 >
                     <WorkGraphLegend
                         collapsed={isLegendCollapsed}
@@ -511,7 +511,7 @@ function InflowOutflowView({ edges, loading, error }: DerivedViewProps) {
 
     return (
         <section
-            className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
+            className="rounded-[1.75rem] border border-(--border) bg-(--card-90) p-6 shadow-sm"
             data-testid="inflow-outflow-panel"
         >
             <div className="mb-4">
@@ -536,7 +536,7 @@ function InflowOutflowView({ edges, loading, error }: DerivedViewProps) {
                     description="No work graph edges are available for this scope and window."
                 />
             ) : (
-                <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90)">
+                <div className="overflow-hidden rounded-2xl border border-(--border) bg-(--card-90)">
                     <table className="w-full text-sm" data-testid="inflow-outflow-table">
                         <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
                             <tr>
@@ -551,7 +551,7 @@ function InflowOutflowView({ edges, loading, error }: DerivedViewProps) {
                                 <tr
                                     key={row.type}
                                     data-testid="inflow-outflow-row"
-                                    className="border-t border-(--card-stroke)/60"
+                                    className="border-t border-(--border)/60"
                                 >
                                     <td className="px-5 py-3 align-middle font-medium">
                                         {NODE_TYPE_LABELS[row.type]}
@@ -626,7 +626,7 @@ function ArtifactsView({ edges, loading, error }: DerivedViewProps) {
 
     return (
         <section
-            className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
+            className="rounded-[1.75rem] border border-(--border) bg-(--card-90) p-6 shadow-sm"
             data-testid="artifacts-panel"
         >
             <div className="mb-4">
@@ -651,7 +651,7 @@ function ArtifactsView({ edges, loading, error }: DerivedViewProps) {
                     description="No work graph entities are available for this scope and window."
                 />
             ) : (
-                <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90)">
+                <div className="overflow-hidden rounded-2xl border border-(--border) bg-(--card-90)">
                     <table className="w-full text-sm" data-testid="artifacts-table">
                         <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
                             <tr>
@@ -666,7 +666,7 @@ function ArtifactsView({ edges, loading, error }: DerivedViewProps) {
                                 <tr
                                     key={`${row.type}:${row.id}`}
                                     data-testid="artifact-row"
-                                    className="border-t border-(--card-stroke)/60"
+                                    className="border-t border-(--border)/60"
                                 >
                                     <td className="px-5 py-3 align-middle text-(--ink-muted)">
                                         {NODE_TYPE_LABELS[row.type]}
@@ -722,7 +722,7 @@ function NodeDetailPanel({ node, incomingEdges, outgoingEdges, onClose }: NodeDe
     };
 
     return (
-        <div className="bg-card rounded-lg border border-(--card-stroke) p-4">
+        <div className="bg-card rounded-lg border border-(--border) p-4">
             <div className="flex items-start justify-between mb-4">
                 <div className="flex items-center gap-3">
                     <span className={`w-3 h-3 rounded-sm ${typeColors[node.type]}`} />
@@ -886,7 +886,7 @@ function ReviewNetworkView({ edges, loading, error }: ReviewNetworkViewProps) {
 
     return (
         <section
-            className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
+            className="rounded-[1.75rem] border border-(--border) bg-(--card-90) p-6 shadow-sm"
             data-testid="review-network-panel"
         >
             <div className="mb-4">
@@ -933,7 +933,7 @@ function ReviewNetworkView({ edges, loading, error }: ReviewNetworkViewProps) {
                             total reviews
                         </span>
                     </div>
-                    <div className="overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card-90)">
+                    <div className="overflow-hidden rounded-2xl border border-(--border) bg-(--card-90)">
                         <table className="w-full text-sm" data-testid="review-network-table">
                             <thead className="bg-(--card-60) text-xs font-semibold uppercase tracking-[0.18em] text-(--ink-muted)">
                                 <tr>
@@ -948,7 +948,7 @@ function ReviewNetworkView({ edges, loading, error }: ReviewNetworkViewProps) {
                                     <tr
                                         key={`${row.reviewer}|${row.author}`}
                                         data-testid="review-network-row"
-                                        className="border-t border-(--card-stroke)/60"
+                                        className="border-t border-(--border)/60"
                                     >
                                         <td className="px-5 py-3 align-middle">
                                             <span className="font-medium" title={row.reviewer}>

--- a/src/components/work/InvestmentView.tsx
+++ b/src/components/work/InvestmentView.tsx
@@ -39,7 +39,7 @@ type InvestmentViewProps = {
 function ExplainerCards() {
     return (
         <div className="grid gap-4 lg:grid-cols-2">
-            <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-4">
+            <details className="rounded-2xl border border-(--border) bg-(--card-70) px-4 py-4">
                 <summary className="cursor-pointer list-none font-(--font-display) text-base">
                     What this investment view represents
                 </summary>
@@ -75,7 +75,7 @@ function ExplainerCards() {
                     </p>
                 </div>
             </details>
-            <details className="rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-4">
+            <details className="rounded-2xl border border-(--border) bg-(--card-70) px-4 py-4">
                 <summary className="cursor-pointer list-none font-(--font-display) text-base">
                     How to read the visuals
                 </summary>
@@ -160,7 +160,7 @@ export function InvestmentView({
     const evidenceBlock = (
         <div
             id="work-unit-calculation"
-            className="rounded-3xl border border-(--card-stroke) bg-card p-5"
+            className="rounded-3xl border border-(--border) bg-card p-5"
         >
             <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
@@ -180,7 +180,7 @@ export function InvestmentView({
                     </label>
                     <select
                         id="work-unit-select"
-                        className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-xs"
+                        className="rounded-lg border border-(--border) bg-(--card-70) px-3 py-2 text-xs"
                         value={selectedUnitId}
                         onChange={(event) => {
                             if (event.target.value) {
@@ -202,7 +202,7 @@ export function InvestmentView({
 
             {data.selectedUnit ? (
                 <div className="mt-6 grid gap-6 lg:grid-cols-3">
-                    <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <div className="rounded-2xl border border-(--border) bg-(--card-70) p-4">
                         <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                             Overview
                         </p>
@@ -212,7 +212,7 @@ export function InvestmentView({
                                 {formatWorkUnitLabel(data.selectedUnit)}
                                 <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-(--ink-muted)">
                                     {data.selectedUnitTypeLabel ? (
-                                        <span className="rounded-full border border-(--card-stroke) px-2 py-0.5 text-[9px] uppercase tracking-[0.2em]">
+                                        <span className="rounded-full border border-(--border) px-2 py-0.5 text-[9px] uppercase tracking-[0.2em]">
                                             {data.selectedUnitTypeLabel}
                                         </span>
                                     ) : null}
@@ -244,7 +244,7 @@ export function InvestmentView({
                         </div>
                     </div>
 
-                    <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <div className="rounded-2xl border border-(--border) bg-(--card-70) p-4">
                         <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                             Structural evidence
                         </p>
@@ -263,7 +263,7 @@ export function InvestmentView({
                         </div>
                     </div>
 
-                    <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <div className="rounded-2xl border border-(--border) bg-(--card-70) p-4">
                         <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                             Contextual evidence
                         </p>
@@ -282,7 +282,7 @@ export function InvestmentView({
                         </div>
                     </div>
 
-                    <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4 lg:col-span-3">
+                    <div className="rounded-2xl border border-(--border) bg-(--card-70) p-4 lg:col-span-3">
                         <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                             Textual evidence
                         </p>
@@ -377,7 +377,7 @@ export function InvestmentView({
                                                             }
                                                         </p>
                                                     </div>
-                                                    <div className="rounded-lg border border-(--card-stroke) bg-(--card-70) p-3">
+                                                    <div className="rounded-lg border border-(--border) bg-(--card-70) p-3">
                                                         <p className="text-xs font-medium italic text-(--ink-muted)">
                                                             {
                                                                 data.explanation

--- a/src/components/work/LandscapeView.tsx
+++ b/src/components/work/LandscapeView.tsx
@@ -114,7 +114,7 @@ export function LandscapeView({
             </section>
 
             <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-4">
+                <div className="rounded-3xl border border-(--border) bg-(--card) p-4">
                     <div className="flex flex-wrap items-center justify-between gap-2">
                         <h2 className="font-(--font-display) text-xl">Investment Mix</h2>
                         <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.2em] text-(--accent-2)">
@@ -144,14 +144,14 @@ export function LandscapeView({
                                 unit={investmentMix.unit ?? "units"}
                             />
                         ) : (
-                            <div className="flex min-h-72 items-center justify-center rounded-3xl border border-(--card-stroke) bg-(--card-70) text-sm text-(--ink-muted)">
+                            <div className="flex min-h-72 items-center justify-center rounded-3xl border border-(--border) bg-(--card-70) text-sm text-(--ink-muted)">
                                 Investment data unavailable.
                             </div>
                         )}
                     </div>
                 </div>
 
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-4">
+                <div className="rounded-3xl border border-(--border) bg-(--card-80) p-4">
                     <div className="flex items-center justify-between">
                         <h2 className="font-(--font-display) text-xl">Planned vs Unplanned</h2>
                         <Link
@@ -163,7 +163,7 @@ export function LandscapeView({
                     </div>
                     {planned && unplanned ? (
                         <div className="mt-4 space-y-4">
-                            <div className="rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3">
+                            <div className="rounded-2xl border border-(--border) bg-(--card) px-4 py-3">
                                 <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                     Planned
                                 </p>
@@ -174,7 +174,7 @@ export function LandscapeView({
                                     {formatNumber(planned.value)} units
                                 </p>
                             </div>
-                            <div className="rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3">
+                            <div className="rounded-2xl border border-(--border) bg-(--card) px-4 py-3">
                                 <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                     Unplanned
                                 </p>

--- a/src/components/work/RelatedEntitiesPanel.tsx
+++ b/src/components/work/RelatedEntitiesPanel.tsx
@@ -98,7 +98,7 @@ export function RelatedEntitiesPanel({
     const grouped = groupEdgesByRelatedType(rootType, rootId, relatedEdges);
 
     return (
-        <section className="rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
+        <section className="rounded-3xl border border-(--border) bg-(--card) p-6">
             <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
                     <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
@@ -110,7 +110,7 @@ export function RelatedEntitiesPanel({
                         relationship evidence that created each edge.
                     </p>
                 </div>
-                <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3 text-sm">
+                <div className="rounded-2xl border border-(--border) bg-(--card-70) px-4 py-3 text-sm">
                     <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
                         Investment theme
                     </p>
@@ -126,7 +126,7 @@ export function RelatedEntitiesPanel({
             </div>
 
             {relatedEdges.length === 0 ? (
-                <div className="mt-6 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
+                <div className="mt-6 rounded-2xl border border-dashed border-(--border) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
                     No data for related entities.
                 </div>
             ) : (
@@ -137,7 +137,7 @@ export function RelatedEntitiesPanel({
                         return (
                             <div
                                 key={type}
-                                className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4"
+                                className="rounded-2xl border border-(--border) bg-(--card-70) p-4"
                             >
                                 <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-(--ink-muted)">
                                     {entityLabels[type] ?? labelInvestmentKey(type)}
@@ -155,7 +155,7 @@ export function RelatedEntitiesPanel({
                                         return (
                                             <article
                                                 key={edge.edgeId}
-                                                className="rounded-2xl border border-(--card-stroke) bg-background/35 p-4"
+                                                className="rounded-2xl border border-(--border) bg-background/35 p-4"
                                             >
                                                 <div className="flex flex-wrap items-center justify-between gap-3">
                                                     <Link
@@ -164,7 +164,7 @@ export function RelatedEntitiesPanel({
                                                     >
                                                         {linkedId}
                                                     </Link>
-                                                    <span className="rounded-full border border-(--card-stroke) px-3 py-1 text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
+                                                    <span className="rounded-full border border-(--border) px-3 py-1 text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
                                                         {labelInvestmentKey(edge.edgeType)}
                                                     </span>
                                                 </div>
@@ -205,7 +205,7 @@ export function RelatedEntitiesPanel({
                 </div>
             )}
 
-            <div className="mt-6 rounded-2xl border border-(--card-stroke) bg-background/35 p-4">
+            <div className="mt-6 rounded-2xl border border-(--border) bg-background/35 p-4">
                 <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-(--ink-muted)">
                     Evidence quotes
                 </h3>

--- a/src/components/work/investment/AllocationCoverage.tsx
+++ b/src/components/work/investment/AllocationCoverage.tsx
@@ -102,7 +102,7 @@ export function AllocationCoverage({
     ];
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+        <div className="rounded-3xl border border-(--border) bg-card p-5">
             <div>
                 <h3 className="font-(--font-display) text-lg">
                     Coverage gaps &amp; unassigned ownership
@@ -116,7 +116,7 @@ export function AllocationCoverage({
                 {cards.map((card) => (
                     <div
                         key={card.id}
-                        className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4"
+                        className="rounded-2xl border border-(--border) bg-(--card-70) p-4"
                     >
                         <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                             {card.label}
@@ -136,7 +136,7 @@ export function AllocationCoverage({
                         )}
                     </div>
                 ))}
-                <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                <div className="rounded-2xl border border-(--border) bg-(--card-70) p-4">
                     <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                         Unassigned ownership
                     </p>

--- a/src/components/work/investment/ConfidencePanel.tsx
+++ b/src/components/work/investment/ConfidencePanel.tsx
@@ -189,7 +189,7 @@ export function ConfidencePanel({
                 </p>
             </div>
 
-            <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+            <div className="rounded-3xl border border-(--border) bg-card p-5">
                 <h3 className="font-(--font-display) text-lg">Classification confidence</h3>
                 {confidence ? (
                     <div className="mt-3 flex flex-wrap items-center gap-3">
@@ -236,7 +236,7 @@ export function ConfidencePanel({
                 )}
             </div>
 
-            <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+            <div className="rounded-3xl border border-(--border) bg-card p-5">
                 <h3 className="font-(--font-display) text-lg">Evidence quality bands</h3>
                 <p className="mt-1 text-sm text-(--ink-muted)">
                     Share of work units at each evidence-quality band. Segment width is the share;
@@ -255,7 +255,7 @@ export function ConfidencePanel({
                 isLoading={isCategoryFlowLoading}
             />
 
-            <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+            <div className="rounded-3xl border border-(--border) bg-card p-5">
                 <h3 className="font-(--font-display) text-lg">Low-confidence areas</h3>
                 <p className="mt-1 text-sm text-(--ink-muted)">
                     Work units whose categorization leans on weaker evidence. These are the first
@@ -270,7 +270,7 @@ export function ConfidencePanel({
                         {lowConfidenceUnits.map(({ unit, themeKey }) => (
                             <li
                                 key={unit.work_unit_id}
-                                className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm"
+                                className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-(--border) bg-(--card-70) px-4 py-2 text-sm"
                             >
                                 <span className="min-w-0 truncate text-foreground">
                                     {formatWorkUnitLabel(unit)}
@@ -289,7 +289,8 @@ export function ConfidencePanel({
                 )}
             </div>
 
-            <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+            {/* No border here: the nested MetricCard draws its own border + elevation (C4 — no stacked outlines) */}
+            <div className="rounded-3xl bg-card p-5">
                 <h3 className="font-(--font-display) text-lg">Rework</h3>
                 <p className="mt-1 text-sm text-(--ink-muted)">
                     Share of PRs that were reopened or required follow-up rework commits. The

--- a/src/components/work/investment/EvidenceEntryCard.tsx
+++ b/src/components/work/investment/EvidenceEntryCard.tsx
@@ -12,13 +12,13 @@ export function EvidenceEntryCard({ entry }: { entry: Record<string, unknown> })
     const entries = Object.entries(entry);
     if (entries.length === 0) {
         return (
-            <div className="rounded-lg border border-(--card-stroke) bg-card px-3 py-2 text-xs text-(--ink-muted)">
+            <div className="rounded-lg border border-(--border) bg-card px-3 py-2 text-xs text-(--ink-muted)">
                 —
             </div>
         );
     }
     return (
-        <div className="rounded-lg border border-(--card-stroke) bg-card px-3 py-2 text-xs">
+        <div className="rounded-lg border border-(--border) bg-card px-3 py-2 text-xs">
             <dl className="space-y-1">
                 {entries.map(([key, value]) => {
                     const label = key

--- a/src/components/work/investment/EvidenceQualityBands.tsx
+++ b/src/components/work/investment/EvidenceQualityBands.tsx
@@ -59,7 +59,7 @@ export function EvidenceQualityBands({ evidenceQualityDistribution }: EvidenceQu
 
     return (
         <div className="space-y-3">
-            <div className="flex h-3 w-full overflow-hidden rounded-full border border-(--card-stroke) bg-(--card-70)">
+            <div className="flex h-3 w-full overflow-hidden rounded-full border border-(--border) bg-(--card-70)">
                 {segments.map((segment) => {
                     const pct = segment.share * 100;
                     if (pct <= 0) return null;

--- a/src/components/work/investment/InvestmentEvidenceTable.tsx
+++ b/src/components/work/investment/InvestmentEvidenceTable.tsx
@@ -140,7 +140,7 @@ export function InvestmentEvidenceTable({
     };
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+        <div className="rounded-3xl border border-(--border) bg-card p-5">
             <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                     <h3 className="font-(--font-display) text-lg">Evidence drilldown</h3>
@@ -157,7 +157,7 @@ export function InvestmentEvidenceTable({
                     <div
                         role="radiogroup"
                         aria-label="Group evidence by"
-                        className="flex gap-1 rounded-full border border-(--card-stroke) bg-(--card-70) p-1"
+                        className="flex gap-1 rounded-full border border-(--border) bg-(--card-70) p-1"
                     >
                         {GROUP_OPTIONS.map((option) => (
                             <button
@@ -179,8 +179,8 @@ export function InvestmentEvidenceTable({
                 </div>
             </div>
 
-            <div className="mt-4 overflow-hidden rounded-2xl border border-(--card-stroke)">
-                <div className="grid grid-cols-[1fr_auto_auto] items-center gap-3 border-b border-(--card-stroke) bg-(--card-70) px-4 py-2 text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+            <div className="mt-4 overflow-hidden rounded-2xl border border-(--border)">
+                <div className="grid grid-cols-[1fr_auto_auto] items-center gap-3 border-b border-(--border) bg-(--card-70) px-4 py-2 text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                     <span>{GROUP_OPTIONS.find((o) => o.id === groupBy)?.label}</span>
                     <span className="text-right">Units</span>
                     <span className="text-right">Weighted effort</span>
@@ -196,7 +196,7 @@ export function InvestmentEvidenceTable({
                         return (
                             <div
                                 key={group.key}
-                                className="border-b border-(--card-stroke) last:border-b-0"
+                                className="border-b border-(--border) last:border-b-0"
                             >
                                 <button
                                     type="button"
@@ -242,7 +242,7 @@ export function InvestmentEvidenceTable({
                                             return (
                                                 <li
                                                     key={unit.work_unit_id}
-                                                    className="rounded-2xl border border-(--card-stroke) bg-(--card-70)"
+                                                    className="rounded-2xl border border-(--border) bg-(--card-70)"
                                                 >
                                                     <button
                                                         type="button"
@@ -263,7 +263,7 @@ export function InvestmentEvidenceTable({
                                                                 {formatWorkUnitLabel(unit)}
                                                             </span>
                                                             {formatWorkUnitTypeLabel(unit) ? (
-                                                                <span className="shrink-0 rounded-full border border-(--card-stroke) px-2 py-0.5 text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                                                                <span className="shrink-0 rounded-full border border-(--border) px-2 py-0.5 text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                                                     {formatWorkUnitTypeLabel(unit)}
                                                                 </span>
                                                             ) : null}
@@ -286,7 +286,7 @@ export function InvestmentEvidenceTable({
                                                     </button>
 
                                                     {unitOpen && (
-                                                        <div className="space-y-4 border-t border-(--card-stroke) px-4 py-4">
+                                                        <div className="space-y-4 border-t border-(--border) px-4 py-4">
                                                             <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                                                 <span>
                                                                     ID:{" "}
@@ -368,7 +368,7 @@ export function InvestmentEvidenceTable({
                                                                         unit.work_unit_id,
                                                                     )
                                                                 }
-                                                                className="rounded-full border border-(--card-stroke) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--accent-2) hover:border-(--accent-2)/40"
+                                                                className="rounded-full border border-(--border) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--accent-2) hover:border-(--accent-2)/40"
                                                             >
                                                                 {CTA_LABELS.openEvidence}
                                                             </button>

--- a/src/components/work/investment/InvestmentExplainer.tsx
+++ b/src/components/work/investment/InvestmentExplainer.tsx
@@ -16,7 +16,7 @@ export function InvestmentExplainer({
     onRegenerate,
 }: InvestmentExplainerProps) {
     return (
-        <details open className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+        <details open className="rounded-3xl border border-(--border) bg-card p-5">
             <summary className="cursor-pointer list-none font-(--font-display) text-lg">
                 What this investment mix indicates
             </summary>
@@ -33,7 +33,7 @@ export function InvestmentExplainer({
                         type="button"
                         onClick={onRegenerate}
                         disabled={isExplainingMix}
-                        className="rounded-full border border-(--card-stroke) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted) disabled:opacity-50"
+                        className="rounded-full border border-(--border) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted) disabled:opacity-50"
                     >
                         {isExplainingMix ? "Generating..." : "Regenerate explanation"}
                     </button>
@@ -64,7 +64,7 @@ export function InvestmentExplainer({
                                     {mixExplanation.data.top_findings.slice(0, 3).map((finding) => (
                                         <div
                                             key={`${finding.finding}-${finding.evidence.theme}-${finding.evidence.share_pct}`}
-                                            className="rounded-lg border border-(--card-stroke) bg-background/50 p-3"
+                                            className="rounded-lg border border-(--border) bg-background/50 p-3"
                                         >
                                             <p className="text-sm">{finding.finding}</p>
                                             <div className="mt-2 flex flex-wrap gap-2 text-xs text-(--ink-muted)">
@@ -85,7 +85,7 @@ export function InvestmentExplainer({
                             </div>
                         )}
 
-                        <div className="rounded-lg border border-(--card-stroke) bg-background/30 p-3">
+                        <div className="rounded-lg border border-(--border) bg-background/30 p-3">
                             <div className="flex items-center gap-3">
                                 <span className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                     Confidence

--- a/src/components/work/investment/charts/InvestmentMixSection.tsx
+++ b/src/components/work/investment/charts/InvestmentMixSection.tsx
@@ -274,7 +274,7 @@ export function InvestmentMixSection({
     const categoryScopeLabel = focusTheme ? "Subcategory" : "Theme";
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+        <div className="rounded-3xl border border-(--border) bg-card p-5">
             <div className="flex flex-wrap items-center justify-between gap-4">
                 <div>
                     <h3 className="font-(--font-display) text-lg">
@@ -291,7 +291,7 @@ export function InvestmentMixSection({
                         <button
                             type="button"
                             onClick={() => setFocusTheme(null)}
-                            className="rounded-full border border-(--card-stroke) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted)"
+                            className="rounded-full border border-(--border) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted)"
                         >
                             {CTA_LABELS.clearTheme}
                         </button>
@@ -344,7 +344,7 @@ export function InvestmentMixSection({
                             {treemapWorkGraphUrl && (
                                 <Link
                                     href={treemapWorkGraphUrl}
-                                    className="ml-auto rounded-full border border-(--card-stroke) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--accent-2) hover:border-(--accent-2)/40"
+                                    className="ml-auto rounded-full border border-(--border) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--accent-2) hover:border-(--accent-2)/40"
                                 >
                                     {CTA_LABELS.openWorkGraph} ↗
                                 </Link>
@@ -387,7 +387,7 @@ export function InvestmentMixSection({
                             onThemeClickAction={handleThemeClick}
                             onSubcategoryClickAction={handleSubcategoryClick}
                         />
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                        <div className="rounded-2xl border border-(--border) bg-(--card-70) p-4">
                             <div className="flex items-center justify-between">
                                 <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                     {focusTheme ? "Subcategory breakdown" : "Themes"}
@@ -401,7 +401,7 @@ export function InvestmentMixSection({
                             {focusedWorkGraphUrl && (
                                 <Link
                                     href={focusedWorkGraphUrl}
-                                    className="mt-3 flex items-center justify-between rounded-xl border border-(--card-stroke) bg-card px-3 py-2 text-xs uppercase tracking-[0.2em] text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
+                                    className="mt-3 flex items-center justify-between rounded-xl border border-(--border) bg-card px-3 py-2 text-xs uppercase tracking-[0.2em] text-foreground hover:border-(--accent-2)/40 hover:bg-(--accent-2)/5 group"
                                 >
                                     <span>{CTA_LABELS.openWorkGraph}</span>
                                     <span className="text-(--accent-2) group-hover:translate-x-0.5 transition-transform">
@@ -423,7 +423,7 @@ export function InvestmentMixSection({
                                                     onClick={() =>
                                                         handleSubcategoryClick(entry.key)
                                                     }
-                                                    className="flex w-full items-center justify-between rounded-xl border border-(--card-stroke) bg-card px-3 py-2 text-left transition hover:border-(--accent-2)"
+                                                    className="flex w-full items-center justify-between rounded-xl border border-(--border) bg-card px-3 py-2 text-left transition hover:border-(--accent-2)"
                                                 >
                                                     <div className="min-w-0">
                                                         <div className="truncate text-sm text-foreground">
@@ -461,7 +461,7 @@ export function InvestmentMixSection({
                                                 key={entry.key}
                                                 type="button"
                                                 onClick={() => handleThemeClick(entry.key)}
-                                                className="flex w-full items-center justify-between rounded-xl border border-(--card-stroke) bg-card px-3 py-2 text-left transition hover:border-(--accent-2)"
+                                                className="flex w-full items-center justify-between rounded-xl border border-(--border) bg-card px-3 py-2 text-left transition hover:border-(--accent-2)"
                                             >
                                                 <div className="min-w-0">
                                                     <div className="truncate text-sm text-foreground">

--- a/src/components/work/investment/charts/RepoTeamSankeySection.tsx
+++ b/src/components/work/investment/charts/RepoTeamSankeySection.tsx
@@ -86,7 +86,7 @@ export function RepoTeamSankeySection({
     );
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+        <div className="rounded-3xl border border-(--border) bg-card p-5">
             <div className="flex flex-wrap items-center justify-between gap-2">
                 <div>
                     <h3 className="font-(--font-display) text-lg">Theme &rarr; Repo &rarr; Team</h3>
@@ -96,7 +96,7 @@ export function RepoTeamSankeySection({
                     Two-hop allocation to highlight team ownership behind repos.
                 </span>
             </div>
-            <div className="mb-4 mt-2 border-l-2 border-(--card-stroke) py-1 pl-3 text-xs leading-relaxed text-(--ink-muted)">
+            <div className="mb-4 mt-2 border-l-2 border-(--border) py-1 pl-3 text-xs leading-relaxed text-(--ink-muted)">
                 This view uses repo-to-team mapping when available. Missing repo associations are
                 routed through an unassigned repo node.
             </div>
@@ -133,7 +133,7 @@ export function RepoTeamSankeySection({
                         }}
                     />
                 ) : (
-                    <div className="flex h-56 items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) text-center text-sm text-(--ink-muted)">
+                    <div className="flex h-56 items-center justify-center rounded-2xl border border-dashed border-(--border) bg-(--card-70) text-center text-sm text-(--ink-muted)">
                         <div>
                             <p>We currently have no teams associated with work items.</p>
                             <p className="mt-2 text-xs text-(--ink-muted)">

--- a/src/components/work/investment/charts/TeamCategorySankeySection.tsx
+++ b/src/components/work/investment/charts/TeamCategorySankeySection.tsx
@@ -205,7 +205,7 @@ export function TeamCategorySankeySection({
     );
 
     return (
-        <div className="rounded-3xl border border-(--card-stroke) bg-card p-5">
+        <div className="rounded-3xl border border-(--border) bg-card p-5">
             <div className="flex flex-wrap items-start justify-between gap-4">
                 <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-3">
@@ -238,7 +238,7 @@ export function TeamCategorySankeySection({
                                 <button
                                     type="button"
                                     onClick={() => setFocusedTeam(null)}
-                                    className="inline-flex items-center gap-2 rounded-full border border-(--card-stroke) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted)"
+                                    className="inline-flex items-center gap-2 rounded-full border border-(--border) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted)"
                                 >
                                     Drilldown: Team = {focusedTeam}
                                     <span className="text-xs">x</span>
@@ -251,7 +251,7 @@ export function TeamCategorySankeySection({
                                         setSelectedCategory(null);
                                         setFocusSubcategory(null);
                                     }}
-                                    className="inline-flex items-center gap-2 rounded-full border border-(--card-stroke) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted)"
+                                    className="inline-flex items-center gap-2 rounded-full border border-(--border) px-3 py-1 text-xs uppercase tracking-[0.2em] text-(--ink-muted)"
                                 >
                                     Drilldown: Theme = {selectedCategory}
                                     <span className="text-xs">x</span>
@@ -273,7 +273,7 @@ export function TeamCategorySankeySection({
                             {topCategorySummary.map((entry) => (
                                 <span
                                     key={entry.name}
-                                    className="rounded-full border border-(--card-stroke) px-2 py-0.5 text-xs"
+                                    className="rounded-full border border-(--border) px-2 py-0.5 text-xs"
                                 >
                                     {entry.name}{" "}
                                     {formatNumber(entry.share, { maximumFractionDigits: 0 })}%
@@ -283,7 +283,7 @@ export function TeamCategorySankeySection({
                     )}
                 </div>
             </div>
-            <div className="mb-4 mt-2 border-l-2 border-(--card-stroke) py-1 pl-3 text-xs leading-relaxed text-(--ink-muted)">
+            <div className="mb-4 mt-2 border-l-2 border-(--border) py-1 pl-3 text-xs leading-relaxed text-(--ink-muted)">
                 This view shows where effort appears to land across teams, themes, and repos for the
                 selected window. Allocation reflects attribution, not dependency or impact.
             </div>
@@ -291,7 +291,7 @@ export function TeamCategorySankeySection({
                 {isSankeyLoading ? (
                     <p className="text-sm text-(--ink-muted)">Loading allocation data...</p>
                 ) : !sankeyFlow || !sankeyFlow.links.length ? (
-                    <div className="flex h-56 items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) text-center text-sm text-(--ink-muted)">
+                    <div className="flex h-56 items-center justify-center rounded-2xl border border-dashed border-(--border) bg-(--card-70) text-center text-sm text-(--ink-muted)">
                         No allocation path available for this scope and window.
                     </div>
                 ) : (

--- a/src/components/work/investment/charts/TeamExchangeChordSection.tsx
+++ b/src/components/work/investment/charts/TeamExchangeChordSection.tsx
@@ -140,7 +140,7 @@ export function TeamExchangeChordSection({
 
     return (
         <section
-            className={`rounded-3xl border border-(--card-stroke) bg-card p-5 ${className ?? ""}`}
+            className={`rounded-3xl border border-(--border) bg-card p-5 ${className ?? ""}`}
             data-scope-level={filters.scope.level}
         >
             <header className="flex flex-wrap items-start justify-between gap-4">
@@ -148,7 +148,7 @@ export function TeamExchangeChordSection({
                     <div className="flex flex-wrap items-center gap-3">
                         <h3 className="font-(--font-display) text-lg">Team exchange chord</h3>
                         {highlightedLabel ? (
-                            <span className="rounded-full border border-(--card-stroke) px-2 py-0.5 text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                            <span className="rounded-full border border-(--border) px-2 py-0.5 text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
                                 Highlighted: {highlightedLabel}
                             </span>
                         ) : null}

--- a/src/lib/design/__tests__/card.test.ts
+++ b/src/lib/design/__tests__/card.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+
+import { CARD_SURFACE, cardClassName } from "../card";
+
+describe("card primitive (framework C4)", () => {
+    it("uses only V1 tokens for the card shell", () => {
+        expect(CARD_SURFACE).toContain("rounded-(--radius-lg)");
+        expect(CARD_SURFACE).toContain("border-(--border)");
+        expect(CARD_SURFACE).toContain("bg-(--surface)");
+        expect(CARD_SURFACE).toContain("shadow-(--elevation-card)");
+        // Legacy bright stroke must not creep back in (CHAOS-2067).
+        expect(CARD_SURFACE).not.toContain("card-stroke)");
+    });
+
+    it("composes call-site classes after the shell", () => {
+        expect(cardClassName("p-4")).toBe(`${CARD_SURFACE} p-4`);
+        expect(cardClassName()).toBe(CARD_SURFACE);
+    });
+});

--- a/src/lib/design/card.ts
+++ b/src/lib/design/card.ts
@@ -1,0 +1,15 @@
+/**
+ * Canonical card surface (framework C4) — the one sanctioned card treatment:
+ * surface fill, hairline `--border` stroke, `--radius-lg`, `--elevation-card`.
+ *
+ * Compose with layout/padding utilities at the call site (`p-4`,
+ * `p-(--space-card)`, …). Interactive emphasis (hover/active) should move the
+ * stroke to `--card-stroke-active`, never to a brighter static border
+ * (CHAOS-2067).
+ */
+export const CARD_SURFACE =
+    "rounded-(--radius-lg) border border-(--border) bg-(--surface) shadow-(--elevation-card)";
+
+export function cardClassName(className = ""): string {
+    return `${CARD_SURFACE} ${className}`.trim();
+}


### PR DESCRIPTION
## CHAOS-2067 — kill the boxed-in dark theme

Dark theme drew bright/near-white (`--card-stroke`) hairlines on nearly every container. V1 (#661) defined `--border` (dark: 65% mix toward background; light: identical to `--card-stroke`). This PR migrates **resting** borders to it; bright strokes stay reserved for hover/focus/active.

### Mechanical sweep (237 files, ~949 class swaps)
- `border-(--card-stroke)` → `border-(--border)` at rest (incl. `/60` opacity variants and `border-[var(...)]` bracket syntax)
- `divide-(--card-stroke)` → `divide-(--border)` (table/list row dividers)
- All 14 `hover:`/`focus-visible:border-(--card-stroke)` usages **kept bright** (interactive states)
- `bg-(--card-stroke)` chip/flame backgrounds untouched (not borders)
- **Light mode renders pixel-identical** (`--border: var(--card-stroke)` in base block); dark mode dims per Framework C2/C4

### Targeted fixes
- **`--border-subtle` bug**: 8 admin call sites (IntegrationCard, CredentialCard ×3, IntegrationForm ×2, ProviderCredentialsList) consumed an UNDEFINED var → borders silently rendered `currentColor` (strong text-colored). Migrated to `border-(--border)`. The V1 `--color-border-subtle` bridge in globals.css is now consumer-less — left in place (token definitions untouched per V1 scope); 2113 can trim.
- **ChartFrame.tsx**: rest border converged to `--border` (was the last primitive on `--card-stroke`)
- **ConfidencePanel** Rework panel: dropped outer border around nested MetricCard (C4 — no stacked outlines; surface contrast instead)
- **MetricCard**: label row + caption unified on `text-label-caps`/`--text-muted` (was legacy ink-muted 12px/0.2em)
- **Operating Review AI accents**: hardcoded `border-sky-400/40|30` (+ matching bg/shadow) → `--accent-ai` token (sky→violet hue shift, disclosed; "changed"-status chips stay sky — different semantic)

### Excluded (parallel agents own)
AreaSignalCard/AreaOverview (CHAOS-2109); DataState/AiWorkflowCallout/LensSelector (CHAOS-2111). Their resting `--card-stroke` borders are listed in Linear for those issues.

### Gates
format ✓ (246 files), quality/tsc ✓, unit 2009/2009 ✓, design-lint 327 problems = identical to main baseline (0 new; scan counters 0), Playwright nav-reachability 7/7 ✓

TEST-WAIVER: class-string-only restyle; no logic changed, no test asserts the swapped border classes (verified by grep + full unit suite green)