### PR TITLE
fix(admin): stop stale schedule keys in sync_options reverting config edits (CHAOS-2295)

### DIFF
--- a/src/components/admin/sync/SyncConfigForm.test.tsx
+++ b/src/components/admin/sync/SyncConfigForm.test.tsx
@@ -444,6 +444,60 @@ describe("SyncConfigForm", () => {
             expect(screen.getByLabelText("Git Data (Commits, Branches)")).toBeChecked();
         });
 
+        it("strips stale schedule keys from sync_options and clears schedule on update", async () => {
+            mockUpdateSyncConfig.mockResolvedValue(undefined);
+            mockUseAdminTier.mockReturnValue({
+                tier: "team",
+                features: { scheduled_jobs: true },
+                limits: {},
+                minSyncIntervalHours: 0.25,
+            });
+            const initialData: SyncConfig = {
+                id: "cfg-clear",
+                name: "Scheduled Config",
+                provider: "github",
+                credential_id: "cred-1",
+                sync_targets: ["git"],
+                sync_options: {
+                    owner: "full-chaos",
+                    search: "full-chaos/*",
+                    schedule_cron: "0 0 * * *",
+                    timezone: "America/Los_Angeles",
+                    initial_sync_depth: 0,
+                },
+                is_active: true,
+                schedule_cron: null,
+                timezone: null,
+                initial_sync_depth: null,
+                last_sync_at: null,
+                last_sync_success: null,
+                last_sync_error: null,
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+                parent_id: null,
+            };
+
+            renderWithToaster(
+                <SyncConfigForm initialData={initialData} credentials={mockCredentials} />,
+            );
+
+            await userEvent.click(screen.getByRole("radio", { name: "Manual only (no schedule)" }));
+            await userEvent.click(screen.getByRole("button", { name: "Update Configuration" }));
+
+            await waitFor(() => {
+                expect(mockUpdateSyncConfig).toHaveBeenCalledWith("cfg-clear", {
+                    sync_targets: ["git"],
+                    is_active: true,
+                    schedule_cron: null,
+                    timezone: "America/Los_Angeles",
+                    initial_sync_depth: 0,
+                    // Stale schedule keys must NOT ride along inside sync_options —
+                    // they previously resurrected the old schedule on the backend.
+                    sync_options: { owner: "full-chaos", search: "full-chaos/*" },
+                });
+            });
+        });
+
         it("falls back to custom cron radio for non-preset schedule_cron in sync_options", () => {
             mockUseAdminTier.mockReturnValue({
                 tier: "team",

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -144,6 +144,12 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
         const opts: Record<string, unknown> = {
             ...(initialData?.sync_options ?? {}),
         };
+        // schedule_cron / timezone / initial_sync_depth are owned by the
+        // top-level payload fields. Strip stale copies from the carried-over
+        // sync_options so they can never resurrect an old schedule on save.
+        delete opts.schedule_cron;
+        delete opts.timezone;
+        delete opts.initial_sync_depth;
         if (formData.owner) opts.owner = formData.owner;
         if (formData.provider === "gitlab" && formData.gitlab_url) {
             opts.gitlab_url = formData.gitlab_url;


### PR DESCRIPTION
## Summary

Editing a sync config showed "Config updated" but nothing changed. `buildSyncOptions()` spread `initialData.sync_options` wholesale into every create/update payload, so the **old** `schedule_cron`/`timezone`/`initial_sync_depth` rode along nested inside `sync_options`. The backend merged those stale copies back over the record, reverting schedule edits — switching to "Manual only" could never save.

**Fix:** top-level payload fields own `schedule_cron`/`timezone`/`initial_sync_depth`; strip them from the carried-over `sync_options` before submit. Other provider options (`owner`, `search`, `repo`, `gitlab_url`, ...) are still preserved.

Counterpart ops PR (full-chaos/dev-health-ops) makes the PATCH endpoint honor explicit nulls via `model_fields_set`, so either side alone now prevents the regression.

## Tests

- New: `strips stale schedule keys from sync_options and clears schedule on update` — edit mode, switch to "Manual only", assert the payload has `schedule_cron: null` and no schedule keys inside `sync_options`.
- `SyncConfigForm.test.tsx`: 25 passed. ESLint + Prettier clean.

SCREENSHOT-WAIVER: submit-payload logic only; no rendered UI change.

Closes CHAOS-2295