### PR TITLE
fix(home): open investigation threads as evidence drawers

### DIFF
--- a/src/components/evidence/EvidencePanel.test.tsx
+++ b/src/components/evidence/EvidencePanel.test.tsx
@@ -139,6 +139,40 @@ describe("EvidencePanel", () => {
         expect(fetchSpy).not.toHaveBeenCalled();
     });
 
+    it.each([
+        [
+            "/api/v1/investment",
+            { theme_distribution: { feature_delivery: 0.7 }, subcategory_distribution: {} },
+            "/investment?f=",
+        ],
+        ["/api/v1/opportunities", { items: [] }, "/opportunities?f="],
+    ])(
+        "links non-Explore evidence API %s to its matching product route",
+        async (apiUrl, payload, expectedHref) => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(
+                new Response(JSON.stringify(payload), { status: 200 }),
+            );
+
+            render(
+                <EvidencePanel
+                    isOpen
+                    onCloseAction={() => undefined}
+                    title="Thread"
+                    apiUrl={apiUrl}
+                    filters={filters}
+                />,
+            );
+
+            await waitFor(() =>
+                expect(screen.getByText("Quality + provenance")).toBeInTheDocument(),
+            );
+            expect(screen.getByRole("link", { name: /Open in Explore View/i })).toHaveAttribute(
+                "href",
+                expect.stringContaining(expectedHref),
+            );
+        },
+    );
+
     afterEach(() => {
         mockGetExplainData.mockReset();
         mockLoggerError.mockReset();

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -5,13 +5,13 @@ import { getExplainData } from "@/lib/api/home";
 import { ValidationErrors } from "@/lib/constants/errors";
 import { logger } from "@/lib/logger";
 import { MetricFilter } from "@/lib/filters/types";
-import { Contributor } from "@/lib/types";
+import { Contributor, HomeResponse, InvestmentResponse, OpportunitiesResponse } from "@/lib/types";
 import { EvidenceContext } from "./EvidenceContext";
 import { EvidenceItems } from "./EvidenceItems";
 import { SuggestedActions } from "./SuggestedActions";
 import { ErrorCard } from "@/components/ui/ErrorCard";
 import { EmptyState } from "@/components/ui/EmptyState";
-import { buildExploreUrl } from "@/lib/filters/url";
+import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
 import { CTA_LABELS } from "@/lib/design/cta";
 import { getMetricDefinition } from "@/lib/metrics/definitions";
 import Link from "next/link";
@@ -61,6 +61,200 @@ type EvidencePanelResult = Partial<EvidencePanelData> & {
     identity_confidence?: number | null;
 };
 
+const formatPercent = (value?: number | null) =>
+    typeof value === "number" ? `${Math.round(value)}%` : "not available";
+
+const humanizeKey = (value: string) =>
+    value
+        .split("_")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ");
+
+const threadFromApiUrl = (apiUrl?: string) => {
+    if (!apiUrl) return undefined;
+    try {
+        const url = new URL(
+            apiUrl,
+            typeof window === "undefined" ? "http://localhost" : window.location.origin,
+        );
+        return url.searchParams.get("thread") ?? undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+type FetchableEvidenceResult =
+    | EvidencePanelResult
+    | HomeResponse
+    | InvestmentResponse
+    | OpportunitiesResponse;
+
+const isHomeResponse = (result: FetchableEvidenceResult): result is HomeResponse =>
+    "freshness" in result && "tiles" in result && "constraint" in result;
+
+const isInvestmentResponse = (result: FetchableEvidenceResult): result is InvestmentResponse =>
+    "theme_distribution" in result && "subcategory_distribution" in result;
+
+const isOpportunitiesResponse = (
+    result: FetchableEvidenceResult,
+): result is OpportunitiesResponse => "items" in result && Array.isArray(result.items);
+
+const normalizeHomeEvidence = (
+    result: HomeResponse,
+    apiUrl: string | undefined,
+    title: string,
+): EvidencePanelResult => {
+    const thread = threadFromApiUrl(apiUrl);
+    const coverage = result.freshness.coverage;
+    const coverageSummary = `Repository coverage ${formatPercent(coverage.repos_covered_pct)}, linked PR coverage ${formatPercent(coverage.prs_linked_to_issues_pct)}, cycle-state coverage ${formatPercent(coverage.issues_with_cycle_states_pct)}.`;
+    const summaryText = result.summary.map((sentence) => sentence.text).join(" ");
+    const evidence: EvidenceItem[] = [
+        ...result.summary.map((sentence) => ({
+            id: sentence.id,
+            title: sentence.text,
+            url: sentence.evidence_link,
+            type: "other" as const,
+            meta: "Cockpit summary",
+        })),
+        ...result.constraint.evidence.map((item, index) => ({
+            id: `constraint-${index}`,
+            title: item.label,
+            url: item.link,
+            type: "other" as const,
+            meta: result.constraint.title,
+        })),
+        ...result.events.map((event, index) => ({
+            id: `event-${index}`,
+            title: event.text,
+            url: event.link,
+            type: "other" as const,
+            meta: event.type,
+        })),
+    ];
+
+    return {
+        label: title,
+        value: result.data_confidence?.coverage_pct ?? coverage.repos_covered_pct,
+        delta_pct: 0,
+        summary:
+            thread === "measure"
+                ? coverageSummary
+                : result.health_state?.summary ||
+                  summaryText ||
+                  result.constraint.claim ||
+                  coverageSummary,
+        why_it_matters:
+            thread === "measure"
+                ? result.data_confidence?.caveats.join(" ") ||
+                  "Coverage and freshness determine how much context the cockpit can safely explain."
+                : result.constraint.claim ||
+                  "This context comes from the same cockpit payload that ranks current operating signals.",
+        evidence,
+        actions: result.constraint.experiments.map((experiment, index) => ({
+            id: `experiment-${index}`,
+            label: experiment,
+            type: "experiment" as const,
+        })),
+        provenance: {
+            last_sync: result.freshness.last_ingested_at,
+            source: "home API",
+            quality: result.data_confidence?.level ?? "partial",
+            partial: evidence.length === 0,
+        },
+    };
+};
+
+const normalizeInvestmentEvidence = (
+    result: InvestmentResponse,
+    title: string,
+): EvidencePanelResult => {
+    const themes = Object.entries(result.theme_distribution).sort(([, a], [, b]) => b - a);
+    const topTheme = themes[0];
+    const evidence = themes.slice(0, 6).map(([theme, share], index) => ({
+        id: `theme-${theme}`,
+        title: `${humanizeKey(theme)}: ${formatPercent(share * 100)}`,
+        url: "/investment",
+        type: "other" as const,
+        meta: index === 0 ? "Largest investment theme" : "Investment theme",
+    }));
+
+    return {
+        label: title,
+        value: topTheme ? topTheme[1] * 100 : 0,
+        delta_pct: 0,
+        summary: topTheme
+            ? `${humanizeKey(topTheme[0])} is the largest persisted investment theme in this scope.`
+            : "No investment mix has been persisted for this scope yet.",
+        why_it_matters:
+            "Investment mix context explains where effort is actually being spent, using persisted WorkUnit distributions.",
+        evidence,
+        actions: [
+            {
+                id: "inspect-investment-mix",
+                label: "Inspect the investment mix and compare it with current priorities.",
+                type: "process",
+            },
+        ],
+        provenance: {
+            source: "investment API",
+            quality: result.evidence_quality_stats ? "moderate" : "partial",
+            partial: evidence.length === 0,
+        },
+    };
+};
+
+const normalizeOpportunitiesEvidence = (
+    result: OpportunitiesResponse,
+    title: string,
+): EvidencePanelResult => {
+    const evidence = result.items.flatMap((item) =>
+        item.evidence_links.map((link, index) => ({
+            id: `${item.id}-${index}`,
+            title: item.title,
+            url: link,
+            type: "other" as const,
+            meta: item.rationale,
+        })),
+    );
+    const actions = result.items.flatMap((item) =>
+        item.suggested_experiments.map((experiment, index) => ({
+            id: `${item.id}-experiment-${index}`,
+            label: experiment,
+            type: "experiment" as const,
+        })),
+    );
+
+    return {
+        label: title,
+        value: result.items.length,
+        delta_pct: 0,
+        summary: result.items.length
+            ? `${result.items.length} opportunity${result.items.length === 1 ? "" : "ies"} matched the selected context.`
+            : "No opportunities matched the selected context yet.",
+        why_it_matters:
+            "Opportunity context connects the investigation thread to the next reversible operating experiment.",
+        evidence,
+        actions,
+        provenance: {
+            source: "opportunities API",
+            quality: evidence.length > 0 ? "moderate" : "partial",
+            partial: evidence.length === 0,
+        },
+    };
+};
+
+const normalizeFetchedEvidence = (
+    result: FetchableEvidenceResult | null,
+    apiUrl: string | undefined,
+    title: string,
+): EvidencePanelResult | null => {
+    if (!result) return null;
+    if (isHomeResponse(result)) return normalizeHomeEvidence(result, apiUrl, title);
+    if (isInvestmentResponse(result)) return normalizeInvestmentEvidence(result, title);
+    if (isOpportunitiesResponse(result)) return normalizeOpportunitiesEvidence(result, title);
+    return result;
+};
+
 const isEvidenceDebugEnabled = () =>
     process.env.NODE_ENV !== "production" &&
     process.env.NEXT_PUBLIC_DEV_HEALTH_EVIDENCE_DEBUG === "true";
@@ -77,6 +271,32 @@ const explainMetricFromApiUrl = (apiUrl?: string) => {
     } catch {
         return undefined;
     }
+};
+
+const evidenceDestination = (params: {
+    apiUrl?: string;
+    metric?: string;
+    filters: MetricFilter;
+}) => {
+    if (params.metric) return buildExploreUrl({ metric: params.metric, filters: params.filters });
+    if (!params.apiUrl) return "#";
+
+    try {
+        const url = new URL(
+            params.apiUrl,
+            typeof window === "undefined" ? "http://localhost" : window.location.origin,
+        );
+        if (url.pathname === "/api/v1/investment") {
+            return withFilterParam("/investment", params.filters);
+        }
+        if (url.pathname === "/api/v1/opportunities") {
+            return withFilterParam("/opportunities", params.filters);
+        }
+    } catch {
+        return buildExploreUrl({ api: params.apiUrl, filters: params.filters });
+    }
+
+    return buildExploreUrl({ api: params.apiUrl, filters: params.filters });
 };
 
 const readJsonOrEmpty = async <T,>(response: Response): Promise<T | null> => {
@@ -145,7 +365,8 @@ export function EvidencePanel({
                         } else {
                             const res = await fetch(apiUrl);
                             if (!res.ok) throw new Error(ValidationErrors.FailedToFetchEvidence);
-                            result = await readJsonOrEmpty<EvidencePanelResult>(res);
+                            const fetched = await readJsonOrEmpty<FetchableEvidenceResult>(res);
+                            result = normalizeFetchedEvidence(fetched, apiUrl, title);
                         }
                     } else if (metric) {
                         requestPath = "/api/v1/explain";
@@ -231,11 +452,7 @@ export function EvidencePanel({
 
     const showDevDiagnostics = isEvidenceDebugEnabled();
 
-    const exploreUrl = metric
-        ? buildExploreUrl({ metric, filters })
-        : apiUrl
-          ? buildExploreUrl({ api: apiUrl, filters })
-          : "#";
+    const exploreUrl = evidenceDestination({ apiUrl, metric, filters });
 
     return (
         <div className="fixed inset-0 z-50 flex justify-end">

--- a/src/components/home/CockpitClient.test.tsx
+++ b/src/components/home/CockpitClient.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@/test/utils";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/test/utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { MetricFilter } from "@/lib/filters/types";
 import type { HomeResponse } from "@/lib/types";
@@ -11,6 +11,10 @@ vi.mock("next/navigation", () => ({
     useRouter: () => ({ push: vi.fn() }),
     usePathname: () => "/",
 }));
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 const filters: MetricFilter = {
     scope: { level: "org", ids: ["org-1"] },
@@ -129,5 +133,94 @@ describe("CockpitClient — Key Shifts row", () => {
         expect(firstCard).toHaveAttribute("href", expect.stringContaining("role=em"));
         // f= must be present — dropping it loses the user's scope/time filter context.
         expect(firstCard).toHaveAttribute("href", expect.stringContaining("f="));
+    });
+
+    it("opens investigation thread tiles in the evidence panel with existing API targets", async () => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+            const url = String(input);
+            if (url.includes("/api/v1/opportunities")) {
+                return new Response(JSON.stringify({ items: [] }), { status: 200 });
+            }
+            return new Response(
+                JSON.stringify({
+                    freshness: {
+                        last_ingested_at: "2026-06-01T00:00:00Z",
+                        sources: { github: "ok" },
+                        coverage: {
+                            repos_covered_pct: 80,
+                            prs_linked_to_issues_pct: 70,
+                            issues_with_cycle_states_pct: 60,
+                        },
+                    },
+                    deltas: [],
+                    summary: [
+                        {
+                            id: "s1",
+                            text: "Cycle time moved in the selected window.",
+                            evidence_link: "/api/v1/explain?metric=cycle_time",
+                        },
+                    ],
+                    tiles: {},
+                    constraint: {
+                        title: "Constraint",
+                        claim: "Review queues are the current constraint.",
+                        evidence: [],
+                        experiments: ["Rebalance review rotation."],
+                    },
+                    events: [],
+                    data_confidence: {
+                        level: "medium",
+                        coverage_pct: 70,
+                        connected_sources: ["github"],
+                        missing_sources: [],
+                        caveats: [],
+                    },
+                }),
+                { status: 200 },
+            );
+        });
+
+        render(
+            <CockpitClient
+                home={makeHome({
+                    tiles: {
+                        understand: {
+                            title: "Understand",
+                            subtitle: "Flow stages",
+                            link: "/explore?view=understand",
+                        },
+                        execute: {
+                            title: "Execute",
+                            subtitle: "Top opportunities",
+                            link: "/opportunities",
+                        },
+                    },
+                })}
+                filters={filters}
+                activeRole="em"
+            />,
+        );
+
+        const understand = screen.getByRole("button", { name: /Understand Flow stages/i });
+        expect(
+            screen.queryByRole("link", { name: /Understand Flow stages/i }),
+        ).not.toBeInTheDocument();
+
+        fireEvent.click(understand);
+        await waitFor(() =>
+            expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining("/api/v1/home?")),
+        );
+        expect(String(fetchSpy.mock.calls[0][0])).toContain("thread=understand");
+        expect(
+            await screen.findAllByText("Cycle time moved in the selected window."),
+        ).not.toHaveLength(0);
+
+        fireEvent.click(screen.getByRole("button", { name: /Execute Top opportunities/i }));
+        await waitFor(() =>
+            expect(fetchSpy).toHaveBeenCalledWith(
+                expect.stringContaining("/api/v1/opportunities?"),
+            ),
+        );
+        expect(String(fetchSpy.mock.calls.at(-1)?.[0])).toContain("thread=execute");
     });
 });

--- a/src/components/home/CockpitClient.tsx
+++ b/src/components/home/CockpitClient.tsx
@@ -19,6 +19,47 @@ type CockpitClientProps = {
     activeRole: string;
 };
 
+const THREAD_API_TARGETS: Record<string, string> = {
+    understand: "/api/v1/home",
+    measure: "/api/v1/home",
+    align: "/api/v1/investment",
+    execute: "/api/v1/opportunities",
+};
+
+const buildThreadApiUrl = (path: string, filters: MetricFilter, thread: string) => {
+    const params = new URLSearchParams({
+        scope_type: filters.scope.level,
+        range_days: String(filters.time.range_days),
+        compare_days: String(filters.time.compare_days),
+        thread,
+    });
+
+    const [scopeId] = filters.scope.ids;
+    if (scopeId) params.set("scope_id", scopeId);
+    if (filters.time.start_date) params.set("start_date", filters.time.start_date);
+    if (filters.time.end_date) params.set("end_date", filters.time.end_date);
+
+    return `${path}?${params.toString()}`;
+};
+
+const getThreadEvidenceTarget = (
+    key: string,
+    tile: HomeResponse["tiles"][string],
+    filters: MetricFilter,
+) => {
+    const thread = key.toLowerCase();
+    const apiPath = THREAD_API_TARGETS[thread];
+    if (apiPath) {
+        return { apiUrl: buildThreadApiUrl(apiPath, filters, thread) };
+    }
+
+    return {
+        apiUrl: tile.link.startsWith("/api/")
+            ? tile.link
+            : buildThreadApiUrl("/api/v1/home", filters, thread),
+    };
+};
+
 export function CockpitClient({ home, filters, activeRole }: CockpitClientProps) {
     const [panelState, setPanelState] = useState<{
         isOpen: boolean;
@@ -152,7 +193,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                     <div className="flex items-center justify-between">
                         <h3 className="font-(--font-display) text-xl">Investigation threads</h3>
                         <Link
-                            href={withFilterParam("/opportunities", filters)}
+                            href={withFilterParam("/opportunities", filters, activeRole)}
                             className="text-xs uppercase tracking-[0.2em] text-(--accent-2)"
                         >
                             View all
@@ -164,7 +205,12 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                                   <button
                                       type="button"
                                       key={key}
-                                      onClick={() => openPanel(tile.title, { apiUrl: tile.link })}
+                                      onClick={() =>
+                                          openPanel(
+                                              tile.title,
+                                              getThreadEvidenceTarget(key, tile, filters),
+                                          )
+                                      }
                                       className="group w-full text-left rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3 transition hover:-translate-y-1"
                                   >
                                       <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">


### PR DESCRIPTION
## Summary
- Keep dashboard Investigation thread cards as evidence-panel buttons instead of navigation links.
- Adapt existing home, investment, and opportunities API payloads into the shared evidence drawer.
- Preserve useful drawer footer destinations for investment and opportunities threads.

## Verification
- pnpm vitest run src/components/home/CockpitClient.test.tsx src/components/evidence/EvidencePanel.test.tsx
- pnpm typecheck
- pnpm build
- pnpm format:check:changed
- Browser QA: signed in as admin@test.com, opened the Align Investigation thread drawer, confirmed no drawer error and footer href points to /investment?f=...

## Visual evidence
![investigation-thread-align-drawer.png](https://github.com/user-attachments/assets/bc88bda3-f910-4123-b15c-767a9b0bbba2)

## Notes
- Full pnpm design-lint still reports existing repo-wide violations unrelated to these changes.
- Unrelated local public/runtime-config.js changes were not included.
