### PR TITLE
feat(admin/sync): surface sync job history context

### DIFF
--- a/src/components/admin/sync/SyncJobHistory.test.tsx
+++ b/src/components/admin/sync/SyncJobHistory.test.tsx
@@ -20,6 +20,7 @@ describe("SyncJobHistory", () => {
     it("renders first page with 10 jobs", () => {
         render(<SyncJobHistory jobs={buildJobs(12)} />);
 
+        expect(screen.getByText("Completed / Last Activity")).toBeInTheDocument();
         expect(screen.getByText("error-1")).toBeInTheDocument();
         expect(screen.getByText("error-10")).toBeInTheDocument();
         expect(screen.queryByText("error-11")).not.toBeInTheDocument();
@@ -74,9 +75,81 @@ describe("SyncJobHistory", () => {
         };
         render(<SyncJobHistory jobs={[pendingJob]} />);
 
-        expect(screen.getByText("—")).toBeInTheDocument();
+        expect(screen.getAllByText("Queued").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("—").length).toBeGreaterThan(0);
         // new Date(null) coerces to epoch 0; the 1969/1970 date must never render.
         expect(screen.queryByText(/19[67]\d/)).not.toBeInTheDocument();
+    });
+
+    it("shows completed activity and structured failure context", () => {
+        const failedJob: SyncJob = {
+            id: "job-failed",
+            config_id: "cfg-1",
+            status: "failed",
+            started_at: "2024-01-01T00:00:00.000Z",
+            completed_at: "2024-01-01T00:00:45.000Z",
+            duration_seconds: null,
+            items_synced: 4,
+            error: "Sync run completed with failed units",
+            result: {
+                dataset_key: "work-items",
+                error_category: "rate_limit",
+                failed_unit_count: 2,
+                total_units: 5,
+                failed_unit_ids: ["unit-1", "unit-2"],
+            },
+        };
+
+        render(<SyncJobHistory jobs={[failedJob]} />);
+
+        expect(screen.getByText("Completed")).toBeInTheDocument();
+        expect(screen.getByText("45s")).toBeInTheDocument();
+        expect(screen.getByText("Sync run completed with failed units")).toBeInTheDocument();
+        expect(
+            screen.getByText(/Part: work-items · Category: rate_limit · Failed units: 2 of 5/),
+        ).toBeInTheDocument();
+    });
+
+    it("marks running jobs as still running when completed_at is not stamped", () => {
+        const runningJob: SyncJob = {
+            id: "job-running",
+            config_id: "cfg-1",
+            status: "running",
+            started_at: "2024-01-01T00:00:00.000Z",
+            completed_at: null,
+            duration_seconds: null,
+            items_synced: 3,
+        };
+
+        render(<SyncJobHistory jobs={[runningJob]} />);
+
+        expect(screen.getAllByText("Still running").length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/Started /).length).toBeGreaterThan(0);
+    });
+
+    it("shows cancelled jobs and object-shaped partial failure summaries", () => {
+        const cancelledJob: SyncJob = {
+            id: "job-cancelled",
+            config_id: "cfg-1",
+            status: "cancelled",
+            started_at: "2024-01-01T00:00:00.000Z",
+            completed_at: "2024-01-01T00:00:10.000Z",
+            duration_seconds: 10,
+            items_synced: 1,
+            result: {
+                partial_failure_summary: {
+                    failed_datasets: ["prs", "work-items"],
+                    error_categories: ["rate_limit"],
+                },
+            },
+        };
+
+        render(<SyncJobHistory jobs={[cancelledJob]} />);
+
+        expect(screen.getAllByText("Cancelled")).toHaveLength(2);
+        expect(
+            screen.getByText(/failed_datasets: prs, work-items; error_categories: rate_limit/),
+        ).toBeInTheDocument();
     });
 
     it("shows empty state when there are no jobs", () => {

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { SyncJob } from "@/lib/admin/types";
+import { CTA_LABELS } from "@/lib/design/cta";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 
 interface SyncJobHistoryProps {
@@ -28,6 +29,7 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
             case "success":
                 return "success";
             case "failed":
+            case "cancelled":
                 return "failed";
             case "running":
                 return "running";
@@ -38,8 +40,137 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
         }
     };
 
+    const getBadgeLabel = (status: SyncJob["status"]) => {
+        switch (status) {
+            case "pending":
+                return "Queued";
+            case "cancelled":
+                return "Cancelled";
+            default:
+                return undefined;
+        }
+    };
+
+    const formatTimestamp = (value: string | null | undefined) => {
+        if (!value) return "—";
+        return new Date(value).toLocaleString();
+    };
+
+    const getDuration = (job: SyncJob) => {
+        if (job.duration_seconds != null) return `${Math.round(job.duration_seconds)}s`;
+        if (job.completed_at && job.started_at) {
+            return `${Math.round(
+                (new Date(job.completed_at).getTime() - new Date(job.started_at).getTime()) / 1000,
+            )}s`;
+        }
+        return "-";
+    };
+
+    const getActivityLabel = (job: SyncJob) => {
+        if (job.status === "cancelled") return "Cancelled";
+        if (job.completed_at) return "Completed";
+        if (job.status === "running") return "Still running";
+        if (job.status === "pending") return "Queued";
+        return "Last activity";
+    };
+
+    const getActivityTimestamp = (job: SyncJob) =>
+        job.completed_at ?? job.started_at ?? job.created_at ?? null;
+
+    const isRecord = (value: unknown): value is Record<string, unknown> =>
+        value !== null && typeof value === "object" && !Array.isArray(value);
+
+    const stringifyValue = (value: unknown): string | null => {
+        if (typeof value === "string" && value.trim().length > 0) return value;
+        if (typeof value === "number" || typeof value === "boolean") return String(value);
+        if (Array.isArray(value)) {
+            const items = value.map((item) => stringifyValue(item)).filter((item) => item != null);
+            return items.length > 0 ? items.join(", ") : null;
+        }
+        if (isRecord(value)) {
+            const entries = Object.entries(value)
+                .map(([key, item]) => {
+                    const text = stringifyValue(item);
+                    return text ? `${key}: ${text}` : null;
+                })
+                .filter((item) => item != null);
+            return entries.length > 0 ? entries.join("; ") : null;
+        }
+        return null;
+    };
+
+    const getResultValue = (result: Record<string, unknown> | null | undefined, key: string) =>
+        result ? stringifyValue(result[key]) : null;
+
+    const getResultDetails = (job: SyncJob) => {
+        const result = isRecord(job.result) ? job.result : null;
+        const details: string[] = [];
+        const part =
+            getResultValue(result, "sync_part") ??
+            getResultValue(result, "phase") ??
+            getResultValue(result, "dataset_key") ??
+            getResultValue(result, "provider") ??
+            getResultValue(result, "mode");
+        const category = getResultValue(result, "error_category");
+        const reason =
+            getResultValue(result, "partial_failure_summary") ??
+            getResultValue(result, "reason") ??
+            getResultValue(result, "message") ??
+            getResultValue(result, "error");
+        const failedUnits =
+            getResultValue(result, "failed_unit_count") ?? getResultValue(result, "failed_units");
+        const totalUnits = getResultValue(result, "total_units");
+        const failedUnitIds = result?.failed_unit_ids;
+
+        if (part) details.push(`Part: ${part}`);
+        if (category) details.push(`Category: ${category}`);
+        if (reason && reason !== job.error) details.push(reason);
+        if (failedUnits) {
+            details.push(
+                totalUnits
+                    ? `Failed units: ${failedUnits} of ${totalUnits}`
+                    : `Failed units: ${failedUnits}`,
+            );
+        }
+        if (Array.isArray(failedUnitIds) && failedUnitIds.length > 0) {
+            details.push(`Unit IDs: ${failedUnitIds.slice(0, 3).join(", ")}`);
+        }
+
+        return details;
+    };
+
+    const getJobDetails = (job: SyncJob) => {
+        const resultDetails = getResultDetails(job);
+        if (job.error) return { primary: job.error, secondary: resultDetails, tone: "error" };
+        if (job.status === "failed") {
+            return {
+                primary: resultDetails[0] ?? "Sync failed without a stored reason",
+                secondary: resultDetails.slice(1),
+                tone: "error",
+            };
+        }
+        if (job.status === "cancelled") {
+            return {
+                primary: resultDetails[0] ?? "Sync was cancelled before completion",
+                secondary: resultDetails.slice(1),
+                tone: "error",
+            };
+        }
+        if (job.status === "running") {
+            return {
+                primary: "Still running",
+                secondary: [`Started ${formatTimestamp(job.started_at)}`],
+                tone: "muted",
+            };
+        }
+        if (job.status === "pending") {
+            return { primary: "Queued", secondary: [], tone: "muted" };
+        }
+        return { primary: "-", secondary: [], tone: "muted" };
+    };
+
     return (
-        <div className="overflow-hidden rounded-xl border border-(--card-stroke) bg-(--card-80)">
+        <div className="overflow-x-auto rounded-xl border border-(--card-stroke) bg-(--card-80)">
             <table className="min-w-full divide-y divide-(--card-stroke)">
                 <thead className="bg-(--card-bg)">
                     <tr>
@@ -59,6 +190,12 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                             scope="col"
                             className="px-6 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
                         >
+                            Completed / Last Activity
+                        </th>
+                        <th
+                            scope="col"
+                            className="px-6 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
+                        >
                             Duration
                         </th>
                         <th
@@ -71,31 +208,32 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                             scope="col"
                             className="px-6 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
                         >
-                            Error
+                            Details
                         </th>
                     </tr>
                 </thead>
                 <tbody className="divide-y divide-(--card-stroke) bg-(--card-80)">
                     {paginatedJobs.map((job) => {
-                        const duration = job.duration_seconds
-                            ? `${Math.round(job.duration_seconds)}s`
-                            : job.completed_at && job.started_at
-                              ? Math.round(
-                                    (new Date(job.completed_at).getTime() -
-                                        new Date(job.started_at).getTime()) /
-                                        1000,
-                                ) + "s"
-                              : "-";
+                        const duration = getDuration(job);
+                        const activityTimestamp = getActivityTimestamp(job);
+                        const details = getJobDetails(job);
 
                         return (
                             <tr key={job.id}>
                                 <td className="px-6 py-4 whitespace-nowrap">
-                                    <SyncStatusBadge status={getBadgeStatus(job.status)} />
+                                    <SyncStatusBadge
+                                        status={getBadgeStatus(job.status)}
+                                        label={getBadgeLabel(job.status)}
+                                    />
                                 </td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
-                                    {job.started_at
-                                        ? new Date(job.started_at).toLocaleString()
-                                        : "—"}
+                                    {formatTimestamp(job.started_at)}
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
+                                    <div>{formatTimestamp(activityTimestamp)}</div>
+                                    <div className="text-xs text-(--ink-muted)">
+                                        {getActivityLabel(job)}
+                                    </div>
                                 </td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-(--ink-muted)">
                                     {duration}
@@ -103,11 +241,26 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-(--ink-muted)">
                                     {job.items_synced ?? "-"}
                                 </td>
-                                <td className="px-6 py-4 text-sm text-red-500">
-                                    {job.error ? (
-                                        <span title={job.error} className="line-clamp-2">
-                                            {job.error}
-                                        </span>
+                                <td
+                                    className={`px-6 py-4 text-sm ${
+                                        details.tone === "error"
+                                            ? "text-red-500"
+                                            : "text-(--ink-muted)"
+                                    }`}
+                                >
+                                    {details.primary !== "-" ? (
+                                        <div
+                                            title={[details.primary, ...details.secondary].join(
+                                                " · ",
+                                            )}
+                                        >
+                                            <div className="line-clamp-2">{details.primary}</div>
+                                            {details.secondary.length > 0 && (
+                                                <div className="mt-1 line-clamp-2 text-xs text-(--ink-muted)">
+                                                    {details.secondary.join(" · ")}
+                                                </div>
+                                            )}
+                                        </div>
                                     ) : (
                                         <span className="text-(--ink-muted)">-</span>
                                     )}
@@ -129,7 +282,7 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                         disabled={offset === 0}
                         className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium hover:bg-(--card-70) disabled:cursor-not-allowed disabled:opacity-50"
                     >
-                        Previous
+                        {CTA_LABELS.previousPage}
                     </button>
                     <button
                         type="button"
@@ -137,7 +290,7 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                         disabled={offset + limit >= total}
                         className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium hover:bg-(--card-70) disabled:cursor-not-allowed disabled:opacity-50"
                     >
-                        Next
+                        {CTA_LABELS.nextPage}
                     </button>
                 </div>
             </div>

--- a/src/components/admin/sync/SyncStatusBadge.tsx
+++ b/src/components/admin/sync/SyncStatusBadge.tsx
@@ -3,9 +3,10 @@ import { SyncStatus } from "@/lib/sync-types";
 interface SyncStatusBadgeProps {
     status: SyncStatus;
     className?: string;
+    label?: string;
 }
 
-export function SyncStatusBadge({ status, className = "" }: SyncStatusBadgeProps) {
+export function SyncStatusBadge({ status, className = "", label }: SyncStatusBadgeProps) {
     const variants = {
         success: "bg-green-100 text-green-700 border-green-200",
         failed: "bg-red-100 text-red-700 border-red-200",
@@ -26,7 +27,7 @@ export function SyncStatusBadge({ status, className = "" }: SyncStatusBadgeProps
         <span
             className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${variants[status]} ${className}`}
         >
-            {labels[status]}
+            {label ?? labels[status]}
         </span>
     );
 }

--- a/src/components/admin/sync/useSyncTrigger.ts
+++ b/src/components/admin/sync/useSyncTrigger.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { triggerSync, getSyncRunStatus, getSyncJobs } from "@/lib/admin/server";
+import { logger } from "@/lib/logger";
 import {
     type SyncStatus,
     type SyncPollTarget,
@@ -17,6 +18,12 @@ import {
 const POLL_INTERVAL_MS = 3500;
 /** Safety cap so a stuck/abandoned run never spins forever (~5 min). */
 const MAX_POLL_DURATION_MS = 5 * 60 * 1000;
+
+const syncLogger = logger.child({ component: "useSyncTrigger" });
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : "Unknown error";
+}
 
 interface UseSyncTriggerResult {
     /**
@@ -68,13 +75,17 @@ export function useSyncTrigger(configId: string): UseSyncTriggerResult {
         if (target.kind === "planner") {
             const res = await getSyncRunStatus(target.runId);
             if (res.error || !res.data) {
-                throw new Error(res.error || "Failed to read sync run status");
+                throw new Error(
+                    `Unable to read planner sync run status: ${res.error || "empty response"}`,
+                );
             }
             return mapPlannerRunStatus(res.data.status);
         }
         const res = await getSyncJobs(target.configId);
         if (res.error || !res.data) {
-            throw new Error(res.error || "Failed to read sync job status");
+            throw new Error(
+                `Unable to read legacy sync job status: ${res.error || "empty response"}`,
+            );
         }
         // Track the specific run we triggered rather than blindly trusting the
         // head of the list — scheduled retries, concurrent admin clicks, or
@@ -109,13 +120,17 @@ export function useSyncTrigger(configId: string): UseSyncTriggerResult {
                     } else {
                         setLiveStatus(status);
                     }
-                } catch {
+                } catch (error) {
                     // Stop on poll error, drop back to the persisted status, and
                     // let the user retry rather than leave an infinite spinner.
                     stopPolling();
                     setLiveStatus(null);
                     setIsSyncing(false);
-                    toast.error("Lost track of sync status — refresh to check");
+                    syncLogger.error(
+                        { err: error, configId, pollTargetKind: target.kind },
+                        "Sync status polling failed",
+                    );
+                    toast.error(`Lost track of sync status: ${errorMessage(error)}`);
                 }
             }, POLL_INTERVAL_MS);
 
@@ -125,10 +140,11 @@ export function useSyncTrigger(configId: string): UseSyncTriggerResult {
                 stopPolling();
                 setLiveStatus(null);
                 setIsSyncing(false);
+                toast("Sync is still running; refreshing persisted status");
                 router.refresh();
             }, MAX_POLL_DURATION_MS);
         },
-        [fetchStatus, router, stopPolling],
+        [configId, fetchStatus, router, stopPolling],
     );
 
     const trigger = useCallback(() => {
@@ -140,7 +156,7 @@ export function useSyncTrigger(configId: string): UseSyncTriggerResult {
                 if (result.error || !result.data) {
                     setLiveStatus(null);
                     setIsSyncing(false);
-                    toast.error(result.error || "Failed to trigger sync");
+                    toast.error(`Unable to start sync: ${result.error || "empty response"}`);
                     return;
                 }
                 toast.success("Sync triggered");
@@ -153,10 +169,11 @@ export function useSyncTrigger(configId: string): UseSyncTriggerResult {
                     return;
                 }
                 startPolling(target);
-            } catch {
+            } catch (error) {
                 setLiveStatus(null);
                 setIsSyncing(false);
-                toast.error("Failed to trigger sync");
+                syncLogger.error({ err: error, configId }, "Sync trigger failed");
+                toast.error(`Unable to start sync: ${errorMessage(error)}`);
             }
         })();
     }, [configId, router, startPolling]);

--- a/src/lib/__tests__/syncStatusMapping.test.ts
+++ b/src/lib/__tests__/syncStatusMapping.test.ts
@@ -101,8 +101,8 @@ describe("mapLegacyJobStatus", () => {
         expect(mapLegacyJobStatus("success")).toBe("success");
     });
 
-    it("maps failed to failed", () => {
-        expect(mapLegacyJobStatus("failed")).toBe("failed");
+    it.each(["failed", "cancelled"])("maps terminal legacy status %s to failed", (status) => {
+        expect(mapLegacyJobStatus(status)).toBe("failed");
     });
 
     it("keeps the spinner up for unknown statuses", () => {

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -141,13 +141,17 @@ export interface SyncConfigRepositorySelectionUpdate {
 
 export interface SyncJob {
     id: string;
-    config_id: string;
-    status: "pending" | "running" | "success" | "failed";
+    config_id?: string;
+    job_id?: string;
+    status: "pending" | "running" | "success" | "failed" | "cancelled";
     started_at: string | null;
     completed_at: string | null;
     duration_seconds: number | null;
     items_synced: number;
-    error?: string;
+    result?: Record<string, unknown> | null;
+    error?: string | null;
+    triggered_by?: string;
+    created_at?: string;
 }
 
 /**

--- a/src/lib/sync-types.ts
+++ b/src/lib/sync-types.ts
@@ -98,7 +98,7 @@ export function mapPlannerRunStatus(status: string): SyncStatus {
 }
 
 /**
- * Map a legacy SyncJob.status (pending|running|success|failed) onto the shared
+ * Map a legacy SyncJob.status (pending|running|success|failed|cancelled) onto the shared
  * UI status union. Unknown / not-yet-terminal values keep "running".
  */
 export function mapLegacyJobStatus(status: string): SyncStatus {
@@ -109,6 +109,7 @@ export function mapLegacyJobStatus(status: string): SyncStatus {
         case "success":
             return "success";
         case "failed":
+        case "cancelled":
             return "failed";
         default:
             return "running";

--- a/tests/admin-sync.spec.ts
+++ b/tests/admin-sync.spec.ts
@@ -63,6 +63,17 @@ test("editing sync config repositories updates selected repos", async ({ page })
     await expect(page).toHaveURL(/\/org\/admin\/sync$/);
 });
 
+test("sync config history exposes completion and failure context", async ({ page }) => {
+    await page.goto("/org/admin/sync/sync-config-edit-repos");
+
+    await expect(page.getByRole("heading", { name: /editable repos/i })).toBeVisible();
+    await expect(page.getByText("Completed / Last Activity")).toBeVisible();
+    await expect(page.getByText("Sync run completed with failed units")).toBeVisible();
+    await expect(page.getByText(/Part: work-items · Category: rate_limit/)).toBeVisible();
+    await expect(page.getByText(/Failed units: 2 of 6/)).toBeVisible();
+    await expect(page.getByText("Still running").first()).toBeVisible();
+});
+
 test("provider selection filters sync targets", async ({ page }) => {
     await page.goto("/org/admin/sync/new");
 

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -753,6 +753,40 @@ const MOCK_SYNC_CONFIGS: MockSyncConfig[] = [
         updated_at: "2026-01-15T00:00:00.000Z",
     },
 ];
+const MOCK_SYNC_JOBS = [
+    {
+        id: "sync-job-failed-units",
+        job_id: "scheduled-job-github",
+        status: "failed",
+        started_at: "2026-06-25T08:48:36.000Z",
+        completed_at: "2026-06-25T12:12:40.000Z",
+        duration_seconds: null,
+        items_synced: 32,
+        error: "Sync run completed with failed units",
+        result: {
+            dataset_key: "work-items",
+            error_category: "rate_limit",
+            failed_unit_count: 2,
+            total_units: 6,
+            failed_unit_ids: ["unit-work-items", "unit-prs"],
+        },
+        triggered_by: "manual",
+        created_at: "2026-06-25T08:48:35.000Z",
+    },
+    {
+        id: "sync-job-running",
+        job_id: "scheduled-job-github",
+        status: "running",
+        started_at: "2026-06-25T12:15:00.000Z",
+        completed_at: null,
+        duration_seconds: null,
+        items_synced: 4,
+        error: null,
+        result: null,
+        triggered_by: "manual",
+        created_at: "2026-06-25T12:15:00.000Z",
+    },
+];
 const MOCK_REPOSITORY_SELECTIONS = new Map<string, { owner: string; repos: string[] }>([
     ["sync-config-edit-repos", { owner: "myorg", repos: ["myorg/repo-alpha"] }],
 ]);
@@ -2586,7 +2620,12 @@ export const handlers = [
         HttpResponse.json({ status: "triggered" }),
     ),
 
-    http.get("*/api/v1/admin/sync-configs/:id/jobs", () => HttpResponse.json([])),
+    http.get("*/api/v1/admin/sync-configs/:id/jobs", ({ params }) => {
+        if (params.id === "sync-config-edit-repos") {
+            return HttpResponse.json(MOCK_SYNC_JOBS);
+        }
+        return HttpResponse.json([]);
+    }),
 
     http.get("*/api/v1/admin/teams", () => HttpResponse.json(MOCK_TEAMS)),
 


### PR DESCRIPTION
## Summary
- add completed/last-activity and details columns to admin sync job history
- surface failed-unit, phase/category, running, queued, and cancelled context from persisted job fields
- tighten sync trigger/polling error messages and add history coverage in unit and Playwright tests

## Verification
- `pnpm exec vitest run src/components/admin/sync/SyncJobHistory.test.tsx src/lib/__tests__/syncStatusMapping.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with one unrelated existing warning in `src/lib/navigation/__tests__/ia-preservation-invariants.test.ts`)
- `pnpm build`
- `pnpm exec playwright test tests/admin-sync.spec.ts -g "sync config history exposes completion and failure context" --project authenticated --no-deps`
- Manual browser QA against mock API + worktree-safe webpack dev server
- Visual QA rerun: PASS
- Implementation review rerun: PASS

## Visual evidence
![sync-history-worktree.png](https://github.com/user-attachments/assets/a2228a51-b5ae-4452-83a2-b38f61037ada)

## Known caveat
- `pnpm design-lint` still fails on pre-existing repository-wide CTA/token violations outside this diff.
