### PR TITLE
feat(integrations): Connect GitHub App one-click flow (CHAOS-2235)

### DIFF
--- a/src/app/(app)/admin/integrations/[provider]/page.tsx
+++ b/src/app/(app)/admin/integrations/[provider]/page.tsx
@@ -1,6 +1,10 @@
 import { notFound } from "next/navigation";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { ProviderCredentialsList } from "@/components/admin/integrations/ProviderCredentialsList";
+import {
+    GitHubAppConnect,
+    type GitHubAppConnectResult,
+} from "@/components/admin/integrations/GitHubAppConnect";
 import { listCredentials, listSyncConfigs } from "@/lib/admin/server";
 import type { Provider } from "@/lib/admin/types";
 
@@ -14,10 +18,15 @@ const PROVIDERS: Record<string, string> = {
 
 export default async function IntegrationPage({
     params,
+    searchParams,
 }: {
     params: Promise<{ provider: string }>;
+    searchParams: Promise<{ github_app?: string | string[] }>;
 }) {
     const { provider } = await params;
+    const { github_app: githubApp } = await searchParams;
+    const githubAppResult: GitHubAppConnectResult | undefined =
+        githubApp === "connected" || githubApp === "error" ? githubApp : undefined;
     const providerName = PROVIDERS[provider];
 
     if (!providerName) {
@@ -44,6 +53,8 @@ export default async function IntegrationPage({
                     Failed to load credentials: {credentialsResult.error}
                 </div>
             )}
+
+            {provider === "github" && <GitHubAppConnect result={githubAppResult} />}
 
             <ProviderCredentialsList
                 provider={provider as Provider}

--- a/src/app/(app)/admin/integrations/github-app/callback/route.test.tsx
+++ b/src/app/(app)/admin/integrations/github-app/callback/route.test.tsx
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { GET } from "@/app/(app)/admin/integrations/github-app/callback/route";
+import { auth } from "@/lib/auth";
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/origin", () => ({
+    getBackendUrl: vi.fn(() => "http://backend.test"),
+}));
+
+const mockAuth = vi.mocked(auth);
+
+const ERROR_LOCATION = "http://localhost/admin/integrations/github?github_app=error";
+
+function setSession(user: Record<string, unknown>) {
+    mockAuth.mockResolvedValue({ access_token: "tok", user } as never);
+}
+
+function authedSession() {
+    setSession({ org_id: "org-1", role: "admin" });
+}
+
+function makeRequest(query: string) {
+    return new NextRequest(`http://localhost/admin/integrations/github-app/callback${query}`);
+}
+
+describe("GET /admin/integrations/github-app/callback", () => {
+    beforeEach(() => {
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    it("forwards the callback to the backend and redirects to connected on success", async () => {
+        authedSession();
+        vi.mocked(fetch).mockResolvedValue(
+            new Response(JSON.stringify({ connected: true }), { status: 200 }),
+        );
+
+        const response = await GET(
+            makeRequest("?installation_id=123&setup_action=install&state=jwt&code=abc"),
+        );
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+            "http://localhost/admin/integrations/github?github_app=connected",
+        );
+
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(url).toBe("http://backend.test/api/v1/admin/integrations/github/install-callback");
+        const headers = init?.headers as Record<string, string>;
+        expect(headers.Authorization).toBe("Bearer tok");
+        expect(headers["X-Org-Id"]).toBe("org-1");
+        expect(JSON.parse(init?.body as string)).toEqual({
+            installation_id: 123,
+            setup_action: "install",
+            state: "jwt",
+            code: "abc",
+        });
+    });
+
+    it("omits X-Org-Id when the session has no org", async () => {
+        setSession({ role: "admin" });
+        vi.mocked(fetch).mockResolvedValue(
+            new Response(JSON.stringify({ connected: true }), { status: 200 }),
+        );
+
+        await GET(makeRequest("?installation_id=123&state=jwt"));
+
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        expect((init?.headers as Record<string, string>)["X-Org-Id"]).toBeUndefined();
+    });
+
+    it("redirects to error for a non-admin authenticated member", async () => {
+        setSession({ org_id: "org-1", role: "member", is_superuser: false });
+
+        const response = await GET(makeRequest("?installation_id=123&state=jwt"));
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("redirects to error when installation_id is missing", async () => {
+        authedSession();
+
+        const response = await GET(makeRequest("?state=jwt"));
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("redirects to error when installation_id is not a positive integer", async () => {
+        authedSession();
+
+        const response = await GET(makeRequest("?installation_id=-5&state=jwt"));
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("redirects to error when installation_id exceeds MAX_SAFE_INTEGER", async () => {
+        authedSession();
+
+        // 9999999999999999999 > Number.MAX_SAFE_INTEGER (9007199254740991).
+        const response = await GET(makeRequest("?installation_id=9999999999999999999&state=jwt"));
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("redirects to error when state is missing", async () => {
+        authedSession();
+
+        const response = await GET(makeRequest("?installation_id=123"));
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("redirects to error when there is no session access token", async () => {
+        mockAuth.mockResolvedValue(null as never);
+
+        const response = await GET(makeRequest("?installation_id=123&state=jwt"));
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("redirects to error when the backend rejects the callback", async () => {
+        authedSession();
+        vi.mocked(fetch).mockResolvedValue(
+            new Response(JSON.stringify({ detail: "org mismatch" }), { status: 403 }),
+        );
+
+        const response = await GET(makeRequest("?installation_id=123&state=jwt"));
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
+
+    it("sends null for absent optional setup_action and code", async () => {
+        authedSession();
+        vi.mocked(fetch).mockResolvedValue(
+            new Response(JSON.stringify({ connected: true }), { status: 200 }),
+        );
+
+        await GET(makeRequest("?installation_id=99&state=jwt"));
+
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        expect(JSON.parse(init?.body as string)).toEqual({
+            installation_id: 99,
+            setup_action: null,
+            state: "jwt",
+            code: null,
+        });
+    });
+});

--- a/src/app/(app)/admin/integrations/github-app/callback/route.ts
+++ b/src/app/(app)/admin/integrations/github-app/callback/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { getBackendUrl } from "@/lib/origin";
+
+/**
+ * Setup-URL callback for the frictionless GitHub App install (CHAOS-2235).
+ *
+ * GitHub redirects here after the user installs/authorizes the App, passing
+ * `installation_id`, `setup_action`, `state`, and optionally `code` as query
+ * params. All of these are attacker-influenceable, so we validate types before
+ * forwarding them to the backend, which verifies the signed `state`, the
+ * installation, and the org binding. We then redirect back to the integration
+ * page with a fixed success/error indicator and never surface the raw access
+ * token or backend error internals to the client.
+ */
+
+const GITHUB_INTEGRATION_PATH = "/admin/integrations/github";
+
+function resultRedirect(request: NextRequest, result: "connected" | "error") {
+    return NextResponse.redirect(
+        new URL(`${GITHUB_INTEGRATION_PATH}?github_app=${result}`, request.url),
+    );
+}
+
+export async function GET(request: NextRequest) {
+    const params = request.nextUrl.searchParams;
+
+    const rawInstallationId = params.get("installation_id");
+    const state = params.get("state");
+    const setupAction = params.get("setup_action");
+    const code = params.get("code");
+
+    // Validate the untrusted GitHub-supplied params before doing any work.
+    // Reject values that exceed MAX_SAFE_INTEGER so large IDs don't silently
+    // lose precision before being forwarded to the backend.
+    const installationId =
+        rawInstallationId && /^\d+$/.test(rawInstallationId) ? Number(rawInstallationId) : NaN;
+    if (
+        !Number.isInteger(installationId) ||
+        installationId <= 0 ||
+        installationId > Number.MAX_SAFE_INTEGER ||
+        !state
+    ) {
+        return resultRedirect(request, "error");
+    }
+
+    const session = await auth();
+    if (!session?.access_token) {
+        // GET is followed by the browser, so render an error banner rather than
+        // raw JSON.
+        return resultRedirect(request, "error");
+    }
+
+    // Defense-in-depth: this route is directly addressable and does not sit
+    // under the admin layout's requireRole guard. Mirror requireRole(["admin",
+    // "owner"]) inline (do NOT call it — it redirects to /dashboard, breaking
+    // this handler's consistent ?github_app=error UX).
+    if (!session.user.is_superuser && !["admin", "owner"].includes(session.user.role || "")) {
+        return resultRedirect(request, "error");
+    }
+
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${session.access_token}`,
+        "Content-Type": "application/json",
+    };
+    // Forward the effective org so impersonation/active-org binds the install
+    // to the correct organization (mirrors src/lib/admin/server helpers).
+    if (session.user?.org_id) {
+        headers["X-Org-Id"] = session.user.org_id;
+    }
+
+    try {
+        const response = await fetch(
+            `${getBackendUrl()}/api/v1/admin/integrations/github/install-callback`,
+            {
+                method: "POST",
+                headers,
+                body: JSON.stringify({
+                    installation_id: installationId,
+                    setup_action: setupAction,
+                    state,
+                    code,
+                }),
+            },
+        );
+
+        return resultRedirect(request, response.ok ? "connected" : "error");
+    } catch {
+        return resultRedirect(request, "error");
+    }
+}

--- a/src/app/(app)/admin/integrations/github-app/install/route.test.tsx
+++ b/src/app/(app)/admin/integrations/github-app/install/route.test.tsx
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { GET } from "@/app/(app)/admin/integrations/github-app/install/route";
+import { auth } from "@/lib/auth";
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/origin", () => ({
+    getBackendUrl: vi.fn(() => "http://backend.test"),
+}));
+
+const mockAuth = vi.mocked(auth);
+
+const ERROR_LOCATION = "http://localhost/admin/integrations/github?github_app=error";
+
+function setSession(user: Record<string, unknown>) {
+    mockAuth.mockResolvedValue({ access_token: "tok", user } as never);
+}
+
+function setAdminSession(extra: Record<string, unknown> = {}) {
+    setSession({ org_id: "org-1", role: "admin", ...extra });
+}
+
+function makeRequest() {
+    return new NextRequest("http://localhost/admin/integrations/github-app/install");
+}
+
+function installUrlResponse(installUrl: unknown) {
+    return new Response(JSON.stringify({ install_url: installUrl }), {
+        status: 200,
+    });
+}
+
+describe("GET /admin/integrations/github-app/install", () => {
+    beforeEach(() => {
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    it("redirects to the backend-minted install URL on success", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockResolvedValue(
+            installUrlResponse("https://github.com/apps/dev-health/installations/new?state=jwt"),
+        );
+
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+            "https://github.com/apps/dev-health/installations/new?state=jwt",
+        );
+        // Forwarded the session token + effective org to the backend.
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        const headers = init?.headers as Record<string, string>;
+        expect(headers.Authorization).toBe("Bearer tok");
+        expect(headers["X-Org-Id"]).toBe("org-1");
+    });
+
+    it("proceeds for a superuser session without an org role", async () => {
+        setSession({ is_superuser: true });
+        vi.mocked(fetch).mockResolvedValue(
+            installUrlResponse("https://github.com/apps/dev-health/installations/new"),
+        );
+
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+            "https://github.com/apps/dev-health/installations/new",
+        );
+    });
+
+    it("redirects to error for a non-admin authenticated member", async () => {
+        setSession({ org_id: "org-1", role: "member", is_superuser: false });
+
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("omits X-Org-Id when the session has no org", async () => {
+        setSession({ role: "admin" });
+        vi.mocked(fetch).mockResolvedValue(
+            installUrlResponse("https://github.com/apps/dev-health/installations/new"),
+        );
+
+        await GET(makeRequest());
+
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        expect((init?.headers as Record<string, string>)["X-Org-Id"]).toBeUndefined();
+    });
+
+    it("redirects to error when there is no session access token", async () => {
+        mockAuth.mockResolvedValue(null as never);
+
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("redirects to the integration page with an error when the backend fails", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockResolvedValue(new Response("nope", { status: 500 }));
+
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
+
+    it("redirects to error when the backend returns a non-URL install_url", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockResolvedValue(installUrlResponse("not a url"));
+
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
+
+    it("redirects to error for a non-https (http) github.com install_url", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockResolvedValue(
+            installUrlResponse("http://github.com/apps/dev-health/installations/new"),
+        );
+
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
+
+    it("redirects to error for an https install_url on a non-github host", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockResolvedValue(
+            installUrlResponse("https://evil.example/apps/dev-health/installations/new"),
+        );
+
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
+
+    it("redirects to error when fetch throws", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockRejectedValue(new Error("network"));
+
+        const response = await GET(makeRequest());
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
+});

--- a/src/app/(app)/admin/integrations/github-app/install/route.ts
+++ b/src/app/(app)/admin/integrations/github-app/install/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { getBackendUrl } from "@/lib/origin";
+
+/**
+ * Initiation route for the frictionless GitHub App install (CHAOS-2235).
+ *
+ * The browser navigates here from the "Connect GitHub App" CTA on the GitHub
+ * integration page. We ask the backend to mint a signed install URL (the state
+ * JWT is created server-side) and redirect the browser to GitHub. On any
+ * backend failure we send the user back to the integration page with an error
+ * indicator rather than leaking backend internals.
+ */
+
+const GITHUB_INTEGRATION_PATH = "/admin/integrations/github";
+
+function errorRedirect(request: NextRequest) {
+    return NextResponse.redirect(
+        new URL(`${GITHUB_INTEGRATION_PATH}?github_app=error`, request.url),
+    );
+}
+
+export async function GET(request: NextRequest) {
+    const session = await auth();
+    if (!session?.access_token) {
+        // GET is followed by the browser, so render an error banner rather than
+        // raw JSON.
+        return errorRedirect(request);
+    }
+
+    // Defense-in-depth: this route is directly addressable and does not sit
+    // under the admin layout's requireRole guard. Mirror requireRole(["admin",
+    // "owner"]) inline (do NOT call it — it redirects to /dashboard, breaking
+    // this handler's consistent ?github_app=error UX).
+    if (!session.user.is_superuser && !["admin", "owner"].includes(session.user.role || "")) {
+        return errorRedirect(request);
+    }
+
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${session.access_token}`,
+        "Content-Type": "application/json",
+    };
+    // Forward the effective org so impersonation/active-org binds the install
+    // to the correct organization (mirrors src/lib/admin/server helpers).
+    if (session.user?.org_id) {
+        headers["X-Org-Id"] = session.user.org_id;
+    }
+
+    let installUrl: string | undefined;
+    try {
+        const response = await fetch(
+            `${getBackendUrl()}/api/v1/admin/integrations/github/install-url`,
+            {
+                method: "POST",
+                headers,
+            },
+        );
+
+        if (!response.ok) {
+            return errorRedirect(request);
+        }
+
+        const data = (await response.json()) as { install_url?: unknown };
+        installUrl = typeof data.install_url === "string" ? data.install_url : undefined;
+    } catch {
+        return errorRedirect(request);
+    }
+
+    // The install URL is minted by our own backend, but validate it before
+    // redirecting so a malformed/compromised response can never become an
+    // open redirect. Pin to https on github.com (GitHub App install host).
+    // GitHub Enterprise host support is a future follow-up.
+    if (!installUrl) {
+        return errorRedirect(request);
+    }
+    let parsed: URL;
+    try {
+        parsed = new URL(installUrl);
+    } catch {
+        return errorRedirect(request);
+    }
+    if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") {
+        return errorRedirect(request);
+    }
+
+    return NextResponse.redirect(parsed.toString());
+}

--- a/src/components/admin/integrations/GitHubAppConnect.test.tsx
+++ b/src/components/admin/integrations/GitHubAppConnect.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { GitHubAppConnect } from "@/components/admin/integrations/GitHubAppConnect";
+
+describe("GitHubAppConnect", () => {
+    it("renders the one-click install CTA linking to the initiation route", () => {
+        render(<GitHubAppConnect />);
+
+        const cta = screen.getByRole("link", { name: "Connect GitHub App" });
+        expect(cta).toHaveAttribute("href", "/admin/integrations/github-app/install");
+        expect(screen.getByText(/one-click install/i)).toBeInTheDocument();
+    });
+
+    it("shows a success banner when the result is connected", () => {
+        render(<GitHubAppConnect result="connected" />);
+
+        const banner = screen.getByRole("status");
+        expect(banner).toHaveTextContent(/GitHub App connected/i);
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("shows an error banner when the result is error", () => {
+        render(<GitHubAppConnect result="error" />);
+
+        const banner = screen.getByRole("alert");
+        expect(banner).toHaveTextContent(/couldn.t connect the GitHub App/i);
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("renders no banner when there is no result", () => {
+        render(<GitHubAppConnect />);
+
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+});

--- a/src/components/admin/integrations/GitHubAppConnect.tsx
+++ b/src/components/admin/integrations/GitHubAppConnect.tsx
@@ -1,0 +1,65 @@
+import { CTA_LABELS } from "@/lib/design/cta";
+
+export type GitHubAppConnectResult = "connected" | "error";
+
+type GitHubAppConnectProps = {
+    /** Result of a returning install callback, surfaced as a banner. */
+    result?: GitHubAppConnectResult;
+};
+
+const INSTALL_PATH = "/admin/integrations/github-app/install";
+
+/**
+ * "Connect GitHub App" call-to-action for the GitHub integration page
+ * (CHAOS-2235). Offers the frictionless, one-click GitHub App install that
+ * sits alongside the manual personal-access-token form. The anchor points at
+ * the server-side initiation route, which mints a signed install URL and
+ * redirects the browser to GitHub.
+ *
+ * When the user returns from the install callback, `result` drives a
+ * success/error banner so the outcome is visible without a toast.
+ */
+export function GitHubAppConnect({ result }: GitHubAppConnectProps) {
+    return (
+        <div className="mb-6 space-y-4">
+            {result === "connected" && (
+                <div
+                    role="status"
+                    className="rounded-lg border border-green-500/20 bg-green-500/10 p-4 text-sm text-green-700"
+                >
+                    GitHub App connected. Repositories will sync using the installation
+                    automatically.
+                </div>
+            )}
+            {result === "error" && (
+                <div
+                    role="alert"
+                    className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-700"
+                >
+                    We couldn&apos;t connect the GitHub App. Please try again, or use a personal
+                    access token below.
+                </div>
+            )}
+
+            <div className="rounded-lg border border-(--border-subtle) bg-(--surface-base) p-6 shadow-sm">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h2 className="text-lg font-medium text-(--ink-base)">
+                            {CTA_LABELS.connectGitHubApp}
+                        </h2>
+                        <p className="mt-1 text-sm text-(--ink-muted)">
+                            One-click install — no tokens to paste. Authorize the GitHub App and
+                            we&apos;ll handle credentials and per-installation rate limits for you.
+                        </p>
+                    </div>
+                    <a
+                        href={INSTALL_PATH}
+                        className="inline-flex shrink-0 items-center justify-center rounded-md bg-(--surface-inverted) px-4 py-2 text-sm font-medium text-(--ink-inverted) hover:bg-(--surface-inverted)/90 focus:outline-none focus:ring-2 focus:ring-(--surface-inverted) focus:ring-offset-2"
+                    >
+                        {CTA_LABELS.connectGitHubApp}
+                    </a>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -61,6 +61,8 @@ export const CTA_LABELS = {
     closePanel: "Close panel",
     /** Return to the cockpit (home) — the canonical single return path. */
     backToCockpit: "Back to Cockpit",
+    /** Start the frictionless one-click GitHub App install (CHAOS-2235). */
+    connectGitHubApp: "Connect GitHub App",
 } as const;
 
 export type CtaKey = keyof typeof CTA_LABELS;


### PR DESCRIPTION
## Summary

Frontend for one‑click GitHub connection (**CHAOS-2235**): a "Connect GitHub App" call‑to‑action on the GitHub integration page, plus the install initiation and Setup‑URL callback route handlers that drive the flow against the ops backend. The existing PAT form stays.

Backend counterpart: full-chaos/dev-health-ops#949 • Parent: CHAOS-2233

## What changed

- **CTA** — `GitHubAppConnect` card ("One‑click install — no tokens to paste") rendered only for `provider === "github"`, above the PAT form, with a `?github_app=connected|error` result banner.
- **`GET …/github-app/install`** — calls the backend to mint the signed install URL and redirects the browser to GitHub.
- **`GET …/github-app/callback`** — GitHub's Setup‑URL target; validates the untrusted query params and forwards to the backend install‑callback.

## Security hardening (from review)

- **RBAC at the route boundary** — both handlers require `is_superuser` or `admin`/`owner` before any backend call (route handlers don't inherit the admin layout's `requireRole`).
- **No open redirect** — the install redirect is pinned to `https://github.com`.
- **Effective‑org forwarding** — both requests forward `X-Org-Id` from the session so impersonation/active‑org binds the correct org; the session `access_token` is never leaked to the client and backend errors collapse to a generic `?github_app=error`.
- **Untrusted input** — `installation_id` validated as a positive integer within `MAX_SAFE_INTEGER`; `state` required.

## Review

- Code review + **`/codex:adversarial-review --model gpt-5.5`**. Findings fixed (open redirect, missing RBAC guard, `X-Org-Id`, browser‑GET error UX, id precision); final gpt‑5.5 verdict: **approve, no material findings**.

## Verification

- `tsc --noEmit` clean • `vitest` **24 passed** (install 10 / callback 10 / component 4, incl. non‑admin denial + redirect‑safety) • eslint + design‑lint clean.

## Visual evidence

![Connect GitHub App CTA](https://github.com/user-attachments/assets/b82bcf1a-71c5-4868-a978-fc2106c74d45)

Refs CHAOS-2235, CHAOS-2233
