### PR TITLE
feat(auth): per-request impersonation resolution with bounded fan-out (CHAOS-2328)

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -522,10 +522,11 @@ describe("jwt callback — token lifecycle", () => {
 
     // ── Impersonation status sync (CHAOS-2309 / CHAOS-2327 / CHAOS-2328) ───
     // The jwt callback mirrors backend impersonation state into the token by
-    // polling the (Valkey-cached) status endpoint on EVERY superuser token
-    // read — no throttle, no update-payload contract. These pin the field
-    // lifecycle at the callback level so a future auth refactor can't break
-    // it while component tests (which mock the session) still pass.
+    // polling the (Valkey-cached) status endpoint on superuser token reads,
+    // bounded by a ~3s per-process memo that update() triggers bypass. These
+    // pin the field lifecycle at the callback level so a future auth refactor
+    // can't break it while component tests (which mock the session) still
+    // pass. Each test uses a distinct token id — the memo is module-global.
 
     function superuserToken(overrides: Record<string, unknown> = {}): Record<string, unknown> {
         return {
@@ -547,7 +548,7 @@ describe("jwt callback — token lifecycle", () => {
         } as unknown as Response);
     }
 
-    it("(l) every superuser token read polls status and stores the target identity", async () => {
+    it("(l) a plain superuser token read polls status and stores the target identity", async () => {
         const fetchMock = statusFetchMock({
             is_impersonating: true,
             target_user_id: "target-1",
@@ -559,7 +560,7 @@ describe("jwt callback — token lifecycle", () => {
         const jwt = getJwtCallback();
         // Plain session read — no update trigger required (CHAOS-2328)
         const result = await jwt({
-            token: superuserToken(),
+            token: superuserToken({ id: "admin-l" }),
             user: null,
             account: null,
         });
@@ -584,6 +585,7 @@ describe("jwt callback — token lifecycle", () => {
         const jwt = getJwtCallback();
         const result = await jwt({
             token: superuserToken({
+                id: "admin-m",
                 is_impersonating: true,
                 impersonated_user_id: "target-1",
                 impersonated_email: "target@example.com",
@@ -612,7 +614,7 @@ describe("jwt callback — token lifecycle", () => {
 
         const jwt = getJwtCallback();
         const result = await jwt({
-            token: superuserToken(),
+            token: superuserToken({ id: "admin-n" }),
             user: null,
             account: null,
             trigger: "update",
@@ -630,12 +632,74 @@ describe("jwt callback — token lifecycle", () => {
 
         const jwt = getJwtCallback();
         const result = await jwt({
-            token: superuserToken({ is_superuser: false }),
+            token: superuserToken({ id: "admin-o", is_superuser: false }),
             user: null,
             account: null,
         });
 
         expect(fetchMock).not.toHaveBeenCalled();
         expect(result.is_impersonating).toBeUndefined();
+    });
+
+    it("(p) update payloads are not trusted even when the status poll fails", async () => {
+        // Codex finding: (n) only proved the property for a successful 200
+        // false. A malicious payload must also be rejected when the server
+        // can't be reached — fields stay at their previous (absent) values.
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            json: async () => ({ detail: "boom" }),
+        } as unknown as Response);
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+        const result = await jwt({
+            token: superuserToken({ id: "admin-p" }),
+            user: null,
+            account: null,
+            trigger: "update",
+            session: {
+                startImpersonation: { status: "active", target_user: { id: "evil" } },
+                impersonationChanged: true,
+            },
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(result.is_impersonating).toBeUndefined();
+        expect(result.impersonated_user_id).toBeUndefined();
+        expect(result.impersonated_org_id).toBeUndefined();
+    });
+
+    it("(q) consecutive plain reads share the memo; update() triggers bypass it", async () => {
+        const fetchMock = statusFetchMock({
+            is_impersonating: true,
+            target_user_id: "target-q",
+            target_email: "q@example.com",
+            target_org_id: "org-q",
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+        // Two plain reads within the memo TTL → one backend fetch, but both
+        // tokens carry the synced state.
+        await jwt({ token: superuserToken({ id: "admin-q" }), user: null, account: null });
+        const second = await jwt({
+            token: superuserToken({ id: "admin-q" }),
+            user: null,
+            account: null,
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(second.is_impersonating).toBe(true);
+        expect(second.impersonated_user_id).toBe("target-q");
+
+        // An update() trigger must bypass the memo and re-poll immediately.
+        await jwt({
+            token: superuserToken({ id: "admin-q" }),
+            user: null,
+            account: null,
+            trigger: "update",
+            session: { impersonationChanged: true },
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -520,12 +520,12 @@ describe("jwt callback — token lifecycle", () => {
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    // ── Impersonation status sync (CHAOS-2309 / CHAOS-2327) ────────────────
-    // The jwt callback mirrors backend impersonation state into the token via
-    // a 30s-throttled poll; update({ impersonationChanged: true }) bypasses
-    // the throttle. These pin the field lifecycle at the callback level so a
-    // future auth refactor can't break it while component tests (which mock
-    // the session) still pass.
+    // ── Impersonation status sync (CHAOS-2309 / CHAOS-2327 / CHAOS-2328) ───
+    // The jwt callback mirrors backend impersonation state into the token by
+    // polling the (Valkey-cached) status endpoint on EVERY superuser token
+    // read — no throttle, no update-payload contract. These pin the field
+    // lifecycle at the callback level so a future auth refactor can't break
+    // it while component tests (which mock the session) still pass.
 
     function superuserToken(overrides: Record<string, unknown> = {}): Record<string, unknown> {
         return {
@@ -535,8 +535,6 @@ describe("jwt callback — token lifecycle", () => {
             is_superuser: true,
             expires_at: Date.now() + 3600 * 1000,
             last_validated: Date.now(),
-            // Recent check — within the 30s throttle window
-            last_impersonation_check: Date.now() - 1000,
             ...overrides,
         };
     }
@@ -549,7 +547,7 @@ describe("jwt callback — token lifecycle", () => {
         } as unknown as Response);
     }
 
-    it("(l) impersonationChanged bypasses the poll throttle and stores the target identity", async () => {
+    it("(l) every superuser token read polls status and stores the target identity", async () => {
         const fetchMock = statusFetchMock({
             is_impersonating: true,
             target_user_id: "target-1",
@@ -559,12 +557,11 @@ describe("jwt callback — token lifecycle", () => {
         vi.stubGlobal("fetch", fetchMock);
 
         const jwt = getJwtCallback();
+        // Plain session read — no update trigger required (CHAOS-2328)
         const result = await jwt({
             token: superuserToken(),
             user: null,
             account: null,
-            trigger: "update",
-            session: { impersonationChanged: true },
         });
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -594,8 +591,6 @@ describe("jwt callback — token lifecycle", () => {
             }),
             user: null,
             account: null,
-            trigger: "update",
-            session: { impersonationChanged: true },
         });
 
         expect(result.is_impersonating).toBe(false);
@@ -604,8 +599,15 @@ describe("jwt callback — token lifecycle", () => {
         expect(result.impersonated_org_id).toBeUndefined();
     });
 
-    it("(n) legacy startImpersonation update payloads are ignored and do not bypass the throttle (CHAOS-2327)", async () => {
-        const fetchMock = statusFetchMock({ is_impersonating: true });
+    it("(n) update payloads are never trusted — the server-verified status wins (CHAOS-2327)", async () => {
+        // Client claims an active impersonation via the legacy payload, but
+        // the backend says none is active: the token must reflect the server.
+        const fetchMock = statusFetchMock({
+            is_impersonating: false,
+            target_user_id: null,
+            target_email: null,
+            target_org_id: null,
+        });
         vi.stubGlobal("fetch", fetchMock);
 
         const jwt = getJwtCallback();
@@ -614,10 +616,25 @@ describe("jwt callback — token lifecycle", () => {
             user: null,
             account: null,
             trigger: "update",
-            session: { startImpersonation: { status: "active" } },
+            session: { startImpersonation: { status: "active", target_user: { id: "x" } } },
         });
 
-        // Throttle window still active — no poll, no trusted client payload
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(result.is_impersonating).toBe(false);
+        expect(result.impersonated_user_id).toBeUndefined();
+    });
+
+    it("(o) non-superuser token reads never call the status endpoint", async () => {
+        const fetchMock = statusFetchMock({ is_impersonating: false });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+        const result = await jwt({
+            token: superuserToken({ is_superuser: false }),
+            user: null,
+            account: null,
+        });
+
         expect(fetchMock).not.toHaveBeenCalled();
         expect(result.is_impersonating).toBeUndefined();
     });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -37,6 +37,31 @@ const authSecret =
     authEnv.NEXTAUTH_SECRET ||
     (authEnv.NODE_ENV === "production" ? undefined : "dev-secret-change-in-production");
 
+/**
+ * Per-process micro-memo for the impersonation status poll (CHAOS-2328).
+ *
+ * The jwt callback runs on every session read — including the proxy, which
+ * calls auth() for every protected route — so an unconditional backend fetch
+ * per read would fan out badly on superuser traffic. The memo bounds it to
+ * one fetch per ~3s per web process. `update()` triggers bypass the memo, so
+ * explicit start/stop (which all impersonation components signal via
+ * update({ impersonationChanged: true })) is observed with zero delay; the
+ * worst-case cross-instance staleness is the memo TTL.
+ *
+ * Superuser sessions only — the map stays tiny; no eviction needed.
+ */
+interface ImpersonationStatusSnapshot {
+    is_impersonating: boolean;
+    impersonated_user_id?: string;
+    impersonated_email?: string;
+    impersonated_org_id?: string;
+}
+const impersonationStatusMemo = new Map<
+    string,
+    { at: number; status: ImpersonationStatusSnapshot }
+>();
+const IMPERSONATION_MEMO_TTL_MS = 3_000;
+
 const nextAuth = NextAuth({
     trustHost: true,
     logger: {
@@ -230,42 +255,7 @@ const nextAuth = NextAuth({
                 token.error = undefined;
             }
 
-            // For superusers: sync impersonation state from the backend on EVERY
-            // token read (CHAOS-2328). The status endpoint reads through a shared
-            // Valkey cache server-side, so this is a cheap in-cluster call for the
-            // handful of superuser sessions — and it removes every staleness
-            // window: start/stop are observed on the next request, on every web
-            // instance, with no update-payload contract between components and
-            // this callback. update({ impersonationChanged: true }) calls from
-            // components remain useful purely as an immediate-session-read
-            // trigger; the payload itself is never trusted.
             const now = Date.now();
-            if (token.is_superuser && token.access_token && !user) {
-                try {
-                    const backendUrl = getBackendUrl();
-                    const statusRes = await fetch(`${backendUrl}/api/v1/admin/impersonate/status`, {
-                        method: "GET",
-                        headers: {
-                            Authorization: `Bearer ${token.access_token as string}`,
-                        },
-                    });
-                    if (statusRes.ok) {
-                        const statusData = (await statusRes.json()) as {
-                            is_impersonating: boolean;
-                            target_user_id?: string | null;
-                            target_email?: string | null;
-                            target_org_id?: string | null;
-                        };
-                        token.is_impersonating = statusData.is_impersonating;
-                        token.impersonated_user_id = statusData.target_user_id ?? undefined;
-                        token.impersonated_email = statusData.target_email ?? undefined;
-                        token.impersonated_org_id = statusData.target_org_id ?? undefined;
-                    }
-                } catch {
-                    // Network error — keep existing impersonation state
-                }
-            }
-
             const expiresAt = token.expires_at as number | undefined;
             const lastValidated = token.last_validated as number | undefined;
             const tokenExpired = expiresAt && now > expiresAt - 5 * 60 * 1000;
@@ -320,6 +310,63 @@ const nextAuth = NextAuth({
                     token.access_token = undefined;
                     token.error = "refresh_unavailable";
                     return token;
+                }
+            }
+
+            // Impersonation sync for superusers (CHAOS-2328). Runs AFTER the
+            // refresh step so a just-refreshed access token is used — polling
+            // before refresh could 401 and silently keep stale impersonation
+            // state for this request. The status endpoint reads through a
+            // shared Valkey cache server-side; the per-process memo above
+            // bounds fetch fan-out, and update() triggers bypass it so
+            // explicit start/stop is observed immediately. The update payload
+            // itself is never trusted — only the server response mutates the
+            // token.
+            if (token.is_superuser && token.access_token && !user) {
+                const memoKey = token.id as string;
+                const memoized = impersonationStatusMemo.get(memoKey);
+                const memoFresh =
+                    memoized !== undefined && now - memoized.at < IMPERSONATION_MEMO_TTL_MS;
+                if (memoFresh && trigger !== "update") {
+                    token.is_impersonating = memoized.status.is_impersonating;
+                    token.impersonated_user_id = memoized.status.impersonated_user_id;
+                    token.impersonated_email = memoized.status.impersonated_email;
+                    token.impersonated_org_id = memoized.status.impersonated_org_id;
+                } else {
+                    try {
+                        const backendUrl = getBackendUrl();
+                        const statusRes = await fetch(
+                            `${backendUrl}/api/v1/admin/impersonate/status`,
+                            {
+                                method: "GET",
+                                headers: {
+                                    Authorization: `Bearer ${token.access_token as string}`,
+                                },
+                            },
+                        );
+                        if (statusRes.ok) {
+                            const statusData = (await statusRes.json()) as {
+                                is_impersonating: boolean;
+                                target_user_id?: string | null;
+                                target_email?: string | null;
+                                target_org_id?: string | null;
+                            };
+                            const status: ImpersonationStatusSnapshot = {
+                                is_impersonating: statusData.is_impersonating,
+                                impersonated_user_id: statusData.target_user_id ?? undefined,
+                                impersonated_email: statusData.target_email ?? undefined,
+                                impersonated_org_id: statusData.target_org_id ?? undefined,
+                            };
+                            token.is_impersonating = status.is_impersonating;
+                            token.impersonated_user_id = status.impersonated_user_id;
+                            token.impersonated_email = status.impersonated_email;
+                            token.impersonated_org_id = status.impersonated_org_id;
+                            impersonationStatusMemo.set(memoKey, { at: now, status });
+                        }
+                    } catch {
+                        // Network error — keep existing impersonation state and
+                        // don't memo the failure (next read retries).
+                    }
                 }
             }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -230,27 +230,17 @@ const nextAuth = NextAuth({
                 token.error = undefined;
             }
 
-            // Impersonation start/stop: the client signals the change via
-            // update({ impersonationChanged: true }). The payload is NOT trusted —
-            // it only bypasses the 30s poll throttle so the status below is
-            // re-read from the backend immediately (server-verified).
-            if (trigger === "update" && session?.impersonationChanged) {
-                token.last_impersonation_check = undefined;
-            }
-
-            // For superusers: sync impersonation state from backend at most every 30s.
-            // This ensures router.refresh() picks up the current impersonation state
-            // without hammering the backend on every JWT callback.
+            // For superusers: sync impersonation state from the backend on EVERY
+            // token read (CHAOS-2328). The status endpoint reads through a shared
+            // Valkey cache server-side, so this is a cheap in-cluster call for the
+            // handful of superuser sessions — and it removes every staleness
+            // window: start/stop are observed on the next request, on every web
+            // instance, with no update-payload contract between components and
+            // this callback. update({ impersonationChanged: true }) calls from
+            // components remain useful purely as an immediate-session-read
+            // trigger; the payload itself is never trusted.
             const now = Date.now();
-            const IMPERSONATION_POLL_INTERVAL = 30 * 1000; // 30 seconds — matches backend cache TTL
-            const lastImpersonationCheck = token.last_impersonation_check as number | undefined;
-            if (
-                token.is_superuser &&
-                token.access_token &&
-                !user &&
-                (!lastImpersonationCheck ||
-                    now - lastImpersonationCheck > IMPERSONATION_POLL_INTERVAL)
-            ) {
+            if (token.is_superuser && token.access_token && !user) {
                 try {
                     const backendUrl = getBackendUrl();
                     const statusRes = await fetch(`${backendUrl}/api/v1/admin/impersonate/status`, {
@@ -273,9 +263,6 @@ const nextAuth = NextAuth({
                     }
                 } catch {
                     // Network error — keep existing impersonation state
-                } finally {
-                    // Always rate-limit impersonation status checks, even on failures
-                    token.last_impersonation_check = now;
                 }
             }
 

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -54,6 +54,5 @@ declare module "next-auth/jwt" {
         impersonated_email?: string;
         impersonated_org_id?: string;
         last_validated?: number;
-        last_impersonation_check?: number;
     }
 }


### PR DESCRIPTION
Implements CHAOS-2328 (web half; pairs with the ops Valkey-cache PR — merge that first so the status endpoint is cheap, though this PR is safe standalone).

## Change

The jwt callback no longer mirrors impersonation state via a **30s-throttled poll with an `update({ impersonationChanged })` bypass contract** — the contract every impersonation component had to remember (CHAOS-2327 was one missed caller). Instead:

- **Per-request resolution with a ~3s per-process micro-memo.** Superuser token reads poll `/impersonate/status` (Valkey-cached server-side); the memo bounds fan-out — `auth()` runs in the proxy for every protected route, so an unconditional per-read fetch would multiply backend calls per page load. `update()` triggers bypass the memo, so explicit start/stop is observed with zero delay; worst-case cross-instance staleness drops from 30s to the 3s memo TTL.
- **Poll moved after the token-refresh step** — polling before refresh could 401 on an expired access token and silently keep stale impersonation state for the request performing the refresh.
- `last_impersonation_check` removed from the JWT (existing cookies carrying it are ignored and rewritten).
- Components keep sending `update({ impersonationChanged: true })` — now purely a "read the session right now + bypass memo" trigger; the payload is never trusted.

## Codex adversarial review

Initial verdict BLOCK: per-read fetch on the proxy hot path (HIGH → fixed with the memo), status-before-refresh 401 staleness (MEDIUM → fixed by reordering), payload-trust test gap under status failure (LOW → new test). Report: `/tmp/claude/codex-review-web-per-request-impersonation.md`.

## Verification

- jwt-callback suite extended to 25 tests: plain-read polling, clear-on-false, payload-never-trusted (success *and* failure paths), non-superuser never polls, memo sharing + update-trigger bypass
- Full web gates green (format/quality/unit — 2065+ tests)
- Live against the ops branch: start/stop observed instantly; Valkey snapshot/sentinel lifecycle confirmed

TEST-WAIVER: not needed — test files included.
