### PR TITLE
fix(admin/sync): add group-level delete for repo-group sync configs (CHAOS-2273)

### DIFF
--- a/src/components/admin/sync/SyncConfigGroup.test.tsx
+++ b/src/components/admin/sync/SyncConfigGroup.test.tsx
@@ -1,0 +1,154 @@
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithToaster, screen, userEvent, waitFor } from "@/test/utils";
+import type { SyncConfig } from "@/lib/admin/types";
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ refresh: mockRefresh }),
+    default: { useRouter: () => ({ refresh: mockRefresh }) },
+}));
+
+const mockDeleteSyncConfig = vi.fn();
+const mockTriggerSync = vi.fn();
+const mockToggleSyncActive = vi.fn();
+vi.mock("@/lib/admin/server", () => ({
+    deleteSyncConfig: (...args: unknown[]) => mockDeleteSyncConfig(...args),
+    triggerSync: (...args: unknown[]) => mockTriggerSync(...args),
+    toggleSyncActive: (...args: unknown[]) => mockToggleSyncActive(...args),
+}));
+
+vi.mock("next/link", () => ({
+    default: ({
+        children,
+        href,
+        ...props
+    }: {
+        children: ReactNode;
+        href: string;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+}));
+
+import { SyncConfigGroup } from "./SyncConfigGroup";
+
+function makeConfig(overrides: Partial<SyncConfig>): SyncConfig {
+    return {
+        id: "cfg-1",
+        name: "chaos",
+        provider: "github",
+        credential_id: "cred-1",
+        sync_targets: ["git"],
+        sync_options: { owner: "full-chaos" },
+        is_active: true,
+        schedule_cron: null,
+        timezone: null,
+        last_sync_at: null,
+        last_sync_success: null,
+        last_sync_error: null,
+        created_at: "2024-01-01",
+        updated_at: "2024-01-01",
+        parent_id: null,
+        ...overrides,
+    };
+}
+
+const parent = makeConfig({ id: "parent-1", name: "chaos" });
+const childConfigs = [
+    makeConfig({ id: "child-1", name: "chaos/repo-a", parent_id: "parent-1" }),
+    makeConfig({ id: "child-2", name: "chaos/repo-b", parent_id: "parent-1" }),
+];
+
+describe("SyncConfigGroup", () => {
+    afterEach(() => {
+        mockRefresh.mockReset();
+        mockDeleteSyncConfig.mockReset();
+        mockTriggerSync.mockReset();
+        mockToggleSyncActive.mockReset();
+    });
+
+    it("renders group header with a delete control", () => {
+        renderWithToaster(<SyncConfigGroup parent={parent} childConfigs={childConfigs} />);
+
+        expect(screen.getByText("chaos")).toBeInTheDocument();
+        expect(screen.getByText("2 repos")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    });
+
+    it("clicking delete shows two-step confirm with group + child count copy", async () => {
+        renderWithToaster(<SyncConfigGroup parent={parent} childConfigs={childConfigs} />);
+
+        await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+        expect(screen.getByText("Delete group and 2 repo configs?")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Yes, Delete" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+        expect(mockDeleteSyncConfig).not.toHaveBeenCalled();
+    });
+
+    it("cancel dismisses the confirm without deleting", async () => {
+        renderWithToaster(<SyncConfigGroup parent={parent} childConfigs={childConfigs} />);
+
+        await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+        await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+        expect(screen.queryByText("Delete group and 2 repo configs?")).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+        expect(mockDeleteSyncConfig).not.toHaveBeenCalled();
+    });
+
+    it("confirming calls deleteSyncConfig with the parent id and refreshes", async () => {
+        mockDeleteSyncConfig.mockResolvedValue({});
+        renderWithToaster(<SyncConfigGroup parent={parent} childConfigs={childConfigs} />);
+
+        await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+        await userEvent.click(screen.getByRole("button", { name: "Yes, Delete" }));
+
+        await waitFor(() => {
+            expect(mockDeleteSyncConfig).toHaveBeenCalledWith("parent-1");
+            expect(screen.getByText("Group deleted")).toBeInTheDocument();
+            expect(mockRefresh).toHaveBeenCalled();
+        });
+    });
+
+    it("failed delete shows error toast and does not refresh", async () => {
+        mockDeleteSyncConfig.mockResolvedValue({ error: "Delete failed upstream" });
+        renderWithToaster(<SyncConfigGroup parent={parent} childConfigs={childConfigs} />);
+
+        await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+        await userEvent.click(screen.getByRole("button", { name: "Yes, Delete" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Delete failed upstream")).toBeInTheDocument();
+        });
+        expect(mockRefresh).not.toHaveBeenCalled();
+        // Confirm collapses back to the initial delete control
+        expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    });
+
+    it("delete click does not toggle expansion; expand toggle still works", async () => {
+        renderWithToaster(<SyncConfigGroup parent={parent} childConfigs={childConfigs} />);
+
+        await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+        expect(screen.queryByText("chaos/repo-a")).not.toBeInTheDocument();
+        await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+        const expandToggle = screen.getByRole("button", { expanded: false });
+        await userEvent.click(expandToggle);
+        expect(screen.getByText("chaos/repo-a")).toBeInTheDocument();
+        expect(screen.getByText("chaos/repo-b")).toBeInTheDocument();
+        expect(expandToggle).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it("uses singular copy for a single repo config", async () => {
+        renderWithToaster(<SyncConfigGroup parent={parent} childConfigs={[childConfigs[0]]} />);
+
+        await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+        expect(screen.getByText("Delete group and 1 repo config?")).toBeInTheDocument();
+    });
+});

--- a/src/components/admin/sync/SyncConfigGroup.tsx
+++ b/src/components/admin/sync/SyncConfigGroup.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
 import { SyncConfig } from "@/lib/admin/types";
+import { deleteSyncConfig } from "@/lib/admin/server";
 import { SyncConfigCard } from "./SyncConfigCard";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 
@@ -11,7 +14,10 @@ type SyncConfigGroupProps = {
 };
 
 export function SyncConfigGroup({ parent, childConfigs }: SyncConfigGroupProps) {
+    const router = useRouter();
     const [expanded, setExpanded] = useState(false);
+    const [isPending, startTransition] = useTransition();
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
     const successCount = childConfigs.filter((c) => c.last_sync_success === true).length;
     const failedCount = childConfigs.filter((c) => c.last_sync_success === false).length;
@@ -19,15 +25,37 @@ export function SyncConfigGroup({ parent, childConfigs }: SyncConfigGroupProps) 
 
     const groupStatus = failedCount > 0 ? "failed" : successCount > 0 ? "success" : "never";
 
+    const handleDelete = () => {
+        startTransition(async () => {
+            try {
+                const result = await deleteSyncConfig(parent.id);
+                if (result.error) {
+                    toast.error(result.error);
+                    setShowDeleteConfirm(false);
+                } else {
+                    toast.success("Group deleted");
+                    router.refresh();
+                }
+            } catch {
+                toast.error("Failed to delete sync config group");
+                setShowDeleteConfirm(false);
+            }
+        });
+    };
+
     return (
         <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) overflow-hidden">
-            {/* Parent header — clickable to expand/collapse */}
-            <button
-                type="button"
-                onClick={() => setExpanded((v) => !v)}
-                className="flex w-full items-start justify-between p-6 text-left hover:bg-(--card-70) transition-colors"
-            >
-                <div className="space-y-1">
+            {/* Parent header — expand/collapse via a stretched button so the
+                action cluster can hold real buttons (no nested interactives) */}
+            <div className="relative flex items-start justify-between p-6 hover:bg-(--card-70) transition-colors">
+                <button
+                    type="button"
+                    onClick={() => setExpanded((v) => !v)}
+                    aria-expanded={expanded}
+                    className="space-y-1 text-left"
+                >
+                    {/* Stretch the click target across the full header row */}
+                    <span aria-hidden className="absolute inset-0" />
                     <div className="flex items-center gap-2">
                         <h3 className="font-medium text-foreground">{parent.name}</h3>
                         <span className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2 py-0.5 text-xs text-(--ink-muted)">
@@ -61,12 +89,58 @@ export function SyncConfigGroup({ parent, childConfigs }: SyncConfigGroupProps) 
                             </>
                         )}
                     </div>
-                </div>
+                </button>
                 <div className="flex items-center gap-3 shrink-0 ml-4">
+                    {/* Lifted above the stretched expand target so clicks here
+                        never toggle expansion */}
+                    <div className="relative z-10 flex items-center gap-2">
+                        {showDeleteConfirm ? (
+                            <>
+                                <span className="text-xs text-red-500">
+                                    Delete group and {childConfigs.length} repo config
+                                    {childConfigs.length !== 1 ? "s" : ""}?
+                                </span>
+                                <button
+                                    type="button"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleDelete();
+                                    }}
+                                    disabled={isPending}
+                                    className="rounded-md bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                                >
+                                    Yes, Delete
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        setShowDeleteConfirm(false);
+                                    }}
+                                    disabled={isPending}
+                                    className="rounded-md border border-(--card-stroke) bg-(--card-70) px-2 py-1 text-xs font-medium text-foreground hover:border-(--accent) hover:text-(--accent)"
+                                >
+                                    Cancel
+                                </button>
+                            </>
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    setShowDeleteConfirm(true);
+                                }}
+                                disabled={isPending}
+                                className="rounded-md bg-(--card-70) px-3 py-1.5 text-xs font-medium text-red-500 hover:bg-red-500/10 disabled:opacity-50"
+                            >
+                                Delete
+                            </button>
+                        )}
+                    </div>
                     <SyncStatusBadge status={groupStatus} />
                     <span className="text-(--ink-muted) text-sm">{expanded ? "▲" : "▼"}</span>
                 </div>
