### PR TITLE
fix(admin): correct admin API client paths to match backend routes (CHAOS-2371)

### DIFF
--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -15,7 +15,6 @@ import {
     testConnection,
     listAuditLogs,
     getAuditLog,
-    listAuditActions,
     listIPAllowlistEntries,
     createIPAllowlistEntry,
     updateIPAllowlistEntry,
@@ -335,21 +334,6 @@ describe("admin/server audit log actions", () => {
             const result = await getAuditLog("al-1");
             expect(result.data).toBeDefined();
             expect(result.data?.id).toBe("al-1");
-            fetchSpy.mockRestore();
-        });
-    });
-
-    describe("listAuditActions", () => {
-        it("returns available actions on success", async () => {
-            mockSession();
-            const actions = ["user.login", "user.logout", "credential.create"];
-            const fetchSpy = vi
-                .spyOn(global, "fetch")
-                .mockResolvedValue(new Response(JSON.stringify(actions), { status: 200 }));
-
-            const result = await listAuditActions();
-            expect(result.data).toBeDefined();
-            expect(result.data).toHaveLength(3);
             fetchSpy.mockRestore();
         });
     });

--- a/src/lib/admin/api/__tests__/admin-api-paths.test.ts
+++ b/src/lib/admin/api/__tests__/admin-api-paths.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Contract tests: assert that retentionApi and auditApi call request()
+ * with the correct backend paths after the /retention-policies and
+ * /audit-logs rename.
+ *
+ * platformAuditApi is intentionally excluded — its /platform/audit-logs
+ * path was already correct and must not be changed.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the request module before importing the API modules
+vi.mock("../_request", () => ({
+    request: vi.fn().mockResolvedValue({}),
+}));
+
+import { request } from "../_request";
+import { retentionApi } from "../retention";
+import { auditApi, platformAuditApi } from "../audit";
+
+const mockRequest = vi.mocked(request);
+
+beforeEach(() => {
+    mockRequest.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// retentionApi — all paths must use /retention-policies
+// ---------------------------------------------------------------------------
+describe("retentionApi path contract", () => {
+    it("list uses /retention-policies?limit=...&offset=...", async () => {
+        await retentionApi.list(10, 5);
+        expect(mockRequest).toHaveBeenCalledOnce();
+        expect(mockRequest.mock.calls[0][0]).toBe("/retention-policies?limit=10&offset=5");
+    });
+
+    it("get uses /retention-policies/:id", async () => {
+        await retentionApi.get("abc-123");
+        expect(mockRequest).toHaveBeenCalledOnce();
+        expect(mockRequest.mock.calls[0][0]).toBe("/retention-policies/abc-123");
+    });
+
+    it("create uses /retention-policies", async () => {
+        await retentionApi.create({
+            name: "test",
+            resource_type: "repo",
+            max_age_days: 30,
+        } as Parameters<typeof retentionApi.create>[0]);
+        expect(mockRequest).toHaveBeenCalledOnce();
+        expect(mockRequest.mock.calls[0][0]).toBe("/retention-policies");
+    });
+
+    it("update uses /retention-policies/:id", async () => {
+        await retentionApi.update("abc-123", { max_age_days: 60 } as Parameters<
+            typeof retentionApi.update
+        >[1]);
+        expect(mockRequest).toHaveBeenCalledOnce();
+        expect(mockRequest.mock.calls[0][0]).toBe("/retention-policies/abc-123");
+    });
+
+    it("delete uses /retention-policies/:id", async () => {
+        await retentionApi.delete("abc-123");
+        expect(mockRequest).toHaveBeenCalledOnce();
+        expect(mockRequest.mock.calls[0][0]).toBe("/retention-policies/abc-123");
+    });
+
+    it("execute uses /retention-policies/:id/execute", async () => {
+        await retentionApi.execute("abc-123");
+        expect(mockRequest).toHaveBeenCalledOnce();
+        expect(mockRequest.mock.calls[0][0]).toBe("/retention-policies/abc-123/execute");
+    });
+
+    it("resourceTypes uses /retention-policies/resource-types", async () => {
+        await retentionApi.resourceTypes();
+        expect(mockRequest).toHaveBeenCalledOnce();
+        expect(mockRequest.mock.calls[0][0]).toBe("/retention-policies/resource-types");
+    });
+
+    it("does NOT use the old /retention prefix", async () => {
+        await retentionApi.list();
+        const path = mockRequest.mock.calls[0][0] as string;
+        expect(path).not.toMatch(/^\/retention(?!-policies)/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// auditApi — all paths must use /audit-logs
+// ---------------------------------------------------------------------------
+describe("auditApi path contract", () => {
+    it("list uses /audit-logs?...", async () => {
+        await auditApi.list(undefined, 20, 0);
+        expect(mockRequest).toHaveBeenCalledOnce();
+        const path = mockRequest.mock.calls[0][0] as string;
+        expect(path).toMatch(/^\/audit-logs\?/);
+    });
+
+    it("get uses /audit-logs/:id", async () => {
+        await auditApi.get("log-456");
+        expect(mockRequest).toHaveBeenCalledOnce();
+        expect(mockRequest.mock.calls[0][0]).toBe("/audit-logs/log-456");
+    });
+
+    it("does NOT use the old /audit prefix (without -logs)", async () => {
+        await auditApi.list();
+        const path = mockRequest.mock.calls[0][0] as string;
+        expect(path).not.toMatch(/^\/audit(?!-logs)/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// platformAuditApi — must remain on /platform/audit-logs (unchanged)
+// ---------------------------------------------------------------------------
+describe("platformAuditApi path contract (must not be changed)", () => {
+    it("list uses /platform/audit-logs?...", async () => {
+        await platformAuditApi.list();
+        expect(mockRequest).toHaveBeenCalledOnce();
+        const path = mockRequest.mock.calls[0][0] as string;
+        expect(path).toMatch(/^\/platform\/audit-logs\?/);
+    });
+});

--- a/src/lib/admin/api/audit.ts
+++ b/src/lib/admin/api/audit.ts
@@ -11,30 +11,11 @@ export const auditApi = {
                 if (value != null) params.set(key, String(value));
             });
         }
-        return request<AuditLogListResponse>(`/audit?${params.toString()}`, {}, token, orgId);
+        return request<AuditLogListResponse>(`/audit-logs?${params.toString()}`, {}, token, orgId);
     },
 
     get: (id: string, token?: string, orgId?: string) =>
-        request<AuditLogListResponse["items"][0]>(`/audit/${id}`, {}, token, orgId),
-
-    export: (
-        format: "json" | "csv" = "json",
-        filters?: AuditLogFilter,
-        token?: string,
-        orgId?: string,
-    ) => {
-        const params = new URLSearchParams();
-        params.set("format", format);
-        if (filters) {
-            Object.entries(filters).forEach(([key, value]) => {
-                if (value != null) params.set(key, String(value));
-            });
-        }
-        return request<Blob>(`/audit/export?${params.toString()}`, {}, token, orgId);
-    },
-
-    actions: (token?: string, orgId?: string) =>
-        request<string[]>("/audit/actions", {}, token, orgId),
+        request<AuditLogListResponse["items"][0]>(`/audit-logs/${id}`, {}, token, orgId),
 };
 
 export const platformAuditApi = {

--- a/src/lib/admin/api/retention.ts
+++ b/src/lib/admin/api/retention.ts
@@ -10,18 +10,18 @@ import type {
 export const retentionApi = {
     list: (limit = 50, offset = 0, token?: string, orgId?: string) =>
         request<RetentionPolicyListResponse>(
-            `/retention?limit=${limit}&offset=${offset}`,
+            `/retention-policies?limit=${limit}&offset=${offset}`,
             {},
             token,
             orgId,
         ),
 
     get: (id: string, token?: string, orgId?: string) =>
-        request<RetentionPolicy>(`/retention/${id}`, {}, token, orgId),
+        request<RetentionPolicy>(`/retention-policies/${id}`, {}, token, orgId),
 
     create: (data: RetentionPolicyCreate, token?: string, orgId?: string) =>
         request<RetentionPolicy>(
-            "/retention",
+            "/retention-policies",
             { method: "POST", body: JSON.stringify(data) },
             token,
             orgId,
@@ -29,23 +29,23 @@ export const retentionApi = {
 
     update: (id: string, data: RetentionPolicyUpdate, token?: string, orgId?: string) =>
         request<RetentionPolicy>(
-            `/retention/${id}`,
+            `/retention-policies/${id}`,
             { method: "PATCH", body: JSON.stringify(data) },
             token,
             orgId,
         ),
 
     delete: (id: string, token?: string, orgId?: string) =>
-        request<void>(`/retention/${id}`, { method: "DELETE" }, token, orgId),
+        request<void>(`/retention-policies/${id}`, { method: "DELETE" }, token, orgId),
 
     execute: (id: string, dryRun = true, token?: string, orgId?: string) =>
         request<RetentionExecuteResponse>(
-            `/retention/${id}/execute`,
+            `/retention-policies/${id}/execute`,
             { method: "POST", body: JSON.stringify({ dry_run: dryRun }) },
             token,
             orgId,
         ),
 
     resourceTypes: (token?: string, orgId?: string) =>
-        request<string[]>("/retention/resource-types", {}, token, orgId),
+        request<string[]>("/retention-policies/resource-types", {}, token, orgId),
 };

--- a/src/lib/admin/server/orgs.ts
+++ b/src/lib/admin/server/orgs.ts
@@ -261,10 +261,3 @@ export async function getAuditLog(
         return adminApi.audit.get(id, token, orgId);
     });
 }
-
-export async function listAuditActions(): Promise<ActionResult<string[]>> {
-    return withErrorHandling(async () => {
-        const { token, orgId } = await getSessionContext();
-        return adminApi.audit.actions(token, orgId);
-    });
-}


### PR DESCRIPTION
## Summary
Fixes the broken `/admin/retention` and `/admin/audit-logs` pages, which returned **"Not Found"**.

The frontend admin API client called paths that do not exist on the backend:
- `/api/v1/admin/retention*` → backend serves `/retention-policies*`
- `/api/v1/admin/audit*` → backend serves `/audit-logs*`

FastAPI returned `404 {"detail":"Not Found"}`, surfaced verbatim in the UI.

## Changes
- `retention.ts`: all 7 methods `/retention` → `/retention-policies`
- `audit.ts`: `auditApi` `list`/`get` `/audit` → `/audit-logs`; `platformAuditApi` left unchanged (already correct at `/platform/audit-logs`)
- Removed dead `auditApi.export` / `auditApi.actions` (no backend route; `/audit-logs/actions` would collide with `/audit-logs/{id}` and 500) and the `listAuditActions` server action
- Added `admin-api-paths.test.ts` contract tests

## Companion backend MR (required for full fix)
The retention feature-key and dry-run data-loss fixes are in **dev-health-ops** (GitLab) — link added in a follow-up comment.

## Verification
- vitest: **38 passed** (path-contract + server tests)
- Live (enterprise org): `GET /api/v1/admin/retention-policies` & `/audit-logs` → **200**; old paths → **404**

## Screenshots (live, enterprise Meridian org)
**/admin/retention** — renders, empty state, no error banner
![admin-retention](https://github.com/user-attachments/assets/3b71b146-1954-4682-9e24-9a18cd1038f2)

**/admin/audit-logs** — renders populated, the original "Error loading audit logs: Not Found" banner is gone
![admin-audit-logs](https://github.com/user-attachments/assets/f776e6c0-1057-4628-9ec7-72eac528c7a9)

Closes CHAOS-2371