### PR TITLE
style(navigation): Area Card chrome to Penpot spec + V1 tokens (CHAOS-2109)

### DIFF
--- a/src/components/home/severityTokens.ts
+++ b/src/components/home/severityTokens.ts
@@ -69,3 +69,17 @@ export const AREA_STATE_LABEL: Record<Exclude<AreaSignalState, "unavailable">, s
     ...SEVERITY_LABEL,
     neutral: NEUTRAL_LABEL,
 };
+
+// ── Penpot Area Card accent tab (CHAOS-2109) ──────────────────────────────────
+// The thin severity-tinted bar across the top of an Area Card. Background-only
+// utilities (the bar is a filled strip, not a bordered chip). "unavailable"
+// excluded — the honest-empty card renders dashed chrome with no tab.
+
+/** Accent-tab fill per badge-bearing area-signal state. */
+export const AREA_STATE_TAB: Record<Exclude<AreaSignalState, "unavailable">, string> = {
+    critical: "bg-red-500/80",
+    high: "bg-amber-500/80",
+    medium: "bg-(--accent-2)/70",
+    low: "bg-(--border)",
+    neutral: "bg-(--border)",
+};

--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -3,6 +3,7 @@ import { LineagePopover } from "@/app/(app)/data-health/_components/LineagePopov
 
 import { SparklineChart } from "@/components/charts/SparklineChart";
 import { MetricDelta } from "@/components/shared/MetricDelta";
+import { CARD_SURFACE } from "@/lib/design/card";
 import { formatMetricValue } from "@/lib/formatters";
 import type { SparkPoint } from "@/lib/types";
 
