### PR TITLE
feat(feature-flags): read full event history + registry via direct-read GraphQL (CHAOS-2629)

### DIFF
--- a/src/lib/feature-flags/__tests__/fetchers.test.ts
+++ b/src/lib/feature-flags/__tests__/fetchers.test.ts
@@ -294,8 +294,7 @@ describe("feature flag direct-read fetchers", () => {
                     eventTs: "2026-04-17T11:00:00Z",
                 },
             ];
-            const flagKey =
-                (variables as { flagKey?: string | null } | undefined)?.flagKey ?? null;
+            const flagKey = (variables as { flagKey?: string | null } | undefined)?.flagKey ?? null;
             const events = flagKey
                 ? allEvents.filter((event) => event.flagKey === flagKey)
                 : allEvents;

--- a/src/lib/feature-flags/__tests__/fetchers.test.ts
+++ b/src/lib/feature-flags/__tests__/fetchers.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { WorkGraphEdge } from "@/lib/graphql/types";
-import { getDistinctSourceIds, getRegistryEdges, parseToggleEvidence } from "../graph";
+import { getDistinctSourceIds } from "../graph";
 import {
     latestFromSpark,
     deltaFromSpark,
     classifySeverity,
     fetchFeatureFlagsData,
+    fetchFeatureFlagEvents,
+    fetchFeatureFlagList,
 } from "../fetchers";
 
 // ── Module mocks ────────────────────────────────────────────────────────────
@@ -67,6 +69,20 @@ function mockSuccessfulFetch(timeseriesBuckets: {
         })),
     });
 
+    const emptyRegistryResponse = {
+        featureFlags: {
+            flags: [],
+            totalCount: 0,
+            degradedReason: null,
+        },
+    };
+    const emptyEventsResponse = {
+        featureFlagEvents: {
+            events: [],
+            totalCount: 0,
+            degradedReason: null,
+        },
+    };
     const emptyEdgesResponse = {
         workGraphEdges: {
             edges: [],
@@ -102,7 +118,12 @@ function mockSuccessfulFetch(timeseriesBuckets: {
                 },
             });
         }
-        // FeatureFlagRegistry and ReleaseImpact both return empty edge sets.
+        if (qs.includes("FeatureFlagRegistry")) {
+            return Promise.resolve(emptyRegistryResponse);
+        }
+        if (qs.includes("FeatureFlagEvents")) {
+            return Promise.resolve(emptyEventsResponse);
+        }
         return Promise.resolve(emptyEdgesResponse);
     });
 }
