### PR TITLE
fix(nav): drop duplicate child crumb from breadcrumb trails

### DIFF
--- a/src/app/(app)/ai/automations/page.tsx
+++ b/src/app/(app)/ai/automations/page.tsx
@@ -28,13 +28,7 @@ export default async function AIAutomationsPage({ searchParams }: AIAutomationsP
             <AIPageHeader
                 eyebrow="AI"
                 title="Automations"
-                breadcrumbs={[
-                    ...navTrailForPathname("/ai/automations").map((c) => ({
-                        ...c,
-                        href: c.href ?? "/ai",
-                    })),
-                    { label: "Automations" },
-                ]}
+                breadcrumbs={navTrailForPathname("/ai/automations")}
             >
                 Candidate patterns for responsible automation, separated from Impact diagnostics so
                 teams can triage opportunities directly.

--- a/src/app/(app)/ai/impact/evidence/page.tsx
+++ b/src/app/(app)/ai/impact/evidence/page.tsx
@@ -32,10 +32,10 @@ export default async function AIImpactEvidencePage({ searchParams }: AIImpactEvi
                 eyebrow="AI"
                 title="PR Evidence"
                 breadcrumbs={[
-                    ...navTrailForPathname("/ai/impact").map((c) => ({
-                        ...c,
-                        href: c.href ?? "/ai",
-                    })),
+                    // Drop the trail's final (current-page) "Impact" crumb and
+                    // re-add it as a filter-preserving link back to the rollups,
+                    // with PR Evidence as the current crumb.
+                    ...navTrailForPathname("/ai/impact").slice(0, -1),
                     { label: "Impact", href: withFilterParam("/ai/impact", filters, role) },
                     { label: "PR Evidence" },
                 ]}

--- a/src/app/(app)/ai/impact/page.tsx
+++ b/src/app/(app)/ai/impact/page.tsx
@@ -30,13 +30,7 @@ export default async function AIImpactPage({ searchParams }: AIImpactPageProps) 
             <AIPageHeader
                 eyebrow="AI"
                 title="Impact"
-                breadcrumbs={[
-                    ...navTrailForPathname("/ai/impact").map((c) => ({
-                        ...c,
-                        href: c.href ?? "/ai",
-                    })),
-                    { label: "Impact" },
-                ]}
+                breadcrumbs={navTrailForPathname("/ai/impact")}
             >
                 Org-wide view of how AI-assisted workflows appear to influence delivery, review
                 load, quality gaps, and operational drag.

--- a/src/app/(app)/ai/review-load/page.tsx
+++ b/src/app/(app)/ai/review-load/page.tsx
@@ -28,13 +28,7 @@ export default async function AIReviewLoadPage({ searchParams }: AIReviewLoadPag
             <AIPageHeader
                 eyebrow="AI"
                 title="Review Load"
-                breadcrumbs={[
-                    ...navTrailForPathname("/ai/review-load").map((c) => ({
-                        ...c,
-                        href: c.href ?? "/ai",
-                    })),
-                    { label: "Review Load" },
-                ]}
+                breadcrumbs={navTrailForPathname("/ai/review-load")}
             >
                 Diagnostic view for AI-generated review pressure, comparing AI-attributed work
                 against the human baseline without person-level rankings.

--- a/src/app/(app)/ai/risk/page.tsx
+++ b/src/app/(app)/ai/risk/page.tsx
@@ -52,18 +52,18 @@ export default async function AIRiskPage({ searchParams }: AIRiskPageProps) {
             <AIPageHeader
                 eyebrow="AI"
                 title="Governance Risk"
-                breadcrumbs={[
-                    ...navTrailForPathname("/ai/risk").map((c) => ({
-                        ...c,
-                        href: c.href ?? "/ai",
-                    })),
-                    ...(view === "overview"
-                        ? [{ label: "Governance Risk" }]
+                breadcrumbs={
+                    view === "overview"
+                        ? navTrailForPathname("/ai/risk")
                         : [
+                              // On a sub-tab the area→child trail's "Governance Risk"
+                              // crumb becomes a link back to the overview, with the
+                              // active view as the final (current) crumb.
+                              ...navTrailForPathname("/ai/risk").slice(0, -1),
                               { label: "Governance Risk", href: "/ai/risk" },
                               { label: VIEW_CRUMBS[view] },
-                          ]),
-                ]}
+                          ]
+                }
             >
                 {VIEW_LEDES[view]}
             </AIPageHeader>

--- a/src/app/(app)/improve/automations/page.tsx
+++ b/src/app/(app)/improve/automations/page.tsx
@@ -36,13 +36,7 @@ export default async function ImproveAutomationsPage({
                     <AIPageHeader
                         eyebrow="Improve"
                         title="Automations"
-                        breadcrumbs={[
-                            ...navTrailForPathname("/improve/automations").map((c) => ({
-                                ...c,
-                                href: c.href ?? "/improve",
-                            })),
-                            { label: "Automations" },
-                        ]}
+                        breadcrumbs={navTrailForPathname("/improve/automations")}
                     >
                         Non-AI flow opportunities — review latency, cycle time, rework, WIP
                         congestion, throughput, churn, and change failure rate — each firing only


### PR DESCRIPTION
## Problem

The **Improve → Automations** page rendered its breadcrumb as `Improve / Automations / Automations` (reported via screenshot). The page itself was *not* broken — the empty "All monitored metrics are within thresholds" card is a legitimate \`detectorReady === true\` empty state.

## Root cause

\`navTrailForPathname()\` is a **complete** trail builder: for a registered nav child it returns the full `Area → Child` pair (its unit-test contract asserts `["Admin","Connections"]`), with the child as the link-less current crumb. Six pages **appended a second hard-coded child crumb** on top of that complete trail, and the accompanying `.map(c => ({ ...c, href: c.href ?? area }))` also forced an `href` onto the link-less current crumb — turning the duplicate into a stray link back to the area landing page.

## Fix

| Page | Before | After |
|---|---|---|
| `improve/automations` | Improve / Automations / **Automations** | Improve / Automations |
| `ai/automations` | AI / Automations / **Automations** | AI / Automations |
| `ai/impact` | AI / Impact / **Impact** | AI / Impact |
| `ai/review-load` | AI / Review Load / **Review Load** | AI / Review Load |
| `ai/risk` | AI / Governance Risk / **Governance Risk** [/ tab] | AI / Governance Risk [/ tab] |
| `ai/impact/evidence` | AI / Impact / **Impact** / PR Evidence | AI / Impact / PR Evidence |

- Simple child pages pass `navTrailForPathname()` through directly.
- Sub-pages (`ai/risk` tabs, `ai/impact/evidence`) `slice(0, -1)` the trail's current-page crumb and re-add the parent as a **filter-preserving link**.
- **`ai/attribution` intentionally unchanged** — its child is `navVisible: false`, so its trail is area-only and the manual append is correct.

No change to `navTrailForPathname` itself, so its unit-test contract is preserved.

## Verification

- `tsc --noEmit`: clean
- Navigation unit tests: **169/169** pass
- Prettier: clean on all 6 files
- e2e `ai-navigation`: **6 passed** · `ai-governance-risk-tabs`: **8 passed**