-            </button>
+            </div>
 
             {/* Children */}
             {expanded && (


### PR DESCRIPTION
## Summary

Fixes [CHAOS-2273](https://linear.app/full-chaos/issue/CHAOS-2273): a batch repo group (e.g. "chaos · 20 repos · Github · full-chaos") rendered its header as a single expand/collapse button with **no actions** — the parent config never renders a SyncConfigCard, so the group could not be deleted at all via the UX.

## Changes

- **Group-level delete** in `SyncConfigGroup`: mirrors the existing `SyncConfigCard` delete pattern (`deleteSyncConfig` server action, `useTransition`, two-step confirm, sonner toasts, `router.refresh()` on success). Backend already cascades parent → children (`ondelete=CASCADE` + delete-orphan), so deleting the parent removes all child repo configs.
- **Cascade-aware confirm copy**: "Delete group and N repo configs?" (singular-aware) so the destructive scope is explicit before confirming.
- **A11y restructure**: the header was one big `<button>`, so adding actions would have nested interactive elements (invalid HTML). The header is now a `div` with a *stretched* expand button (absolutely-positioned overlay span preserves full-row click-to-expand, including badge/chevron area) and a `z-10` action cluster holding the real delete buttons. Delete clicks also `stopPropagation()` and never toggle expansion. Added `aria-expanded` to the toggle. Existing styling tokens (`--card-stroke`, `--card-70/80`, `--ink-muted`) unchanged — no new borders or layout shift.

## Tests

- New `src/components/admin/sync/SyncConfigGroup.test.tsx` (vitest + testing-library, follows `SyncConfigForm.test.tsx` conventions): renders delete control, two-step confirm + copy, cancel path, success path (`deleteSyncConfig(parent.id)` + refresh + toast), error path (toast, no refresh), delete/expand isolation, singular copy.
- Gates: `ci/run_tests.sh format`, `quality`, `unit` all pass locally (217 files / 2028 tests).
- Playwright impact: none — `MOCK_SYNC_CONFIGS` is empty in the mock harness, so `SyncConfigGroup` never renders in the e2e suite, and `tests/admin-sync.spec.ts` only asserts empty-state/form elements.

SCREENSHOT-WAIVER: mock e2e harness seeds no sync configs (group never renders without a live batch config); change mirrors the already-shipped SyncConfigCard delete UI 1:1 with existing tokens.