### PR TITLE
feat(work-graph): wire theme/subcategory filters in explorer (CHAOS-2431)

### DIFF
--- a/src/app/(app)/diagnose/work-graph/buildTabs.test.tsx
+++ b/src/app/(app)/diagnose/work-graph/buildTabs.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWorkGraphTabs } from "./buildTabs";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+
+/** Parse the query string of a tab href into URLSearchParams. */
+function queryOf(path: string): URLSearchParams {
+    return new URLSearchParams(path.split("?")[1] ?? "");
+}
+
+describe("buildWorkGraphTabs", () => {
+    const filters = defaultMetricFilter;
+
+    it("does not add graph_theme/graph_subcategory when none are active", () => {
+        const tabs = buildWorkGraphTabs({ filters });
+        for (const tab of tabs) {
+            const query = queryOf(tab.path);
+            expect(query.has("graph_theme")).toBe(false);
+            expect(query.has("graph_subcategory")).toBe(false);
+            // The global filter is still carried.
+            expect(query.has("f")).toBe(true);
+        }
+    });
+
+    it("carries graph_theme + graph_subcategory onto every tab href when active", () => {
+        const tabs = buildWorkGraphTabs({
+            filters,
+            graphTheme: "quality",
+            graphSubcategory: "quality.bugfix",
+        });
+
+        expect(tabs.map((t) => t.id)).toEqual([
+            "overview",
+            "dependencies",
+            "inflow-outflow",
+            "review-network",
+            "artifacts",
+        ]);
+
+        for (const tab of tabs) {
+            const query = queryOf(tab.path);
+            expect(query.get("graph_theme")).toBe("quality");
+            expect(query.get("graph_subcategory")).toBe("quality.bugfix");
+            // Global filter and per-tab `tab` param are preserved alongside.
+            expect(query.has("f")).toBe(true);
+        }
+
+        // Non-overview tabs keep their `tab` discriminator.
+        expect(queryOf(tabs[1].path).get("tab")).toBe("dependencies");
+        expect(queryOf(tabs[2].path).get("tab")).toBe("inflow-outflow");
+        expect(queryOf(tabs[4].path).get("tab")).toBe("artifacts");
+    });
+
+    it("carries only graph_theme when no subcategory is active", () => {
+        const tabs = buildWorkGraphTabs({ filters, graphTheme: "quality" });
+        for (const tab of tabs) {
+            const query = queryOf(tab.path);
+            expect(query.get("graph_theme")).toBe("quality");
+            expect(query.has("graph_subcategory")).toBe(false);
+        }
+    });
+
+    it("produces well-formed single-?-prefixed hrefs (no double ?)", () => {
+        const tabs = buildWorkGraphTabs({
+            filters,
+            graphTheme: "quality",
+            graphSubcategory: "quality.bugfix",
+        });
+        for (const tab of tabs) {
+            // Exactly one "?" separates path from query.
+            expect(tab.path.split("?").length).toBe(2);
+        }
+    });
+});

