### PR TITLE
fix(admin/sync): org-wide toggle + preserve options on edit + create revalidation (CHAOS-2251)

### DIFF
--- a/src/components/admin/sync/SyncConfigForm.test.tsx
+++ b/src/components/admin/sync/SyncConfigForm.test.tsx
@@ -275,7 +275,10 @@ describe("SyncConfigForm", () => {
                     schedule_cron: null,
                     timezone: null,
                     initial_sync_depth: 30,
-                    sync_options: { owner: "glorg", gitlab_url: "https://gitlab.example.com" },
+                    sync_options: {
+                        owner: "glorg",
+                        gitlab_url: "https://gitlab.example.com",
+                    },
                 });
             });
         });
@@ -319,7 +322,7 @@ describe("SyncConfigForm", () => {
             expect(screen.getByLabelText("Owner / Organization")).toHaveValue("existingorg");
         });
 
-        it("sends sync_options on update in edit mode", async () => {
+        it("preserves existing sync_options on update in edit mode", async () => {
             mockUpdateSyncConfig.mockResolvedValue(undefined);
             const initialData: SyncConfig = {
                 id: "cfg-1",
@@ -355,7 +358,7 @@ describe("SyncConfigForm", () => {
                     schedule_cron: null,
                     timezone: null,
                     initial_sync_depth: 30,
-                    sync_options: { owner: "neworg" },
+                    sync_options: { owner: "neworg", repo: "oldrepo" },
                 });
             });
         });
@@ -393,6 +396,95 @@ describe("SyncConfigForm", () => {
             render(<SyncConfigForm credentials={mockCredentials} />);
 
             expect(screen.getByText("Manual only (no schedule)")).toBeInTheDocument();
+        });
+
+        it("org-wide toggle uses createSyncConfig with search and not batch", async () => {
+            mockCreateSyncConfig.mockResolvedValue(undefined);
+            renderWithToaster(<SyncConfigForm credentials={mockCredentials} />);
+
+            await userEvent.type(screen.getByLabelText("Configuration Name"), "Org Sync");
+            await userEvent.selectOptions(screen.getByLabelText("Credential"), "cred-1");
+            await userEvent.type(screen.getByLabelText("Owner / Organization"), "myorg");
+            await userEvent.click(
+                screen.getByLabelText("Sync all repositories in this organization"),
+            );
+            await userEvent.click(screen.getByRole("button", { name: "Create Configuration" }));
+
+            await waitFor(() => {
+                expect(mockCreateSyncConfig).toHaveBeenCalledWith({
+                    name: "Org Sync",
+                    provider: "github",
+                    credential_id: "cred-1",
+                    sync_targets: [],
+                    schedule_cron: null,
+                    timezone: null,
+                    initial_sync_depth: 30,
+                    sync_options: { owner: "myorg", search: "myorg/*" },
+                });
+            });
+            expect(mockBatchCreateSyncConfigs).not.toHaveBeenCalled();
+        });
+
+        it("hides repo selector when org-wide toggle is on", async () => {
+            render(<SyncConfigForm credentials={mockCredentials} />);
+
+            await userEvent.selectOptions(screen.getByLabelText("Credential"), "cred-1");
+            await userEvent.type(screen.getByLabelText("Owner / Organization"), "myorg");
+            expect(screen.getByText("Select Repositories")).toBeInTheDocument();
+
+            await userEvent.click(
+                screen.getByLabelText("Sync all repositories in this organization"),
+            );
+            expect(screen.queryByText("Select Repositories")).not.toBeInTheDocument();
+        });
+
+        it("selecting concrete repos still uses batchCreateSyncConfigs", async () => {
+            mockBatchCreateSyncConfigs.mockResolvedValue({ data: { count: 1 } });
+            mockListReposForCredential.mockResolvedValue({
+                data: {
+                    provider: "github",
+                    owner: "myorg",
+                    repos: [
+                        {
+                            name: "repo-a",
+                            full_name: "myorg/repo-a",
+                            description: null,
+                            is_private: false,
+                            is_archived: false,
+                            default_branch: "main",
+                            language: null,
+                            stargazers_count: null,
+                            forks_count: null,
+                            updated_at: null,
+                        },
+                    ],
+                    total: 1,
+                },
+            });
+            renderWithToaster(<SyncConfigForm credentials={mockCredentials} />);
+
+            await userEvent.type(screen.getByLabelText("Configuration Name"), "Repo Sync");
+            await userEvent.selectOptions(screen.getByLabelText("Credential"), "cred-1");
+            await userEvent.type(screen.getByLabelText("Owner / Organization"), "myorg");
+
+            const repoCheckbox = await screen.findByLabelText("repo-a");
+            await userEvent.click(repoCheckbox);
+            await userEvent.click(screen.getByRole("button", { name: "Create Configuration" }));
+
+            await waitFor(() => {
+                expect(mockBatchCreateSyncConfigs).toHaveBeenCalledWith({
+                    name: "Repo Sync",
+                    provider: "github",
+                    credential_id: "cred-1",
+                    sync_targets: [],
+                    schedule_cron: null,
+                    timezone: null,
+                    initial_sync_depth: 30,
+                    sync_options: { owner: "myorg" },
+                    repos: ["repo-a"],
+                });
+            });
+            expect(mockCreateSyncConfig).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -57,6 +57,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
     const [localCredentials, setLocalCredentials] = useState(credentials);
     const { features, minSyncIntervalHours, limits } = useAdminTier();
     const maxRepos = (limits?.licensed_repos as number | null | undefined) ?? undefined;
+    const [syncAllRepos, setSyncAllRepos] = useState(false);
 
     const {
         formData,
@@ -111,11 +112,12 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                     repos: [],
                     gitlab_url: "",
                 }));
+                setSyncAllRepos(false);
             } else {
                 handleBaseChange(e);
             }
         },
