### PR TITLE
feat(plan): surface insufficient-history forecast state (CHAOS-2575)

### DIFF
--- a/src/app/(app)/plan/page.tsx
+++ b/src/app/(app)/plan/page.tsx
@@ -3,6 +3,7 @@ import { FilterBar } from "@/components/filters/FilterBar";
 import { GlobalContextBar } from "@/components/navigation/GlobalContextBar";
 import { PrimaryNav } from "@/components/navigation/PrimaryNav";
 import { ServiceUnavailable } from "@/components/ServiceUnavailable";
+import { InsufficientHistoryNotice } from "@/components/capacity/InsufficientHistoryNotice";
 import { checkApiHealth } from "@/lib/api/system";
 import { requireSession } from "@/lib/auth";
 import { fetchOrNull } from "@/lib/fetchOrNull";
@@ -144,6 +145,11 @@ export default async function PlanPage({ searchParams }: PlanPageProps) {
                                 </div>
                             </section>
 
+                            <InsufficientHistoryNotice
+                                insufficientHistory={forecast.insufficientHistory}
+                                rollingWindows={forecast.rollingWindows}
+                            />
+
                             <section className="grid gap-4 md:grid-cols-3">
                                 {[
                                     ["P50", forecast.p50Weeks],
@@ -152,11 +158,20 @@ export default async function PlanPage({ searchParams }: PlanPageProps) {
                                 ].map(([label, weeks]) => (
                                     <div
                                         key={label as string}
-                                        className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6"
+                                        className={`rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6 ${
+                                            forecast.insufficientHistory ? "opacity-60" : ""
+                                        }`}
                                     >
-                                        <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
-                                            {label}
-                                        </p>
+                                        <div className="flex items-center justify-between gap-2">
+                                            <p className="text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
+                                                {label}
+                                            </p>
+                                            {forecast.insufficientHistory ? (
+                                                <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs uppercase tracking-[0.16em] text-amber-200">
+                                                    Limited history
+                                                </span>
+                                            ) : null}
+                                        </div>
                                         <p className="mt-3 text-3xl font-semibold">
                                             {formatWeeks(weeks as number | null)}
                                         </p>

--- a/src/components/capacity/InsufficientHistoryNotice.test.tsx
+++ b/src/components/capacity/InsufficientHistoryNotice.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/utils";
+import type { ThroughputRollingWindow } from "@/lib/graphql/types";
+import { InsufficientHistoryNotice } from "./InsufficientHistoryNotice";
+
+function windows(overrides: Partial<ThroughputRollingWindow>[] = []): ThroughputRollingWindow[] {
+    const base: ThroughputRollingWindow[] = [
+        {
+            windowWeeks: 4,
+            meanWeeklyThroughput: 0,
+            sampleCount: 0,
+            insufficientHistory: true,
+        },
+        {
+            windowWeeks: 8,
+            meanWeeklyThroughput: 0,
+            sampleCount: 0,
+            insufficientHistory: true,
+        },
+        {
+            windowWeeks: 12,
+            meanWeeklyThroughput: 0,
+            sampleCount: 0,
+            insufficientHistory: true,
+        },
+    ];
+    return base.map((window, index) => ({ ...window, ...overrides[index] }));
+}
+
+describe("InsufficientHistoryNotice", () => {
+    it("renders nothing when history is sufficient", () => {
+        const { container } = render(
+            <InsufficientHistoryNotice insufficientHistory={false} rollingWindows={windows()} />,
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("surfaces a status warning when history is insufficient", () => {
+        render(<InsufficientHistoryNotice insufficientHistory rollingWindows={windows()} />);
+        const notice = screen.getByRole("status");
+        expect(notice).toBeInTheDocument();
+        expect(screen.getByText("Limited history")).toBeInTheDocument();
+        expect(screen.getByText("Forecast provisional")).toBeInTheDocument();
+    });
+
+    it("breaks down per-window sample counts with an insufficient marker", () => {
+        render(
+            <InsufficientHistoryNotice
+                insufficientHistory
+                rollingWindows={windows([
+                    { windowWeeks: 4, sampleCount: 3, insufficientHistory: false },
+                ])}
+            />,
+        );
+        expect(screen.getByText("4w")).toBeInTheDocument();
+        expect(screen.getByText("3 samples")).toBeInTheDocument();
+        // Short windows still flag insufficiency.
+        expect(screen.getAllByText(/insufficient/).length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("uses the singular noun for a single sample", () => {
+        render(
+            <InsufficientHistoryNotice
+                insufficientHistory
+                rollingWindows={windows([
+                    { windowWeeks: 4, sampleCount: 1, insufficientHistory: false },
+                ])}
+            />,
+        );
+        expect(screen.getByText("1 sample")).toBeInTheDocument();
+    });
+});

--- a/src/components/capacity/InsufficientHistoryNotice.tsx
+++ b/src/components/capacity/InsufficientHistoryNotice.tsx
@@ -1,0 +1,64 @@
+import type { ThroughputRollingWindow } from "@/lib/graphql/types";
+
+type InsufficientHistoryNoticeProps = {
+    insufficientHistory: boolean;
+    rollingWindows: ThroughputRollingWindow[];
+};
+
+/**
+ * Warning banner shown when the throughput forecast is built on too little
+ * history to produce a reliable estimate (CHAOS-2575).
+ *
+ * The backend now returns an honest no-estimate contract under short history:
+ * each rolling window is flagged `insufficientHistory` and emits no samples,
+ * and the forecast-level `insufficientHistory` flag is set. This component
+ * surfaces that state so the percentile estimates are read as provisional, and
+ * breaks down how many weekly samples each 4/8/12-week window actually had.
+ *
+ * Renders nothing when history is sufficient.
+ */
+export function InsufficientHistoryNotice({
+    insufficientHistory,
+    rollingWindows,
+}: InsufficientHistoryNoticeProps) {
+    if (!insufficientHistory) return null;
+
+    return (
+        <section
+            role="status"
+            aria-live="polite"
+            className="rounded-3xl border border-amber-500/30 bg-amber-500/10 p-6"
+        >
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <h2 className="text-base font-semibold text-amber-200">Limited history</h2>
+                <span className="rounded-full bg-amber-500/15 px-3 py-1 text-xs uppercase tracking-[0.16em] text-amber-200">
+                    Forecast provisional
+                </span>
+            </div>
+            <p className="mt-3 text-sm text-amber-100/80">
+                There isn&apos;t enough throughput history to compute reliable 4/8/12-week rolling
+                estimates for this scope. The weeks-to-complete figures below may be unavailable or
+                provisional — widen the date range, pick a different team, or sync more work-item
+                history.
+            </p>
+            <dl className="mt-4 flex flex-wrap gap-2">
+                {rollingWindows.map((window) => (
+                    <div
+                        key={window.windowWeeks}
+                        className={`flex items-center gap-2 rounded-full px-3 py-1 text-xs ${
+                            window.insufficientHistory
+                                ? "bg-amber-500/15 text-amber-200"
+                                : "bg-foreground/10 text-(--ink-muted)"
+                        }`}
+                    >
+                        <dt className="font-semibold">{window.windowWeeks}w</dt>
+                        <dd>
+                            {window.sampleCount} {window.sampleCount === 1 ? "sample" : "samples"}
+                            {window.insufficientHistory ? " · insufficient" : ""}
+                        </dd>
+                    </div>
+                ))}
+            </dl>
+        </section>
+    );
+}


### PR DESCRIPTION
## Summary

Adds a /plan capacity forecast warning when the throughput forecast reports insufficient history. The page now surfaces the top-level `insufficientHistory` state, shows per-window `sampleCount` provenance, and visually de-emphasizes unavailable percentile estimates.

## Screenshot

![chaos-2575-plan-insufficient-history-after.png](https://github.com/user-attachments/assets/2efe8c65-6414-4b65-af89-0503e750b28d)

## Verification

- `pnpm exec vitest run src/components/capacity/InsufficientHistoryNotice.test.tsx`
- `pnpm run typecheck`
- Playwright MCP against local dev server: `/plan` indicator screenshot captured and uploaded
- `pnpm run design-lint` was attempted; it currently fails on existing repo-wide design-lint backlog outside this change.

Closes CHAOS-2575