### PR TITLE
feat(admin): auto-import teams/projects/members toggle in sync config (CHAOS-2543)

### DIFF
--- a/src/components/admin/sync/SyncConfigForm.test.tsx
+++ b/src/components/admin/sync/SyncConfigForm.test.tsx
@@ -177,7 +177,7 @@ describe("SyncConfigForm", () => {
                 schedule_cron: null,
                 timezone: null,
                 initial_sync_depth: 30,
-                sync_options: {},
+                sync_options: { auto_import_teams: false },
             });
             expect(screen.getByText("Config created")).toBeInTheDocument();
             expect(mockPush).toHaveBeenCalledWith("/org/admin/sync");
@@ -250,7 +250,7 @@ describe("SyncConfigForm", () => {
                     schedule_cron: null,
                     timezone: null,
                     initial_sync_depth: 30,
-                    sync_options: { owner: "myorg" },
+                    sync_options: { owner: "myorg", auto_import_teams: false },
                 });
             });
         });
@@ -278,6 +278,7 @@ describe("SyncConfigForm", () => {
                     sync_options: {
                         owner: "glorg",
                         gitlab_url: "https://gitlab.example.com",
+                        auto_import_teams: false,
                     },
                 });
             });
@@ -358,7 +359,11 @@ describe("SyncConfigForm", () => {
                     schedule_cron: null,
                     timezone: null,
                     initial_sync_depth: 30,
-                    sync_options: { owner: "neworg", repo: "oldrepo" },
+                    sync_options: {
+                        owner: "neworg",
+                        repo: "oldrepo",
+                        auto_import_teams: false,
+                    },
                 });
             });
         });
@@ -493,7 +498,11 @@ describe("SyncConfigForm", () => {
                     initial_sync_depth: 0,
                     // Stale schedule keys must NOT ride along inside sync_options —
                     // they previously resurrected the old schedule on the backend.
-                    sync_options: { owner: "full-chaos", search: "full-chaos/*" },
+                    sync_options: {
+                        owner: "full-chaos",
+                        search: "full-chaos/*",
+                        auto_import_teams: false,
+                    },
                 });
             });
         });
@@ -558,7 +567,11 @@ describe("SyncConfigForm", () => {
                     schedule_cron: null,
                     timezone: null,
                     initial_sync_depth: 30,
-                    sync_options: { all_repos: true, owner: "myorg" },
+                    sync_options: {
+                        all_repos: true,
+                        owner: "myorg",
+                        auto_import_teams: false,
+                    },
                 });
             });
             expect(mockBatchCreateSyncConfigs).not.toHaveBeenCalled();
@@ -584,7 +597,7 @@ describe("SyncConfigForm", () => {
                     schedule_cron: null,
                     timezone: null,
                     initial_sync_depth: 30,
-                    sync_options: { all_repos: true },
+                    sync_options: { all_repos: true, auto_import_teams: false },
                 });
             });
             expect(mockBatchCreateSyncConfigs).not.toHaveBeenCalled();
@@ -645,11 +658,98 @@ describe("SyncConfigForm", () => {
                     schedule_cron: null,
                     timezone: null,
                     initial_sync_depth: 30,
-                    sync_options: { owner: "myorg" },
+                    sync_options: { owner: "myorg", auto_import_teams: false },
                     repos: ["repo-a"],
                 });
             });
             expect(mockCreateSyncConfig).not.toHaveBeenCalled();