@@ -44,8 +45,8 @@ export function MetricCard({
     const sparkLabels = spark?.map((point) => point.ts) ?? [];
     // Only a real destination earns the clickable affordance + "Open evidence" cue.
     const captionText = caption ?? (href ? "Open evidence" : null);
-    const cardClassName = `group rounded-3xl border border-(--card-stroke) bg-card p-4 ${
-        href ? "transition hover:-translate-y-1 hover:shadow-lg" : ""
+    const cardClassName = `group ${CARD_SURFACE} p-4 ${
+        href ? "transition hover:-translate-y-1 hover:border-(--card-stroke-active)" : ""
     } ${className ?? ""}`;
 
     const body = (
@@ -78,7 +79,7 @@ export function MetricCard({
                     ) : (
                         <div
                             title="Not enough data points to plot a trend yet"
-                            className="flex h-full items-center justify-center rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-2 text-center text-[10px] uppercase tracking-[0.2em] text-(--ink-muted)"
+                            className="flex h-full items-center justify-center rounded-(--radius-md) border border-dashed border-(--border) bg-(--card-70) px-2 text-center text-label-caps uppercase text-(--text-muted)"
                         >
                             No trend yet
                         </div>

--- a/src/components/navigation/AreaOverview.test.tsx
+++ b/src/components/navigation/AreaOverview.test.tsx
@@ -123,6 +123,45 @@ describe("AreaOverview — summarize + route (no hero/grid duplication)", () => 
         expect(gridCards[1]).toHaveAttribute("data-signal-id", "b");
     });
 
+    it("derives the count badge from resolved signals — attention states win (CHAOS-2109)", () => {
+        renderOverview([signal("crit", "critical"), signal("high", "high"), signal("low", "low")]);
+        const count = screen.getByTestId("area-overview-count");
+        expect(count.textContent).toBe("2 need attention");
+    });
+
+    it("falls back to a neutral signal count when nothing needs attention (CHAOS-2109)", () => {
+        renderOverview([signal("a", "low"), signal("b", "medium")]);
+        expect(screen.getByTestId("area-overview-count").textContent).toBe("2 signals");
+    });
+
+    it("omits the count badge when no real-data signal exists (CHAOS-2109)", () => {
+        renderOverview([signal("gap", "unavailable")]);
+        expect(screen.queryByTestId("area-overview-count")).toBeNull();
+    });
+
+    it("renders severity accent tabs on real cards, none on unavailable cards (CHAOS-2109)", () => {
+        renderOverview([signal("crit", "critical"), signal("gap", "unavailable")]);
+        const cards = screen.getAllByTestId("area-signal-card");
+        const critCard = cards.find((c) => c.getAttribute("data-signal-id") === "crit")!;
+        const gapCard = cards.find((c) => c.getAttribute("data-signal-id") === "gap")!;
+        expect(within(critCard).getByTestId("area-signal-accent-tab")).toBeInTheDocument();
+        expect(within(gapCard).queryByTestId("area-signal-accent-tab")).toBeNull();
+    });
+
+    it("keeps demoted R4 cards tab-free so they stay visually secondary (CHAOS-2109)", () => {
+        renderOverview([
+            signal("hero", "critical"),
+            signal("lead", "high"),
+            signal("flag", "low", { demoted: true }),
+        ]);
+        const cards = screen.getAllByTestId("area-signal-card");
+        const demotedCard = cards.find((c) => c.getAttribute("data-signal-id") === "flag")!;
+        expect(within(demotedCard).queryByTestId("area-signal-accent-tab")).toBeNull();
+        // Hero + remaining grid card both carry tabs.
+        const tabs = screen.getAllByTestId("area-signal-accent-tab");
+        expect(tabs).toHaveLength(2);
+    });
+
     it("renders a PREVIEW empty-tier chip as non-clickable, a routed one as a link (CHAOS-2217)", () => {
         renderOverview([
             signal("routed", "unavailable"),

--- a/src/components/navigation/AreaOverview.tsx
+++ b/src/components/navigation/AreaOverview.tsx
@@ -22,6 +22,9 @@ import { AreaSignalCard } from "./AreaSignalCard";
 //     quieter than real-data cards — and always sort LAST.
 //   - It summarizes and ROUTES: every card is a link into its sub-area. The
 //     Overview never embeds a full child workflow inline.
+//   - Penpot Area Card chrome (CHAOS-2109): the header carries a count badge
+//     DERIVED from the resolved signals (critical+high → "N need attention",
+//     else "N signals"); cards carry severity accent tabs (see AreaSignalCard).
 //
 // Presentational RSC: the area landing resolves the `AreaSignal[]` (via
 // `getAreaSignals`) and passes it in. No data-fetching here.
@@ -63,6 +66,21 @@ export function AreaOverview({
 
     if (!hero && gridSignals.length === 0 && unavailable.length === 0) return null;
 
+    // Penpot Area Card chrome: the count badge summarizes the severity-sorted
+    // signal set — DERIVED from the resolved signals, never a fetched/fabricated
+    // number. Attention = critical + high (the states that demand triage).
+    const attention = available.filter(
+        (signal) => signal.state === "critical" || signal.state === "high",
+    ).length;
+    const countBadgeClassName =
+        attention > 0
+            ? "border-amber-500/30 bg-amber-500/15 text-amber-300"
+            : "border-(--border) bg-(--surface) text-(--text-muted)";
+    const countBadgeLabel =
+        attention > 0
+            ? `${attention} need${attention === 1 ? "s" : ""} attention`
+            : `${available.length} signal${available.length === 1 ? "" : "s"}`;
+
     return (
         <section
             aria-label={`${area.label} overview`}
@@ -70,11 +88,21 @@ export function AreaOverview({
             className="flex flex-col gap-6"
         >
             <div>
-                <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                    {title ?? `${area.label} area`}
-                </p>
+                <div className="flex items-center gap-3">
+                    <p className="text-label-caps uppercase text-(--text-muted)">
+                        {title ?? `${area.label} area`}
+                    </p>
+                    {available.length > 0 ? (
+                        <span
+                            data-testid="area-overview-count"
+                            className={`text-label-caps rounded-(--radius-pill) border px-2.5 py-0.5 uppercase ${countBadgeClassName}`}
+                        >
+                            {countBadgeLabel}
+                        </span>
+                    ) : null}
+                </div>
                 {description ? (
-                    <p className="mt-1 text-sm text-(--ink-muted)">{description}</p>
+                    <p className="mt-1 text-sm text-(--text-secondary)">{description}</p>
                 ) : null}
             </div>
 

--- a/src/components/navigation/AreaSignalCard.tsx
+++ b/src/components/navigation/AreaSignalCard.tsx
@@ -4,24 +4,27 @@ import { DataState } from "@/components/ui/DataState";
 import {
     AREA_STATE_BADGE,
     AREA_STATE_LABEL,
+    AREA_STATE_TAB,
     DIRECTION_GLYPH,
 } from "@/components/home/severityTokens";
 import type { AreaSignal } from "@/lib/areaSignals/types";
+import { cardClassName } from "@/lib/design/card";
 import { AREA_UNAVAILABLE_EMPTY_STATE } from "@/lib/design/emptyState";
 import { withFilterParam } from "@/lib/filters/url";
 import type { MetricFilter } from "@/lib/filters/types";
 
-// ── AreaSignalCard (CHAOS-2074) ───────────────────────────────────────────────
+// ── AreaSignalCard (CHAOS-2074, visual: CHAOS-2109) ──────────────────────────
 //
 // One sub-area rendered as a signal card on its area's landing page (Framework
-// A2a): a severity badge + metric label + state value + drill-in affordance,
-// matching {@link SignalCard}'s visual language via the shared severity tokens.
-// An RSC (no client state) — the whole card is a link into the sub-area.
+// A2a): the Penpot Area Card chrome — severity accent tab + title + state badge
+// + metric line — on the canonical C4 card shell. An RSC (no client state) —
+// the whole card is a link into the sub-area.
 //
 // Honest states (owner decision 1): a signal whose value is genuinely
 // unavailable renders an inline {@link DataState} instead of a fabricated
 // number. Demoted signals (R4 low-value single surfaces) render visually
-// secondary — tighter padding, no emphasis — within their cluster.
+// secondary — tighter padding, no emphasis, no accent tab — within their
+// cluster.
 
 type AreaSignalCardProps = {
     signal: AreaSignal;
@@ -30,6 +33,21 @@ type AreaSignalCardProps = {
     /** Top-signal emphasis (mirrors RankedSignals' lead card). */
     emphasized?: boolean;
 };
+
+/**
+ * The Penpot Area Card accent tab: a thin severity-tinted strip across the top
+ * of the card chrome. The hero card's tab is always accent-colored; grid cards
+ * tint by state. Rendered OUTSIDE the padded body so it bleeds to the card edge.
+ */
+function AccentTab({ className }: { className: string }) {
+    return (
+        <span
+            aria-hidden
+            data-testid="area-signal-accent-tab"
+            className={`absolute inset-x-0 top-0 h-1 ${className}`}
+        />
+    );
+}
 
 export function AreaSignalCard({ signal, filters, role, emphasized = false }: AreaSignalCardProps) {
     const href = withFilterParam(signal.href, filters, role);
@@ -44,16 +62,15 @@ export function AreaSignalCard({ signal, filters, role, emphasized = false }: Ar
     // sub-area stays a link so it remains reachable; a preview sub-area renders as
     // a plain <div> (same visual) so the dead route is never linked.
     if (signal.state === "unavailable") {
-        // Base dashed treatment; only ROUTED (clickable) cards get the hover
-        // affordance — a preview card must not look interactive.
+        // Base dashed treatment (no accent tab — there is no signal to tint by);
+        // only ROUTED (clickable) cards get the hover affordance — a preview card
+        // must not look interactive.
         const unavailableBaseClassName =
-            "group block rounded-2xl border border-dashed border-(--card-stroke)/70 bg-(--card-80)/60 p-4 opacity-70 transition";
-        const unavailableClassName = `${unavailableBaseClassName} hover:border-(--accent) hover:opacity-100`;
+            "group block rounded-(--radius-lg) border border-dashed border-(--border) bg-(--surface)/60 p-4 opacity-70 transition";
+        const unavailableClassName = `${unavailableBaseClassName} hover:border-(--card-stroke-active) hover:opacity-100`;
         const body = (
             <>
-                <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
-                    {signal.label}
-                </p>
+                <p className="text-label-caps uppercase text-(--text-muted)">{signal.label}</p>
                 <DataState
                     variant="detector-unavailable"
                     title={AREA_UNAVAILABLE_EMPTY_STATE.title}
@@ -96,6 +113,8 @@ export function AreaSignalCard({ signal, filters, role, emphasized = false }: Ar
 
     const badge = AREA_STATE_BADGE[signal.state];
     const stateLabel = AREA_STATE_LABEL[signal.state];
+    // Hero cards always carry the area accent; grid cards tint by severity.
+    const tab = emphasized ? "bg-(--accent)" : AREA_STATE_TAB[signal.state];
 
     return (
         <Link
@@ -107,33 +126,38 @@ export function AreaSignalCard({ signal, filters, role, emphasized = false }: Ar
             data-emphasized={emphasized ? "true" : "false"}
             className={
                 emphasized
-                    ? "group relative block overflow-hidden rounded-3xl border border-(--accent)/30 bg-gradient-to-br from-(--card) to-(--card-80) p-6 shadow-lg ring-1 ring-(--accent)/10 transition hover:-translate-y-1 hover:border-(--accent)"
+                    ? cardClassName(
+                          "group relative block overflow-hidden bg-gradient-to-br from-(--surface-raised) to-(--surface) p-6 transition hover:-translate-y-1 hover:border-(--card-stroke-active)",
+                      )
                     : demoted
-                      ? "group block rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3 transition hover:border-(--accent)"
-                      : "group block overflow-hidden rounded-2xl border border-(--card-stroke) bg-(--card) p-4 transition hover:-translate-y-1 hover:border-(--accent)"
+                      ? "group block rounded-(--radius-md) border border-(--border) bg-(--surface) px-4 py-3 transition hover:border-(--card-stroke-active)"
+                      : cardClassName(
+                            "group relative block overflow-hidden p-4 transition hover:-translate-y-1 hover:border-(--card-stroke-active)",
+                        )
             }
         >
+            {/* Demoted R4 surfaces stay visually secondary: no accent tab. */}
+            {demoted ? null : <AccentTab className={tab} />}
+
             {emphasized ? (
-                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-(--accent)">
-                    Top signal
-                </p>
+                <p className="text-label-caps uppercase text-(--accent)">Top signal</p>
             ) : null}
 
             <header className="mt-1 flex items-start justify-between gap-3">
                 <h3
                     className={
                         emphasized
-                            ? "font-(--font-display) text-xl leading-tight text-foreground"
+                            ? "font-(--font-display) text-xl leading-tight text-(--text-primary)"
                             : demoted
-                              ? "text-sm font-medium text-foreground"
-                              : "font-(--font-display) text-base leading-tight text-foreground"
+                              ? "text-sm font-medium text-(--text-primary)"
+                              : "font-(--font-display) text-base leading-tight text-(--text-primary)"
                     }
                 >
                     {signal.label}
                 </h3>
                 <span
                     data-testid="area-signal-badge"
-                    className={`shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-bold uppercase tracking-[0.18em] ${badge}`}
+                    className={`text-label-caps shrink-0 rounded-(--radius-pill) border px-2.5 py-0.5 uppercase ${badge}`}
                 >
                     {stateLabel}
                 </span>
@@ -147,23 +171,23 @@ export function AreaSignalCard({ signal, filters, role, emphasized = false }: Ar
                         data-testid="area-signal-value"
                         className={
                             demoted
-                                ? "metric-hero text-lg font-semibold text-foreground"
-                                : "metric-hero text-2xl font-semibold text-foreground"
+                                ? "metric-hero text-lg font-semibold text-(--text-primary)"
+                                : "metric-hero text-2xl font-semibold text-(--text-primary)"
                         }
                     >
                         {signal.value}
                     </span>
                     {signal.direction ? (
-                        <span aria-hidden className="text-xs text-(--ink-muted)">
+                        <span aria-hidden className="text-xs text-(--text-muted)">
                             {DIRECTION_GLYPH[signal.direction]}
                         </span>
                     ) : null}
-                    <span className="text-xs uppercase tracking-[0.12em] text-(--ink-muted)">
+                    <span className="text-label-caps uppercase text-(--text-muted)">
                         {signal.metricLabel}
                     </span>
                 </div>
             ) : (
-                <p className="mt-2 text-sm text-(--ink-muted)">{signal.metricLabel}</p>
+                <p className="mt-2 text-sm text-(--text-secondary)">{signal.metricLabel}</p>
             )}
         </Link>
     );

--- a/src/components/shared/BackLink.test.tsx
+++ b/src/components/shared/BackLink.test.tsx
@@ -41,7 +41,7 @@ describe("BackLink", () => {
     it("is not styled as a filter pill (quiet inline link, no pill background)", () => {
         render(<BackLink href="/" />);
         const link = screen.getByRole("link", { name: /back to cockpit/i });
-        expect(link.className).not.toContain("rounded-full");
-        expect(link.className).toContain("text-(--ink-muted)");
+        expect(link.className).not.toContain("rounded-(--radius-pill)");
+        expect(link.className).toContain("text-(--text-muted)");
     });
 });

--- a/src/components/shared/BackLink.tsx
+++ b/src/components/shared/BackLink.tsx
@@ -37,7 +37,7 @@ export function BackLink({ href, label, area, className }: BackLinkProps) {
     return (
         <Link
             href={href}
-            className={`group inline-flex items-center gap-1.5 text-xs uppercase tracking-[0.2em] text-(--ink-muted) transition-colors hover:text-foreground ${className ?? ""}`.trim()}
+            className={`group inline-flex items-center gap-1.5 text-label-caps uppercase text-(--text-muted) transition-colors hover:text-(--text-primary) ${className ?? ""}`.trim()}
         >
             <span aria-hidden="true" className="transition-transform group-hover:-translate-x-0.5">
                 &larr;

--- a/src/components/shared/Button.test.tsx
+++ b/src/components/shared/Button.test.tsx
@@ -20,9 +20,11 @@ describe("Button", () => {
     it("applies variant + size classes through buttonClassName", () => {
         const primary = buttonClassName("primary", "md");
         expect(primary).toContain("bg-(--accent-2)");
-        expect(primary).toContain("rounded-full");
+        expect(primary).toContain("rounded-(--radius-pill)");
+        expect(primary).toContain("text-label-caps");
         const ghostSm = buttonClassName("ghost", "sm");
         expect(ghostSm).toContain("border-transparent");
-        expect(ghostSm).toContain("text-[10px]");
+        expect(ghostSm).toContain("px-3");
+        expect(ghostSm).toContain("text-(--text-muted)");
     });
 });

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -4,18 +4,19 @@ export type ButtonVariant = "primary" | "secondary" | "ghost";
 export type ButtonSize = "sm" | "md";
 
 const BASE =
-    "inline-flex items-center justify-center gap-1.5 rounded-full font-medium uppercase tracking-[0.2em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-not-allowed disabled:opacity-50";
+    "inline-flex items-center justify-center gap-1.5 rounded-(--radius-pill) text-label-caps font-medium uppercase transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) disabled:cursor-not-allowed disabled:opacity-50";
 
 const SIZES: Record<ButtonSize, string> = {
-    sm: "px-3 py-1.5 text-[10px]",
-    md: "px-4 py-2 text-xs",
+    sm: "px-3 py-1.5",
+    md: "px-4 py-2",
 };
 
 const VARIANTS: Record<ButtonVariant, string> = {
+    /* No on-accent role token exists yet; text-white is the interim contrast color. */
     primary: "border border-(--accent-2) bg-(--accent-2) text-white hover:bg-(--accent-2)/90",
     secondary:
-        "border border-(--card-stroke) bg-(--card-70) text-foreground hover:border-(--ink-muted)",
-    ghost: "border border-transparent text-(--ink-muted) hover:text-foreground hover:bg-(--card-80)",
+        "border border-(--border) bg-(--card-70) text-(--text-primary) hover:border-(--card-stroke-active)",
+    ghost: "border border-transparent text-(--text-muted) hover:text-(--text-primary) hover:bg-(--card-80)",
 };
 
 /**

--- a/src/components/shared/FilterPills.tsx
+++ b/src/components/shared/FilterPills.tsx
@@ -23,10 +23,10 @@ type FilterPillsProps<TId extends string = string> = {
 
 const ACTIVE = "border-(--accent) bg-(--accent)/15 text-(--accent)";
 const INACTIVE =
-    "border-(--card-stroke) bg-(--card-80) text-(--ink-muted) hover:border-(--accent)/40 hover:text-foreground";
+    "border-(--border) bg-(--card-80) text-(--text-muted) hover:border-(--accent)/40 hover:text-(--text-primary)";
 
 const PILL =
-    "inline-flex items-center gap-1.5 rounded-(--radius-pill) border px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.15em] transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--accent)";
+    "inline-flex items-center gap-1.5 rounded-(--radius-pill) border px-3 py-1.5 text-label-caps font-medium uppercase transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--accent)";
 
 /**
  * Segmented selection primitive (framework A3).
@@ -55,7 +55,7 @@ export function FilterPills<TId extends string = string>({
             data-testid={testId}
         >
             {leadingLabel ? (
-                <span className="text-xs uppercase tracking-[0.25em] text-(--ink-muted)">
+                <span className="text-label-caps uppercase text-(--text-muted)">
                     {leadingLabel}
                 </span>
             ) : null}

--- a/src/components/shared/ModeTabs.tsx
+++ b/src/components/shared/ModeTabs.tsx
@@ -18,14 +18,14 @@ type ModeTabsProps<TId extends string = string> = {
 };
 
 const CONTAINER =
-    "flex items-center gap-1 overflow-x-auto whitespace-nowrap border-b border-(--card-stroke) px-1 scrollbar-hide";
+    "flex items-center gap-1 overflow-x-auto whitespace-nowrap border-b border-(--border) px-1 scrollbar-hide";
 
 const TAB_BASE =
-    "-mb-px flex items-center gap-1.5 border-b-2 px-3.5 py-3 text-[10px] uppercase tracking-[0.18em] transition-all";
+    "-mb-px flex items-center gap-1.5 border-b-2 px-3.5 py-3 text-label-caps uppercase transition-all";
 
-const TAB_ACTIVE = "border-(--accent) text-foreground font-semibold";
+const TAB_ACTIVE = "border-(--accent) text-(--text-primary) font-semibold";
 const TAB_INACTIVE =
-    "border-transparent text-(--ink-muted) hover:border-(--card-stroke) hover:text-foreground";
+    "border-transparent text-(--text-muted) hover:border-(--border) hover:text-(--text-primary)";
 
 /**
  * Shared route-tab strip primitive (framework A2).

--- a/src/lib/design/__tests__/card.test.ts
+++ b/src/lib/design/__tests__/card.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+
+import { CARD_SURFACE, cardClassName } from "../card";
+
+describe("card primitive (framework C4)", () => {
+    it("uses only V1 tokens for the card shell", () => {
+        expect(CARD_SURFACE).toContain("rounded-(--radius-lg)");
+        expect(CARD_SURFACE).toContain("border-(--border)");
+        expect(CARD_SURFACE).toContain("bg-(--surface)");
+        expect(CARD_SURFACE).toContain("shadow-(--elevation-card)");
+        // Legacy bright stroke must not creep back in (CHAOS-2067).
+        expect(CARD_SURFACE).not.toContain("card-stroke)");
+    });
+
+    it("composes call-site classes after the shell", () => {
+        expect(cardClassName("p-4")).toBe(`${CARD_SURFACE} p-4`);
+        expect(cardClassName()).toBe(CARD_SURFACE);
+    });
+});

--- a/src/lib/design/card.ts
+++ b/src/lib/design/card.ts
@@ -1,0 +1,15 @@
+/**
+ * Canonical card surface (framework C4) — the one sanctioned card treatment:
+ * surface fill, hairline `--border` stroke, `--radius-lg`, `--elevation-card`.
+ *
+ * Compose with layout/padding utilities at the call site (`p-4`,
+ * `p-(--space-card)`, …). Interactive emphasis (hover/active) should move the
+ * stroke to `--card-stroke-active`, never to a brighter static border
+ * (CHAOS-2067).
+ */
+export const CARD_SURFACE =
+    "rounded-(--radius-lg) border border-(--border) bg-(--surface) shadow-(--elevation-card)";
+
+export function cardClassName(className = ""): string {
+    return `${CARD_SURFACE} ${className}`.trim();
+}


### PR DESCRIPTION
## CHAOS-2109 — V3: AreaSignalCard / AreaOverview to the Penpot Area Card + J9 contract

### What changed
- **AreaSignalCard**: canonical C4 card shell via `cardClassName()` (src/lib/design/card.ts — second production consumer), severity-tinted **accent tab** (new `AREA_STATE_TAB` map in severityTokens, hero = `--accent`), caps labels → `text-label-caps`, ink → role text tokens (`--text-primary/-secondary/-muted`), rest borders → `--border` with `--card-stroke-active` hover only (CHAOS-2067 discipline). Demoted R4 cards and unavailable cards stay tab-free (visually secondary / honest-empty).
- **AreaOverview**: header **count badge** derived from the resolved signals — `N need attention` (amber) when critical+high exist, else neutral `N signals`; omitted when no real-data signal. Derivation-only, no fetched/fabricated number. J9 hero/grid/empty-tier contract (CHAOS-2082) structurally unchanged — all 7 existing contract tests pass unmodified.
- Tests: +5 (count-badge derivation ×3, accent-tab presence/absence ×2).

### J9 contract: wired vs gaps
- Wired: severity-sorted hero+grid, DataState empty tier, count badge (new), accent tab (new), question line (existing `description` slot, restyled).
- **Deferred — destination chips**: the Penpot Destination Chip primitive is CHAOS-2111's scope (parallel PR); the card itself remains the single destination link. Chips can be slotted in when 2111 lands.
- **Deferred — Penpot before/after render**: no Penpot export in this run; visual-baseline comparison lands with CHAOS-2113 (V7), same as V1/V2 precedent.

### Honest visual deltas
- Cards gain a 4px severity accent strip at top (hero: accent color).
- Radius 24/16 mix → `--radius-lg` 16 (emphasized was rounded-3xl); demoted → `--radius-md`.
- Hero loses `ring-(--accent)/10` + accent-tinted border in favor of canonical shell + accent tab; gradient now `--surface-raised`→`--surface`.
- Rest borders dimmer in dark mode (`--border` vs old `--card-stroke`); hover brightens via `--card-stroke-active`.
- Caps labels converge on 11px/0.08em (`text-label-caps`).

### Gates
format ✓ · quality (tsc+eslint) ✓ · unit **2014/2014** ✓ · design-lint **326 errors = main baseline, 0 in touched files** ✓ · Playwright nav-reachability **7/7** ✓

Closes CHAOS-2109