### PR TITLE
fix(auth): add jittered backoff to /auth/refresh path (CHAOS-2485)

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -225,6 +225,9 @@ describe("jwt callback — token lifecycle", () => {
 
     type JwtCallback = (params: JwtCallbackParams) => Promise<Record<string, unknown>>;
 
+    const REFRESH_BACKOFF_BASE = 60 * 1000;
+    const REFRESH_BACKOFF_FLOOR = 5 * 1000;
+
     interface NextAuthCallbacks {
         jwt?: JwtCallback;
     }
@@ -238,6 +241,17 @@ describe("jwt callback — token lifecycle", () => {
         const jwt = config?.callbacks?.jwt;
         if (!jwt) throw new Error("JWT callback not captured from NextAuth config");
         return jwt;
+    }
+
+    function refreshDueToken(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+        return {
+            id: "user-1",
+            access_token: "valid-access",
+            refresh_token: "valid-refresh",
+            expires_at: Date.now() - 1000,
+            last_validated: Date.now(),
+            ...overrides,
+        };
     }
 
     afterEach(() => {
@@ -388,6 +402,84 @@ describe("jwt callback — token lifecycle", () => {
         expect(result.refresh_token).toBe(newRefreshToken);
         expect(result.expires_at as number).toBeGreaterThan(Date.now());
         expect(result.error).toBeUndefined();
+    });
+
+    it("(e1) 429 on /auth/refresh preserves refresh_token and backs off instead of retrying every request", async () => {
+        vi.spyOn(Math, "random").mockReturnValue(1.0);
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 429,
+            json: async () => ({ detail: "rate limited" }),
+        } as unknown as Response);
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+        const first = await jwt({
+            token: refreshDueToken(),
+            user: null,
+            account: null,
+        });
+
+        expect(first.access_token).toBeUndefined();
+        expect(first.refresh_token).toBe("valid-refresh");
+        expect(first.error).toBe("refresh_unavailable");
+        expect(first.refresh_failures).toBe(1);
+        const nextRefreshAt = (first.expires_at as number) - 5 * 60 * 1000;
+        expect(nextRefreshAt).toBeGreaterThan(Date.now());
+        expect(nextRefreshAt).toBeLessThanOrEqual(Date.now() + REFRESH_BACKOFF_BASE + 100);
+
+        const second = await jwt({ token: first, user: null, account: null });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(second.refresh_token).toBe("valid-refresh");
+        expect(second.error).toBe("refresh_unavailable");
+    });
+
+    it("(e2) refresh success resets refresh_failures after a transient backoff", async () => {
+        const newAccessToken = "recovered-access-token";
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                access_token: newAccessToken,
+                expires_in: 3600,
+            }),
+        } as unknown as Response);
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+        const result = await jwt({
+            token: refreshDueToken({
+                access_token: undefined,
+                error: "refresh_unavailable",
+                refresh_failures: 3,
+            }),
+            user: null,
+            account: null,
+        });
+
+        expect(result.access_token).toBe(newAccessToken);
+        expect(result.refresh_token).toBe("valid-refresh");
+        expect(result.refresh_failures).toBe(0);
+        expect(result.error).toBeUndefined();
+    });
+
+    it("(e3) network error on /auth/refresh uses the full-jitter floor", async () => {
+        vi.spyOn(Math, "random").mockReturnValue(0.0);
+        const fetchMock = vi.fn().mockRejectedValue(new Error("fetch failed: ECONNREFUSED"));
+        vi.stubGlobal("fetch", fetchMock);
+
+        const jwt = getJwtCallback();
+        const result = await jwt({
+            token: refreshDueToken(),
+            user: null,
+            account: null,
+        });
+
+        const nextRefreshAt = (result.expires_at as number) - 5 * 60 * 1000;
+        const delay = nextRefreshAt - Date.now();
+        expect(result.refresh_failures).toBe(1);
+        expect(delay).toBeGreaterThanOrEqual(REFRESH_BACKOFF_FLOOR - 100);
+        expect(delay).toBeLessThanOrEqual(REFRESH_BACKOFF_FLOOR + 100);
     });
 
     // CHAOS-2232 / CHAOS-2458: periodic /auth/validate backoff — a 429/5xx/network failure must

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -261,6 +261,12 @@ const nextAuth = NextAuth({
             const tokenExpired = expiresAt && now > expiresAt - 5 * 60 * 1000;
 
             // Step 1: Refresh expired tokens first (before validation).
+            // On a failed refresh attempt (429/5xx/network), use the same
+            // full-jitter exponential backoff shape as validation so repeated
+            // failures across tabs/instances don't hammer the backend limiter.
+            const REFRESH_BACKOFF_BASE = 60 * 1000; // 60 s
+            const REFRESH_BACKOFF_CAP = 15 * 60 * 1000; // 15 min
+            const REFRESH_BACKOFF_FLOOR = 5 * 1000; // 5 s minimum so next attempt isn't immediate
             if (tokenExpired && token.refresh_token) {
                 try {
                     const backendUrl = getBackendUrl();
@@ -277,11 +283,12 @@ const nextAuth = NextAuth({
                         // an already-rotated refresh_token and receive a 401. The ?? fallback below
                         // preserves the most recently issued token if data.refresh_token is absent,
                         // but a brief window exists between concurrent rotations.
-                        // A backend refresh-idempotency or grace-period mechanism is needed for a
-                        // full fix; this is tracked in a follow-up issue.
+                        // Backend refresh grace shipped in CHAOS-2162 (PR #827); keep the client-side
+                        // fallback so older/mixed backend deployments remain safe during rollouts.
                         token.refresh_token = data.refresh_token ?? token.refresh_token;
                         token.expires_at = now + (data.expires_in || 3600) * 1000;
                         token.last_validated = now;
+                        token.refresh_failures = 0;
                         token.error = undefined;
                         if (data.user) {
                             token.id = data.user.id;
@@ -296,18 +303,39 @@ const nextAuth = NextAuth({
                         token.error = "refresh_failed";
                         return token;
                     } else {
-                        // Transient/5xx error — revoke access_token to prevent exposing an expired
-                        // bearer token, but keep refresh_token so the next JWT callback can retry
-                        // (self-healing). expires_at is left unchanged so tokenExpired stays true.
+                        // 429/5xx/transient error — revoke access_token to prevent exposing an
+                        // expired bearer token, but keep refresh_token so a later JWT callback can
+                        // retry after full jittered exponential backoff (self-healing).
                         token.access_token = undefined;
+                        const failures = ((token.refresh_failures as number | undefined) ?? 0) + 1;
+                        token.refresh_failures = failures;
+                        const cappedDelay = Math.min(
+                            REFRESH_BACKOFF_CAP,
+                            REFRESH_BACKOFF_BASE * Math.pow(2, failures - 1),
+                        );
+                        // Full jitter: spread across [floor, cappedDelay]
+                        const jitteredDelay =
+                            REFRESH_BACKOFF_FLOOR +
+                            Math.random() * (cappedDelay - REFRESH_BACKOFF_FLOOR);
+                        token.expires_at = now + 5 * 60 * 1000 + jitteredDelay;
                         token.error = "refresh_unavailable";
                         return token;
                     }
                 } catch {
                     // Network error — revoke access_token to prevent exposing an expired bearer
-                    // token, but keep refresh_token so the next JWT callback can retry (self-healing).
-                    // expires_at is left unchanged so tokenExpired stays true on the next call.
+                    // token, but keep refresh_token so a later JWT callback can retry after backoff.
                     token.access_token = undefined;
+                    const failures = ((token.refresh_failures as number | undefined) ?? 0) + 1;
+                    token.refresh_failures = failures;
+                    const cappedDelay = Math.min(
+                        REFRESH_BACKOFF_CAP,
+                        REFRESH_BACKOFF_BASE * Math.pow(2, failures - 1),
+                    );
+                    // Full jitter: spread across [floor, cappedDelay]
+                    const jitteredDelay =
+                        REFRESH_BACKOFF_FLOOR +
+                        Math.random() * (cappedDelay - REFRESH_BACKOFF_FLOOR);
+                    token.expires_at = now + 5 * 60 * 1000 + jitteredDelay;
                     token.error = "refresh_unavailable";
                     return token;
                 }


### PR DESCRIPTION
## Summary
- Added full-jitter exponential backoff to the `/api/v1/auth/refresh` JWT path for 429, 5xx, and network failures.
- Track `refresh_failures` across retries and reset it on successful refresh.
- Updated the refresh-token rotation comment to reference merged CHAOS-2162 / PR #827.

## Tests
- `pnpm exec prettier --check src/lib/auth.ts src/lib/__tests__/auth.test.ts`
- `pnpm exec eslint src/lib/auth.ts src/lib/__tests__/auth.test.ts`
- `pnpm exec vitest run src/lib/__tests__/auth.test.ts`
- `pnpm exec tsc --noEmit`

SCREENSHOT-WAIVER: auth token-refresh backoff logic, no rendered UI change

Closes CHAOS-2485