### PR TITLE
fix(admin/sync): render — for null started_at instead of epoch date (12/31/1969)

### DIFF
--- a/src/components/admin/sync/SyncJobHistory.test.tsx
+++ b/src/components/admin/sync/SyncJobHistory.test.tsx
@@ -62,6 +62,23 @@ describe("SyncJobHistory", () => {
         expect(screen.getByText("Showing 1-10 of 12")).toBeInTheDocument();
     });
 
+    it("renders an em dash for pending jobs with null started_at, not the epoch date", () => {
+        const pendingJob: SyncJob = {
+            id: "job-pending",
+            config_id: "cfg-1",
+            status: "pending",
+            started_at: null,
+            completed_at: null,
+            duration_seconds: null,
+            items_synced: 0,
+        };
+        render(<SyncJobHistory jobs={[pendingJob]} />);
+
+        expect(screen.getByText("—")).toBeInTheDocument();
+        // new Date(null) coerces to epoch 0; the 1969/1970 date must never render.
+        expect(screen.queryByText(/19[67]\d/)).not.toBeInTheDocument();
+    });
+
     it("shows empty state when there are no jobs", () => {
         render(<SyncJobHistory jobs={[]} />);
 

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -79,7 +79,7 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                     {paginatedJobs.map((job) => {
                         const duration = job.duration_seconds
                             ? `${Math.round(job.duration_seconds)}s`
-                            : job.completed_at
+                            : job.completed_at && job.started_at
                               ? Math.round(
                                     (new Date(job.completed_at).getTime() -
                                         new Date(job.started_at).getTime()) /
@@ -93,7 +93,9 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                                     <SyncStatusBadge status={getBadgeStatus(job.status)} />
                                 </td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
-                                    {new Date(job.started_at).toLocaleString()}
+                                    {job.started_at
+                                        ? new Date(job.started_at).toLocaleString()
+                                        : "—"}
                                 </td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-(--ink-muted)">
                                     {duration}

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -132,7 +132,7 @@ export interface SyncJob {
     id: string;
     config_id: string;
     status: "pending" | "running" | "success" | "failed";
-    started_at: string;
+    started_at: string | null;
     completed_at: string | null;
     duration_seconds: number | null;
     items_synced: number;


### PR DESCRIPTION
## Problem
Admin sync detail page shows **Started At: 12/31/1969, 4:00:00 PM** for PENDING runs.

## Root cause
PENDING JobRuns are persisted at Sync Now trigger time (CHAOS-2255) with `started_at = NULL`. `SyncJobHistory.tsx` called `new Date(job.started_at)` unguarded, and `new Date(null)` silently coerces to epoch 0 (not Invalid Date). The `SyncJob` type also wrongly declared `started_at: string` while the backend model (`JobRun.started_at`) is nullable.

## Fix
- `SyncJob.started_at` → `string | null`
- Render `—` when null
- Guard the duration fallback calculation (`completed_at && started_at`)

## Verification
- format/quality/unit gates pass (2020 unit tests, tsc clean — no other consumers needed guards)
- No Playwright spec asserts on this table (checked `tests/admin-sync.spec.ts`); mock data remains type-compatible

Companion ops PR restores the `pending_run_id` kwarg on `run_sync_config` that left these runs orphaned in PENDING.