### PR TITLE
fix(lens): Evidence/Investigation surfaces follow the Lens control (CHAOS-2249)

### DIFF
--- a/src/components/charts/InvestigationPanel.tsx
+++ b/src/components/charts/InvestigationPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useActiveRole } from "@/components/RoleSelector";
+import { useActiveRole } from "@/lib/lensContext.client";
 import { getRoleConfig } from "@/lib/roleContext";
 import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
 import type { QuadrantPoint, QuadrantResponse } from "@/lib/types";

--- a/src/components/evidence/EvidenceContext.tsx
+++ b/src/components/evidence/EvidenceContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActiveRole } from "@/components/RoleSelector";
+import { useActiveRole } from "@/lib/lensContext.client";
 import { getRoleConfig } from "@/lib/roleContext";
 
 type EvidenceData = {

--- a/src/lib/__tests__/lensContext.client.test.tsx
+++ b/src/lib/__tests__/lensContext.client.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { renderHook } from "@testing-library/react";
+
+import { useActiveLens, useActiveRole } from "../lensContext.client";
+
+let search = "";
+
+vi.mock("next/navigation", () => ({
+    useSearchParams: () => new URLSearchParams(search),
+}));
+
+describe("useActiveRole (lens-aware, CHAOS-2249)", () => {
+    beforeEach(() => {
+        search = "";
+    });
+
+    it("defaults to the default role when no lens or role param is set", () => {
+        const { result } = renderHook(() => useActiveRole());
+        expect(result.current).toBe("ic");
+    });
+
+    it("follows the lens= param (the Lens control's canonical param)", () => {
+        search = "lens=pm";
+        const { result } = renderHook(() => useActiveRole());
+        expect(result.current).toBe("pm");
+    });
+
+    it("still honours legacy role= as an alias", () => {
+        search = "role=em";
+        const { result } = renderHook(() => useActiveRole());
+        expect(result.current).toBe("em");
+    });
+
+    it("prefers lens= over a stale legacy role=", () => {
+        search = "lens=leadership&role=ic";
+        const { result } = renderHook(() => useActiveRole());
+        expect(result.current).toBe("leadership");
+    });
+
+    it("maps the neutral lens to the default role", () => {
+        search = "lens=neutral";
+        const { result } = renderHook(() => useActiveRole());
+        expect(result.current).toBe("ic");
+    });
+});
+
+describe("useActiveLens", () => {
+    it("returns neutral when nothing is set", () => {
+        search = "";
+        const { result } = renderHook(() => useActiveLens());
+        expect(result.current).toBe("neutral");
+    });
+
+    it("reads the lens param", () => {
+        search = "lens=em";
+        const { result } = renderHook(() => useActiveLens());
+        expect(result.current).toBe("em");
+    });
+});

--- a/src/lib/lensContext.client.ts
+++ b/src/lib/lensContext.client.ts
@@ -9,11 +9,25 @@
  */
 import { useSearchParams } from "next/navigation";
 
-import { getLensFromSearchParams } from "./lensContext";
-import type { LensId } from "./lensContext";
+import { DEFAULT_ROLE, getLensFromSearchParams } from "./lensContext";
+import type { LensId, RoleType } from "./lensContext";
 
 /** Hook — returns the active lens ID, defaulting to "neutral". Client-only. */
 export function useActiveLens(): LensId {
     const searchParams = useSearchParams();
     return getLensFromSearchParams(searchParams) ?? "neutral";
+}
+
+/**
+ * Hook — the active role implied by the Lens control (CHAOS-2249).
+ *
+ * The Lens control writes `lens=` to the URL and deletes `role=`, so
+ * role-shaped consumers (evidence rail, investigation panel) must read the
+ * lens first and treat `role=` only as a legacy alias — otherwise switching
+ * the lens silently changes nothing on those surfaces. The neutral lens maps
+ * to the default role.
+ */
+export function useActiveRole(): RoleType {
+    const lens = useActiveLens();
+    return lens === "neutral" ? DEFAULT_ROLE : lens;
 }


### PR DESCRIPTION
## Problem
LensSelector writes `lens=` to the URL and deletes `role=`, but EvidenceContext and InvestigationPanel read only `role=` — so switching IC/EM/PM/Leadership/Default on the Lens control silently changed nothing on those surfaces.

## Fix (wiring only)
- `useActiveRole` is now a lens-aware reader in `src/lib/lensContext.client.ts`: `lens=` first, `role=` accepted as legacy alias, neutral lens maps to the default role (`ic`).
- `EvidenceContext` and `InvestigationPanel` import it from there instead of `@/components/RoleSelector` (whose role=-only hook caused the mismatch; that file is otherwise untouched).
- 7 hook behavior tests added.

**Zero styling changes** — diff contains no className edits. Extracted from the rejected chaos-2111 styling branch per CHAOS-2249; only the behavior fix is ported.

## Gates
- format / quality (tsc) / unit: ✅ 2014/2014 (216 files)
- Playwright: cognitive-load.spec.ts 8/8 ✅, chord-chart.spec.ts ✅ (17 passed, 2 skipped pre-existing)

Closes CHAOS-2249