### PR TITLE
fix(admin): gate Impersonate button on actor superuser status (CHAOS-2303)

### DIFF
--- a/src/components/admin/users/ImpersonateUserButton.test.tsx
+++ b/src/components/admin/users/ImpersonateUserButton.test.tsx
@@ -9,83 +9,77 @@ import type { User } from "@/lib/admin/types";
 let mockSessionUser: Record<string, unknown> | null;
 
 vi.mock("next-auth/react", () => ({
-	useSession: () => ({
-		data: mockSessionUser ? { user: mockSessionUser } : null,
-	}),
+    useSession: () => ({
+        data: mockSessionUser ? { user: mockSessionUser } : null,
+    }),
 }));
 
 vi.mock("next/navigation", () => ({
-	useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+    useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
 }));
 
 vi.mock("@/lib/admin/server", () => ({
-	startImpersonation: vi.fn(),
+    startImpersonation: vi.fn(),
 }));
 
 function makeUser(overrides: Partial<User> = {}): User {
-	return {
-		id: "target-1",
-		email: "target@example.com",
-		username: null,
-		full_name: null,
-		avatar_url: null,
-		auth_provider: "local",
-		is_active: true,
-		is_verified: true,
-		is_superuser: false,
-		role: "member",
-		last_login_at: null,
-		created_at: "2026-01-01T00:00:00Z",
-		updated_at: "2026-01-01T00:00:00Z",
-		...overrides,
-	};
+    return {
+        id: "target-1",
+        email: "target@example.com",
+        username: null,
+        full_name: null,
+        avatar_url: null,
+        auth_provider: "local",
+        is_active: true,
+        is_verified: true,
+        is_superuser: false,
+        role: "member",
+        last_login_at: null,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        ...overrides,
+    };
 }
 
 describe("ImpersonateUserButton", () => {
-	beforeEach(() => {
-		// Default actor: a superuser (the only role allowed to impersonate).
-		mockSessionUser = { id: "admin-1", is_superuser: true };
-	});
+    beforeEach(() => {
+        // Default actor: a superuser (the only role allowed to impersonate).
+        mockSessionUser = { id: "admin-1", is_superuser: true };
+    });
 
-	it("renders for a superuser actor targeting a regular user", () => {
-		render(<ImpersonateUserButton user={makeUser()} />);
-		expect(
-			screen.queryByRole("button", { name: /impersonate user/i }),
-		).not.toBeNull();
-	});
+    it("renders for a superuser actor targeting a regular user", () => {
+        render(<ImpersonateUserButton user={makeUser()} />);
+        expect(screen.queryByRole("button", { name: /impersonate user/i })).not.toBeNull();
+    });
 
-	it("is hidden when the actor is not a superuser (CHAOS-2303)", () => {
-		// Regression: a normal admin must not be offered an action that the
-		// backend always rejects with 403.
-		mockSessionUser = { id: "admin-1", is_superuser: false };
-		const { container } = render(<ImpersonateUserButton user={makeUser()} />);
-		expect(container.firstChild).toBeNull();
-	});
+    it("is hidden when the actor is not a superuser (CHAOS-2303)", () => {
+        // Regression: a normal admin must not be offered an action that the
+        // backend always rejects with 403.
+        mockSessionUser = { id: "admin-1", is_superuser: false };
+        const { container } = render(<ImpersonateUserButton user={makeUser()} />);
+        expect(container.firstChild).toBeNull();
+    });
 
-	it("is hidden when there is no session", () => {
-		mockSessionUser = null;
-		const { container } = render(<ImpersonateUserButton user={makeUser()} />);
-		expect(container.firstChild).toBeNull();
-	});
+    it("is hidden when there is no session", () => {
+        mockSessionUser = null;
+        const { container } = render(<ImpersonateUserButton user={makeUser()} />);
+        expect(container.firstChild).toBeNull();
+    });
 
-	it("is hidden when targeting a superuser", () => {
-		const { container } = render(
-			<ImpersonateUserButton user={makeUser({ is_superuser: true })} />,
-		);
-		expect(container.firstChild).toBeNull();
-	});
+    it("is hidden when targeting a superuser", () => {
+        const { container } = render(
+            <ImpersonateUserButton user={makeUser({ is_superuser: true })} />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
 
-	it("is hidden when targeting an admin", () => {
-		const { container } = render(
-			<ImpersonateUserButton user={makeUser({ role: "admin" })} />,
-		);
-		expect(container.firstChild).toBeNull();
-	});
+    it("is hidden when targeting an admin", () => {
+        const { container } = render(<ImpersonateUserButton user={makeUser({ role: "admin" })} />);
+        expect(container.firstChild).toBeNull();
+    });
 
-	it("is hidden when targeting yourself", () => {
-		const { container } = render(
-			<ImpersonateUserButton user={makeUser({ id: "admin-1" })} />,
-		);
-		expect(container.firstChild).toBeNull();
-	});
+    it("is hidden when targeting yourself", () => {
+        const { container } = render(<ImpersonateUserButton user={makeUser({ id: "admin-1" })} />);
+        expect(container.firstChild).toBeNull();
+    });
 });

--- a/src/components/admin/users/ImpersonateUserButton.test.tsx
+++ b/src/components/admin/users/ImpersonateUserButton.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { render } from "@/test/utils";
+import { ImpersonateUserButton } from "./ImpersonateUserButton";
+import type { User } from "@/lib/admin/types";
+
+// useSession is read for the ACTOR (the logged-in admin). A mutable holder lets
+// each test swap the session without re-mocking the module.
+let mockSessionUser: Record<string, unknown> | null;
+
+vi.mock("next-auth/react", () => ({
+	useSession: () => ({
+		data: mockSessionUser ? { user: mockSessionUser } : null,
+	}),
+}));
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock("@/lib/admin/server", () => ({
+	startImpersonation: vi.fn(),
+}));
+
+function makeUser(overrides: Partial<User> = {}): User {
+	return {
+		id: "target-1",
+		email: "target@example.com",
+		username: null,
+		full_name: null,
+		avatar_url: null,
+		auth_provider: "local",
+		is_active: true,
+		is_verified: true,
+		is_superuser: false,
+		role: "member",
+		last_login_at: null,
+		created_at: "2026-01-01T00:00:00Z",
+		updated_at: "2026-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+describe("ImpersonateUserButton", () => {
+	beforeEach(() => {
+		// Default actor: a superuser (the only role allowed to impersonate).
+		mockSessionUser = { id: "admin-1", is_superuser: true };
+	});
+
+	it("renders for a superuser actor targeting a regular user", () => {
+		render(<ImpersonateUserButton user={makeUser()} />);
+		expect(
+			screen.queryByRole("button", { name: /impersonate user/i }),
+		).not.toBeNull();
+	});
+
+	it("is hidden when the actor is not a superuser (CHAOS-2303)", () => {
+		// Regression: a normal admin must not be offered an action that the
+		// backend always rejects with 403.
+		mockSessionUser = { id: "admin-1", is_superuser: false };
+		const { container } = render(<ImpersonateUserButton user={makeUser()} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("is hidden when there is no session", () => {
+		mockSessionUser = null;
+		const { container } = render(<ImpersonateUserButton user={makeUser()} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("is hidden when targeting a superuser", () => {
+		const { container } = render(
+			<ImpersonateUserButton user={makeUser({ is_superuser: true })} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("is hidden when targeting an admin", () => {
+		const { container } = render(
+			<ImpersonateUserButton user={makeUser({ role: "admin" })} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("is hidden when targeting yourself", () => {
+		const { container } = render(
+			<ImpersonateUserButton user={makeUser({ id: "admin-1" })} />,
+		);
+		expect(container.firstChild).toBeNull();
+	});
+});

--- a/src/components/admin/users/ImpersonateUserButton.tsx
+++ b/src/components/admin/users/ImpersonateUserButton.tsx
@@ -8,51 +8,51 @@ import { toast } from "sonner";
 import type { User } from "@/lib/admin/types";
 
 export function ImpersonateUserButton({ user }: { user: User }) {
-	const { data: session } = useSession();
-	const router = useRouter();
-	const [loading, setLoading] = useState(false);
+    const { data: session } = useSession();
+    const router = useRouter();
+    const [loading, setLoading] = useState(false);
 
-	// Impersonation is a superuser-only capability on the backend
-	// (start_impersonation 403s non-superusers, ImpersonationMiddleware skips
-	// them). Gate the button on the ACTOR being a superuser so non-superuser
-	// admins are not offered an action that always fails (CHAOS-2303).
-	const canImpersonate =
-		!!session?.user?.is_superuser &&
-		session?.user?.id !== user.id &&
-		!user.is_superuser &&
-		user.role !== "admin";
+    // Impersonation is a superuser-only capability on the backend
+    // (start_impersonation 403s non-superusers, ImpersonationMiddleware skips
+    // them). Gate the button on the ACTOR being a superuser so non-superuser
+    // admins are not offered an action that always fails (CHAOS-2303).
+    const canImpersonate =
+        !!session?.user?.is_superuser &&
+        session?.user?.id !== user.id &&
+        !user.is_superuser &&
+        user.role !== "admin";
 
-	if (!canImpersonate) {
-		return null;
-	}
+    if (!canImpersonate) {
+        return null;
+    }
 
-	const handleImpersonate = async () => {
-		setLoading(true);
-		try {
-			const result = await startImpersonation(user.id);
-			if (result.error) {
-				toast.error(result.error);
-				return;
-			}
-			if (result.data) {
-				router.refresh();
-				router.push("/dashboard");
-			}
-		} catch {
-			toast.error("Failed to start impersonation");
-		} finally {
-			setLoading(false);
-		}
-	};
+    const handleImpersonate = async () => {
+        setLoading(true);
+        try {
+            const result = await startImpersonation(user.id);
+            if (result.error) {
+                toast.error(result.error);
+                return;
+            }
+            if (result.data) {
+                router.refresh();
+                router.push("/dashboard");
+            }
+        } catch {
+            toast.error("Failed to start impersonation");
+        } finally {
+            setLoading(false);
+        }
+    };
 
-	return (
-		<button
-			type="button"
-			onClick={handleImpersonate}
-			disabled={loading}
-			className="block w-full rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-500 hover:bg-amber-500/20 text-left transition-colors disabled:opacity-50"
-		>
-			{loading ? "Impersonating…" : "Impersonate User"}
-		</button>
-	);
+    return (
+        <button
+            type="button"
+            onClick={handleImpersonate}
+            disabled={loading}
+            className="block w-full rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-500 hover:bg-amber-500/20 text-left transition-colors disabled:opacity-50"
+        >
+            {loading ? "Impersonating…" : "Impersonate User"}
+        </button>
+    );
 }

--- a/src/components/admin/users/ImpersonateUserButton.tsx
+++ b/src/components/admin/users/ImpersonateUserButton.tsx
@@ -8,44 +8,51 @@ import { toast } from "sonner";
 import type { User } from "@/lib/admin/types";
 
 export function ImpersonateUserButton({ user }: { user: User }) {
-    const { data: session } = useSession();
-    const router = useRouter();
-    const [loading, setLoading] = useState(false);
+	const { data: session } = useSession();
+	const router = useRouter();
+	const [loading, setLoading] = useState(false);
 
-    const canImpersonate =
-        session?.user?.id !== user.id && !user.is_superuser && user.role !== "admin";
+	// Impersonation is a superuser-only capability on the backend
+	// (start_impersonation 403s non-superusers, ImpersonationMiddleware skips
+	// them). Gate the button on the ACTOR being a superuser so non-superuser
+	// admins are not offered an action that always fails (CHAOS-2303).
+	const canImpersonate =
+		!!session?.user?.is_superuser &&
+		session?.user?.id !== user.id &&
+		!user.is_superuser &&
+		user.role !== "admin";
 
-    if (!canImpersonate) {
-        return null;
-    }
+	if (!canImpersonate) {
+		return null;
+	}
 
-    const handleImpersonate = async () => {
-        setLoading(true);
-        try {
-            const result = await startImpersonation(user.id);
-            if (result.error) {
-                toast.error(result.error);
-                return;
-            }
-            if (result.data) {
-                router.refresh();
-                router.push("/dashboard");
-            }
-        } catch {
-            toast.error("Failed to start impersonation");
-        } finally {
-            setLoading(false);
-        }
-    };
+	const handleImpersonate = async () => {
+		setLoading(true);
+		try {
+			const result = await startImpersonation(user.id);
+			if (result.error) {
+				toast.error(result.error);
+				return;
+			}
+			if (result.data) {
+				router.refresh();
+				router.push("/dashboard");
+			}
+		} catch {
+			toast.error("Failed to start impersonation");
+		} finally {
+			setLoading(false);
+		}
+	};
 
-    return (
-        <button
-            type="button"
-            onClick={handleImpersonate}
-            disabled={loading}
-            className="block w-full rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-500 hover:bg-amber-500/20 text-left transition-colors disabled:opacity-50"
-        >
-            {loading ? "Impersonating…" : "Impersonate User"}
-        </button>
-    );
+	return (
+		<button
+			type="button"
+			onClick={handleImpersonate}
+			disabled={loading}
+			className="block w-full rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-500 hover:bg-amber-500/20 text-left transition-colors disabled:opacity-50"
+		>
+			{loading ? "Impersonating…" : "Impersonate User"}
+		</button>
+	);
 }


### PR DESCRIPTION
## Summary

Impersonation is a **superuser-only** capability on the backend (`start_impersonation` 403s non-superusers and `ImpersonationMiddleware` skips them), but `ImpersonateUserButton` only checked the **target** user. Any logged-in admin therefore saw an "Impersonate User" button that always failed with a 403 — part of the "impersonate doesn't work" report.

## Change

- Gate the button on the **actor** (`session.user.is_superuser`) in addition to the existing target checks (not self, target not superuser, target not admin).
- Add `ImpersonateUserButton.test.tsx` covering the full visibility matrix:
  - actor superuser + regular target → **renders**
  - actor not superuser → **hidden** (the regression)
  - no session → hidden
  - target superuser → hidden
  - target admin → hidden
  - target is self → hidden

## Testing

- `vitest run src/components/admin/users/ImpersonateUserButton.test.tsx` (components project) → **6 passed**.

## Screenshot

Worktree build logged in as the seeded superuser (`admin@devhealth.example`) on the superadmin user-detail page — the amber **Impersonate User** button renders for a superuser actor (the positive "after" state; hidden states are covered by the component test):

![chaos-2303-impersonate-button-after.png](https://github.com/user-attachments/assets/abdbd28d-f812-48b0-ad9a-702ead846eb4)

## Related

Backend fix (the core "impersonation shows wrong data" bug) ships in dev-health-ops PR #866 for the same Linear issue: the middleware ordering fix so the impersonated org actually scopes queries.

Closes CHAOS-2303
