### PR TITLE
fix(admin/sync): round-trip saved settings on edit (schedule mapping) (CHAOS-2260)

### DIFF
--- a/src/components/admin/sync/SyncConfigForm.test.tsx
+++ b/src/components/admin/sync/SyncConfigForm.test.tsx
@@ -398,6 +398,91 @@ describe("SyncConfigForm", () => {
             expect(screen.getByText("Manual only (no schedule)")).toBeInTheDocument();
         });
 
+        it("round-trips preset schedule_cron + timezone from sync_options in edit mode", () => {
+            mockUseAdminTier.mockReturnValue({
+                tier: "team",
+                features: { scheduled_jobs: true },
+                limits: {},
+                minSyncIntervalHours: 0.25,
+            });
+            const initialData: SyncConfig = {
+                id: "cfg-sched",
+                name: "Scheduled Config",
+                provider: "github",
+                credential_id: "cred-1",
+                sync_targets: ["git"],
+                sync_options: {
+                    owner: "full-chaos",
+                    search: "full-chaos/*",
+                    schedule_cron: "0 */6 * * *",
+                    timezone: "America/New_York",
+                    initial_sync_depth: 90,
+                },
+                is_active: true,
+                schedule_cron: null,
+                timezone: null,
+                initial_sync_depth: null,
+                last_sync_at: null,
+                last_sync_success: null,
+                last_sync_error: null,
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+                parent_id: null,
+            };
+
+            render(<SyncConfigForm initialData={initialData} credentials={mockCredentials} />);
+
+            // Schedule radio reflects the saved cron — NOT 'Manual only' (the bug)
+            expect(screen.getByRole("radio", { name: "Every 6 hours" })).toBeChecked();
+            expect(
+                screen.getByRole("radio", { name: "Manual only (no schedule)" }),
+            ).not.toBeChecked();
+            // Timezone round-trips from sync_options
+            expect(screen.getByLabelText("Timezone")).toHaveValue("America/New_York");
+            // Other fields still round-trip
+            expect(screen.getByLabelText("Owner / Organization")).toHaveValue("full-chaos");
+            expect(screen.getByLabelText("Git Data (Commits, Branches)")).toBeChecked();
+        });
+
+        it("falls back to custom cron radio for non-preset schedule_cron in sync_options", () => {
+            mockUseAdminTier.mockReturnValue({
+                tier: "team",
+                features: { scheduled_jobs: true },
+                limits: {},
+                minSyncIntervalHours: 0.25,
+            });
+            const initialData: SyncConfig = {
+                id: "cfg-custom",
+                name: "Custom Schedule Config",
+                provider: "github",
+                credential_id: "cred-1",
+                sync_targets: ["git"],
+                sync_options: {
+                    owner: "full-chaos",
+                    schedule_cron: "15 3 * * *",
+                    timezone: "UTC",
+                },
+                is_active: true,
+                schedule_cron: null,
+                timezone: null,
+                initial_sync_depth: null,
+                last_sync_at: null,
+                last_sync_success: null,
+                last_sync_error: null,
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+                parent_id: null,
+            };
+
+            render(<SyncConfigForm initialData={initialData} credentials={mockCredentials} />);
+
+            expect(screen.getByRole("radio", { name: "Custom cron expression" })).toBeChecked();
+            expect(
+                screen.getByRole("radio", { name: "Manual only (no schedule)" }),
+            ).not.toBeChecked();
+            expect(screen.getByLabelText("Custom cron")).toHaveValue("15 3 * * *");
+        });
+
         it("org-wide toggle uses createSyncConfig with search and not batch", async () => {
             mockCreateSyncConfig.mockResolvedValue(undefined);
             renderWithToaster(<SyncConfigForm credentials={mockCredentials} />);

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -69,9 +69,17 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
         credential_id: initialData?.credential_id || "",
         sync_targets: initialData?.sync_targets || [],
         is_active: initialData?.is_active ?? true,
-        schedule_cron: initialData?.schedule_cron ?? null,
-        timezone: initialData?.timezone ?? null,
-        initial_sync_depth: (initialData?.initial_sync_depth ?? 30) as number | null,
+        schedule_cron:
+            initialData?.schedule_cron ??
+            (initialData?.sync_options?.schedule_cron as string | null | undefined) ??
+            null,
+        timezone:
+            initialData?.timezone ??
+            (initialData?.sync_options?.timezone as string | null | undefined) ??
+            null,
+        initial_sync_depth: (initialData?.initial_sync_depth ??
+            (initialData?.sync_options?.initial_sync_depth as number | null | undefined) ??
+            30) as number | null,
         owner: (initialData?.sync_options?.owner as string) || "",
         repos: [] as string[],
         gitlab_url: (initialData?.sync_options?.gitlab_url as string) || "",


### PR DESCRIPTION
## Summary

The sync-config **edit** form did not round-trip the saved schedule. For config `765c0423` ('chaos-all', github, owner `full-chaos`) the screenshot showed **"Enable automatic sync schedule" checked** while the Schedule radio showed **"Manual only (no schedule)"** — the saved cron was not mapped back to its preset radio.

### Root cause
`SyncConfigForm` initialized `formData.schedule_cron`/`timezone` from **top-level** `initialData.schedule_cron` / `initialData.timezone`, but the backend persists these inside **`sync_options`**. So `formData.schedule_cron` was `null` → `SchedulePicker.getMode(null)` returned `"manual"`. `SchedulePicker` already maps known crons → presets and falls back to "Custom cron"; it was simply never handed the value.

### Fix (`SyncConfigForm.tsx` initialData derivation)
Read schedule fields from `sync_options` as a fallback (top-level first, then `sync_options`, then default):
- `schedule_cron`: `initialData?.schedule_cron ?? initialData?.sync_options?.schedule_cron ?? null`
- `timezone`: `initialData?.timezone ?? initialData?.sync_options?.timezone ?? null`
- `initial_sync_depth`: `initialData?.initial_sync_depth ?? initialData?.sync_options?.initial_sync_depth ?? 30`

This stays consistent with the CHAOS-2251 `buildSyncOptions` MERGE, so Update preserves these fields too.

### Fields audited for round-trip on load
- **schedule_cron** — was broken (read from top-level only); now reads from `sync_options`. ✅
- **timezone** — was broken (same cause); now reads from `sync_options`. ✅
- **initial_sync_depth** — worked from top-level; now also falls back to `sync_options` for robustness. ✅
- **sync_targets** — already round-tripped (top-level). ✅
- **owner / search** — owner reads from `sync_options.owner`; `search` preserved via the CHAOS-2251 merge. ✅
- name / provider / credential — already fine. ✅

Known crons map to their preset radio (Every hour / Every 6 hours / Daily at midnight / Weekly on Monday); unknown crons fall back to **Custom cron expression** showing the cron; **Manual only** only when there is genuinely no schedule.

## Tests (included — no TEST-WAIVER needed)
- `SyncConfigForm.test.tsx`: scheduled config with `schedule_cron`/`timezone` in `sync_options` pre-populates the **"Every 6 hours"** radio (NOT "Manual only"), timezone select = `America/New_York`, owner + sync_targets round-trip.
- Non-preset cron (`15 3 * * *`) in `sync_options` selects **"Custom cron expression"** and fills the custom input.
- Verification: **vitest 24/24 pass**, `tsc --noEmit` clean, `eslint` clean.

SCREENSHOT-WAIVER: Same constraint as #668 — this isolated worktree cannot be rendered against the live stack without disrupting shared infra. The shared docker `web` container serves main-branch code and the backend `api` is only reachable inside the docker network (`api:8000`, not host-exposed); a host dev server can't reach it, host `node_modules` are darwin-native (can't run in a network-joined linux container), and swapping the shared compose `web` would break other team agents on this stack. The schedule round-trip is fully exercised by the two new jsdom component tests above (assert the correct radio/cron/timezone, not "Manual only").

Closes CHAOS-2260