### PR TITLE
feat(admin/teams): migrate drift-review wire to change_id (CHAOS-2654)

### DIFF
--- a/src/components/admin/teams/PendingChangesPanel.tsx
+++ b/src/components/admin/teams/PendingChangesPanel.tsx
@@ -40,9 +40,9 @@ export function PendingChangesPanel() {
         loadChanges();
     }, [loadChanges]);
 
-    const handleApprove = (teamId: string, changeIndex: number) => {
+    const handleApprove = (teamId: string, changeId: string) => {
         startTransition(async () => {
-            const result = await approveTeamChanges(teamId, [changeIndex]);
+            const result = await approveTeamChanges(teamId, [changeId]);
             if (result.error) {
                 toast.error("Failed to approve change: " + result.error);
             } else {
@@ -53,9 +53,9 @@ export function PendingChangesPanel() {
         });
     };
 
-    const handleDismiss = (teamId: string, changeIndex: number) => {
+    const handleDismiss = (teamId: string, changeId: string) => {
         startTransition(async () => {
-            const result = await dismissTeamChanges(teamId, [changeIndex]);
+            const result = await dismissTeamChanges(teamId, [changeId]);
             if (result.error) {
                 toast.error("Failed to dismiss change: " + result.error);
             } else {
@@ -143,7 +143,7 @@ export function PendingChangesPanel() {
 
                     {changes.map((change) => (
                         <div
-                            key={`${change.team_id}-${change.change_type}-${change.field ?? "all"}-${change.change_index}`}
+                            key={change.change_id}
                             className="flex items-center justify-between border-b border-(--card-stroke) px-4 py-3 last:border-0 hover:bg-(--card-70)"
                         >
                             <div className="flex flex-col gap-1">
@@ -197,7 +197,7 @@ export function PendingChangesPanel() {
                                 <button
                                     type="button"
                                     onClick={() =>
-                                        handleApprove(change.team_id, change.change_index)
+                                        handleApprove(change.team_id, change.change_id)
                                     }
                                     disabled={isPending}
                                     className="cursor-pointer rounded px-2 py-1 text-xs font-medium text-green-600 hover:bg-green-500/10 disabled:opacity-50"
@@ -207,7 +207,7 @@ export function PendingChangesPanel() {
                                 <button
                                     type="button"
                                     onClick={() =>
-                                        handleDismiss(change.team_id, change.change_index)
+                                        handleDismiss(change.team_id, change.change_id)
                                     }
                                     disabled={isPending}
                                     className="cursor-pointer rounded px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-500/10 disabled:opacity-50"

--- a/src/components/admin/teams/PendingChangesPanel.tsx
+++ b/src/components/admin/teams/PendingChangesPanel.tsx
@@ -196,9 +196,7 @@ export function PendingChangesPanel() {
                             <div className="flex items-center gap-2">
                                 <button
                                     type="button"
-                                    onClick={() =>
-                                        handleApprove(change.team_id, change.change_id)
-                                    }
+                                    onClick={() => handleApprove(change.team_id, change.change_id)}
                                     disabled={isPending}
                                     className="cursor-pointer rounded px-2 py-1 text-xs font-medium text-green-600 hover:bg-green-500/10 disabled:opacity-50"
                                 >
@@ -206,9 +204,7 @@ export function PendingChangesPanel() {
                                 </button>
                                 <button
                                     type="button"
-                                    onClick={() =>
-                                        handleDismiss(change.team_id, change.change_id)
-                                    }
+                                    onClick={() => handleDismiss(change.team_id, change.change_id)}
                                     disabled={isPending}
                                     className="cursor-pointer rounded px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-500/10 disabled:opacity-50"
                                 >

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -28,6 +28,8 @@ import {
     listRetentionResourceTypes,
     getOrgEntitlements,
     createSyncConfig,
+    approveTeamChanges,
+    dismissTeamChanges,
 } from "../server";
 
 function mockSession() {
@@ -590,5 +592,62 @@ describe("admin/server retention policy actions", () => {
             expect(result.data).toHaveLength(3);
             fetchSpy.mockRestore();
         });
+    });
+});
+
+
+describe("admin/server team drift-review actions", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.stubEnv("BACKEND_URL", "http://test-ops:8000");
+    });
+
+    it("approveTeamChanges posts change_ids (not change_indices)", async () => {
+        mockSession();
+        const fetchSpy = vi
+            .spyOn(global, "fetch")
+            .mockResolvedValue(
+                new Response(JSON.stringify({ approved: 2 }), { status: 200 }),
+            );
+
+        const result = await approveTeamChanges("team-1", ["chg-1", "chg-2"]);
+
+        expect(result.error).toBeUndefined();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [url, options] = fetchSpy.mock.calls[0] as [
+            string,
+            RequestInit | undefined,
+        ];
+        expect(url).toContain("/api/v1/admin/teams/team-1/approve-changes");
+        const body = JSON.parse(String(options?.body ?? "{}"));
+        expect(body).toMatchObject({
+            change_ids: ["chg-1", "chg-2"],
+            approve_all: false,
+        });
+        expect(body).not.toHaveProperty("change_indices");
+        fetchSpy.mockRestore();
+    });
+
+    it("dismissTeamChanges posts change_ids (not change_indices)", async () => {
+        mockSession();
+        const fetchSpy = vi
+            .spyOn(global, "fetch")
+            .mockResolvedValue(
+                new Response(JSON.stringify({ dismissed: 1 }), { status: 200 }),
+            );
+
+        const result = await dismissTeamChanges("team-1", ["chg-9"]);
+
+        expect(result.error).toBeUndefined();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [url, options] = fetchSpy.mock.calls[0] as [
+            string,
+            RequestInit | undefined,
+        ];
+        expect(url).toContain("/api/v1/admin/teams/team-1/dismiss-changes");
+        const body = JSON.parse(String(options?.body ?? "{}"));
+        expect(body).toMatchObject({ change_ids: ["chg-9"], dismiss_all: false });
+        expect(body).not.toHaveProperty("change_indices");
+        fetchSpy.mockRestore();
     });
 });

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -595,7 +595,6 @@ describe("admin/server retention policy actions", () => {
     });
 });
 
-
 describe("admin/server team drift-review actions", () => {
     beforeEach(() => {
         vi.resetAllMocks();
@@ -606,18 +605,13 @@ describe("admin/server team drift-review actions", () => {
         mockSession();
         const fetchSpy = vi
             .spyOn(global, "fetch")
-            .mockResolvedValue(
-                new Response(JSON.stringify({ approved: 2 }), { status: 200 }),
-            );
+            .mockResolvedValue(new Response(JSON.stringify({ approved: 2 }), { status: 200 }));
 
         const result = await approveTeamChanges("team-1", ["chg-1", "chg-2"]);
 
         expect(result.error).toBeUndefined();
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        const [url, options] = fetchSpy.mock.calls[0] as [
-            string,
-            RequestInit | undefined,
-        ];
+        const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
         expect(url).toContain("/api/v1/admin/teams/team-1/approve-changes");
         const body = JSON.parse(String(options?.body ?? "{}"));
         expect(body).toMatchObject({
@@ -632,18 +626,13 @@ describe("admin/server team drift-review actions", () => {
         mockSession();
         const fetchSpy = vi
             .spyOn(global, "fetch")
-            .mockResolvedValue(
-                new Response(JSON.stringify({ dismissed: 1 }), { status: 200 }),
-            );
+            .mockResolvedValue(new Response(JSON.stringify({ dismissed: 1 }), { status: 200 }));
 
         const result = await dismissTeamChanges("team-1", ["chg-9"]);
 
         expect(result.error).toBeUndefined();
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        const [url, options] = fetchSpy.mock.calls[0] as [
-            string,
-            RequestInit | undefined,
-        ];
+        const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
         expect(url).toContain("/api/v1/admin/teams/team-1/dismiss-changes");
         const body = JSON.parse(String(options?.body ?? "{}"));
         expect(body).toMatchObject({ change_ids: ["chg-9"], dismiss_all: false });

--- a/src/lib/admin/api/teams.ts
+++ b/src/lib/admin/api/teams.ts
@@ -50,7 +50,7 @@ export const teamsApi = {
 
     approveChanges: (
         teamId: string,
-        changeIndices?: number[],
+        changeIds?: string[],
         approveAll = false,
         token?: string,
         orgId?: string,
@@ -60,7 +60,7 @@ export const teamsApi = {
             {
                 method: "POST",
                 body: JSON.stringify({
-                    change_indices: changeIndices,
+                    change_ids: changeIds,
                     approve_all: approveAll,
                 }),
             },
@@ -70,7 +70,7 @@ export const teamsApi = {
 
     dismissChanges: (
         teamId: string,
-        changeIndices?: number[],
+        changeIds?: string[],
         dismissAll = false,
         token?: string,
         orgId?: string,
@@ -80,7 +80,7 @@ export const teamsApi = {
             {
                 method: "POST",
                 body: JSON.stringify({
-                    change_indices: changeIndices,
+                    change_ids: changeIds,
                     dismiss_all: dismissAll,
                 }),
             },

--- a/src/lib/admin/server/teams.ts
+++ b/src/lib/admin/server/teams.ts
@@ -78,14 +78,14 @@ export async function getPendingTeamChanges(): Promise<ActionResult<PendingChang
 
 export async function approveTeamChanges(
     teamId: string,
-    changeIndices?: number[],
+    changeIds?: string[],
     approveAll = false,
 ): Promise<ActionResult<{ approved: number }>> {
     return withErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
         const result = await adminApi.teams.approveChanges(
             teamId,
-            changeIndices,
+            changeIds,
             approveAll,
             token,
             orgId,
@@ -97,14 +97,14 @@ export async function approveTeamChanges(
 
 export async function dismissTeamChanges(
     teamId: string,
-    changeIndices?: number[],
+    changeIds?: string[],
     dismissAll = false,
 ): Promise<ActionResult<{ dismissed: number }>> {
     return withErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
         const result = await adminApi.teams.dismissChanges(
             teamId,
-            changeIndices,
+            changeIds,
             dismissAll,
             token,
             orgId,

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -338,6 +338,7 @@ export interface TeamImportResponse {
 }
 
 export interface FlaggedChange {
+    change_id: string;
     team_id: string;
     team_name: string;
     change_type: "field_changed" | "provider_removed" | "new_team_available";


### PR DESCRIPTION
## What & why

Switches the team drift-review (Pending Changes) admin surface from the fragile index-based approve/dismiss path to a stable **change_id**-canonical wire, matching the rebuilt ClickHouse drift-review service in dev-health-ops (CHAOS-2622).

The four `/admin/teams` drift endpoints were HTTP 501 stubs; the rebuilt backend (dev-health-ops PR #1044) returns each `FlaggedChange` with a stable `change_id` and accepts `change_ids[]` for approve/dismiss. This PR updates the client wire to match so the Pending Changes panel works end-to-end again.

## Changes

- `lib/admin/types.ts` — `FlaggedChange` carries `change_id`.
- `lib/admin/api/teams.ts` + `lib/admin/server/teams.ts` — approve/dismiss send `change_ids` (not `change_indices`).
- `components/admin/teams/PendingChangesPanel.tsx` — approve/dismiss handlers + row keys use `change_id`.

## Testing

`npx tsc --noEmit` clean.

## Dependency

Pairs with **dev-health-ops PR #1044** (must merge together for the wire to resolve). Part of CHAOS-2622.