### PR TITLE
feat(admin): edit selected sync repositories

### DIFF
--- a/src/app/(app)/org/admin/sync/[configId]/edit/page.tsx
+++ b/src/app/(app)/org/admin/sync/[configId]/edit/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { SyncConfigForm } from "@/components/admin/sync/SyncConfigForm";
-import { getSyncConfig, listCredentials } from "@/lib/admin/server";
+import { getSyncConfig, getSyncConfigRepositories, listCredentials } from "@/lib/admin/server";
 import { RunBackfill } from "@/components/admin/sync/RunBackfill";
 
 interface EditSyncConfigPageProps {
@@ -10,9 +10,10 @@ interface EditSyncConfigPageProps {
 
 export default async function EditSyncConfigPage({ params }: EditSyncConfigPageProps) {
     const { configId } = await params;
-    const [configResult, credentialsResult] = await Promise.all([
+    const [configResult, credentialsResult, repositorySelectionResult] = await Promise.all([
         getSyncConfig(configId),
         listCredentials(),
+        getSyncConfigRepositories(configId),
     ]);
 
     if (configResult.error || !configResult.data) {
@@ -29,7 +30,11 @@ export default async function EditSyncConfigPage({ params }: EditSyncConfigPageP
                 description="Update sync configuration settings."
             />
 
-            <SyncConfigForm initialData={config} credentials={credentials} />
+            <SyncConfigForm
+                initialData={config}
+                initialRepositorySelection={repositorySelectionResult.data}
+                credentials={credentials}
+            />
 
             <div className="max-w-2xl">
                 <RunBackfill configId={configId} />

--- a/src/components/admin/sync/SyncConfigForm.test.tsx
+++ b/src/components/admin/sync/SyncConfigForm.test.tsx
@@ -11,6 +11,7 @@ vi.mock("next/navigation", () => ({
 
 const mockCreateSyncConfig = vi.fn();
 const mockUpdateSyncConfig = vi.fn();
+const mockUpdateSyncConfigRepositories = vi.fn();
 const mockBatchCreateSyncConfigs = vi.fn();
 const mockListReposForCredential = vi.fn();
 const mockTestConnection = vi.fn();
@@ -18,6 +19,7 @@ const mockCreateCredential = vi.fn();
 vi.mock("@/lib/admin/server", () => ({
     createSyncConfig: (...args: unknown[]) => mockCreateSyncConfig(...args),
     updateSyncConfig: (...args: unknown[]) => mockUpdateSyncConfig(...args),
+    updateSyncConfigRepositories: (...args: unknown[]) => mockUpdateSyncConfigRepositories(...args),
     batchCreateSyncConfigs: (...args: unknown[]) => mockBatchCreateSyncConfigs(...args),
     listReposForCredential: (...args: unknown[]) => mockListReposForCredential(...args),
     testConnection: (...args: unknown[]) => mockTestConnection(...args),
@@ -84,6 +86,7 @@ describe("SyncConfigForm", () => {
         mockPush.mockReset();
         mockCreateSyncConfig.mockReset();
         mockUpdateSyncConfig.mockReset();
+        mockUpdateSyncConfigRepositories.mockReset();
         mockBatchCreateSyncConfigs.mockReset();
         mockListReposForCredential.mockReset();
         mockListReposForCredential.mockResolvedValue({
@@ -365,6 +368,141 @@ describe("SyncConfigForm", () => {
                         auto_import_teams: false,
                     },
                 });
+            });
+        });
+
+        it("shows selected repositories in edit mode", async () => {
+            mockListReposForCredential.mockResolvedValue({
+                data: {
+                    provider: "github",
+                    owner: "myorg",
+                    repos: [
+                        {
+                            name: "repo-a",
+                            full_name: "myorg/repo-a",
+                            description: null,
+                            is_private: false,
+                            is_archived: false,
+                            default_branch: "main",
+                            language: null,
+                            stargazers_count: null,
+                            forks_count: null,
+                            updated_at: null,
+                        },
+                    ],
+                    total: 1,
+                },
+            });
+            const initialData: SyncConfig = {
+                id: "cfg-repos",
+                name: "Existing Config",
+                provider: "github",
+                credential_id: "cred-1",
+                sync_targets: ["git"],
+                sync_options: { owner: "myorg" },
+                is_active: true,
+                schedule_cron: null,
+                timezone: null,
+                last_sync_at: null,
+                last_sync_success: null,
+                last_sync_error: null,
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+                parent_id: null,
+            };
+
+            render(
+                <SyncConfigForm
+                    initialData={initialData}
+                    initialRepositorySelection={{
+                        owner: "myorg",
+                        repos: ["myorg/repo-a"],
+                        sync_all_repos: false,
+                    }}
+                    credentials={mockCredentials}
+                />,
+            );
+
+            expect(screen.getByText("Select Repositories")).toBeInTheDocument();
+            const repoCheckbox = await screen.findByLabelText("repo-a");
+            expect(repoCheckbox).toBeChecked();
+        });
+
+        it("updates repository selection after scalar config update in edit mode", async () => {
+            mockUpdateSyncConfig.mockResolvedValue(undefined);
+            mockUpdateSyncConfigRepositories.mockResolvedValue(undefined);
+            mockListReposForCredential.mockResolvedValue({
+                data: {
+                    provider: "github",
+                    owner: "myorg",
+                    repos: [
+                        {
+                            name: "repo-a",
+                            full_name: "myorg/repo-a",
+                            description: null,
+                            is_private: false,
+                            is_archived: false,
+                            default_branch: "main",
+                            language: null,
+                            stargazers_count: null,
+                            forks_count: null,
+                            updated_at: null,
+                        },
+                        {
+                            name: "repo-b",
+                            full_name: "myorg/repo-b",
+                            description: null,
+                            is_private: false,
+                            is_archived: false,
+                            default_branch: "main",
+                            language: null,
+                            stargazers_count: null,
+                            forks_count: null,
+                            updated_at: null,
+                        },
+                    ],
+                    total: 2,
+                },
+            });
+            const initialData: SyncConfig = {
+                id: "cfg-repos-save",
+                name: "Existing Config",
+                provider: "github",
+                credential_id: "cred-1",
+                sync_targets: ["git"],
+                sync_options: { owner: "myorg" },
+                is_active: true,
+                schedule_cron: null,
+                timezone: null,
+                last_sync_at: null,
+                last_sync_success: null,
+                last_sync_error: null,
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+                parent_id: null,
+            };
+
+            renderWithToaster(
+                <SyncConfigForm
+                    initialData={initialData}
+                    initialRepositorySelection={{
+                        owner: "myorg",
+                        repos: ["myorg/repo-a"],
+                        sync_all_repos: false,
+                    }}
+                    credentials={mockCredentials}
+                />,
+            );
+
+            await userEvent.click(await screen.findByLabelText("repo-b"));
+            await userEvent.click(screen.getByRole("button", { name: "Update Configuration" }));
+
+            await waitFor(() => {
+                expect(mockUpdateSyncConfigRepositories).toHaveBeenCalledWith("cfg-repos-save", {
+                    owner: "myorg",
+                    repos: ["myorg/repo-a", "myorg/repo-b"],
+                });
+                expect(screen.getByText("Config updated")).toBeInTheDocument();
             });
         });
 

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -19,8 +19,14 @@ import {
     PROVIDERS,
     PROVIDER_LABELS,
     PROVIDER_SYNC_TARGETS,
+    SyncConfigRepositorySelection,
 } from "@/lib/admin/types";
-import { batchCreateSyncConfigs, createSyncConfig, updateSyncConfig } from "@/lib/admin/server";
+import {
+    batchCreateSyncConfigs,
+    createSyncConfig,
+    updateSyncConfig,
+    updateSyncConfigRepositories,
+} from "@/lib/admin/server";
 import { UpgradeGate } from "@/components/billing/UpgradeGate";
 import { useAdminTier } from "@/components/admin/AdminTierContext";
 import { BaseForm, inputClass, useBaseFormState } from "@/components/shared/BaseForm";
@@ -31,6 +37,7 @@ import { SchedulePicker } from "./SchedulePicker";
 
 type SyncConfigFormProps = {
     initialData?: SyncConfig;
+    initialRepositorySelection?: SyncConfigRepositorySelection;
     credentials: IntegrationCredential[];
     onSuccessAction?: () => void;
 };
@@ -56,14 +63,28 @@ function getSyncTargetsForProvider(provider: string) {
     return ALL_SYNC_TARGETS.filter((t) => allowed.includes(t.id));
 }
 
-export function SyncConfigForm({ initialData, credentials, onSuccessAction }: SyncConfigFormProps) {
+function sameRepoSelection(left: string[], right: string[]) {
+    if (left.length !== right.length) return false;
+    const rightSet = new Set(right);
+    return left.every((repo) => rightSet.has(repo));
+}
+
+export function SyncConfigForm({
+    initialData,
+    initialRepositorySelection,
+    credentials,
+    onSuccessAction,
+}: SyncConfigFormProps) {
     const router = useRouter();
     const [isPending, startTransition] = useTransition();
     const [showCredentialModal, setShowCredentialModal] = useState(false);
     const [localCredentials, setLocalCredentials] = useState(credentials);
     const { features, minSyncIntervalHours, limits } = useAdminTier();
     const maxRepos = (limits?.licensed_repos as number | null | undefined) ?? undefined;
-    const [syncAllRepos, setSyncAllRepos] = useState(false);
+    const [syncAllRepos, setSyncAllRepos] = useState(
+        initialRepositorySelection?.sync_all_repos ??
+            ((initialData?.sync_options?.all_repos as boolean | undefined) || false),
+    );
 
     const {
         formData,
@@ -86,8 +107,9 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
         initial_sync_depth: (initialData?.initial_sync_depth ??
             (initialData?.sync_options?.initial_sync_depth as number | null | undefined) ??
             30) as number | null,
-        owner: (initialData?.sync_options?.owner as string) || "",
-        repos: [] as string[],
+        owner:
+            initialRepositorySelection?.owner || (initialData?.sync_options?.owner as string) || "",
+        repos: initialRepositorySelection?.repos || ([] as string[]),
         gitlab_url: (initialData?.sync_options?.gitlab_url as string) || "",
         auto_import_teams: (initialData?.sync_options?.auto_import_teams as boolean) ?? false,
     });
@@ -106,6 +128,7 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
         () => getSyncTargetsForProvider(formData.provider),
         [formData.provider],
     );
+    const canBrowseRepos = !initialData || !!initialRepositorySelection;
 
     const handleChange = useCallback(
         (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -205,6 +228,30 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                         if (result?.error) {
                             toast.error(result.error);
                         } else {
+                            const shouldUpdateRepos = Boolean(
+                                (formData.provider === "github" ||
+                                    formData.provider === "gitlab") &&
+                                !syncAllRepos &&
+                                formData.owner &&
+                                (!sameRepoSelection(
+                                    initialRepositorySelection?.repos ?? [],
+                                    formData.repos,
+                                ) ||
+                                    (initialRepositorySelection?.owner ?? "") !== formData.owner),
+                            );
+                            if (shouldUpdateRepos) {
+                                const repoResult = await updateSyncConfigRepositories(
+                                    initialData.id,
+                                    {
+                                        owner: formData.owner,
+                                        repos: formData.repos,
+                                    },
+                                );
+                                if (repoResult?.error) {
+                                    toast.error(repoResult.error);
+                                    return;
+                                }
+                            }
                             toast.success("Config updated");
                             if (onSuccessAction) {
                                 onSuccessAction();
@@ -285,7 +332,15 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                 }
             });
         },
-        [initialData, formData, syncAllRepos, buildSyncOptions, onSuccessAction, router],
+        [
+            initialData,
+            initialRepositorySelection,
+            formData,
+            syncAllRepos,
+            buildSyncOptions,
+            onSuccessAction,
+            router,
+        ],
     );
 
     return (
@@ -454,15 +509,15 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                                 </label>
                             </div>
                         )}
-                        {!initialData && syncAllRepos && (
+                        {syncAllRepos && (
                             <p className="text-xs text-(--ink-muted)">
                                 Every repository the selected credential can reach will be synced.
                                 Enter an owner above to narrow this to a single organization
                                 (optional).
                             </p>
                         )}
-                        {!initialData &&
-                        !syncAllRepos &&
+                        {!syncAllRepos &&
+                        canBrowseRepos &&
                         formData.credential_id &&
                         formData.owner ? (
                             <div>
@@ -480,7 +535,8 @@ export function SyncConfigForm({ initialData, credentials, onSuccessAction }: Sy
                                 />
                             </div>
                         ) : (
-                            !initialData && (
+                            !syncAllRepos &&
+                            canBrowseRepos && (
                                 <p className="text-xs text-(--ink-muted)">
                                     Select a credential and enter an owner above to browse and
                                     select repositories.

--- a/src/lib/admin/api/sync.ts
+++ b/src/lib/admin/api/sync.ts
@@ -8,6 +8,8 @@ import type {
     BackfillJob,
     SyncConfigBatchCreate,
     SyncConfigBatchResponse,
+    SyncConfigRepositorySelection,
+    SyncConfigRepositorySelectionUpdate,
     SyncTriggerResult,
     SyncRun,
 } from "../types";
@@ -31,6 +33,27 @@ export const syncConfigsApi = {
         request<SyncConfig>(
             `/sync-configs/${id}`,
             { method: "PATCH", body: JSON.stringify(data) },
+            token,
+            orgId,
+        ),
+
+    getRepositories: (id: string, token?: string, orgId?: string) =>
+        request<SyncConfigRepositorySelection>(
+            `/sync-configs/${id}/repositories`,
+            {},
+            token,
+            orgId,
+        ),
+
+    updateRepositories: (
+        id: string,
+        data: SyncConfigRepositorySelectionUpdate,
+        token?: string,
+        orgId?: string,
+    ) =>
+        request<SyncConfigRepositorySelection>(
+            `/sync-configs/${id}/repositories`,
+            { method: "PUT", body: JSON.stringify(data) },
             token,
             orgId,
         ),

--- a/src/lib/admin/server/sync.ts
+++ b/src/lib/admin/server/sync.ts
@@ -13,6 +13,8 @@ import type {
     DiscoveredReposResponse,
     SyncConfigBatchCreate,
     SyncConfigBatchResponse,
+    SyncConfigRepositorySelection,
+    SyncConfigRepositorySelectionUpdate,
     SyncTriggerResult,
     SyncRun,
 } from "../types";
@@ -74,6 +76,29 @@ export async function updateSyncConfig(
         const result = await adminApi.syncConfigs.update(id, data, token, orgId);
         revalidatePath("/org/admin/sync");
         revalidatePath(`/org/admin/sync/${id}`);
+        return result;
+    });
+}
+
+export async function getSyncConfigRepositories(
+    id: string,
+): Promise<ActionResult<SyncConfigRepositorySelection>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.syncConfigs.getRepositories(id, token, orgId);
+    });
+}
+
+export async function updateSyncConfigRepositories(
+    id: string,
+    data: SyncConfigRepositorySelectionUpdate,
+): Promise<ActionResult<SyncConfigRepositorySelection>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        const result = await adminApi.syncConfigs.updateRepositories(id, data, token, orgId);
+        revalidatePath("/org/admin/sync");
+        revalidatePath(`/org/admin/sync/${id}`);
+        revalidatePath(`/org/admin/sync/${id}/edit`);
         return result;
     });
 }

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -128,6 +128,17 @@ export interface SyncConfigBatchResponse {
     count: number;
 }
 
+export interface SyncConfigRepositorySelection {
+    owner: string;
+    repos: string[];
+    sync_all_repos: boolean;
+}
+
+export interface SyncConfigRepositorySelectionUpdate {
+    owner: string;
+    repos: string[];
+}
+
 export interface SyncJob {
     id: string;
     config_id: string;

--- a/tests/admin-sync.spec.ts
+++ b/tests/admin-sync.spec.ts
@@ -49,6 +49,20 @@ test("selecting discovered repos submits full names", async ({ page }) => {
     await expect(page).toHaveURL(/\/org\/admin\/sync$/);
 });
 
+test("editing sync config repositories updates selected repos", async ({ page }) => {
+    await page.goto("/org/admin/sync/sync-config-edit-repos/edit");
+
+    await expect(page.getByRole("heading", { name: /edit editable repos/i })).toBeVisible();
+    await expect(page.getByText("Select Repositories")).toBeVisible();
+    await expect(page.getByRole("checkbox", { name: /repo-alpha/i })).toBeChecked();
+
+    await page.getByRole("checkbox", { name: /repo-beta/i }).check();
+    await expect(page.getByText("2 of 2 selected")).toBeVisible();
+    await page.getByRole("button", { name: /update configuration/i }).click();
+
+    await expect(page).toHaveURL(/\/org\/admin\/sync$/);
+});
+
 test("provider selection filters sync targets", async ({ page }) => {
     await page.goto("/org/admin/sync/new");
 

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -732,7 +732,30 @@ const MOCK_CREDENTIALS: MockCredential[] = [
     },
 ];
 
-const MOCK_SYNC_CONFIGS: MockSyncConfig[] = [];
+const MOCK_SYNC_CONFIGS: MockSyncConfig[] = [
+    {
+        id: "sync-config-edit-repos",
+        provider: "github",
+        name: "Editable Repos",
+        enabled: true,
+        credential_id: "cred-github-1",
+        sync_targets: ["git"],
+        sync_options: { owner: "myorg" },
+        is_active: true,
+        schedule_cron: null,
+        timezone: null,
+        initial_sync_depth: 30,
+        last_sync_at: null,
+        last_sync_success: null,
+        last_sync_error: null,
+        parent_id: null,
+        created_at: "2026-01-15T00:00:00.000Z",
+        updated_at: "2026-01-15T00:00:00.000Z",
+    },
+];
+const MOCK_REPOSITORY_SELECTIONS = new Map<string, { owner: string; repos: string[] }>([
+    ["sync-config-edit-repos", { owner: "myorg", repos: ["myorg/repo-alpha"] }],
+]);
 const MOCK_TEAMS: MockTeam[] = [];
 const MOCK_IDENTITIES: MockIdentity[] = [];
 
@@ -2428,6 +2451,28 @@ export const handlers = [
         HttpResponse.json<MockSyncConfig[]>(MOCK_SYNC_CONFIGS),
     ),
 
+    http.get("*/api/v1/admin/sync-configs/:id", ({ params }) => {
+        const syncConfigId = params.id as string;
+        const syncConfig = MOCK_SYNC_CONFIGS.find((item) => item.id === syncConfigId);
+        if (!syncConfig) {
+            return HttpResponse.json({ detail: "Sync config not found" }, { status: 404 });
+        }
+        return HttpResponse.json<MockSyncConfig>(syncConfig);
+    }),
+
+    http.get("*/api/v1/admin/sync-configs/:id/repositories", ({ params }) => {
+        const syncConfigId = params.id as string;
+        const syncConfig = MOCK_SYNC_CONFIGS.find((item) => item.id === syncConfigId);
+        if (!syncConfig) {
+            return HttpResponse.json({ detail: "Sync config not found" }, { status: 404 });
+        }
+        const selection = MOCK_REPOSITORY_SELECTIONS.get(syncConfigId) ?? {
+            owner: String(syncConfig.sync_options?.owner ?? ""),
+            repos: [],
+        };
+        return HttpResponse.json({ ...selection, sync_all_repos: false });
+    }),
+
     http.post("*/api/v1/admin/sync-configs", async ({ request }) => {
         const body = (await request.json()) as Partial<MockSyncConfig> | null;
         const created: MockSyncConfig = {
@@ -2435,6 +2480,19 @@ export const handlers = [
             provider: body?.provider ?? "github",
             name: body?.name ?? "Sync Config",
             enabled: body?.enabled ?? true,
+            credential_id:
+                (body as { credential_id?: string | null } | null)?.credential_id ?? null,
+            sync_targets: (body as { sync_targets?: string[] } | null)?.sync_targets ?? [],
+            sync_options:
+                (body as { sync_options?: Record<string, unknown> } | null)?.sync_options ?? {},
+            is_active: true,
+            schedule_cron: null,
+            timezone: null,
+            initial_sync_depth: 30,
+            last_sync_at: null,
+            last_sync_success: null,
+            last_sync_error: null,
+            parent_id: null,
             created_at: body?.created_at ?? new Date().toISOString(),
             updated_at: body?.updated_at ?? new Date().toISOString(),
         };
@@ -2451,19 +2509,50 @@ export const handlers = [
                 { status: 400 },
             );
         }
-        const created = repos.map((repo, index) => ({
-            id: `sync-config-batch-${index}`,
+        const parentId = `sync-config-batch-${Date.now()}`;
+        const owner = repos[0]?.split("/")[0] ?? "myorg";
+        const parent: MockSyncConfig = {
+            id: parentId,
             provider: body?.provider ?? "github",
-            name: repo,
+            name: "Selected Repos",
             enabled: true,
+            credential_id:
+                (body as { credential_id?: string | null } | null)?.credential_id ?? null,
+            sync_targets: (body as { sync_targets?: string[] } | null)?.sync_targets ?? [],
+            sync_options: { owner },
+            is_active: true,
+            schedule_cron: null,
+            timezone: null,
+            initial_sync_depth: 30,
+            last_sync_at: null,
+            last_sync_success: null,
+            last_sync_error: null,
+            parent_id: null,
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),
-        }));
+        };
+        MOCK_SYNC_CONFIGS.push(parent);
+        MOCK_REPOSITORY_SELECTIONS.set(parentId, { owner, repos });
         return HttpResponse.json({
-            created,
-            parent: created[0] ?? null,
-            count: created.length,
+            created: [],
+            parent,
+            count: repos.length,
         });
+    }),
+
+    http.put("*/api/v1/admin/sync-configs/:id/repositories", async ({ params, request }) => {
+        const syncConfigId = params.id as string;
+        const body = (await request.json()) as { owner?: string; repos?: string[] } | null;
+        const syncConfig = MOCK_SYNC_CONFIGS.find((item) => item.id === syncConfigId);
+        if (!syncConfig) {
+            return HttpResponse.json({ detail: "Sync config not found" }, { status: 404 });
+        }
+        const owner = body?.owner ?? "myorg";
+        const repos = body?.repos ?? [];
+        MOCK_REPOSITORY_SELECTIONS.set(syncConfigId, { owner, repos });
+        syncConfig.sync_options = { ...(syncConfig.sync_options ?? {}), owner };
+        syncConfig.updated_at = new Date().toISOString();
+        return HttpResponse.json({ owner, repos, sync_all_repos: false });
     }),
 
     http.patch("*/api/v1/admin/sync-configs/:id", async ({ params, request }) => {

--- a/tests/mocks/types.ts
+++ b/tests/mocks/types.ts
@@ -111,6 +111,17 @@ export interface MockSyncConfig {
     provider: string;
     name: string;
     enabled: boolean;
+    credential_id?: string | null;
+    sync_targets?: string[];
+    sync_options?: Record<string, unknown>;
+    is_active?: boolean;
+    schedule_cron?: string | null;
+    timezone?: string | null;
+    initial_sync_depth?: number | null;
+    last_sync_at?: string | null;
+    last_sync_success?: boolean | null;
+    last_sync_error?: string | null;
+    parent_id?: string | null;
     created_at: string;
     updated_at: string;
 }


### PR DESCRIPTION
## Summary
- Fetch persisted repository selection on the sync config edit page
- Render RepoSelector in edit mode and save changed selections through the new repositories endpoint
- Add typed client/server actions and mocked API support
- Add Vitest and Playwright coverage for editing selected repositories

Depends on full-chaos/dev-health-ops#1038.

## Verification
- pnpm vitest run src/components/admin/sync/SyncConfigForm.test.tsx
- pnpm typecheck
- pnpm exec prettier --check "src/app/(app)/org/admin/sync/[configId]/edit/page.tsx" src/components/admin/sync/SyncConfigForm.tsx src/components/admin/sync/SyncConfigForm.test.tsx src/lib/admin/api/sync.ts src/lib/admin/server/sync.ts src/lib/admin/types.ts tests/admin-sync.spec.ts tests/mocks/handlers.ts tests/mocks/types.ts
- pnpm exec eslint "src/app/(app)/org/admin/sync/[configId]/edit/page.tsx" src/components/admin/sync/SyncConfigForm.tsx src/components/admin/sync/SyncConfigForm.test.tsx src/lib/admin/api/sync.ts src/lib/admin/server/sync.ts src/lib/admin/types.ts tests/admin-sync.spec.ts tests/mocks/handlers.ts tests/mocks/types.ts
- pnpm test:e2e -- tests/admin-sync.spec.ts -g "editing sync config repositories updates selected repos" --project=authenticated
- Browser QA: opened /org/admin/sync/sync-config-edit-repos/edit, verified repo-alpha initially checked, checked repo-beta, observed "2 of 2 selected"

Note: pnpm design-lint still reports pre-existing repo-wide CTA/design-token issues outside this change.

## Screenshot
![chaos-sync-repo-selection-edit-after.png](https://github.com/user-attachments/assets/b9aa0529-a2a4-4501-bce5-4f926ccd9bb8)