### PR TITLE
fix(work-graph): wire derived tabs to scoped fetch + server aggregates (CHAOS-2442)

### DIFF
--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -1304,8 +1304,9 @@ describe("GraphView", () => {
     // nodeId in visible text OR in a title attribute, and must show the
     // controlled unresolved label. Resolved rows must still show displayName.
 
-    it("artifacts unresolved row (displayName null) never leaks the raw nodeId", () => {
+    it("artifacts unresolved rows (null or whitespace-only displayName) never leak the raw nodeId", () => {
         const opaqueId = "abc123def456deadbeef";
+        const blankNameId = "f00dcafebabe9999feed";
         mockUseWorkGraphEdges.mockReturnValue({
             edges: [],
             loading: false,
@@ -1329,6 +1330,15 @@ describe("GraphView", () => {
                     degree: 2,
                     evidence: null,
                 },
+                {
+                    // Whitespace-only displayName is NOT a resolved name — must
+                    // degrade to the unresolved state, never the raw id.
+                    nodeType: "COMMIT",
+                    nodeId: blankNameId,
+                    displayName: "   ",
+                    degree: 1,
+                    evidence: null,
+                },
             ],
             loading: false,
             error: null,
@@ -1339,22 +1349,29 @@ describe("GraphView", () => {
         render(<GraphView filters={filters} activeTab="artifacts" />);
 
         const rows = screen.getAllByTestId("artifact-row");
-        expect(rows.length).toBe(2);
+        expect(rows.length).toBe(3);
 
         // Resolved row still shows its displayName.
         expect(screen.getByText("ISS-7: Resolved title")).toBeInTheDocument();
 
-        // The opaque id must NOT appear anywhere — not in visible text…
+        // Neither opaque id may appear anywhere — not in visible text…
         expect(screen.queryByText(opaqueId)).not.toBeInTheDocument();
-        // …and not in any title attribute (hover tooltip) either.
-        const opaqueRow = rows[1];
-        expect(opaqueRow.innerHTML).not.toContain(opaqueId);
-        expect(opaqueRow.querySelector(`[title*="${opaqueId}"]`)).toBeNull();
+        expect(screen.queryByText(blankNameId)).not.toBeInTheDocument();
 
-        // The controlled unresolved label is shown instead.
-        const unresolvedCell = within(opaqueRow).getByTestId("artifact-entity");
-        expect(unresolvedCell).toHaveAttribute("data-resolved", "false");
-        expect(unresolvedCell).toHaveTextContent(/Unresolved/i);
+        // …and not in any title attribute (hover tooltip) either.
+        const nullRow = rows[1];
+        const blankRow = rows[2];
+        expect(nullRow.innerHTML).not.toContain(opaqueId);
+        expect(blankRow.innerHTML).not.toContain(blankNameId);
+        expect(nullRow.querySelector(`[title*="${opaqueId}"]`)).toBeNull();
+        expect(blankRow.querySelector(`[title*="${blankNameId}"]`)).toBeNull();
+
+        // Both degrade to the controlled unresolved label.
+        for (const row of [nullRow, blankRow]) {
+            const cell = within(row).getByTestId("artifact-entity");
+            expect(cell).toHaveAttribute("data-resolved", "false");
+            expect(cell).toHaveTextContent(/Unresolved/i);
+        }
     });
 
     it("renders a scope-preserving Open evidence linkback in the explorer header", () => {

--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -5,14 +5,23 @@ import { GraphView } from "@/components/work/GraphView";
 import type { MetricFilter } from "@/lib/filters/types";
 import { CTA_LABELS } from "@/lib/design/cta";
 
-const { mockUseSearchParams, mockUseWorkGraphEdges, mockUseOrgId, mockReplace, mockUsePathname } =
-    vi.hoisted(() => ({
-        mockUseSearchParams: vi.fn(() => new URLSearchParams()),
-        mockUseWorkGraphEdges: vi.fn(),
-        mockUseOrgId: vi.fn(() => "org-1"),
-        mockReplace: vi.fn(),
-        mockUsePathname: vi.fn(() => "/diagnose/work-graph"),
-    }));
+const {
+    mockUseSearchParams,
+    mockUseWorkGraphEdges,
+    mockUseWorkGraphFlow,
+    mockUseWorkGraphArtifacts,
+    mockUseOrgId,
+    mockReplace,
+    mockUsePathname,
+} = vi.hoisted(() => ({
+    mockUseSearchParams: vi.fn(() => new URLSearchParams()),
+    mockUseWorkGraphEdges: vi.fn(),
+    mockUseWorkGraphFlow: vi.fn(),
+    mockUseWorkGraphArtifacts: vi.fn(),
+    mockUseOrgId: vi.fn(() => "org-1"),
+    mockReplace: vi.fn(),
+    mockUsePathname: vi.fn(() => "/diagnose/work-graph"),
+}));
 
 vi.mock("next/navigation", () => ({
     useSearchParams: mockUseSearchParams,
@@ -22,7 +31,18 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/lib/graphql/hooks", () => ({
     useWorkGraphEdges: mockUseWorkGraphEdges,
+    useWorkGraphFlow: mockUseWorkGraphFlow,
+    useWorkGraphArtifacts: mockUseWorkGraphArtifacts,
 }));
+
+/** Default empty return for the aggregate hooks (overridden per-test as needed). */
+const emptyAggregate = () => ({
+    rows: [],
+    loading: false,
+    error: null,
+    degradedReason: null,
+    refetch: vi.fn(),
+});
 
 vi.mock("@/lib/graphql/provider", () => ({
     useOrgId: mockUseOrgId,
@@ -44,6 +64,10 @@ describe("GraphView", () => {
         vi.clearAllMocks();
         mockUseSearchParams.mockReturnValue(new URLSearchParams());
         mockUsePathname.mockReturnValue("/diagnose/work-graph");
+        // Aggregate hooks default to empty; tests that exercise the
+        // inflow-outflow / artifacts tabs override these as needed.
+        mockUseWorkGraphFlow.mockReturnValue(emptyAggregate());
+        mockUseWorkGraphArtifacts.mockReturnValue(emptyAggregate());
     });
 
     it("shows empty state when no edges returned", () => {
@@ -679,60 +703,72 @@ describe("GraphView", () => {
         expect(screen.getByTestId("work-graph-explorer")).toBeInTheDocument();
     });
 
-    it("inflow-outflow tab renders a per-entity-type table instead of the canvas", () => {
+    it("inflow-outflow tab renders rows from the workGraphFlow aggregate instead of the canvas", () => {
         mockUseWorkGraphEdges.mockReturnValue({
-            edges: [
-                {
-                    edgeId: "e1",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-1",
-                    targetType: "PR",
-                    targetId: "PR-1",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1,
-                    evidence: null,
-                },
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+        // Rows come from the server-side aggregate (CHAOS-2442), NOT derived edges.
+        mockUseWorkGraphFlow.mockReturnValue({
+            rows: [
+                { nodeType: "ISSUE", inflow: 0, outflow: 1 },
+                { nodeType: "PR", inflow: 1, outflow: 0 },
             ],
             loading: false,
             error: null,
-            totalCount: 1,
+            degradedReason: null,
             refetch: vi.fn(),
         });
 
         render(<GraphView filters={filters} activeTab="inflow-outflow" />);
 
         expect(screen.getByTestId("inflow-outflow-panel")).toBeInTheDocument();
-        // Issue (outflow) + PR (inflow) → 2 rows.
-        expect(screen.getAllByTestId("inflow-outflow-row").length).toBeGreaterThanOrEqual(2);
+        // Two aggregate rows → two table rows.
+        expect(screen.getAllByTestId("inflow-outflow-row").length).toBe(2);
         expect(screen.queryByTestId("work-graph-explorer")).not.toBeInTheDocument();
     });
 
-    it("artifacts tab ranks entities by connection count", () => {
+    it("artifacts tab renders rows from the workGraphArtifacts aggregate", () => {
         mockUseWorkGraphEdges.mockReturnValue({
-            edges: [
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+        mockUseWorkGraphArtifacts.mockReturnValue({
+            rows: [
                 {
-                    edgeId: "e1",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-1",
-                    targetType: "PR",
-                    targetId: "PR-1",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1,
+                    nodeType: "ISSUE",
+                    nodeId: "ISS-1",
+                    displayName: "ISS-1: Login bug",
+                    degree: 3,
                     evidence: "Fixes ISS-1",
+                },
+                {
+                    nodeType: "PR",
+                    nodeId: "PR-1",
+                    displayName: "PR-1: Add login form",
+                    degree: 2,
+                    evidence: null,
                 },
             ],
             loading: false,
             error: null,
-            totalCount: 1,
+            degradedReason: null,
             refetch: vi.fn(),
         });
 
         render(<GraphView filters={filters} activeTab="artifacts" />);
 
         expect(screen.getByTestId("artifacts-panel")).toBeInTheDocument();
-        expect(screen.getAllByTestId("artifact-row").length).toBeGreaterThanOrEqual(2);
+        expect(screen.getAllByTestId("artifact-row").length).toBe(2);
+        // displayName is shown when present (resolved rows).
+        expect(screen.getByText("ISS-1: Login bug")).toBeInTheDocument();
+        expect(screen.getByText("PR-1: Add login form")).toBeInTheDocument();
         expect(screen.queryByTestId("work-graph-explorer")).not.toBeInTheDocument();
     });
 
@@ -822,6 +858,13 @@ describe("GraphView", () => {
             loading: false,
             error: null,
             totalCount: 0,
+            refetch: vi.fn(),
+        });
+        // The degraded signal now comes from the workGraphFlow aggregate.
+        mockUseWorkGraphFlow.mockReturnValue({
+            rows: [],
+            loading: false,
+            error: null,
             degradedReason: "MEMBERSHIP_NOT_MATERIALIZED",
             refetch: vi.fn(),
         });
@@ -847,6 +890,12 @@ describe("GraphView", () => {
             loading: false,
             error: null,
             totalCount: 0,
+            refetch: vi.fn(),
+        });
+        mockUseWorkGraphFlow.mockReturnValue({
+            rows: [],
+            loading: false,
+            error: null,
             degradedReason: "MEMBERSHIP_NOT_MATERIALIZED",
             refetch: vi.fn(),
         });
@@ -866,24 +915,16 @@ describe("GraphView", () => {
     it("inflow-outflow tab renders normally when degradedReason is null", () => {
         mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "quality" }));
         mockUseWorkGraphEdges.mockReturnValue({
-            edges: [
-                {
-                    edgeId: "e1",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-1",
-                    targetType: "PR",
-                    targetId: "PR-1",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1,
-                    evidence: null,
-                    theme: "quality",
-                    subcategory: "quality.bugfix",
-                },
-            ],
+            edges: [],
             loading: false,
             error: null,
-            totalCount: 1,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+        mockUseWorkGraphFlow.mockReturnValue({
+            rows: [{ nodeType: "ISSUE", inflow: 0, outflow: 1 }],
+            loading: false,
+            error: null,
             degradedReason: null,
             refetch: vi.fn(),
         });
@@ -901,6 +942,12 @@ describe("GraphView", () => {
             loading: false,
             error: null,
             totalCount: 0,
+            refetch: vi.fn(),
+        });
+        mockUseWorkGraphArtifacts.mockReturnValue({
+            rows: [],
+            loading: false,
+            error: null,
             degradedReason: "MEMBERSHIP_NOT_MATERIALIZED",
             refetch: vi.fn(),
         });
@@ -924,6 +971,12 @@ describe("GraphView", () => {
             loading: false,
             error: null,
             totalCount: 0,
+            refetch: vi.fn(),
+        });
+        mockUseWorkGraphArtifacts.mockReturnValue({
+            rows: [],
+            loading: false,
+            error: null,
             degradedReason: "MEMBERSHIP_NOT_MATERIALIZED",
             refetch: vi.fn(),
         });
@@ -943,24 +996,24 @@ describe("GraphView", () => {
     it("artifacts tab renders normally when degradedReason is null", () => {
         mockUseSearchParams.mockReturnValue(new URLSearchParams({ graph_theme: "quality" }));
         mockUseWorkGraphEdges.mockReturnValue({
-            edges: [
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+        mockUseWorkGraphArtifacts.mockReturnValue({
+            rows: [
                 {
-                    edgeId: "e1",
-                    sourceType: "ISSUE",
-                    sourceId: "ISS-1",
-                    targetType: "PR",
-                    targetId: "PR-1",
-                    edgeType: "FIXES",
-                    provenance: "NATIVE",
-                    confidence: 1,
+                    nodeType: "ISSUE",
+                    nodeId: "ISS-1",
+                    displayName: "ISS-1",
+                    degree: 2,
                     evidence: "Fixes ISS-1",
-                    theme: "quality",
-                    subcategory: "quality.bugfix",
                 },
             ],
             loading: false,
             error: null,
-            totalCount: 1,
             degradedReason: null,
             refetch: vi.fn(),
         });
@@ -1141,6 +1194,167 @@ describe("GraphView", () => {
         // We match the description paragraph to avoid ambiguity with the heading.
         expect(screen.getByText("Failed to load review network data")).toBeInTheDocument();
         expect(screen.queryByTestId("work-graph-explorer")).not.toBeInTheDocument();
+    });
+
+    // ── CHAOS-2442 regression: tabs no longer starved by the capped edge page ───
+    //
+    // The bug: a single capped page of edges (GRAPH_EDGE_QUERY_LIMIT) fed all
+    // tabs. For reference-heavy orgs the first page was dominated by `references`
+    // edges, so the Dependencies tab client-filtered to ~0, and Inflow/Outflow +
+    // Artifacts derived degenerate counts. The fix scopes Dependencies to
+    // `edgeTypes` server-side and points the two table tabs at true aggregates.
+
+    it("dependencies tab carries edgeTypes in the edge query so dependency edges arrive pre-scoped", () => {
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="dependencies" />);
+
+        const filtersArg = lastEdgeFilters();
+        // The dependency edge-type slice is sent to the backend (applied BEFORE
+        // the LIMIT) — the tab no longer relies on the capped global page.
+        expect(Array.isArray(filtersArg.edgeTypes)).toBe(true);
+        expect(filtersArg.edgeTypes).toContain("BLOCKS");
+        expect(filtersArg.edgeTypes).toContain("PARENT_OF");
+        // Non-dependency edge types must not be requested here.
+        expect(filtersArg.edgeTypes).not.toContain("FIXES");
+        expect(filtersArg.edgeTypes).not.toContain("REFERENCES");
+    });
+
+    it("overview tab does NOT carry edgeTypes (keeps the broad fetch)", () => {
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="overview" />);
+
+        expect(lastEdgeFilters()).not.toHaveProperty("edgeTypes");
+    });
+
+    it("inflow-outflow renders aggregate rows even when the edge page is empty (cap-immune)", () => {
+        // Simulate a skewed/capped edge page that contains NO usable edges for
+        // this tab — the aggregate query is the sole data source now.
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+        mockUseWorkGraphFlow.mockReturnValue({
+            rows: [
+                { nodeType: "ISSUE", inflow: 5, outflow: 9 },
+                { nodeType: "COMMIT", inflow: 7, outflow: 2 },
+            ],
+            loading: false,
+            error: null,
+            degradedReason: null,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="inflow-outflow" />);
+
+        expect(screen.getAllByTestId("inflow-outflow-row").length).toBe(2);
+    });
+
+    it("artifacts renders aggregate rows even when the edge page is empty (cap-immune)", () => {
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+        mockUseWorkGraphArtifacts.mockReturnValue({
+            rows: [
+                {
+                    nodeType: "ISSUE",
+                    nodeId: "ISS-9",
+                    displayName: "ISS-9: Flaky CI",
+                    degree: 11,
+                    evidence: null,
+                },
+            ],
+            loading: false,
+            error: null,
+            degradedReason: null,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="artifacts" />);
+
+        expect(screen.getAllByTestId("artifact-row").length).toBe(1);
+        expect(screen.getByText("ISS-9: Flaky CI")).toBeInTheDocument();
+    });
+
+    // ── Artifacts unresolved-id leak guard (CHAOS-2442 review) ──────────────────
+    //
+    // The backend returns displayName=null for unresolvable/opaque node ids so
+    // the UI can render a controlled "Unresolved" state and NEVER leak a bare id.
+    // Regression for the Codex finding: an unresolved row must not surface its raw
+    // nodeId in visible text OR in a title attribute, and must show the
+    // controlled unresolved label. Resolved rows must still show displayName.
+
+    it("artifacts unresolved row (displayName null) never leaks the raw nodeId", () => {
+        const opaqueId = "abc123def456deadbeef";
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+        mockUseWorkGraphArtifacts.mockReturnValue({
+            rows: [
+                {
+                    nodeType: "ISSUE",
+                    nodeId: "ISS-7",
+                    displayName: "ISS-7: Resolved title",
+                    degree: 4,
+                    evidence: null,
+                },
+                {
+                    nodeType: "COMMIT",
+                    nodeId: opaqueId,
+                    displayName: null,
+                    degree: 2,
+                    evidence: null,
+                },
+            ],
+            loading: false,
+            error: null,
+            degradedReason: null,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="artifacts" />);
+
+        const rows = screen.getAllByTestId("artifact-row");
+        expect(rows.length).toBe(2);
+
+        // Resolved row still shows its displayName.
+        expect(screen.getByText("ISS-7: Resolved title")).toBeInTheDocument();
+
+        // The opaque id must NOT appear anywhere — not in visible text…
+        expect(screen.queryByText(opaqueId)).not.toBeInTheDocument();
+        // …and not in any title attribute (hover tooltip) either.
+        const opaqueRow = rows[1];
+        expect(opaqueRow.innerHTML).not.toContain(opaqueId);
+        expect(opaqueRow.querySelector(`[title*="${opaqueId}"]`)).toBeNull();
+
+        // The controlled unresolved label is shown instead.
+        const unresolvedCell = within(opaqueRow).getByTestId("artifact-entity");
+        expect(unresolvedCell).toHaveAttribute("data-resolved", "false");
+        expect(unresolvedCell).toHaveTextContent(/Unresolved/i);
     });
 
     it("renders a scope-preserving Open evidence linkback in the explorer header", () => {

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -6,12 +6,15 @@ import Link from "next/link";
 
 import { WorkGraphExplorer, WorkGraphLegend } from "@/components/charts/WorkGraphExplorer";
 import { DataState } from "@/components/ui/DataState";
-import { useWorkGraphEdges } from "@/lib/graphql/hooks";
+import { EntityLabel } from "@/components/labels/EntityLabel";
+import { useWorkGraphEdges, useWorkGraphFlow, useWorkGraphArtifacts } from "@/lib/graphql/hooks";
 import type {
     WorkGraphEdge,
     WorkGraphEdgeFilterInput,
     WorkGraphEdgeType,
     WorkGraphNodeType,
+    WorkGraphFlowRow,
+    WorkGraphArtifactRow,
 } from "@/lib/graphql/types";
 import type { ReviewEdgeRow } from "@/lib/graphql/reviewEdgesFetchers";
 import type { MetricFilter } from "@/lib/filters/types";
@@ -328,19 +331,65 @@ export function GraphView({
     // outside the edge cap and produce a false-empty graph. We therefore pass
     // the active theme/subcategory (when not "all") straight into the query
     // variables instead of filtering the fetched page client-side.
+    // Only the explorer tabs (overview / dependencies) consume the raw edge
+    // page; inflow-outflow / artifacts now fetch their own server-side
+    // aggregates (CHAOS-2442) and review-network uses pre-fetched review edges.
+    const graphTabActive = activeTab === "overview" || activeTab === "dependencies";
     const edgeFilters = useMemo<WorkGraphEdgeFilterInput>(
         () => ({
             repoIds: filters.what?.repos,
             limit: GRAPH_EDGE_QUERY_LIMIT,
             ...(theme !== "all" ? { theme } : {}),
             ...(subcategory !== "all" ? { subcategory } : {}),
+            // Dependencies tab (CHAOS-2442): scope the edge query to dependency
+            // edge types SERVER-SIDE so they arrive pre-filtered before the LIMIT
+            // and can never be starved by a reference-heavy capped page. The
+            // client-side DEPENDENCY_EDGE_TYPES filter below is kept only as a
+            // harmless safety net. The overview tab keeps the broad set.
+            ...(activeTab === "dependencies" ? { edgeTypes: DEPENDENCY_EDGE_TYPES } : {}),
         }),
-        [filters.what?.repos, theme, subcategory],
+        [filters.what?.repos, theme, subcategory, activeTab],
     );
     const { edges, loading, error, totalCount, degradedReason } = useWorkGraphEdges({
         orgId,
         filters: edgeFilters,
-        pause: !orgId,
+        pause: !orgId || !graphTabActive,
+    });
+
+    // Aggregate queries backing the derived table tabs (CHAOS-2442). Both share
+    // the org/repo/theme scope; artifacts additionally caps to the top 50 rows.
+    // Each is paused unless its tab is active so we never issue a needless fetch.
+    const aggregateFilters = useMemo<WorkGraphEdgeFilterInput>(
+        () => ({
+            repoIds: filters.what?.repos,
+            ...(theme !== "all" ? { theme } : {}),
+            ...(subcategory !== "all" ? { subcategory } : {}),
+        }),
+        [filters.what?.repos, theme, subcategory],
+    );
+    const artifactFilters = useMemo<WorkGraphEdgeFilterInput>(
+        () => ({ ...aggregateFilters, limit: 50 }),
+        [aggregateFilters],
+    );
+    const {
+        rows: flowRows,
+        loading: flowLoading,
+        error: flowError,
+        degradedReason: flowDegradedReason,
+    } = useWorkGraphFlow({
+        orgId,
+        filters: aggregateFilters,
+        pause: !orgId || activeTab !== "inflow-outflow",
+    });
+    const {
+        rows: artifactRows,
+        loading: artifactsLoading,
+        error: artifactsError,
+        degradedReason: artifactsDegradedReason,
+    } = useWorkGraphArtifacts({
+        orgId,
+        filters: artifactFilters,
+        pause: !orgId || activeTab !== "artifacts",
     });
 
     // The Overview tab honours the in-explorer connection-type selector; the
@@ -448,7 +497,12 @@ export function GraphView({
     // while the membership index is preparing would have no way to clear the
     // scope — the fail-safe would be a dead-end.
     if (activeTab === "inflow-outflow") {
-        if (!loading && !error && themeDataPreparing) {
+        // Degraded fail-safe now reads the aggregate query's degradedReason
+        // (CHAOS-2442): the inflow/outflow rows come from workGraphFlow, so its
+        // MEMBERSHIP_NOT_MATERIALIZED signal is what surfaces the prepared state.
+        const flowPreparing =
+            themeFilterActive && flowDegradedReason === "MEMBERSHIP_NOT_MATERIALIZED";
+        if (!flowLoading && !flowError && flowPreparing) {
             return (
                 <>
                     {themeScopeChip}
@@ -459,12 +513,14 @@ export function GraphView({
         return (
             <>
                 {themeScopeChip}
-                <InflowOutflowView edges={edges} loading={loading} error={error} />
+                <InflowOutflowView rows={flowRows} loading={flowLoading} error={flowError} />
             </>
         );
     }
     if (activeTab === "artifacts") {
-        if (!loading && !error && themeDataPreparing) {
+        const artifactsPreparing =
+            themeFilterActive && artifactsDegradedReason === "MEMBERSHIP_NOT_MATERIALIZED";
+        if (!artifactsLoading && !artifactsError && artifactsPreparing) {
             return (
                 <>
                     {themeScopeChip}
@@ -475,7 +531,11 @@ export function GraphView({
         return (
             <>
                 {themeScopeChip}
-                <ArtifactsView edges={edges} loading={loading} error={error} />
+                <ArtifactsView
+                    rows={artifactRows}
+                    loading={artifactsLoading}
+                    error={artifactsError}
+                />
             </>
         );
     }
@@ -690,28 +750,23 @@ export function GraphView({
 // Inflow / Outflow tab — relationship direction by entity type
 // ---------------------------------------------------------------------------
 
-type DerivedViewProps = {
-    edges: WorkGraphEdge[];
+type InflowOutflowViewProps = {
+    rows: WorkGraphFlowRow[];
     loading: boolean;
     error: { message: string } | null;
 };
 
-function InflowOutflowView({ edges, loading, error }: DerivedViewProps) {
-    const rows = useMemo(() => {
-        const inflow = new Map<WorkGraphNodeType, number>();
-        const outflow = new Map<WorkGraphNodeType, number>();
-        for (const edge of edges) {
-            outflow.set(edge.sourceType, (outflow.get(edge.sourceType) ?? 0) + 1);
-            inflow.set(edge.targetType, (inflow.get(edge.targetType) ?? 0) + 1);
-        }
-        return NODE_TYPES.map((type) => ({
-            type,
-            inflow: inflow.get(type) ?? 0,
-            outflow: outflow.get(type) ?? 0,
-        }))
-            .filter((row) => row.inflow > 0 || row.outflow > 0)
-            .sort((a, b) => b.inflow + b.outflow - (a.inflow + a.outflow));
-    }, [edges]);
+function InflowOutflowView({ rows: serverRows, loading, error }: InflowOutflowViewProps) {
+    // Rows now come from the server-side workGraphFlow aggregate (CHAOS-2442),
+    // so they are no longer derived from a capped edge page. We only drop
+    // all-zero rows and rank by total volume for a stable, readable order.
+    const rows = useMemo(
+        () =>
+            serverRows
+                .filter((row) => row.inflow > 0 || row.outflow > 0)
+                .sort((a, b) => b.inflow + b.outflow - (a.inflow + a.outflow)),
+        [serverRows],
+    );
 
     const max = rows.reduce((m, r) => Math.max(m, r.inflow, r.outflow), 1);
 
@@ -755,12 +810,12 @@ function InflowOutflowView({ edges, loading, error }: DerivedViewProps) {
                         <tbody>
                             {rows.map((row) => (
                                 <tr
-                                    key={row.type}
+                                    key={row.nodeType}
                                     data-testid="inflow-outflow-row"
                                     className="border-t border-(--card-stroke)/60"
                                 >
                                     <td className="px-5 py-3 align-middle font-medium">
-                                        {NODE_TYPE_LABELS[row.type]}
+                                        {NODE_TYPE_LABELS[row.nodeType]}
                                     </td>
                                     <td className="px-5 py-3 text-right tabular-nums">
                                         {formatNumber(row.inflow)}
@@ -800,36 +855,13 @@ function InflowOutflowView({ edges, loading, error }: DerivedViewProps) {
 // Artifacts tab — distinct entities in the graph and how connected they are
 // ---------------------------------------------------------------------------
 
-function ArtifactsView({ edges, loading, error }: DerivedViewProps) {
-    const rows = useMemo(() => {
-        const counts = new Map<
-            string,
-            {
-                type: WorkGraphNodeType;
-                id: string;
-                degree: number;
-                evidence: string | null;
-            }
-        >();
-        const bump = (type: WorkGraphNodeType, id: string, evidence: string | null) => {
-            const key = `${type}:${id}`;
-            const existing = counts.get(key);
-            if (existing) {
-                existing.degree += 1;
-                if (!existing.evidence && evidence) existing.evidence = evidence;
-            } else {
-                counts.set(key, { type, id, degree: 1, evidence });
-            }
-        };
-        for (const edge of edges) {
-            bump(edge.sourceType, edge.sourceId, edge.evidence ?? null);
-            bump(edge.targetType, edge.targetId, edge.evidence ?? null);
-        }
-        return Array.from(counts.values())
-            .sort((a, b) => b.degree - a.degree)
-            .slice(0, 50);
-    }, [edges]);
+type ArtifactsViewProps = {
+    rows: WorkGraphArtifactRow[];
+    loading: boolean;
+    error: { message: string } | null;
+};
 
+function ArtifactsView({ rows, loading, error }: ArtifactsViewProps) {
     return (
         <section
             className="rounded-[1.75rem] border border-(--card-stroke) bg-(--card-90) p-6 shadow-sm"
@@ -870,18 +902,39 @@ function ArtifactsView({ edges, loading, error }: DerivedViewProps) {
                         <tbody>
                             {rows.map((row) => (
                                 <tr
-                                    key={`${row.type}:${row.id}`}
+                                    key={`${row.nodeType}:${row.nodeId}`}
                                     data-testid="artifact-row"
                                     className="border-t border-(--card-stroke)/60"
                                 >
                                     <td className="px-5 py-3 align-middle text-(--ink-muted)">
-                                        {NODE_TYPE_LABELS[row.type]}
+                                        {NODE_TYPE_LABELS[row.nodeType]}
                                     </td>
-                                    <td
-                                        className="px-5 py-3 align-middle font-mono text-[0.82em]"
-                                        title={row.id}
-                                    >
-                                        {row.id}
+                                    <td className="px-5 py-3 align-middle text-[0.82em]">
+                                        {/*
+                                          A7/A8 render-safety (CHAOS-2442 review):
+                                          the backend returns displayName=null for
+                                          unresolvable/opaque node ids precisely so
+                                          the UI never leaks a bare id. Branch on
+                                          that authoritative signal — do NOT fall
+                                          back to nodeId (in text OR title) when
+                                          unresolved. Resolved rows keep nodeId as
+                                          a traceability tooltip via EntityLabel.
+                                        */}
+                                        {row.displayName ? (
+                                            <EntityLabel
+                                                id={row.nodeId}
+                                                displayName={row.displayName}
+                                                className="font-mono"
+                                                data-testid="artifact-entity"
+                                            />
+                                        ) : (
+                                            <EntityLabel
+                                                fallback="Unresolved"
+                                                showUnresolvedBadge={false}
+                                                className="italic text-(--ink-muted)"
+                                                data-testid="artifact-entity"
+                                            />
+                                        )}
                                     </td>
                                     <td className="px-5 py-3 text-right tabular-nums">
                                         {formatNumber(row.degree)}

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -919,11 +919,14 @@ function ArtifactsView({ rows, loading, error }: ArtifactsViewProps) {
                                           back to nodeId (in text OR title) when
                                           unresolved. Resolved rows keep nodeId as
                                           a traceability tooltip via EntityLabel.
+                                          Trim first: a whitespace-only displayName
+                                          is NOT a resolved name (EntityLabel would
+                                          trim it away and normalize the id back in).
                                         */}
-                                        {row.displayName ? (
+                                        {row.displayName?.trim() ? (
                                             <EntityLabel
                                                 id={row.nodeId}
-                                                displayName={row.displayName}
+                                                displayName={row.displayName.trim()}
                                                 className="font-mono"
                                                 data-testid="artifact-entity"
                                             />

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -1227,8 +1227,12 @@ export type Query = {
   securityOverview: SecurityOverview;
   /** Compute throughput-based capacity forecast */
   throughputForecast?: Maybe<ThroughputForecast>;
+  /** Server-side artifact ranking (node degree) for the work graph */
+  workGraphArtifacts: WorkGraphArtifactsResult;
   /** Query work graph edges with optional filters */
   workGraphEdges: WorkGraphEdgesResult;
+  /** Server-side inflow/outflow aggregate per node type for the work graph */
+  workGraphFlow: WorkGraphFlowResult;
 };
 
 
@@ -1437,7 +1441,19 @@ export type QueryThroughputForecastArgs = {
 };
 
 
+export type QueryWorkGraphArtifactsArgs = {
+  filters?: InputMaybe<WorkGraphEdgeFilterInput>;
+  orgId: Scalars['String']['input'];
+};
+
+
 export type QueryWorkGraphEdgesArgs = {
+  filters?: InputMaybe<WorkGraphEdgeFilterInput>;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryWorkGraphFlowArgs = {
   filters?: InputMaybe<WorkGraphEdgeFilterInput>;
   orgId: Scalars['String']['input'];
 };
@@ -1878,8 +1894,24 @@ export type WindowUnit =
   | 'DAY'
   | 'WEEK';
 
+export type WorkGraphArtifactRow = {
+  __typename?: 'WorkGraphArtifactRow';
+  degree: Scalars['Int']['output'];
+  displayName?: Maybe<Scalars['String']['output']>;
+  evidence?: Maybe<Scalars['String']['output']>;
+  nodeId: Scalars['String']['output'];
+  nodeType: WorkGraphNodeType;
+};
+
+export type WorkGraphArtifactsResult = {
+  __typename?: 'WorkGraphArtifactsResult';
+  degradedReason?: Maybe<Scalars['String']['output']>;
+  rows: Array<WorkGraphArtifactRow>;
+};
+
 export type WorkGraphEdgeFilterInput = {
   edgeType?: InputMaybe<WorkGraphEdgeTypeInput>;
+  edgeTypes?: InputMaybe<Array<WorkGraphEdgeTypeInput>>;
   limit?: Scalars['Int']['input'];
   nodeId?: InputMaybe<Scalars['String']['input']>;
   repoIds?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -1962,6 +1994,19 @@ export type WorkGraphEdgesResult = {
   edges: Array<WorkGraphEdgeResult>;
   pageInfo: PageInfo;
   totalCount: Scalars['Int']['output'];
+};
+
+export type WorkGraphFlowResult = {
+  __typename?: 'WorkGraphFlowResult';
+  degradedReason?: Maybe<Scalars['String']['output']>;
+  rows: Array<WorkGraphFlowRow>;
+};
+
+export type WorkGraphFlowRow = {
+  __typename?: 'WorkGraphFlowRow';
+  inflow: Scalars['Int']['output'];
+  nodeType: WorkGraphNodeType;
+  outflow: Scalars['Int']['output'];
 };
 
 export type WorkGraphNodeType =

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -1227,11 +1227,11 @@ export type Query = {
   securityOverview: SecurityOverview;
   /** Compute throughput-based capacity forecast */
   throughputForecast?: Maybe<ThroughputForecast>;
-  /** Server-side artifact ranking (node degree) for the work graph */
+  /** Top-N work graph nodes ranked by degree over the full graph */
   workGraphArtifacts: WorkGraphArtifactsResult;
   /** Query work graph edges with optional filters */
   workGraphEdges: WorkGraphEdgesResult;
-  /** Server-side inflow/outflow aggregate per node type for the work graph */
+  /** Per-node-type inflow/outflow over the full work graph */
   workGraphFlow: WorkGraphFlowResult;
 };
 

--- a/src/lib/graphql/hooks/index.ts
+++ b/src/lib/graphql/hooks/index.ts
@@ -17,5 +17,10 @@ export {
     type TaskStatus,
     type SyncProgress,
 } from "./useSubscription";
-export { useWorkGraphEdges, useNodeEdges } from "./useWorkGraph";
+export {
+    useWorkGraphEdges,
+    useWorkGraphFlow,
+    useWorkGraphArtifacts,
+    useNodeEdges,
+} from "./useWorkGraph";
 export { useSecurityOverview, useSecurityAlerts } from "./useSecurity";

--- a/src/lib/graphql/hooks/useWorkGraph.ts
+++ b/src/lib/graphql/hooks/useWorkGraph.ts
@@ -1,9 +1,17 @@
 import { useQuery } from "urql";
-import { WORK_GRAPH_EDGES_QUERY } from "../queries";
+import {
+    WORK_GRAPH_EDGES_QUERY,
+    WORK_GRAPH_FLOW_QUERY,
+    WORK_GRAPH_ARTIFACTS_QUERY,
+} from "../queries";
 import type {
     WorkGraphEdge,
     WorkGraphEdgeFilterInput,
     WorkGraphEdgesResult,
+    WorkGraphFlowResult,
+    WorkGraphFlowRow,
+    WorkGraphArtifactsResult,
+    WorkGraphArtifactRow,
     PageInfo,
 } from "../types";
 
@@ -44,6 +52,74 @@ export function useWorkGraphEdges(options: UseWorkGraphEdgesOptions): UseWorkGra
         loading: result.fetching,
         error: result.error ?? null,
         degradedReason: result.data?.workGraphEdges?.degradedReason ?? null,
+        refetch: reexecute,
+    };
+}
+
+// ── Aggregate hooks (CHAOS-2442) ────────────────────────────────────────────
+// The Inflow/Outflow and Artifacts tabs fetch true server-side aggregates
+// instead of deriving from a capped page of edges. Both mirror
+// useWorkGraphEdges: same options (orgId, filters, pause), cache-and-network,
+// and surface rows + loading + error + degradedReason.
+
+interface UseWorkGraphAggregateOptions {
+    orgId: string;
+    filters?: WorkGraphEdgeFilterInput;
+    pause?: boolean;
+}
+
+interface UseWorkGraphFlowResult {
+    rows: WorkGraphFlowRow[];
+    loading: boolean;
+    error: Error | null;
+    degradedReason: string | null;
+    refetch: () => void;
+}
+
+export function useWorkGraphFlow(options: UseWorkGraphAggregateOptions): UseWorkGraphFlowResult {
+    const { orgId, filters, pause = false } = options;
+
+    const [result, reexecute] = useQuery<{ workGraphFlow: WorkGraphFlowResult }>({
+        query: WORK_GRAPH_FLOW_QUERY,
+        variables: { orgId, filters },
+        pause,
+        requestPolicy: "cache-and-network",
+    });
+
+    return {
+        rows: result.data?.workGraphFlow?.rows ?? [],
+        loading: result.fetching,
+        error: result.error ?? null,
+        degradedReason: result.data?.workGraphFlow?.degradedReason ?? null,
+        refetch: reexecute,
+    };
+}
+
+interface UseWorkGraphArtifactsResult {
+    rows: WorkGraphArtifactRow[];
+    loading: boolean;
+    error: Error | null;
+    degradedReason: string | null;
+    refetch: () => void;
+}
+
+export function useWorkGraphArtifacts(
+    options: UseWorkGraphAggregateOptions,
+): UseWorkGraphArtifactsResult {
+    const { orgId, filters, pause = false } = options;
+
+    const [result, reexecute] = useQuery<{ workGraphArtifacts: WorkGraphArtifactsResult }>({
+        query: WORK_GRAPH_ARTIFACTS_QUERY,
+        variables: { orgId, filters },
+        pause,
+        requestPolicy: "cache-and-network",
+    });
+
+    return {
+        rows: result.data?.workGraphArtifacts?.rows ?? [],
+        loading: result.fetching,
+        error: result.error ?? null,
+        degradedReason: result.data?.workGraphArtifacts?.degradedReason ?? null,
         refetch: reexecute,
     };
 }

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -393,6 +393,39 @@ query WorkGraphEdges($orgId: String!, $filters: WorkGraphEdgeFilterInput) {
 }
 `;
 
+// Server-side inflow/outflow aggregate per node type (CHAOS-2442). Replaces the
+// client-side derivation that the Inflow/Outflow tab previously computed from a
+// capped page of edges.
+export const WORK_GRAPH_FLOW_QUERY = `
+query WorkGraphFlow($orgId: String!, $filters: WorkGraphEdgeFilterInput) {
+  workGraphFlow(orgId: $orgId, filters: $filters) {
+    rows {
+      nodeType
+      inflow
+      outflow
+    }
+    degradedReason
+  }
+}
+`;
+
+// Server-side artifact ranking by node degree (CHAOS-2442). Replaces the
+// client-side degree count the Artifacts tab previously derived from edges.
+export const WORK_GRAPH_ARTIFACTS_QUERY = `
+query WorkGraphArtifacts($orgId: String!, $filters: WorkGraphEdgeFilterInput) {
+  workGraphArtifacts(orgId: $orgId, filters: $filters) {
+    rows {
+      nodeType
+      nodeId
+      displayName
+      degree
+      evidence
+    }
+    degradedReason
+  }
+}
+`;
+
 // ==== Security Alert Queries ====
 
 export const SECURITY_OVERVIEW_QUERY = `

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1063,10 +1063,10 @@ type Query {
   """Query work graph edges with optional filters"""
   workGraphEdges(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphEdgesResult!
 
-  """Server-side inflow/outflow aggregate per node type for the work graph"""
+  """Per-node-type inflow/outflow over the full work graph"""
   workGraphFlow(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphFlowResult!
 
-  """Server-side artifact ranking (node degree) for the work graph"""
+  """Top-N work graph nodes ranked by degree over the full graph"""
   workGraphArtifacts(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphArtifactsResult!
 
   """Paginated list of security alerts"""
@@ -1569,6 +1569,19 @@ enum WindowUnit {
   CYCLE
 }
 
+type WorkGraphArtifactRow {
+  nodeType: WorkGraphNodeType!
+  nodeId: String!
+  displayName: String
+  degree: Int!
+  evidence: String
+}
+
+type WorkGraphArtifactsResult {
+  rows: [WorkGraphArtifactRow!]!
+  degradedReason: String
+}
+
 input WorkGraphEdgeFilterInput {
   repoIds: [String!] = null
   sourceType: WorkGraphNodeTypeInput = null
@@ -1656,28 +1669,15 @@ type WorkGraphEdgesResult {
   degradedReason: String
 }
 
-type WorkGraphFlowRow {
-  nodeType: WorkGraphNodeType!
-  inflow: Int!
-  outflow: Int!
-}
-
 type WorkGraphFlowResult {
   rows: [WorkGraphFlowRow!]!
   degradedReason: String
 }
 
-type WorkGraphArtifactRow {
+type WorkGraphFlowRow {
   nodeType: WorkGraphNodeType!
-  nodeId: String!
-  displayName: String
-  degree: Int!
-  evidence: String
-}
-
-type WorkGraphArtifactsResult {
-  rows: [WorkGraphArtifactRow!]!
-  degradedReason: String
+  inflow: Int!
+  outflow: Int!
 }
 
 enum WorkGraphNodeType {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1063,6 +1063,12 @@ type Query {
   """Query work graph edges with optional filters"""
   workGraphEdges(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphEdgesResult!
 
+  """Server-side inflow/outflow aggregate per node type for the work graph"""
+  workGraphFlow(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphFlowResult!
+
+  """Server-side artifact ranking (node degree) for the work graph"""
+  workGraphArtifacts(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphArtifactsResult!
+
   """Paginated list of security alerts"""
   securityAlerts(orgId: String!, filters: SecurityAlertFilterInput = null, pagination: SecurityPaginationInput = null): SecurityAlertConnection!
 
@@ -1568,6 +1574,7 @@ input WorkGraphEdgeFilterInput {
   sourceType: WorkGraphNodeTypeInput = null
   targetType: WorkGraphNodeTypeInput = null
   edgeType: WorkGraphEdgeTypeInput = null
+  edgeTypes: [WorkGraphEdgeTypeInput!] = null
   nodeId: String = null
   theme: String = null
   subcategory: String = null
@@ -1646,6 +1653,30 @@ type WorkGraphEdgesResult {
   edges: [WorkGraphEdgeResult!]!
   totalCount: Int!
   pageInfo: PageInfo!
+  degradedReason: String
+}
+
+type WorkGraphFlowRow {
+  nodeType: WorkGraphNodeType!
+  inflow: Int!
+  outflow: Int!
+}
+
+type WorkGraphFlowResult {
+  rows: [WorkGraphFlowRow!]!
+  degradedReason: String
+}
+
+type WorkGraphArtifactRow {
+  nodeType: WorkGraphNodeType!
+  nodeId: String!
+  displayName: String
+  degree: Int!
+  evidence: String
+}
+
+type WorkGraphArtifactsResult {
+  rows: [WorkGraphArtifactRow!]!
   degradedReason: String
 }
 

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -547,6 +547,14 @@ export interface WorkGraphEdgeFilterInput {
     sourceType?: WorkGraphNodeType;
     targetType?: WorkGraphNodeType;
     edgeType?: WorkGraphEdgeType;
+    /**
+     * Plural edge-type filter (CHAOS-2442). When set, the backend returns only
+     * edges whose type is in this list, applied BEFORE the edge LIMIT — so a
+     * narrow slice (e.g. dependency edges) can't be starved by a capped page
+     * dominated by other edge types. Keep the singular `edgeType` for callers
+     * that only need one type.
+     */
+    edgeTypes?: WorkGraphEdgeType[];
     nodeId?: string;
     theme?: string;
     subcategory?: string;
@@ -568,6 +576,46 @@ export interface WorkGraphEdgesResult {
 
 export interface WorkGraphEdgesQueryResponse {
     workGraphEdges: WorkGraphEdgesResult;
+}
+
+// ==== Work Graph aggregate queries (CHAOS-2442) ====
+//
+// Two true server-side aggregates so the Inflow/Outflow and Artifacts tabs no
+// longer derive counts from a capped page of edges (which, for reference-heavy
+// orgs, was dominated by `references` edges and produced degenerate results).
+
+export interface WorkGraphFlowRow {
+    nodeType: WorkGraphNodeType;
+    inflow: number;
+    outflow: number;
+}
+
+export interface WorkGraphFlowResult {
+    rows: WorkGraphFlowRow[];
+    /** Same fail-safe contract as WorkGraphEdgesResult (CHAOS-2431). */
+    degradedReason?: string | null;
+}
+
+export interface WorkGraphFlowQueryResponse {
+    workGraphFlow: WorkGraphFlowResult;
+}
+
+export interface WorkGraphArtifactRow {
+    nodeType: WorkGraphNodeType;
+    nodeId: string;
+    displayName?: string | null;
+    degree: number;
+    evidence?: string | null;
+}
+
+export interface WorkGraphArtifactsResult {
+    rows: WorkGraphArtifactRow[];
+    /** Same fail-safe contract as WorkGraphEdgesResult (CHAOS-2431). */
+    degradedReason?: string | null;
+}
+
+export interface WorkGraphArtifactsQueryResponse {
+    workGraphArtifacts: WorkGraphArtifactsResult;
 }
 
 export type AIWorkflowRootTypeInput = "ISSUE" | "PR" | "WORK_UNIT";

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -908,6 +908,61 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
         });
     }
 
+    // Work graph inflow/outflow aggregate (CHAOS-2442). The Inflow/Outflow tab
+    // now calls workGraphFlow instead of deriving from the capped edge page, so
+    // the mock must serve it directly. nodeType values are UPPERCASE enum names.
+    if (query.includes("workGraphFlow") || query.includes("WorkGraphFlow")) {
+        return HttpResponse.json({
+            data: {
+                workGraphFlow: {
+                    rows: [
+                        { nodeType: "ISSUE", inflow: 18, outflow: 42 },
+                        { nodeType: "PR", inflow: 37, outflow: 21 },
+                        { nodeType: "COMMIT", inflow: 24, outflow: 15 },
+                        { nodeType: "FILE", inflow: 31, outflow: 4 },
+                    ],
+                    degradedReason: null,
+                },
+            },
+        });
+    }
+
+    // Work graph artifact ranking aggregate (CHAOS-2442). The Artifacts tab now
+    // calls workGraphArtifacts (server-side node-degree ranking) instead of
+    // deriving degree from the capped edge page.
+    if (query.includes("workGraphArtifacts") || query.includes("WorkGraphArtifacts")) {
+        return HttpResponse.json({
+            data: {
+                workGraphArtifacts: {
+                    rows: [
+                        {
+                            nodeType: "ISSUE",
+                            nodeId: "PROJ-101",
+                            displayName: "PROJ-101: Launch onboarding",
+                            degree: 7,
+                            evidence: "Fixes #101",
+                        },
+                        {
+                            nodeType: "PR",
+                            nodeId: "PR-201",
+                            displayName: "github:pr:#201",
+                            degree: 5,
+                            evidence: "Merged after review",
+                        },
+                        {
+                            nodeType: "COMMIT",
+                            nodeId: "abc123",
+                            displayName: null,
+                            degree: 3,
+                            evidence: null,
+                        },
+                    ],
+                    degradedReason: null,
+                },
+            },
+        });
+    }
+
     // Capacity forecast.
     if (query.includes("capacityForecast") || query.includes("CapacityForecast")) {
         return HttpResponse.json({


### PR DESCRIPTION
## CHAOS-2442 — Work Graph 1000-edge cap starvation (frontend)

**Pairs with backend PR** dev-health-ops#937 — consumes the new `edgeTypes` filter + `workGraphFlow` / `workGraphArtifacts` fields it adds. Ship together.

### Problem
`GraphView` fed all four work-graph tabs from one capped 1000-edge `workGraphEdges` fetch. For reference-heavy orgs this starved the Dependencies tab (client-filtered to ~0) and collapsed Inflow/Outflow + Artifacts into cap artifacts.

### Fix
- **Dependencies tab** now sends `edgeTypes: DEPENDENCY_EDGE_TYPES` so dependency edges are fetched server-side **before** the cap (can't be starved). `edgeTypes` is sent only on this tab; overview keeps the broad fetch.
- **Inflow/Outflow** → new `useWorkGraphFlow` hook (`workGraphFlow`), renders `rows {nodeType, inflow, outflow}` directly.
- **Artifacts** → new `useWorkGraphArtifacts` hook (`workGraphArtifacts`, limit 50), renders degree-ranked `rows`.
- The raw `workGraphEdges` fetch is **paused** on the aggregate/review tabs (only overview + dependencies consume raw edges).
- **Artifacts unresolved-id safety (A7/A8):** when `displayName` is null **or whitespace-only**, render a controlled `Unresolved` label — never leak a raw node id in text or title. *(Two Codex adversarial review findings.)*
- `degradedReason` (MEMBERSHIP_NOT_MATERIALIZED → "Theme data is being prepared") now read per-tab from each aggregate query.

### Contract
`schema.graphql` updated + `pnpm codegen` regenerated; the SDL was diffed byte-for-byte against the backend's Strawberry export.

### Tests / gates
- `GraphView.test.tsx` regression tests: dependencies carries `edgeTypes`; overview does not; Inflow/Outflow + Artifacts render from aggregates even when the edge page is empty (cap-immune); unresolved (null + whitespace) displayName never leaks the raw id. 48 pass.
- Mock API (`tests/mocks/handlers.ts`) extended with `workGraphFlow` / `workGraphArtifacts` (UPPERCASE enum vocabulary).
- `codegen:check`, `typecheck`, `lint`, vitest, Playwright work-graph spec: pass. Two rounds of `/codex:adversarial-review --model gpt-5.5`; all findings fixed.