### PR TITLE
feat(admin): BYO-LLM "AI Setup" org-admin page + nav (CHAOS-2559)

### DIFF
--- a/src/app/(app)/org/admin/ai/page.tsx
+++ b/src/app/(app)/org/admin/ai/page.tsx
@@ -1,0 +1,18 @@
+import { ByoLlmSettings } from "@/components/admin/llm/ByoLlmSettings";
+import { getLLMSettings, upsertLLMSettings, deleteLLMSettings } from "@/lib/admin/server";
+
+// Bring Your Own LLM (BYO-LLM) org-admin settings page. Sits inside
+// (app)/org/admin so it inherits the AdminSidebar + AdminTierProvider and the
+// requireRole(["admin","owner"]) guard from the admin layout. The page is a thin
+// server component that injects the real server actions into the client form;
+// tier/flag gating (402/403) is enforced server-side and surfaced as a locked
+// state by the form itself.
+export default function ByoLlmAdminPage() {
+    return (
+        <ByoLlmSettings
+            loadSettingsAction={getLLMSettings}
+            saveSettingsAction={upsertLLMSettings}
+            removeSettingsAction={deleteLLMSettings}
+        />
+    );
+}

--- a/src/components/admin/AdminSidebar.test.tsx
+++ b/src/components/admin/AdminSidebar.test.tsx
@@ -66,12 +66,14 @@ describe("AdminSidebar", () => {
                     audit_log: true,
                     ip_allowlist: false,
                     custom_retention: true,
+                    byo_llm: true,
                 }}
             />,
         );
 
         expect(screen.getByRole("link", { name: /audit logsenterprise/i })).toBeInTheDocument();
         expect(screen.getByRole("link", { name: /retentioncompliance/i })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /ai setupllm/i })).toBeInTheDocument();
         expect(
             screen.queryByRole("link", { name: /ip allowlistsecurity/i }),
         ).not.toBeInTheDocument();

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -13,8 +13,18 @@ type NavItem = {
 };
 
 const navItems: NavItem[] = [
-    { id: "dashboard", label: "Dashboard", href: "/org/admin", description: "Overview" },
-    { id: "users", label: "Users", href: "/org/admin/users", description: "Management" },
+    {
+        id: "dashboard",
+        label: "Dashboard",
+        href: "/org/admin",
+        description: "Overview",
+    },
+    {
+        id: "users",
+        label: "Users",
+        href: "/org/admin/users",
+        description: "Management",
+    },
     {
         id: "organization",
         label: "Organization",
@@ -27,8 +37,18 @@ const navItems: NavItem[] = [
         href: "/org/admin/integrations",
         description: "Connectors",
     },
-    { id: "sync", label: "Sync Status", href: "/org/admin/sync", description: "Jobs" },
-    { id: "teams", label: "Teams", href: "/org/admin/teams", description: "Identity" },
+    {
+        id: "sync",
+        label: "Sync Status",
+        href: "/org/admin/sync",
+        description: "Jobs",
+    },
+    {
+        id: "teams",
+        label: "Teams",
+        href: "/org/admin/teams",
+        description: "Identity",
+    },
     {
         id: "identities",
         label: "Identities",
@@ -56,6 +76,13 @@ const navItems: NavItem[] = [
         description: "Compliance",
         featureKey: "custom_retention",
     },
+    {
+        id: "byo-llm",
+        label: "AI Setup",
+        href: "/org/admin/ai",
+        description: "LLM",
+        featureKey: "byo_llm",
+    },
 ];
 
 type AdminSidebarProps = {
@@ -77,7 +104,7 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
     });
 
     return (
-        <aside className="w-full md:max-w-[220px] md:shrink-0">
+        <aside className="w-full md:max-w-56 md:shrink-0">
             <div className="md:sticky md:top-6">
                 <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-5">
                     <div>
@@ -86,7 +113,7 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                         </p>
                         <p className="mt-3 font-(--font-display) text-lg">Admin</p>
                         {isSuperuser && (
-                            <span className="mt-1 inline-flex items-center rounded-full bg-purple-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-widest text-purple-500">
+                            <span className="mt-1 inline-flex items-center rounded-full bg-purple-500/10 px-2 py-0.5 text-label-caps font-medium uppercase text-purple-500">
                                 Platform Admin
                             </span>
                         )}
@@ -112,7 +139,7 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                                 >
                                     <span className="font-medium">{item.label}</span>
                                     <span
-                                        className={`text-[10px] uppercase tracking-widest ${
+                                        className={`text-label-caps uppercase ${
                                             isActive ? "text-(--accent)" : "text-(--ink-muted)"
                                         }`}
                                     >
@@ -127,9 +154,7 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                                 className="group flex items-center justify-between rounded-2xl border border-purple-500/20 bg-purple-500/10 px-3 py-2 text-purple-400 hover:bg-purple-500/20 transition"
                             >
                                 <span className="font-medium">Platform Admin</span>
-                                <span className="text-[10px] uppercase tracking-widest">
-                                    Global
-                                </span>
+                                <span className="text-label-caps uppercase">Global</span>
                             </Link>
                         )}
                     </nav>

--- a/src/components/admin/llm/ByoLlmSettings.test.tsx
+++ b/src/components/admin/llm/ByoLlmSettings.test.tsx
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithToaster, screen, userEvent, waitFor } from "@/test/utils";
+
+vi.mock("next/link", () => ({
+    default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+import { ByoLlmSettings, type ByoLlmSettingsProps } from "./ByoLlmSettings";
+
+const mockLoad = vi.fn<ByoLlmSettingsProps["loadSettingsAction"]>();
+const mockSave = vi.fn<ByoLlmSettingsProps["saveSettingsAction"]>();
+const mockRemove = vi.fn<ByoLlmSettingsProps["removeSettingsAction"]>();
+
+function renderForm() {
+    return renderWithToaster(
+        <ByoLlmSettings
+            loadSettingsAction={mockLoad}
+            saveSettingsAction={mockSave}
+            removeSettingsAction={mockRemove}
+        />,
+    );
+}
+
+describe("ByoLlmSettings", () => {
+    beforeEach(() => {
+        mockLoad.mockReset();
+        mockSave.mockReset();
+        mockRemove.mockReset();
+    });
+
+    it("renders the form with a Not configured status for an empty config", async () => {
+        mockLoad.mockResolvedValue({ data: {} });
+        renderForm();
+
+        expect(await screen.findByText("Not configured")).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "AI Setup" })).toBeInTheDocument();
+        expect(screen.getByLabelText("Provider")).toBeInTheDocument();
+        expect(screen.getByLabelText("API Key")).toBeInTheDocument();
+    });
+
+    it("hydrates fields and shows Saved when settings are persisted", async () => {
+        mockLoad.mockResolvedValue({
+            data: {
+                provider: "anthropic",
+                model: "claude-3-5-sonnet",
+                api_key: "sk-1…last",
+                base_url: "https://example.test",
+            },
+        });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        expect(screen.getByText("Saved")).toBeInTheDocument();
+        expect(screen.getByLabelText<HTMLSelectElement>("Provider").value).toBe("anthropic");
+        expect(screen.getByLabelText<HTMLInputElement>("Model").value).toBe("claude-3-5-sonnet");
+        expect(screen.getByLabelText<HTMLInputElement>("Base URL").value).toBe(
+            "https://example.test",
+        );
+    });
+
+    it("blocks saving until settings load successfully after a retry", async () => {
+        mockLoad
+            .mockResolvedValueOnce({
+                error: "temporary backend failure",
+                status: 500,
+            })
+            .mockResolvedValueOnce({ data: { provider: "openai" } });
+        renderForm();
+
+        expect(await screen.findByText("temporary backend failure")).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+        expect(screen.queryByLabelText("Provider")).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+        expect(await screen.findByText("Saved")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+        expect(mockLoad).toHaveBeenCalledTimes(2);
+        expect(mockSave).not.toHaveBeenCalled();
+    });
+
+    it("renders a locked upsell state when the backend returns 402", async () => {
+        mockLoad.mockResolvedValue({
+            error: "This feature requires the Team plan.",
+            status: 402,
+        });
+        renderForm();
+
+        expect(await screen.findByText("BYO-LLM is locked")).toBeInTheDocument();
+        expect(screen.getByText("This feature requires the Team plan.")).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /Upgrade to Team/ })).toBeInTheDocument();
+        expect(screen.queryByLabelText("Provider")).not.toBeInTheDocument();
+    });
+
+    it("renders a locked state without an upgrade link when the flag is off (403)", async () => {
+        mockLoad.mockResolvedValue({
+            error: "BYO LLM is not enabled for this organization",
+            status: 403,
+        });
+        renderForm();
+
+        expect(await screen.findByText("BYO-LLM is locked")).toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: /Upgrade to Team/ })).not.toBeInTheDocument();
+    });
+
+    it("submits the upsert payload and shows a success toast", async () => {
+        mockLoad.mockResolvedValue({ data: {} });
+        mockSave.mockResolvedValue({
+            data: { provider: "openai", model: "gpt-4o" },
+        });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        await userEvent.type(screen.getByLabelText("Model"), "gpt-4o");
+        await userEvent.type(screen.getByLabelText("API Key"), "sk-secret");
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(mockSave).toHaveBeenCalledWith(
+            expect.objectContaining({
+                provider: "openai",
+                model: "gpt-4o",
+                api_key: "sk-secret",
+            }),
+        );
+        await waitFor(() => {
+            expect(screen.getByText("BYO-LLM settings saved.")).toBeInTheDocument();
+        });
+    });
+
+    it("surfaces a 400 base_url validation error inline", async () => {
+        mockLoad.mockResolvedValue({ data: { provider: "openai" } });
+        mockSave.mockResolvedValue({ error: "invalid_base_url", status: 400 });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        await userEvent.type(screen.getByLabelText("Base URL"), "not-a-url");
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() => {
+            expect(screen.getByText("invalid_base_url")).toBeInTheDocument();
+        });
+    });
+
+    it("requires a confirmation click before deleting", async () => {
+        mockLoad.mockResolvedValue({
+            data: { provider: "openai", api_key: "sk-1…last" },
+        });
+        mockRemove.mockResolvedValue({ data: { deleted: true } });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+        expect(mockRemove).not.toHaveBeenCalled();
+
+        await userEvent.click(screen.getByRole("button", { name: "Confirm delete?" }));
+        expect(mockRemove).toHaveBeenCalledTimes(1);
+        await waitFor(() => {
+            expect(screen.getByText("BYO-LLM settings removed.")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/admin/llm/ByoLlmSettings.tsx
+++ b/src/components/admin/llm/ByoLlmSettings.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { CTA_LABELS } from "@/lib/design/cta";
+import {
+    LLM_PROVIDERS,
+    LLM_PROVIDER_LABELS,
+    type LLMProvider,
+    type LLMSettingsActionResult,
+    type LLMSettingsResponse,
+    type LLMSettingsUpsert,
+} from "@/lib/admin/types";
+
+const DEFAULT_PROVIDER: LLMProvider = "openai";
+const BYO_REQUIRED_TIER_LABEL = "Team";
+
+type LockState = {
+    reason: "not_licensed" | "not_enabled";
+    message: string;
+} | null;
+
+export type ByoLlmSettingsProps = {
+    loadSettingsAction: () => Promise<LLMSettingsActionResult<LLMSettingsResponse>>;
+    saveSettingsAction: (
+        data: LLMSettingsUpsert,
+    ) => Promise<LLMSettingsActionResult<LLMSettingsResponse>>;
+    removeSettingsAction: () => Promise<LLMSettingsActionResult<{ deleted: boolean }>>;
+};
+
+const inputClass =
+    "w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none";
+const labelClass = "mb-1 block text-xs font-medium uppercase tracking-wide text-(--ink-muted)";
+const captionClass = "mt-1 text-xs text-(--ink-muted)";
+
+export function ByoLlmSettings({
+    loadSettingsAction,
+    saveSettingsAction,
+    removeSettingsAction,
+}: ByoLlmSettingsProps) {
+    const [loading, setLoading] = useState(true);
+    const [locked, setLocked] = useState<LockState>(null);
+    const [loadError, setLoadError] = useState<string | null>(null);
+
+    const [provider, setProvider] = useState<string>(DEFAULT_PROVIDER);
+    const [model, setModel] = useState("");
+    const [apiKey, setApiKey] = useState("");
+    const [baseUrl, setBaseUrl] = useState("");
+    const [hasStoredKey, setHasStoredKey] = useState(false);
+    const [maskedKey, setMaskedKey] = useState<string | null>(null);
+    const [hasSavedSettings, setHasSavedSettings] = useState(false);
+
+    const [saving, setSaving] = useState(false);
+    const [deleting, setDeleting] = useState(false);
+    const [confirmingDelete, setConfirmingDelete] = useState(false);
+    const [baseUrlError, setBaseUrlError] = useState<string | null>(null);
+    const [formError, setFormError] = useState<string | null>(null);
+
+    const applySettings = useCallback((data: LLMSettingsResponse) => {
+        setProvider(data.provider ?? DEFAULT_PROVIDER);
+        setModel(data.model ?? "");
+        setBaseUrl(data.base_url ?? "");
+        setMaskedKey(data.api_key ?? null);
+        setHasStoredKey(Boolean(data.api_key));
+        // TODO(CHAOS-2560): replace Saved/Not configured with backend validity-driven routing states.
+        setHasSavedSettings(Boolean(data.provider));
+        setApiKey("");
+    }, []);
+
+    const fetchSettings = useCallback(async () => {
+        setLoading(true);
+        setLoadError(null);
+        setLocked(null);
+        const result = await loadSettingsAction();
+        if (result.status === 402) {
+            setLocked({
+                reason: "not_licensed",
+                message:
+                    result.error ?? "BYO-LLM requires Team tier or higher for this organization.",
+            });
+        } else if (result.status === 403) {
+            setLocked({
+                reason: "not_enabled",
+                message: result.error ?? "BYO-LLM is not enabled for this organization.",
+            });
+        } else if (result.error) {
+            setLoadError(result.error);
+        } else if (result.data) {
+            applySettings(result.data);
+        }
+        setLoading(false);
+    }, [loadSettingsAction, applySettings]);
+
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- fetchSettings coordinates async loading state after mount.
+        fetchSettings();
+    }, [fetchSettings]);
+
+    const handleSave = async () => {
+        if (!provider.trim()) {
+            setFormError("Select a provider before saving.");
+            return;
+        }
+        setSaving(true);
+        setFormError(null);
+        setBaseUrlError(null);
+        const payload: LLMSettingsUpsert = {
+            provider: provider.trim(),
+            model: model.trim() ? model.trim() : null,
+            base_url: baseUrl.trim() ? baseUrl.trim() : null,
+        };
+        // Only send the api_key when the admin actually typed a new one; leaving
+        // it blank preserves the previously-stored (masked) key server-side.
+        if (apiKey.trim()) {
+            payload.api_key = apiKey.trim();
+        }
+        const result = await saveSettingsAction(payload);
+        setSaving(false);
+        if (result.status === 400) {
+            setBaseUrlError(result.error ?? "The base URL is invalid.");
+            toast.error("Could not save BYO-LLM settings.");
+            return;
+        }
+        if (result.error) {
+            setFormError(result.error);
+            toast.error("Could not save BYO-LLM settings.");
+            return;
+        }
+        if (result.data) {
+            applySettings(result.data);
+        }
+        toast.success("BYO-LLM settings saved.");
+    };
+
+    const handleDelete = async () => {
+        if (!confirmingDelete) {
+            setConfirmingDelete(true);
+            return;
+        }
+        setDeleting(true);
+        setFormError(null);
+        const result = await removeSettingsAction();
+        setDeleting(false);
+        setConfirmingDelete(false);
+        if (result.error && result.status !== 404) {
+            setFormError(result.error);
+            toast.error("Could not remove BYO-LLM settings.");
+            return;
+        }
+        setProvider(DEFAULT_PROVIDER);
+        setModel("");
+        setBaseUrl("");
+        setApiKey("");
+        setMaskedKey(null);
+        setHasStoredKey(false);
+        setHasSavedSettings(false);
+        toast.success("BYO-LLM settings removed.");
+    };
+
+    const eyebrow = (
+        <p className="text-xs font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
+            Organization Settings
+        </p>
+    );
+
+    if (loading) {
+        return (
+            <div>
+                {eyebrow}
+                <h1 className="mt-2 font-(--font-display) text-2xl font-bold">AI Setup</h1>
+                <div className="mt-8 py-12 text-center text-(--ink-muted)">Loading AI setup...</div>
+            </div>
+        );
+    }
+
+    if (locked) {
+        return (
+            <div>
+                {eyebrow}
+                <h1 className="mt-2 mb-6 font-(--font-display) text-2xl font-bold">AI Setup</h1>
+                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center">
+                    <div className="mx-auto max-w-md space-y-4">
+                        <p className="text-xs font-semibold uppercase tracking-wider text-(--accent)">
+                            {locked.reason === "not_licensed"
+                                ? `${BYO_REQUIRED_TIER_LABEL} Plan Feature`
+                                : "Feature Disabled"}
+                        </p>
+                        <h2 className="font-(--font-display) text-2xl text-foreground">
+                            BYO-LLM is locked
+                        </h2>
+                        <p className="text-sm text-(--ink-muted)">{locked.message}</p>
+                        <p className="text-sm text-(--ink-muted)">
+                            BYO-LLM requires Team tier or higher. Keys are encrypted with the org
+                            settings store and masked in all responses.
+                        </p>
+                        {locked.reason === "not_licensed" ? (
+                            <Link
+                                href="/org/admin/settings"
+                                className="inline-flex items-center justify-center rounded-full bg-(--accent) px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-(--accent)/90"
+                            >
+                                {`Upgrade to ${BYO_REQUIRED_TIER_LABEL}`}
+                            </Link>
+                        ) : null}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (loadError) {
+        return (
+            <div>
+                <header className="mb-8">
+                    {eyebrow}
+                    <h1 className="mt-2 font-(--font-display) text-2xl font-bold">AI Setup</h1>
+                </header>
+
+                <div className="rounded-2xl border border-(--negative)/20 bg-(--negative)/10 p-6 text-sm text-(--negative)">
+                    <p>{loadError}</p>
+                    <button
+                        type="button"
+                        onClick={fetchSettings}
+                        className="mt-4 rounded-lg border border-(--negative)/30 bg-(--card-80) px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-(--negative)/50"
+                    >
+                        {CTA_LABELS.retry}
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    const statusBadge = (
+        <span
+            className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${
+                hasSavedSettings
+                    ? "bg-(--positive)/10 text-(--positive)"
+                    : "bg-(--card-70) text-(--ink-muted)"
+            }`}
+        >
+            <span
+                aria-hidden="true"
+                className={`h-2 w-2 rounded-full ${
+                    hasSavedSettings ? "bg-(--positive)" : "bg-(--ink-muted)"
+                }`}
+            />
+            {hasSavedSettings ? "Saved" : "Not configured"}
+        </span>
+    );
+
+    return (
+        <div>
+            <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div>
+                    {eyebrow}
+                    <h1 className="mt-2 font-(--font-display) text-2xl font-bold">AI Setup</h1>
+                    <p className="mt-1 max-w-2xl text-sm text-(--ink-muted)">
+                        Provide your own provider, model, and credentials. Resolution precedence:
+                        per-call kill-switch › org settings › platform default.
+                    </p>
+                </div>
+                <div className="shrink-0">{statusBadge}</div>
+            </header>
+
+            {formError && (
+                <div className="mb-6 rounded-2xl border border-(--negative)/20 bg-(--negative)/10 p-4 text-sm text-(--negative)">
+                    {formError}
+                </div>
+            )}
+
+            <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="grid gap-5 sm:grid-cols-2">
+                    <div>
+                        <label htmlFor="byo-provider" className={labelClass}>
+                            Provider
+                        </label>
+                        <select
+                            id="byo-provider"
+                            value={provider}
+                            onChange={(e) => setProvider(e.target.value)}
+                            className={inputClass}
+                        >
+                            {LLM_PROVIDERS.map((p) => (
+                                <option key={p} value={p}>
+                                    {LLM_PROVIDER_LABELS[p]}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    <div>
+                        <label htmlFor="byo-model" className={labelClass}>
+                            Model
+                        </label>
+                        <input
+                            id="byo-model"
+                            type="text"
+                            value={model}
+                            placeholder="Model name"
+                            onChange={(e) => setModel(e.target.value)}
+                            className={inputClass}
+                        />
+                    </div>
+
+                    <div>
+                        <label htmlFor="byo-api-key" className={labelClass}>
+                            API Key
+                        </label>
+                        <input
+                            id="byo-api-key"
+                            type="password"
+                            autoComplete="off"
+                            value={apiKey}
+                            placeholder={hasStoredKey ? (maskedKey ?? "••••••••") : "sk-..."}
+                            onChange={(e) => setApiKey(e.target.value)}
+                            className={inputClass}
+                        />
+                        <p className={captionClass}>
+                            {hasStoredKey
+                                ? "Encrypted at rest, never returned. Enter a new key to replace the stored key."
+                                : "Encrypted at rest, never returned."}
+                        </p>
+                    </div>
+
+                    <div>
+                        <label htmlFor="byo-base-url" className={labelClass}>
+                            Base URL
+                        </label>
+                        <input
+                            id="byo-base-url"
+                            type="text"
+                            value={baseUrl}
+                            placeholder="https://..."
+                            onChange={(e) => setBaseUrl(e.target.value)}
+                            className={`${inputClass} ${baseUrlError ? "border-(--negative)/60" : ""}`}
+                            aria-invalid={baseUrlError ? true : undefined}
+                        />
+                        {baseUrlError ? (
+                            <p className="mt-1 text-xs text-(--negative)">{baseUrlError}</p>
+                        ) : (
+                            <p className={captionClass}>Optional. OpenAI-compatible endpoints.</p>
+                        )}
+                    </div>
+                </div>
+
+                <div className="mt-6 rounded-xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-xs text-(--ink-muted)">
+                    BYO-LLM requires Team tier or higher. Keys are encrypted with the org settings
+                    store and masked in all responses.
+                </div>
+
+                <div className="mt-6 flex flex-wrap gap-2">
+                    <button
+                        type="button"
+                        onClick={handleSave}
+                        disabled={saving}
+                        className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                    >
+                        {saving ? "Saving…" : CTA_LABELS.save}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleDelete}
+                        disabled={deleting || (!hasSavedSettings && !hasStoredKey)}
+                        className="rounded-lg bg-(--negative)/10 px-4 py-2 text-sm font-medium text-(--negative) disabled:opacity-50"
+                    >
+                        {deleting
+                            ? "Deleting…"
+                            : confirmingDelete
+                              ? CTA_LABELS.confirmDelete
+                              : CTA_LABELS.delete}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/lib/admin/api.ts
+++ b/src/lib/admin/api.ts
@@ -11,6 +11,7 @@ import { licensingApi } from "./api/billing";
 import { auditApi, platformAuditApi } from "./api/audit";
 import { ipAllowlistApi } from "./api/security";
 import { retentionApi } from "./api/retention";
+import { llmSettingsApi } from "./api/llm-settings";
 import { platformApi, impersonationApi } from "./api/platform";
 
 export const adminApi = {
@@ -25,6 +26,7 @@ export const adminApi = {
     audit: auditApi,
     ipAllowlist: ipAllowlistApi,
     retention: retentionApi,
+    llmSettings: llmSettingsApi,
     impersonation: impersonationApi,
     platform: platformApi,
     platformAudit: platformAuditApi,

--- a/src/lib/admin/api/_request.ts
+++ b/src/lib/admin/api/_request.ts
@@ -15,14 +15,18 @@ function formatErrorDetail(raw: unknown): string | undefined {
     if (typeof raw === "string") return raw;
     if (raw == null) return undefined;
     if (typeof raw === "object" && "error" in raw) {
-        const obj = raw as Record<string, string>;
+        const obj = raw as Record<string, unknown>;
         if (obj.error === "feature_not_licensed") {
-            const tier = obj.required_tier || "a higher";
-            return `This feature requires the ${tier} plan (current plan: ${obj.current_tier || "community"}).`;
+            const tier = typeof obj.required_tier === "string" ? obj.required_tier : "a higher";
+            const currentTier =
+                typeof obj.current_tier === "string" ? obj.current_tier : "community";
+            return `This feature requires the ${tier} plan (current plan: ${currentTier}).`;
         }
         if (obj.error === "limit_exceeded") {
-            return `Plan limit reached: ${obj.limit || "resource"} (${obj.current}/${obj.maximum}).`;
+            const limit = typeof obj.limit === "string" ? obj.limit : "resource";
+            return `Plan limit reached: ${limit} (${obj.current}/${obj.maximum}).`;
         }
+        if (typeof obj.message === "string") return obj.message;
     }
     return JSON.stringify(raw);
 }

--- a/src/lib/admin/api/llm-settings.ts
+++ b/src/lib/admin/api/llm-settings.ts
@@ -1,0 +1,21 @@
+import { request } from "./_request";
+import type { LLMSettingsResponse, LLMSettingsUpsert } from "../types";
+
+// Admin BYO-LLM settings endpoints. The backend force-encrypts and masks the
+// api_key, and tier/flag gates GET/PUT (402/403) while always allowing DELETE
+// cleanup. See ops admin/routers/settings.py for the contract.
+export const llmSettingsApi = {
+    get: (token?: string, orgId?: string) =>
+        request<LLMSettingsResponse>("/llm-settings", {}, token, orgId),
+
+    upsert: (data: LLMSettingsUpsert, token?: string, orgId?: string) =>
+        request<LLMSettingsResponse>(
+            "/llm-settings",
+            { method: "PUT", body: JSON.stringify(data) },
+            token,
+            orgId,
+        ),
+
+    remove: (token?: string, orgId?: string) =>
+        request<{ deleted: boolean }>("/llm-settings", { method: "DELETE" }, token, orgId),
+};

--- a/src/lib/admin/server/settings.ts
+++ b/src/lib/admin/server/settings.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { adminApi } from "../api";
+import { AdminApiError } from "../api";
 import { revalidatePath } from "next/cache";
 import type { ActionResult } from "@/lib/result";
 import type {
@@ -17,6 +18,9 @@ import type {
     RetentionPolicyUpdate,
     RetentionPolicyListResponse,
     RetentionExecuteResponse,
+    LLMSettingsResponse,
+    LLMSettingsUpsert,
+    LLMSettingsActionResult,
 } from "../types";
 import { getSessionContext, withErrorHandling } from "./_shared";
 
@@ -189,5 +193,54 @@ export async function listRetentionResourceTypes(): Promise<ActionResult<string[
     return withErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
         return adminApi.retention.resourceTypes(token, orgId);
+    });
+}
+
+// ---- BYO LLM Settings ----
+// These actions preserve the HTTP status so the page can render a locked/upsell
+// state for tier/flag gating (402/403) and an inline field error for base_url
+// validation (400), rather than collapsing everything into a generic message.
+
+async function withStatusErrorHandling<T>(
+    fn: () => Promise<T>,
+): Promise<LLMSettingsActionResult<T>> {
+    try {
+        return { data: await fn() };
+    } catch (err) {
+        if (err instanceof AdminApiError) {
+            const detail = err.detail || err.message;
+            return {
+                error: typeof detail === "string" ? detail : JSON.stringify(detail),
+                status: err.status,
+            };
+        }
+        return { error: err instanceof Error ? err.message : "Unknown error" };
+    }
+}
+
+export async function getLLMSettings(): Promise<LLMSettingsActionResult<LLMSettingsResponse>> {
+    return withStatusErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.llmSettings.get(token, orgId);
+    });
+}
+
+export async function upsertLLMSettings(
+    data: LLMSettingsUpsert,
+): Promise<LLMSettingsActionResult<LLMSettingsResponse>> {
+    return withStatusErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        const result = await adminApi.llmSettings.upsert(data, token, orgId);
+        revalidatePath("/org/admin/ai");
+        return result;
+    });
+}
+
+export async function deleteLLMSettings(): Promise<LLMSettingsActionResult<{ deleted: boolean }>> {
+    return withStatusErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        const result = await adminApi.llmSettings.remove(token, orgId);
+        revalidatePath("/org/admin/ai");
+        return result;
     });
 }

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -513,6 +513,56 @@ export interface RetentionExecuteResponse {
     error: string | null;
 }
 
