### PR TITLE
fix(admin/sync): submit selected repo full names (CHAOS-2637)

### DIFF
--- a/src/components/admin/sync/RepoSelector.tsx
+++ b/src/components/admin/sync/RepoSelector.tsx
@@ -81,8 +81,7 @@ export function RepoSelector({
     const filteredRepos = repos.filter((repo) => {
         const query = search.toLowerCase();
         return (
-            repo.name.toLowerCase().includes(query) ||
-            repo.full_name.toLowerCase().includes(query)
+            repo.name.toLowerCase().includes(query) || repo.full_name.toLowerCase().includes(query)
         );
     });
 
@@ -199,9 +198,7 @@ export function RepoSelector({
                                     type="checkbox"
                                     checked={isChecked}
                                     disabled={isDisabled}
-                                    onChange={(e) =>
-                                        handleToggle(repo.full_name, e.target.checked)
-                                    }
+                                    onChange={(e) => handleToggle(repo.full_name, e.target.checked)}
                                     className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
                                 />
                                 <div className="min-w-0 flex-1">

--- a/src/components/admin/sync/RepoSelector.tsx
+++ b/src/components/admin/sync/RepoSelector.tsx
@@ -4,12 +4,13 @@ import { useCallback, useEffect, useReducer, useState } from "react";
 import { SkeletonLine } from "@/components/ui/Skeleton";
 import { listReposForCredential } from "@/lib/admin/server";
 import type { DiscoveredRepo } from "@/lib/admin/types";
+import { CTA_LABELS } from "@/lib/design/cta";
 
 export type RepoSelectorProps = {
     credentialId: string;
     owner: string;
     selectedRepos: string[];
-    onSelectionChange: (repos: string[]) => void;
+    onSelectionChangeAction: (repos: string[]) => void;
     maxRepos?: number;
 };
 
@@ -42,7 +43,7 @@ export function RepoSelector({
     credentialId,
     owner,
     selectedRepos,
-    onSelectionChange,
+    onSelectionChangeAction,
     maxRepos,
 }: RepoSelectorProps) {
     const [state, dispatch] = useReducer(fetchReducer, {
@@ -77,29 +78,35 @@ export function RepoSelector({
 
     const { repos, loading, error } = state;
 
-    const filteredRepos = repos.filter((r) => r.name.toLowerCase().includes(search.toLowerCase()));
+    const filteredRepos = repos.filter((repo) => {
+        const query = search.toLowerCase();
+        return (
+            repo.name.toLowerCase().includes(query) ||
+            repo.full_name.toLowerCase().includes(query)
+        );
+    });
 
     const handleToggle = useCallback(
-        (repoName: string, checked: boolean) => {
+        (repoFullName: string, checked: boolean) => {
             if (checked) {
                 if (maxRepos !== undefined && selectedRepos.length >= maxRepos) return;
-                onSelectionChange([...selectedRepos, repoName]);
+                onSelectionChangeAction([...selectedRepos, repoFullName]);
             } else {
-                onSelectionChange(selectedRepos.filter((r) => r !== repoName));
+                onSelectionChangeAction(selectedRepos.filter((r) => r !== repoFullName));
             }
         },
-        [selectedRepos, onSelectionChange, maxRepos],
+        [selectedRepos, onSelectionChangeAction, maxRepos],
     );
 
     const handleSelectAll = useCallback(() => {
-        const names = filteredRepos.map((r) => r.name);
-        const next = maxRepos !== undefined ? names.slice(0, maxRepos) : names;
-        onSelectionChange(next);
-    }, [filteredRepos, maxRepos, onSelectionChange]);
+        const fullNames = filteredRepos.map((repo) => repo.full_name);
+        const next = maxRepos !== undefined ? fullNames.slice(0, maxRepos) : fullNames;
+        onSelectionChangeAction(next);
+    }, [filteredRepos, maxRepos, onSelectionChangeAction]);
 
     const handleClear = useCallback(() => {
-        onSelectionChange([]);
-    }, [onSelectionChange]);
+        onSelectionChangeAction([]);
+    }, [onSelectionChangeAction]);
 
     // Not ready to show — need both inputs
     if (!credentialId || !owner) {
@@ -152,14 +159,14 @@ export function RepoSelector({
                         onClick={handleSelectAll}
                         className="rounded-md border border-(--card-stroke) px-2 py-1 text-xs font-medium text-(--foreground) hover:bg-(--card-70)"
                     >
-                        Select All
+                        {CTA_LABELS.selectAll}
                     </button>
                     <button
                         type="button"
                         onClick={handleClear}
                         className="rounded-md border border-(--card-stroke) px-2 py-1 text-xs font-medium text-(--foreground) hover:bg-(--card-70)"
                     >
-                        Clear
+                        {CTA_LABELS.clear}
                     </button>
                 </div>
             </div>
@@ -179,11 +186,11 @@ export function RepoSelector({
                     <p className="text-xs text-(--ink-muted)">No repositories match your search.</p>
                 ) : (
                     filteredRepos.map((repo) => {
-                        const isChecked = selectedRepos.includes(repo.name);
+                        const isChecked = selectedRepos.includes(repo.full_name);
                         const isDisabled = !isChecked && atLimit;
                         return (
                             <label
-                                key={repo.name}
+                                key={repo.full_name}
                                 className={`flex items-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 hover:bg-(--card-60) ${
                                     isDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"
                                 }`}
@@ -192,7 +199,9 @@ export function RepoSelector({
                                     type="checkbox"
                                     checked={isChecked}
                                     disabled={isDisabled}
-                                    onChange={(e) => handleToggle(repo.name, e.target.checked)}
+                                    onChange={(e) =>
+                                        handleToggle(repo.full_name, e.target.checked)
+                                    }
                                     className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
                                 />
                                 <div className="min-w-0 flex-1">
@@ -208,7 +217,7 @@ export function RepoSelector({
                                 <div className="flex shrink-0 items-center gap-2 text-xs text-(--ink-muted)">
                                     {repo.language && <span>{repo.language}</span>}
                                     {repo.is_private && (
-                                        <span className="rounded-full border border-(--card-stroke) px-1.5 py-0.5 text-[10px]">
+                                        <span className="rounded-full border border-(--card-stroke) px-1.5 py-0.5 text-label-caps">
                                             private
                                         </span>
                                     )}

--- a/src/components/admin/sync/SyncConfigForm.test.tsx
+++ b/src/components/admin/sync/SyncConfigForm.test.tsx
@@ -659,7 +659,7 @@ describe("SyncConfigForm", () => {
                     timezone: null,
                     initial_sync_depth: 30,
                     sync_options: { owner: "myorg", auto_import_teams: false },
-                    repos: ["repo-a"],
+                    repos: ["myorg/repo-a"],
                 });
             });
             expect(mockCreateSyncConfig).not.toHaveBeenCalled();

--- a/src/components/admin/sync/SyncConfigForm.test.tsx
+++ b/src/components/admin/sync/SyncConfigForm.test.tsx
@@ -665,6 +665,58 @@ describe("SyncConfigForm", () => {
             expect(mockCreateSyncConfig).not.toHaveBeenCalled();
         });
 
+        it("clears selected repos when owner changes", async () => {
+            mockCreateSyncConfig.mockResolvedValue(undefined);
+            mockListReposForCredential.mockResolvedValue({
+                data: {
+                    provider: "github",
+                    owner: "myorg",
+                    repos: [
+                        {
+                            name: "repo-a",
+                            full_name: "myorg/repo-a",
+                            description: null,
+                            is_private: false,
+                            is_archived: false,
+                            default_branch: "main",
+                            language: null,
+                            stargazers_count: null,
+                            forks_count: null,
+                            updated_at: null,
+                        },
+                    ],
+                    total: 1,
+                },
+            });
+            renderWithToaster(<SyncConfigForm credentials={mockCredentials} />);
+
+            await userEvent.type(screen.getByLabelText("Configuration Name"), "Repo Sync");
+            await userEvent.selectOptions(screen.getByLabelText("Credential"), "cred-1");
+            await userEvent.type(screen.getByLabelText("Owner / Organization"), "myorg");
+
+            const repoCheckbox = await screen.findByLabelText("repo-a");
+            await userEvent.click(repoCheckbox);
+
+            const ownerInput = screen.getByLabelText("Owner / Organization");
+            await userEvent.clear(ownerInput);
+            await userEvent.type(ownerInput, "otherorg");
+            await userEvent.click(screen.getByRole("button", { name: "Create Configuration" }));
+
+            await waitFor(() => {
+                expect(mockCreateSyncConfig).toHaveBeenCalledWith({
+                    name: "Repo Sync",
+                    provider: "github",
+                    credential_id: "cred-1",
+                    sync_targets: [],
+                    schedule_cron: null,
+                    timezone: null,
+                    initial_sync_depth: 30,
+                    sync_options: { owner: "otherorg", auto_import_teams: false },
+                });
+            });
+            expect(mockBatchCreateSyncConfigs).not.toHaveBeenCalled();
+        });
+
         it("includes auto_import_teams=true in sync_options when toggled on (create)", async () => {
             mockCreateSyncConfig.mockResolvedValue(undefined);
             renderWithToaster(<SyncConfigForm credentials={mockCredentials} />);

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -128,6 +128,12 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                     gitlab_url: "",
                 }));
                 setSyncAllRepos(false);
+            } else if (name === "owner" || name === "credential_id") {
+                setFormData((prev) => ({
+                    ...prev,
+                    [name]: value,
+                    repos: [],
+                }));
             } else {
                 handleBaseChange(e);
             }

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -24,6 +24,7 @@ import { batchCreateSyncConfigs, createSyncConfig, updateSyncConfig } from "@/li
 import { UpgradeGate } from "@/components/billing/UpgradeGate";
 import { useAdminTier } from "@/components/admin/AdminTierContext";
 import { BaseForm, inputClass, useBaseFormState } from "@/components/shared/BaseForm";
+import { CTA_LABELS } from "@/lib/design/cta";
 import { CreateCredentialModal } from "./CreateCredentialModal";
 import { RepoSelector } from "./RepoSelector";
 import { SchedulePicker } from "./SchedulePicker";
@@ -301,7 +302,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                         href="/org/admin/sync"
                         className="rounded-lg px-4 py-2 text-sm font-medium text-(--ink-muted) hover:text-foreground"
                     >
-                        Cancel
+                        {CTA_LABELS.cancel}
                     </Link>
                 }
             >
@@ -377,7 +378,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                         <div className="mt-1 flex items-center gap-1 text-xs text-amber-500">
                             <span>No credentials found for this provider.</span>
                             <Link href="/org/admin/integrations" className="underline">
-                                Add one first
+                                {CTA_LABELS.addOneFirst}
                             </Link>
                             <span>or</span>
                             <button
@@ -385,7 +386,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                                 onClick={() => setShowCredentialModal(true)}
                                 className="underline"
                             >
-                                Create One Now
+                                {CTA_LABELS.createOneNow}
                             </button>
                             <span>.</span>
                         </div>
@@ -466,7 +467,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                                     credentialId={formData.credential_id}
                                     owner={formData.owner}
                                     selectedRepos={formData.repos}
-                                    onSelectionChange={(repos) =>
+                                    onSelectionChangeAction={(repos) =>
                                         setFormData((prev) => ({ ...prev, repos }))
                                     }
                                     maxRepos={maxRepos}
@@ -572,7 +573,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                                     }`}
                                 >
                                     {opt.label}
-                                    {isGated && <span className="ml-1 text-[10px]">🔒</span>}
+                                    {isGated && <span className="ml-1 text-label-caps">🔒</span>}
                                 </button>
                             );
                         })}

--- a/src/components/admin/sync/__tests__/RepoSelector.test.tsx
+++ b/src/components/admin/sync/__tests__/RepoSelector.test.tsx
@@ -199,7 +199,9 @@ describe("RepoSelector", () => {
         });
 
         it("calls onSelectionChange to remove a repo when unchecked", async () => {
-            const { onSelectionChangeAction } = renderSelector({ selectedRepos: ["myorg/repo-alpha"] });
+            const { onSelectionChangeAction } = renderSelector({
+                selectedRepos: ["myorg/repo-alpha"],
+            });
             await waitFor(() => screen.getByText("repo-alpha"));
 
             const checkboxes = screen.getAllByRole("checkbox");

--- a/src/components/admin/sync/__tests__/RepoSelector.test.tsx
+++ b/src/components/admin/sync/__tests__/RepoSelector.test.tsx
@@ -51,17 +51,17 @@ const MOCK_REPOS = [
 ];
 
 function renderSelector(overrides: Partial<React.ComponentProps<typeof RepoSelector>> = {}) {
-    const onSelectionChange = vi.fn();
+    const onSelectionChangeAction = vi.fn();
     render(
         <RepoSelector
             credentialId="cred-123"
             owner="myorg"
             selectedRepos={[]}
-            onSelectionChange={onSelectionChange}
+            onSelectionChangeAction={onSelectionChangeAction}
             {...overrides}
         />,
     );
-    return { onSelectionChange };
+    return { onSelectionChangeAction };
 }
 
 describe("RepoSelector", () => {
@@ -76,7 +76,7 @@ describe("RepoSelector", () => {
                     credentialId=""
                     owner="myorg"
                     selectedRepos={[]}
-                    onSelectionChange={vi.fn()}
+                    onSelectionChangeAction={vi.fn()}
                 />,
             );
             expect(screen.getByText(/Select a credential and enter an owner/i)).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe("RepoSelector", () => {
                     credentialId="cred-123"
                     owner=""
                     selectedRepos={[]}
-                    onSelectionChange={vi.fn()}
+                    onSelectionChangeAction={vi.fn()}
                 />,
             );
             expect(screen.getByText(/Select a credential and enter an owner/i)).toBeInTheDocument();
@@ -189,60 +189,63 @@ describe("RepoSelector", () => {
         });
 
         it("calls onSelectionChange when a repo is checked", async () => {
-            const { onSelectionChange } = renderSelector();
+            const { onSelectionChangeAction } = renderSelector();
             await waitFor(() => screen.getByText("repo-alpha"));
 
             const checkboxes = screen.getAllByRole("checkbox");
             await userEvent.click(checkboxes[0]);
 
-            expect(onSelectionChange).toHaveBeenCalledWith(["repo-alpha"]);
+            expect(onSelectionChangeAction).toHaveBeenCalledWith(["myorg/repo-alpha"]);
         });
 
         it("calls onSelectionChange to remove a repo when unchecked", async () => {
-            const { onSelectionChange } = renderSelector({ selectedRepos: ["repo-alpha"] });
+            const { onSelectionChangeAction } = renderSelector({ selectedRepos: ["myorg/repo-alpha"] });
             await waitFor(() => screen.getByText("repo-alpha"));
 
             const checkboxes = screen.getAllByRole("checkbox");
             await userEvent.click(checkboxes[0]);
 
-            expect(onSelectionChange).toHaveBeenCalledWith([]);
+            expect(onSelectionChangeAction).toHaveBeenCalledWith([]);
         });
 
         it("Select All selects all repos", async () => {
-            const { onSelectionChange } = renderSelector();
+            const { onSelectionChangeAction } = renderSelector();
             await waitFor(() => screen.getByRole("button", { name: "Select All" }));
 
             await userEvent.click(screen.getByRole("button", { name: "Select All" }));
 
-            expect(onSelectionChange).toHaveBeenCalledWith([
-                "repo-alpha",
-                "repo-beta",
-                "repo-gamma",
+            expect(onSelectionChangeAction).toHaveBeenCalledWith([
+                "myorg/repo-alpha",
+                "myorg/repo-beta",
+                "myorg/repo-gamma",
             ]);
         });
 
         it("Select All respects maxRepos limit", async () => {
-            const { onSelectionChange } = renderSelector({ maxRepos: 2 });
+            const { onSelectionChangeAction } = renderSelector({ maxRepos: 2 });
             await waitFor(() => screen.getByRole("button", { name: "Select All" }));
 
             await userEvent.click(screen.getByRole("button", { name: "Select All" }));
 
-            expect(onSelectionChange).toHaveBeenCalledWith(["repo-alpha", "repo-beta"]);
+            expect(onSelectionChangeAction).toHaveBeenCalledWith([
+                "myorg/repo-alpha",
+                "myorg/repo-beta",
+            ]);
         });
 
         it("Clear clears all selected repos", async () => {
-            const { onSelectionChange } = renderSelector({
-                selectedRepos: ["repo-alpha", "repo-beta"],
+            const { onSelectionChangeAction } = renderSelector({
+                selectedRepos: ["myorg/repo-alpha", "myorg/repo-beta"],
             });
             await waitFor(() => screen.getByRole("button", { name: "Clear" }));
 
             await userEvent.click(screen.getByRole("button", { name: "Clear" }));
 
-            expect(onSelectionChange).toHaveBeenCalledWith([]);
+            expect(onSelectionChangeAction).toHaveBeenCalledWith([]);
         });
 
         it("disables unchecked repos when at maxRepos", async () => {
-            renderSelector({ selectedRepos: ["repo-alpha"], maxRepos: 1 });
+            renderSelector({ selectedRepos: ["myorg/repo-alpha"], maxRepos: 1 });
             await waitFor(() => screen.getByText("repo-beta"));
 
             const checkboxes = screen.getAllByRole("checkbox");
@@ -262,6 +265,17 @@ describe("RepoSelector", () => {
 
             expect(screen.getByText("repo-alpha")).toBeInTheDocument();
             expect(screen.queryByText("repo-beta")).not.toBeInTheDocument();
+        });
+
+        it("filters repos by full name", async () => {
+            renderSelector();
+            await waitFor(() => screen.getByText("repo-alpha"));
+
+            const searchInput = screen.getByPlaceholderText("Search repositories...");
+            await userEvent.type(searchInput, "myorg/repo-beta");
+
+            expect(screen.getByText("repo-beta")).toBeInTheDocument();
+            expect(screen.queryByText("repo-alpha")).not.toBeInTheDocument();
         });
 
         it("shows empty search message when no repos match", async () => {
@@ -291,7 +305,7 @@ describe("RepoSelector", () => {
                     credentialId="cred-123"
                     owner="myorg"
                     selectedRepos={[]}
-                    onSelectionChange={vi.fn()}
+                    onSelectionChangeAction={vi.fn()}
                 />,
             );
 
@@ -307,7 +321,7 @@ describe("RepoSelector", () => {
                     credentialId="cred-123"
                     owner="otherorg"
                     selectedRepos={[]}
-                    onSelectionChange={vi.fn()}
+                    onSelectionChangeAction={vi.fn()}
                 />,
             );
 

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -25,6 +25,11 @@ export const CTA_LABELS = {
     applyFilters: "Apply filters",
     /** Reset filters back to defaults. */
     resetFilters: "Reset filters",
+    selectAll: "Select All",
+    clear: "Clear",
+    cancel: "Cancel",
+    addOneFirst: "Add one first",
+    createOneNow: "Create One Now",
     /** Copy the current selection / link to the clipboard. */
     copy: "Copy",
     save: "Save",

--- a/tests/admin-sync.spec.ts
+++ b/tests/admin-sync.spec.ts
@@ -27,6 +27,28 @@ test("creating sync config navigates back to list", async ({ page }) => {
     await expect(page).toHaveURL(/\/org\/admin\/sync$/);
 });
 
+test("selecting discovered repos submits full names", async ({ page }) => {
+    await page.goto("/org/admin/sync/new");
+
+    await page.locator("#name").fill("Selected Repos");
+    await page.locator("#provider").selectOption("github");
+    await page.locator("#credential_id").selectOption("cred-github-1");
+    await page.locator("#owner").fill("myorg");
+
+    await expect(page.getByText("repo-alpha")).toBeVisible();
+    await expect(page.getByText("myorg/repo-alpha")).toHaveCount(0);
+
+    await page.getByPlaceholder("Search repositories...").fill("myorg/repo-beta");
+    await expect(page.getByText("repo-beta")).toBeVisible();
+    await expect(page.getByText("repo-alpha")).toHaveCount(0);
+
+    await page.getByRole("checkbox", { name: /repo-beta/i }).check();
+    await expect(page.getByText("1 of 2 selected")).toBeVisible();
+    await page.getByRole("button", { name: /submit|save|create/i }).click();
+
+    await expect(page).toHaveURL(/\/org\/admin\/sync$/);
+});
+
 test("provider selection filters sync targets", async ({ page }) => {
     await page.goto("/org/admin/sync/new");
 

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -2370,6 +2370,37 @@ export const handlers = [
         HttpResponse.json<MockCredential[]>(MOCK_CREDENTIALS),
     ),
 
+    http.get("*/api/v1/admin/credentials/:id/repos", ({ request }) => {
+        const owner = new URL(request.url).searchParams.get("owner") ?? "myorg";
+        const repos = [
+            {
+                name: "repo-alpha",
+                full_name: `${owner}/repo-alpha`,
+                description: "Alpha service",
+                is_private: false,
+                is_archived: false,
+                default_branch: "main",
+                language: "TypeScript",
+                stargazers_count: 0,
+                forks_count: 0,
+                updated_at: "2026-01-15T00:00:00.000Z",
+            },
+            {
+                name: "repo-beta",
+                full_name: `${owner}/repo-beta`,
+                description: "Beta service",
+                is_private: true,
+                is_archived: false,
+                default_branch: "main",
+                language: "Python",
+                stargazers_count: 0,
+                forks_count: 0,
+                updated_at: "2026-01-15T00:00:00.000Z",
+            },
+        ];
+        return HttpResponse.json({ provider: "github", owner, repos, total: repos.length });
+    }),
+
     http.post("*/api/v1/admin/credentials", async ({ request }) => {
         const body = (await request.json()) as Partial<MockCredential> | null;
         const created: MockCredential = {
@@ -2409,6 +2440,30 @@ export const handlers = [
         };
         MOCK_SYNC_CONFIGS.push(created);
         return HttpResponse.json<MockSyncConfig>(created);
+    }),
+
+    http.post("*/api/v1/admin/sync-configs/batch", async ({ request }) => {
+        const body = (await request.json()) as { repos?: string[]; provider?: string } | null;
+        const repos = body?.repos ?? [];
+        if (repos.length === 0 || repos.some((repo) => !repo.includes("/"))) {
+            return HttpResponse.json(
+                { detail: "Batch sync repo selections must use full names." },
+                { status: 400 },
+            );
+        }
+        const created = repos.map((repo, index) => ({
+            id: `sync-config-batch-${index}`,
+            provider: body?.provider ?? "github",
+            name: repo,
+            enabled: true,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+        }));
+        return HttpResponse.json({
+            created,
+            parent: created[0] ?? null,
+            count: created.length,
+        });
     }),
 
     http.patch("*/api/v1/admin/sync-configs/:id", async ({ params, request }) => {


### PR DESCRIPTION
## Summary
- Store selected discovered repositories by full_name while keeping repo-only labels visible in the selector.
- Search discovered repos by both repo name and owner/repo full name.
- Submit batch sync selections as owner/repo and add browser/MSW coverage that rejects bare repo names.
- Add CTA registry labels for touched sync buttons/links.

## Validation
- pnpm vitest run src/components/admin/sync/__tests__/RepoSelector.test.tsx src/components/admin/sync/SyncConfigForm.test.tsx (50 passed)
- pnpm exec playwright test tests/admin-sync.spec.ts --project=authenticated --grep "selecting discovered repos submits full names" (passed)
- pnpm typecheck (passed)
- pnpm lint (passed; existing unrelated unused-var warning remains)
- pnpm test:unit (passed; existing React act warnings remain)
- Scoped touched-file design lint (passed)
- LSP diagnostics clean for changed files
- git diff --check (passed)

## Visual evidence
![chaos-2637-repo-selector-full-name.png](https://github.com/user-attachments/assets/624fd1f5-cc04-43c8-a0c8-39001da50eb0)

Linear: CHAOS-2637

Update after review: added stale-selection regression/fix. Extra validation: pnpm vitest run src/components/admin/sync/SyncConfigForm.test.tsx (30 passed), focused Playwright full-name proof passed, LSP clean for touched files, Prettier check passed.
