### PR TITLE
fix(auth): add Chrome login form metadata

### DIFF
--- a/src/components/auth/LoginForm.test.tsx
+++ b/src/components/auth/LoginForm.test.tsx
@@ -33,8 +33,15 @@ describe("LoginForm", () => {
 
     test("renders email and password fields", () => {
         renderWithToaster(<LoginForm />);
-        expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+        const email = screen.getByLabelText(/email/i);
+        const password = screen.getByLabelText(/password/i);
+
+        expect(email).toBeInTheDocument();
+        expect(email).toHaveAttribute("name", "email");
+        expect(email).toHaveAttribute("autocomplete", "email");
+        expect(password).toBeInTheDocument();
+        expect(password).toHaveAttribute("name", "password");
+        expect(password).toHaveAttribute("autocomplete", "current-password");
     });
 
     test("renders submit button", () => {

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { type ComponentProps, useState } from "react";
 import { signIn, getSession } from "next-auth/react";
 import Link from "next/link";
 import { toast } from "sonner";
@@ -9,6 +9,9 @@ type LoginFormProps = {
     plan?: string;
     trialIntent?: boolean;
 };
+
+type FormSubmitEvent = Parameters<NonNullable<ComponentProps<"form">["onSubmit"]>>[0];
+type TextInputKeyEvent = Parameters<NonNullable<ComponentProps<"input">["onKeyDown"]>>[0];
 
 async function getSessionWithRetry(attempts = 2, delayMs = 150) {
     for (let i = 0; i < attempts; i++) {
@@ -26,7 +29,7 @@ export function LoginForm({ plan, trialIntent = false }: LoginFormProps) {
     const [verifyEmail, setVerifyEmail] = useState(false);
     const isTeamTrialIntent = trialIntent && plan?.toLowerCase() === "team";
 
-    const handleSubmit = async (e: React.FormEvent) => {
+    const handleSubmit = async (e: FormSubmitEvent) => {
         e.preventDefault();
         setLoading(true);
 
@@ -71,7 +74,7 @@ export function LoginForm({ plan, trialIntent = false }: LoginFormProps) {
         }
     };
 
-    const submitOnEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const submitOnEnter = (e: TextInputKeyEvent) => {
         if (e.key !== "Enter" || e.nativeEvent.isComposing || loading) return;
 
         const form = e.currentTarget.form;
@@ -94,7 +97,7 @@ export function LoginForm({ plan, trialIntent = false }: LoginFormProps) {
                     </p>
                 </div>
             )}
-            <form onSubmit={handleSubmit} className="space-y-5">
+            <form onSubmit={handleSubmit} className="space-y-5" autoComplete="on">
                 <div className="space-y-2">
                     <label
                         htmlFor="email"
@@ -104,7 +107,9 @@ export function LoginForm({ plan, trialIntent = false }: LoginFormProps) {
                     </label>
                     <input
                         id="email"
+                        name="email"
                         type="email"
+                        autoComplete="email"
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                         onKeyDown={submitOnEnter}
@@ -123,7 +128,9 @@ export function LoginForm({ plan, trialIntent = false }: LoginFormProps) {
                     </label>
                     <input
                         id="password"
+                        name="password"
                         type="password"
+                        autoComplete="current-password"
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                         onKeyDown={submitOnEnter}


### PR DESCRIPTION
## Summary
- add explicit `name` and `autocomplete` metadata to the sign-in email/password fields
- keep the existing client-side sign-in flow unchanged
- cover the browser-facing attributes in `LoginForm` tests

## Investigation note
I could not reproduce the sandboxed-frame form-submission error in clean Chromium against production, and repo search did not find app-owned iframe/sandbox usage. This PR addresses the real Chrome form warning seen during investigation, but if the original error persists after deploy the next likely source is an embedding/injected frame layer such as a browser extension or challenge script.

## Verification
- `pnpm exec vitest run src/components/auth/LoginForm.test.tsx`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint` (passes with one existing warning in `src/lib/navigation/__tests__/ia-preservation-invariants.test.ts`)
- Playwright: production invalid-login path in Chromium did not reproduce the sandbox error; local production render confirmed the new form attributes.

SCREENSHOT-WAIVER: form metadata only; no visual rendering change.