### PR TITLE
fix(feature-flags): drop registry environment + true totalCount (CHAOS-2632)

### DIFF
--- a/src/lib/feature-flags/__tests__/fetchers.test.ts
+++ b/src/lib/feature-flags/__tests__/fetchers.test.ts
@@ -242,7 +242,6 @@ describe("feature flag direct-read fetchers", () => {
                                 flagKey: "checkout-redesign",
                                 provider: "launchdarkly",
                                 projectKey: "web",
-                                environment: "prod",
                                 flagType: "boolean",
                                 createdAt: "2026-04-01T00:00:00Z",
                                 archivedAt: null,
@@ -252,7 +251,6 @@ describe("feature flag direct-read fetchers", () => {
                                 flagKey: "search-v2",
                                 provider: "launchdarkly",
                                 projectKey: "web",
-                                environment: "prod",
                                 flagType: "boolean",
                                 createdAt: "2026-04-02T00:00:00Z",
                                 archivedAt: null,
@@ -333,6 +331,45 @@ describe("feature flag direct-read fetchers", () => {
         expect(result.hasNextPage).toBe(false);
     });
 
+    it("surfaces the backend totalCount even when it exceeds the fetched page (CHAOS-2632)", async () => {
+        mockGraphql.mockImplementation((query, variables) => {
+            const qs = typeof query === "string" ? query : "";
+            if (qs.includes("FeatureFlagRegistry")) {
+                return Promise.resolve({
+                    featureFlags: {
+                        flags: [
+                            {
+                                flagId: "hashed-flag-a",
+                                flagKey: "checkout-redesign",
+                                provider: "launchdarkly",
+                                projectKey: "web",
+                                flagType: "boolean",
+                                createdAt: "2026-04-01T00:00:00Z",
+                                archivedAt: null,
+                            },
+                        ],
+                        // count() reports the full population, larger than the
+                        // single flag returned in this limited page.
+                        totalCount: 50,
+                        degradedReason: null,
+                    },
+                });
+            }
+            void variables;
+            return Promise.resolve({
+                featureFlagEvents: {
+                    events: [],
+                    totalCount: 0,
+                    degradedReason: null,
+                },
+            });
+        });
+
+        const result = await fetchFeatureFlagList(0, 20, "org-test");
+        expect(result.totalCount).toBe(50);
+        expect(result.items).toHaveLength(1);
+    });
+
     it("reports isActive null when the latest event state is empty/unknown", async () => {
         mockGraphql.mockImplementation((query, variables) => {
             const qs = typeof query === "string" ? query : "";
@@ -345,7 +382,6 @@ describe("feature flag direct-read fetchers", () => {
                                 flagKey: "unknown-state",
                                 provider: "gitlab",
                                 projectKey: "infra",
-                                environment: "prod",
                                 flagType: "boolean",
                                 createdAt: "2026-04-03T00:00:00Z",
                                 archivedAt: null,

--- a/src/lib/feature-flags/fetchers.ts
+++ b/src/lib/feature-flags/fetchers.ts
@@ -335,7 +335,10 @@ export async function fetchFeatureFlagList(
 
         return {
             items,
-            totalCount: registry.flags.length,
+            // totalCount is the true backend population (CHAOS-2632: the resolver
+            // now issues a dedicated count() rather than count-after-limit), while
+            // hasNextPage governs the in-memory window over the fetched (≤500) page.
+            totalCount: registry.totalCount,
             hasNextPage: offset + limit < registry.flags.length,
         };
     } catch (error) {

--- a/src/lib/feature-flags/queries.ts
+++ b/src/lib/feature-flags/queries.ts
@@ -6,7 +6,6 @@ query FeatureFlagRegistry($orgId: String!, $provider: String, $project: String, 
       flagKey
       provider
       projectKey
-      environment
       flagType
       createdAt
       archivedAt

--- a/src/lib/feature-flags/types.ts
+++ b/src/lib/feature-flags/types.ts
@@ -8,7 +8,6 @@ export interface FeatureFlag {
     flagKey: string;
     provider: string;
     projectKey: string;
-    environment: string;
     flagType: string;
     createdAt: string;
     archivedAt: string | null;

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -806,7 +806,6 @@ export type FeatureFlagItem = {
   __typename?: 'FeatureFlagItem';
   archivedAt?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['String']['output'];
-  environment: Scalars['String']['output'];
   flagId: Scalars['String']['output'];
   flagKey: Scalars['String']['output'];
   flagType: Scalars['String']['output'];

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -737,7 +737,6 @@ type FeatureFlagItem {
   flagKey: String!
   provider: String!
   projectKey: String!
-  environment: String!
   flagType: String!
   createdAt: String!
   archivedAt: String


### PR DESCRIPTION
Closes CHAOS-2632 (web side). Pairs with dev-health-ops#1031 — **merge ops first** (schema drift gate).

## Changes
- Sync `schema.graphql` + regenerated types with the ops resolver: `FeatureFlagItem` no longer carries `environment`. The registry is one row per `(provider, project, flag)`; the field was an arbitrary `FINAL` pick over an env-agnostic ReplacingMergeTree key. Per-environment data still flows through `featureFlagEvents`.
- Drop `environment` from the registry query selection and the `FeatureFlag` type.
- `fetchFeatureFlagList` now sources `totalCount` from the backend `count()` (`registry.totalCount`) instead of the fetched page length, so the count is honest beyond the 500-flag fetch window. `hasNextPage` still governs the in-memory window over the fetched page.

## Tests
- `src/lib/feature-flags/__tests__/fetchers.test.ts`: registry mocks no longer carry `environment`; new test asserts `fetchFeatureFlagList` surfaces the backend `totalCount` even when it exceeds the fetched page.
- Local gates green: `pnpm typecheck`, `pnpm codegen:check`, `pnpm vitest run src/lib/feature-flags` (34 passing), prettier + eslint on changed files. Pre-existing `design-lint` errors are all in untouched `src/app/**` files.

SCREENSHOT-WAIVER: data-layer only — no rendered-UI/component change. The registry `environment` field was never rendered; `totalCount` only diverges from the page length on orgs with >500 flags, and sample/test-mode data is unchanged.