@@ -110,34 +131,6 @@ function mockSuccessfulFetch(timeseriesBuckets: {
 // ── Graph helper tests (unchanged from prior suite) ─────────────────────────
 
 describe("feature flag fetcher helpers", () => {
-    it("keeps one registry edge per flag identity", () => {
-        const registryEdges = getRegistryEdges([
-            makeEdge({ edgeId: "registry-1", sourceId: "flag-a" }),
-            makeEdge({ edgeId: "registry-2", sourceId: "flag-a" }),
-            makeEdge({
-                edgeId: "pr-link",
-                sourceId: "flag-a",
-                targetType: "PR",
-                targetId: "repo#pr1",
-                edgeType: "REFERENCES",
-            }),
-            makeEdge({ edgeId: "registry-3", sourceId: "flag-b", targetId: "flag-b" }),
-        ]);
-
-        expect(registryEdges.map((edge) => edge.sourceId)).toEqual(["flag-a", "flag-b"]);
-    });
-
-    it("parses toggle evidence into timestamp and active state", () => {
-        expect(parseToggleEvidence("2026-04-15T10:15:00Z|toggle|on")).toEqual({
-            ts: "2026-04-15T10:15:00Z",
-            active: true,
-        });
-        expect(parseToggleEvidence("2026-04-16T08:00:00Z|toggle|off")).toEqual({
-            ts: "2026-04-16T08:00:00Z",
-            active: false,
-        });
-    });
-
     it("counts distinct release sources for impact coverage", () => {
         const edges = [
             makeEdge({
@@ -175,6 +168,218 @@ describe("feature flag fetcher helpers", () => {
 
         expect(getDistinctSourceIds(edges).size).toBe(2);
         expect(getDistinctSourceIds(edges, "IMPACTS").size).toBe(1);
+    });
+});
+
+describe("feature flag direct-read fetchers", () => {
+    beforeEach(() => {
+        mockGraphql.mockReset();
+        mockAuth.mockResolvedValue({ user: { org_id: "org-test" } } as never);
+    });
+
+    it("maps the full ordered event timeline and passes the plain flag key", async () => {
+        mockGraphql.mockResolvedValueOnce({
+            featureFlagEvents: {
+                events: [
+                    {
+                        flagKey: "checkout-redesign",
+                        eventType: "created",
+                        prevState: "",
+                        nextState: "off",
+                        actorType: "system",
+                        environment: "prod",
+                        eventTs: "2026-04-15T09:00:00Z",
+                    },
+                    {
+                        flagKey: "checkout-redesign",
+                        eventType: "toggled",
+                        prevState: "off",
+                        nextState: "on",
+                        actorType: "user",
+                        environment: "prod",
+                        eventTs: "2026-04-15T10:15:00Z",
+                    },
+                    {
+                        flagKey: "checkout-redesign",
+                        eventType: "toggled",
+                        prevState: "on",
+                        nextState: "disabled",
+                        actorType: "user",
+                        environment: "prod",
+                        eventTs: "2026-04-16T08:00:00Z",
+                    },
+                ],
+                totalCount: 3,
+                degradedReason: null,
+            },
+        });
+
+        const result = await fetchFeatureFlagEvents("checkout-redesign", "org-test", 50);
+
+        expect(mockGraphql).toHaveBeenCalledWith(expect.any(String), {
+            orgId: "org-test",
+            flagKey: "checkout-redesign",
+            environment: null,
+            limit: 50,
+        });
+        expect(result.events.map((event) => event.eventTs)).toEqual([
+            "2026-04-15T09:00:00Z",
+            "2026-04-15T10:15:00Z",
+            "2026-04-16T08:00:00Z",
+        ]);
+        expect(result.totalCount).toBe(3);
+    });
+
+    it("renders registry list rows from featureFlags joined to latest featureFlagEvents by flagKey", async () => {
+        mockGraphql.mockImplementation((query, variables) => {
+            const qs = typeof query === "string" ? query : "";
+            if (qs.includes("FeatureFlagRegistry")) {
+                return Promise.resolve({
+                    featureFlags: {
+                        flags: [
+                            {
+                                flagId: "hashed-flag-a",
+                                flagKey: "checkout-redesign",
+                                provider: "launchdarkly",
+                                projectKey: "web",
+                                environment: "prod",
+                                flagType: "boolean",
+                                createdAt: "2026-04-01T00:00:00Z",
+                                archivedAt: null,
+                            },
+                            {
+                                flagId: "hashed-flag-b",
+                                flagKey: "search-v2",
+                                provider: "launchdarkly",
+                                projectKey: "web",
+                                environment: "prod",
+                                flagType: "boolean",
+                                createdAt: "2026-04-02T00:00:00Z",
+                                archivedAt: null,
+                            },
+                        ],
+                        totalCount: 2,
+                        degradedReason: null,
+                    },
+                });
+            }
+            // featureFlagEvents is now fetched per-flag (scoped by flagKey);
+            // return only the events matching the requested flag.
+            const allEvents = [
+                {
+                    flagKey: "checkout-redesign",
+                    eventType: "toggled",
+                    prevState: "off",
+                    nextState: "on",
+                    actorType: "user",
+                    environment: "prod",
+                    eventTs: "2026-04-15T10:15:00Z",
+                },
+                {
+                    flagKey: "checkout-redesign",
+                    eventType: "toggled",
+                    prevState: "on",
+                    nextState: "disabled",
+                    actorType: "user",
+                    environment: "prod",
+                    eventTs: "2026-04-16T08:00:00Z",
+                },
+                {
+                    flagKey: "search-v2",
+                    eventType: "toggled",
+                    prevState: "off",
+                    nextState: "enabled",
+                    actorType: "system",
+                    environment: "prod",
+                    eventTs: "2026-04-17T11:00:00Z",
+                },
+            ];
+            const flagKey =
+                (variables as { flagKey?: string | null } | undefined)?.flagKey ?? null;
+            const events = flagKey
+                ? allEvents.filter((event) => event.flagKey === flagKey)
+                : allEvents;
+            return Promise.resolve({
+                featureFlagEvents: {
+                    events,
+                    totalCount: events.length,
+                    degradedReason: null,
+                },
+            });
+        });
+
+        const result = await fetchFeatureFlagList(0, 20, "org-test");
+
+        expect(result.items).toEqual([
+            {
+                flagId: "hashed-flag-a",
+                flagKey: "checkout-redesign",
+                provider: "launchdarkly",
+                projectKey: "web",
+                createdAt: "2026-04-01T00:00:00Z",
+                lastToggledAt: "2026-04-16T08:00:00Z",
+                isActive: false,
+            },
+            {
+                flagId: "hashed-flag-b",
+                flagKey: "search-v2",
+                provider: "launchdarkly",
+                projectKey: "web",
+                createdAt: "2026-04-02T00:00:00Z",
+                lastToggledAt: "2026-04-17T11:00:00Z",
+                isActive: true,
+            },
+        ]);
+        expect(result.totalCount).toBe(2);
+        expect(result.hasNextPage).toBe(false);
+    });
+
+    it("reports isActive null when the latest event state is empty/unknown", async () => {
+        mockGraphql.mockImplementation((query, variables) => {
+            const qs = typeof query === "string" ? query : "";
+            if (qs.includes("FeatureFlagRegistry")) {
+                return Promise.resolve({
+                    featureFlags: {
+                        flags: [
+                            {
+                                flagId: "hashed-flag-c",
+                                flagKey: "unknown-state",
+                                provider: "gitlab",
+                                projectKey: "infra",
+                                environment: "prod",
+                                flagType: "boolean",
+                                createdAt: "2026-04-03T00:00:00Z",
+                                archivedAt: null,
+                            },
+                        ],
+                        totalCount: 1,
+                        degradedReason: null,
+                    },
+                });
+            }
+            void variables;
+            return Promise.resolve({
+                featureFlagEvents: {
+                    events: [
+                        {
+                            flagKey: "unknown-state",
+                            eventType: "created",
+                            prevState: "",
+                            nextState: "",
+                            actorType: "system",
+                            environment: "prod",
+                            eventTs: "2026-04-10T00:00:00Z",
+                        },
+                    ],
+                    totalCount: 1,
+                    degradedReason: null,
+                },
+            });
+        });
+
+        const result = await fetchFeatureFlagList(0, 20, "org-test");
+        expect(result.items[0].isActive).toBeNull();
+        expect(result.items[0].lastToggledAt).toBe("2026-04-10T00:00:00Z");
     });
 });
 

--- a/src/lib/feature-flags/fetchers.ts
+++ b/src/lib/feature-flags/fetchers.ts
@@ -18,8 +18,10 @@ import type {
     ReleaseImpactResult,
     FeatureFlagData,
     FeatureFlagsData,
+    FeatureFlag,
+    FeatureFlagEvent,
 } from "./types";
-import { getDistinctSourceIds, getRegistryEdges, parseToggleEvidence } from "./graph";
+import { getDistinctSourceIds } from "./graph";
 
 const EMPTY_RESULT: WorkGraphEdgesResult = {
     edges: [],
@@ -40,61 +42,78 @@ export async function fetchFeatureFlagRegistry(
     const orgId = await resolveOrgId(orgIdOverride);
 
     try {
-        const res = await graphqlFetch<{ workGraphEdges: WorkGraphEdgesResult }>(
+        const res = await graphqlFetch<{ featureFlags: FeatureFlagRegistryResult }>(
             FEATURE_FLAG_REGISTRY_QUERY,
             {
                 orgId,
-                filters: {
-                    sourceType: "FEATURE_FLAG",
-                    targetType: "FEATURE_FLAG",
-                    edgeType: "RELATES",
-                    limit,
-                },
+                provider: null,
+                project: null,
+                includeArchived: false,
+                limit,
             },
         );
 
-        const flags = getRegistryEdges(res.workGraphEdges.edges);
-
         return {
-            flags,
-            totalCount: flags.length,
-            pageInfo: res.workGraphEdges.pageInfo,
+            flags: res.featureFlags.flags,
+            totalCount: res.featureFlags.totalCount,
+            degradedReason: res.featureFlags.degradedReason,
         };
     } catch (error) {
         logger.error({ err: error }, "Failed to fetch feature flag registry");
-        return { flags: [], totalCount: 0, pageInfo: EMPTY_RESULT.pageInfo };
+        return { flags: [], totalCount: 0, degradedReason: null };
     }
 }
 
 export async function fetchFeatureFlagEvents(
-    flagId: string,
+    flagKey?: string,
     orgIdOverride?: string,
     limit: number = 200,
+    environment?: string,
 ): Promise<FeatureFlagEventsResult> {
     const orgId = await resolveOrgId(orgIdOverride);
 
     try {
-        const res = await graphqlFetch<{ workGraphEdges: WorkGraphEdgesResult }>(
+        const res = await graphqlFetch<{ featureFlagEvents: FeatureFlagEventsResult }>(
             FEATURE_FLAG_EVENTS_QUERY,
             {
                 orgId,
-                filters: {
-                    nodeId: flagId,
-                    edgeType: "CONFIG_CHANGED_BY",
-                    limit,
-                },
+                flagKey: flagKey || null,
+                environment: environment || null,
+                limit,
             },
         );
 
         return {
-            events: res.workGraphEdges.edges,
-            totalCount: res.workGraphEdges.totalCount,
-            pageInfo: res.workGraphEdges.pageInfo,
+            events: res.featureFlagEvents.events,
+            totalCount: res.featureFlagEvents.totalCount,
+            degradedReason: res.featureFlagEvents.degradedReason,
         };
     } catch (error) {
         logger.error({ err: error }, "Failed to fetch feature flag events");
-        return { events: [], totalCount: 0, pageInfo: EMPTY_RESULT.pageInfo };
+        return { events: [], totalCount: 0, degradedReason: null };
     }
+}
+
+function eventStateIsActive(nextState: string): boolean | null {
+    const normalized = nextState.trim().toLowerCase();
+    if (!normalized) return null;
+    if (["on", "enabled", "active", "true"].includes(normalized)) return true;
+    if (["off", "disabled", "inactive", "false"].includes(normalized)) return false;
+    // Unknown/unrecognized state (incl. empty next_state from LD audit events):
+    // report unknown rather than defaulting to active.
+    return null;
+}
+
+function mapFlagToListItem(flag: FeatureFlag, latestEvent?: FeatureFlagEvent): FeatureFlagListItem {
+    return {
+        flagId: flag.flagId,
+        flagKey: flag.flagKey,
+        provider: flag.provider,
+        projectKey: flag.projectKey,
+        createdAt: flag.createdAt,
+        lastToggledAt: latestEvent?.eventTs ?? null,
+        isActive: latestEvent ? eventStateIsActive(latestEvent.nextState) : null,
+    };
 }
 
 export async function fetchReleaseImpact(
@@ -297,47 +316,27 @@ export async function fetchFeatureFlagList(
     const orgId = await resolveOrgId(orgIdOverride);
 
     try {
-        const [registry, events] = await Promise.all([
-            fetchFeatureFlagRegistry(orgId, 500),
-            fetchFeatureFlagEvents("", orgId, 500),
-        ]);
+        const registry = await fetchFeatureFlagRegistry(orgId, 500);
+        const pagedFlags = registry.flags.slice(offset, offset + limit);
 
-        const togglesByFlag = new Map<string, { ts: string; active: boolean }>();
-        for (const evt of events.events) {
-            const existing = togglesByFlag.get(evt.sourceId);
-            const parsedToggle = parseToggleEvidence(evt.evidence);
-            const isToggle = evt.edgeType === "CONFIG_CHANGED_BY";
-            if (isToggle && (!existing || parsedToggle.ts > existing.ts)) {
-                togglesByFlag.set(evt.sourceId, {
-                    ts: parsedToggle.ts,
-                    active: parsedToggle.active,
-                });
-            }
-        }
+        // Resolve the latest event per VISIBLE flag, scoped by flagKey. A single
+        // global event fetch ordered event_ts ASC only surfaces the OLDEST N
+        // events org-wide, yielding stale lastToggledAt/isActive on busy orgs
+        // (CHAOS-2629 review). Per-flag fetches keep each pool to one flag's
+        // history, so the last (newest) entry is the true latest.
+        const items: FeatureFlagListItem[] = await Promise.all(
+            pagedFlags.map(async (flag) => {
+                const flagEvents = await fetchFeatureFlagEvents(flag.flagKey, orgId, 1000);
+                const evs = flagEvents.events;
+                const latest = evs.length > 0 ? evs[evs.length - 1] : undefined;
+                return mapFlagToListItem(flag, latest);
+            }),
+        );
 
-        const items: FeatureFlagListItem[] = registry.flags.map((edge) => {
-            const parts = edge.evidence?.replace("flag:", "").split("/") ?? [];
-            const provider = parts[0] ?? edge.provider ?? "";
-            const projectKey = parts[1] ?? "";
-            const flagKey = parts[2] ?? edge.sourceId;
-            const toggle = togglesByFlag.get(edge.sourceId);
-
-            return {
-                flagId: edge.sourceId,
-                flagKey,
-                provider,
-                projectKey,
-                createdAt: null,
-                lastToggledAt: toggle?.ts ?? null,
-                isActive: toggle?.active ?? null,
-            };
-        });
-
-        const page = items.slice(offset, offset + limit);
         return {
-            items: page,
-            totalCount: items.length,
-            hasNextPage: offset + limit < items.length,
+            items,
+            totalCount: registry.flags.length,
+            hasNextPage: offset + limit < registry.flags.length,
         };
     } catch (error) {
         logger.error({ err: error }, "Failed to fetch feature flag list");
@@ -359,8 +358,8 @@ export async function fetchFeatureFlagData(orgIdOverride?: string): Promise<Feat
     } catch (error) {
         logger.error({ err: error }, "Failed to fetch feature flag data");
         return {
-            registry: { flags: [], totalCount: 0, pageInfo: EMPTY_RESULT.pageInfo },
-            events: { events: [], totalCount: 0, pageInfo: EMPTY_RESULT.pageInfo },
+            registry: { flags: [], totalCount: 0, degradedReason: null },
+            events: { events: [], totalCount: 0, degradedReason: null },
             releaseImpact: { edges: [], totalCount: 0, pageInfo: EMPTY_RESULT.pageInfo },
         };
     }

--- a/src/lib/feature-flags/graph.ts
+++ b/src/lib/feature-flags/graph.ts
@@ -1,23 +1,5 @@
 import type { WorkGraphEdge } from "@/lib/graphql/types";
 
-export function getRegistryEdges(edges: WorkGraphEdge[]): WorkGraphEdge[] {
-    const seen = new Set<string>();
-    return edges.filter((edge) => {
-        if (
-            edge.sourceType !== "FEATURE_FLAG" ||
-            edge.targetType !== "FEATURE_FLAG" ||
-            edge.edgeType !== "RELATES"
-        ) {
-            return false;
-        }
-        if (seen.has(edge.sourceId)) {
-            return false;
-        }
-        seen.add(edge.sourceId);
-        return true;
-    });
-}
-
 export function getDistinctSourceIds(
     edges: WorkGraphEdge[],
     edgeType?: WorkGraphEdge["edgeType"],
@@ -28,12 +10,4 @@ export function getDistinctSourceIds(
             .map((edge) => edge.sourceId)
             .filter(Boolean),
     );
-}
-
-export function parseToggleEvidence(evidence?: string | null): { ts: string; active: boolean } {
-    if (!evidence) {
-        return { ts: "", active: false };
-    }
-    const [ts = "", , state = evidence] = evidence.split("|");
-    return { ts, active: !state.toLowerCase().includes("off") };
 }

--- a/src/lib/feature-flags/queries.ts
+++ b/src/lib/feature-flags/queries.ts
@@ -1,53 +1,36 @@
 export const FEATURE_FLAG_REGISTRY_QUERY = `
-query FeatureFlagRegistry($orgId: String!, $filters: WorkGraphEdgeFilterInput) {
-  workGraphEdges(orgId: $orgId, filters: $filters) {
-    edges {
-      edgeId
-      sourceType
-      sourceId
-      targetType
-      targetId
-      edgeType
-      provenance
-      confidence
-      evidence
-      repoId
+query FeatureFlagRegistry($orgId: String!, $provider: String, $project: String, $includeArchived: Boolean, $limit: Int!) {
+  featureFlags(orgId: $orgId, provider: $provider, project: $project, includeArchived: $includeArchived, limit: $limit) {
+    flags {
+      flagId
+      flagKey
       provider
+      projectKey
+      environment
+      flagType
+      createdAt
+      archivedAt
     }
     totalCount
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
-    }
+    degradedReason
   }
 }
 `;
 
 export const FEATURE_FLAG_EVENTS_QUERY = `
-query FeatureFlagEvents($orgId: String!, $filters: WorkGraphEdgeFilterInput) {
-  workGraphEdges(orgId: $orgId, filters: $filters) {
-    edges {
-      edgeId
-      sourceType
-      sourceId
-      targetType
-      targetId
-      edgeType
-      provenance
-      confidence
-      evidence
-      repoId
-      provider
+query FeatureFlagEvents($orgId: String!, $flagKey: String, $environment: String, $limit: Int!) {
+  featureFlagEvents(orgId: $orgId, flagKey: $flagKey, environment: $environment, limit: $limit) {
+    events {
+      flagKey
+      eventType
+      prevState
+      nextState
+      actorType
+      environment
+      eventTs
     }
     totalCount
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
-    }
+    degradedReason
   }
 }
 `;

--- a/src/lib/feature-flags/types.ts
+++ b/src/lib/feature-flags/types.ts
@@ -3,16 +3,37 @@ import type { SparkPoint } from "@/lib/types";
 
 export type FeatureFlagEdgeType = "INTRODUCED_BY" | "CONFIG_CHANGED_BY" | "GUARDS" | "IMPACTS";
 
+export interface FeatureFlag {
+    flagId: string;
+    flagKey: string;
+    provider: string;
+    projectKey: string;
+    environment: string;
+    flagType: string;
+    createdAt: string;
+    archivedAt: string | null;
+}
+
+export interface FeatureFlagEvent {
+    flagKey: string;
+    eventType: string;
+    prevState: string;
+    nextState: string;
+    actorType: string;
+    environment: string;
+    eventTs: string;
+}
+
 export interface FeatureFlagRegistryResult {
-    flags: WorkGraphEdge[];
+    flags: FeatureFlag[];
     totalCount: number;
-    pageInfo: PageInfo;
+    degradedReason?: string | null;
 }
 
 export interface FeatureFlagEventsResult {
-    events: WorkGraphEdge[];
+    events: FeatureFlagEvent[];
     totalCount: number;
-    pageInfo: PageInfo;
+    degradedReason?: string | null;
 }
 
 export interface ReleaseImpactResult {

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -784,6 +784,43 @@ export type ExperimentsResult = {
   items: Array<Experiment>;
 };
 
+export type FeatureFlagEventItem = {
+  __typename?: 'FeatureFlagEventItem';
+  actorType: Scalars['String']['output'];
+  environment: Scalars['String']['output'];
+  eventTs: Scalars['String']['output'];
+  eventType: Scalars['String']['output'];
+  flagKey: Scalars['String']['output'];
+  nextState: Scalars['String']['output'];
+  prevState: Scalars['String']['output'];
+};
+
+export type FeatureFlagEventsResult = {
+  __typename?: 'FeatureFlagEventsResult';
+  degradedReason?: Maybe<Scalars['String']['output']>;
+  events: Array<FeatureFlagEventItem>;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type FeatureFlagItem = {
+  __typename?: 'FeatureFlagItem';
+  archivedAt?: Maybe<Scalars['String']['output']>;
+  createdAt: Scalars['String']['output'];
+  environment: Scalars['String']['output'];
+  flagId: Scalars['String']['output'];
+  flagKey: Scalars['String']['output'];
+  flagType: Scalars['String']['output'];
+  projectKey: Scalars['String']['output'];
+  provider: Scalars['String']['output'];
+};
+
+export type FeatureFlagRegistryResult = {
+  __typename?: 'FeatureFlagRegistryResult';
+  degradedReason?: Maybe<Scalars['String']['output']>;
+  flags: Array<FeatureFlagItem>;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type FilterInput = {
   how?: InputMaybe<HowFilterInput>;
   scope?: InputMaybe<ScopeFilterInput>;
@@ -1199,6 +1236,10 @@ export type Query = {
   dataHealth: DataHealth;
   /** Experiments derived from opportunity suggested_experiments (CHAOS-2219). v1: computed at query-time — no persistence table. Each experiment is a typed promotion of a suggestion string with hypothesis / metric / owner / stop_condition. ``derived_from_opportunities`` is False when the opportunities service was unavailable; items will be empty in that case. */
   experiments: ExperimentsResult;
+  /** List feature flag state-change events */
+  featureFlagEvents: FeatureFlagEventsResult;
+  /** List feature flags from the ClickHouse registry */
+  featureFlags: FeatureFlagRegistryResult;
   /** Get home dashboard metrics */
   home: HomeResult;
   /** Top file hotspots ranked by risk_score (churn x complexity x ownership concentration). Reads from the append-only ``file_hotspot_daily`` table. */
@@ -1356,6 +1397,23 @@ export type QueryDataHealthArgs = {
 export type QueryExperimentsArgs = {
   filters?: InputMaybe<FilterInput>;
   orgId: Scalars['String']['input'];
+};
+
+
+export type QueryFeatureFlagEventsArgs = {
+  environment?: InputMaybe<Scalars['String']['input']>;
+  flagKey?: InputMaybe<Scalars['String']['input']>;
+  limit?: Scalars['Int']['input'];
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryFeatureFlagsArgs = {
+  includeArchived?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: Scalars['Int']['input'];
+  orgId: Scalars['String']['input'];
+  project?: InputMaybe<Scalars['String']['input']>;
+  provider?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -716,6 +716,39 @@ type ExperimentsResult {
   derivedFromOpportunities: Boolean!
 }
 
+type FeatureFlagEventItem {
+  flagKey: String!
+  eventType: String!
+  prevState: String!
+  nextState: String!
+  actorType: String!
+  environment: String!
+  eventTs: String!
+}
+
+type FeatureFlagEventsResult {
+  events: [FeatureFlagEventItem!]!
+  totalCount: Int!
+  degradedReason: String
+}
+
+type FeatureFlagItem {
+  flagId: String!
+  flagKey: String!
+  provider: String!
+  projectKey: String!
+  environment: String!
+  flagType: String!
+  createdAt: String!
+  archivedAt: String
+}
+
+type FeatureFlagRegistryResult {
+  flags: [FeatureFlagItem!]!
+  totalCount: Int!
+  degradedReason: String
+}
+
 input FilterInput {
   scope: ScopeFilterInput = null
   who: WhoFilterInput = null
@@ -1068,6 +1101,12 @@ type Query {
 
   """Top-N work graph nodes ranked by degree over the full graph"""
   workGraphArtifacts(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphArtifactsResult!
+
+  """List feature flags from the ClickHouse registry"""
+  featureFlags(orgId: String!, provider: String = null, project: String = null, includeArchived: Boolean = false, limit: Int! = 1000): FeatureFlagRegistryResult!
+
+  """List feature flag state-change events"""
+  featureFlagEvents(orgId: String!, flagKey: String = null, environment: String = null, limit: Int! = 1000): FeatureFlagEventsResult!
 
   """
   Team-attribution provenance per work item (source/confidence/evidence/is_primary) — CHAOS-2600


### PR DESCRIPTION
## CHAOS-2629 — `/feature-flags`: read full history from direct-read GraphQL (web side)

Repoints the `/feature-flags` read path from `work_graph_edges` projections to the new `featureFlags` / `featureFlagEvents` queries (added in the companion ops PR), so event timelines show the **full** persisted history (not ≤1 point) and the registry renders from `feature_flag` directly.

**Depends on the ops PR** (provides the GraphQL schema). `schema.graphql` + generated types here are synced from the ops SDL export (drift-clean: only the 4 new types + 2 Query fields).

### What changed
- `queries.ts`: `FeatureFlagRegistry` / `FeatureFlagEvents` now hit the new fields. `RELEASE_IMPACT` + `FLAG_*` timeseries left **unchanged** (orthogonal pipeline / Phase C).
- `fetchers.ts`: `fetchFeatureFlagEvents` keys on `flagKey` (not the hashed id). The list derives latest state **per visible flag** (scoped fetch) instead of from a globally-truncated event page, and `isActive` is `null` for empty/unknown `next_state` rather than defaulting to active.
- `types.ts` / `graph.ts`: typed `FeatureFlag` / `FeatureFlagEvent` shapes; dead work-graph helpers removed (kept `getDistinctSourceIds` for release-impact coverage).
- Test-mode (`sample-data`) short-circuit preserved.

### Verification
- `pnpm typecheck`, `pnpm codegen:check` → green.
- `pnpm test:unit` → **235 files / 2212 tests pass** (incl. updated feature-flags fetcher tests: full-timeline mapping, per-flag latest-state join, unknown-state → null).
- `pnpm design-lint` static governance scan → **0 violations**; eslint scoped to changed files → clean.

### SCREENSHOT-WAIVER
This is a **data-layer repoint** under `src/lib/feature-flags` (+ generated schema) with **no rendering component, layout, or style change** — the existing `/feature-flags` components are untouched; only the data they receive changes. Correctness is proven by the ops live-ClickHouse resolver test (full ordered history) plus the web unit suites above. Happy to attach live-stack screenshots if a reviewer prefers a rendered capture.

Governance: test change included (no `TEST-WAIVER` needed).

Part of CHAOS-2629. Follow-ups: CHAOS-2630 (Phase-C associations), CHAOS-2631 (LD pagination), CHAOS-2632 (registry env/totalCount).