+// ---- BYO LLM Settings ----
+
+/** Providers selectable for Bring-Your-Own-LLM. Mirrors the backend-supported set. */
+export type LLMProvider = "openai" | "anthropic" | "gemini" | "qwen";
+
+export const LLM_PROVIDERS: LLMProvider[] = ["openai", "anthropic", "gemini", "qwen"];
+
+export const LLM_PROVIDER_LABELS: Record<LLMProvider, string> = {
+    openai: "OpenAI",
+    anthropic: "Anthropic",
+    gemini: "Gemini",
+    qwen: "Qwen",
+};
+
+/**
+ * GET /admin/llm-settings response. The api_key is write-only server-side and is
+ * returned masked (never the real key). Null/absent fields are omitted by the
+ * backend (response_model_exclude_none=True).
+ */
+export interface LLMSettingsResponse {
+    provider?: string | null;
+    model?: string | null;
+    api_key?: string | null;
+    base_url?: string | null;
+    concurrency?: number | null;
+}
+
+/**
+ * PUT /admin/llm-settings payload. provider is required; api_key is optional and
+ * only sent when (re)setting the key so a blank field preserves the stored key.
+ */
+export interface LLMSettingsUpsert {
+    provider: string;
+    model?: string | null;
+    api_key?: string | null;
+    base_url?: string | null;
+    concurrency?: number | null;
+}
+
+/**
+ * Result wrapper for the BYO-LLM server actions that preserves the HTTP status
+ * so the UI can distinguish tier/flag gating (402/403) and base_url validation
+ * (400) from generic failures.
+ */
+export interface LLMSettingsActionResult<T> {
+    data?: T;
+    error?: string;
+    status?: number;
+}
+
 // ---- Provider types ----
 
 export type Provider = "github" | "gitlab" | "jira" | "linear" | "launchdarkly";

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -27,9 +27,13 @@ export const CTA_LABELS = {
     resetFilters: "Reset filters",
     /** Copy the current selection / link to the clipboard. */
     copy: "Copy",
+    save: "Save",
+    delete: "Delete",
+    confirmDelete: "Confirm delete?",
     monteCarloView: "Monte Carlo view",
     viewGuide: "View guide",
     reset: "Reset",
+    retry: "Retry",
     clearContext: "Clear context",
     clearTheme: "Clear theme",
     allThemes: "All themes",


### PR DESCRIPTION
## Summary

Adds the BYO-LLM **AI Setup** org-admin surface.

- New route `/org/admin/ai` rendering `ByoLlmSettings`, wired to the admin LLM-settings API (`/api/v1/admin/llm-settings`).
- Nav entry **"AI Setup"** gated on the `byo_llm` feature flag.
- Status badge: **"Saved"** / **"Not configured"** (richer validity/active-routing states are deferred to CHAOS-2560).
- Blocking load-error state with retry so a failed settings fetch doesn't render a misleading empty form.
- Hardened admin error formatting + CTA labels.
- Component tests included (covers retry-blocking and status states).

API key is masked on round-trip; live-backend lifecycle (GET/PUT/GET/DELETE) verified.

## Screenshots

![chaos-2559-ai-setup-not-configured-after.png](https://github.com/user-attachments/assets/554e9aaa-c19d-4f39-bd1a-5797df3273b1)

![chaos-2559-ai-setup-not-configured-viewport-after.png](https://github.com/user-attachments/assets/338b1d1f-51ac-458a-85b0-e6870bd52743)

## Follow-ups (tracked)

- CHAOS-2560 — validity / active-routing surface (richer status states).
- CHAOS-2563 / CHAOS-2564 — Explain Error-States / Spend panels.

Closes CHAOS-2559