--- a/src/app/(app)/diagnose/work-graph/buildTabs.test.tsx
+++ b/src/app/(app)/diagnose/work-graph/buildTabs.test.tsx
@@ -11,6 +11,13 @@ function queryOf(path: string): URLSearchParams {
 describe("buildWorkGraphTabs", () => {
     const filters = defaultMetricFilter;
 
+    // Theme-aware tabs read the theme-filtered work_graph edges; review-network
+    // is backed by review_edges_daily (no theme attribution), so it must NOT
+    // carry the theme params (CHAOS-2431, round-5).
+    const THEME_AWARE = ["overview", "dependencies", "inflow-outflow", "artifacts"];
+    const tabById = (tabs: ReturnType<typeof buildWorkGraphTabs>, id: string) =>
+        tabs.find((t) => t.id === id)!;
+
     it("does not add graph_theme/graph_subcategory when none are active", () => {
         const tabs = buildWorkGraphTabs({ filters });
         for (const tab of tabs) {
@@ -22,7 +29,7 @@ describe("buildWorkGraphTabs", () => {
         }
     });
 
-    it("carries graph_theme + graph_subcategory onto every tab href when active", () => {
+    it("carries graph_theme + graph_subcategory onto theme-aware tab hrefs when active", () => {
         const tabs = buildWorkGraphTabs({
             filters,
             graphTheme: "quality",
@@ -37,8 +44,8 @@ describe("buildWorkGraphTabs", () => {
             "artifacts",
         ]);
 
-        for (const tab of tabs) {
-            const query = queryOf(tab.path);
+        for (const id of THEME_AWARE) {
+            const query = queryOf(tabById(tabs, id).path);
             expect(query.get("graph_theme")).toBe("quality");
             expect(query.get("graph_subcategory")).toBe("quality.bugfix");
             // Global filter and per-tab `tab` param are preserved alongside.
@@ -46,18 +53,38 @@ describe("buildWorkGraphTabs", () => {
         }
 
         // Non-overview tabs keep their `tab` discriminator.
-        expect(queryOf(tabs[1].path).get("tab")).toBe("dependencies");
-        expect(queryOf(tabs[2].path).get("tab")).toBe("inflow-outflow");
-        expect(queryOf(tabs[4].path).get("tab")).toBe("artifacts");
+        expect(queryOf(tabById(tabs, "dependencies").path).get("tab")).toBe("dependencies");
+        expect(queryOf(tabById(tabs, "inflow-outflow").path).get("tab")).toBe("inflow-outflow");
+        expect(queryOf(tabById(tabs, "artifacts").path).get("tab")).toBe("artifacts");
     });
 
-    it("carries only graph_theme when no subcategory is active", () => {
+    it("does NOT carry graph_theme/graph_subcategory onto the review-network tab", () => {
+        const tabs = buildWorkGraphTabs({
+            filters,
+            graphTheme: "quality",
+            graphSubcategory: "quality.bugfix",
+        });
+
+        const reviewQuery = queryOf(tabById(tabs, "review-network").path);
+        // review_edges_daily has no theme attribution, so the URL must not
+        // advertise a theme scope it cannot honor.
+        expect(reviewQuery.has("graph_theme")).toBe(false);
+        expect(reviewQuery.has("graph_subcategory")).toBe(false);
+        // It still carries the global filter and its own tab discriminator.
+        expect(reviewQuery.has("f")).toBe(true);
+        expect(reviewQuery.get("tab")).toBe("review-network");
+    });
+
+    it("carries only graph_theme onto theme-aware tabs when no subcategory is active", () => {
         const tabs = buildWorkGraphTabs({ filters, graphTheme: "quality" });
-        for (const tab of tabs) {
-            const query = queryOf(tab.path);
+        for (const id of THEME_AWARE) {
+            const query = queryOf(tabById(tabs, id).path);
             expect(query.get("graph_theme")).toBe("quality");
             expect(query.has("graph_subcategory")).toBe(false);
         }
+        // review-network still excluded.
+        const reviewQuery = queryOf(tabById(tabs, "review-network").path);
+        expect(reviewQuery.has("graph_theme")).toBe(false);
     });
 
     it("produces well-formed single-?-prefixed hrefs (no double ?)", () => {

--- a/src/app/(app)/diagnose/work-graph/buildTabs.ts
+++ b/src/app/(app)/diagnose/work-graph/buildTabs.ts
@@ -9,7 +9,14 @@ import type { MetricFilter } from "@/lib/filters/types";
  * href, but NOT the explorer-scoped `graph_theme` / `graph_subcategory`
  * params. Because theme/subcategory are now authoritative server-side filters
  * (CHAOS-2431), they must survive tab navigation — so when present they are
- * appended to every tab href here.
+ * appended to the theme-aware tab hrefs here.
+ *
+ * The Review Network tab is intentionally excluded from the theme-param carry
+ * (CHAOS-2431, round-5): it is backed by `review_edges_daily` reviewer→author
+ * data, which has NO theme attribution and ignores the filter. Carrying the
+ * params there would advertise a theme scope in the URL while showing unscoped
+ * data. The theme-aware tabs (overview, dependencies, inflow-outflow,
+ * artifacts) all read the theme-filtered `work_graph` edges, so they keep them.
  */
 export function buildWorkGraphTabs(options: {
     filters: MetricFilter;
@@ -30,23 +37,28 @@ export function buildWorkGraphTabs(options: {
     const withGraphScope = (path: string) =>
         graphScopeSuffix ? `${path}${path.includes("?") ? "&" : "?"}${graphScopeSuffix}` : path;
 
-    const tab = (id: string, label: string, tabQuery?: string): ViewSetItem => {
-        const base = tabQuery
-            ? `/diagnose/work-graph?tab=${tabQuery}`
-            : "/diagnose/work-graph";
+    const tab = (
+        id: string,
+        label: string,
+        tabQuery: string | undefined,
+        themeAware: boolean,
+    ): ViewSetItem => {
+        const base = tabQuery ? `/diagnose/work-graph?tab=${tabQuery}` : "/diagnose/work-graph";
+        const withFilter = withFilterParam(base, filters, activeRole);
         return {
             id,
             label,
-            path: withGraphScope(withFilterParam(base, filters, activeRole)),
+            // Only theme-aware tabs carry graph_theme/graph_subcategory.
+            path: themeAware ? withGraphScope(withFilter) : withFilter,
             navVisible: true,
         };
     };
 
     return [
-        tab("overview", "Overview"),
-        tab("dependencies", "Dependencies", "dependencies"),
-        tab("inflow-outflow", "Inflow-Outflow", "inflow-outflow"),
-        tab("review-network", "Review Network", "review-network"),
-        tab("artifacts", "Artifacts", "artifacts"),
+        tab("overview", "Overview", undefined, true),
+        tab("dependencies", "Dependencies", "dependencies", true),
+        tab("inflow-outflow", "Inflow-Outflow", "inflow-outflow", true),
+        tab("review-network", "Review Network", "review-network", false),
+        tab("artifacts", "Artifacts", "artifacts", true),
     ];
 }

--- a/src/app/(app)/diagnose/work-graph/buildTabs.ts
+++ b/src/app/(app)/diagnose/work-graph/buildTabs.ts
@@ -1,0 +1,52 @@
+import { withFilterParam } from "@/lib/filters/url";
+import type { ViewSetItem } from "@/components/navigation/ViewSet";
+import type { MetricFilter } from "@/lib/filters/types";
+
+/**
+ * Build the Work Graph ViewSet tab items.
+ *
+ * `withFilterParam` carries the global `f` filter (and `role`) onto each tab
+ * href, but NOT the explorer-scoped `graph_theme` / `graph_subcategory`
+ * params. Because theme/subcategory are now authoritative server-side filters
+ * (CHAOS-2431), they must survive tab navigation — so when present they are
+ * appended to every tab href here.
+ */
+export function buildWorkGraphTabs(options: {
+    filters: MetricFilter;
+    activeRole?: string;
+    graphTheme?: string;
+    graphSubcategory?: string;
+}): ViewSetItem[] {
+    const { filters, activeRole, graphTheme, graphSubcategory } = options;
+
+    const graphScopeQuery = new URLSearchParams();
+    if (graphTheme) {
+        graphScopeQuery.set("graph_theme", graphTheme);
+    }
+    if (graphSubcategory) {
+        graphScopeQuery.set("graph_subcategory", graphSubcategory);
+    }
+    const graphScopeSuffix = graphScopeQuery.toString();
+    const withGraphScope = (path: string) =>
+        graphScopeSuffix ? `${path}${path.includes("?") ? "&" : "?"}${graphScopeSuffix}` : path;
+
+    const tab = (id: string, label: string, tabQuery?: string): ViewSetItem => {
+        const base = tabQuery
+            ? `/diagnose/work-graph?tab=${tabQuery}`
+            : "/diagnose/work-graph";
+        return {
+            id,
+            label,
+            path: withGraphScope(withFilterParam(base, filters, activeRole)),
+            navVisible: true,
+        };
+    };
+
+    return [
+        tab("overview", "Overview"),
+        tab("dependencies", "Dependencies", "dependencies"),
+        tab("inflow-outflow", "Inflow-Outflow", "inflow-outflow"),
+        tab("review-network", "Review Network", "review-network"),
+        tab("artifacts", "Artifacts", "artifacts"),
+    ];
+}

--- a/src/app/(app)/diagnose/work-graph/page.tsx
+++ b/src/app/(app)/diagnose/work-graph/page.tsx
@@ -1,10 +1,11 @@
 import { FilterBar } from "@/components/filters/FilterBar";
 import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
-import { ViewSet, type ViewSetItem } from "@/components/navigation/ViewSet";
+import { ViewSet } from "@/components/navigation/ViewSet";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { BackLink } from "@/components/shared/BackLink";
 import { GraphView, type WorkGraphTab } from "@/components/work/GraphView";
+import { buildWorkGraphTabs } from "./buildTabs";
 import { checkApiHealth } from "@/lib/api/system";
 import { requireSession } from "@/lib/auth";
 import { getServerEnv } from "@/lib/config";
@@ -45,38 +46,20 @@ export default async function WorkGraphPage({ searchParams }: WorkGraphPageProps
     const activeRole = typeof roleParam === "string" ? roleParam : undefined;
     const activeOrigin = typeof originParam === "string" ? originParam : undefined;
     const filters = encodedFilter ? decodeFilter(encodedFilter) : filterFromQueryParams(params);
-    const tabs: ViewSetItem[] = [
-        {
-            id: "overview",
-            label: "Overview",
-            path: withFilterParam("/diagnose/work-graph", filters, activeRole),
-            navVisible: true,
-        },
-        {
-            id: "dependencies",
-            label: "Dependencies",
-            path: withFilterParam("/diagnose/work-graph?tab=dependencies", filters, activeRole),
-            navVisible: true,
-        },
-        {
-            id: "inflow-outflow",
-            label: "Inflow-Outflow",
-            path: withFilterParam("/diagnose/work-graph?tab=inflow-outflow", filters, activeRole),
-            navVisible: true,
-        },
-        {
-            id: "review-network",
-            label: "Review Network",
-            path: withFilterParam("/diagnose/work-graph?tab=review-network", filters, activeRole),
-            navVisible: true,
-        },
-        {
-            id: "artifacts",
-            label: "Artifacts",
-            path: withFilterParam("/diagnose/work-graph?tab=artifacts", filters, activeRole),
-            navVisible: true,
-        },
-    ];
+
+    const graphThemeParam = Array.isArray(params.graph_theme)
+        ? params.graph_theme[0]
+        : params.graph_theme;
+    const graphSubcategoryParam = Array.isArray(params.graph_subcategory)
+        ? params.graph_subcategory[0]
+        : params.graph_subcategory;
+    const tabs = buildWorkGraphTabs({
+        filters,
+        activeRole,
+        graphTheme: typeof graphThemeParam === "string" ? graphThemeParam : undefined,
+        graphSubcategory:
+            typeof graphSubcategoryParam === "string" ? graphSubcategoryParam : undefined,
+    });
     const activeTab =
         evidenceParam === "open"
             ? "artifacts"

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -415,6 +415,101 @@ describe("GraphView", () => {
         });
     });
 
+    // ── Scope normalization (CHAOS-2431, round-6) ───────────────────────────────
+
+    it("normalizes a contradictory theme/subcategory pair: keeps explicit theme, drops mismatched subcategory", () => {
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({
+                graph_theme: "risk",
+                graph_subcategory: "quality.bugfix",
+            }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        // The impossible conjunctive pair is never sent: theme=risk, no subcategory.
+        const filtersArg = lastEdgeFilters();
+        expect(filtersArg).toHaveProperty("theme", "risk");
+        expect(filtersArg).not.toHaveProperty("subcategory");
+    });
+
+    it("canonicalizes a stale/bookmarked contradictory URL via router.replace", () => {
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({
+                graph_theme: "risk",
+                graph_subcategory: "quality.bugfix",
+            }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        // The URL self-heals: graph_theme stays risk, the mismatched subcategory is removed.
+        expect(mockReplace).toHaveBeenCalled();
+        const url = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]?.[0] as string;
+        const query = new URLSearchParams(url.split("?")[1] ?? "");
+        expect(query.get("graph_theme")).toBe("risk");
+        expect(query.has("graph_subcategory")).toBe(false);
+    });
+
+    it("preserves a matching theme/subcategory pair without rewriting the URL", () => {
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({
+                graph_theme: "quality",
+                graph_subcategory: "quality.bugfix",
+            }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        expect(lastEdgeFilters()).toMatchObject({
+            theme: "quality",
+            subcategory: "quality.bugfix",
+        });
+        // Already canonical → no self-heal rewrite.
+        expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it("derives the parent theme from a subcategory-only URL", () => {
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({ graph_subcategory: "risk.security" }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        expect(lastEdgeFilters()).toMatchObject({
+            theme: "risk",
+            subcategory: "risk.security",
+        });
+    });
+
     it("renders an empty state naming the active theme filter for a server-filtered set", () => {
         mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "quality" }));
         mockUseWorkGraphEdges.mockReturnValue({
@@ -639,6 +734,83 @@ describe("GraphView", () => {
         expect(screen.getByTestId("artifacts-panel")).toBeInTheDocument();
         expect(screen.getAllByTestId("artifact-row").length).toBeGreaterThanOrEqual(2);
         expect(screen.queryByTestId("work-graph-explorer")).not.toBeInTheDocument();
+    });
+
+    // ── Active-scope chip on theme-aware non-overview tabs (CHAOS-2431, round-6) ──
+
+    it("renders an active-scope chip with the scope label on a non-overview tab when filtered", () => {
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({ graph_theme: "risk", graph_subcategory: "risk.security" }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="inflow-outflow" />);
+
+        const chip = screen.getByTestId("theme-scope-chip");
+        expect(chip).toBeInTheDocument();
+        expect(chip).toHaveTextContent(/Scope:/i);
+        expect(chip).toHaveTextContent(/Risk \/ Security/i);
+    });
+
+    it("clear action on the scope chip removes graph_theme and graph_subcategory from the URL", async () => {
+        const user = userEvent.setup();
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({ graph_theme: "risk", graph_subcategory: "risk.security" }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="dependencies" />);
+
+        await user.click(screen.getByRole("button", { name: /clear theme scope/i }));
+
+        expect(mockReplace).toHaveBeenCalled();
+        const url = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]?.[0] as string;
+        const query = new URLSearchParams(url.split("?")[1] ?? "");
+        expect(query.has("graph_theme")).toBe(false);
+        expect(query.has("graph_subcategory")).toBe(false);
+    });
+
+    it("does not render the scope chip when no theme filter is active", () => {
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="dependencies" />);
+
+        expect(screen.queryByTestId("theme-scope-chip")).not.toBeInTheDocument();
+    });
+
+    it("does not render the scope chip on the overview tab (selectors are shown there instead)", () => {
+        mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "risk" }));
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="overview" />);
+
+        expect(screen.queryByTestId("theme-scope-chip")).not.toBeInTheDocument();
+        // Overview keeps its full Theme selector.
+        expect(screen.getByLabelText(/Theme/i)).toBeInTheDocument();
     });
 
     // ── Degraded fail-safe on non-canvas tabs (CHAOS-2431, round-3) ──────────────

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -416,9 +416,7 @@ describe("GraphView", () => {
     });
 
     it("renders an empty state naming the active theme filter for a server-filtered set", () => {
-        mockUseSearchParams.mockReturnValue(
-            new URLSearchParams({ graph_theme: "quality" }),
-        );
+        mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "quality" }));
         mockUseWorkGraphEdges.mockReturnValue({
             edges: [],
             loading: false,
@@ -448,9 +446,7 @@ describe("GraphView", () => {
 
         // Distinct degraded state — NOT the generic empty state.
         expect(screen.getByText(/Theme data is being prepared/i)).toBeInTheDocument();
-        expect(
-            screen.getByText(/Theme insights are still being computed/i),
-        ).toBeInTheDocument();
+        expect(screen.getByText(/Theme insights are still being computed/i)).toBeInTheDocument();
         expect(screen.queryByText(/No relationships to show/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/No work graph data/i)).not.toBeInTheDocument();
     });

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -938,6 +938,71 @@ describe("GraphView", () => {
         expect(screen.queryByTestId("work-graph-explorer")).not.toBeInTheDocument();
     });
 
+    // ── Review Network self-heals theme scope from the URL (CHAOS-2431, round-7) ──
+
+    it("strips graph_theme/graph_subcategory from a direct review-network URL via router.replace", () => {
+        // review_edges_daily has no theme attribution, so a scoped URL is
+        // misleading — it must self-heal to an unscoped URL.
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({
+                tab: "review-network",
+                graph_theme: "quality",
+                graph_subcategory: "quality.bugfix",
+            }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(
+            <GraphView
+                filters={filters}
+                activeTab="review-network"
+                reviewEdges={null}
+                reviewEdgesLoading={false}
+                reviewEdgesError={null}
+            />,
+        );
+
+        expect(mockReplace).toHaveBeenCalled();
+        const url = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]?.[0] as string;
+        const query = new URLSearchParams(url.split("?")[1] ?? "");
+        expect(query.has("graph_theme")).toBe(false);
+        expect(query.has("graph_subcategory")).toBe(false);
+        // The tab param (and other non-scope params) are preserved.
+        expect(query.get("tab")).toBe("review-network");
+        // ReviewNetworkView still renders.
+        expect(screen.getByTestId("review-network-panel")).toBeInTheDocument();
+    });
+
+    it("does not rewrite the URL on review-network when no theme scope params are present", () => {
+        mockUseSearchParams.mockReturnValue(new URLSearchParams({ tab: "review-network" }));
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(
+            <GraphView
+                filters={filters}
+                activeTab="review-network"
+                reviewEdges={null}
+                reviewEdgesLoading={false}
+                reviewEdgesError={null}
+            />,
+        );
+
+        expect(mockReplace).not.toHaveBeenCalled();
+        expect(screen.getByTestId("review-network-panel")).toBeInTheDocument();
+    });
+
     it("review-network tab renders real reviewer→author edges when provided", () => {
         mockUseWorkGraphEdges.mockReturnValue({
             edges: [],

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -831,6 +831,36 @@ describe("GraphView", () => {
         expect(screen.getByText(/Theme data is being prepared/i)).toBeInTheDocument();
         // The generic table panel and its empty state must NOT render.
         expect(screen.queryByTestId("inflow-outflow-panel")).not.toBeInTheDocument();
+        // The scope chip / clear control must still render so the fail-safe is
+        // not a dead-end (CHAOS-2431, round-8).
+        expect(screen.getByTestId("theme-scope-chip")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /clear theme scope/i })).toBeInTheDocument();
+    });
+
+    it("clear-scope works on a degraded inflow-outflow tab (fail-safe is not a dead-end)", async () => {
+        const user = userEvent.setup();
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({ graph_theme: "quality", graph_subcategory: "quality.bugfix" }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            degradedReason: "MEMBERSHIP_NOT_MATERIALIZED",
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="inflow-outflow" />);
+
+        expect(screen.getByText(/Theme data is being prepared/i)).toBeInTheDocument();
+        await user.click(screen.getByRole("button", { name: /clear theme scope/i }));
+
+        expect(mockReplace).toHaveBeenCalled();
+        const url = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]?.[0] as string;
+        const query = new URLSearchParams(url.split("?")[1] ?? "");
+        expect(query.has("graph_theme")).toBe(false);
+        expect(query.has("graph_subcategory")).toBe(false);
     });
 
     it("inflow-outflow tab renders normally when degradedReason is null", () => {
@@ -879,6 +909,35 @@ describe("GraphView", () => {
 
         expect(screen.getByText(/Theme data is being prepared/i)).toBeInTheDocument();
         expect(screen.queryByTestId("artifacts-panel")).not.toBeInTheDocument();
+        // Scope chip / clear control still available (CHAOS-2431, round-8).
+        expect(screen.getByTestId("theme-scope-chip")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /clear theme scope/i })).toBeInTheDocument();
+    });
+
+    it("clear-scope works on a degraded artifacts tab (fail-safe is not a dead-end)", async () => {
+        const user = userEvent.setup();
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({ graph_theme: "quality", graph_subcategory: "quality.bugfix" }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            degradedReason: "MEMBERSHIP_NOT_MATERIALIZED",
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="artifacts" />);
+
+        expect(screen.getByText(/Theme data is being prepared/i)).toBeInTheDocument();
+        await user.click(screen.getByRole("button", { name: /clear theme scope/i }));
+
+        expect(mockReplace).toHaveBeenCalled();
+        const url = mockReplace.mock.calls[mockReplace.mock.calls.length - 1]?.[0] as string;
+        const query = new URLSearchParams(url.split("?")[1] ?? "");
+        expect(query.has("graph_theme")).toBe(false);
+        expect(query.has("graph_subcategory")).toBe(false);
     });
 
     it("artifacts tab renders normally when degradedReason is null", () => {

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -5,14 +5,19 @@ import { GraphView } from "@/components/work/GraphView";
 import type { MetricFilter } from "@/lib/filters/types";
 import { CTA_LABELS } from "@/lib/design/cta";
 
-const { mockUseSearchParams, mockUseWorkGraphEdges, mockUseOrgId } = vi.hoisted(() => ({
-    mockUseSearchParams: vi.fn(() => new URLSearchParams()),
-    mockUseWorkGraphEdges: vi.fn(),
-    mockUseOrgId: vi.fn(() => "org-1"),
-}));
+const { mockUseSearchParams, mockUseWorkGraphEdges, mockUseOrgId, mockReplace, mockUsePathname } =
+    vi.hoisted(() => ({
+        mockUseSearchParams: vi.fn(() => new URLSearchParams()),
+        mockUseWorkGraphEdges: vi.fn(),
+        mockUseOrgId: vi.fn(() => "org-1"),
+        mockReplace: vi.fn(),
+        mockUsePathname: vi.fn(() => "/diagnose/work-graph"),
+    }));
 
 vi.mock("next/navigation", () => ({
     useSearchParams: mockUseSearchParams,
+    useRouter: () => ({ replace: mockReplace, push: vi.fn(), prefetch: vi.fn() }),
+    usePathname: mockUsePathname,
 }));
 
 vi.mock("@/lib/graphql/hooks", () => ({
@@ -38,6 +43,7 @@ describe("GraphView", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockUseSearchParams.mockReturnValue(new URLSearchParams());
+        mockUsePathname.mockReturnValue("/diagnose/work-graph");
     });
 
     it("shows empty state when no edges returned", () => {
@@ -282,6 +288,108 @@ describe("GraphView", () => {
         const filtersArg = lastEdgeFilters();
         expect(filtersArg).not.toHaveProperty("theme");
         expect(filtersArg).not.toHaveProperty("subcategory");
+    });
+
+    // ── URL persistence of theme/subcategory (CHAOS-2431, round-4) ──────────────
+
+    /** Returns the URL string from the most recent router.replace call. */
+    function lastReplacedUrl() {
+        const calls = mockReplace.mock.calls;
+        return calls[calls.length - 1]?.[0] as string | undefined;
+    }
+
+    it("writes graph_theme to the URL when a theme is selected", async () => {
+        const user = userEvent.setup();
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
+
+        expect(mockReplace).toHaveBeenCalled();
+        const url = lastReplacedUrl() ?? "";
+        const query = new URLSearchParams(url.split("?")[1] ?? "");
+        expect(url).toContain("/diagnose/work-graph");
+        expect(query.get("graph_theme")).toBe("quality");
+    });
+
+    it("writes graph_subcategory to the URL when a subcategory is selected", async () => {
+        const user = userEvent.setup();
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
+        await user.selectOptions(screen.getByLabelText(/Subcategory/i), "quality.bugfix");
+
+        const query = new URLSearchParams((lastReplacedUrl() ?? "").split("?")[1] ?? "");
+        expect(query.get("graph_theme")).toBe("quality");
+        expect(query.get("graph_subcategory")).toBe("quality.bugfix");
+    });
+
+    it("removes graph_theme and graph_subcategory from the URL when All themes is selected", async () => {
+        const user = userEvent.setup();
+        // Start with both params present in the URL.
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({
+                graph_theme: "quality",
+                graph_subcategory: "quality.bugfix",
+            }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        await user.selectOptions(screen.getByLabelText(/Theme/i), "all");
+
+        const url = lastReplacedUrl() ?? "";
+        const query = new URLSearchParams(url.split("?")[1] ?? "");
+        // Selecting "All themes" clears BOTH the theme and its subcategory.
+        expect(query.has("graph_theme")).toBe(false);
+        expect(query.has("graph_subcategory")).toBe(false);
+    });
+
+    it("preserves other query params when writing graph_theme to the URL", async () => {
+        const user = userEvent.setup();
+        // The theme/subcategory selectors only render on the overview tab, so
+        // exercise the write there while carrying an unrelated `f` filter param.
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({ f: "encoded-filter", role: "ic" }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
+
+        const query = new URLSearchParams((lastReplacedUrl() ?? "").split("?")[1] ?? "");
+        expect(query.get("f")).toBe("encoded-filter");
+        expect(query.get("role")).toBe("ic");
+        expect(query.get("graph_theme")).toBe("quality");
     });
 
     it("hydrates theme/subcategory into the query variables from URL search params", () => {

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -156,7 +156,7 @@ describe("GraphView", () => {
         expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
     });
 
-    it("shows theme and subcategory filter context without recomputing graph data", async () => {
+    it("shows selected theme/subcategory context in summary line", async () => {
         const user = userEvent.setup();
         mockUseWorkGraphEdges.mockReturnValue({
             edges: [
@@ -170,6 +170,8 @@ describe("GraphView", () => {
                     provenance: "NATIVE",
                     confidence: 1.0,
                     evidence: "Fixes ISS-1",
+                    theme: "quality",
+                    subcategory: "quality.bugfix",
                 },
             ],
             loading: false,
@@ -185,8 +187,201 @@ describe("GraphView", () => {
 
         expect(screen.getByText(/Quality \/ Quality \/ Bugfix/i)).toBeInTheDocument();
         expect(
-            screen.getByText(/persisted distributions drive the selected theme context/i),
-        ).toBeInTheDocument();
+            screen.queryByText(/persisted distributions drive the selected theme context/i),
+        ).not.toBeInTheDocument();
+    });
+
+    // ── Theme / subcategory filter wiring (CHAOS-2431) ─────────────────────────
+
+    it("selecting a theme hides edges whose dominant theme differs", async () => {
+        const user = userEvent.setup();
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [
+                {
+                    edgeId: "e1",
+                    sourceType: "ISSUE",
+                    sourceId: "ISS-1",
+                    targetType: "PR",
+                    targetId: "PR-1",
+                    edgeType: "FIXES",
+                    provenance: "NATIVE",
+                    confidence: 1.0,
+                    evidence: "test",
+                    theme: "quality",
+                    subcategory: "quality.bugfix",
+                },
+                {
+                    edgeId: "e2",
+                    sourceType: "ISSUE",
+                    sourceId: "ISS-2",
+                    targetType: "PR",
+                    targetId: "PR-2",
+                    edgeType: "FIXES",
+                    provenance: "NATIVE",
+                    confidence: 1.0,
+                    evidence: "test",
+                    theme: "feature_delivery",
+                    subcategory: "feature_delivery.customer",
+                },
+            ],
+            loading: false,
+            error: null,
+            totalCount: 2,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        // Before filter: both edges visible (both are FIXES which is in work-to-change slice)
+        expect(screen.getByText(/2 edges/i)).toBeInTheDocument();
+
+        await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
+
+        // Only the quality edge remains
+        expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
+    });
+
+    it('"All themes" shows all edges regardless of their dominant theme', async () => {
+        const user = userEvent.setup();
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [
+                {
+                    edgeId: "e1",
+                    sourceType: "ISSUE",
+                    sourceId: "ISS-1",
+                    targetType: "PR",
+                    targetId: "PR-1",
+                    edgeType: "FIXES",
+                    provenance: "NATIVE",
+                    confidence: 1.0,
+                    evidence: "test",
+                    theme: "quality",
+                    subcategory: "quality.bugfix",
+                },
+                {
+                    edgeId: "e2",
+                    sourceType: "ISSUE",
+                    sourceId: "ISS-2",
+                    targetType: "PR",
+                    targetId: "PR-2",
+                    edgeType: "FIXES",
+                    provenance: "NATIVE",
+                    confidence: 1.0,
+                    evidence: "test",
+                    theme: "maintenance",
+                    subcategory: "maintenance.refactor",
+                },
+            ],
+            loading: false,
+            error: null,
+            totalCount: 2,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        // Start with a theme selected
+        await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
+        expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
+
+        // Switch back to All themes
+        await user.selectOptions(screen.getByLabelText(/Theme/i), "all");
+        expect(screen.getByText(/2 edges/i)).toBeInTheDocument();
+    });
+
+    it("subcategory filter narrows edges within a selected theme", async () => {
+        const user = userEvent.setup();
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [
+                {
+                    edgeId: "e1",
+                    sourceType: "ISSUE",
+                    sourceId: "ISS-1",
+                    targetType: "PR",
+                    targetId: "PR-1",
+                    edgeType: "FIXES",
+                    provenance: "NATIVE",
+                    confidence: 1.0,
+                    evidence: "test",
+                    theme: "quality",
+                    subcategory: "quality.bugfix",
+                },
+                {
+                    edgeId: "e2",
+                    sourceType: "ISSUE",
+                    sourceId: "ISS-2",
+                    targetType: "PR",
+                    targetId: "PR-2",
+                    edgeType: "FIXES",
+                    provenance: "NATIVE",
+                    confidence: 1.0,
+                    evidence: "test",
+                    theme: "quality",
+                    subcategory: "quality.testing",
+                },
+            ],
+            loading: false,
+            error: null,
+            totalCount: 2,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        // Select the theme first (both are quality)
+        await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
+        expect(screen.getByText(/2 edges/i)).toBeInTheDocument();
+
+        // Now narrow to just quality.bugfix
+        await user.selectOptions(screen.getByLabelText(/Subcategory/i), "quality.bugfix");
+        expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
+    });
+
+    it("an edge with theme null is hidden under a specific theme but visible under All themes", async () => {
+        const user = userEvent.setup();
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [
+                {
+                    edgeId: "e1",
+                    sourceType: "ISSUE",
+                    sourceId: "ISS-1",
+                    targetType: "PR",
+                    targetId: "PR-1",
+                    edgeType: "FIXES",
+                    provenance: "NATIVE",
+                    confidence: 1.0,
+                    evidence: "test",
+                    theme: "quality",
+                    subcategory: "quality.bugfix",
+                },
+                {
+                    edgeId: "e2",
+                    sourceType: "ISSUE",
+                    sourceId: "ISS-2",
+                    targetType: "PR",
+                    targetId: "PR-2",
+                    edgeType: "FIXES",
+                    provenance: "NATIVE",
+                    confidence: 1.0,
+                    evidence: "test",
+                    theme: null,
+                    subcategory: null,
+                },
+            ],
+            loading: false,
+            error: null,
+            totalCount: 2,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        // Under "All themes": both edges visible
+        expect(screen.getByText(/2 edges/i)).toBeInTheDocument();
+
+        // Select a specific theme: null-theme edge is hidden
+        await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
+        expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
     });
 
     it("hydrates graph drilldown state from URL search params", () => {
@@ -210,6 +405,8 @@ describe("GraphView", () => {
                     provenance: "NATIVE",
                     confidence: 1.0,
                     evidence: "Touches src/app/page.tsx",
+                    theme: "quality",
+                    subcategory: "quality.bugfix",
                 },
             ],
             loading: false,

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -192,196 +192,137 @@ describe("GraphView", () => {
     });
 
     // ── Theme / subcategory filter wiring (CHAOS-2431) ─────────────────────────
+    //
+    // Filtering is performed SERVER-SIDE: the selected theme/subcategory are
+    // passed into the workGraphEdges query variables so the backend filters
+    // before its 1000-edge LIMIT (a sparse theme's edges must not fall outside
+    // the cap and produce a false-empty graph). These tests assert the query
+    // variables, NOT a client-side post-filter of the fetched page.
 
-    it("selecting a theme hides edges whose dominant theme differs", async () => {
-        const user = userEvent.setup();
+    /** Returns the `filters` object from the most recent useWorkGraphEdges call. */
+    function lastEdgeFilters() {
+        const calls = mockUseWorkGraphEdges.mock.calls;
+        return calls[calls.length - 1]?.[0]?.filters;
+    }
+
+    it("omits theme/subcategory from query variables under All themes", () => {
         mockUseWorkGraphEdges.mockReturnValue({
-            edges: [
-                {
-                    edgeId: "e1",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-1",
-                    targetType: "PR",
-                    targetId: "PR-1",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1.0,
-                    evidence: "test",
-                    theme: "quality",
-                    subcategory: "quality.bugfix",
-                },
-                {
-                    edgeId: "e2",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-2",
-                    targetType: "PR",
-                    targetId: "PR-2",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1.0,
-                    evidence: "test",
-                    theme: "feature_delivery",
-                    subcategory: "feature_delivery.customer",
-                },
-            ],
+            edges: [],
             loading: false,
             error: null,
-            totalCount: 2,
+            totalCount: 0,
             refetch: vi.fn(),
         });
 
         render(<GraphView filters={filters} />);
 
-        // Before filter: both edges visible (both are FIXES which is in work-to-change slice)
-        expect(screen.getByText(/2 edges/i)).toBeInTheDocument();
-
-        await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
-
-        // Only the quality edge remains
-        expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
+        const filtersArg = lastEdgeFilters();
+        expect(filtersArg).toEqual({ repoIds: ["repo-1"], limit: 1000 });
+        expect(filtersArg).not.toHaveProperty("theme");
+        expect(filtersArg).not.toHaveProperty("subcategory");
     });
 
-    it('"All themes" shows all edges regardless of their dominant theme', async () => {
+    it("passes the selected theme into the query variables for server-side filtering", async () => {
         const user = userEvent.setup();
         mockUseWorkGraphEdges.mockReturnValue({
-            edges: [
-                {
-                    edgeId: "e1",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-1",
-                    targetType: "PR",
-                    targetId: "PR-1",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1.0,
-                    evidence: "test",
-                    theme: "quality",
-                    subcategory: "quality.bugfix",
-                },
-                {
-                    edgeId: "e2",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-2",
-                    targetType: "PR",
-                    targetId: "PR-2",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1.0,
-                    evidence: "test",
-                    theme: "maintenance",
-                    subcategory: "maintenance.refactor",
-                },
-            ],
+            edges: [],
             loading: false,
             error: null,
-            totalCount: 2,
+            totalCount: 0,
             refetch: vi.fn(),
         });
 
         render(<GraphView filters={filters} />);
 
-        // Start with a theme selected
         await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
-        expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
 
-        // Switch back to All themes
-        await user.selectOptions(screen.getByLabelText(/Theme/i), "all");
-        expect(screen.getByText(/2 edges/i)).toBeInTheDocument();
+        const filtersArg = lastEdgeFilters();
+        expect(filtersArg).toMatchObject({ theme: "quality", limit: 1000 });
+        // No subcategory selected → it must not be sent.
+        expect(filtersArg).not.toHaveProperty("subcategory");
     });
 
-    it("subcategory filter narrows edges within a selected theme", async () => {
+    it("passes the selected subcategory into the query variables", async () => {
         const user = userEvent.setup();
         mockUseWorkGraphEdges.mockReturnValue({
-            edges: [
-                {
-                    edgeId: "e1",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-1",
-                    targetType: "PR",
-                    targetId: "PR-1",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1.0,
-                    evidence: "test",
-                    theme: "quality",
-                    subcategory: "quality.bugfix",
-                },
-                {
-                    edgeId: "e2",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-2",
-                    targetType: "PR",
-                    targetId: "PR-2",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1.0,
-                    evidence: "test",
-                    theme: "quality",
-                    subcategory: "quality.testing",
-                },
-            ],
+            edges: [],
             loading: false,
             error: null,
-            totalCount: 2,
+            totalCount: 0,
             refetch: vi.fn(),
         });
 
         render(<GraphView filters={filters} />);
 
-        // Select the theme first (both are quality)
         await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
-        expect(screen.getByText(/2 edges/i)).toBeInTheDocument();
-
-        // Now narrow to just quality.bugfix
         await user.selectOptions(screen.getByLabelText(/Subcategory/i), "quality.bugfix");
-        expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
+
+        expect(lastEdgeFilters()).toMatchObject({
+            theme: "quality",
+            subcategory: "quality.bugfix",
+        });
     });
 
-    it("an edge with theme null is hidden under a specific theme but visible under All themes", async () => {
+    it("drops theme/subcategory from variables when switching back to All themes", async () => {
         const user = userEvent.setup();
         mockUseWorkGraphEdges.mockReturnValue({
-            edges: [
-                {
-                    edgeId: "e1",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-1",
-                    targetType: "PR",
-                    targetId: "PR-1",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1.0,
-                    evidence: "test",
-                    theme: "quality",
-                    subcategory: "quality.bugfix",
-                },
-                {
-                    edgeId: "e2",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-2",
-                    targetType: "PR",
-                    targetId: "PR-2",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1.0,
-                    evidence: "test",
-                    theme: null,
-                    subcategory: null,
-                },
-            ],
+            edges: [],
             loading: false,
             error: null,
-            totalCount: 2,
+            totalCount: 0,
             refetch: vi.fn(),
         });
 
         render(<GraphView filters={filters} />);
 
-        // Under "All themes": both edges visible
-        expect(screen.getByText(/2 edges/i)).toBeInTheDocument();
-
-        // Select a specific theme: null-theme edge is hidden
         await user.selectOptions(screen.getByLabelText(/Theme/i), "quality");
-        expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
+        expect(lastEdgeFilters()).toHaveProperty("theme", "quality");
+
+        await user.selectOptions(screen.getByLabelText(/Theme/i), "all");
+        const filtersArg = lastEdgeFilters();
+        expect(filtersArg).not.toHaveProperty("theme");
+        expect(filtersArg).not.toHaveProperty("subcategory");
+    });
+
+    it("hydrates theme/subcategory into the query variables from URL search params", () => {
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({
+                graph_theme: "quality",
+                graph_subcategory: "quality.bugfix",
+            }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        expect(lastEdgeFilters()).toMatchObject({
+            theme: "quality",
+            subcategory: "quality.bugfix",
+        });
+    });
+
+    it("renders an empty state naming the active theme filter for a server-filtered set", () => {
+        mockUseSearchParams.mockReturnValue(
+            new URLSearchParams({ graph_theme: "quality" }),
+        );
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        // Backend returned no edges for this theme → empty copy names the filter.
+        expect(screen.getByText(/No work graph data matching Quality/i)).toBeInTheDocument();
     });
 
     it("hydrates graph drilldown state from URL search params", () => {

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -325,6 +325,64 @@ describe("GraphView", () => {
         expect(screen.getByText(/No work graph data matching Quality/i)).toBeInTheDocument();
     });
 
+    it("shows the 'theme data is being prepared' state when degradedReason=MEMBERSHIP_NOT_MATERIALIZED under an active theme filter", () => {
+        mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "quality" }));
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            degradedReason: "MEMBERSHIP_NOT_MATERIALIZED",
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        // Distinct degraded state — NOT the generic empty state.
+        expect(screen.getByText(/Theme data is being prepared/i)).toBeInTheDocument();
+        expect(
+            screen.getByText(/Theme insights are still being computed/i),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/No relationships to show/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/No work graph data/i)).not.toBeInTheDocument();
+    });
+
+    it("shows the normal empty state when degradedReason is null and edges are empty", () => {
+        mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "quality" }));
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            degradedReason: null,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        // No degradation → generic empty state, no "being prepared" message.
+        expect(screen.getByText(/No relationships to show/i)).toBeInTheDocument();
+        expect(screen.queryByText(/Theme data is being prepared/i)).not.toBeInTheDocument();
+    });
+
+    it("does NOT show the degraded state when no theme filter is active even if degradedReason is set", () => {
+        // No theme/subcategory filter → the membership index is irrelevant, so a
+        // degradedReason must not hijack the normal empty/graph rendering.
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            degradedReason: "MEMBERSHIP_NOT_MATERIALIZED",
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} />);
+
+        expect(screen.queryByText(/Theme data is being prepared/i)).not.toBeInTheDocument();
+        expect(screen.getByText(/No relationships to show/i)).toBeInTheDocument();
+    });
+
     it("hydrates graph drilldown state from URL search params", () => {
         mockUseSearchParams.mockReturnValue(
             new URLSearchParams({

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -537,6 +537,105 @@ describe("GraphView", () => {
         expect(screen.queryByTestId("work-graph-explorer")).not.toBeInTheDocument();
     });
 
+    // ── Degraded fail-safe on non-canvas tabs (CHAOS-2431, round-3) ──────────────
+
+    it("inflow-outflow tab shows the prepared/degraded state under an active theme filter when degraded", () => {
+        mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "quality" }));
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            degradedReason: "MEMBERSHIP_NOT_MATERIALIZED",
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="inflow-outflow" />);
+
+        expect(screen.getByText(/Theme data is being prepared/i)).toBeInTheDocument();
+        // The generic table panel and its empty state must NOT render.
+        expect(screen.queryByTestId("inflow-outflow-panel")).not.toBeInTheDocument();
+    });
+
+    it("inflow-outflow tab renders normally when degradedReason is null", () => {
+        mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "quality" }));
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [
+                {
+                    edgeId: "e1",
+                    sourceType: "ISSUE",
+                    sourceId: "ISS-1",
+                    targetType: "PR",
+                    targetId: "PR-1",
+                    edgeType: "FIXES",
+                    provenance: "NATIVE",
+                    confidence: 1,
+                    evidence: null,
+                    theme: "quality",
+                    subcategory: "quality.bugfix",
+                },
+            ],
+            loading: false,
+            error: null,
+            totalCount: 1,
+            degradedReason: null,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="inflow-outflow" />);
+
+        expect(screen.getByTestId("inflow-outflow-panel")).toBeInTheDocument();
+        expect(screen.queryByText(/Theme data is being prepared/i)).not.toBeInTheDocument();
+    });
+
+    it("artifacts tab shows the prepared/degraded state under an active theme filter when degraded", () => {
+        mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "quality" }));
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            degradedReason: "MEMBERSHIP_NOT_MATERIALIZED",
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="artifacts" />);
+
+        expect(screen.getByText(/Theme data is being prepared/i)).toBeInTheDocument();
+        expect(screen.queryByTestId("artifacts-panel")).not.toBeInTheDocument();
+    });
+
+    it("artifacts tab renders normally when degradedReason is null", () => {
+        mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "quality" }));
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [
+                {
+                    edgeId: "e1",
+                    sourceType: "ISSUE",
+                    sourceId: "ISS-1",
+                    targetType: "PR",
+                    targetId: "PR-1",
+                    edgeType: "FIXES",
+                    provenance: "NATIVE",
+                    confidence: 1,
+                    evidence: "Fixes ISS-1",
+                    theme: "quality",
+                    subcategory: "quality.bugfix",
+                },
+            ],
+            loading: false,
+            error: null,
+            totalCount: 1,
+            degradedReason: null,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="artifacts" />);
+
+        expect(screen.getByTestId("artifacts-panel")).toBeInTheDocument();
+        expect(screen.queryByText(/Theme data is being prepared/i)).not.toBeInTheDocument();
+    });
+
     it("review-network tab shows an honest empty state when reviewEdges prop is null", () => {
         // reviewEdges=null means "not yet fetched / wrong tab" — renders the
         // review-network panel with an empty state (no work-graph-edges fallback).

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -293,11 +293,33 @@ export function GraphView({
         return { incomingEdges, outgoingEdges };
     }, [selectedNode, displayEdges]);
 
+    // Fail-safe (CHAOS-2431): when a theme/subcategory filter is active but the
+    // backend has not yet materialized the membership index for this org, it
+    // returns degradedReason="MEMBERSHIP_NOT_MATERIALIZED" instead of a
+    // (false-)empty edge set. Show a distinct "being prepared" state so the
+    // user does not read it as "no relationships/artifacts exist". This must be
+    // computed BEFORE the per-tab early-returns so the non-canvas tabs
+    // (inflow-outflow, artifacts) surface the same fail-safe rather than their
+    // generic empty states.
+    const themeFilterActive = theme !== "all" || subcategory !== "all";
+    const themeDataPreparing =
+        themeFilterActive && degradedReason === "MEMBERSHIP_NOT_MATERIALIZED";
+    const themeDataPreparingState = (
+        <DataState
+            variant="preview-not-populated"
+            title="Theme data is being prepared"
+            description="Theme insights are still being computed for this view — check back shortly."
+            data-testid="data-state-theme-preparing"
+        />
+    );
+
     // ── Derived table tabs (no force-directed canvas) ───────────────────────────
     if (activeTab === "inflow-outflow") {
+        if (!loading && !error && themeDataPreparing) return themeDataPreparingState;
         return <InflowOutflowView edges={edges} loading={loading} error={error} />;
     }
     if (activeTab === "artifacts") {
+        if (!loading && !error && themeDataPreparing) return themeDataPreparingState;
         return <ArtifactsView edges={edges} loading={loading} error={error} />;
     }
     if (activeTab === "review-network") {
@@ -322,17 +344,9 @@ export function GraphView({
         dependencies: "Blocking, related, duplicate, and parent-child links between work items.",
     };
     const graphTab = activeTab as "overview" | "dependencies";
-    const themeFilterActive = theme !== "all" || subcategory !== "all";
     const themeFilterSuffix = themeFilterActive
         ? ` matching ${subcategory === "all" ? labelInvestmentKey(theme) : labelInvestmentKey(subcategory)}`
         : "";
-    // Fail-safe (CHAOS-2431): when a theme/subcategory filter is active but the
-    // backend has not yet materialized the membership index for this org, it
-    // returns degradedReason="MEMBERSHIP_NOT_MATERIALIZED" instead of a
-    // (false-)empty edge set. Show a distinct "being prepared" state so the
-    // user does not read it as "no relationships exist".
-    const themeDataPreparing =
-        themeFilterActive && degradedReason === "MEMBERSHIP_NOT_MATERIALIZED";
     const emptyCopy =
         activeTab === "dependencies"
             ? `No dependency links between work items${themeFilterSuffix} in this scope and window.`
@@ -462,12 +476,7 @@ export function GraphView({
                     )}
 
                     {!loading && !error && themeDataPreparing ? (
-                        <DataState
-                            variant="preview-not-populated"
-                            title="Theme data is being prepared"
-                            description="Theme insights are still being computed for this view — check back shortly."
-                            data-testid="data-state-theme-preparing"
-                        />
+                        themeDataPreparingState
                     ) : !loading && !error && tabEdges.length === 0 ? (
                         <DataState
                             variant="detector-enabled-no-findings"

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -22,6 +22,7 @@ import { formatNumber } from "@/lib/formatters";
 import {
     INVESTMENT_SUBCATEGORIES,
     INVESTMENT_THEMES,
+    SUBCATEGORY_TO_THEME,
     labelInvestmentKey,
 } from "@/lib/workGraph/taxonomy";
 
@@ -178,13 +179,33 @@ function getGraphSearchState(searchParams: URLSearchParams) {
     const subcategoryParam = searchParams.get("graph_subcategory");
     const themeParam = searchParams.get("graph_theme");
     const connectionParam = searchParams.get("graph_connection");
-    const subcategory = isInvestmentSubcategory(subcategoryParam) ? subcategoryParam : "all";
-    const subcategoryTheme = subcategory === "all" ? null : subcategory.split(".", 1)[0];
-    const theme = isInvestmentTheme(themeParam)
-        ? themeParam
-        : isInvestmentTheme(subcategoryTheme)
-          ? subcategoryTheme
-          : "all";
+
+    // Theme + subcategory are ONE invariant (CHAOS-2431): a subcategory belongs
+    // to exactly one parent theme, so an explicit graph_theme that contradicts a
+    // present graph_subcategory (e.g. theme=risk + subcategory=quality.bugfix)
+    // must never be sent as a conjunctive pair (it yields a false-empty graph).
+    // We normalize here: a valid subcategory implies its parent theme; an
+    // explicit, mismatching theme wins and the stale subcategory is dropped.
+    const rawSubcategory = isInvestmentSubcategory(subcategoryParam) ? subcategoryParam : "all";
+    const subcategoryTheme = rawSubcategory === "all" ? null : SUBCATEGORY_TO_THEME[rawSubcategory];
+    const explicitTheme = isInvestmentTheme(themeParam) ? themeParam : null;
+
+    let theme: string;
+    let subcategory: string;
+    if (rawSubcategory !== "all" && subcategoryTheme) {
+        if (explicitTheme && explicitTheme !== subcategoryTheme) {
+            // Contradiction: keep the explicit theme, drop the mismatched subcategory.
+            theme = explicitTheme;
+            subcategory = "all";
+        } else {
+            // Subcategory present (no theme, or matching theme): its parent theme wins.
+            theme = subcategoryTheme;
+            subcategory = rawSubcategory;
+        }
+    } else {
+        theme = explicitTheme ?? "all";
+        subcategory = "all";
+    }
 
     return {
         theme,
@@ -266,6 +287,21 @@ export function GraphView({
         setConnectionSliceId(searchState.connectionSliceId);
         setSelectedNode(searchState.selectedNode);
     }, [searchState]);
+
+    // Self-heal a stale/bookmarked URL whose raw params disagree with the
+    // normalized scope (CHAOS-2431): e.g. ?graph_theme=risk&graph_subcategory=
+    // quality.bugfix canonicalizes to graph_theme=risk with the subcategory
+    // dropped. writeGraphScope is idempotent, so this only fires when needed.
+    useEffect(() => {
+        const rawTheme = searchParams.get("graph_theme") ?? "all";
+        const rawSubcategory = searchParams.get("graph_subcategory") ?? "all";
+        const canonTheme = searchState.theme === "all" ? "all" : searchState.theme;
+        const canonSubcategory =
+            searchState.subcategory === "all" ? "all" : searchState.subcategory;
+        if (rawTheme !== canonTheme || rawSubcategory !== canonSubcategory) {
+            writeGraphScope(canonTheme, canonSubcategory);
+        }
+    }, [searchParams, searchState, writeGraphScope]);
 
     const contextOrgId = useOrgId();
     const orgId = filters.scope.ids[0] || contextOrgId || "";
@@ -359,14 +395,53 @@ export function GraphView({
         />
     );
 
+    const scopeLabel =
+        subcategory === "all" ? labelInvestmentKey(theme) : labelInvestmentKey(subcategory);
+
+    // Active-scope chip (CHAOS-2431): the theme/subcategory selectors only render
+    // on overview, but dependencies/inflow-outflow/artifacts also query
+    // theme-scoped edges. So on those theme-aware tabs we surface a compact chip
+    // showing the active scope with a Clear action that removes the params from
+    // the URL. Rendered BEFORE the per-tab early-returns so every theme-aware tab
+    // shows it. Overview keeps its full selectors instead.
+    const themeScopeChip =
+        themeFilterActive && activeTab !== "overview" ? (
+            <div
+                data-testid="theme-scope-chip"
+                className="mb-4 flex items-center gap-3 rounded-full border border-(--card-stroke) bg-(--card-70) px-3 py-1.5 text-xs text-(--ink-muted)"
+            >
+                <span>
+                    Scope: <span className="text-foreground">{scopeLabel}</span>
+                </span>
+                <button
+                    type="button"
+                    onClick={() => handleThemeChange("all")}
+                    className="uppercase tracking-[0.18em] text-(--accent-2)"
+                    aria-label="Clear theme scope"
+                >
+                    Clear
+                </button>
+            </div>
+        ) : null;
+
     // ── Derived table tabs (no force-directed canvas) ───────────────────────────
     if (activeTab === "inflow-outflow") {
         if (!loading && !error && themeDataPreparing) return themeDataPreparingState;
-        return <InflowOutflowView edges={edges} loading={loading} error={error} />;
+        return (
+            <>
+                {themeScopeChip}
+                <InflowOutflowView edges={edges} loading={loading} error={error} />
+            </>
+        );
     }
     if (activeTab === "artifacts") {
         if (!loading && !error && themeDataPreparing) return themeDataPreparingState;
-        return <ArtifactsView edges={edges} loading={loading} error={error} />;
+        return (
+            <>
+                {themeScopeChip}
+                <ArtifactsView edges={edges} loading={loading} error={error} />
+            </>
+        );
     }
     if (activeTab === "review-network") {
         return (
@@ -425,6 +500,9 @@ export function GraphView({
                             </div>
                         </div>
                     </div>
+
+                    {/* On the dependencies tab (no selectors) show the active-scope chip. */}
+                    {themeScopeChip}
 
                     {showConnectionSelector && (
                         <div className="mb-4 rounded-2xl border border-(--card-stroke) bg-(--card-70) p-3 text-xs">

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -237,7 +237,7 @@ export function GraphView({
         }),
         [filters.what?.repos, theme, subcategory],
     );
-    const { edges, loading, error, totalCount } = useWorkGraphEdges({
+    const { edges, loading, error, totalCount, degradedReason } = useWorkGraphEdges({
         orgId,
         filters: edgeFilters,
         pause: !orgId,
@@ -326,6 +326,13 @@ export function GraphView({
     const themeFilterSuffix = themeFilterActive
         ? ` matching ${subcategory === "all" ? labelInvestmentKey(theme) : labelInvestmentKey(subcategory)}`
         : "";
+    // Fail-safe (CHAOS-2431): when a theme/subcategory filter is active but the
+    // backend has not yet materialized the membership index for this org, it
+    // returns degradedReason="MEMBERSHIP_NOT_MATERIALIZED" instead of a
+    // (false-)empty edge set. Show a distinct "being prepared" state so the
+    // user does not read it as "no relationships exist".
+    const themeDataPreparing =
+        themeFilterActive && degradedReason === "MEMBERSHIP_NOT_MATERIALIZED";
     const emptyCopy =
         activeTab === "dependencies"
             ? `No dependency links between work items${themeFilterSuffix} in this scope and window.`
@@ -454,7 +461,14 @@ export function GraphView({
                         />
                     )}
 
-                    {!loading && !error && tabEdges.length === 0 ? (
+                    {!loading && !error && themeDataPreparing ? (
+                        <DataState
+                            variant="preview-not-populated"
+                            title="Theme data is being prepared"
+                            description="Theme insights are still being computed for this view — check back shortly."
+                            data-testid="data-state-theme-preparing"
+                        />
+                    ) : !loading && !error && tabEdges.length === 0 ? (
                         <DataState
                             variant="detector-enabled-no-findings"
                             title="No relationships to show"

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -443,8 +443,19 @@ export function GraphView({
         ) : null;
 
     // ── Derived table tabs (no force-directed canvas) ───────────────────────────
+    // The preparing/degraded state must include the scope chip too (CHAOS-2431):
+    // these tabs have no overview selectors, so without it a user on a scoped URL
+    // while the membership index is preparing would have no way to clear the
+    // scope — the fail-safe would be a dead-end.
     if (activeTab === "inflow-outflow") {
-        if (!loading && !error && themeDataPreparing) return themeDataPreparingState;
+        if (!loading && !error && themeDataPreparing) {
+            return (
+                <>
+                    {themeScopeChip}
+                    {themeDataPreparingState}
+                </>
+            );
+        }
         return (
             <>
                 {themeScopeChip}
@@ -453,7 +464,14 @@ export function GraphView({
         );
     }
     if (activeTab === "artifacts") {
-        if (!loading && !error && themeDataPreparing) return themeDataPreparingState;
+        if (!loading && !error && themeDataPreparing) {
+            return (
+                <>
+                    {themeScopeChip}
+                    {themeDataPreparingState}
+                </>
+            );
+        }
         return (
             <>
                 {themeScopeChip}

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -7,7 +7,12 @@ import Link from "next/link";
 import { WorkGraphExplorer, WorkGraphLegend } from "@/components/charts/WorkGraphExplorer";
 import { DataState } from "@/components/ui/DataState";
 import { useWorkGraphEdges } from "@/lib/graphql/hooks";
-import type { WorkGraphEdge, WorkGraphEdgeType, WorkGraphNodeType } from "@/lib/graphql/types";
+import type {
+    WorkGraphEdge,
+    WorkGraphEdgeFilterInput,
+    WorkGraphEdgeType,
+    WorkGraphNodeType,
+} from "@/lib/graphql/types";
 import type { ReviewEdgeRow } from "@/lib/graphql/reviewEdgesFetchers";
 import type { MetricFilter } from "@/lib/filters/types";
 import { CTA_LABELS } from "@/lib/design/cta";
@@ -218,9 +223,23 @@ export function GraphView({
 
     const contextOrgId = useOrgId();
     const orgId = filters.scope.ids[0] || contextOrgId || "";
+    // Theme / subcategory are filtered SERVER-SIDE (CHAOS-2431): the backend
+    // applies them before the LIMIT, so a sparse theme's edges can't fall
+    // outside the edge cap and produce a false-empty graph. We therefore pass
+    // the active theme/subcategory (when not "all") straight into the query
+    // variables instead of filtering the fetched page client-side.
+    const edgeFilters = useMemo<WorkGraphEdgeFilterInput>(
+        () => ({
+            repoIds: filters.what?.repos,
+            limit: GRAPH_EDGE_QUERY_LIMIT,
+            ...(theme !== "all" ? { theme } : {}),
+            ...(subcategory !== "all" ? { subcategory } : {}),
+        }),
+        [filters.what?.repos, theme, subcategory],
+    );
     const { edges, loading, error, totalCount } = useWorkGraphEdges({
         orgId,
-        filters: { repoIds: filters.what?.repos, limit: GRAPH_EDGE_QUERY_LIMIT },
+        filters: edgeFilters,
         pause: !orgId,
     });
 
@@ -230,25 +249,19 @@ export function GraphView({
         CONNECTION_SLICES.find((slice) => slice.id === connectionSliceId) ?? CONNECTION_SLICES[0];
 
     const tabEdges = useMemo(() => {
-        let filtered: typeof edges;
+        // NB: theme/subcategory are filtered server-side (see edgeFilters above),
+        // so `edges` is already scoped to the active theme/subcategory. This
+        // memo only applies the connection-slice edge-type filter for the tab.
         if (activeTab === "dependencies") {
-            filtered = edges.filter((edge) => DEPENDENCY_EDGE_TYPES.includes(edge.edgeType));
-        } else {
-            // review-network is handled by the ReviewNetworkView early-return above;
-            // this path is only reached for overview and dependencies.
-            // overview
-            filtered = activeConnectionSlice.edgeTypes.length
-                ? edges.filter((edge) => activeConnectionSlice.edgeTypes.includes(edge.edgeType))
-                : edges;
+            return edges.filter((edge) => DEPENDENCY_EDGE_TYPES.includes(edge.edgeType));
         }
-        if (theme !== "all") {
-            filtered = filtered.filter((edge) => edge.theme === theme);
-        }
-        if (subcategory !== "all") {
-            filtered = filtered.filter((edge) => edge.subcategory === subcategory);
-        }
-        return filtered;
-    }, [activeTab, edges, activeConnectionSlice, theme, subcategory]);
+        // review-network is handled by the ReviewNetworkView early-return above;
+        // this path is only reached for overview and dependencies.
+        // overview
+        return activeConnectionSlice.edgeTypes.length
+            ? edges.filter((edge) => activeConnectionSlice.edgeTypes.includes(edge.edgeType))
+            : edges;
+    }, [activeTab, edges, activeConnectionSlice]);
 
     const displayEdges = useMemo(() => tabEdges.slice(0, GRAPH_RENDER_EDGE_LIMIT), [tabEdges]);
     const hiddenEdgeCount = Math.max(0, tabEdges.length - displayEdges.length);
@@ -309,10 +322,14 @@ export function GraphView({
         dependencies: "Blocking, related, duplicate, and parent-child links between work items.",
     };
     const graphTab = activeTab as "overview" | "dependencies";
+    const themeFilterActive = theme !== "all" || subcategory !== "all";
+    const themeFilterSuffix = themeFilterActive
+        ? ` matching ${subcategory === "all" ? labelInvestmentKey(theme) : labelInvestmentKey(subcategory)}`
+        : "";
     const emptyCopy =
         activeTab === "dependencies"
-            ? "No dependency links between work items in this scope and window."
-            : "No work graph data available for this scope and window.";
+            ? `No dependency links between work items${themeFilterSuffix} in this scope and window.`
+            : `No work graph data${themeFilterSuffix} available for this scope and window.`;
 
     return (
         <div

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -292,7 +292,11 @@ export function GraphView({
     // normalized scope (CHAOS-2431): e.g. ?graph_theme=risk&graph_subcategory=
     // quality.bugfix canonicalizes to graph_theme=risk with the subcategory
     // dropped. writeGraphScope is idempotent, so this only fires when needed.
+    // The review-network tab is NOT theme-scoped, so its canonicalization is
+    // handled by the dedicated strip effect below — skip it here so the two do
+    // not fight (this effect would otherwise keep a valid theme).
     useEffect(() => {
+        if (activeTab === "review-network") return;
         const rawTheme = searchParams.get("graph_theme") ?? "all";
         const rawSubcategory = searchParams.get("graph_subcategory") ?? "all";
         const canonTheme = searchState.theme === "all" ? "all" : searchState.theme;
@@ -301,7 +305,21 @@ export function GraphView({
         if (rawTheme !== canonTheme || rawSubcategory !== canonSubcategory) {
             writeGraphScope(canonTheme, canonSubcategory);
         }
-    }, [searchParams, searchState, writeGraphScope]);
+    }, [activeTab, searchParams, searchState, writeGraphScope]);
+
+    // Review Network is backed by review_edges_daily, which has NO theme
+    // attribution and ignores the filter (CHAOS-2431). A direct/bookmarked URL
+    // like ?tab=review-network&graph_theme=quality would advertise a theme
+    // scope it cannot honor, so self-heal by stripping the params. Idempotent:
+    // only fires when at least one of them is actually present.
+    useEffect(() => {
+        if (activeTab !== "review-network") return;
+        const hasTheme = searchParams.has("graph_theme");
+        const hasSubcategory = searchParams.has("graph_subcategory");
+        if (hasTheme || hasSubcategory) {
+            writeGraphScope("all", "all");
+        }
+    }, [activeTab, searchParams, writeGraphScope]);
 
     const contextOrgId = useOrgId();
     const orgId = filters.scope.ids[0] || contextOrgId || "";

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useCallback, useEffect } from "react";
-import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
 import { WorkGraphExplorer, WorkGraphLegend } from "@/components/charts/WorkGraphExplorer";
@@ -205,6 +205,8 @@ export function GraphView({
     reviewEdgesError = null,
 }: GraphViewProps) {
     const searchParams = useSearchParams();
+    const router = useRouter();
+    const pathname = usePathname();
     const searchState = useMemo(() => getGraphSearchState(searchParams), [searchParams]);
     const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(searchState.selectedNode);
     const [theme, setTheme] = useState(searchState.theme);
@@ -212,6 +214,50 @@ export function GraphView({
     const [connectionSliceId, setConnectionSliceId] = useState(searchState.connectionSliceId);
     const [isLegendCollapsed, setIsLegendCollapsed] = useState(true);
     const graphHeight = 580;
+
+    // Theme/subcategory are authoritative server-side filters (CHAOS-2431), so
+    // the URL is their single source of truth: writing the params here updates
+    // the URL, and the searchState effect below mirrors it back into local
+    // state — keeping selection alive across reload and tab navigation. "all"
+    // removes the param. Setting a theme always clears the now-stale
+    // subcategory so the two never drift.
+    const writeGraphScope = useCallback(
+        (nextTheme: string, nextSubcategory: string) => {
+            const params = new URLSearchParams(searchParams.toString());
+            if (nextTheme === "all") {
+                params.delete("graph_theme");
+            } else {
+                params.set("graph_theme", nextTheme);
+            }
+            if (nextSubcategory === "all") {
+                params.delete("graph_subcategory");
+            } else {
+                params.set("graph_subcategory", nextSubcategory);
+            }
+            const query = params.toString();
+            router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+        },
+        [pathname, router, searchParams],
+    );
+
+    const handleThemeChange = useCallback(
+        (nextTheme: string) => {
+            // Switching theme always resets the subcategory (it belongs to the
+            // previous theme); mirror local state for immediate responsiveness.
+            setTheme(nextTheme);
+            setSubcategory("all");
+            writeGraphScope(nextTheme, "all");
+        },
+        [writeGraphScope],
+    );
+
+    const handleSubcategoryChange = useCallback(
+        (nextSubcategory: string) => {
+            setSubcategory(nextSubcategory);
+            writeGraphScope(theme, nextSubcategory);
+        },
+        [theme, writeGraphScope],
+    );
 
     useEffect(() => {
         // eslint-disable-next-line react-hooks/set-state-in-effect -- graph state mirrors URL search parameters.
@@ -408,10 +454,7 @@ export function GraphView({
                                     </span>
                                     <select
                                         value={theme}
-                                        onChange={(event) => {
-                                            setTheme(event.target.value);
-                                            setSubcategory("all");
-                                        }}
+                                        onChange={(event) => handleThemeChange(event.target.value)}
                                         className="min-w-0 rounded-xl border border-(--card-stroke) bg-background px-3 py-2 text-foreground"
                                     >
                                         <option value="all">All themes</option>
@@ -428,7 +471,9 @@ export function GraphView({
                                     </span>
                                     <select
                                         value={subcategory}
-                                        onChange={(event) => setSubcategory(event.target.value)}
+                                        onChange={(event) =>
+                                            handleSubcategoryChange(event.target.value)
+                                        }
                                         className="min-w-0 rounded-xl border border-(--card-stroke) bg-background px-3 py-2 text-foreground"
                                     >
                                         <option value="all">All subcategories</option>

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -230,16 +230,25 @@ export function GraphView({
         CONNECTION_SLICES.find((slice) => slice.id === connectionSliceId) ?? CONNECTION_SLICES[0];
 
     const tabEdges = useMemo(() => {
+        let filtered: typeof edges;
         if (activeTab === "dependencies") {
-            return edges.filter((edge) => DEPENDENCY_EDGE_TYPES.includes(edge.edgeType));
+            filtered = edges.filter((edge) => DEPENDENCY_EDGE_TYPES.includes(edge.edgeType));
+        } else {
+            // review-network is handled by the ReviewNetworkView early-return above;
+            // this path is only reached for overview and dependencies.
+            // overview
+            filtered = activeConnectionSlice.edgeTypes.length
+                ? edges.filter((edge) => activeConnectionSlice.edgeTypes.includes(edge.edgeType))
+                : edges;
         }
-        // review-network is handled by the ReviewNetworkView early-return above;
-        // this path is only reached for overview and dependencies.
-        // overview
-        return activeConnectionSlice.edgeTypes.length
-            ? edges.filter((edge) => activeConnectionSlice.edgeTypes.includes(edge.edgeType))
-            : edges;
-    }, [activeTab, edges, activeConnectionSlice]);
+        if (theme !== "all") {
+            filtered = filtered.filter((edge) => edge.theme === theme);
+        }
+        if (subcategory !== "all") {
+            filtered = filtered.filter((edge) => edge.subcategory === subcategory);
+        }
+        return filtered;
+    }, [activeTab, edges, activeConnectionSlice, theme, subcategory]);
 
     const displayEdges = useMemo(() => tabEdges.slice(0, GRAPH_RENDER_EDGE_LIMIT), [tabEdges]);
     const hiddenEdgeCount = Math.max(0, tabEdges.length - displayEdges.length);
@@ -397,13 +406,11 @@ export function GraphView({
                                 <span title={activeConnectionSlice.description}>
                                     {activeConnectionSlice.description}
                                 </span>
-                                <span>
-                                    {theme !== "all" || subcategory !== "all"
-                                        ? `Selected context: ${theme === "all" ? "all themes" : labelInvestmentKey(theme)} / ${subcategory === "all" ? "all subcategories" : labelInvestmentKey(subcategory)}. `
-                                        : ""}
-                                    Theme/subcategory are context only; persisted distributions
-                                    drive the selected theme context.
-                                </span>
+                                {(theme !== "all" || subcategory !== "all") && (
+                                    <span>
+                                        {`Selected: ${theme === "all" ? "all themes" : labelInvestmentKey(theme)} / ${subcategory === "all" ? "all subcategories" : labelInvestmentKey(subcategory)}`}
+                                    </span>
+                                )}
                             </div>
                         </div>
                     )}

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -1884,7 +1884,9 @@ export type WorkGraphEdgeFilterInput = {
   nodeId?: InputMaybe<Scalars['String']['input']>;
   repoIds?: InputMaybe<Array<Scalars['String']['input']>>;
   sourceType?: InputMaybe<WorkGraphNodeTypeInput>;
+  subcategory?: InputMaybe<Scalars['String']['input']>;
   targetType?: InputMaybe<WorkGraphNodeTypeInput>;
+  theme?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type WorkGraphEdgeResult = {
@@ -1899,9 +1901,11 @@ export type WorkGraphEdgeResult = {
   sourceDisplayName?: Maybe<Scalars['String']['output']>;
   sourceId: Scalars['String']['output'];
   sourceType: WorkGraphNodeType;
+  subcategory?: Maybe<Scalars['String']['output']>;
   targetDisplayName?: Maybe<Scalars['String']['output']>;
   targetId: Scalars['String']['output'];
   targetType: WorkGraphNodeType;
+  theme?: Maybe<Scalars['String']['output']>;
 };
 
 export type WorkGraphEdgeType =

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -1958,6 +1958,7 @@ export type WorkGraphEdgeTypeInput =
 
 export type WorkGraphEdgesResult = {
   __typename?: 'WorkGraphEdgesResult';
+  degradedReason?: Maybe<Scalars['String']['output']>;
   edges: Array<WorkGraphEdgeResult>;
   pageInfo: PageInfo;
   totalCount: Scalars['Int']['output'];

--- a/src/lib/graphql/hooks/useWorkGraph.ts
+++ b/src/lib/graphql/hooks/useWorkGraph.ts
@@ -19,6 +19,11 @@ interface UseWorkGraphEdgesResult {
     pageInfo: PageInfo | null;
     loading: boolean;
     error: Error | null;
+    /**
+     * Fail-safe signal from the backend (CHAOS-2431). `"MEMBERSHIP_NOT_MATERIALIZED"`
+     * means theme membership data is not yet built for this org; null = OK.
+     */
+    degradedReason: string | null;
     refetch: () => void;
 }
 
@@ -38,6 +43,7 @@ export function useWorkGraphEdges(options: UseWorkGraphEdgesOptions): UseWorkGra
         pageInfo: result.data?.workGraphEdges?.pageInfo ?? null,
         loading: result.fetching,
         error: result.error ?? null,
+        degradedReason: result.data?.workGraphEdges?.degradedReason ?? null,
         refetch: reexecute,
     };
 }

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -378,6 +378,8 @@ query WorkGraphEdges($orgId: String!, $filters: WorkGraphEdgeFilterInput) {
       evidence
       repoId
       provider
+      theme
+      subcategory
     }
     totalCount
     pageInfo {

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -388,6 +388,7 @@ query WorkGraphEdges($orgId: String!, $filters: WorkGraphEdgeFilterInput) {
       startCursor
       endCursor
     }
+    degradedReason
   }
 }
 `;

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1646,6 +1646,7 @@ type WorkGraphEdgesResult {
   edges: [WorkGraphEdgeResult!]!
   totalCount: Int!
   pageInfo: PageInfo!
+  degradedReason: String
 }
 
 enum WorkGraphNodeType {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1569,6 +1569,8 @@ input WorkGraphEdgeFilterInput {
   targetType: WorkGraphNodeTypeInput = null
   edgeType: WorkGraphEdgeTypeInput = null
   nodeId: String = null
+  theme: String = null
+  subcategory: String = null
   limit: Int! = 1000
 }
 
@@ -1586,6 +1588,8 @@ type WorkGraphEdgeResult {
   evidence: String!
   repoId: String
   provider: String
+  theme: String
+  subcategory: String
 }
 
 enum WorkGraphEdgeType {

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -557,6 +557,13 @@ export interface WorkGraphEdgesResult {
     edges: WorkGraphEdge[];
     totalCount: number;
     pageInfo: PageInfo;
+    /**
+     * Non-null when the result is a fail-safe degraded response. The value
+     * `"MEMBERSHIP_NOT_MATERIALIZED"` means theme/subcategory membership data
+     * has not yet been built for this org, so a theme filter would otherwise
+     * silently return a false-empty graph (CHAOS-2431).
+     */
+    degradedReason?: string | null;
 }
 
 export interface WorkGraphEdgesQueryResponse {

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -548,6 +548,8 @@ export interface WorkGraphEdgeFilterInput {
     targetType?: WorkGraphNodeType;
     edgeType?: WorkGraphEdgeType;
     nodeId?: string;
+    theme?: string;
+    subcategory?: string;
     limit?: number;
 }
 

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -538,6 +538,8 @@ export interface WorkGraphEdge {
     evidence: string;
     repoId?: string;
     provider?: string;
+    theme?: string | null;
+    subcategory?: string | null;
 }
 
 export interface WorkGraphEdgeFilterInput {

--- a/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
+++ b/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
@@ -49,10 +49,7 @@ const workGraphPageSource = readFileSync(join(appRoot, "diagnose/work-graph/page
 // Work Graph tab construction was extracted into buildTabs.ts (CHAOS-2431) so
 // the explorer-scoped graph_theme/graph_subcategory params can be carried onto
 // every tab href. The tab labels now live there rather than inline in page.tsx.
-const workGraphTabsSource = readFileSync(
-    join(appRoot, "diagnose/work-graph/buildTabs.ts"),
-    "utf8",
-);
+const workGraphTabsSource = readFileSync(join(appRoot, "diagnose/work-graph/buildTabs.ts"), "utf8");
 
 const testOpsTabRoutes = [
     {

--- a/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
+++ b/src/lib/navigation/__tests__/ia-preservation-invariants.test.ts
@@ -46,6 +46,13 @@ const bottleneckPageSource = readFileSync(join(appRoot, "bottleneck/page.tsx"), 
 const complexityPageSource = readFileSync(join(appRoot, "complexity/page.tsx"), "utf8");
 const cognitiveLoadPageSource = readFileSync(join(appRoot, "cognitive-load/page.tsx"), "utf8");
 const workGraphPageSource = readFileSync(join(appRoot, "diagnose/work-graph/page.tsx"), "utf8");
+// Work Graph tab construction was extracted into buildTabs.ts (CHAOS-2431) so
+// the explorer-scoped graph_theme/graph_subcategory params can be carried onto
+// every tab href. The tab labels now live there rather than inline in page.tsx.
+const workGraphTabsSource = readFileSync(
+    join(appRoot, "diagnose/work-graph/buildTabs.ts"),
+    "utf8",
+);
 
 const testOpsTabRoutes = [
     {
@@ -267,6 +274,7 @@ describe("IA preservation invariant #2 — no redirect-only tabs", () => {
         if (basePath(path) === "/diagnose/work-graph") {
             expect(routePageExists(path), path).toBe(true);
             expect(workGraphPageSource).toContain("Work Graph views");
+            // Tab labels live in buildTabs.ts (see note at workGraphTabsSource).
             for (const label of [
                 "Overview",
                 "Dependencies",
@@ -274,7 +282,7 @@ describe("IA preservation invariant #2 — no redirect-only tabs", () => {
                 "Review Network",
                 "Artifacts",
             ]) {
-                expect(workGraphPageSource).toContain(label);
+                expect(workGraphTabsSource).toContain(label);
             }
         }
         if (basePath(path) === "/cognitive-load") {


### PR DESCRIPTION
## Summary

Wires the Work Graph explorer Theme + Subcategory dropdowns to actually filter the graph (CHAOS-2431, parent CHAOS-2427). Filtering is performed **server-side**, with a fail-safe for orgs whose theme membership index is not yet materialized.

## Design: server-side filtering (revised after review)

The selected `theme`/`subcategory` are passed into the `workGraphEdges` GraphQL query variables (`WorkGraphEdgeFilterInput.theme` / `.subcategory`), so the backend filters **before** its 1000-edge `LIMIT`. This avoids a false-empty graph where a sparse theme's edges sit beyond the edge cap. When "All themes"/"All subcategories" is selected, the field is omitted from the variables. There is no client-side post-filter on `edge.theme`/`edge.subcategory`.

## Fail-safe: degradedReason

The backend adds a nullable `degradedReason: String` to the `workGraphEdges` result (`WorkGraphEdgesResult`). `null` = OK; `"MEMBERSHIP_NOT_MATERIALIZED"` = theme/subcategory membership data has not yet been built for this org. When a theme/subcategory filter is active **and** the result is degraded, the explorer renders a distinct **"Theme data is being prepared"** state (DataState `preview-not-populated` variant) instead of the generic "No relationships to show" empty state — so a not-yet-materialized index is never misread as "no relationships exist". With no active theme filter, `degradedReason` is ignored and behavior is unchanged.

## Changes

- `src/lib/graphql/schema.graphql`: add `theme: String` + `subcategory: String` to `WorkGraphEdgeResult`; `theme`/`subcategory` to `WorkGraphEdgeFilterInput`; **`degradedReason: String` to `WorkGraphEdgesResult`**.
- `src/lib/graphql/__generated__/types.ts`: regenerated via `pnpm codegen` (`codegen:check` passes).
- `src/lib/graphql/types.ts`: `theme?`/`subcategory?` on `WorkGraphEdge` and `WorkGraphEdgeFilterInput`; **`degradedReason?` on `WorkGraphEdgesResult`**.
- `src/lib/graphql/queries.ts`: `theme`/`subcategory` in the edge selection set; **`degradedReason` on the result**.
- `src/lib/graphql/hooks/useWorkGraph.ts`: thread `degradedReason` through `useWorkGraphEdges`.
- `src/components/work/GraphView.tsx`: `edgeFilters` memo passes theme/subcategory into the query; `tabEdges` keeps only the connection-slice edge-type filter; empty-state copy names the active theme filter; misleading "context only" caption removed; **distinct degraded "Theme data is being prepared" state when `degradedReason === "MEMBERSHIP_NOT_MATERIALIZED"` under an active filter**.
- `src/components/work/GraphView.test.tsx`: query-variable assertion tests (present when selected, omitted under "All", hydrated from URL, dropped on reset) + server-filtered empty-state test + **degraded-state tests (degraded renders the prepared message; null degradedReason renders the normal empty state; no degraded state without an active filter)**.

## Backend dependency

Depends on the ops PR (CHAOS-2429/2430): `WorkGraphEdgeFilterInput` gains `theme`/`subcategory`; the resolver filters server-side **before** LIMIT; `WorkGraphEdgeResult` carries `theme`/`subcategory`; `WorkGraphEdgesResult` carries `degradedReason` (set to `"MEMBERSHIP_NOT_MATERIALIZED"` when the membership index is not yet built). Backend must merge + run migration first. The backend's internal multi-membership threshold model is invisible to the client — the client just sends a single theme/subcategory string.

## Test plan

- [x] `pnpm codegen:check` — generated types in sync with schema
- [x] `pnpm test:unit src/components/work/GraphView.test.tsx` — 23 passed
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors
- [ ] After backend merges: verify selecting a theme issues a query with `filters.theme` and the canvas shows only matching edges; sparse themes are not falsely empty; an org without a materialized membership index shows the "Theme data is being prepared" state.

Parent: CHAOS-2427
