### PR TITLE
fix(integrations): use public origin for GitHub App redirects

### DIFF
--- a/src/app/(app)/org/admin/integrations/github-app/callback/route.test.tsx
+++ b/src/app/(app)/org/admin/integrations/github-app/callback/route.test.tsx
@@ -6,244 +6,226 @@ import { auth } from "@/lib/auth";
 
 vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
 vi.mock("@/lib/origin", () => ({
-	getBackendUrl: vi.fn(() => "http://backend.test"),
+    getBackendUrl: vi.fn(() => "http://backend.test"),
 }));
 
 const mockAuth = vi.mocked(auth);
 
-const ERROR_LOCATION =
-	"http://localhost/org/admin/integrations/github?github_app=error";
+const ERROR_LOCATION = "http://localhost/org/admin/integrations/github?github_app=error";
 const ORIGINAL_AUTH_URL = process.env.AUTH_URL;
 const ORIGINAL_NEXTAUTH_URL = process.env.NEXTAUTH_URL;
 const ORIGINAL_TRUST_PROXY = process.env.TRUST_PROXY;
 
 function setSession(user: Record<string, unknown>) {
-	mockAuth.mockResolvedValue({ access_token: "tok", user } as never);
+    mockAuth.mockResolvedValue({ access_token: "tok", user } as never);
 }
 
 function authedSession() {
-	setSession({ org_id: "org-1", role: "admin" });
+    setSession({ org_id: "org-1", role: "admin" });
 }
 
 function makeRequest(query: string) {
-	return new NextRequest(
-		`http://localhost/org/admin/integrations/github-app/callback${query}`,
-	);
+    return new NextRequest(`http://localhost/org/admin/integrations/github-app/callback${query}`);
 }
 
 function makeForwardedRequest(query: string) {
-	return new NextRequest(
-		`http://[::]:3000/org/admin/integrations/github-app/callback${query}`,
-		{
-			headers: {
-				"x-forwarded-host": "app.example.test",
-				"x-forwarded-proto": "https",
-			},
-		},
-	);
+    return new NextRequest(`http://[::]:3000/org/admin/integrations/github-app/callback${query}`, {
+        headers: {
+            "x-forwarded-host": "app.example.test",
+            "x-forwarded-proto": "https",
+        },
+    });
 }
 
 describe("GET /org/admin/integrations/github-app/callback", () => {
-	beforeEach(() => {
-		delete process.env.AUTH_URL;
-		delete process.env.NEXTAUTH_URL;
-		delete process.env.TRUST_PROXY;
-		vi.stubGlobal("fetch", vi.fn());
-	});
+    beforeEach(() => {
+        delete process.env.AUTH_URL;
+        delete process.env.NEXTAUTH_URL;
+        delete process.env.TRUST_PROXY;
+        vi.stubGlobal("fetch", vi.fn());
+    });
 
-	afterEach(() => {
-		if (ORIGINAL_AUTH_URL === undefined) {
-			delete process.env.AUTH_URL;
-		} else {
-			process.env.AUTH_URL = ORIGINAL_AUTH_URL;
-		}
-		if (ORIGINAL_NEXTAUTH_URL === undefined) {
-			delete process.env.NEXTAUTH_URL;
-		} else {
-			process.env.NEXTAUTH_URL = ORIGINAL_NEXTAUTH_URL;
-		}
-		if (ORIGINAL_TRUST_PROXY === undefined) {
-			delete process.env.TRUST_PROXY;
-		} else {
-			process.env.TRUST_PROXY = ORIGINAL_TRUST_PROXY;
-		}
-		vi.unstubAllGlobals();
-		vi.clearAllMocks();
-	});
+    afterEach(() => {
+        if (ORIGINAL_AUTH_URL === undefined) {
+            delete process.env.AUTH_URL;
+        } else {
+            process.env.AUTH_URL = ORIGINAL_AUTH_URL;
+        }
+        if (ORIGINAL_NEXTAUTH_URL === undefined) {
+            delete process.env.NEXTAUTH_URL;
+        } else {
+            process.env.NEXTAUTH_URL = ORIGINAL_NEXTAUTH_URL;
+        }
+        if (ORIGINAL_TRUST_PROXY === undefined) {
+            delete process.env.TRUST_PROXY;
+        } else {
+            process.env.TRUST_PROXY = ORIGINAL_TRUST_PROXY;
+        }
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
 
-	it("forwards the callback to the backend and redirects to connected on success", async () => {
-		authedSession();
-		vi.mocked(fetch).mockResolvedValue(
-			new Response(JSON.stringify({ connected: true }), { status: 200 }),
-		);
+    it("forwards the callback to the backend and redirects to connected on success", async () => {
+        authedSession();
+        vi.mocked(fetch).mockResolvedValue(
+            new Response(JSON.stringify({ connected: true }), { status: 200 }),
+        );
 
-		const response = await GET(
-			makeRequest(
-				"?installation_id=123&setup_action=install&state=jwt&code=abc",
-			),
-		);
+        const response = await GET(
+            makeRequest("?installation_id=123&setup_action=install&state=jwt&code=abc"),
+        );
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(
-			"http://localhost/org/admin/integrations/github?github_app=connected",
-		);
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+            "http://localhost/org/admin/integrations/github?github_app=connected",
+        );
 
-		const [url, init] = vi.mocked(fetch).mock.calls[0];
-		expect(url).toBe(
-			"http://backend.test/api/v1/admin/integrations/github/install-callback",
-		);
-		const headers = init?.headers as Record<string, string>;
-		expect(headers.Authorization).toBe("Bearer tok");
-		expect(headers["X-Org-Id"]).toBe("org-1");
-		expect(JSON.parse(init?.body as string)).toEqual({
-			installation_id: 123,
-			setup_action: "install",
-			state: "jwt",
-			code: "abc",
-		});
-	});
+        const [url, init] = vi.mocked(fetch).mock.calls[0];
+        expect(url).toBe("http://backend.test/api/v1/admin/integrations/github/install-callback");
+        const headers = init?.headers as Record<string, string>;
+        expect(headers.Authorization).toBe("Bearer tok");
+        expect(headers["X-Org-Id"]).toBe("org-1");
+        expect(JSON.parse(init?.body as string)).toEqual({
+            installation_id: 123,
+            setup_action: "install",
+            state: "jwt",
+            code: "abc",
+        });
+    });
 
-	it("uses configured public origin for the final connected redirect", async () => {
-		process.env.AUTH_URL = "https://app.example.test";
-		authedSession();
-		vi.mocked(fetch).mockResolvedValue(
-			new Response(JSON.stringify({ connected: true }), { status: 200 }),
-		);
+    it("uses configured public origin for the final connected redirect", async () => {
+        process.env.AUTH_URL = "https://app.example.test";
+        authedSession();
+        vi.mocked(fetch).mockResolvedValue(
+            new Response(JSON.stringify({ connected: true }), { status: 200 }),
+        );
 
-		const response = await GET(
-			makeForwardedRequest(
-				"?installation_id=123&setup_action=install&state=jwt&code=abc",
-			),
-		);
+        const response = await GET(
+            makeForwardedRequest("?installation_id=123&setup_action=install&state=jwt&code=abc"),
+        );
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(
-			"https://app.example.test/org/admin/integrations/github?github_app=connected",
-		);
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+            "https://app.example.test/org/admin/integrations/github?github_app=connected",
+        );
+    });
 
-	it("uses forwarded public origin when proxy trust is enabled", async () => {
-		process.env.TRUST_PROXY = "true";
-		authedSession();
-		vi.mocked(fetch).mockResolvedValue(
-			new Response(JSON.stringify({ connected: true }), { status: 200 }),
-		);
+    it("uses forwarded public origin when proxy trust is enabled", async () => {
+        process.env.TRUST_PROXY = "true";
+        authedSession();
+        vi.mocked(fetch).mockResolvedValue(
+            new Response(JSON.stringify({ connected: true }), { status: 200 }),
+        );
 
-		const response = await GET(
-			makeForwardedRequest(
-				"?installation_id=123&setup_action=install&state=jwt&code=abc",
-			),
-		);
+        const response = await GET(
+            makeForwardedRequest("?installation_id=123&setup_action=install&state=jwt&code=abc"),
+        );
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(
-			"https://app.example.test/org/admin/integrations/github?github_app=connected",
-		);
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+            "https://app.example.test/org/admin/integrations/github?github_app=connected",
+        );
+    });
 
-	it("omits X-Org-Id when the session has no org", async () => {
-		setSession({ role: "admin" });
-		vi.mocked(fetch).mockResolvedValue(
-			new Response(JSON.stringify({ connected: true }), { status: 200 }),
-		);
+    it("omits X-Org-Id when the session has no org", async () => {
+        setSession({ role: "admin" });
+        vi.mocked(fetch).mockResolvedValue(
+            new Response(JSON.stringify({ connected: true }), { status: 200 }),
+        );
 
-		await GET(makeRequest("?installation_id=123&state=jwt"));
+        await GET(makeRequest("?installation_id=123&state=jwt"));
 
-		const [, init] = vi.mocked(fetch).mock.calls[0];
-		expect(
-			(init?.headers as Record<string, string>)["X-Org-Id"],
-		).toBeUndefined();
-	});
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        expect((init?.headers as Record<string, string>)["X-Org-Id"]).toBeUndefined();
+    });
 
-	it("redirects to error for a non-admin authenticated member", async () => {
-		setSession({ org_id: "org-1", role: "member", is_superuser: false });
+    it("redirects to error for a non-admin authenticated member", async () => {
+        setSession({ org_id: "org-1", role: "member", is_superuser: false });
 
-		const response = await GET(makeRequest("?installation_id=123&state=jwt"));
+        const response = await GET(makeRequest("?installation_id=123&state=jwt"));
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-		expect(fetch).not.toHaveBeenCalled();
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
 
-	it("redirects to error when installation_id is missing", async () => {
-		authedSession();
+    it("redirects to error when installation_id is missing", async () => {
+        authedSession();
 
-		const response = await GET(makeRequest("?state=jwt"));
+        const response = await GET(makeRequest("?state=jwt"));
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-		expect(fetch).not.toHaveBeenCalled();
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
 
-	it("redirects to error when installation_id is not a positive integer", async () => {
-		authedSession();
+    it("redirects to error when installation_id is not a positive integer", async () => {
+        authedSession();
 
-		const response = await GET(makeRequest("?installation_id=-5&state=jwt"));
+        const response = await GET(makeRequest("?installation_id=-5&state=jwt"));
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-		expect(fetch).not.toHaveBeenCalled();
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
 
-	it("redirects to error when installation_id exceeds MAX_SAFE_INTEGER", async () => {
-		authedSession();
+    it("redirects to error when installation_id exceeds MAX_SAFE_INTEGER", async () => {
+        authedSession();
 
-		// 9999999999999999999 > Number.MAX_SAFE_INTEGER (9007199254740991).
-		const response = await GET(
-			makeRequest("?installation_id=9999999999999999999&state=jwt"),
-		);
+        // 9999999999999999999 > Number.MAX_SAFE_INTEGER (9007199254740991).
+        const response = await GET(makeRequest("?installation_id=9999999999999999999&state=jwt"));
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-		expect(fetch).not.toHaveBeenCalled();
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
 
-	it("redirects to error when state is missing", async () => {
-		authedSession();
+    it("redirects to error when state is missing", async () => {
+        authedSession();
 
-		const response = await GET(makeRequest("?installation_id=123"));
+        const response = await GET(makeRequest("?installation_id=123"));
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-		expect(fetch).not.toHaveBeenCalled();
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
 
-	it("redirects to error when there is no session access token", async () => {
-		mockAuth.mockResolvedValue(null as never);
+    it("redirects to error when there is no session access token", async () => {
+        mockAuth.mockResolvedValue(null as never);
 
-		const response = await GET(makeRequest("?installation_id=123&state=jwt"));
+        const response = await GET(makeRequest("?installation_id=123&state=jwt"));
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-		expect(fetch).not.toHaveBeenCalled();
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
 
-	it("redirects to error when the backend rejects the callback", async () => {
-		authedSession();
-		vi.mocked(fetch).mockResolvedValue(
-			new Response(JSON.stringify({ detail: "org mismatch" }), { status: 403 }),
-		);
+    it("redirects to error when the backend rejects the callback", async () => {
+        authedSession();
+        vi.mocked(fetch).mockResolvedValue(
+            new Response(JSON.stringify({ detail: "org mismatch" }), { status: 403 }),
+        );
 
-		const response = await GET(makeRequest("?installation_id=123&state=jwt"));
+        const response = await GET(makeRequest("?installation_id=123&state=jwt"));
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
 
-	it("sends null for absent optional setup_action and code", async () => {
-		authedSession();
-		vi.mocked(fetch).mockResolvedValue(
-			new Response(JSON.stringify({ connected: true }), { status: 200 }),
-		);
+    it("sends null for absent optional setup_action and code", async () => {
+        authedSession();
+        vi.mocked(fetch).mockResolvedValue(
+            new Response(JSON.stringify({ connected: true }), { status: 200 }),
+        );
 
-		await GET(makeRequest("?installation_id=99&state=jwt"));
+        await GET(makeRequest("?installation_id=99&state=jwt"));
 
-		const [, init] = vi.mocked(fetch).mock.calls[0];
-		expect(JSON.parse(init?.body as string)).toEqual({
-			installation_id: 99,
-			setup_action: null,
-			state: "jwt",
-			code: null,
-		});
-	});
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        expect(JSON.parse(init?.body as string)).toEqual({
+            installation_id: 99,
+            setup_action: null,
+            state: "jwt",
+            code: null,
+        });
+    });
 });

--- a/src/app/(app)/org/admin/integrations/github-app/callback/route.test.tsx
+++ b/src/app/(app)/org/admin/integrations/github-app/callback/route.test.tsx
@@ -6,162 +6,244 @@ import { auth } from "@/lib/auth";
 
 vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
 vi.mock("@/lib/origin", () => ({
-    getBackendUrl: vi.fn(() => "http://backend.test"),
+	getBackendUrl: vi.fn(() => "http://backend.test"),
 }));
 
 const mockAuth = vi.mocked(auth);
 
-const ERROR_LOCATION = "http://localhost/org/admin/integrations/github?github_app=error";
+const ERROR_LOCATION =
+	"http://localhost/org/admin/integrations/github?github_app=error";
+const ORIGINAL_AUTH_URL = process.env.AUTH_URL;
+const ORIGINAL_NEXTAUTH_URL = process.env.NEXTAUTH_URL;
+const ORIGINAL_TRUST_PROXY = process.env.TRUST_PROXY;
 
 function setSession(user: Record<string, unknown>) {
-    mockAuth.mockResolvedValue({ access_token: "tok", user } as never);
+	mockAuth.mockResolvedValue({ access_token: "tok", user } as never);
 }
 
 function authedSession() {
-    setSession({ org_id: "org-1", role: "admin" });
+	setSession({ org_id: "org-1", role: "admin" });
 }
 
 function makeRequest(query: string) {
-    return new NextRequest(`http://localhost/org/admin/integrations/github-app/callback${query}`);
+	return new NextRequest(
+		`http://localhost/org/admin/integrations/github-app/callback${query}`,
+	);
+}
+
+function makeForwardedRequest(query: string) {
+	return new NextRequest(
+		`http://[::]:3000/org/admin/integrations/github-app/callback${query}`,
+		{
+			headers: {
+				"x-forwarded-host": "app.example.test",
+				"x-forwarded-proto": "https",
+			},
+		},
+	);
 }
 
 describe("GET /org/admin/integrations/github-app/callback", () => {
-    beforeEach(() => {
-        vi.stubGlobal("fetch", vi.fn());
-    });
+	beforeEach(() => {
+		delete process.env.AUTH_URL;
+		delete process.env.NEXTAUTH_URL;
+		delete process.env.TRUST_PROXY;
+		vi.stubGlobal("fetch", vi.fn());
+	});
 
-    afterEach(() => {
-        vi.unstubAllGlobals();
-        vi.clearAllMocks();
-    });
+	afterEach(() => {
+		if (ORIGINAL_AUTH_URL === undefined) {
+			delete process.env.AUTH_URL;
+		} else {
+			process.env.AUTH_URL = ORIGINAL_AUTH_URL;
+		}
+		if (ORIGINAL_NEXTAUTH_URL === undefined) {
+			delete process.env.NEXTAUTH_URL;
+		} else {
+			process.env.NEXTAUTH_URL = ORIGINAL_NEXTAUTH_URL;
+		}
+		if (ORIGINAL_TRUST_PROXY === undefined) {
+			delete process.env.TRUST_PROXY;
+		} else {
+			process.env.TRUST_PROXY = ORIGINAL_TRUST_PROXY;
+		}
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
 
-    it("forwards the callback to the backend and redirects to connected on success", async () => {
-        authedSession();
-        vi.mocked(fetch).mockResolvedValue(
-            new Response(JSON.stringify({ connected: true }), { status: 200 }),
-        );
+	it("forwards the callback to the backend and redirects to connected on success", async () => {
+		authedSession();
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ connected: true }), { status: 200 }),
+		);
 
-        const response = await GET(
-            makeRequest("?installation_id=123&setup_action=install&state=jwt&code=abc"),
-        );
+		const response = await GET(
+			makeRequest(
+				"?installation_id=123&setup_action=install&state=jwt&code=abc",
+			),
+		);
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(
-            "http://localhost/org/admin/integrations/github?github_app=connected",
-        );
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(
+			"http://localhost/org/admin/integrations/github?github_app=connected",
+		);
 
-        const [url, init] = vi.mocked(fetch).mock.calls[0];
-        expect(url).toBe("http://backend.test/api/v1/admin/integrations/github/install-callback");
-        const headers = init?.headers as Record<string, string>;
-        expect(headers.Authorization).toBe("Bearer tok");
-        expect(headers["X-Org-Id"]).toBe("org-1");
-        expect(JSON.parse(init?.body as string)).toEqual({
-            installation_id: 123,
-            setup_action: "install",
-            state: "jwt",
-            code: "abc",
-        });
-    });
+		const [url, init] = vi.mocked(fetch).mock.calls[0];
+		expect(url).toBe(
+			"http://backend.test/api/v1/admin/integrations/github/install-callback",
+		);
+		const headers = init?.headers as Record<string, string>;
+		expect(headers.Authorization).toBe("Bearer tok");
+		expect(headers["X-Org-Id"]).toBe("org-1");
+		expect(JSON.parse(init?.body as string)).toEqual({
+			installation_id: 123,
+			setup_action: "install",
+			state: "jwt",
+			code: "abc",
+		});
+	});
 
-    it("omits X-Org-Id when the session has no org", async () => {
-        setSession({ role: "admin" });
-        vi.mocked(fetch).mockResolvedValue(
-            new Response(JSON.stringify({ connected: true }), { status: 200 }),
-        );
+	it("uses configured public origin for the final connected redirect", async () => {
+		process.env.AUTH_URL = "https://app.example.test";
+		authedSession();
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ connected: true }), { status: 200 }),
+		);
 
-        await GET(makeRequest("?installation_id=123&state=jwt"));
+		const response = await GET(
+			makeForwardedRequest(
+				"?installation_id=123&setup_action=install&state=jwt&code=abc",
+			),
+		);
 
-        const [, init] = vi.mocked(fetch).mock.calls[0];
-        expect((init?.headers as Record<string, string>)["X-Org-Id"]).toBeUndefined();
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(
+			"https://app.example.test/org/admin/integrations/github?github_app=connected",
+		);
+	});
 
-    it("redirects to error for a non-admin authenticated member", async () => {
-        setSession({ org_id: "org-1", role: "member", is_superuser: false });
+	it("uses forwarded public origin when proxy trust is enabled", async () => {
+		process.env.TRUST_PROXY = "true";
+		authedSession();
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ connected: true }), { status: 200 }),
+		);
 
-        const response = await GET(makeRequest("?installation_id=123&state=jwt"));
+		const response = await GET(
+			makeForwardedRequest(
+				"?installation_id=123&setup_action=install&state=jwt&code=abc",
+			),
+		);
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-        expect(fetch).not.toHaveBeenCalled();
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(
+			"https://app.example.test/org/admin/integrations/github?github_app=connected",
+		);
+	});
 
-    it("redirects to error when installation_id is missing", async () => {
-        authedSession();
+	it("omits X-Org-Id when the session has no org", async () => {
+		setSession({ role: "admin" });
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ connected: true }), { status: 200 }),
+		);
 
-        const response = await GET(makeRequest("?state=jwt"));
+		await GET(makeRequest("?installation_id=123&state=jwt"));
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-        expect(fetch).not.toHaveBeenCalled();
-    });
+		const [, init] = vi.mocked(fetch).mock.calls[0];
+		expect(
+			(init?.headers as Record<string, string>)["X-Org-Id"],
+		).toBeUndefined();
+	});
 
-    it("redirects to error when installation_id is not a positive integer", async () => {
-        authedSession();
+	it("redirects to error for a non-admin authenticated member", async () => {
+		setSession({ org_id: "org-1", role: "member", is_superuser: false });
 
-        const response = await GET(makeRequest("?installation_id=-5&state=jwt"));
+		const response = await GET(makeRequest("?installation_id=123&state=jwt"));
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-        expect(fetch).not.toHaveBeenCalled();
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+		expect(fetch).not.toHaveBeenCalled();
+	});
 
-    it("redirects to error when installation_id exceeds MAX_SAFE_INTEGER", async () => {
-        authedSession();
+	it("redirects to error when installation_id is missing", async () => {
+		authedSession();
 
-        // 9999999999999999999 > Number.MAX_SAFE_INTEGER (9007199254740991).
-        const response = await GET(makeRequest("?installation_id=9999999999999999999&state=jwt"));
+		const response = await GET(makeRequest("?state=jwt"));
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-        expect(fetch).not.toHaveBeenCalled();
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+		expect(fetch).not.toHaveBeenCalled();
+	});
 
-    it("redirects to error when state is missing", async () => {
-        authedSession();
+	it("redirects to error when installation_id is not a positive integer", async () => {
+		authedSession();
 
-        const response = await GET(makeRequest("?installation_id=123"));
+		const response = await GET(makeRequest("?installation_id=-5&state=jwt"));
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-        expect(fetch).not.toHaveBeenCalled();
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+		expect(fetch).not.toHaveBeenCalled();
+	});
 
-    it("redirects to error when there is no session access token", async () => {
-        mockAuth.mockResolvedValue(null as never);
+	it("redirects to error when installation_id exceeds MAX_SAFE_INTEGER", async () => {
+		authedSession();
 
-        const response = await GET(makeRequest("?installation_id=123&state=jwt"));
+		// 9999999999999999999 > Number.MAX_SAFE_INTEGER (9007199254740991).
+		const response = await GET(
+			makeRequest("?installation_id=9999999999999999999&state=jwt"),
+		);
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-        expect(fetch).not.toHaveBeenCalled();
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+		expect(fetch).not.toHaveBeenCalled();
+	});
 
-    it("redirects to error when the backend rejects the callback", async () => {
-        authedSession();
-        vi.mocked(fetch).mockResolvedValue(
-            new Response(JSON.stringify({ detail: "org mismatch" }), { status: 403 }),
-        );
+	it("redirects to error when state is missing", async () => {
+		authedSession();
 
-        const response = await GET(makeRequest("?installation_id=123&state=jwt"));
+		const response = await GET(makeRequest("?installation_id=123"));
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+		expect(fetch).not.toHaveBeenCalled();
+	});
 
-    it("sends null for absent optional setup_action and code", async () => {
-        authedSession();
-        vi.mocked(fetch).mockResolvedValue(
-            new Response(JSON.stringify({ connected: true }), { status: 200 }),
-        );
+	it("redirects to error when there is no session access token", async () => {
+		mockAuth.mockResolvedValue(null as never);
 
-        await GET(makeRequest("?installation_id=99&state=jwt"));
+		const response = await GET(makeRequest("?installation_id=123&state=jwt"));
 
-        const [, init] = vi.mocked(fetch).mock.calls[0];
-        expect(JSON.parse(init?.body as string)).toEqual({
-            installation_id: 99,
-            setup_action: null,
-            state: "jwt",
-            code: null,
-        });
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("redirects to error when the backend rejects the callback", async () => {
+		authedSession();
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ detail: "org mismatch" }), { status: 403 }),
+		);
+
+		const response = await GET(makeRequest("?installation_id=123&state=jwt"));
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+	});
+
+	it("sends null for absent optional setup_action and code", async () => {
+		authedSession();
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ connected: true }), { status: 200 }),
+		);
+
+		await GET(makeRequest("?installation_id=99&state=jwt"));
+
+		const [, init] = vi.mocked(fetch).mock.calls[0];
+		expect(JSON.parse(init?.body as string)).toEqual({
+			installation_id: 99,
+			setup_action: null,
+			state: "jwt",
+			code: null,
+		});
+	});
 });

--- a/src/app/(app)/org/admin/integrations/github-app/callback/route.ts
+++ b/src/app/(app)/org/admin/integrations/github-app/callback/route.ts
@@ -19,128 +19,116 @@ import { getBackendUrl } from "@/lib/origin";
 const GITHUB_INTEGRATION_PATH = "/org/admin/integrations/github";
 
 function firstHeaderValue(value: string | null) {
-	return value?.split(",")[0]?.trim() || undefined;
+    return value?.split(",")[0]?.trim() || undefined;
 }
 
 function configuredOrigin() {
-	const env = getServerEnv();
-	const publicUrl = env.AUTH_URL ?? env.NEXTAUTH_URL;
-	if (!publicUrl) return undefined;
+    const env = getServerEnv();
+    const publicUrl = env.AUTH_URL ?? env.NEXTAUTH_URL;
+    if (!publicUrl) return undefined;
 
-	try {
-		return new URL(publicUrl).origin;
-	} catch {
-		return undefined;
-	}
+    try {
+        return new URL(publicUrl).origin;
+    } catch {
+        return undefined;
+    }
 }
 
 function publicOrigin(request: NextRequest) {
-	const configured = configuredOrigin();
-	if (configured) {
-		return configured;
-	}
+    const configured = configuredOrigin();
+    if (configured) {
+        return configured;
+    }
 
-	const env = getServerEnv();
-	if (env.TRUST_PROXY !== "true" && env.TRUST_PROXY !== "1") {
-		return request.nextUrl.origin;
-	}
+    const env = getServerEnv();
+    if (env.TRUST_PROXY !== "true" && env.TRUST_PROXY !== "1") {
+        return request.nextUrl.origin;
+    }
 
-	const forwardedHost = firstHeaderValue(
-		request.headers.get("x-forwarded-host"),
-	);
-	if (!forwardedHost) {
-		return request.nextUrl.origin;
-	}
+    const forwardedHost = firstHeaderValue(request.headers.get("x-forwarded-host"));
+    if (!forwardedHost) {
+        return request.nextUrl.origin;
+    }
 
-	const forwardedProto = firstHeaderValue(
-		request.headers.get("x-forwarded-proto"),
-	);
-	const protocol =
-		forwardedProto === "http" || forwardedProto === "https"
-			? forwardedProto
-			: request.nextUrl.protocol.slice(0, -1);
+    const forwardedProto = firstHeaderValue(request.headers.get("x-forwarded-proto"));
+    const protocol =
+        forwardedProto === "http" || forwardedProto === "https"
+            ? forwardedProto
+            : request.nextUrl.protocol.slice(0, -1);
 
-	return `${protocol}://${forwardedHost}`;
+    return `${protocol}://${forwardedHost}`;
 }
 
 function resultRedirect(request: NextRequest, result: "connected" | "error") {
-	return NextResponse.redirect(
-		new URL(
-			`${GITHUB_INTEGRATION_PATH}?github_app=${result}`,
-			publicOrigin(request),
-		),
-	);
+    return NextResponse.redirect(
+        new URL(`${GITHUB_INTEGRATION_PATH}?github_app=${result}`, publicOrigin(request)),
+    );
 }
 
 export async function GET(request: NextRequest) {
-	const params = request.nextUrl.searchParams;
+    const params = request.nextUrl.searchParams;
 
-	const rawInstallationId = params.get("installation_id");
-	const state = params.get("state");
-	const setupAction = params.get("setup_action");
-	const code = params.get("code");
+    const rawInstallationId = params.get("installation_id");
+    const state = params.get("state");
+    const setupAction = params.get("setup_action");
+    const code = params.get("code");
 
-	// Validate the untrusted GitHub-supplied params before doing any work.
-	// Reject values that exceed MAX_SAFE_INTEGER so large IDs don't silently
-	// lose precision before being forwarded to the backend.
-	const installationId =
-		rawInstallationId && /^\d+$/.test(rawInstallationId)
-			? Number(rawInstallationId)
-			: NaN;
-	if (
-		!Number.isInteger(installationId) ||
-		installationId <= 0 ||
-		installationId > Number.MAX_SAFE_INTEGER ||
-		!state
-	) {
-		return resultRedirect(request, "error");
-	}
+    // Validate the untrusted GitHub-supplied params before doing any work.
+    // Reject values that exceed MAX_SAFE_INTEGER so large IDs don't silently
+    // lose precision before being forwarded to the backend.
+    const installationId =
+        rawInstallationId && /^\d+$/.test(rawInstallationId) ? Number(rawInstallationId) : NaN;
+    if (
+        !Number.isInteger(installationId) ||
+        installationId <= 0 ||
+        installationId > Number.MAX_SAFE_INTEGER ||
+        !state
+    ) {
+        return resultRedirect(request, "error");
+    }
 
-	const session = await auth();
-	if (!session?.access_token) {
-		// GET is followed by the browser, so render an error banner rather than
-		// raw JSON.
-		return resultRedirect(request, "error");
-	}
+    const session = await auth();
+    if (!session?.access_token) {
+        // GET is followed by the browser, so render an error banner rather than
+        // raw JSON.
+        return resultRedirect(request, "error");
+    }
 
-	// Defense-in-depth: this route is directly addressable and does not sit
-	// under the admin layout's requireRole guard. Mirror requireRole(["admin",
-	// "owner"]) inline (do NOT call it — it redirects to /dashboard, breaking
-	// this handler's consistent ?github_app=error UX).
-	if (
-		!session.user.is_superuser &&
-		!["admin", "owner"].includes(session.user.role || "")
-	) {
-		return resultRedirect(request, "error");
-	}
+    // Defense-in-depth: this route is directly addressable and does not sit
+    // under the admin layout's requireRole guard. Mirror requireRole(["admin",
+    // "owner"]) inline (do NOT call it — it redirects to /dashboard, breaking
+    // this handler's consistent ?github_app=error UX).
+    if (!session.user.is_superuser && !["admin", "owner"].includes(session.user.role || "")) {
+        return resultRedirect(request, "error");
+    }
 
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${session.access_token}`,
-		"Content-Type": "application/json",
-	};
-	// Forward the effective org so impersonation/active-org binds the install
-	// to the correct organization (mirrors src/lib/admin/server helpers).
-	if (session.user?.org_id) {
-		headers["X-Org-Id"] = session.user.org_id;
-	}
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${session.access_token}`,
+        "Content-Type": "application/json",
+    };
+    // Forward the effective org so impersonation/active-org binds the install
+    // to the correct organization (mirrors src/lib/admin/server helpers).
+    if (session.user?.org_id) {
+        headers["X-Org-Id"] = session.user.org_id;
+    }
 
-	try {
-		const response = await fetch(
-			`${getBackendUrl()}/api/v1/admin/integrations/github/install-callback`,
-			{
-				method: "POST",
-				headers,
-				body: JSON.stringify({
-					installation_id: installationId,
-					setup_action: setupAction,
-					state,
-					code,
-				}),
-			},
-		);
+    try {
+        const response = await fetch(
+            `${getBackendUrl()}/api/v1/admin/integrations/github/install-callback`,
+            {
+                method: "POST",
+                headers,
+                body: JSON.stringify({
+                    installation_id: installationId,
+                    setup_action: setupAction,
+                    state,
+                    code,
+                }),
+            },
+        );
 
-		return resultRedirect(request, response.ok ? "connected" : "error");
-	} catch {
-		return resultRedirect(request, "error");
-	}
+        return resultRedirect(request, response.ok ? "connected" : "error");
+    } catch {
+        return resultRedirect(request, "error");
+    }
 }

--- a/src/app/(app)/org/admin/integrations/github-app/callback/route.ts
+++ b/src/app/(app)/org/admin/integrations/github-app/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import { auth } from "@/lib/auth";
+import { getServerEnv } from "@/lib/config";
 import { getBackendUrl } from "@/lib/origin";
 
 /**
@@ -17,76 +18,129 @@ import { getBackendUrl } from "@/lib/origin";
 
 const GITHUB_INTEGRATION_PATH = "/org/admin/integrations/github";
 
+function firstHeaderValue(value: string | null) {
+	return value?.split(",")[0]?.trim() || undefined;
+}
+
+function configuredOrigin() {
+	const env = getServerEnv();
+	const publicUrl = env.AUTH_URL ?? env.NEXTAUTH_URL;
+	if (!publicUrl) return undefined;
+
+	try {
+		return new URL(publicUrl).origin;
+	} catch {
+		return undefined;
+	}
+}
+
+function publicOrigin(request: NextRequest) {
+	const configured = configuredOrigin();
+	if (configured) {
+		return configured;
+	}
+
+	const env = getServerEnv();
+	if (env.TRUST_PROXY !== "true" && env.TRUST_PROXY !== "1") {
+		return request.nextUrl.origin;
+	}
+
+	const forwardedHost = firstHeaderValue(
+		request.headers.get("x-forwarded-host"),
+	);
+	if (!forwardedHost) {
+		return request.nextUrl.origin;
+	}
+
+	const forwardedProto = firstHeaderValue(
+		request.headers.get("x-forwarded-proto"),
+	);
+	const protocol =
+		forwardedProto === "http" || forwardedProto === "https"
+			? forwardedProto
+			: request.nextUrl.protocol.slice(0, -1);
+
+	return `${protocol}://${forwardedHost}`;
+}
+
 function resultRedirect(request: NextRequest, result: "connected" | "error") {
-    return NextResponse.redirect(
-        new URL(`${GITHUB_INTEGRATION_PATH}?github_app=${result}`, request.url),
-    );
+	return NextResponse.redirect(
+		new URL(
+			`${GITHUB_INTEGRATION_PATH}?github_app=${result}`,
+			publicOrigin(request),
+		),
+	);
 }
 
 export async function GET(request: NextRequest) {
-    const params = request.nextUrl.searchParams;
+	const params = request.nextUrl.searchParams;
 
-    const rawInstallationId = params.get("installation_id");
-    const state = params.get("state");
-    const setupAction = params.get("setup_action");
-    const code = params.get("code");
+	const rawInstallationId = params.get("installation_id");
+	const state = params.get("state");
+	const setupAction = params.get("setup_action");
+	const code = params.get("code");
 
-    // Validate the untrusted GitHub-supplied params before doing any work.
-    // Reject values that exceed MAX_SAFE_INTEGER so large IDs don't silently
-    // lose precision before being forwarded to the backend.
-    const installationId =
-        rawInstallationId && /^\d+$/.test(rawInstallationId) ? Number(rawInstallationId) : NaN;
-    if (
-        !Number.isInteger(installationId) ||
-        installationId <= 0 ||
-        installationId > Number.MAX_SAFE_INTEGER ||
-        !state
-    ) {
-        return resultRedirect(request, "error");
-    }
+	// Validate the untrusted GitHub-supplied params before doing any work.
+	// Reject values that exceed MAX_SAFE_INTEGER so large IDs don't silently
+	// lose precision before being forwarded to the backend.
+	const installationId =
+		rawInstallationId && /^\d+$/.test(rawInstallationId)
+			? Number(rawInstallationId)
+			: NaN;
+	if (
+		!Number.isInteger(installationId) ||
+		installationId <= 0 ||
+		installationId > Number.MAX_SAFE_INTEGER ||
+		!state
+	) {
+		return resultRedirect(request, "error");
+	}
 
-    const session = await auth();
-    if (!session?.access_token) {
-        // GET is followed by the browser, so render an error banner rather than
-        // raw JSON.
-        return resultRedirect(request, "error");
-    }
+	const session = await auth();
+	if (!session?.access_token) {
+		// GET is followed by the browser, so render an error banner rather than
+		// raw JSON.
+		return resultRedirect(request, "error");
+	}
 
-    // Defense-in-depth: this route is directly addressable and does not sit
-    // under the admin layout's requireRole guard. Mirror requireRole(["admin",
-    // "owner"]) inline (do NOT call it — it redirects to /dashboard, breaking
-    // this handler's consistent ?github_app=error UX).
-    if (!session.user.is_superuser && !["admin", "owner"].includes(session.user.role || "")) {
-        return resultRedirect(request, "error");
-    }
+	// Defense-in-depth: this route is directly addressable and does not sit
+	// under the admin layout's requireRole guard. Mirror requireRole(["admin",
+	// "owner"]) inline (do NOT call it — it redirects to /dashboard, breaking
+	// this handler's consistent ?github_app=error UX).
+	if (
+		!session.user.is_superuser &&
+		!["admin", "owner"].includes(session.user.role || "")
+	) {
+		return resultRedirect(request, "error");
+	}
 
-    const headers: Record<string, string> = {
-        Authorization: `Bearer ${session.access_token}`,
-        "Content-Type": "application/json",
-    };
-    // Forward the effective org so impersonation/active-org binds the install
-    // to the correct organization (mirrors src/lib/admin/server helpers).
-    if (session.user?.org_id) {
-        headers["X-Org-Id"] = session.user.org_id;
-    }
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${session.access_token}`,
+		"Content-Type": "application/json",
+	};
+	// Forward the effective org so impersonation/active-org binds the install
+	// to the correct organization (mirrors src/lib/admin/server helpers).
+	if (session.user?.org_id) {
+		headers["X-Org-Id"] = session.user.org_id;
+	}
 
-    try {
-        const response = await fetch(
-            `${getBackendUrl()}/api/v1/admin/integrations/github/install-callback`,
-            {
-                method: "POST",
-                headers,
-                body: JSON.stringify({
-                    installation_id: installationId,
-                    setup_action: setupAction,
-                    state,
-                    code,
-                }),
-            },
-        );
+	try {
+		const response = await fetch(
+			`${getBackendUrl()}/api/v1/admin/integrations/github/install-callback`,
+			{
+				method: "POST",
+				headers,
+				body: JSON.stringify({
+					installation_id: installationId,
+					setup_action: setupAction,
+					state,
+					code,
+				}),
+			},
+		);
 
-        return resultRedirect(request, response.ok ? "connected" : "error");
-    } catch {
-        return resultRedirect(request, "error");
-    }
+		return resultRedirect(request, response.ok ? "connected" : "error");
+	} catch {
+		return resultRedirect(request, "error");
+	}
 }

--- a/src/app/(app)/org/admin/integrations/github-app/install/route.test.tsx
+++ b/src/app/(app)/org/admin/integrations/github-app/install/route.test.tsx
@@ -6,229 +6,213 @@ import { auth } from "@/lib/auth";
 
 vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
 vi.mock("@/lib/origin", () => ({
-	getBackendUrl: vi.fn(() => "http://backend.test"),
+    getBackendUrl: vi.fn(() => "http://backend.test"),
 }));
 
 const mockAuth = vi.mocked(auth);
 
-const ERROR_LOCATION =
-	"http://localhost/org/admin/integrations/github?github_app=error";
+const ERROR_LOCATION = "http://localhost/org/admin/integrations/github?github_app=error";
 const ORIGINAL_AUTH_URL = process.env.AUTH_URL;
 const ORIGINAL_NEXTAUTH_URL = process.env.NEXTAUTH_URL;
 const ORIGINAL_TRUST_PROXY = process.env.TRUST_PROXY;
 
 function setSession(user: Record<string, unknown>) {
-	mockAuth.mockResolvedValue({ access_token: "tok", user } as never);
+    mockAuth.mockResolvedValue({ access_token: "tok", user } as never);
 }
 
 function setAdminSession(extra: Record<string, unknown> = {}) {
-	setSession({ org_id: "org-1", role: "admin", ...extra });
+    setSession({ org_id: "org-1", role: "admin", ...extra });
 }
 
 function makeRequest() {
-	return new NextRequest(
-		"http://localhost/org/admin/integrations/github-app/install",
-	);
+    return new NextRequest("http://localhost/org/admin/integrations/github-app/install");
 }
 
 function makeForwardedRequest() {
-	return new NextRequest(
-		"http://[::]:3000/org/admin/integrations/github-app/install",
-		{
-			headers: {
-				"x-forwarded-host": "app.example.test",
-				"x-forwarded-proto": "https",
-			},
-		},
-	);
+    return new NextRequest("http://[::]:3000/org/admin/integrations/github-app/install", {
+        headers: {
+            "x-forwarded-host": "app.example.test",
+            "x-forwarded-proto": "https",
+        },
+    });
 }
 
 function installUrlResponse(installUrl: unknown) {
-	return new Response(JSON.stringify({ install_url: installUrl }), {
-		status: 200,
-	});
+    return new Response(JSON.stringify({ install_url: installUrl }), {
+        status: 200,
+    });
 }
 
 describe("GET /org/admin/integrations/github-app/install", () => {
-	beforeEach(() => {
-		delete process.env.AUTH_URL;
-		delete process.env.NEXTAUTH_URL;
-		delete process.env.TRUST_PROXY;
-		vi.stubGlobal("fetch", vi.fn());
-	});
+    beforeEach(() => {
+        delete process.env.AUTH_URL;
+        delete process.env.NEXTAUTH_URL;
+        delete process.env.TRUST_PROXY;
+        vi.stubGlobal("fetch", vi.fn());
+    });
 
-	afterEach(() => {
-		if (ORIGINAL_AUTH_URL === undefined) {
-			delete process.env.AUTH_URL;
-		} else {
-			process.env.AUTH_URL = ORIGINAL_AUTH_URL;
-		}
-		if (ORIGINAL_NEXTAUTH_URL === undefined) {
-			delete process.env.NEXTAUTH_URL;
-		} else {
-			process.env.NEXTAUTH_URL = ORIGINAL_NEXTAUTH_URL;
-		}
-		if (ORIGINAL_TRUST_PROXY === undefined) {
-			delete process.env.TRUST_PROXY;
-		} else {
-			process.env.TRUST_PROXY = ORIGINAL_TRUST_PROXY;
-		}
-		vi.unstubAllGlobals();
-		vi.clearAllMocks();
-	});
+    afterEach(() => {
+        if (ORIGINAL_AUTH_URL === undefined) {
+            delete process.env.AUTH_URL;
+        } else {
+            process.env.AUTH_URL = ORIGINAL_AUTH_URL;
+        }
+        if (ORIGINAL_NEXTAUTH_URL === undefined) {
+            delete process.env.NEXTAUTH_URL;
+        } else {
+            process.env.NEXTAUTH_URL = ORIGINAL_NEXTAUTH_URL;
+        }
+        if (ORIGINAL_TRUST_PROXY === undefined) {
+            delete process.env.TRUST_PROXY;
+        } else {
+            process.env.TRUST_PROXY = ORIGINAL_TRUST_PROXY;
+        }
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
 
-	it("redirects to the backend-minted install URL on success", async () => {
-		setAdminSession();
-		vi.mocked(fetch).mockResolvedValue(
-			installUrlResponse(
-				"https://github.com/apps/dev-health/installations/new?state=jwt",
-			),
-		);
+    it("redirects to the backend-minted install URL on success", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockResolvedValue(
+            installUrlResponse("https://github.com/apps/dev-health/installations/new?state=jwt"),
+        );
 
-		const response = await GET(makeRequest());
+        const response = await GET(makeRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(
-			"https://github.com/apps/dev-health/installations/new?state=jwt",
-		);
-		// Forwarded the session token + effective org to the backend.
-		const [, init] = vi.mocked(fetch).mock.calls[0];
-		const headers = init?.headers as Record<string, string>;
-		expect(headers.Authorization).toBe("Bearer tok");
-		expect(headers["X-Org-Id"]).toBe("org-1");
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+            "https://github.com/apps/dev-health/installations/new?state=jwt",
+        );
+        // Forwarded the session token + effective org to the backend.
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        const headers = init?.headers as Record<string, string>;
+        expect(headers.Authorization).toBe("Bearer tok");
+        expect(headers["X-Org-Id"]).toBe("org-1");
+    });
 
-	it("proceeds for a superuser session without an org role", async () => {
-		setSession({ is_superuser: true });
-		vi.mocked(fetch).mockResolvedValue(
-			installUrlResponse(
-				"https://github.com/apps/dev-health/installations/new",
-			),
-		);
+    it("proceeds for a superuser session without an org role", async () => {
+        setSession({ is_superuser: true });
+        vi.mocked(fetch).mockResolvedValue(
+            installUrlResponse("https://github.com/apps/dev-health/installations/new"),
+        );
 
-		const response = await GET(makeRequest());
+        const response = await GET(makeRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(
-			"https://github.com/apps/dev-health/installations/new",
-		);
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+            "https://github.com/apps/dev-health/installations/new",
+        );
+    });
 
-	it("redirects to error for a non-admin authenticated member", async () => {
-		setSession({ org_id: "org-1", role: "member", is_superuser: false });
+    it("redirects to error for a non-admin authenticated member", async () => {
+        setSession({ org_id: "org-1", role: "member", is_superuser: false });
 
-		const response = await GET(makeRequest());
+        const response = await GET(makeRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-		expect(fetch).not.toHaveBeenCalled();
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
 
-	it("uses configured public origin for install error redirects", async () => {
-		process.env.AUTH_URL = "https://app.example.test";
-		setSession({ org_id: "org-1", role: "member", is_superuser: false });
+    it("uses configured public origin for install error redirects", async () => {
+        process.env.AUTH_URL = "https://app.example.test";
+        setSession({ org_id: "org-1", role: "member", is_superuser: false });
 
-		const response = await GET(makeForwardedRequest());
+        const response = await GET(makeForwardedRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(
-			"https://app.example.test/org/admin/integrations/github?github_app=error",
-		);
-		expect(fetch).not.toHaveBeenCalled();
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+            "https://app.example.test/org/admin/integrations/github?github_app=error",
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
 
-	it("uses forwarded public origin for install error redirects when proxy trust is enabled", async () => {
-		process.env.TRUST_PROXY = "true";
-		setSession({ org_id: "org-1", role: "member", is_superuser: false });
+    it("uses forwarded public origin for install error redirects when proxy trust is enabled", async () => {
+        process.env.TRUST_PROXY = "true";
+        setSession({ org_id: "org-1", role: "member", is_superuser: false });
 
-		const response = await GET(makeForwardedRequest());
+        const response = await GET(makeForwardedRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(
-			"https://app.example.test/org/admin/integrations/github?github_app=error",
-		);
-		expect(fetch).not.toHaveBeenCalled();
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+            "https://app.example.test/org/admin/integrations/github?github_app=error",
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
 
-	it("omits X-Org-Id when the session has no org", async () => {
-		setSession({ role: "admin" });
-		vi.mocked(fetch).mockResolvedValue(
-			installUrlResponse(
-				"https://github.com/apps/dev-health/installations/new",
-			),
-		);
+    it("omits X-Org-Id when the session has no org", async () => {
+        setSession({ role: "admin" });
+        vi.mocked(fetch).mockResolvedValue(
+            installUrlResponse("https://github.com/apps/dev-health/installations/new"),
+        );
 
-		await GET(makeRequest());
+        await GET(makeRequest());
 
-		const [, init] = vi.mocked(fetch).mock.calls[0];
-		expect(
-			(init?.headers as Record<string, string>)["X-Org-Id"],
-		).toBeUndefined();
-	});
+        const [, init] = vi.mocked(fetch).mock.calls[0];
+        expect((init?.headers as Record<string, string>)["X-Org-Id"]).toBeUndefined();
+    });
 
-	it("redirects to error when there is no session access token", async () => {
-		mockAuth.mockResolvedValue(null as never);
+    it("redirects to error when there is no session access token", async () => {
+        mockAuth.mockResolvedValue(null as never);
 
-		const response = await GET(makeRequest());
+        const response = await GET(makeRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-		expect(fetch).not.toHaveBeenCalled();
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+        expect(fetch).not.toHaveBeenCalled();
+    });
 
-	it("redirects to the integration page with an error when the backend fails", async () => {
-		setAdminSession();
-		vi.mocked(fetch).mockResolvedValue(new Response("nope", { status: 500 }));
+    it("redirects to the integration page with an error when the backend fails", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockResolvedValue(new Response("nope", { status: 500 }));
 
-		const response = await GET(makeRequest());
+        const response = await GET(makeRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
 
-	it("redirects to error when the backend returns a non-URL install_url", async () => {
-		setAdminSession();
-		vi.mocked(fetch).mockResolvedValue(installUrlResponse("not a url"));
+    it("redirects to error when the backend returns a non-URL install_url", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockResolvedValue(installUrlResponse("not a url"));
 
-		const response = await GET(makeRequest());
+        const response = await GET(makeRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
 
-	it("redirects to error for a non-https (http) github.com install_url", async () => {
-		setAdminSession();
-		vi.mocked(fetch).mockResolvedValue(
-			installUrlResponse("http://github.com/apps/dev-health/installations/new"),
-		);
+    it("redirects to error for a non-https (http) github.com install_url", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockResolvedValue(
+            installUrlResponse("http://github.com/apps/dev-health/installations/new"),
+        );
 
-		const response = await GET(makeRequest());
+        const response = await GET(makeRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
 
-	it("redirects to error for an https install_url on a non-github host", async () => {
-		setAdminSession();
-		vi.mocked(fetch).mockResolvedValue(
-			installUrlResponse(
-				"https://evil.example/apps/dev-health/installations/new",
-			),
-		);
+    it("redirects to error for an https install_url on a non-github host", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockResolvedValue(
+            installUrlResponse("https://evil.example/apps/dev-health/installations/new"),
+        );
 
-		const response = await GET(makeRequest());
+        const response = await GET(makeRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
 
-	it("redirects to error when fetch throws", async () => {
-		setAdminSession();
-		vi.mocked(fetch).mockRejectedValue(new Error("network"));
+    it("redirects to error when fetch throws", async () => {
+        setAdminSession();
+        vi.mocked(fetch).mockRejectedValue(new Error("network"));
 
-		const response = await GET(makeRequest());
+        const response = await GET(makeRequest());
 
-		expect(response.status).toBe(307);
-		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-	});
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+    });
 });

--- a/src/app/(app)/org/admin/integrations/github-app/install/route.test.tsx
+++ b/src/app/(app)/org/admin/integrations/github-app/install/route.test.tsx
@@ -6,157 +6,229 @@ import { auth } from "@/lib/auth";
 
 vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
 vi.mock("@/lib/origin", () => ({
-    getBackendUrl: vi.fn(() => "http://backend.test"),
+	getBackendUrl: vi.fn(() => "http://backend.test"),
 }));
 
 const mockAuth = vi.mocked(auth);
 
-const ERROR_LOCATION = "http://localhost/org/admin/integrations/github?github_app=error";
+const ERROR_LOCATION =
+	"http://localhost/org/admin/integrations/github?github_app=error";
+const ORIGINAL_AUTH_URL = process.env.AUTH_URL;
+const ORIGINAL_NEXTAUTH_URL = process.env.NEXTAUTH_URL;
+const ORIGINAL_TRUST_PROXY = process.env.TRUST_PROXY;
 
 function setSession(user: Record<string, unknown>) {
-    mockAuth.mockResolvedValue({ access_token: "tok", user } as never);
+	mockAuth.mockResolvedValue({ access_token: "tok", user } as never);
 }
 
 function setAdminSession(extra: Record<string, unknown> = {}) {
-    setSession({ org_id: "org-1", role: "admin", ...extra });
+	setSession({ org_id: "org-1", role: "admin", ...extra });
 }
 
 function makeRequest() {
-    return new NextRequest("http://localhost/org/admin/integrations/github-app/install");
+	return new NextRequest(
+		"http://localhost/org/admin/integrations/github-app/install",
+	);
+}
+
+function makeForwardedRequest() {
+	return new NextRequest(
+		"http://[::]:3000/org/admin/integrations/github-app/install",
+		{
+			headers: {
+				"x-forwarded-host": "app.example.test",
+				"x-forwarded-proto": "https",
+			},
+		},
+	);
 }
 
 function installUrlResponse(installUrl: unknown) {
-    return new Response(JSON.stringify({ install_url: installUrl }), {
-        status: 200,
-    });
+	return new Response(JSON.stringify({ install_url: installUrl }), {
+		status: 200,
+	});
 }
 
 describe("GET /org/admin/integrations/github-app/install", () => {
-    beforeEach(() => {
-        vi.stubGlobal("fetch", vi.fn());
-    });
+	beforeEach(() => {
+		delete process.env.AUTH_URL;
+		delete process.env.NEXTAUTH_URL;
+		delete process.env.TRUST_PROXY;
+		vi.stubGlobal("fetch", vi.fn());
+	});
 
-    afterEach(() => {
-        vi.unstubAllGlobals();
-        vi.clearAllMocks();
-    });
+	afterEach(() => {
+		if (ORIGINAL_AUTH_URL === undefined) {
+			delete process.env.AUTH_URL;
+		} else {
+			process.env.AUTH_URL = ORIGINAL_AUTH_URL;
+		}
+		if (ORIGINAL_NEXTAUTH_URL === undefined) {
+			delete process.env.NEXTAUTH_URL;
+		} else {
+			process.env.NEXTAUTH_URL = ORIGINAL_NEXTAUTH_URL;
+		}
+		if (ORIGINAL_TRUST_PROXY === undefined) {
+			delete process.env.TRUST_PROXY;
+		} else {
+			process.env.TRUST_PROXY = ORIGINAL_TRUST_PROXY;
+		}
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
 
-    it("redirects to the backend-minted install URL on success", async () => {
-        setAdminSession();
-        vi.mocked(fetch).mockResolvedValue(
-            installUrlResponse("https://github.com/apps/dev-health/installations/new?state=jwt"),
-        );
+	it("redirects to the backend-minted install URL on success", async () => {
+		setAdminSession();
+		vi.mocked(fetch).mockResolvedValue(
+			installUrlResponse(
+				"https://github.com/apps/dev-health/installations/new?state=jwt",
+			),
+		);
 
-        const response = await GET(makeRequest());
+		const response = await GET(makeRequest());
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(
-            "https://github.com/apps/dev-health/installations/new?state=jwt",
-        );
-        // Forwarded the session token + effective org to the backend.
-        const [, init] = vi.mocked(fetch).mock.calls[0];
-        const headers = init?.headers as Record<string, string>;
-        expect(headers.Authorization).toBe("Bearer tok");
-        expect(headers["X-Org-Id"]).toBe("org-1");
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(
+			"https://github.com/apps/dev-health/installations/new?state=jwt",
+		);
+		// Forwarded the session token + effective org to the backend.
+		const [, init] = vi.mocked(fetch).mock.calls[0];
+		const headers = init?.headers as Record<string, string>;
+		expect(headers.Authorization).toBe("Bearer tok");
+		expect(headers["X-Org-Id"]).toBe("org-1");
+	});
 
-    it("proceeds for a superuser session without an org role", async () => {
-        setSession({ is_superuser: true });
-        vi.mocked(fetch).mockResolvedValue(
-            installUrlResponse("https://github.com/apps/dev-health/installations/new"),
-        );
+	it("proceeds for a superuser session without an org role", async () => {
+		setSession({ is_superuser: true });
+		vi.mocked(fetch).mockResolvedValue(
+			installUrlResponse(
+				"https://github.com/apps/dev-health/installations/new",
+			),
+		);
 
-        const response = await GET(makeRequest());
+		const response = await GET(makeRequest());
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(
-            "https://github.com/apps/dev-health/installations/new",
-        );
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(
+			"https://github.com/apps/dev-health/installations/new",
+		);
+	});
 
-    it("redirects to error for a non-admin authenticated member", async () => {
-        setSession({ org_id: "org-1", role: "member", is_superuser: false });
+	it("redirects to error for a non-admin authenticated member", async () => {
+		setSession({ org_id: "org-1", role: "member", is_superuser: false });
 
-        const response = await GET(makeRequest());
+		const response = await GET(makeRequest());
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-        expect(fetch).not.toHaveBeenCalled();
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+		expect(fetch).not.toHaveBeenCalled();
+	});
 
-    it("omits X-Org-Id when the session has no org", async () => {
-        setSession({ role: "admin" });
-        vi.mocked(fetch).mockResolvedValue(
-            installUrlResponse("https://github.com/apps/dev-health/installations/new"),
-        );
+	it("uses configured public origin for install error redirects", async () => {
+		process.env.AUTH_URL = "https://app.example.test";
+		setSession({ org_id: "org-1", role: "member", is_superuser: false });
 
-        await GET(makeRequest());
+		const response = await GET(makeForwardedRequest());
 
-        const [, init] = vi.mocked(fetch).mock.calls[0];
-        expect((init?.headers as Record<string, string>)["X-Org-Id"]).toBeUndefined();
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(
+			"https://app.example.test/org/admin/integrations/github?github_app=error",
+		);
+		expect(fetch).not.toHaveBeenCalled();
+	});
 
-    it("redirects to error when there is no session access token", async () => {
-        mockAuth.mockResolvedValue(null as never);
+	it("uses forwarded public origin for install error redirects when proxy trust is enabled", async () => {
+		process.env.TRUST_PROXY = "true";
+		setSession({ org_id: "org-1", role: "member", is_superuser: false });
 
-        const response = await GET(makeRequest());
+		const response = await GET(makeForwardedRequest());
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-        expect(fetch).not.toHaveBeenCalled();
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(
+			"https://app.example.test/org/admin/integrations/github?github_app=error",
+		);
+		expect(fetch).not.toHaveBeenCalled();
+	});
 
-    it("redirects to the integration page with an error when the backend fails", async () => {
-        setAdminSession();
-        vi.mocked(fetch).mockResolvedValue(new Response("nope", { status: 500 }));
+	it("omits X-Org-Id when the session has no org", async () => {
+		setSession({ role: "admin" });
+		vi.mocked(fetch).mockResolvedValue(
+			installUrlResponse(
+				"https://github.com/apps/dev-health/installations/new",
+			),
+		);
 
-        const response = await GET(makeRequest());
+		await GET(makeRequest());
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-    });
+		const [, init] = vi.mocked(fetch).mock.calls[0];
+		expect(
+			(init?.headers as Record<string, string>)["X-Org-Id"],
+		).toBeUndefined();
+	});
 
-    it("redirects to error when the backend returns a non-URL install_url", async () => {
-        setAdminSession();
-        vi.mocked(fetch).mockResolvedValue(installUrlResponse("not a url"));
+	it("redirects to error when there is no session access token", async () => {
+		mockAuth.mockResolvedValue(null as never);
 
-        const response = await GET(makeRequest());
+		const response = await GET(makeRequest());
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+		expect(fetch).not.toHaveBeenCalled();
+	});
 
-    it("redirects to error for a non-https (http) github.com install_url", async () => {
-        setAdminSession();
-        vi.mocked(fetch).mockResolvedValue(
-            installUrlResponse("http://github.com/apps/dev-health/installations/new"),
-        );
+	it("redirects to the integration page with an error when the backend fails", async () => {
+		setAdminSession();
+		vi.mocked(fetch).mockResolvedValue(new Response("nope", { status: 500 }));
 
-        const response = await GET(makeRequest());
+		const response = await GET(makeRequest());
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+	});
 
-    it("redirects to error for an https install_url on a non-github host", async () => {
-        setAdminSession();
-        vi.mocked(fetch).mockResolvedValue(
-            installUrlResponse("https://evil.example/apps/dev-health/installations/new"),
-        );
+	it("redirects to error when the backend returns a non-URL install_url", async () => {
+		setAdminSession();
+		vi.mocked(fetch).mockResolvedValue(installUrlResponse("not a url"));
 
-        const response = await GET(makeRequest());
+		const response = await GET(makeRequest());
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+	});
 
-    it("redirects to error when fetch throws", async () => {
-        setAdminSession();
-        vi.mocked(fetch).mockRejectedValue(new Error("network"));
+	it("redirects to error for a non-https (http) github.com install_url", async () => {
+		setAdminSession();
+		vi.mocked(fetch).mockResolvedValue(
+			installUrlResponse("http://github.com/apps/dev-health/installations/new"),
+		);
 
-        const response = await GET(makeRequest());
+		const response = await GET(makeRequest());
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(ERROR_LOCATION);
-    });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+	});
+
+	it("redirects to error for an https install_url on a non-github host", async () => {
+		setAdminSession();
+		vi.mocked(fetch).mockResolvedValue(
+			installUrlResponse(
+				"https://evil.example/apps/dev-health/installations/new",
+			),
+		);
+
+		const response = await GET(makeRequest());
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+	});
+
+	it("redirects to error when fetch throws", async () => {
+		setAdminSession();
+		vi.mocked(fetch).mockRejectedValue(new Error("network"));
+
+		const response = await GET(makeRequest());
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(ERROR_LOCATION);
+	});
 });

--- a/src/app/(app)/org/admin/integrations/github-app/install/route.ts
+++ b/src/app/(app)/org/admin/integrations/github-app/install/route.ts
@@ -17,125 +17,114 @@ import { getBackendUrl } from "@/lib/origin";
 const GITHUB_INTEGRATION_PATH = "/org/admin/integrations/github";
 
 function firstHeaderValue(value: string | null) {
-	return value?.split(",")[0]?.trim() || undefined;
+    return value?.split(",")[0]?.trim() || undefined;
 }
 
 function configuredOrigin() {
-	const env = getServerEnv();
-	const publicUrl = env.AUTH_URL ?? env.NEXTAUTH_URL;
-	if (!publicUrl) return undefined;
+    const env = getServerEnv();
+    const publicUrl = env.AUTH_URL ?? env.NEXTAUTH_URL;
+    if (!publicUrl) return undefined;
 
-	try {
-		return new URL(publicUrl).origin;
-	} catch {
-		return undefined;
-	}
+    try {
+        return new URL(publicUrl).origin;
+    } catch {
+        return undefined;
+    }
 }
 
 function publicOrigin(request: NextRequest) {
-	const configured = configuredOrigin();
-	if (configured) {
-		return configured;
-	}
+    const configured = configuredOrigin();
+    if (configured) {
+        return configured;
+    }
 
-	const env = getServerEnv();
-	if (env.TRUST_PROXY !== "true" && env.TRUST_PROXY !== "1") {
-		return request.nextUrl.origin;
-	}
+    const env = getServerEnv();
+    if (env.TRUST_PROXY !== "true" && env.TRUST_PROXY !== "1") {
+        return request.nextUrl.origin;
+    }
 
-	const forwardedHost = firstHeaderValue(
-		request.headers.get("x-forwarded-host"),
-	);
-	if (!forwardedHost) {
-		return request.nextUrl.origin;
-	}
+    const forwardedHost = firstHeaderValue(request.headers.get("x-forwarded-host"));
+    if (!forwardedHost) {
+        return request.nextUrl.origin;
+    }
 
-	const forwardedProto = firstHeaderValue(
-		request.headers.get("x-forwarded-proto"),
-	);
-	const protocol =
-		forwardedProto === "http" || forwardedProto === "https"
-			? forwardedProto
-			: request.nextUrl.protocol.slice(0, -1);
+    const forwardedProto = firstHeaderValue(request.headers.get("x-forwarded-proto"));
+    const protocol =
+        forwardedProto === "http" || forwardedProto === "https"
+            ? forwardedProto
+            : request.nextUrl.protocol.slice(0, -1);
 
-	return `${protocol}://${forwardedHost}`;
+    return `${protocol}://${forwardedHost}`;
 }
 
 function errorRedirect(request: NextRequest) {
-	return NextResponse.redirect(
-		new URL(
-			`${GITHUB_INTEGRATION_PATH}?github_app=error`,
-			publicOrigin(request),
-		),
-	);
+    return NextResponse.redirect(
+        new URL(`${GITHUB_INTEGRATION_PATH}?github_app=error`, publicOrigin(request)),
+    );
 }
 
 export async function GET(request: NextRequest) {
-	const session = await auth();
-	if (!session?.access_token) {
-		// GET is followed by the browser, so render an error banner rather than
-		// raw JSON.
-		return errorRedirect(request);
-	}
+    const session = await auth();
+    if (!session?.access_token) {
+        // GET is followed by the browser, so render an error banner rather than
+        // raw JSON.
+        return errorRedirect(request);
+    }
 
-	// Defense-in-depth: this route is directly addressable and does not sit
-	// under the admin layout's requireRole guard. Mirror requireRole(["admin",
-	// "owner"]) inline (do NOT call it — it redirects to /dashboard, breaking
-	// this handler's consistent ?github_app=error UX).
-	if (
-		!session.user.is_superuser &&
-		!["admin", "owner"].includes(session.user.role || "")
-	) {
-		return errorRedirect(request);
-	}
+    // Defense-in-depth: this route is directly addressable and does not sit
+    // under the admin layout's requireRole guard. Mirror requireRole(["admin",
+    // "owner"]) inline (do NOT call it — it redirects to /dashboard, breaking
+    // this handler's consistent ?github_app=error UX).
+    if (!session.user.is_superuser && !["admin", "owner"].includes(session.user.role || "")) {
+        return errorRedirect(request);
+    }
 
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${session.access_token}`,
-		"Content-Type": "application/json",
-	};
-	// Forward the effective org so impersonation/active-org binds the install
-	// to the correct organization (mirrors src/lib/admin/server helpers).
-	if (session.user?.org_id) {
-		headers["X-Org-Id"] = session.user.org_id;
-	}
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${session.access_token}`,
+        "Content-Type": "application/json",
+    };
+    // Forward the effective org so impersonation/active-org binds the install
+    // to the correct organization (mirrors src/lib/admin/server helpers).
+    if (session.user?.org_id) {
+        headers["X-Org-Id"] = session.user.org_id;
+    }
 
-	let installUrl: string | undefined;
-	try {
-		const response = await fetch(
-			`${getBackendUrl()}/api/v1/admin/integrations/github/install-url`,
-			{
-				method: "POST",
-				headers,
-			},
-		);
+    let installUrl: string | undefined;
+    try {
+        const response = await fetch(
+            `${getBackendUrl()}/api/v1/admin/integrations/github/install-url`,
+            {
+                method: "POST",
+                headers,
+            },
+        );
 
-		if (!response.ok) {
-			return errorRedirect(request);
-		}
+        if (!response.ok) {
+            return errorRedirect(request);
+        }
 
-		const data = (await response.json()) as { install_url?: unknown };
-		installUrl =
-			typeof data.install_url === "string" ? data.install_url : undefined;
-	} catch {
-		return errorRedirect(request);
-	}
+        const data = (await response.json()) as { install_url?: unknown };
+        installUrl = typeof data.install_url === "string" ? data.install_url : undefined;
+    } catch {
+        return errorRedirect(request);
+    }
 
-	// The install URL is minted by our own backend, but validate it before
-	// redirecting so a malformed/compromised response can never become an
-	// open redirect. Pin to https on github.com (GitHub App install host).
-	// GitHub Enterprise host support is a future follow-up.
-	if (!installUrl) {
-		return errorRedirect(request);
-	}
-	let parsed: URL;
-	try {
-		parsed = new URL(installUrl);
-	} catch {
-		return errorRedirect(request);
-	}
-	if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") {
-		return errorRedirect(request);
-	}
+    // The install URL is minted by our own backend, but validate it before
+    // redirecting so a malformed/compromised response can never become an
+    // open redirect. Pin to https on github.com (GitHub App install host).
+    // GitHub Enterprise host support is a future follow-up.
+    if (!installUrl) {
+        return errorRedirect(request);
+    }
+    let parsed: URL;
+    try {
+        parsed = new URL(installUrl);
+    } catch {
+        return errorRedirect(request);
+    }
+    if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") {
+        return errorRedirect(request);
+    }
 
-	return NextResponse.redirect(parsed.toString());
+    return NextResponse.redirect(parsed.toString());
 }

--- a/src/app/(app)/org/admin/integrations/github-app/install/route.ts
+++ b/src/app/(app)/org/admin/integrations/github-app/install/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import { auth } from "@/lib/auth";
+import { getServerEnv } from "@/lib/config";
 import { getBackendUrl } from "@/lib/origin";
 
 /**
@@ -15,74 +16,126 @@ import { getBackendUrl } from "@/lib/origin";
 
 const GITHUB_INTEGRATION_PATH = "/org/admin/integrations/github";
 
+function firstHeaderValue(value: string | null) {
+	return value?.split(",")[0]?.trim() || undefined;
+}
+
+function configuredOrigin() {
+	const env = getServerEnv();
+	const publicUrl = env.AUTH_URL ?? env.NEXTAUTH_URL;
+	if (!publicUrl) return undefined;
+
+	try {
+		return new URL(publicUrl).origin;
+	} catch {
+		return undefined;
+	}
+}
+
+function publicOrigin(request: NextRequest) {
+	const configured = configuredOrigin();
+	if (configured) {
+		return configured;
+	}
+
+	const env = getServerEnv();
+	if (env.TRUST_PROXY !== "true" && env.TRUST_PROXY !== "1") {
+		return request.nextUrl.origin;
+	}
+
+	const forwardedHost = firstHeaderValue(
+		request.headers.get("x-forwarded-host"),
+	);
+	if (!forwardedHost) {
+		return request.nextUrl.origin;
+	}
+
+	const forwardedProto = firstHeaderValue(
+		request.headers.get("x-forwarded-proto"),
+	);
+	const protocol =
+		forwardedProto === "http" || forwardedProto === "https"
+			? forwardedProto
+			: request.nextUrl.protocol.slice(0, -1);
+
+	return `${protocol}://${forwardedHost}`;
+}
+
 function errorRedirect(request: NextRequest) {
-    return NextResponse.redirect(
-        new URL(`${GITHUB_INTEGRATION_PATH}?github_app=error`, request.url),
-    );
+	return NextResponse.redirect(
+		new URL(
+			`${GITHUB_INTEGRATION_PATH}?github_app=error`,
+			publicOrigin(request),
+		),
+	);
 }
 
 export async function GET(request: NextRequest) {
-    const session = await auth();
-    if (!session?.access_token) {
-        // GET is followed by the browser, so render an error banner rather than
-        // raw JSON.
-        return errorRedirect(request);
-    }
+	const session = await auth();
+	if (!session?.access_token) {
+		// GET is followed by the browser, so render an error banner rather than
+		// raw JSON.
+		return errorRedirect(request);
+	}
 
-    // Defense-in-depth: this route is directly addressable and does not sit
-    // under the admin layout's requireRole guard. Mirror requireRole(["admin",
-    // "owner"]) inline (do NOT call it — it redirects to /dashboard, breaking
-    // this handler's consistent ?github_app=error UX).
-    if (!session.user.is_superuser && !["admin", "owner"].includes(session.user.role || "")) {
-        return errorRedirect(request);
-    }
+	// Defense-in-depth: this route is directly addressable and does not sit
+	// under the admin layout's requireRole guard. Mirror requireRole(["admin",
+	// "owner"]) inline (do NOT call it — it redirects to /dashboard, breaking
+	// this handler's consistent ?github_app=error UX).
+	if (
+		!session.user.is_superuser &&
+		!["admin", "owner"].includes(session.user.role || "")
+	) {
+		return errorRedirect(request);
+	}
 
-    const headers: Record<string, string> = {
-        Authorization: `Bearer ${session.access_token}`,
-        "Content-Type": "application/json",
-    };
-    // Forward the effective org so impersonation/active-org binds the install
-    // to the correct organization (mirrors src/lib/admin/server helpers).
-    if (session.user?.org_id) {
-        headers["X-Org-Id"] = session.user.org_id;
-    }
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${session.access_token}`,
+		"Content-Type": "application/json",
+	};
+	// Forward the effective org so impersonation/active-org binds the install
+	// to the correct organization (mirrors src/lib/admin/server helpers).
+	if (session.user?.org_id) {
+		headers["X-Org-Id"] = session.user.org_id;
+	}
 
-    let installUrl: string | undefined;
-    try {
-        const response = await fetch(
-            `${getBackendUrl()}/api/v1/admin/integrations/github/install-url`,
-            {
-                method: "POST",
-                headers,
-            },
-        );
+	let installUrl: string | undefined;
+	try {
+		const response = await fetch(
+			`${getBackendUrl()}/api/v1/admin/integrations/github/install-url`,
+			{
+				method: "POST",
+				headers,
+			},
+		);
 
-        if (!response.ok) {
-            return errorRedirect(request);
-        }
+		if (!response.ok) {
+			return errorRedirect(request);
+		}
 
-        const data = (await response.json()) as { install_url?: unknown };
-        installUrl = typeof data.install_url === "string" ? data.install_url : undefined;
-    } catch {
-        return errorRedirect(request);
-    }
+		const data = (await response.json()) as { install_url?: unknown };
+		installUrl =
+			typeof data.install_url === "string" ? data.install_url : undefined;
+	} catch {
+		return errorRedirect(request);
+	}
 
-    // The install URL is minted by our own backend, but validate it before
-    // redirecting so a malformed/compromised response can never become an
-    // open redirect. Pin to https on github.com (GitHub App install host).
-    // GitHub Enterprise host support is a future follow-up.
-    if (!installUrl) {
-        return errorRedirect(request);
-    }
-    let parsed: URL;
-    try {
-        parsed = new URL(installUrl);
-    } catch {
-        return errorRedirect(request);
-    }
-    if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") {
-        return errorRedirect(request);
-    }
+	// The install URL is minted by our own backend, but validate it before
+	// redirecting so a malformed/compromised response can never become an
+	// open redirect. Pin to https on github.com (GitHub App install host).
+	// GitHub Enterprise host support is a future follow-up.
+	if (!installUrl) {
+		return errorRedirect(request);
+	}
+	let parsed: URL;
+	try {
+		parsed = new URL(installUrl);
+	} catch {
+		return errorRedirect(request);
+	}
+	if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") {
+		return errorRedirect(request);
+	}
 
-    return NextResponse.redirect(parsed.toString());
+	return NextResponse.redirect(parsed.toString());
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -20,96 +20,94 @@ import { z } from "zod";
 import { ValidationErrors } from "@/lib/constants/errors";
 
 const publicEnvSchema = z.object({
-	NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: z.string().optional(),
-	NEXT_PUBLIC_DOCS_URL: z.string().default("/docs"),
-	NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: z.string().optional(),
-	NEXT_PUBLIC_DEMO_MODE: z.string().optional(),
-	NEXT_PUBLIC_BETA: z.string().optional(),
-	NEXT_PUBLIC_RUM_ENDPOINT: z.string().optional(),
-	NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
-	NODE_ENV: z.string().optional(),
+    NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: z.string().optional(),
+    NEXT_PUBLIC_DOCS_URL: z.string().default("/docs"),
+    NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: z.string().optional(),
+    NEXT_PUBLIC_DEMO_MODE: z.string().optional(),
+    NEXT_PUBLIC_BETA: z.string().optional(),
+    NEXT_PUBLIC_RUM_ENDPOINT: z.string().optional(),
+    NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
+    NODE_ENV: z.string().optional(),
 });
 
 export type PublicEnv = z.infer<typeof publicEnvSchema>;
 
 function parsePublicEnv(): PublicEnv {
-	return publicEnvSchema.parse({
-		NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS:
-			process.env.NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS,
-		NEXT_PUBLIC_DOCS_URL: process.env.NEXT_PUBLIC_DOCS_URL,
-		NEXT_PUBLIC_DEV_HEALTH_TEST_MODE:
-			process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE,
-		NEXT_PUBLIC_DEMO_MODE: process.env.NEXT_PUBLIC_DEMO_MODE,
-		NEXT_PUBLIC_BETA: process.env.NEXT_PUBLIC_BETA,
-		NEXT_PUBLIC_RUM_ENDPOINT: process.env.NEXT_PUBLIC_RUM_ENDPOINT,
-		NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
-		NODE_ENV: process.env.NODE_ENV,
-	});
+    return publicEnvSchema.parse({
+        NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: process.env.NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS,
+        NEXT_PUBLIC_DOCS_URL: process.env.NEXT_PUBLIC_DOCS_URL,
+        NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE,
+        NEXT_PUBLIC_DEMO_MODE: process.env.NEXT_PUBLIC_DEMO_MODE,
+        NEXT_PUBLIC_BETA: process.env.NEXT_PUBLIC_BETA,
+        NEXT_PUBLIC_RUM_ENDPOINT: process.env.NEXT_PUBLIC_RUM_ENDPOINT,
+        NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
+        NODE_ENV: process.env.NODE_ENV,
+    });
 }
 
 export const publicEnv: PublicEnv = new Proxy({} as PublicEnv, {
-	get(_target, prop) {
-		if (typeof prop !== "string") return undefined;
-		const parsed = parsePublicEnv();
-		return (parsed as Record<string, unknown>)[prop];
-	},
-	has(_target, prop) {
-		if (typeof prop !== "string") return false;
-		const parsed = parsePublicEnv();
-		return prop in (parsed as Record<string, unknown>);
-	},
-	ownKeys() {
-		return Object.keys(parsePublicEnv());
-	},
-	getOwnPropertyDescriptor(_target, prop) {
-		if (typeof prop !== "string") return undefined;
-		const parsed = parsePublicEnv();
-		if (!(prop in (parsed as Record<string, unknown>))) return undefined;
-		return {
-			enumerable: true,
-			configurable: true,
-			value: (parsed as Record<string, unknown>)[prop],
-		};
-	},
+    get(_target, prop) {
+        if (typeof prop !== "string") return undefined;
+        const parsed = parsePublicEnv();
+        return (parsed as Record<string, unknown>)[prop];
+    },
+    has(_target, prop) {
+        if (typeof prop !== "string") return false;
+        const parsed = parsePublicEnv();
+        return prop in (parsed as Record<string, unknown>);
+    },
+    ownKeys() {
+        return Object.keys(parsePublicEnv());
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+        if (typeof prop !== "string") return undefined;
+        const parsed = parsePublicEnv();
+        if (!(prop in (parsed as Record<string, unknown>))) return undefined;
+        return {
+            enumerable: true,
+            configurable: true,
+            value: (parsed as Record<string, unknown>)[prop],
+        };
+    },
 });
 
 const serverEnvSchema = z.object({
-	NODE_ENV: z.string().optional(),
-	LOG_LEVEL: z.string().optional(),
-	LOG_FORMAT: z.string().optional(),
-	BACKEND_URL: z.string().optional(),
-	BASE_PATH: z.string().optional(),
-	AUTH_SECRET: z.string().optional(),
-	AUTH_URL: z.string().optional(),
-	NEXTAUTH_SECRET: z.string().optional(),
-	NEXTAUTH_URL: z.string().optional(),
-	AUTH_GITHUB_ID: z.string().optional(),
-	AUTH_GITHUB_SECRET: z.string().optional(),
-	AUTH_GOOGLE_ID: z.string().optional(),
-	AUTH_GOOGLE_SECRET: z.string().optional(),
-	AUTH_GITLAB_ID: z.string().optional(),
-	AUTH_GITLAB_SECRET: z.string().optional(),
-	LINEAR_API_KEY: z.string().optional(),
-	LINEAR_TEAM_ID: z.string().optional(),
-	REDIS_URL: z.string().optional(),
-	/**
-	 * When set to "true" or "1", the application trusts the `X-Forwarded-For`
-	 * header for client IP extraction (used by rate limiting). Only enable this
-	 * when the app is deployed behind a trusted reverse proxy that strips or
-	 * rewrites forwarded headers. Defaults to false (untrusted) to prevent IP
-	 * spoofing attacks.
-	 */
-	TRUST_PROXY: z.string().optional(),
-	USE_GRAPHQL_ANALYTICS: z.string().optional(),
-	DEV_HEALTH_TEST_MODE: z.string().optional(),
-	DEMO_EXPORT: z.string().optional(),
-	NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: z.string().optional(),
-	NEXT_PUBLIC_DOCS_URL: z.string().optional(),
-	NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: z.string().optional(),
-	NEXT_PUBLIC_DEMO_MODE: z.string().optional(),
-	NEXT_PUBLIC_BETA: z.string().optional(),
-	NEXT_PUBLIC_RUM_ENDPOINT: z.string().optional(),
-	NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
+    NODE_ENV: z.string().optional(),
+    LOG_LEVEL: z.string().optional(),
+    LOG_FORMAT: z.string().optional(),
+    BACKEND_URL: z.string().optional(),
+    BASE_PATH: z.string().optional(),
+    AUTH_SECRET: z.string().optional(),
+    AUTH_URL: z.string().optional(),
+    NEXTAUTH_SECRET: z.string().optional(),
+    NEXTAUTH_URL: z.string().optional(),
+    AUTH_GITHUB_ID: z.string().optional(),
+    AUTH_GITHUB_SECRET: z.string().optional(),
+    AUTH_GOOGLE_ID: z.string().optional(),
+    AUTH_GOOGLE_SECRET: z.string().optional(),
+    AUTH_GITLAB_ID: z.string().optional(),
+    AUTH_GITLAB_SECRET: z.string().optional(),
+    LINEAR_API_KEY: z.string().optional(),
+    LINEAR_TEAM_ID: z.string().optional(),
+    REDIS_URL: z.string().optional(),
+    /**
+     * When set to "true" or "1", the application trusts the `X-Forwarded-For`
+     * header for client IP extraction (used by rate limiting). Only enable this
+     * when the app is deployed behind a trusted reverse proxy that strips or
+     * rewrites forwarded headers. Defaults to false (untrusted) to prevent IP
+     * spoofing attacks.
+     */
+    TRUST_PROXY: z.string().optional(),
+    USE_GRAPHQL_ANALYTICS: z.string().optional(),
+    DEV_HEALTH_TEST_MODE: z.string().optional(),
+    DEMO_EXPORT: z.string().optional(),
+    NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: z.string().optional(),
+    NEXT_PUBLIC_DOCS_URL: z.string().optional(),
+    NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: z.string().optional(),
+    NEXT_PUBLIC_DEMO_MODE: z.string().optional(),
+    NEXT_PUBLIC_BETA: z.string().optional(),
+    NEXT_PUBLIC_RUM_ENDPOINT: z.string().optional(),
+    NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
 });
 
 export type ServerEnv = z.infer<typeof serverEnvSchema>;
@@ -120,42 +118,41 @@ export type ServerEnv = z.infer<typeof serverEnvSchema>;
  * called from a client bundle as a defensive guard.
  */
 export function getServerEnv(): ServerEnv {
-	// Allow the call when running under a Node-based test runner even if the
-	// environment has stubbed a `window` (jsdom/happy-dom). The bundle-guard
-	// is about preventing accidental inclusion in *client* bundles, not about
-	// blocking server-side tests.
-	const inNodeTest =
-		typeof process !== "undefined" &&
-		// Indirect access via globalThis prevents Next.js's Edge-runtime
-		// static analyzer from flagging the Node-only `process.versions`
-		// token. The check correctly evaluates to `false` in Edge runtime,
-		// which is the desired semantics (Edge is never a Node test runner).
-		!!(globalThis as { process?: { versions?: { node?: string } } }).process
-			?.versions?.node &&
-		(process.env.VITEST === "true" ||
-			process.env.NODE_ENV === "test" ||
-			typeof (globalThis as { jest?: unknown }).jest !== "undefined");
+    // Allow the call when running under a Node-based test runner even if the
+    // environment has stubbed a `window` (jsdom/happy-dom). The bundle-guard
+    // is about preventing accidental inclusion in *client* bundles, not about
+    // blocking server-side tests.
+    const inNodeTest =
+        typeof process !== "undefined" &&
+        // Indirect access via globalThis prevents Next.js's Edge-runtime
+        // static analyzer from flagging the Node-only `process.versions`
+        // token. The check correctly evaluates to `false` in Edge runtime,
+        // which is the desired semantics (Edge is never a Node test runner).
+        !!(globalThis as { process?: { versions?: { node?: string } } }).process?.versions?.node &&
+        (process.env.VITEST === "true" ||
+            process.env.NODE_ENV === "test" ||
+            typeof (globalThis as { jest?: unknown }).jest !== "undefined");
 
-	if (typeof window !== "undefined" && !inNodeTest) {
-		throw new Error(ValidationErrors.ServerEnvCalledFromClientBundle);
-	}
-	return serverEnvSchema.parse(process.env);
+    if (typeof window !== "undefined" && !inNodeTest) {
+        throw new Error(ValidationErrors.ServerEnvCalledFromClientBundle);
+    }
+    return serverEnvSchema.parse(process.env);
 }
 
 export const isServer = typeof window === "undefined";
 export const isBrowser = !isServer;
 
 export const config = {
-	api: {
-		baseUrl: "",
-		get docsUrl(): string {
-			// Lazy getter to avoid a top-level import cycle with runtimeConfig.
-			// The runtimeConfig module itself depends on this file for
-			// `getServerEnv`, so we must not eagerly import it at module load.
-			const { runtimeConfig } =
-				// eslint-disable-next-line @typescript-eslint/no-require-imports
-				require("@/lib/runtimeConfig") as typeof import("@/lib/runtimeConfig");
-			return runtimeConfig.docsUrl();
-		},
-	},
+    api: {
+        baseUrl: "",
+        get docsUrl(): string {
+            // Lazy getter to avoid a top-level import cycle with runtimeConfig.
+            // The runtimeConfig module itself depends on this file for
+            // `getServerEnv`, so we must not eagerly import it at module load.
+            const { runtimeConfig } =
+                // eslint-disable-next-line @typescript-eslint/no-require-imports
+                require("@/lib/runtimeConfig") as typeof import("@/lib/runtimeConfig");
+            return runtimeConfig.docsUrl();
+        },
+    },
 };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -20,93 +20,96 @@ import { z } from "zod";
 import { ValidationErrors } from "@/lib/constants/errors";
 
 const publicEnvSchema = z.object({
-    NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: z.string().optional(),
-    NEXT_PUBLIC_DOCS_URL: z.string().default("/docs"),
-    NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: z.string().optional(),
-    NEXT_PUBLIC_DEMO_MODE: z.string().optional(),
-    NEXT_PUBLIC_BETA: z.string().optional(),
-    NEXT_PUBLIC_RUM_ENDPOINT: z.string().optional(),
-    NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
-    NODE_ENV: z.string().optional(),
+	NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: z.string().optional(),
+	NEXT_PUBLIC_DOCS_URL: z.string().default("/docs"),
+	NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: z.string().optional(),
+	NEXT_PUBLIC_DEMO_MODE: z.string().optional(),
+	NEXT_PUBLIC_BETA: z.string().optional(),
+	NEXT_PUBLIC_RUM_ENDPOINT: z.string().optional(),
+	NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
+	NODE_ENV: z.string().optional(),
 });
 
 export type PublicEnv = z.infer<typeof publicEnvSchema>;
 
 function parsePublicEnv(): PublicEnv {
-    return publicEnvSchema.parse({
-        NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: process.env.NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS,
-        NEXT_PUBLIC_DOCS_URL: process.env.NEXT_PUBLIC_DOCS_URL,
-        NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE,
-        NEXT_PUBLIC_DEMO_MODE: process.env.NEXT_PUBLIC_DEMO_MODE,
-        NEXT_PUBLIC_BETA: process.env.NEXT_PUBLIC_BETA,
-        NEXT_PUBLIC_RUM_ENDPOINT: process.env.NEXT_PUBLIC_RUM_ENDPOINT,
-        NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
-        NODE_ENV: process.env.NODE_ENV,
-    });
+	return publicEnvSchema.parse({
+		NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS:
+			process.env.NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS,
+		NEXT_PUBLIC_DOCS_URL: process.env.NEXT_PUBLIC_DOCS_URL,
+		NEXT_PUBLIC_DEV_HEALTH_TEST_MODE:
+			process.env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE,
+		NEXT_PUBLIC_DEMO_MODE: process.env.NEXT_PUBLIC_DEMO_MODE,
+		NEXT_PUBLIC_BETA: process.env.NEXT_PUBLIC_BETA,
+		NEXT_PUBLIC_RUM_ENDPOINT: process.env.NEXT_PUBLIC_RUM_ENDPOINT,
+		NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
+		NODE_ENV: process.env.NODE_ENV,
+	});
 }
 
 export const publicEnv: PublicEnv = new Proxy({} as PublicEnv, {
-    get(_target, prop) {
-        if (typeof prop !== "string") return undefined;
-        const parsed = parsePublicEnv();
-        return (parsed as Record<string, unknown>)[prop];
-    },
-    has(_target, prop) {
-        if (typeof prop !== "string") return false;
-        const parsed = parsePublicEnv();
-        return prop in (parsed as Record<string, unknown>);
-    },
-    ownKeys() {
-        return Object.keys(parsePublicEnv());
-    },
-    getOwnPropertyDescriptor(_target, prop) {
-        if (typeof prop !== "string") return undefined;
-        const parsed = parsePublicEnv();
-        if (!(prop in (parsed as Record<string, unknown>))) return undefined;
-        return {
-            enumerable: true,
-            configurable: true,
-            value: (parsed as Record<string, unknown>)[prop],
-        };
-    },
+	get(_target, prop) {
+		if (typeof prop !== "string") return undefined;
+		const parsed = parsePublicEnv();
+		return (parsed as Record<string, unknown>)[prop];
+	},
+	has(_target, prop) {
+		if (typeof prop !== "string") return false;
+		const parsed = parsePublicEnv();
+		return prop in (parsed as Record<string, unknown>);
+	},
+	ownKeys() {
+		return Object.keys(parsePublicEnv());
+	},
+	getOwnPropertyDescriptor(_target, prop) {
+		if (typeof prop !== "string") return undefined;
+		const parsed = parsePublicEnv();
+		if (!(prop in (parsed as Record<string, unknown>))) return undefined;
+		return {
+			enumerable: true,
+			configurable: true,
+			value: (parsed as Record<string, unknown>)[prop],
+		};
+	},
 });
 
 const serverEnvSchema = z.object({
-    NODE_ENV: z.string().optional(),
-    LOG_LEVEL: z.string().optional(),
-    LOG_FORMAT: z.string().optional(),
-    BACKEND_URL: z.string().optional(),
-    BASE_PATH: z.string().optional(),
-    AUTH_SECRET: z.string().optional(),
-    NEXTAUTH_SECRET: z.string().optional(),
-    NEXTAUTH_URL: z.string().optional(),
-    AUTH_GITHUB_ID: z.string().optional(),
-    AUTH_GITHUB_SECRET: z.string().optional(),
-    AUTH_GOOGLE_ID: z.string().optional(),
-    AUTH_GOOGLE_SECRET: z.string().optional(),
-    AUTH_GITLAB_ID: z.string().optional(),
-    AUTH_GITLAB_SECRET: z.string().optional(),
-    LINEAR_API_KEY: z.string().optional(),
-    LINEAR_TEAM_ID: z.string().optional(),
-    REDIS_URL: z.string().optional(),
-    /**
-     * When set to "true" or "1", the application trusts the `X-Forwarded-For`
-     * header for client IP extraction (used by rate limiting). Only enable this
-     * when the app is deployed behind a trusted reverse proxy that strips or
-     * rewrites forwarded headers. Defaults to false (untrusted) to prevent IP
-     * spoofing attacks.
-     */
-    TRUST_PROXY: z.string().optional(),
-    USE_GRAPHQL_ANALYTICS: z.string().optional(),
-    DEV_HEALTH_TEST_MODE: z.string().optional(),
-    DEMO_EXPORT: z.string().optional(),
-    NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: z.string().optional(),
-    NEXT_PUBLIC_DOCS_URL: z.string().optional(),
-    NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: z.string().optional(),
-    NEXT_PUBLIC_DEMO_MODE: z.string().optional(),
-    NEXT_PUBLIC_BETA: z.string().optional(),
-    NEXT_PUBLIC_RUM_ENDPOINT: z.string().optional(),
-    NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
+	NODE_ENV: z.string().optional(),
+	LOG_LEVEL: z.string().optional(),
+	LOG_FORMAT: z.string().optional(),
+	BACKEND_URL: z.string().optional(),
+	BASE_PATH: z.string().optional(),
+	AUTH_SECRET: z.string().optional(),
+	AUTH_URL: z.string().optional(),
+	NEXTAUTH_SECRET: z.string().optional(),
+	NEXTAUTH_URL: z.string().optional(),
+	AUTH_GITHUB_ID: z.string().optional(),
+	AUTH_GITHUB_SECRET: z.string().optional(),
+	AUTH_GOOGLE_ID: z.string().optional(),
+	AUTH_GOOGLE_SECRET: z.string().optional(),
+	AUTH_GITLAB_ID: z.string().optional(),
+	AUTH_GITLAB_SECRET: z.string().optional(),
+	LINEAR_API_KEY: z.string().optional(),
+	LINEAR_TEAM_ID: z.string().optional(),
+	REDIS_URL: z.string().optional(),
+	/**
+	 * When set to "true" or "1", the application trusts the `X-Forwarded-For`
+	 * header for client IP extraction (used by rate limiting). Only enable this
+	 * when the app is deployed behind a trusted reverse proxy that strips or
+	 * rewrites forwarded headers. Defaults to false (untrusted) to prevent IP
+	 * spoofing attacks.
+	 */
+	TRUST_PROXY: z.string().optional(),
+	USE_GRAPHQL_ANALYTICS: z.string().optional(),
+	DEV_HEALTH_TEST_MODE: z.string().optional(),
+	DEMO_EXPORT: z.string().optional(),
+	NEXT_PUBLIC_USE_GRAPHQL_ANALYTICS: z.string().optional(),
+	NEXT_PUBLIC_DOCS_URL: z.string().optional(),
+	NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: z.string().optional(),
+	NEXT_PUBLIC_DEMO_MODE: z.string().optional(),
+	NEXT_PUBLIC_BETA: z.string().optional(),
+	NEXT_PUBLIC_RUM_ENDPOINT: z.string().optional(),
+	NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
 });
 
 export type ServerEnv = z.infer<typeof serverEnvSchema>;
@@ -117,41 +120,42 @@ export type ServerEnv = z.infer<typeof serverEnvSchema>;
  * called from a client bundle as a defensive guard.
  */
 export function getServerEnv(): ServerEnv {
-    // Allow the call when running under a Node-based test runner even if the
-    // environment has stubbed a `window` (jsdom/happy-dom). The bundle-guard
-    // is about preventing accidental inclusion in *client* bundles, not about
-    // blocking server-side tests.
-    const inNodeTest =
-        typeof process !== "undefined" &&
-        // Indirect access via globalThis prevents Next.js's Edge-runtime
-        // static analyzer from flagging the Node-only `process.versions`
-        // token. The check correctly evaluates to `false` in Edge runtime,
-        // which is the desired semantics (Edge is never a Node test runner).
-        !!(globalThis as { process?: { versions?: { node?: string } } }).process?.versions?.node &&
-        (process.env.VITEST === "true" ||
-            process.env.NODE_ENV === "test" ||
-            typeof (globalThis as { jest?: unknown }).jest !== "undefined");
+	// Allow the call when running under a Node-based test runner even if the
+	// environment has stubbed a `window` (jsdom/happy-dom). The bundle-guard
+	// is about preventing accidental inclusion in *client* bundles, not about
+	// blocking server-side tests.
+	const inNodeTest =
+		typeof process !== "undefined" &&
+		// Indirect access via globalThis prevents Next.js's Edge-runtime
+		// static analyzer from flagging the Node-only `process.versions`
+		// token. The check correctly evaluates to `false` in Edge runtime,
+		// which is the desired semantics (Edge is never a Node test runner).
+		!!(globalThis as { process?: { versions?: { node?: string } } }).process
+			?.versions?.node &&
+		(process.env.VITEST === "true" ||
+			process.env.NODE_ENV === "test" ||
+			typeof (globalThis as { jest?: unknown }).jest !== "undefined");
 
-    if (typeof window !== "undefined" && !inNodeTest) {
-        throw new Error(ValidationErrors.ServerEnvCalledFromClientBundle);
-    }
-    return serverEnvSchema.parse(process.env);
+	if (typeof window !== "undefined" && !inNodeTest) {
+		throw new Error(ValidationErrors.ServerEnvCalledFromClientBundle);
+	}
+	return serverEnvSchema.parse(process.env);
 }
 
 export const isServer = typeof window === "undefined";
 export const isBrowser = !isServer;
 
 export const config = {
-    api: {
-        baseUrl: "",
-        get docsUrl(): string {
-            // Lazy getter to avoid a top-level import cycle with runtimeConfig.
-            // The runtimeConfig module itself depends on this file for
-            // `getServerEnv`, so we must not eagerly import it at module load.
-            const { runtimeConfig } =
-                // eslint-disable-next-line @typescript-eslint/no-require-imports
-                require("@/lib/runtimeConfig") as typeof import("@/lib/runtimeConfig");
-            return runtimeConfig.docsUrl();
-        },
-    },
+	api: {
+		baseUrl: "",
+		get docsUrl(): string {
+			// Lazy getter to avoid a top-level import cycle with runtimeConfig.
+			// The runtimeConfig module itself depends on this file for
+			// `getServerEnv`, so we must not eagerly import it at module load.
+			const { runtimeConfig } =
+				// eslint-disable-next-line @typescript-eslint/no-require-imports
+				require("@/lib/runtimeConfig") as typeof import("@/lib/runtimeConfig");
+			return runtimeConfig.docsUrl();
+		},
+	},
 };


### PR DESCRIPTION
## Summary
- use `AUTH_URL`/`NEXTAUTH_URL` as the canonical public origin for GitHub App callback result redirects
- gate `X-Forwarded-Host` / `X-Forwarded-Proto` fallback behind `TRUST_PROXY=true` or `1`
- add regression coverage for callback success redirects and install error redirects using neutral test hosts

## Verification
- `pnpm exec vitest run --project components 'src/app/(app)/org/admin/integrations/github-app/callback/route.test.tsx' 'src/app/(app)/org/admin/integrations/github-app/install/route.test.tsx'`

SCREENSHOT-WAIVER: Route-handler redirect behavior only; no rendered UI changed.