-        [handleBaseChange, setFormData],
+        [handleBaseChange, setFormData, setSyncAllRepos],
     );
 
     const handleTargetChange = useCallback(
@@ -131,13 +133,15 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
     );
 
     const buildSyncOptions = useCallback((): Record<string, unknown> => {
-        const opts: Record<string, unknown> = {};
+        const opts: Record<string, unknown> = {
+            ...(initialData?.sync_options ?? {}),
+        };
         if (formData.owner) opts.owner = formData.owner;
         if (formData.provider === "gitlab" && formData.gitlab_url) {
             opts.gitlab_url = formData.gitlab_url;
         }
         return opts;
-    }, [formData.owner, formData.provider, formData.gitlab_url]);
+    }, [initialData, formData.owner, formData.provider, formData.gitlab_url]);
 
     const handleSubmit = useCallback(
         (e: SyntheticEvent<HTMLFormElement>) => {
@@ -178,7 +182,27 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                             sync_options: syncOptions,
                         };
 
-                        if (formData.repos.length > 0) {
+                        if (syncAllRepos) {
+                            const orgSyncOptions = {
+                                ...syncOptions,
+                                owner: formData.owner,
+                                search: `${formData.owner}/*`,
+                            };
+                            result = await createSyncConfig({
+                                ...base,
+                                sync_options: orgSyncOptions,
+                            });
+                            if (result?.error) {
+                                toast.error(result.error);
+                            } else {
+                                toast.success("Config created");
+                                if (onSuccessAction) {
+                                    onSuccessAction();
+                                } else {
+                                    router.push("/admin/sync");
+                                }
+                            }
+                        } else if (formData.repos.length > 0) {
                             result = await batchCreateSyncConfigs({
                                 ...base,
                                 repos: formData.repos,
@@ -215,7 +239,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                 }
             });
         },
-        [initialData, formData, buildSyncOptions, onSuccessAction, router],
+        [initialData, formData, syncAllRepos, buildSyncOptions, onSuccessAction, router],
     );
 
     return (
@@ -369,7 +393,25 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                                 />
                             </div>
                         )}
-                        {!initialData && formData.credential_id && formData.owner ? (
+                        {!initialData && (
+                            <div className="flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    id="sync_all_repos"
+                                    name="sync_all_repos"
+                                    checked={syncAllRepos}
+                                    onChange={(e) => setSyncAllRepos(e.target.checked)}
+                                    className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
+                                />
+                                <label htmlFor="sync_all_repos" className="text-sm font-medium">
+                                    Sync all repositories in this organization
+                                </label>
+                            </div>
+                        )}
+                        {!initialData &&
+                        !syncAllRepos &&
+                        formData.credential_id &&
+                        formData.owner ? (
                             <div>
                                 <span className="mb-2 block text-sm font-medium text-(--ink-muted)">
                                     Select Repositories
@@ -483,7 +525,11 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                         value={formData.schedule_cron}
                         timezone={formData.timezone}
                         onChange={(cron, tz) =>
-                            setFormData((prev) => ({ ...prev, schedule_cron: cron, timezone: tz }))
+                            setFormData((prev) => ({
+                                ...prev,
+                                schedule_cron: cron,
+                                timezone: tz,
+                            }))
                         }
                         minIntervalHours={minSyncIntervalHours}
                     />

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -28,6 +28,7 @@ import {
     executeRetentionPolicy,
     listRetentionResourceTypes,
     getOrgEntitlements,
+    createSyncConfig,
 } from "../server";
 
 function mockSession() {
@@ -131,6 +132,50 @@ describe("admin/server credential actions", () => {
             const result = await deleteCredential("github", "default");
             expect(result.error).toBeUndefined();
             expect(revalidatePath).toHaveBeenCalledWith("/admin/integrations", "page");
+            fetchSpy.mockRestore();
+        });
+    });
+});
+
+describe("admin/server sync config actions", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.stubEnv("BACKEND_URL", "http://test-ops:8000");
+    });
+
+    describe("createSyncConfig", () => {
+        it("calls revalidatePath after successful creation", async () => {
+            mockSession();
+            const cfg = {
+                id: "sc-1",
+                name: "Nightly",
+                provider: "github",
+                credential_id: "cred-1",
+                sync_targets: ["git"],
+                sync_options: { owner: "myorg" },
+                is_active: true,
+                schedule_cron: null,
+                timezone: null,
+                last_sync_at: null,
+                last_sync_success: null,
+                last_sync_error: null,
+                created_at: "2025-01-01T00:00:00Z",
+                updated_at: "2025-01-01T00:00:00Z",
+                parent_id: null,
+            };
+            const fetchSpy = vi
+                .spyOn(global, "fetch")
+                .mockResolvedValue(new Response(JSON.stringify(cfg), { status: 200 }));
+
+            const result = await createSyncConfig({
+                name: "Nightly",
+                provider: "github",
+                credential_id: "cred-1",
+                sync_targets: ["git"],
+                sync_options: { owner: "myorg" },
+            });
+            expect(result.data).toBeDefined();
+            expect(revalidatePath).toHaveBeenCalledWith("/admin/sync");
             fetchSpy.mockRestore();
         });
     });