+        });
+
+        it("includes auto_import_teams=true in sync_options when toggled on (create)", async () => {
+            mockCreateSyncConfig.mockResolvedValue(undefined);
+            renderWithToaster(<SyncConfigForm credentials={mockCredentials} />);
+
+            await userEvent.type(screen.getByLabelText("Configuration Name"), "Team Sync");
+            await userEvent.selectOptions(screen.getByLabelText("Credential"), "cred-1");
+            await userEvent.click(screen.getByLabelText("Auto-import teams, projects & members"));
+            await userEvent.click(screen.getByRole("button", { name: "Create Configuration" }));
+
+            await waitFor(() => {
+                expect(mockCreateSyncConfig).toHaveBeenCalledWith({
+                    name: "Team Sync",
+                    provider: "github",
+                    credential_id: "cred-1",
+                    sync_targets: [],
+                    schedule_cron: null,
+                    timezone: null,
+                    initial_sync_depth: 30,
+                    sync_options: { auto_import_teams: true },
+                });
+            });
+        });
+
+        it("round-trips auto_import_teams and preserves other sync_options on update", async () => {
+            mockUpdateSyncConfig.mockResolvedValue(undefined);
+            const initialData: SyncConfig = {
+                id: "cfg-ai",
+                name: "Existing Config",
+                provider: "github",
+                credential_id: "cred-1",
+                sync_targets: ["git"],
+                sync_options: {
+                    owner: "myorg",
+                    search: "myorg/*",
+                    auto_import_teams: true,
+                },
+                is_active: true,
+                schedule_cron: null,
+                timezone: null,
+                initial_sync_depth: null,
+                last_sync_at: null,
+                last_sync_success: null,
+                last_sync_error: null,
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+                parent_id: null,
+            };
+
+            renderWithToaster(
+                <SyncConfigForm initialData={initialData} credentials={mockCredentials} />,
+            );
+
+            const toggle = screen.getByLabelText("Auto-import teams, projects & members");
+            expect(toggle).toBeChecked();
+            await userEvent.click(toggle); // turn off
+            await userEvent.click(screen.getByRole("button", { name: "Update Configuration" }));
+
+            await waitFor(() => {
+                expect(mockUpdateSyncConfig).toHaveBeenCalledWith("cfg-ai", {
+                    sync_targets: ["git"],
+                    is_active: true,
+                    schedule_cron: null,
+                    timezone: null,
+                    initial_sync_depth: 30,
+                    sync_options: {
+                        owner: "myorg",
+                        search: "myorg/*",
+                        auto_import_teams: false,
+                    },
+                });
+            });
+        });
+
+        it("hides auto-import toggle for launchdarkly provider", async () => {
+            render(<SyncConfigForm credentials={mockCredentials} />);
+
+            expect(
+                screen.getByLabelText("Auto-import teams, projects & members"),
+            ).toBeInTheDocument();
+
+            await userEvent.selectOptions(screen.getByLabelText("Provider"), "launchdarkly");
+
+            expect(
+                screen.queryByLabelText("Auto-import teams, projects & members"),
+            ).not.toBeInTheDocument();
         });
     });
 });

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -44,6 +44,11 @@ const ALL_SYNC_TARGETS = [
     { id: "feature-flags", label: "Feature Flags" },
 ];
 
+// Providers where work-item / team attribution applies, so auto-importing
+// teams, projects & members is meaningful. Pure feature-flag providers
+// (e.g. launchdarkly) and pure-git/local sources are excluded.
+const AUTO_IMPORT_PROVIDERS = ["github", "gitlab", "jira", "linear"];
+
 function getSyncTargetsForProvider(provider: string) {
     const allowed =
         PROVIDER_SYNC_TARGETS[provider as Provider] ?? Object.values(PROVIDER_SYNC_TARGETS).flat();
@@ -83,6 +88,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
         owner: (initialData?.sync_options?.owner as string) || "",
         repos: [] as string[],
         gitlab_url: (initialData?.sync_options?.gitlab_url as string) || "",
+        auto_import_teams: (initialData?.sync_options?.auto_import_teams as boolean) ?? false,
     });
 
     useEffect(() => {
@@ -154,8 +160,23 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
         if (formData.provider === "gitlab" && formData.gitlab_url) {
             opts.gitlab_url = formData.gitlab_url;
         }
+        // Auto-import teams/projects/members is only meaningful for providers
+        // with work-item/team attribution. Persist the explicit boolean for
+        // those, and strip any stale flag when switched to an unsupported
+        // provider so it never rides along inappropriately.
+        if (AUTO_IMPORT_PROVIDERS.includes(formData.provider)) {
+            opts.auto_import_teams = formData.auto_import_teams;
+        } else {
+            delete opts.auto_import_teams;
+        }
         return opts;
-    }, [initialData, formData.owner, formData.provider, formData.gitlab_url]);
+    }, [
+        initialData,
+        formData.owner,
+        formData.provider,
+        formData.gitlab_url,
+        formData.auto_import_teams,
+    ]);
 
     const handleSubmit = useCallback(
         (e: SyntheticEvent<HTMLFormElement>) => {
@@ -484,6 +505,34 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                         ))}
                     </div>
                 </div>
