### PR TITLE
docs(investment): Investment View user journey + relabel e2e specs (CHAOS-2318/2319)

### DIFF
--- a/docs/auth-system.md
+++ b/docs/auth-system.md
@@ -28,7 +28,7 @@ The system uses **NextAuth.js v5 (beta)** with the `CredentialsProvider`.
 
 All supported **authentication** journeys documented below. Each includes a Mermaid diagram and test coverage annotations showing where the journey is verified.
 
-> For non-auth journeys (onboarding, admin, user, platform admin), see [User Journeys](user-journeys/README.md).
+> For non-auth journeys (onboarding, admin, user, platform admin), see the [E2E Test Journey Specs](testing/e2e-specs/README.md) (test-coverage maps). For narrative product walkthroughs, see the end-user [User Journeys](user-journeys/README.md).
 
 ### Authentication
 

--- a/docs/testing/e2e-specs/README.md
+++ b/docs/testing/e2e-specs/README.md
@@ -1,0 +1,100 @@
+# E2E Test Journey Specs
+
+> **These are test-coverage specifications, not end-user guides.** Each page below
+> maps a platform flow to the Playwright / unit test files that exercise it (routes,
+> actors, response contracts, coverage matrix). If you are looking for a narrative,
+> first-time walkthrough of the product UI, see the end-user
+> [User Journeys](../../user-journeys/README.md) instead.
+>
+> Comprehensive documentation of all user-facing flows across the Full Chaos Dev Health platform.
+> For authentication journeys (registration, login, verification, SSO, RBAC), see [auth-system.md](../../auth-system.md).
+
+## Table of Contents
+
+### [Onboarding Journeys](onboarding.md)
+
+- [Full Account Setup (7-Step Journey)](onboarding.md#full-account-setup-7-step-journey)
+- [Workspace Creation](onboarding.md#workspace-creation)
+- [Organization Invite Lifecycle](onboarding.md#organization-invite-lifecycle)
+
+### [Account Admin Journeys](account-admin.md)
+
+- [Integration Setup](account-admin.md#integration-setup)
+- [Sync Configuration](account-admin.md#sync-configuration)
+- [Team Management](account-admin.md#team-management)
+- [Identity Mapping](account-admin.md#identity-mapping)
+- [Organization Settings](account-admin.md#organization-settings)
+
+### [Account User Journeys](account-user.md)
+
+- [Dashboard Landing & Drill-down](account-user.md#dashboard-landing--drill-down)
+- [Work Tabbed Navigation](account-user.md#work-tabbed-navigation)
+- [Filter Propagation](account-user.md#filter-propagation)
+- [People Search & Individual Views](account-user.md#people-search--individual-views)
+- [Chart Interactions](account-user.md#chart-interactions)
+- [Deployment Flame View](account-user.md#deployment-flame-view)
+- [Marketing & Pricing Pages](account-user.md#marketing--pricing-pages)
+
+### [Platform Admin Journeys](platform-admin.md)
+
+- [Impersonation Lifecycle](platform-admin.md#impersonation-lifecycle)
+- [Billing Plan Management](platform-admin.md#billing-plan-management)
+- [Subscription Management](platform-admin.md#subscription-management)
+- [Invoice Management](platform-admin.md#invoice-management)
+- [Refund Validation](platform-admin.md#refund-validation)
+- [Billing Audit](platform-admin.md#billing-audit)
+- [IP Allowlisting](platform-admin.md#ip-allowlisting)
+- [Retention Policies](platform-admin.md#retention-policies)
+- [Platform Stats](platform-admin.md#platform-stats)
+- [Tier Feature Gating](platform-admin.md#tier-feature-gating)
+
+---
+
+## Test Coverage Summary
+
+### Master Coverage Matrix
+
+| Journey                | Backend Unit                           | Frontend Unit                   | Frontend E2E                                                       | Live E2E                     |
+| ---------------------- | -------------------------------------- | ------------------------------- | ------------------------------------------------------------------ | ---------------------------- |
+| Full Account Setup     | —                                      | —                               | ✅                                                                 | ✅                           |
+| Integration Setup      | ✅ (`test_admin_credentials.py`)       | ✅ (`IntegrationForm.test.tsx`) | ✅ (`admin-integrations.spec.ts`, account-creation-journey step 4) | ✅ (`journey.spec.ts`)       |
+| Sync Configuration     | ✅ (`test_sync_configs.py`)            | ✅ (`SyncConfigForm.test.tsx`)  | ✅ (`admin-sync.spec.ts`, account-creation-journey step 5)         | ✅ (`journey.spec.ts`)       |
+| Team Management        | ✅ (`test_teams.py`)                   | ✅ (`TeamForm.test.tsx`)        | ✅ (`admin-teams.spec.ts`, account-creation-journey step 6)        | —                            |
+| Identity Mapping       | ✅ (`test_identities.py`)              | ✅ (`IdentityForm.test.tsx`)    | ✅ (`admin-identities.spec.ts`, account-creation-journey step 7)   | —                            |
+| Organization Settings  | —                                      | —                               | ✅ (`admin-settings.spec.ts`)                                      | —                            |
+| Dashboard & Drill-down | —                                      | —                               | ✅ (`home-flow.spec.ts`)                                           | —                            |
+| Work Navigation        | —                                      | —                               | ✅ (`work-navigation.spec.ts`)                                     | —                            |
+| Filter Propagation     | —                                      | —                               | ✅ (`filter-propagation.spec.ts`)                                  | —                            |
+| People Search          | —                                      | —                               | ✅ (`people.spec.ts`)                                              | —                            |
+| Chart Rendering        | —                                      | —                               | ✅ (`sankey/quadrant/heatmap/flame.spec.ts`)                       | —                            |
+| Deployment Flame       | —                                      | —                               | ✅ (`deployments.spec.ts`)                                         | —                            |
+| Marketing/Pricing      | —                                      | —                               | ✅ (`marketing-pricing.spec.ts`)                                   | —                            |
+| Impersonation          | ✅ (`test_impersonation_endpoints.py`) | ✅ (`access-matrix.test.ts`)    | —                                                                  | ✅ (`impersonation.spec.ts`) |
+| Billing Plans          | ✅ (`test_billing_plans.py`)           | —                               | ✅ (`billing-plans.spec.ts`)                                       | —                            |
+| Subscriptions          | ✅ (`test_subscriptions.py`)           | —                               | ✅ (`billing-subscriptions.spec.ts`)                               | —                            |
+| Invoices               | —                                      | —                               | ✅ (`billing-invoices.spec.ts`)                                    | —                            |
+| Refunds                | ✅ (`test_refunds.py`)                 | —                               | ✅ (`billing-refunds.spec.ts`)                                     | —                            |
+| Billing Audit          | —                                      | —                               | ✅ (`billing-audit.spec.ts`)                                       | —                            |
+| IP Allowlisting        | ✅ (`test_ip_allowlist.py`)            | ✅ (`server.test.ts`)           | —                                                                  | —                            |
+| Retention Policies     | ✅ (`test_retention.py`)               | ✅ (`server.test.ts`)           | —                                                                  | —                            |
+| Platform Stats         | ✅ (`test_platform_stats.py`)          | —                               | —                                                                  | —                            |
+| Tier Feature Gating    | ✅ (`test_community_features.py`)      | ✅ (`access-matrix.test.ts`)    | —                                                                  | —                            |
+
+### Coverage Gaps
+
+| Journey                | Missing Coverage                          | Priority |
+| ---------------------- | ----------------------------------------- | -------- |
+| Organization Settings  | No backend unit tests for settings CRUD   | Medium   |
+| Dashboard & Drill-down | No backend or unit tests                  | Low      |
+| Work Navigation        | No backend or unit tests                  | Low      |
+| Filter Propagation     | No backend or unit tests (URL-only logic) | Low      |
+| People Search          | No backend unit tests for search endpoint | Medium   |
+| Chart Rendering        | No unit tests for chart components        | Medium   |
+| Deployment Flame       | No backend unit tests for deployment data | Medium   |
+| Marketing/Pricing      | No backend tests for pricing page data    | Low      |
+| Invoices               | No backend unit tests for invoice CRUD    | Medium   |
+| Billing Audit          | No backend or unit tests                  | Medium   |
+| IP Allowlisting        | No frontend E2E tests                     | Low      |
+| Retention Policies     | No frontend E2E tests                     | Low      |
+| Platform Stats         | No frontend tests at all                  | Medium   |
+| Tier Feature Gating    | No frontend E2E tests                     | Low      |

--- a/docs/testing/e2e-specs/account-admin.md
+++ b/docs/testing/e2e-specs/account-admin.md
@@ -1,4 +1,4 @@
-# Account Admin Journeys
+# E2E Spec: Account Admin Journeys
 
 ## Integration Setup
 

--- a/docs/testing/e2e-specs/account-user.md
+++ b/docs/testing/e2e-specs/account-user.md
@@ -1,4 +1,4 @@
-# Account User Journeys
+# E2E Spec: Account User Journeys
 
 ## Dashboard Landing & Drill-down
 

--- a/docs/testing/e2e-specs/onboarding.md
+++ b/docs/testing/e2e-specs/onboarding.md
@@ -1,4 +1,4 @@
-# Onboarding Journeys
+# E2E Spec: Onboarding Journeys
 
 ## Full Account Setup (7-Step Journey)
 

--- a/docs/testing/e2e-specs/platform-admin.md
+++ b/docs/testing/e2e-specs/platform-admin.md
@@ -1,4 +1,4 @@
-# Platform Admin Journeys
+# E2E Spec: Platform Admin Journeys
 
 ## Impersonation Lifecycle
 

--- a/docs/user-journeys/README.md
+++ b/docs/user-journeys/README.md
@@ -1,94 +1,22 @@
 # User Journeys
 
-> Comprehensive documentation of all user-facing flows across the Full Chaos Dev Health platform.
-> For authentication journeys (registration, login, verification, SSO, RBAC), see [auth-system.md](../auth-system.md).
+> **Narrative, end-user walkthroughs of the product UI.** These pages read like a guided
+> tour: log in, open a view, and interpret what you see. They are written for leaders and
+> individual contributors, not for engineers.
+>
+> Looking for the Playwright / unit **test-coverage maps** (routes, actors, response
+> contracts, coverage matrix)? Those moved to the
+> [E2E Test Journey Specs](../testing/e2e-specs/README.md).
+>
+> For **authentication** journeys (registration, login, verification, SSO, RBAC), see
+> [auth-system.md](../auth-system.md).
 
-## Table of Contents
+## Walkthroughs
 
-### [Onboarding Journeys](onboarding.md)
-
-- [Full Account Setup (7-Step Journey)](onboarding.md#full-account-setup-7-step-journey)
-- [Workspace Creation](onboarding.md#workspace-creation)
-- [Organization Invite Lifecycle](onboarding.md#organization-invite-lifecycle)
-
-### [Account Admin Journeys](account-admin.md)
-
-- [Integration Setup](account-admin.md#integration-setup)
-- [Sync Configuration](account-admin.md#sync-configuration)
-- [Team Management](account-admin.md#team-management)
-- [Identity Mapping](account-admin.md#identity-mapping)
-- [Organization Settings](account-admin.md#organization-settings)
-
-### [Account User Journeys](account-user.md)
-
-- [Dashboard Landing & Drill-down](account-user.md#dashboard-landing--drill-down)
-- [Work Tabbed Navigation](account-user.md#work-tabbed-navigation)
-- [Filter Propagation](account-user.md#filter-propagation)
-- [People Search & Individual Views](account-user.md#people-search--individual-views)
-- [Chart Interactions](account-user.md#chart-interactions)
-- [Deployment Flame View](account-user.md#deployment-flame-view)
-- [Marketing & Pricing Pages](account-user.md#marketing--pricing-pages)
-
-### [Platform Admin Journeys](platform-admin.md)
-
-- [Impersonation Lifecycle](platform-admin.md#impersonation-lifecycle)
-- [Billing Plan Management](platform-admin.md#billing-plan-management)
-- [Subscription Management](platform-admin.md#subscription-management)
-- [Invoice Management](platform-admin.md#invoice-management)
-- [Refund Validation](platform-admin.md#refund-validation)
-- [Billing Audit](platform-admin.md#billing-audit)
-- [IP Allowlisting](platform-admin.md#ip-allowlisting)
-- [Retention Policies](platform-admin.md#retention-policies)
-- [Platform Stats](platform-admin.md#platform-stats)
-- [Tier Feature Gating](platform-admin.md#tier-feature-gating)
+- [Reading the Investment View](investment-view.md) — sign in → read the theme mix → drill
+  Theme → Subcategory → Evidence → interpret confidence.
 
 ---
 
-## Test Coverage Summary
-
-### Master Coverage Matrix
-
-| Journey                | Backend Unit                           | Frontend Unit                   | Frontend E2E                                                       | Live E2E                     |
-| ---------------------- | -------------------------------------- | ------------------------------- | ------------------------------------------------------------------ | ---------------------------- |
-| Full Account Setup     | —                                      | —                               | ✅                                                                 | ✅                           |
-| Integration Setup      | ✅ (`test_admin_credentials.py`)       | ✅ (`IntegrationForm.test.tsx`) | ✅ (`admin-integrations.spec.ts`, account-creation-journey step 4) | ✅ (`journey.spec.ts`)       |
-| Sync Configuration     | ✅ (`test_sync_configs.py`)            | ✅ (`SyncConfigForm.test.tsx`)  | ✅ (`admin-sync.spec.ts`, account-creation-journey step 5)         | ✅ (`journey.spec.ts`)       |
-| Team Management        | ✅ (`test_teams.py`)                   | ✅ (`TeamForm.test.tsx`)        | ✅ (`admin-teams.spec.ts`, account-creation-journey step 6)        | —                            |
-| Identity Mapping       | ✅ (`test_identities.py`)              | ✅ (`IdentityForm.test.tsx`)    | ✅ (`admin-identities.spec.ts`, account-creation-journey step 7)   | —                            |
-| Organization Settings  | —                                      | —                               | ✅ (`admin-settings.spec.ts`)                                      | —                            |
-| Dashboard & Drill-down | —                                      | —                               | ✅ (`home-flow.spec.ts`)                                           | —                            |
-| Work Navigation        | —                                      | —                               | ✅ (`work-navigation.spec.ts`)                                     | —                            |
-| Filter Propagation     | —                                      | —                               | ✅ (`filter-propagation.spec.ts`)                                  | —                            |
-| People Search          | —                                      | —                               | ✅ (`people.spec.ts`)                                              | —                            |
-| Chart Rendering        | —                                      | —                               | ✅ (`sankey/quadrant/heatmap/flame.spec.ts`)                       | —                            |
-| Deployment Flame       | —                                      | —                               | ✅ (`deployments.spec.ts`)                                         | —                            |
-| Marketing/Pricing      | —                                      | —                               | ✅ (`marketing-pricing.spec.ts`)                                   | —                            |
-| Impersonation          | ✅ (`test_impersonation_endpoints.py`) | ✅ (`access-matrix.test.ts`)    | —                                                                  | ✅ (`impersonation.spec.ts`) |
-| Billing Plans          | ✅ (`test_billing_plans.py`)           | —                               | ✅ (`billing-plans.spec.ts`)                                       | —                            |
-| Subscriptions          | ✅ (`test_subscriptions.py`)           | —                               | ✅ (`billing-subscriptions.spec.ts`)                               | —                            |
-| Invoices               | —                                      | —                               | ✅ (`billing-invoices.spec.ts`)                                    | —                            |
-| Refunds                | ✅ (`test_refunds.py`)                 | —                               | ✅ (`billing-refunds.spec.ts`)                                     | —                            |
-| Billing Audit          | —                                      | —                               | ✅ (`billing-audit.spec.ts`)                                       | —                            |
-| IP Allowlisting        | ✅ (`test_ip_allowlist.py`)            | ✅ (`server.test.ts`)           | —                                                                  | —                            |
-| Retention Policies     | ✅ (`test_retention.py`)               | ✅ (`server.test.ts`)           | —                                                                  | —                            |
-| Platform Stats         | ✅ (`test_platform_stats.py`)          | —                               | —                                                                  | —                            |
-| Tier Feature Gating    | ✅ (`test_community_features.py`)      | ✅ (`access-matrix.test.ts`)    | —                                                                  | —                            |
-
-### Coverage Gaps
-
-| Journey                | Missing Coverage                          | Priority |
-| ---------------------- | ----------------------------------------- | -------- |
-| Organization Settings  | No backend unit tests for settings CRUD   | Medium   |
-| Dashboard & Drill-down | No backend or unit tests                  | Low      |
-| Work Navigation        | No backend or unit tests                  | Low      |
-| Filter Propagation     | No backend or unit tests (URL-only logic) | Low      |
-| People Search          | No backend unit tests for search endpoint | Medium   |
-| Chart Rendering        | No unit tests for chart components        | Medium   |
-| Deployment Flame       | No backend unit tests for deployment data | Medium   |
-| Marketing/Pricing      | No backend tests for pricing page data    | Low      |
-| Invoices               | No backend unit tests for invoice CRUD    | Medium   |
-| Billing Audit          | No backend or unit tests                  | Medium   |
-| IP Allowlisting        | No frontend E2E tests                     | Low      |
-| Retention Policies     | No frontend E2E tests                     | Low      |
-| Platform Stats         | No frontend tests at all                  | Medium   |
-| Tier Feature Gating    | No frontend E2E tests                     | Low      |
+_More end-user walkthroughs will be added here. Keep each one narrative and first-person:
+what the reader clicks, what they see, and how to interpret it._

--- a/docs/user-journeys/investment-view.md
+++ b/docs/user-journeys/investment-view.md
@@ -33,12 +33,12 @@ to interpreting the **confidence** of what you are looking at.
 
 You land on the **Overview** tab. Across the top you will see four tabs:
 
-| Tab | What it is for |
-| --- | -------------- |
-| **Overview** | The headline mix and the story it suggests. |
+| Tab            | What it is for                                                                  |
+| -------------- | ------------------------------------------------------------------------------- |
+| **Overview**   | The headline mix and the story it suggests.                                     |
 | **Allocation** | The full Theme → Subcategory breakdown and where effort flows (by repo / team). |
-| **Evidence** | The actual issues, PRs, and commits behind the mix. |
-| **Confidence** | How much to trust the picture (evidence quality). |
+| **Evidence**   | The actual issues, PRs, and commits behind the mix.                             |
+| **Confidence** | How much to trust the picture (evidence quality).                               |
 
 > _Screenshot placeholder: `/investment` Overview tab, showing the theme mix and headline._
 > `![Investment View — Overview tab](../screenshots/investment-overview.png)`
@@ -77,10 +77,10 @@ high-churn items can carry the mix.
 Move to the **Allocation** tab (route: `/investment?tab=allocation`) and select a theme —
 say **Feature Delivery**. It opens into its **subcategories**, the finer-grained mix:
 
-| Subcategory | Plain meaning |
-| ----------- | ------------- |
-| `feature_delivery.customer` | Work driven by a specific customer ask. |
-| `feature_delivery.roadmap` | Planned roadmap features. |
+| Subcategory                   | Plain meaning                                  |
+| ----------------------------- | ---------------------------------------------- |
+| `feature_delivery.customer`   | Work driven by a specific customer ask.        |
+| `feature_delivery.roadmap`    | Planned roadmap features.                      |
 | `feature_delivery.enablement` | Platform/tooling that enables others to build. |
 
 So a Feature Delivery slice might further suggest it **leans toward roadmap work** rather

--- a/docs/user-journeys/investment-view.md
+++ b/docs/user-journeys/investment-view.md
@@ -1,0 +1,166 @@
+# User Journey: Reading the Investment View
+
+A narrative, first-time walkthrough of the **Investment View** in the product UI — from
+logging in, to reading the top-level mix, to drilling **Theme → Subcategory → Evidence**,
+to interpreting the **confidence** of what you are looking at.
+
+> **This is an end-user guide, not a test spec.** For the Playwright/unit test coverage
+> maps, see the [E2E Test Journey Specs](../testing/e2e-specs/README.md).
+>
+> For the conceptual definition of the view (what the numbers mean, why they are
+> effort-weighted), see the backend user guide:
+> [Investment View (dev-health-ops)](https://github.com/full-chaos/dev-health-ops/blob/main/docs/user-guide/investment-view.md)
+> and the shared
+> [Investment Taxonomy](https://github.com/full-chaos/dev-health-ops/blob/main/docs/product/investment-taxonomy.md).
+
+---
+
+## Before you start
+
+- A signed-in account on an organization that has synced at least one repository and some
+  work items (issues / PRs / commits). A freshly seeded demo org
+  (`admin@devhealth.example`) works well for a first look.
+- One sentence to keep in mind the whole way through: **the percentages describe a
+  _distribution_ of effort, not a count of tickets, and every number is a lean — read it
+  as "appears," never "is."**
+
+---
+
+## Step 1 — Sign in and open the view
+
+1. Sign in at `/auth/signin`.
+2. From the primary navigation, open **Investment** (route: `/investment`).
+
+You land on the **Overview** tab. Across the top you will see four tabs:
+
+| Tab | What it is for |
+| --- | -------------- |
+| **Overview** | The headline mix and the story it suggests. |
+| **Allocation** | The full Theme → Subcategory breakdown and where effort flows (by repo / team). |
+| **Evidence** | The actual issues, PRs, and commits behind the mix. |
+| **Confidence** | How much to trust the picture (evidence quality). |
+
+> _Screenshot placeholder: `/investment` Overview tab, showing the theme mix and headline._
+> `![Investment View — Overview tab](../screenshots/investment-overview.png)`
+
+---
+
+## Step 2 — Read the top-level theme mix
+
+The Overview leads with the five-way **theme** split:
+
+- Feature Delivery
+- Operational / Support
+- Maintenance / Tech Debt
+- Quality / Reliability
+- Risk / Security
+
+A typical headline reads like:
+
+> Effort this period **appears to lean ~60% Feature Delivery**, ~25% Quality /
+> Reliability, ~15% Maintenance / Tech Debt.
+
+**Read this as a story, not a scoreboard.** It suggests the team is mostly building new
+capability, with a real slice of quality work and some maintenance — a "shipping mode"
+period. It does **not** say 60% of your _tickets_ were features; it says 60% of the
+**weighted effort** (weighted by code churn / active hours) leans that way. A few
+high-churn items can carry the mix.
+
+> The language in the UI is deliberately tentative — **appears, leans, suggests** — never
+> "is," "was," or "detected." The view starts conversations; it does not hand down
+> verdicts.
+
+---
+
+## Step 3 — Drill into a Theme → its Subcategories
+
+Move to the **Allocation** tab (route: `/investment?tab=allocation`) and select a theme —
+say **Feature Delivery**. It opens into its **subcategories**, the finer-grained mix:
+
+| Subcategory | Plain meaning |
+| ----------- | ------------- |
+| `feature_delivery.customer` | Work driven by a specific customer ask. |
+| `feature_delivery.roadmap` | Planned roadmap features. |
+| `feature_delivery.enablement` | Platform/tooling that enables others to build. |
+
+So a Feature Delivery slice might further suggest it **leans toward roadmap work** rather
+than one-off customer commitments. Same effort-weighted logic, just more resolution. The
+subcategory shares always roll up to the theme you opened — nothing is invented at this
+level.
+
+> _Screenshot placeholder: Allocation tab with a theme expanded into subcategories._
+> `![Investment View — Allocation drill](../screenshots/investment-allocation.png)`
+
+You may also see a **flow** view (repo / team) on this tab. If a slice is labelled
+**`unassigned`**, that is **not** a kind of work — it means some effort could not be tied
+back to a known repo or team (a scope-attribution gap to chase), and it never appears
+inside a theme or subcategory mix.
+
+---
+
+## Step 4 — Drill into the Evidence behind a subcategory
+
+Open the **Evidence** tab (route: `/investment?tab=evidence`), or click through from a
+subcategory. Here the view grounds every number in the **actual linked work** — the
+issues, PRs, and commits that shaped the mix:
+
+- A list/table of the underlying items (titles, type, the repo/PR they came from).
+- Short **extractive quotes** pulled directly from issue or PR text — these are verbatim
+  snippets, not paraphrases, so you can see exactly what the categorization leaned on.
+
+This is where "appears ~60% Feature Delivery" stops being abstract: you can read the two
+big feature PRs that carried most of the churn and see why the mix leaned that way, and
+spot the smaller bugfix and upgrade items contributing the Quality and Maintenance slices.
+
+> _Screenshot placeholder: Evidence tab listing linked issues/PRs/commits with quotes._
+> `![Investment View — Evidence table](../screenshots/investment-evidence.png)`
+
+> **Note:** evidence quotes are only present when the backend was materialized with snippet
+> persistence enabled. If quotes are sparse, the underlying items and their links are still
+> shown.
+
+---
+
+## Step 5 — Interpret the Confidence
+
+Before you act on anything, open the **Confidence** tab (route:
+`/investment?tab=confidence`). It surfaces the **evidence-quality band** behind the mix —
+**high**, **moderate**, **low**, or **very low** — reflecting how much trustworthy signal
+was available (how much text there was, whether issues / PRs / commits agreed, how densely
+the work was linked).
+
+**Read the confidence band _before_ you lean on the percentages:**
+
+- **High / moderate** — the mix rests on substantial, agreeing evidence. Reasonable to use
+  as a conversation starter.
+- **Low / very low** — the picture is thin. The view still shows a distribution (it never
+  says "unknown"), but when evidence is too sparse it falls back to a **neutral prior** — an
+  even-ish spread that effectively means _"not enough validated evidence to suggest a
+  confident mix."_ Treat that as a prompt to open the **Evidence** tab and look at the
+  items yourself, not as a finding.
+
+In short: the percentages tell you which way effort **appears** to lean; the confidence
+band tells you **how much weight to put on that lean.** A confident-looking 60% built on
+very-low-quality evidence deserves far more skepticism than a 45% on high-quality evidence.
+
+> _Screenshot placeholder: Confidence tab showing evidence-quality bands._
+> `![Investment View — Confidence panel](../screenshots/investment-confidence.png)`
+
+---
+
+## What you should walk away knowing
+
+- The Investment View shows a **distribution of effort**, not hand-applied tags.
+- Percentages are **effort-weighted** (code churn / active hours), **not** % of tickets.
+- You can trace any number down **Theme → Subcategory → Evidence** to real work.
+- **`unassigned`** is a missing-scope state, not a category.
+- Always read the **Confidence** band; low confidence means _look closer_, not _trust it_.
+
+---
+
+## Related
+
+- [E2E Test Journey Specs](../testing/e2e-specs/README.md) — test-coverage maps (not end-user guides)
+- [Auth System](../auth-system.md) — sign-in and access journeys
+- [Investment View (dev-health-ops)](https://github.com/full-chaos/dev-health-ops/blob/main/docs/user-guide/investment-view.md) — what the numbers mean
+- [Investment Taxonomy (dev-health-ops)](https://github.com/full-chaos/dev-health-ops/blob/main/docs/product/investment-taxonomy.md) — the fixed themes and subcategories


### PR DESCRIPTION
## Summary

End-user documentation for the Investment View, plus disambiguation of the existing journey docs (Milestone 2 remainder).

**CHAOS-2318 — new end-user walkthrough**
- Adds `docs/user-journeys/investment-view.md`: a narrative, first-time UI walkthrough — sign in → read the theme mix → drill **Theme → Subcategory → Evidence** → interpret **Confidence** — grounded in the real `/investment` route and its Overview/Allocation/Evidence/Confidence tabs.
- Effort-weighting, `unassigned`-as-scope-state, and confidence bands explained in plain language; probabilistic wording throughout (appears/leans/suggests). Screenshot placeholders included.

**CHAOS-2319 — relabel the Playwright spec docs**
- The docs under `docs/user-journeys/` were **test-coverage maps** (journey → Playwright/unit test files), not end-user guides. Moved them to `docs/testing/e2e-specs/` and retitled as **"E2E Spec: …"** / **"E2E Test Journey Specs"** with a clear banner.
- Added a new end-user `docs/user-journeys/README.md` index, and updated the `docs/auth-system.md` cross-reference to distinguish the two.

All internal `.md` links verified to resolve (including the moved relative paths). Links to the dev-health-ops Investment View / Taxonomy docs for the conceptual definitions.

SCREENSHOT-WAIVER: docs-only change, no `src/` or rendered UI output (screenshot placeholders are intentional for a later capture pass).
TEST-WAIVER: docs-only change, no files under `src/` touched.

Refs CHAOS-2317 CHAOS-2318 CHAOS-2319