### PR TITLE
fix(auth): full-jitter backoff + recoverable transient validation (CHAOS-2458)

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -427,7 +427,7 @@ describe("jwt callback — token lifecycle", () => {
         expect(first.error).toBeUndefined();
         expect(fetchMock).toHaveBeenCalledTimes(1);
         // Backoff stamped: next attempt is deferred, not permanently skipped.
-        // With jitter the delay is in [base*0.5, base] = [30s, 60s] for failure 1.
+        // With full jitter the delay is in [floor, base] = [5s, 60s] for failure 1.
         const nextDue = (first.last_validated as number) + VALIDATION_INTERVAL;
         expect(nextDue).toBeGreaterThan(Date.now());
         expect(nextDue).toBeLessThanOrEqual(Date.now() + VALIDATION_BACKOFF_BASE);
@@ -547,7 +547,7 @@ describe("jwt callback — token lifecycle", () => {
     // CHAOS-2458: jittered exponential backoff — new tests
 
     it("(r) consecutive 429 failures produce escalating (capped) backoff delays", async () => {
-        // Pin Math.random to 1.0 so jitter = delay * 1.0 (upper bound) — makes
+        // Pin Math.random to 1.0 so jitter = cappedDelay (upper bound) — makes
         // the escalation easy to assert without floating-point ambiguity.
         vi.spyOn(Math, "random").mockReturnValue(1.0);
         const fetchMock = vi.fn().mockResolvedValue({
@@ -559,15 +559,15 @@ describe("jwt callback — token lifecycle", () => {
 
         const jwt = getJwtCallback();
 
-        // Failure 1: delay = min(cap, base * 2^0) * 1.0 = 60s
+        // Failure 1: cappedDelay = min(cap, base * 2^0) = 60s; random=1 → delay = floor + 1*(60s-floor) = 60s
         const t1 = validationDueToken();
         const r1 = await jwt({ token: t1, user: null, account: null });
         expect(r1.validation_failures).toBe(1);
         const delay1 = (r1.last_validated as number) - (Date.now() - VALIDATION_INTERVAL);
-        expect(delay1).toBeGreaterThanOrEqual(VALIDATION_BACKOFF_BASE * 0.5);
+        expect(delay1).toBeGreaterThanOrEqual(VALIDATION_BACKOFF_BASE - 100);
         expect(delay1).toBeLessThanOrEqual(VALIDATION_BACKOFF_BASE + 100);
 
-        // Failure 2: delay = min(cap, base * 2^1) * 1.0 = 120s
+        // Failure 2: cappedDelay = min(cap, base * 2^1) = 120s; random=1 → delay = 120s
         const t2 = {
             ...r1,
             last_validated: Date.now() - VALIDATION_INTERVAL - 1000,
@@ -577,7 +577,7 @@ describe("jwt callback — token lifecycle", () => {
         const delay2 = (r2.last_validated as number) - (Date.now() - VALIDATION_INTERVAL);
         expect(delay2).toBeGreaterThan(delay1);
 
-        // Failure 3: delay = min(cap, base * 2^2) * 1.0 = 240s
+        // Failure 3: cappedDelay = min(cap, base * 2^2) = 240s; random=1 → delay = 240s
         const t3 = {
             ...r2,
             last_validated: Date.now() - VALIDATION_INTERVAL - 1000,
@@ -591,7 +591,7 @@ describe("jwt callback — token lifecycle", () => {
         expect(delay3).toBeLessThanOrEqual(VALIDATION_BACKOFF_CAP + 100);
     });
 
-    it("(s) jitter is applied — delay varies with Math.random", async () => {
+    it("(s) jitter is applied — delay varies with Math.random (full window)", async () => {
         const fetchMock = vi.fn().mockResolvedValue({
             ok: false,
             status: 429,
@@ -600,26 +600,30 @@ describe("jwt callback — token lifecycle", () => {
         vi.stubGlobal("fetch", fetchMock);
 
         const jwt = getJwtCallback();
+        // failure 1: cappedDelay = base = 60s
+        // full jitter: delay = floor + random * (cappedDelay - floor)
+        //   random=0 → delay = floor (5s)
+        //   random=1 → delay = cappedDelay (60s)
 
-        // Low random → delay near lower bound (base * 0.5)
+        // Low random → delay near floor (5s)
         vi.spyOn(Math, "random").mockReturnValue(0.0);
         const tLow = validationDueToken();
         const rLow = await jwt({ token: tLow, user: null, account: null });
         const delayLow = (rLow.last_validated as number) - (Date.now() - VALIDATION_INTERVAL);
 
-        // High random → delay near upper bound (base * 1.0)
+        // High random → delay near cappedDelay (60s)
         vi.spyOn(Math, "random").mockReturnValue(1.0);
         const tHigh = validationDueToken();
         const rHigh = await jwt({ token: tHigh, user: null, account: null });
         const delayHigh = (rHigh.last_validated as number) - (Date.now() - VALIDATION_INTERVAL);
 
-        // Lower bound: ~30s (base * 0.5)
-        expect(delayLow).toBeGreaterThanOrEqual(VALIDATION_BACKOFF_BASE * 0.5 - 100);
-        expect(delayLow).toBeLessThanOrEqual(VALIDATION_BACKOFF_BASE * 0.5 + 100);
-        // Upper bound: ~60s (base * 1.0)
-        expect(delayHigh).toBeGreaterThanOrEqual(VALIDATION_BACKOFF_BASE * 0.9);
+        // Lower bound: ~5s (floor)
+        expect(delayLow).toBeGreaterThanOrEqual(4900);
+        expect(delayLow).toBeLessThanOrEqual(5100);
+        // Upper bound: ~60s (cappedDelay = base)
+        expect(delayHigh).toBeGreaterThanOrEqual(VALIDATION_BACKOFF_BASE - 100);
         expect(delayHigh).toBeLessThanOrEqual(VALIDATION_BACKOFF_BASE + 100);
-        // High > Low (jitter spreads the range)
+        // High > Low — full window spread
         expect(delayHigh).toBeGreaterThan(delayLow);
     });
 
@@ -644,7 +648,7 @@ describe("jwt callback — token lifecycle", () => {
         expect(result.validation_failures).toBe(0);
     });
 
-    it("(u) 5 consecutive 429 failures sign the user out (max-failures threshold)", async () => {
+    it("(u) many consecutive 429 failures keep the session recoverable (no forced logout)", async () => {
         const fetchMock = vi.fn().mockResolvedValue({
             ok: false,
             status: 429,
@@ -653,33 +657,95 @@ describe("jwt callback — token lifecycle", () => {
         vi.stubGlobal("fetch", fetchMock);
 
         const jwt = getJwtCallback();
-        // Token already at 4 failures — one more should trip the threshold
+        // Token already at 9 failures — well past the old threshold of 5
         const token = {
             ...validationDueToken(),
-            validation_failures: 4,
+            validation_failures: 9,
         };
         const result = await jwt({ token, user: null, account: null });
 
-        expect(result.access_token).toBeUndefined();
-        expect(result.refresh_token).toBeUndefined();
-        expect(result.error).toBe("user_invalid");
-        expect(result.validation_failures).toBe(5);
+        // Session must remain recoverable — tokens preserved, no terminal error
+        expect(result.access_token).toBe("valid-access");
+        expect(result.refresh_token).toBe("valid-refresh");
+        expect(result.error).toBeUndefined();
+        expect(result.validation_failures).toBe(10);
+        // Delay is capped at 15 min regardless of failure count
+        const nextDue = (result.last_validated as number) + VALIDATION_INTERVAL;
+        expect(nextDue).toBeLessThanOrEqual(Date.now() + VALIDATION_BACKOFF_CAP + 100);
     });
 
-    it("(v) 5 consecutive network errors sign the user out (max-failures threshold)", async () => {
+    it("(v) many consecutive network errors keep the session recoverable (no forced logout)", async () => {
         const fetchMock = vi.fn().mockRejectedValue(new Error("fetch failed: ECONNREFUSED"));
         vi.stubGlobal("fetch", fetchMock);
 
         const jwt = getJwtCallback();
+        // Token already at 9 failures — well past the old threshold of 5
         const token = {
             ...validationDueToken(),
-            validation_failures: 4,
+            validation_failures: 9,
         };
         const result = await jwt({ token, user: null, account: null });
 
-        expect(result.access_token).toBeUndefined();
-        expect(result.refresh_token).toBeUndefined();
-        expect(result.error).toBe("user_invalid");
+        // Session must remain recoverable — tokens preserved, no terminal error
+        expect(result.access_token).toBe("valid-access");
+        expect(result.refresh_token).toBe("valid-refresh");
+        expect(result.error).toBeUndefined();
+        expect(result.validation_failures).toBe(10);
+    });
+
+    it("(x) long run of transient failures then success resets counter and restores normal cadence", async () => {
+        const failMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 503,
+            json: async () => ({ detail: "service unavailable" }),
+        } as unknown as Response);
+        vi.stubGlobal("fetch", failMock);
+
+        const jwt = getJwtCallback();
+
+        // Simulate 6 consecutive failures — well past the old threshold of 5
+        let tok: Record<string, unknown> = validationDueToken();
+        for (let i = 1; i <= 6; i++) {
+            tok = await jwt({
+                token: {
+                    ...tok,
+                    last_validated: Date.now() - VALIDATION_INTERVAL - 1000,
+                },
+                user: null,
+                account: null,
+            });
+            // Session must remain recoverable throughout
+            expect(tok.access_token).toBe("valid-access");
+            expect(tok.refresh_token).toBe("valid-refresh");
+            expect(tok.error).toBeUndefined();
+            expect(tok.validation_failures).toBe(i);
+        }
+
+        // Backend recovers — next validation succeeds
+        const successMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ valid: true }),
+        } as unknown as Response);
+        vi.stubGlobal("fetch", successMock);
+
+        const recovered = await jwt({
+            token: {
+                ...tok,
+                last_validated: Date.now() - VALIDATION_INTERVAL - 1000,
+            },
+            user: null,
+            account: null,
+        });
+
+        // Counter reset, normal 5-min cadence restored
+        expect(recovered.access_token).toBe("valid-access");
+        expect(recovered.refresh_token).toBe("valid-refresh");
+        expect(recovered.error).toBeUndefined();
+        expect(recovered.validation_failures).toBe(0);
+        // last_validated is now (full interval stamp, not a backoff offset)
+        const nextDue = (recovered.last_validated as number) + VALIDATION_INTERVAL;
+        expect(nextDue).toBeGreaterThan(Date.now() + VALIDATION_INTERVAL - 1000);
     });
 
     it("(w) valid:false from /auth/validate still invalidates the session (unchanged)", async () => {

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -390,9 +390,12 @@ describe("jwt callback — token lifecycle", () => {
         expect(result.error).toBeUndefined();
     });
 
-    // CHAOS-2232: periodic /auth/validate backoff — a 429/5xx/network failure must
-    // not invalidate the session AND must not retry on every subsequent request.
+    // CHAOS-2232 / CHAOS-2458: periodic /auth/validate backoff — a 429/5xx/network failure must
+    // not invalidate the session AND must not retry on every subsequent request. Backoff is
+    // jittered exponential (base 60s, cap 15min) so concurrent tabs/instances spread out.
     const VALIDATION_INTERVAL = 5 * 60 * 1000;
+    const VALIDATION_BACKOFF_BASE = 60 * 1000;
+    const VALIDATION_BACKOFF_CAP = 15 * 60 * 1000;
 
     function validationDueToken(): Record<string, unknown> {
         return {
@@ -413,16 +416,21 @@ describe("jwt callback — token lifecycle", () => {
         vi.stubGlobal("fetch", fetchMock);
 
         const jwt = getJwtCallback();
-        const first = await jwt({ token: validationDueToken(), user: null, account: null });
+        const first = await jwt({
+            token: validationDueToken(),
+            user: null,
+            account: null,
+        });
 
         expect(first.access_token).toBe("valid-access");
         expect(first.refresh_token).toBe("valid-refresh");
         expect(first.error).toBeUndefined();
         expect(fetchMock).toHaveBeenCalledTimes(1);
-        // Backoff stamped: next attempt is deferred, not permanently skipped
+        // Backoff stamped: next attempt is deferred, not permanently skipped.
+        // With jitter the delay is in [base*0.5, base] = [30s, 60s] for failure 1.
         const nextDue = (first.last_validated as number) + VALIDATION_INTERVAL;
         expect(nextDue).toBeGreaterThan(Date.now());
-        expect(nextDue).toBeLessThanOrEqual(Date.now() + 60 * 1000);
+        expect(nextDue).toBeLessThanOrEqual(Date.now() + VALIDATION_BACKOFF_BASE);
 
         // Immediate follow-up callback must NOT re-fetch
         const second = await jwt({ token: first, user: null, account: null });
@@ -435,7 +443,11 @@ describe("jwt callback — token lifecycle", () => {
         vi.stubGlobal("fetch", fetchMock);
 
         const jwt = getJwtCallback();
-        const result = await jwt({ token: validationDueToken(), user: null, account: null });
+        const result = await jwt({
+            token: validationDueToken(),
+            user: null,
+            account: null,
+        });
 
         expect(result.access_token).toBe("valid-access");
         expect(result.error).toBeUndefined();
@@ -474,7 +486,11 @@ describe("jwt callback — token lifecycle", () => {
         vi.stubGlobal("fetch", fetchMock);
 
         const jwt = getJwtCallback();
-        const result = await jwt({ token: validationDueToken(), user: null, account: null });
+        const result = await jwt({
+            token: validationDueToken(),
+            user: null,
+            account: null,
+        });
 
         expect(result.access_token).toBeUndefined();
         expect(result.refresh_token).toBeUndefined();
@@ -490,7 +506,11 @@ describe("jwt callback — token lifecycle", () => {
         vi.stubGlobal("fetch", fetchMock);
 
         const jwt = getJwtCallback();
-        const result = await jwt({ token: validationDueToken(), user: null, account: null });
+        const result = await jwt({
+            token: validationDueToken(),
+            user: null,
+            account: null,
+        });
 
         expect(result.access_token).toBeUndefined();
         expect(result.refresh_token).toBeUndefined();
@@ -506,18 +526,180 @@ describe("jwt callback — token lifecycle", () => {
         vi.stubGlobal("fetch", fetchMock);
 
         const jwt = getJwtCallback();
-        const first = await jwt({ token: validationDueToken(), user: null, account: null });
+        const first = await jwt({
+            token: validationDueToken(),
+            user: null,
+            account: null,
+        });
 
         expect(first.access_token).toBe("valid-access");
         expect(first.refresh_token).toBe("valid-refresh");
         expect(first.error).toBeUndefined();
         const nextDue = (first.last_validated as number) + VALIDATION_INTERVAL;
         expect(nextDue).toBeGreaterThan(Date.now());
-        expect(nextDue).toBeLessThanOrEqual(Date.now() + 60 * 1000);
+        expect(nextDue).toBeLessThanOrEqual(Date.now() + VALIDATION_BACKOFF_BASE);
 
         // Immediate follow-up callback must NOT re-fetch
         await jwt({ token: first, user: null, account: null });
         expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // CHAOS-2458: jittered exponential backoff — new tests
+
+    it("(r) consecutive 429 failures produce escalating (capped) backoff delays", async () => {
+        // Pin Math.random to 1.0 so jitter = delay * 1.0 (upper bound) — makes
+        // the escalation easy to assert without floating-point ambiguity.
+        vi.spyOn(Math, "random").mockReturnValue(1.0);
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 429,
+            json: async () => ({ detail: "rate limited" }),
+        } as unknown as Response);
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+
+        // Failure 1: delay = min(cap, base * 2^0) * 1.0 = 60s
+        const t1 = validationDueToken();
+        const r1 = await jwt({ token: t1, user: null, account: null });
+        expect(r1.validation_failures).toBe(1);
+        const delay1 = (r1.last_validated as number) - (Date.now() - VALIDATION_INTERVAL);
+        expect(delay1).toBeGreaterThanOrEqual(VALIDATION_BACKOFF_BASE * 0.5);
+        expect(delay1).toBeLessThanOrEqual(VALIDATION_BACKOFF_BASE + 100);
+
+        // Failure 2: delay = min(cap, base * 2^1) * 1.0 = 120s
+        const t2 = {
+            ...r1,
+            last_validated: Date.now() - VALIDATION_INTERVAL - 1000,
+        };
+        const r2 = await jwt({ token: t2, user: null, account: null });
+        expect(r2.validation_failures).toBe(2);
+        const delay2 = (r2.last_validated as number) - (Date.now() - VALIDATION_INTERVAL);
+        expect(delay2).toBeGreaterThan(delay1);
+
+        // Failure 3: delay = min(cap, base * 2^2) * 1.0 = 240s
+        const t3 = {
+            ...r2,
+            last_validated: Date.now() - VALIDATION_INTERVAL - 1000,
+        };
+        const r3 = await jwt({ token: t3, user: null, account: null });
+        expect(r3.validation_failures).toBe(3);
+        const delay3 = (r3.last_validated as number) - (Date.now() - VALIDATION_INTERVAL);
+        expect(delay3).toBeGreaterThan(delay2);
+
+        // Cap: delay never exceeds VALIDATION_BACKOFF_CAP (15 min)
+        expect(delay3).toBeLessThanOrEqual(VALIDATION_BACKOFF_CAP + 100);
+    });
+
+    it("(s) jitter is applied — delay varies with Math.random", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 429,
+            json: async () => ({ detail: "rate limited" }),
+        } as unknown as Response);
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+
+        // Low random → delay near lower bound (base * 0.5)
+        vi.spyOn(Math, "random").mockReturnValue(0.0);
+        const tLow = validationDueToken();
+        const rLow = await jwt({ token: tLow, user: null, account: null });
+        const delayLow = (rLow.last_validated as number) - (Date.now() - VALIDATION_INTERVAL);
+
+        // High random → delay near upper bound (base * 1.0)
+        vi.spyOn(Math, "random").mockReturnValue(1.0);
+        const tHigh = validationDueToken();
+        const rHigh = await jwt({ token: tHigh, user: null, account: null });
+        const delayHigh = (rHigh.last_validated as number) - (Date.now() - VALIDATION_INTERVAL);
+
+        // Lower bound: ~30s (base * 0.5)
+        expect(delayLow).toBeGreaterThanOrEqual(VALIDATION_BACKOFF_BASE * 0.5 - 100);
+        expect(delayLow).toBeLessThanOrEqual(VALIDATION_BACKOFF_BASE * 0.5 + 100);
+        // Upper bound: ~60s (base * 1.0)
+        expect(delayHigh).toBeGreaterThanOrEqual(VALIDATION_BACKOFF_BASE * 0.9);
+        expect(delayHigh).toBeLessThanOrEqual(VALIDATION_BACKOFF_BASE + 100);
+        // High > Low (jitter spreads the range)
+        expect(delayHigh).toBeGreaterThan(delayLow);
+    });
+
+    it("(t) success after failures resets the failure counter to 0", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ valid: true }),
+        } as unknown as Response);
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+        // Token that already has 3 accumulated failures
+        const token = {
+            ...validationDueToken(),
+            validation_failures: 3,
+        };
+        const result = await jwt({ token, user: null, account: null });
+
+        expect(result.access_token).toBe("valid-access");
+        expect(result.error).toBeUndefined();
+        expect(result.validation_failures).toBe(0);
+    });
+
+    it("(u) 5 consecutive 429 failures sign the user out (max-failures threshold)", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 429,
+            json: async () => ({ detail: "rate limited" }),
+        } as unknown as Response);
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+        // Token already at 4 failures — one more should trip the threshold
+        const token = {
+            ...validationDueToken(),
+            validation_failures: 4,
+        };
+        const result = await jwt({ token, user: null, account: null });
+
+        expect(result.access_token).toBeUndefined();
+        expect(result.refresh_token).toBeUndefined();
+        expect(result.error).toBe("user_invalid");
+        expect(result.validation_failures).toBe(5);
+    });
+
+    it("(v) 5 consecutive network errors sign the user out (max-failures threshold)", async () => {
+        const fetchMock = vi.fn().mockRejectedValue(new Error("fetch failed: ECONNREFUSED"));
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+        const token = {
+            ...validationDueToken(),
+            validation_failures: 4,
+        };
+        const result = await jwt({ token, user: null, account: null });
+
+        expect(result.access_token).toBeUndefined();
+        expect(result.refresh_token).toBeUndefined();
+        expect(result.error).toBe("user_invalid");
+    });
+
+    it("(w) valid:false from /auth/validate still invalidates the session (unchanged)", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ valid: false }),
+        } as unknown as Response);
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+        const result = await jwt({
+            token: validationDueToken(),
+            user: null,
+            account: null,
+        });
+
+        expect(result.access_token).toBeUndefined();
+        expect(result.refresh_token).toBeUndefined();
+        expect(result.error).toBe("user_invalid");
     });
 
     // ── Impersonation status sync (CHAOS-2309 / CHAOS-2327 / CHAOS-2328) ───
@@ -618,7 +800,9 @@ describe("jwt callback — token lifecycle", () => {
             user: null,
             account: null,
             trigger: "update",
-            session: { startImpersonation: { status: "active", target_user: { id: "x" } } },
+            session: {
+                startImpersonation: { status: "active", target_user: { id: "x" } },
+            },
         });
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -682,7 +866,11 @@ describe("jwt callback — token lifecycle", () => {
         const jwt = getJwtCallback();
         // Two plain reads within the memo TTL → one backend fetch, but both
         // tokens carry the synced state.
-        await jwt({ token: superuserToken({ id: "admin-q" }), user: null, account: null });
+        await jwt({
+            token: superuserToken({ id: "admin-q" }),
+            user: null,
+            account: null,
+        });
         const second = await jwt({
             token: superuserToken({ id: "admin-q" }),
             user: null,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -377,12 +377,12 @@ const nextAuth = NextAuth({
             // On a failed validation attempt (429/5xx/network), use jittered
             // exponential backoff so repeated failures across tabs/instances spread
             // out and don't self-DOS the backend (CHAOS-2458).
-            // Formula: delay = min(CAP, BASE * 2^failures), jitter = delay * random(0.5..1.0)
+            // Formula: delay = floor + Math.random() * (cappedDelay - floor)
+            //   where cappedDelay = min(CAP, BASE * 2^(failures-1))
+            // Full jitter across [floor, cappedDelay] — not upper-half only.
             const VALIDATION_BACKOFF_BASE = 60 * 1000; // 60 s
             const VALIDATION_BACKOFF_CAP = 15 * 60 * 1000; // 15 min
-            // After this many consecutive failures treat the backend as persistently
-            // unavailable and sign the user out rather than looping forever.
-            const VALIDATION_MAX_FAILURES = 5;
+            const VALIDATION_BACKOFF_FLOOR = 5 * 1000; // 5 s minimum so next attempt isn't immediate
             if (
                 !user &&
                 token.access_token &&
@@ -408,23 +408,19 @@ const nextAuth = NextAuth({
                         token.last_validated = now;
                         token.validation_failures = 0;
                     } else if (res.status === 429 || res.status >= 500) {
-                        // 429/5xx — transient; don't invalidate, retry after jittered
-                        // exponential backoff so concurrent tabs/instances spread out.
+                        // 429/5xx — transient; don't invalidate, retry after full
+                        // jittered exponential backoff so concurrent tabs/instances spread out.
                         const failures =
                             ((token.validation_failures as number | undefined) ?? 0) + 1;
                         token.validation_failures = failures;
-                        if (failures >= VALIDATION_MAX_FAILURES) {
-                            // Persistently rate-limited / broken backend — sign out.
-                            token.access_token = undefined;
-                            token.refresh_token = undefined;
-                            token.error = "user_invalid";
-                            return token;
-                        }
                         const cappedDelay = Math.min(
                             VALIDATION_BACKOFF_CAP,
                             VALIDATION_BACKOFF_BASE * Math.pow(2, failures - 1),
                         );
-                        const jitteredDelay = cappedDelay * (0.5 + Math.random() * 0.5);
+                        // Full jitter: spread across [floor, cappedDelay]
+                        const jitteredDelay =
+                            VALIDATION_BACKOFF_FLOOR +
+                            Math.random() * (cappedDelay - VALIDATION_BACKOFF_FLOOR);
                         token.last_validated = now - VALIDATION_INTERVAL + jitteredDelay;
                     } else {
                         // Other 4xx (400/401/403/422) — the backend rejected the token
@@ -437,21 +433,18 @@ const nextAuth = NextAuth({
                     }
                 } catch {
                     // Network error — don't invalidate for transient failures,
-                    // but back off with jittered exponential delay instead of
+                    // but back off with full jittered exponential delay instead of
                     // retrying on every request.
                     const failures = ((token.validation_failures as number | undefined) ?? 0) + 1;
                     token.validation_failures = failures;
-                    if (failures >= VALIDATION_MAX_FAILURES) {
-                        token.access_token = undefined;
-                        token.refresh_token = undefined;
-                        token.error = "user_invalid";
-                        return token;
-                    }
                     const cappedDelay = Math.min(
                         VALIDATION_BACKOFF_CAP,
                         VALIDATION_BACKOFF_BASE * Math.pow(2, failures - 1),
                     );
-                    const jitteredDelay = cappedDelay * (0.5 + Math.random() * 0.5);
+                    // Full jitter: spread across [floor, cappedDelay]
+                    const jitteredDelay =
+                        VALIDATION_BACKOFF_FLOOR +
+                        Math.random() * (cappedDelay - VALIDATION_BACKOFF_FLOOR);
                     token.last_validated = now - VALIDATION_INTERVAL + jitteredDelay;
                 }
             }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -374,10 +374,15 @@ const nextAuth = NextAuth({
             // Only runs when token is NOT expired (fresh or just-refreshed).
             // Runs every 5 minutes, skips on initial login.
             const VALIDATION_INTERVAL = 5 * 60 * 1000;
-            // On a failed validation attempt (429/5xx/network), retry after a short
-            // backoff instead of on every request — otherwise a rate-limited backend
-            // gets hammered by every JWT callback until one succeeds (CHAOS-2232).
-            const VALIDATION_BACKOFF = 60 * 1000;
+            // On a failed validation attempt (429/5xx/network), use jittered
+            // exponential backoff so repeated failures across tabs/instances spread
+            // out and don't self-DOS the backend (CHAOS-2458).
+            // Formula: delay = min(CAP, BASE * 2^failures), jitter = delay * random(0.5..1.0)
+            const VALIDATION_BACKOFF_BASE = 60 * 1000; // 60 s
+            const VALIDATION_BACKOFF_CAP = 15 * 60 * 1000; // 15 min
+            // After this many consecutive failures treat the backend as persistently
+            // unavailable and sign the user out rather than looping forever.
+            const VALIDATION_MAX_FAILURES = 5;
             if (
                 !user &&
                 token.access_token &&
@@ -399,10 +404,28 @@ const nextAuth = NextAuth({
                             token.error = "user_invalid";
                             return token;
                         }
+                        // Success — reset failure counter and stamp full interval.
                         token.last_validated = now;
+                        token.validation_failures = 0;
                     } else if (res.status === 429 || res.status >= 500) {
-                        // 429/5xx — transient; don't invalidate, retry after backoff
-                        token.last_validated = now - VALIDATION_INTERVAL + VALIDATION_BACKOFF;
+                        // 429/5xx — transient; don't invalidate, retry after jittered
+                        // exponential backoff so concurrent tabs/instances spread out.
+                        const failures =
+                            ((token.validation_failures as number | undefined) ?? 0) + 1;
+                        token.validation_failures = failures;
+                        if (failures >= VALIDATION_MAX_FAILURES) {
+                            // Persistently rate-limited / broken backend — sign out.
+                            token.access_token = undefined;
+                            token.refresh_token = undefined;
+                            token.error = "user_invalid";
+                            return token;
+                        }
+                        const cappedDelay = Math.min(
+                            VALIDATION_BACKOFF_CAP,
+                            VALIDATION_BACKOFF_BASE * Math.pow(2, failures - 1),
+                        );
+                        const jitteredDelay = cappedDelay * (0.5 + Math.random() * 0.5);
+                        token.last_validated = now - VALIDATION_INTERVAL + jitteredDelay;
                     } else {
                         // Other 4xx (400/401/403/422) — the backend rejected the token
                         // outright; no backoff reprieve. Defense-in-depth: the endpoint
@@ -414,8 +437,22 @@ const nextAuth = NextAuth({
                     }
                 } catch {
                     // Network error — don't invalidate for transient failures,
-                    // but back off instead of retrying on every request
-                    token.last_validated = now - VALIDATION_INTERVAL + VALIDATION_BACKOFF;
+                    // but back off with jittered exponential delay instead of
+                    // retrying on every request.
+                    const failures = ((token.validation_failures as number | undefined) ?? 0) + 1;
+                    token.validation_failures = failures;
+                    if (failures >= VALIDATION_MAX_FAILURES) {
+                        token.access_token = undefined;
+                        token.refresh_token = undefined;
+                        token.error = "user_invalid";
+                        return token;
+                    }
+                    const cappedDelay = Math.min(
+                        VALIDATION_BACKOFF_CAP,
+                        VALIDATION_BACKOFF_BASE * Math.pow(2, failures - 1),
+                    );
+                    const jitteredDelay = cappedDelay * (0.5 + Math.random() * 0.5);
+                    token.last_validated = now - VALIDATION_INTERVAL + jitteredDelay;
                 }
             }
 


### PR DESCRIPTION
Part of **CHAOS-2458** (auth incident remediation). One of three workstreams.

## Problem
The NextAuth jwt-callback token-validation loop retried `POST /api/v1/auth/validate` after a flat 60s backoff on 429/5xx/network errors. Across tabs/instances this kept re-hitting the endpoint within the same 15-min rate-limit window and never escaped (429 → 60s → 429 …) — the self-sustaining storm seen in the incident logs.

## Change
- **Full jitter** over a capped window: `delay = floor(5s) + random()*(cappedDelay - floor)`, `cappedDelay = min(15min, 60s*2^(failures-1))`.
- Track `token.validation_failures`; **reset on success** (5-min happy-path cadence unchanged).
- Transient 429/5xx/network failures now retry **indefinitely** with capped jitter and **never clear** `access_token`/`refresh_token` (self-healing once the backend returns) — consistent with the existing refresh-outage path.
- Terminal sign-out only on backend-confirmed invalid (`res.ok + valid:false`) or hard 4xx.

## Adversarial review
Reviewed via `/codex:adversarial-review --model gpt-5.5`. First pass caught two **[high]**s: partial (upper-half) jitter, and a forced sign-out after 5 transient failures that turned a short outage into a terminal logout. Both fixed; re-review: **approve, no material findings**.

## Verification
- prettier + eslint + `tsc --noEmit` clean; vitest: **32 passed** (added: full-window jitter bounds, escalating cap, success-resets-counter, and long-transient-run-stays-recoverable).

SCREENSHOT-WAIVER: non-visual auth-client logic; no rendered UI change.
TEST-WAIVER: n/a (test file updated).

Relates to CHAOS-2458