### PR TITLE
feat(nav): hide Lens control until lens prioritization works across surfaces (CHAOS-2253)

### DIFF
--- a/src/components/navigation/GlobalContextBar.test.tsx
+++ b/src/components/navigation/GlobalContextBar.test.tsx
@@ -108,12 +108,11 @@ describe("GlobalContextBar", () => {
         expect(lastFilter().what.repos).toEqual([]);
     });
 
-    it("renders the Lens selector in the global context bar", () => {
+    it("does not render the Lens selector while it is hidden (CHAOS-2253)", () => {
         render(<GlobalContextBar filters={defaultMetricFilter} />);
 
-        expect(screen.getByTestId("lens-selector")).toBeInTheDocument();
-        // The bar has role=em in searchParams so the legacy alias is resolved.
-        expect(screen.getByText("Lens")).toBeInTheDocument();
+        expect(screen.queryByTestId("lens-selector")).not.toBeInTheDocument();
+        expect(screen.queryByText("Lens")).not.toBeInTheDocument();
     });
 
     it("preserves existing query params (role=em) when filter changes", () => {

--- a/src/components/navigation/GlobalContextBarClient.tsx
+++ b/src/components/navigation/GlobalContextBarClient.tsx
@@ -5,7 +5,6 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 
 import { toggleValue } from "@/components/filters/filterBarUtils";
-import { LensSelector } from "@/components/navigation/LensSelector";
 import { QuickFilterMenu } from "@/components/filters/sections/QuickFilterMenu";
 import { useFilterOptions } from "@/components/filters/useFilterOptions";
 import { encodeFilterParam } from "@/lib/filters/encode";
@@ -250,12 +249,8 @@ export function GlobalContextBarClient({ filters, origin, orgName }: GlobalConte
                     value={repoLabel}
                 />
 
-                {/* Lens separator — visually separates perspective from data filters */}
-                <span aria-hidden="true" className="mx-1 text-(--ink-muted)/40">
-                    |
-                </span>
-
-                <LensSelector />
+                {/* Lens control hidden until lens-driven prioritization works across
+                    surfaces (CHAOS-2253); lens=/role= URL params remain honored. */}
 
                 {origin ? (
                     <div className="ml-auto flex items-center gap-2 text-xs text-(--ink-muted)">

--- a/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
+++ b/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
@@ -381,8 +381,9 @@ describe("IA preservation invariant #8 — Lens present in global context bar", 
         "utf8",
     );
 
-    it("GlobalContextBarClient imports and renders LensSelector", () => {
-        expect(globalContextBarClientSource).toContain("LensSelector");
+    it("GlobalContextBarClient keeps LensSelector hidden until CHAOS-2253", () => {
+        expect(globalContextBarClientSource).not.toContain("<LensSelector");
+        expect(globalContextBarClientSource).toContain("CHAOS-2253");
     });
 
     it("LensSelector has a data-testid for test discoverability", () => {

--- a/tests/cognitive-load.spec.ts
+++ b/tests/cognitive-load.spec.ts
@@ -3,10 +3,10 @@ import { expect, test } from "@playwright/test";
 import { clickUntilUrl, waitForHydration } from "./helpers/nav";
 
 test.describe("IA rejection regressions", () => {
-    test("Cockpit exposes the Lens control", async ({ page }) => {
+    test("Cockpit does not expose the Lens control while hidden (CHAOS-2253)", async ({ page }) => {
         await page.goto("/dashboard");
 
-        await expect(page.getByRole("radiogroup", { name: "Lens" })).toBeVisible();
+        await expect(page.getByRole("radiogroup", { name: "Lens" })).not.toBeVisible();
     });
 
     test("Landscape does not show a selected Lens state", async ({ page }) => {


### PR DESCRIPTION
Removes the Lens pill row (IC/EM/PM/LEADERSHIP/DEFAULT) from the global context bar. It rendered on every page but only three surfaces consume lens state (Cockpit Key Shifts ordering, InvestigationPanel ordering/CTA, EvidenceContext framing) — everywhere else it was a no-op control.

- LensSelector.tsx stays in-tree; `lens=`/`role=` URL params remain fully honored by the wired surfaces (deep links unaffected).
- Re-enable criteria tracked in CHAOS-2253.
- Tests inverted to pin the hidden state (unit, IA source-invariant, Playwright cognitive-load).

Gates: format/quality/unit ✓ (rate-limit.test.ts failures are local REDIS_URL env contamination — passes with clean env; root cause noted for CHAOS-2231), Playwright cognitive-load 8/8 ✓.