### PR TITLE
fix(improve): render PrimaryNav chrome on Automations page

### DIFF
--- a/src/app/(app)/improve/automations/page.tsx
+++ b/src/app/(app)/improve/automations/page.tsx
@@ -1,6 +1,7 @@
 import { AIPageHeader } from "@/components/ai/AIPageHeader";
 import { FilterBar } from "@/components/filters/FilterBar";
 import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
+import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { ImproveAutomationsDashboard } from "@/components/improve/ImproveAutomationsDashboard";
 import { checkApiHealth } from "@/lib/api/system";
@@ -28,25 +29,31 @@ export default async function ImproveAutomationsPage({
     const aiAutomationsHref = withFilterParam("/ai/automations", filters, roleParam);
 
     return (
-        <>
-            <AIPageHeader
-                eyebrow="Improve"
-                title="Automations"
-                breadcrumbs={[
-                    ...navTrailForPathname("/improve/automations").map((c) => ({
-                        ...c,
-                        href: c.href ?? "/improve",
-                    })),
-                    { label: "Automations" },
-                ]}
-            >
-                Non-AI flow opportunities — review latency, cycle time, rework, WIP congestion,
-                throughput, churn, and change failure rate — each firing only when metrics exceed
-                documented thresholds. For AI-workflow automation candidates, see the AI surface.
-            </AIPageHeader>
-            <GlobalContextBar filters={filters} />
-            <FilterBar view="opportunities" />
-            <ImproveAutomationsDashboard aiAutomationsHref={aiAutomationsHref} />
-        </>
+        <div className="min-h-screen bg-background text-foreground">
+            <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+                <PrimaryNav filters={filters} active="improve-automations" role={roleParam} />
+                <main className="flex min-w-0 flex-1 flex-col gap-8">
+                    <AIPageHeader
+                        eyebrow="Improve"
+                        title="Automations"
+                        breadcrumbs={[
+                            ...navTrailForPathname("/improve/automations").map((c) => ({
+                                ...c,
+                                href: c.href ?? "/improve",
+                            })),
+                            { label: "Automations" },
+                        ]}
+                    >
+                        Non-AI flow opportunities — review latency, cycle time, rework, WIP
+                        congestion, throughput, churn, and change failure rate — each firing only
+                        when metrics exceed documented thresholds. For AI-workflow automation
+                        candidates, see the AI surface.
+                    </AIPageHeader>
+                    <GlobalContextBar filters={filters} />
+                    <FilterBar view="opportunities" />
+                    <ImproveAutomationsDashboard aiAutomationsHref={aiAutomationsHref} />
+                </main>
+            </div>
+        </div>
     );
 }

--- a/tests/nav-reachability.spec.ts
+++ b/tests/nav-reachability.spec.ts
@@ -324,6 +324,13 @@ test.describe("primary navigation reachability", () => {
             { path: "/plan/delivery-forecast", selectedLabel: "Plan" },
             { path: "/plan/capacity", selectedLabel: "Plan" },
             { path: "/operating-review", selectedLabel: "Plan" },
+            // Improve leaf routes: the Improve area has no layout.tsx, so each page
+            // must render PrimaryNav itself. /improve/automations shipped without it
+            // (full-bleed, no sidebar) — this asserts the chrome is present, since a
+            // chromeless page has no `aside a[data-active]` and fails the count check.
+            { path: "/improve/automations", selectedLabel: "Improve" },
+            { path: "/improve/experiments", selectedLabel: "Improve" },
+            { path: "/opportunities", selectedLabel: "Improve" },
         ]) {
             await expectSingleSelectedArea(page, route.path, route.selectedLabel);
         }


### PR DESCRIPTION
## Problem

The **Improve → Automations** page rendered **full-bleed with no app chrome** — no left sidebar nav, no container frame. Reported via screenshot.

## Root cause

This app composes chrome **per page**, not via a single shell layout. Most areas render `<PrimaryNav>` inside each page; a few (`ai`, `admin`, `testops`, `data-health`, …) hoist it into an area `layout.tsx`. The `improve` area has **no** `layout.tsx`, so each Improve page must render `PrimaryNav` itself.

When `/improve/automations` was built (CHAOS-2220) it shipped as a bare fragment:

```tsx
return (
  <>
    <AIPageHeader … />
    <GlobalContextBar … />
    <FilterBar … />
    <ImproveAutomationsDashboard … />
  </>
);
```

With no `PrimaryNav` and no `min-h-screen` flex shell, it fell through to the root `(app)/layout.tsx` (which only paints the gradient + user menu), so the sidebar and frame were absent. Every sibling — `/improve`, `/improve/experiments`, `/opportunities` — renders the shell per-page.

## Fix

Wrap the content in the **same** `min-h-screen` → `PrimaryNav` + `<main>` shell the sibling Improve pages use, with `active="improve-automations"`. Child highlight is pathname-driven, so the sidebar correctly expands **Improve** and marks **Automations** active.

This is the only page with the regression — the other non-layout pages flagged in an audit are redirect shims (`work`, `team-flow`, `capacity-planning`, `plan/delivery-forecast`, `explore/landscape`).

## Verification

- `tsc --noEmit`: clean
- prettier + eslint: clean
- Playwright: loaded `/improve/automations`, confirmed the **Primary areas** nav (sidebar) and the dashboard render inside the frame; sidebar shows Improve expanded with Automations active.

## Note

Scope is intentionally limited to the missing chrome. The duplicate-breadcrumb fix for this and 5 AI pages is in a separate PR (#681); the two touch the same `return` block in this file, so whichever merges second will need a trivial rebase.