### PR TITLE
feat(admin): impersonation opens a dedicated tab; Stop closes it; all tabs sync instantly (CHAOS-2347)

### DIFF
--- a/src/components/admin/ImpersonationBanner.test.tsx
+++ b/src/components/admin/ImpersonationBanner.test.tsx
@@ -119,8 +119,10 @@ describe("ImpersonationBanner", () => {
         }
     });
 
-    it("re-polls the session when another tab starts or stops impersonating", async () => {
-        mockUpdate.mockResolvedValue(undefined);
+    it("re-polls the session when another tab stops impersonating", async () => {
+        // This tab still shows is_impersonating=true; a "stopped" event from
+        // another tab must force the server-verified re-poll.
+        mockUpdate.mockResolvedValue({});
         renderWithToaster(<ImpersonationBanner />);
 
         expect(eventHandlerHolder.handler).not.toBeNull();
@@ -130,6 +132,54 @@ describe("ImpersonationBanner", () => {
             expect(mockUpdate).toHaveBeenCalledWith({ impersonationChanged: true });
             expect(mockRefresh).toHaveBeenCalled();
         });
+    });
+
+    it("skips the re-poll when the tab already reflects the event", () => {
+        // session is impersonating; a "started" event carries no new state —
+        // guards against N-tab update() storms.
+        renderWithToaster(<ImpersonationBanner />);
+
+        eventHandlerHolder.handler?.({ type: "started" });
+
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("retries the forced re-poll when next-auth drops update() mid-flight", async () => {
+        vi.useFakeTimers();
+        try {
+            // First update() is dropped (returns undefined while a session
+            // fetch is in flight); the retry must fire after the backoff.
+            mockUpdate.mockResolvedValueOnce(undefined).mockResolvedValue({});
+            renderWithToaster(<ImpersonationBanner />);
+
+            eventHandlerHolder.handler?.({ type: "stopped" });
+            await vi.advanceTimersByTimeAsync(0);
+            expect(mockUpdate).toHaveBeenCalledTimes(1);
+
+            await vi.advanceTimersByTimeAsync(1500);
+            expect(mockUpdate).toHaveBeenCalledTimes(2);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("navigates the impersonation tab to /superadmin when a remote stop cannot close it", async () => {
+        vi.mocked(isImpersonationWindow).mockReturnValue(true);
+        const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+        // window.closed stays false — the browser refused to close the tab.
+        mockUpdate.mockResolvedValue({});
+        try {
+            renderWithToaster(<ImpersonationBanner />);
+
+            eventHandlerHolder.handler?.({ type: "stopped" });
+
+            await waitFor(() => {
+                expect(closeSpy).toHaveBeenCalled();
+                expect(mockPush).toHaveBeenCalledWith("/superadmin");
+            });
+        } finally {
+            closeSpy.mockRestore();
+        }
     });
 
     it("surfaces a toast and does not navigate when stop fails", async () => {

--- a/src/components/admin/ImpersonationBanner.test.tsx
+++ b/src/components/admin/ImpersonationBanner.test.tsx
@@ -25,11 +25,28 @@ vi.mock("@/lib/admin/server", () => ({
     stopImpersonation: vi.fn(),
 }));
 
+// Mutable holder for the cross-tab event handler registered by the banner.
+const eventHandlerHolder: {
+    handler: ((event: { type: "started" | "stopped" }) => void) | null;
+} = { handler: null };
+
+vi.mock("@/lib/impersonation-events", () => ({
+    broadcastImpersonationEvent: vi.fn(),
+    isImpersonationWindow: vi.fn(() => false),
+    onImpersonationEvent: vi.fn((handler: (event: { type: "started" | "stopped" }) => void) => {
+        eventHandlerHolder.handler = handler;
+        return () => {};
+    }),
+}));
+
 import { stopImpersonation } from "@/lib/admin/server";
+import { broadcastImpersonationEvent, isImpersonationWindow } from "@/lib/impersonation-events";
 
 describe("ImpersonationBanner", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.mocked(isImpersonationWindow).mockReturnValue(false);
+        eventHandlerHolder.handler = null;
         mockSessionUser = {
             id: "admin-1",
             email: "admin@devhealth.example",
@@ -67,7 +84,7 @@ describe("ImpersonationBanner", () => {
         expect(screen.getByText(/viewing as/i).textContent).toContain("target-1");
     });
 
-    it("forces a session re-poll and navigates on successful stop", async () => {
+    it("forces a session re-poll, broadcasts, and navigates on successful stop", async () => {
         vi.mocked(stopImpersonation).mockResolvedValue({ data: { status: "stopped" } });
         renderWithToaster(<ImpersonationBanner />);
 
@@ -76,8 +93,42 @@ describe("ImpersonationBanner", () => {
         await waitFor(() => {
             expect(stopImpersonation).toHaveBeenCalledTimes(1);
             expect(mockUpdate).toHaveBeenCalledWith({ impersonationChanged: true });
+            expect(broadcastImpersonationEvent).toHaveBeenCalledWith({ type: "stopped" });
             expect(mockRefresh).toHaveBeenCalled();
             expect(mockPush).toHaveBeenCalledWith("/superadmin");
+        });
+    });
+
+    it("closes the dedicated impersonation tab on stop instead of navigating (CHAOS-2347)", async () => {
+        vi.mocked(stopImpersonation).mockResolvedValue({ data: { status: "stopped" } });
+        vi.mocked(isImpersonationWindow).mockReturnValue(true);
+        const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+        Object.defineProperty(window, "closed", { value: true, configurable: true });
+        try {
+            renderWithToaster(<ImpersonationBanner />);
+
+            await userEvent.click(screen.getByRole("button", { name: /stop impersonating/i }));
+
+            await waitFor(() => {
+                expect(closeSpy).toHaveBeenCalled();
+            });
+            expect(mockPush).not.toHaveBeenCalled();
+        } finally {
+            closeSpy.mockRestore();
+            Object.defineProperty(window, "closed", { value: false, configurable: true });
+        }
+    });
+
+    it("re-polls the session when another tab starts or stops impersonating", async () => {
+        mockUpdate.mockResolvedValue(undefined);
+        renderWithToaster(<ImpersonationBanner />);
+
+        expect(eventHandlerHolder.handler).not.toBeNull();
+        eventHandlerHolder.handler?.({ type: "stopped" });
+
+        await waitFor(() => {
+            expect(mockUpdate).toHaveBeenCalledWith({ impersonationChanged: true });
+            expect(mockRefresh).toHaveBeenCalled();
         });
     });
 

--- a/src/components/admin/ImpersonationBanner.tsx
+++ b/src/components/admin/ImpersonationBanner.tsx
@@ -14,6 +14,7 @@ import {
 export function ImpersonationBanner() {
     const { data: session, update } = useSession();
     const router = useRouter();
+    const isImpersonating = !!session?.user?.is_impersonating;
 
     // Impersonation is per ADMIN USER server-side, so a start/stop in any tab
     // changes the effective org in EVERY tab. React to events from other tabs
@@ -21,15 +22,33 @@ export function ImpersonationBanner() {
     // waiting for the 30s throttle (CHAOS-2347). The dedicated impersonation
     // tab closes itself when impersonation ends elsewhere.
     useEffect(() => {
+        const syncSession = async () => {
+            // next-auth's update() silently no-ops while a session fetch is
+            // already in flight — retry once so the forced re-poll cannot be
+            // dropped in the cross-tab race.
+            const result = await update({ impersonationChanged: true });
+            if (result === undefined) {
+                await new Promise((resolve) => setTimeout(resolve, 1500));
+                await update({ impersonationChanged: true });
+            }
+            router.refresh();
+        };
+
         return onImpersonationEvent((event) => {
             if (event.type === "stopped" && isImpersonationWindow()) {
                 window.close();
-                // Fall through: if the browser refused to close (e.g. the tab
-                // was reached by direct navigation), sync state like any tab.
+                if (window.closed) return;
+                // Browser refused to close (restored/duplicated tab) — don't
+                // strand the user on a route scoped to a stopped impersonation.
+                router.push("/superadmin");
             }
-            void update({ impersonationChanged: true }).then(() => router.refresh());
+            // Skip the re-poll when this tab already reflects the event (e.g.
+            // next-auth's own cross-tab session sync got here first) — keeps
+            // N-tab broadcast traffic bounded.
+            if (isImpersonating === (event.type === "started")) return;
+            void syncSession();
         });
-    }, [update, router]);
+    }, [update, router, isImpersonating]);
 
     if (!session?.user?.is_impersonating) {
         return null;

--- a/src/components/admin/ImpersonationBanner.tsx
+++ b/src/components/admin/ImpersonationBanner.tsx
@@ -1,13 +1,35 @@
 "use client";
 
+import { useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { stopImpersonation } from "@/lib/admin/server";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import {
+    broadcastImpersonationEvent,
+    isImpersonationWindow,
+    onImpersonationEvent,
+} from "@/lib/impersonation-events";
 
 export function ImpersonationBanner() {
     const { data: session, update } = useSession();
     const router = useRouter();
+
+    // Impersonation is per ADMIN USER server-side, so a start/stop in any tab
+    // changes the effective org in EVERY tab. React to events from other tabs
+    // by forcing the server-verified session re-poll immediately instead of
+    // waiting for the 30s throttle (CHAOS-2347). The dedicated impersonation
+    // tab closes itself when impersonation ends elsewhere.
+    useEffect(() => {
+        return onImpersonationEvent((event) => {
+            if (event.type === "stopped" && isImpersonationWindow()) {
+                window.close();
+                // Fall through: if the browser refused to close (e.g. the tab
+                // was reached by direct navigation), sync state like any tab.
+            }
+            void update({ impersonationChanged: true }).then(() => router.refresh());
+        });
+    }, [update, router]);
 
     if (!session?.user?.is_impersonating) {
         return null;
@@ -20,9 +42,15 @@ export function ImpersonationBanner() {
             return;
         }
         // Force an immediate server-verified impersonation status re-poll so
-        // org scoping reverts to the admin's own org right away (CHAOS-2309).
+        // org scoping reverts to the admin's own org right away (CHAOS-2309),
+        // then tell every other tab to do the same.
         await update({ impersonationChanged: true });
+        broadcastImpersonationEvent({ type: "stopped" });
         router.refresh();
+        if (isImpersonationWindow()) {
+            window.close();
+            if (window.closed) return;
+        }
         router.push("/superadmin");
     };
 

--- a/src/components/admin/users/ImpersonateUserButton.tsx
+++ b/src/components/admin/users/ImpersonateUserButton.tsx
@@ -6,6 +6,7 @@ import { startImpersonation } from "@/lib/admin/server";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { User } from "@/lib/admin/types";
+import { broadcastImpersonationEvent, openImpersonationWindow } from "@/lib/impersonation-events";
 
 export function ImpersonateUserButton({ user }: { user: User }) {
     const { data: session, update } = useSession();
@@ -28,9 +29,14 @@ export function ImpersonateUserButton({ user }: { user: User }) {
 
     const handleImpersonate = async () => {
         setLoading(true);
+        // Open the impersonation tab synchronously, before any await — popup
+        // blockers do not reliably honor window.open after a network
+        // round-trip. Null (blocked) falls back to same-tab navigation.
+        const impersonationWindow = openImpersonationWindow();
         try {
             const result = await startImpersonation(user.id);
             if (result.error) {
+                impersonationWindow?.close();
                 toast.error(result.error);
                 return;
             }
@@ -39,10 +45,19 @@ export function ImpersonateUserButton({ user }: { user: User }) {
                 // so org scoping switches to the target org without waiting for
                 // the 30s JWT poll interval (CHAOS-2309).
                 await update({ impersonationChanged: true });
+                broadcastImpersonationEvent({ type: "started" });
                 router.refresh();
-                router.push("/dashboard");
+                if (impersonationWindow && !impersonationWindow.closed) {
+                    impersonationWindow.location.href = "/dashboard";
+                    impersonationWindow.focus();
+                } else {
+                    router.push("/dashboard");
+                }
+            } else {
+                impersonationWindow?.close();
             }
         } catch {
+            impersonationWindow?.close();
             toast.error("Failed to start impersonation");
         } finally {
             setLoading(false);

--- a/src/components/superadmin/UserTable.test.tsx
+++ b/src/components/superadmin/UserTable.test.tsx
@@ -23,7 +23,26 @@ vi.mock("@/lib/admin/server", () => ({
     startImpersonation: vi.fn(),
 }));
 
+vi.mock("@/lib/impersonation-events", () => ({
+    broadcastImpersonationEvent: vi.fn(),
+    openImpersonationWindow: vi.fn(() => null),
+    isImpersonationWindow: vi.fn(() => false),
+    onImpersonationEvent: vi.fn(() => () => {}),
+}));
+
 import { startImpersonation } from "@/lib/admin/server";
+import { broadcastImpersonationEvent, openImpersonationWindow } from "@/lib/impersonation-events";
+
+interface FakeImpersonationWindow {
+    closed: boolean;
+    location: { href: string };
+    focus: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeWindow(): FakeImpersonationWindow {
+    return { closed: false, location: { href: "" }, focus: vi.fn(), close: vi.fn() };
+}
 
 function makeUser(overrides: Partial<User> = {}): User {
     return {
@@ -47,6 +66,8 @@ function makeUser(overrides: Partial<User> = {}): User {
 describe("UserTable impersonation", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        // Default: popup blocked → same-tab fallback. Tests opt into a window.
+        vi.mocked(openImpersonationWindow).mockReturnValue(null);
     });
 
     it("signals impersonationChanged so the session re-polls immediately (CHAOS-2309)", async () => {
@@ -75,8 +96,51 @@ describe("UserTable impersonation", () => {
             expect(startImpersonation).toHaveBeenCalledWith("target-1");
             expect(mockUpdate).toHaveBeenCalledWith({ impersonationChanged: true });
             expect(mockRefresh).toHaveBeenCalled();
+            // openImpersonationWindow is mocked to null (popup blocked) by
+            // default — the fallback is same-tab navigation.
             expect(mockPush).toHaveBeenCalledWith("/dashboard");
         });
+    });
+
+    it("opens the impersonated view in the new tab and broadcasts the start (CHAOS-2347)", async () => {
+        const fakeWindow = makeFakeWindow();
+        vi.mocked(openImpersonationWindow).mockReturnValue(fakeWindow as unknown as Window);
+        vi.mocked(startImpersonation).mockResolvedValue({
+            data: {
+                status: "active",
+                target_user: {
+                    id: "target-1",
+                    email: "target@example.com",
+                    org_id: "org-target",
+                    role: "member",
+                },
+                expires_at: "2026-01-01T01:00:00Z",
+            },
+        });
+        renderWithToaster(<UserTable users={[makeUser()]} />);
+
+        await userEvent.click(screen.getByRole("button", { name: /^impersonate$/i }));
+
+        await waitFor(() => {
+            expect(fakeWindow.location.href).toBe("/dashboard");
+            expect(fakeWindow.focus).toHaveBeenCalled();
+            expect(broadcastImpersonationEvent).toHaveBeenCalledWith({ type: "started" });
+            expect(mockPush).not.toHaveBeenCalled();
+        });
+    });
+
+    it("closes the pre-opened tab when the start action fails", async () => {
+        const fakeWindow = makeFakeWindow();
+        vi.mocked(openImpersonationWindow).mockReturnValue(fakeWindow as unknown as Window);
+        vi.mocked(startImpersonation).mockResolvedValue({ error: "Superuser access required" });
+        renderWithToaster(<UserTable users={[makeUser()]} />);
+
+        await userEvent.click(screen.getByRole("button", { name: /^impersonate$/i }));
+
+        await waitFor(() => {
+            expect(fakeWindow.close).toHaveBeenCalled();
+        });
+        expect(broadcastImpersonationEvent).not.toHaveBeenCalled();
     });
 
     it("shows an error toast and does not navigate when start fails", async () => {

--- a/src/components/superadmin/UserTable.tsx
+++ b/src/components/superadmin/UserTable.tsx
@@ -8,6 +8,7 @@ import { startImpersonation } from "@/lib/admin/server";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { DataTable } from "@/components/shared/DataTable";
+import { broadcastImpersonationEvent, openImpersonationWindow } from "@/lib/impersonation-events";
 
 type UserTableProps = {
     users: User[];
@@ -20,9 +21,14 @@ export function UserTable({ users }: UserTableProps) {
 
     const handleImpersonate = async (userId: string) => {
         setImpersonatingId(userId);
+        // Open the impersonation tab synchronously, before any await — popup
+        // blockers do not reliably honor window.open after a network
+        // round-trip. Null (blocked) falls back to same-tab navigation.
+        const impersonationWindow = openImpersonationWindow();
         try {
             const result = await startImpersonation(userId);
             if (result.error) {
+                impersonationWindow?.close();
                 toast.error(result.error);
                 return;
             }
@@ -34,10 +40,19 @@ export function UserTable({ users }: UserTableProps) {
                 // already scopes data to the target org, poisoning org-keyed
                 // client caches with the wrong org's data.
                 await update({ impersonationChanged: true });
+                broadcastImpersonationEvent({ type: "started" });
                 router.refresh();
-                router.push("/dashboard");
+                if (impersonationWindow && !impersonationWindow.closed) {
+                    impersonationWindow.location.href = "/dashboard";
+                    impersonationWindow.focus();
+                } else {
+                    router.push("/dashboard");
+                }
+            } else {
+                impersonationWindow?.close();
             }
         } catch {
+            impersonationWindow?.close();
             toast.error("Failed to start impersonation");
         } finally {
             setImpersonatingId(null);

--- a/src/lib/__tests__/impersonation-events.test.ts
+++ b/src/lib/__tests__/impersonation-events.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    broadcastImpersonationEvent,
+    IMPERSONATION_CHANNEL,
+    IMPERSONATION_WINDOW_NAME,
+    isImpersonationWindow,
+    onImpersonationEvent,
+    openImpersonationWindow,
+    type ImpersonationEvent,
+} from "@/lib/impersonation-events";
+
+class FakeBroadcastChannel {
+    static instances: FakeBroadcastChannel[] = [];
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    posted: unknown[] = [];
+    closed = false;
+
+    constructor(public name: string) {
+        FakeBroadcastChannel.instances.push(this);
+    }
+
+    postMessage(data: unknown): void {
+        this.posted.push(data);
+    }
+
+    close(): void {
+        this.closed = true;
+    }
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    FakeBroadcastChannel.instances = [];
+    window.name = "";
+});
+
+describe("impersonation-events", () => {
+    it("broadcasts on the shared channel and closes it", () => {
+        vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+
+        broadcastImpersonationEvent({ type: "stopped" });
+
+        const channel = FakeBroadcastChannel.instances[0];
+        expect(channel.name).toBe(IMPERSONATION_CHANNEL);
+        expect(channel.posted).toEqual([{ type: "stopped" }]);
+        expect(channel.closed).toBe(true);
+    });
+
+    it("delivers only well-formed events to subscribers", () => {
+        vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+        const received: ImpersonationEvent[] = [];
+
+        const unsubscribe = onImpersonationEvent((event) => received.push(event));
+        const channel = FakeBroadcastChannel.instances[0];
+
+        channel.onmessage?.({ data: { type: "started" } } as MessageEvent);
+        channel.onmessage?.({ data: { type: "bogus" } } as MessageEvent);
+        channel.onmessage?.({ data: null } as MessageEvent);
+
+        expect(received).toEqual([{ type: "started" }]);
+        unsubscribe();
+        expect(channel.closed).toBe(true);
+    });
+
+    it("is a no-op without BroadcastChannel support", () => {
+        vi.stubGlobal("BroadcastChannel", undefined);
+
+        expect(() => broadcastImpersonationEvent({ type: "started" })).not.toThrow();
+        expect(onImpersonationEvent(() => {})).toBeTypeOf("function");
+    });
+
+    it("identifies the impersonation tab by window.name", () => {
+        expect(isImpersonationWindow()).toBe(false);
+        window.name = IMPERSONATION_WINDOW_NAME;
+        expect(isImpersonationWindow()).toBe(true);
+    });
+
+    it("opens the named tab via window.open", () => {
+        const openSpy = vi
+            .spyOn(window, "open")
+            .mockReturnValue({ closed: false } as unknown as Window);
+
+        const result = openImpersonationWindow();
+
+        expect(openSpy).toHaveBeenCalledWith("", IMPERSONATION_WINDOW_NAME);
+        expect(result).not.toBeNull();
+        openSpy.mockRestore();
+    });
+});

--- a/src/lib/impersonation-events.ts
+++ b/src/lib/impersonation-events.ts
@@ -1,0 +1,63 @@
+/**
+ * Cross-tab impersonation event plumbing (CHAOS-2347).
+ *
+ * Impersonation state is per ADMIN USER on the server (DB session + shared
+ * cookie), so a start/stop in one tab changes the effective org in EVERY tab
+ * of the browser. Without a push signal, other tabs only notice on their next
+ * 30s-throttled session poll. A BroadcastChannel lets every tab force the
+ * server-verified re-poll (`update({ impersonationChanged: true })`) the
+ * moment any tab starts or stops impersonating.
+ *
+ * Client-only: every export guards on BroadcastChannel availability so the
+ * module is safe to import from shared code paths.
+ */
+
+export const IMPERSONATION_CHANNEL = "dev-health:impersonation";
+
+/**
+ * `window.name` marker for the tab opened by the Impersonate buttons.
+ * Identifies the tab that should self-close when impersonation stops —
+ * without it, any tab that happens to have an opener would close.
+ */
+export const IMPERSONATION_WINDOW_NAME = "dev-health-impersonation";
+
+export type ImpersonationEvent = { type: "started" } | { type: "stopped" };
+
+export function broadcastImpersonationEvent(event: ImpersonationEvent): void {
+    if (typeof BroadcastChannel === "undefined") return;
+    const channel = new BroadcastChannel(IMPERSONATION_CHANNEL);
+    channel.postMessage(event);
+    channel.close();
+}
+
+/**
+ * Subscribe to impersonation events from OTHER tabs. Returns an unsubscribe
+ * callback (no-op when BroadcastChannel is unavailable, e.g. jsdom).
+ */
+export function onImpersonationEvent(handler: (event: ImpersonationEvent) => void): () => void {
+    if (typeof BroadcastChannel === "undefined") return () => {};
+    const channel = new BroadcastChannel(IMPERSONATION_CHANNEL);
+    channel.onmessage = (message: MessageEvent) => {
+        const data = message.data as ImpersonationEvent | undefined;
+        if (data?.type === "started" || data?.type === "stopped") {
+            handler(data);
+        }
+    };
+    return () => channel.close();
+}
+
+/** True when this tab is the impersonation tab opened by an Impersonate button. */
+export function isImpersonationWindow(): boolean {
+    return typeof window !== "undefined" && window.name === IMPERSONATION_WINDOW_NAME;
+}
+
+/**
+ * Open (or reuse) the impersonation tab synchronously — MUST be called inside
+ * the click handler, before any `await`, or popup blockers may eat it: the
+ * user-gesture context does not reliably survive a network round-trip.
+ * Returns null when blocked; callers fall back to same-tab navigation.
+ */
+export function openImpersonationWindow(): Window | null {
+    if (typeof window === "undefined") return null;
+    return window.open("", IMPERSONATION_WINDOW_NAME);
+}


### PR DESCRIPTION
Fixes CHAOS-2347. Builds on #678 (CHAOS-2327, merged).

## What

- **Impersonate opens a dedicated tab** at `/dashboard` (the target's view). The tab is opened synchronously inside the click handler — popup blockers don't reliably honor `window.open` after a network round-trip — and navigated once the server action resolves. When blocked, falls back to the previous same-tab navigation.
- **Stop closes that tab**, returning the admin to their superadmin tab. Identified via a `window.name` marker (not `window.opener`, so any tab with an opener isn't at risk of closing). If the browser refuses to close (restored/duplicated tab), falls back to `/superadmin`.
- **Cross-tab sync via `BroadcastChannel`**: impersonation is per *admin user* server-side (shared cookie), so a start/stop in any tab changes the effective org in **every** tab. Previously other tabs stayed visually stale for up to 30s (the jwt-callback poll throttle). Now every tab forces the server-verified re-poll the moment any tab starts/stops, and the dedicated tab self-closes on a remote stop.

## Design constraint worth knowing

A new tab does **not** isolate impersonation — the opener superadmin tab is also scoped to the target org while impersonating (state is cookie/DB-side, per admin). The global banner renders in every tab, which keeps the shared state visible. True per-tab impersonation would need a per-tab header token; noted in CHAOS-2328.

## Codex adversarial review

Initial verdict BLOCK; resolved as follows:
- **HIGH (update() dropped in cross-tab race / N-tab request storm)** — fixed: listener skips the re-poll when the tab already reflects the event, and retries once when next-auth's `update()` no-ops mid-flight. Note the worst case was milder than stated: the cookie is browser-global and committed *before* the broadcast fires, so any session refetch yields correct state; the fix removes the residual UI-staleness race and bounds traffic.
- **MEDIUM (stranded tab when remote stop can't close it)** — fixed: fallback navigation to `/superadmin`.
- **MEDIUM (named-window reuse)** — rejected with rationale: `window.open("", name)` only targets windows in this page's browsing-context group, i.e. the impersonation tab we ourselves opened; re-navigating it on re-impersonation is the intended reuse. Cross-origin/unrelated tabs are not reachable by name.

## Verification

- 17 component/unit tests across the banner, UserTable, and the new `impersonation-events` module; full suite green locally (`format`/`quality`/`unit`)
- Live on rebuilt compose stack: Impersonate from users list → second tab opens at `/dashboard` with "Viewing as admin@int.ex" banner; Stop in that tab → tab closes itself, original tab reverts instantly (no 30s lag); backend `impersonate/status` false, 0 dangling sessions

SCREENSHOT-WAIVER: behavioral change (tab open/self-close, cross-tab sync) — no rendered-pixel diff; banner visuals unchanged from the screenshot on #678.