--- a/src/lib/admin/server/sync.ts
+++ b/src/lib/admin/server/sync.ts
@@ -26,7 +26,9 @@ export async function listSyncConfigs(): Promise<ActionResult<SyncConfig[]>> {
 export async function createSyncConfig(data: SyncConfigCreate): Promise<ActionResult<SyncConfig>> {
     return withErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
-        return adminApi.syncConfigs.create(data, token, orgId);
+        const result = await adminApi.syncConfigs.create(data, token, orgId);
+        revalidatePath("/admin/sync");
+        return result;
     });
 }
 


### PR DESCRIPTION
## Summary

Fixes three CHAOS-2251 sub-issues in the admin sync config UI (web half only — no backend changes).

### Issue 2 — org-wide sync toggle
- Adds an explicit checkbox **"Sync all repositories in this organization"** to `SyncConfigForm`, shown for `github`/`gitlab` in **create** mode alongside the owner field.
- When **checked**: calls `createSyncConfig` with `sync_options.owner = owner` and `sync_options.search = \`${owner}/*\`` (canonical org-wide contract) — does **not** call `batchCreateSyncConfigs`. The per-repo `RepoSelector` is hidden while the toggle is on.
- Explicit repo selection (`RepoSelector`, `repos.length > 0`) still uses `batchCreateSyncConfigs` as before.

### Issue 3 — edit data loss
- `buildSyncOptions()` now **merges** instead of replacing: starts from `{ ...(initialData?.sync_options ?? {}) }` then overlays the current `owner`/`gitlab_url`. Previously it returned only `{ owner }` (+`gitlab_url`), dropping `search`/`discover`/`schedule_cron`/`timezone`/`initial_sync_depth` on update.
- `SyncConfigUpdate` and `SyncConfigCreate` **already** include `schedule_cron`, `timezone`, `initial_sync_depth` top-level (sent on both create and update) — no `types.ts` change needed. Backend contract (CHAOS-2250) coordinated via lead.

### Issue 6 — "Sync Now" triggers the wrong/first config
- `createSyncConfig` now calls `revalidatePath('/admin/sync')` after a successful create (matching `batchCreateSyncConfigs`/`updateSyncConfig`/`deleteSyncConfig`/`triggerSync`). Root cause: a stale RSC list bound `SyncConfigCard`/`SyncNowButton` to an old config id. `SyncConfigCard` id binding is correct and untouched.

## Tests (included — no TEST-WAIVER needed)
- `SyncConfigForm.test.tsx`: org-wide toggle → `createSyncConfig` with `sync_options.search="owner/*"` (asserts batch NOT called); concrete repo selection still → `batchCreateSyncConfigs`; toggle hides RepoSelector; edit mode now **preserves** existing `sync_options` (`{ owner: "neworg", repo: "oldrepo" }`).
- `server.test.ts`: `createSyncConfig` calls `revalidatePath('/admin/sync')`.
- Verification: **vitest 49/49 pass**, `tsc --noEmit` clean, `eslint` clean.

SCREENSHOT-WAIVER: The new toggle is a client-side change but cannot be rendered against the live stack from this isolated worktree without disrupting shared infra. The shared docker `web` container serves main-branch code and the backend `api` is only reachable inside the docker network (`api:8000`, not host-exposed); a host dev server can't reach it, host `node_modules` are darwin-native (can't run in a linux container joined to the compose network), and swapping the shared compose `web` would break other team agents using this stack. The toggle's rendering and behavior are fully exercised by jsdom component tests (render, toggle on/off, hide RepoSelector, drive `createSyncConfig` with `search`).

Closes CHAOS-2251