+
+                {/* Auto-import teams, projects & members */}
+                {AUTO_IMPORT_PROVIDERS.includes(formData.provider) && (
+                    <div className="space-y-1.5">
+                        <div className="flex items-center gap-2">
+                            <input
+                                type="checkbox"
+                                id="auto_import_teams"
+                                name="auto_import_teams"
+                                checked={formData.auto_import_teams}
+                                onChange={(e) =>
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        auto_import_teams: e.target.checked,
+                                    }))
+                                }
+                                className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
+                            />
+                            <label htmlFor="auto_import_teams" className="text-sm font-medium">
+                                Auto-import teams, projects &amp; members
+                            </label>
+                        </div>
+                        <p className="text-xs text-(--ink-muted)">
+                            Discover and import teams, projects, and members from this provider
+                            during sync to populate ownership and attribution.
+                        </p>
+                    </div>
+                )}
 
                 {/* Initial Sync Depth */}
                 <div className="space-y-3">


### PR DESCRIPTION
## Summary

Adds an **"Auto-import teams, projects & members"** toggle to the sync-config UX so users can enable `sync_options.auto_import_teams`. The backend (Stream A + B/C of CHAOS-2401) honors this flag during sync to populate team/project/member ownership dimensions; this toggle is the only way users enable it.

## Changes

- **`src/components/admin/sync/SyncConfigForm.tsx`**
  - New `AUTO_IMPORT_PROVIDERS = ["github", "gitlab", "jira", "linear"]` — providers where work-item/team attribution applies. The toggle is **hidden** for pure feature-flag providers (launchdarkly) and is not shown for pure-git/local.
  - New `auto_import_teams` form-state field, hydrated from `initialData?.sync_options?.auto_import_teams` (default OFF).
  - `buildSyncOptions()` sets an explicit boolean `sync_options.auto_import_teams` for supported providers and **strips** the key when switched to an unsupported provider. This carries through the **create**, **edit**, and **batch-create** paths (all three build their payload from `buildSyncOptions()`).
  - New checkbox + description rendered after Sync Targets, matching existing form-control styling (Tailwind v4 tokens).
- **`src/components/admin/sync/SyncConfigForm.test.tsx`**
  - Existing payload assertions for supported providers updated to include `auto_import_teams: false`.
  - New tests: create with toggle ON (`auto_import_teams: true`), edit round-trip (pre-checked from `initialData`, toggle off → `false`, other `sync_options` keys preserved), and toggle hidden for `launchdarkly`.

## Preserving existing `sync_options`

`buildSyncOptions()` spreads the carried-over `initialData.sync_options` first, strips the schedule-owned keys (existing behavior), then sets only `auto_import_teams`. Unknown/unrelated keys (e.g. `owner`, `search`, `repo`) are preserved; no stale schedule keys are resurrected.

## Scope

No backend/ops changes — the API already accepts free-form `sync_options`, so persisting the key needs no API change.

## Web gate (all exit 0)

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors; 1 pre-existing unrelated warning)
- `pnpm test:unit` ✅ (229 files, 2163 tests; SyncConfigForm 29 tests)
- `pnpm build` ✅

## Visual evidence

New sync config (`/org/admin/sync/new`), toggle enabled:

![auto-import toggle — new sync config](https://github.com/user-attachments/assets/1ee1d5cf-385a-4938-80f6-57357cbb7f3e)

Existing sync config edit page (Edit Linear), toggle enabled:

![auto-import toggle — edit sync config](https://github.com/user-attachments/assets/5e306da0-bf34-41c3-bda8-ca92e8ef15d7)

Closes CHAOS-2543