### PR TITLE
fix(filters): lift context/filter bar stacking contexts so menus paint over siblings (CHAOS-2261)

### DIFF
--- a/src/components/filters/FilterBarClient.tsx
+++ b/src/components/filters/FilterBarClient.tsx
@@ -66,7 +66,10 @@ export function FilterBarClient({
             ref={barRef}
             data-testid="filter-bar"
             data-view={view ?? "default"}
-            className={`w-full rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4 backdrop-blur-sm transition-all duration-300 ease-in-out ${condensed ? "py-2" : "py-4"}`}
+            // relative z-20 keeps this bar's stacking context (created by
+            // backdrop-blur) above page content but below the global context
+            // bar (z-30), so each bar's open menus paint over what follows it.
+            className={`relative z-20 w-full rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4 backdrop-blur-sm transition-all duration-300 ease-in-out ${condensed ? "py-2" : "py-4"}`}
         >
             <div className="flex w-full flex-col gap-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/components/navigation/GlobalContextBarClient.tsx
+++ b/src/components/navigation/GlobalContextBarClient.tsx
@@ -162,11 +162,14 @@ export function GlobalContextBarClient({ filters, origin, orgName }: GlobalConte
     const isOrgScope = filters.scope.level === "org";
 
     return (
+        // backdrop-blur creates a stacking context, so the menus' inner z-50
+        // cannot escape it — the bar itself must sit above the FilterBar's
+        // sibling stacking context (relative z-20) for open menus to paint over it.
         <section
             ref={barRef}
             aria-label="Global context"
             data-testid="global-context-bar"
-            className="rounded-2xl border border-(--card-stroke) bg-(--card-90)/80 px-4 py-3 text-xs backdrop-blur-sm"
+            className="relative z-30 rounded-2xl border border-(--card-stroke) bg-(--card-90)/80 px-4 py-3 text-xs backdrop-blur-sm"
         >
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
Fixes CHAOS-2261

## Problem

The global context bar's TEAM/REPO dropdown panels render **behind** the page FilterBar (Developer/Work) below it — only the first row of the menu is visible.

## Root cause

Both `GlobalContextBarClient` and `FilterBarClient` use `backdrop-blur-sm`; `backdrop-filter` creates a stacking context. `QuickFilterMenu`'s `z-50` panel can only compete *within* its bar's context — between the two sibling contexts (both `z-index: auto`) paint order is DOM order, so the later FilterBar wins.

## Fix

- `GlobalContextBarClient`: `relative z-30` on the bar section
- `FilterBarClient`: `relative z-20` — keeps its own menus above page content while staying below the global bar

## Verification

Visually verified in the running dark-theme app (Playwright, /landscape): Team dropdown now paints fully over the FilterBar and tab strip. No styling/sizing changes — z-index only.

Gates: prettier ✓, format ✓, tsc ✓. Unit: 3 pre-existing failures in `rate-limit.test.ts` reproduce on clean origin/main (env-sensitive, unrelated).