### PR TITLE
fix(admin/sync): sync-all uses all_repos signal, works with blank owner (CHAOS-2448)

### DIFF
--- a/src/components/admin/sync/SyncConfigForm.test.tsx
+++ b/src/components/admin/sync/SyncConfigForm.test.tsx
@@ -537,7 +537,7 @@ describe("SyncConfigForm", () => {
             expect(screen.getByLabelText("Custom cron")).toHaveValue("15 3 * * *");
         });
 
-        it("org-wide toggle uses createSyncConfig with search and not batch", async () => {
+        it("sync-all toggle with owner sends all_repos + owner and not batch", async () => {
             mockCreateSyncConfig.mockResolvedValue(undefined);
             renderWithToaster(<SyncConfigForm credentials={mockCredentials} />);
 
@@ -545,7 +545,7 @@ describe("SyncConfigForm", () => {
             await userEvent.selectOptions(screen.getByLabelText("Credential"), "cred-1");
             await userEvent.type(screen.getByLabelText("Owner / Organization"), "myorg");
             await userEvent.click(
-                screen.getByLabelText("Sync all repositories in this organization"),
+                screen.getByLabelText("Sync all repositories this token can access"),
             );
             await userEvent.click(screen.getByRole("button", { name: "Create Configuration" }));
 
@@ -558,7 +558,33 @@ describe("SyncConfigForm", () => {
                     schedule_cron: null,
                     timezone: null,
                     initial_sync_depth: 30,
-                    sync_options: { owner: "myorg", search: "myorg/*" },
+                    sync_options: { all_repos: true, owner: "myorg" },
+                });
+            });
+            expect(mockBatchCreateSyncConfigs).not.toHaveBeenCalled();
+        });
+
+        it("sync-all toggle with blank owner sends all_repos only (no search)", async () => {
+            mockCreateSyncConfig.mockResolvedValue(undefined);
+            renderWithToaster(<SyncConfigForm credentials={mockCredentials} />);
+
+            await userEvent.type(screen.getByLabelText("Configuration Name"), "Token Sync");
+            await userEvent.selectOptions(screen.getByLabelText("Credential"), "cred-1");
+            await userEvent.click(
+                screen.getByLabelText("Sync all repositories this token can access"),
+            );
+            await userEvent.click(screen.getByRole("button", { name: "Create Configuration" }));
+
+            await waitFor(() => {
+                expect(mockCreateSyncConfig).toHaveBeenCalledWith({
+                    name: "Token Sync",
+                    provider: "github",
+                    credential_id: "cred-1",
+                    sync_targets: [],
+                    schedule_cron: null,
+                    timezone: null,
+                    initial_sync_depth: 30,
+                    sync_options: { all_repos: true },
                 });
             });
             expect(mockBatchCreateSyncConfigs).not.toHaveBeenCalled();
@@ -572,7 +598,7 @@ describe("SyncConfigForm", () => {
             expect(screen.getByText("Select Repositories")).toBeInTheDocument();
 
             await userEvent.click(
-                screen.getByLabelText("Sync all repositories in this organization"),
+                screen.getByLabelText("Sync all repositories this token can access"),
             );
             expect(screen.queryByText("Select Repositories")).not.toBeInTheDocument();
         });

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -197,14 +197,18 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                         };
 
                         if (syncAllRepos) {
-                            const orgSyncOptions = {
+                            // Token-wide signal: the backend enumerates every
+                            // repository the credential can access when
+                            // `all_repos` is true. `owner` rides along only when
+                            // provided (buildSyncOptions adds it when truthy) to
+                            // optionally scope to a single org.
+                            const allReposSyncOptions = {
                                 ...syncOptions,
-                                owner: formData.owner,
-                                search: `${formData.owner}/*`,
+                                all_repos: true,
                             };
                             result = await createSyncConfig({
                                 ...base,
-                                sync_options: orgSyncOptions,
+                                sync_options: allReposSyncOptions,
                             });
                             if (result?.error) {
                                 toast.error(result.error);
@@ -418,9 +422,16 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                                     className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
                                 />
                                 <label htmlFor="sync_all_repos" className="text-sm font-medium">
-                                    Sync all repositories in this organization
+                                    Sync all repositories this token can access
                                 </label>
                             </div>
+                        )}
+                        {!initialData && syncAllRepos && (
+                            <p className="text-xs text-(--ink-muted)">
+                                Every repository the selected credential can reach will be synced.
+                                Enter an owner above to narrow this to a single organization
+                                (optional).
+                            </p>
                         )}
                         {!initialData &&
                         !syncAllRepos &&


### PR DESCRIPTION
## Summary

The **"Sync all repositories"** checkbox now sends `sync_options: { all_repos: true }` (the backend token-wide signal) instead of `search: "${owner}/*"`. With a blank owner the old form produced `"/*"`, which the backend enumerated to nothing. The flag now works with a blank owner; `owner` rides along only when provided (to optionally narrow to a single org). The checkbox is relabeled to "Sync all repositories this token can access".

## Testing

```bash
pnpm vitest run src/components/admin/sync/SyncConfigForm.test.tsx
# 26 passed
```

- blank owner → `{ all_repos: true }` (no `search`)
- owner provided → `{ all_repos: true, owner }` (no `owner/*` search)
- explicit repo-selection (batch) path unchanged

## Dependency

Requires backend `sync_options.all_repos` support (dev-health-ops, CHAOS-2444). Deploy/merge the ops change first.

SCREENSHOT-PENDING: the `/admin/sync/new` checkbox screenshot could not be captured headlessly in this environment; it must be attached before merge per the repo visual-evidence policy.

Closes CHAOS-2448
