### PR TITLE
feat(admin/sync): sync run detail page + clickable job history (CHAOS-2703)

### DIFF
--- a/src/app/(app)/org/admin/sync/[configId]/page.tsx
+++ b/src/app/(app)/org/admin/sync/[configId]/page.tsx
@@ -111,7 +111,7 @@ export default async function SyncConfigDetailPage({ params }: PageProps) {
 
             <div className="space-y-4">
                 <h2 className="text-lg font-medium text-foreground">Job History</h2>
-                <SyncJobHistory jobs={jobs} />
+                <SyncJobHistory jobs={jobs} configId={config.id} />
             </div>
         </div>
     );

--- a/src/app/(app)/org/admin/sync/[configId]/runs/[runId]/page.tsx
+++ b/src/app/(app)/org/admin/sync/[configId]/runs/[runId]/page.tsx
@@ -1,0 +1,79 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { SyncRunDetailLive } from "@/components/admin/sync/SyncRunDetailLive";
+import { getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
+import { getServerEnv } from "@/lib/config";
+import { backToArea } from "@/lib/design/cta";
+import {
+    SAMPLE_SYNC_RUN,
+    SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+} from "@/data/syncRunDetailSample";
+import type { SyncRun, SyncRunUnitSummary } from "@/lib/admin/types";
+
+interface PageProps {
+    params: Promise<{ configId: string; runId: string }>;
+}
+
+export default async function SyncRunDetailPage({ params }: PageProps) {
+    const { configId, runId } = await params;
+
+    const env = getServerEnv();
+    const isTestMode =
+        env.DEV_HEALTH_TEST_MODE === "true" || env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
+
+    let run: SyncRun;
+    let summary: SyncRunUnitSummary | null;
+    let unitsError: string | null = null;
+
+    if (isTestMode) {
+        // Render deterministic sample data without hitting the admin API so the
+        // page is exercisable in Playwright/test mode (web AGENTS test-mode rule).
+        run = SAMPLE_SYNC_RUN;
+        summary = SAMPLE_SYNC_RUN_UNIT_SUMMARY;
+    } else {
+        const [runResult, unitsResult] = await Promise.all([
+            getSyncRunStatus(runId),
+            getSyncRunUnits(runId),
+        ]);
+
+        if (runResult.error || !runResult.data) {
+            notFound();
+        }
+
+        run = runResult.data;
+
+        // withErrorHandling RETURNS { error } (never throws), so a 401/404/500
+        // from the units endpoint surfaces here. Do NOT fabricate an empty
+        // summary — that would render "No data yet"/"Units (0)" as if the run
+        // had no units, violating render-persisted-backend-state-only. Pass the
+        // error through so the units region renders an explicit notice while the
+        // (successful) run header still shows.
+        if (unitsResult.error || !unitsResult.data) {
+            summary = null;
+            unitsError = unitsResult.error ?? "Unit details are unavailable.";
+        } else {
+            summary = unitsResult.data;
+        }
+    }
+
+    return (
+        <div className="space-y-8">
+            <Link
+                href={`/org/admin/sync/${configId}`}
+                className="inline-flex items-center text-sm font-medium text-(--ink-muted) hover:text-(--accent)"
+            >
+                {backToArea("config")}
+            </Link>
+
+            <AdminHeader title="Sync run" description={`Run ${runId.slice(0, 8)}`} />
+
+            <SyncRunDetailLive
+                initialRun={run}
+                initialSummary={summary}
+                initialUnitsError={unitsError}
+                testMode={isTestMode}
+            />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/sync/[configId]/runs/[runId]/page.tsx
+++ b/src/app/(app)/org/admin/sync/[configId]/runs/[runId]/page.tsx
@@ -5,10 +5,7 @@ import { SyncRunDetailLive } from "@/components/admin/sync/SyncRunDetailLive";
 import { getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
 import { getServerEnv } from "@/lib/config";
 import { backToArea } from "@/lib/design/cta";
-import {
-    SAMPLE_SYNC_RUN,
-    SAMPLE_SYNC_RUN_UNIT_SUMMARY,
-} from "@/data/syncRunDetailSample";
+import { SAMPLE_SYNC_RUN, SAMPLE_SYNC_RUN_UNIT_SUMMARY } from "@/data/syncRunDetailSample";
 import type { SyncRun, SyncRunUnitSummary } from "@/lib/admin/types";
 
 interface PageProps {

--- a/src/components/admin/sync/SyncJobHistory.test.tsx
+++ b/src/components/admin/sync/SyncJobHistory.test.tsx
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, userEvent } from "@/test/utils";
 import type { SyncJob } from "@/lib/admin/types";
 import { SyncJobHistory } from "./SyncJobHistory";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: mockPush }),
+}));
+
+beforeEach(() => {
+    mockPush.mockClear();
+});
 
 function buildJobs(count: number): SyncJob[] {
     return Array.from({ length: count }, (_, index) => ({
@@ -18,7 +27,7 @@ function buildJobs(count: number): SyncJob[] {
 
 describe("SyncJobHistory", () => {
     it("renders first page with 10 jobs", () => {
-        render(<SyncJobHistory jobs={buildJobs(12)} />);
+        render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" />);
 
         expect(screen.getByText("Completed / Last Activity")).toBeInTheDocument();
         expect(screen.getByText("error-1")).toBeInTheDocument();
@@ -28,13 +37,13 @@ describe("SyncJobHistory", () => {
     });
 
     it("disables Previous on first page", () => {
-        render(<SyncJobHistory jobs={buildJobs(12)} />);
+        render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" />);
 
         expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
     });
 
     it("disables Next on last page", async () => {
-        render(<SyncJobHistory jobs={buildJobs(12)} />);
+        render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" />);
 
         await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
@@ -43,7 +52,7 @@ describe("SyncJobHistory", () => {
     });
 
     it("clicking Next shows next page", async () => {
-        render(<SyncJobHistory jobs={buildJobs(12)} />);
+        render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" />);
 
         await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
@@ -53,7 +62,7 @@ describe("SyncJobHistory", () => {
     });
 
     it("clicking Previous returns to previous page", async () => {
-        render(<SyncJobHistory jobs={buildJobs(12)} />);
+        render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" />);
 
         await userEvent.click(screen.getByRole("button", { name: "Next" }));
         await userEvent.click(screen.getByRole("button", { name: "Previous" }));
@@ -73,7 +82,7 @@ describe("SyncJobHistory", () => {
             duration_seconds: null,
             items_synced: 0,
         };
-        render(<SyncJobHistory jobs={[pendingJob]} />);
+        render(<SyncJobHistory jobs={[pendingJob]} configId="cfg-1" />);
 
         expect(screen.getAllByText("Queued").length).toBeGreaterThan(0);
         expect(screen.getAllByText("—").length).toBeGreaterThan(0);
@@ -100,7 +109,7 @@ describe("SyncJobHistory", () => {
             },
         };
 
-        render(<SyncJobHistory jobs={[failedJob]} />);
+        render(<SyncJobHistory jobs={[failedJob]} configId="cfg-1" />);
 
         expect(screen.getByText("Completed")).toBeInTheDocument();
         expect(screen.getByText("45s")).toBeInTheDocument();
@@ -121,7 +130,7 @@ describe("SyncJobHistory", () => {
             items_synced: 3,
         };
 
-        render(<SyncJobHistory jobs={[runningJob]} />);
+        render(<SyncJobHistory jobs={[runningJob]} configId="cfg-1" />);
 
         expect(screen.getAllByText("Still running").length).toBeGreaterThan(0);
         expect(screen.getAllByText(/Started /).length).toBeGreaterThan(0);
@@ -144,7 +153,7 @@ describe("SyncJobHistory", () => {
             },
         };
 
-        render(<SyncJobHistory jobs={[cancelledJob]} />);
+        render(<SyncJobHistory jobs={[cancelledJob]} configId="cfg-1" />);
 
         expect(screen.getAllByText("Cancelled")).toHaveLength(2);
         expect(
@@ -153,9 +162,70 @@ describe("SyncJobHistory", () => {
     });
 
     it("shows empty state when there are no jobs", () => {
-        render(<SyncJobHistory jobs={[]} />);
+        render(<SyncJobHistory jobs={[]} configId="cfg-1" />);
 
         expect(screen.getByText("No sync history available.")).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
+    });
+
+    it("links planner-backed rows to the run detail page", () => {
+        const plannerJob: SyncJob = {
+            id: "job-planner",
+            config_id: "cfg-1",
+            status: "success",
+            started_at: "2024-01-01T00:00:00.000Z",
+            completed_at: "2024-01-01T00:00:30.000Z",
+            duration_seconds: 30,
+            items_synced: 5,
+            result: {
+                sync_run_id: "run-123",
+            },
+        };
+
+        render(<SyncJobHistory jobs={[plannerJob]} configId="cfg-1" />);
+
+        const link = screen.getByRole("link", { name: /View run details/ });
+        expect(link).toHaveAttribute("href", "/org/admin/sync/cfg-1/runs/run-123");
+    });
+
+    it("navigates to the run detail page when a planner-backed row is clicked", async () => {
+        const plannerJob: SyncJob = {
+            id: "job-planner",
+            config_id: "cfg-1",
+            status: "success",
+            started_at: "2024-01-01T00:00:00.000Z",
+            completed_at: "2024-01-01T00:00:30.000Z",
+            duration_seconds: 30,
+            items_synced: 5,
+            result: {
+                sync_run_id: "run-123",
+            },
+        };
+
+        render(<SyncJobHistory jobs={[plannerJob]} configId="cfg-1" />);
+
+        // Click a NON-link cell (duration) to prove whole-row navigation, not link bubbling.
+        await userEvent.click(screen.getByText("30s"));
+
+        expect(mockPush).toHaveBeenCalledWith("/org/admin/sync/cfg-1/runs/run-123");
+    });
+
+    it("does not link legacy rows without a sync_run_id", () => {
+        const legacyJob: SyncJob = {
+            id: "job-legacy",
+            config_id: "cfg-1",
+            status: "success",
+            started_at: "2024-01-01T00:00:00.000Z",
+            completed_at: "2024-01-01T00:00:30.000Z",
+            duration_seconds: 30,
+            items_synced: 5,
+            result: {
+                dataset_key: "work-items",
+            },
+        };
+
+        render(<SyncJobHistory jobs={[legacyJob]} configId="cfg-1" />);
+
+        expect(screen.queryByRole("link", { name: "View run details" })).not.toBeInTheDocument();
     });
 });

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -225,9 +225,7 @@ export function SyncJobHistory({ jobs, configId, totalJobs }: SyncJobHistoryProp
                             isRecord(job.result) && typeof job.result.sync_run_id === "string"
                                 ? job.result.sync_run_id
                                 : null;
-                        const href = runId
-                            ? `/org/admin/sync/${configId}/runs/${runId}`
-                            : null;
+                        const href = runId ? `/org/admin/sync/${configId}/runs/${runId}` : null;
 
                         return (
                             <tr

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -1,16 +1,20 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { SyncJob } from "@/lib/admin/types";
 import { CTA_LABELS } from "@/lib/design/cta";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 
 interface SyncJobHistoryProps {
     jobs: SyncJob[];
+    configId: string;
     totalJobs?: number;
 }
 
-export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
+export function SyncJobHistory({ jobs, configId, totalJobs }: SyncJobHistoryProps) {
+    const router = useRouter();
     const [offset, setOffset] = useState(0);
     const limit = 10;
     const total = totalJobs ?? jobs.length;
@@ -217,14 +221,44 @@ export function SyncJobHistory({ jobs, totalJobs }: SyncJobHistoryProps) {
                         const duration = getDuration(job);
                         const activityTimestamp = getActivityTimestamp(job);
                         const details = getJobDetails(job);
+                        const runId =
+                            isRecord(job.result) && typeof job.result.sync_run_id === "string"
+                                ? job.result.sync_run_id
+                                : null;
+                        const href = runId
+                            ? `/org/admin/sync/${configId}/runs/${runId}`
+                            : null;
 
                         return (
-                            <tr key={job.id}>
+                            <tr
+                                key={job.id}
+                                onClick={href ? () => router.push(href) : undefined}
+                                className={
+                                    href
+                                        ? "cursor-pointer transition-colors hover:bg-(--card-70)"
+                                        : undefined
+                                }
+                            >
                                 <td className="px-6 py-4 whitespace-nowrap">
-                                    <SyncStatusBadge
-                                        status={getBadgeStatus(job.status)}
-                                        label={getBadgeLabel(job.status)}
-                                    />
+                                    {href ? (
+                                        <Link
+                                            href={href}
+                                            aria-label={`View run details for sync run started ${formatTimestamp(
+                                                job.started_at,
+                                            )}`}
+                                            className="inline-flex rounded-xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--accent)"
+                                        >
+                                            <SyncStatusBadge
+                                                status={getBadgeStatus(job.status)}
+                                                label={getBadgeLabel(job.status)}
+                                            />
+                                        </Link>
+                                    ) : (
+                                        <SyncStatusBadge
+                                            status={getBadgeStatus(job.status)}
+                                            label={getBadgeLabel(job.status)}
+                                        />
+                                    )}
                                 </td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
                                     {formatTimestamp(job.started_at)}

--- a/src/components/admin/sync/SyncRunDetail.test.tsx
+++ b/src/components/admin/sync/SyncRunDetail.test.tsx
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen } from "@/test/utils";
 import { SyncRunDetailLive } from "./SyncRunDetailLive";
-import {
-    SAMPLE_SYNC_RUN,
-    SAMPLE_SYNC_RUN_UNIT_SUMMARY,
-} from "@/data/syncRunDetailSample";
+import { SAMPLE_SYNC_RUN, SAMPLE_SYNC_RUN_UNIT_SUMMARY } from "@/data/syncRunDetailSample";
 import { getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
 
 // The detail component imports the admin server actions for live polling. The
@@ -63,9 +60,9 @@ describe("SyncRunDetailLive", () => {
         expect(
             screen.getAllByText("Upstream returned 500 while paginating pull requests").length,
         ).toBeGreaterThan(0);
-        expect(
-            screen.getAllByText("Secondary rate limit hit; backing off").length,
-        ).toBeGreaterThan(0);
+        expect(screen.getAllByText("Secondary rate limit hit; backing off").length).toBeGreaterThan(
+            0,
+        );
     });
 
     it("renders a row per unit in the unit table", () => {

--- a/src/components/admin/sync/SyncRunDetail.test.tsx
+++ b/src/components/admin/sync/SyncRunDetail.test.tsx
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@/test/utils";
+import { SyncRunDetailLive } from "./SyncRunDetailLive";
+import {
+    SAMPLE_SYNC_RUN,
+    SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+} from "@/data/syncRunDetailSample";
+import { getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
+
+// The detail component imports the admin server actions for live polling. The
+// real module pulls in next-auth (which fails to resolve next/server under
+// vitest), and test-mode never invokes them, so stub them out at module load.
+vi.mock("@/lib/admin/server", () => ({
+    getSyncRunStatus: vi.fn(),
+    getSyncRunUnits: vi.fn(),
+}));
+
+function renderDetail() {
+    return render(
+        <SyncRunDetailLive
+            initialRun={SAMPLE_SYNC_RUN}
+            initialSummary={SAMPLE_SYNC_RUN_UNIT_SUMMARY}
+            testMode
+        />,
+    );
+}
+
+describe("SyncRunDetailLive", () => {
+    it("renders overall progress and unit status counts", () => {
+        renderDetail();
+
+        // completed (2) + failed (1) = 3 of 4 settled → 75%
+        expect(screen.getByText(/3 \/ 4/)).toBeInTheDocument();
+        expect(screen.getByText(/75%/)).toBeInTheDocument();
+
+        // Status rollup labels from by_status.
+        expect(screen.getByText("Unit status")).toBeInTheDocument();
+        expect(screen.getAllByText("retrying").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("failed").length).toBeGreaterThan(0);
+
+        // Unit count header reflects the summary.
+        expect(screen.getByText(/Units \(4\)/)).toBeInTheDocument();
+    });
+
+    it("renders resolved source NAMES and never the raw source id", () => {
+        renderDetail();
+
+        expect(screen.getAllByText("fullchaos/platform-api").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("fullchaos/billing-service").length).toBeGreaterThan(0);
+
+        // Raw source ids must never surface in the UI.
+        expect(screen.queryByText("sample-source-1")).not.toBeInTheDocument();
+        expect(screen.queryByText("sample-source-2")).not.toBeInTheDocument();
+    });
+
+    it("surfaces failed/retrying error_category and the next retry", () => {
+        renderDetail();
+
+        expect(screen.getByText("Needs attention")).toBeInTheDocument();
+        expect(screen.getByText(/Next retry/)).toBeInTheDocument();
+        expect(screen.getByText(/Category: rate_limit/)).toBeInTheDocument();
+        // Error text renders in both the attention panel and the unit table.
+        expect(
+            screen.getAllByText("Upstream returned 500 while paginating pull requests").length,
+        ).toBeGreaterThan(0);
+        expect(
+            screen.getAllByText("Secondary rate limit hit; backing off").length,
+        ).toBeGreaterThan(0);
+    });
+
+    it("renders a row per unit in the unit table", () => {
+        renderDetail();
+
+        // Datasets and cost classes from the four sample units appear as cells.
+        expect(screen.getAllByText("git").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("cicd").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("expensive").length).toBeGreaterThan(0);
+
+        // Each unit's status renders as a badge label inside the table.
+        expect(screen.getAllByText("success").length).toBeGreaterThan(0);
+
+        // Short unit id prefix is rendered (mono cell), proving table rows exist.
+        expect(screen.getAllByText("sample-u").length).toBe(
+            SAMPLE_SYNC_RUN_UNIT_SUMMARY.units.length,
+        );
+    });
+});
+
+describe("SyncRunDetailLive — live poll error handling", () => {
+    // A non-terminal run so the poll loop actually starts (the sample run is
+    // partial_failed → terminal, which never polls).
+    const RUNNING_RUN = { ...SAMPLE_SYNC_RUN, status: "running" };
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("stops polling and surfaces an error indicator when a poll returns { error }", async () => {
+        // withErrorHandling RETURNS { error } (never throws); the loop must not
+        // apply it as data nor spin forever.
+        vi.mocked(getSyncRunStatus).mockResolvedValue({ error: "Unauthorized (401)" });
+        vi.mocked(getSyncRunUnits).mockResolvedValue({ error: "Unauthorized (401)" });
+
+        render(
+            <SyncRunDetailLive
+                initialRun={RUNNING_RUN}
+                initialSummary={SAMPLE_SYNC_RUN_UNIT_SUMMARY}
+                initialUnitsError={null}
+            />,
+        );
+
+        // First poll tick fires after the interval and resolves to { error }.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3500);
+        });
+
+        expect(getSyncRunStatus).toHaveBeenCalledTimes(1);
+        // Non-fatal error indicator renders with the surfaced message.
+        expect(
+            screen.getByText(/Failed to load unit details: Unauthorized \(401\)/),
+        ).toBeInTheDocument();
+
+        // Polling STOPPED: advancing well past several intervals triggers no
+        // further polls (no infinite spinner).
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3500 * 4);
+        });
+        expect(getSyncRunStatus).toHaveBeenCalledTimes(1);
+
+        // Last good snapshot is retained — units were NOT fabricated/emptied.
+        expect(screen.getByText(/Units \(4\)/)).toBeInTheDocument();
+    });
+
+    it("renders the server-side initialUnitsError without polling for a terminal run", () => {
+        render(
+            <SyncRunDetailLive
+                initialRun={SAMPLE_SYNC_RUN}
+                initialSummary={null}
+                initialUnitsError="Internal Server Error (500)"
+            />,
+        );
+
+        // Run header still renders from the successful run fetch (terminal run).
+        expect(screen.getByText(/Run complete/)).toBeInTheDocument();
+        // Explicit units error notice, no fabricated empty "Units (0)".
+        expect(
+            screen.getByText(/Failed to load unit details: Internal Server Error \(500\)/),
+        ).toBeInTheDocument();
+        expect(screen.queryByText(/Units \(0\)/)).not.toBeInTheDocument();
+        // Terminal run → no polling occurred.
+        expect(getSyncRunStatus).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/admin/sync/SyncRunDetailLive.tsx
+++ b/src/components/admin/sync/SyncRunDetailLive.tsx
@@ -1,0 +1,536 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ClientTimestamp } from "@/components/ClientTimestamp";
+import { SyncStatusBadge } from "./SyncStatusBadge";
+import { getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
+import { formatNumber, formatPercent } from "@/lib/formatters";
+import { type SyncStatus, isTerminalSyncStatus, mapPlannerRunStatus } from "@/lib/sync-types";
+import type { SyncRun, SyncRunUnit, SyncRunUnitSummary } from "@/lib/admin/types";
+
+/** How often to refresh live run + unit state while non-terminal. */
+const POLL_INTERVAL_MS = 3500;
+/** Safety cap so a stuck/abandoned run never polls forever (~10 min). */
+const MAX_POLL_DURATION_MS = 10 * 60 * 1000;
+/** Cap the rendered unit table so a huge fan-out stays readable. */
+const UNIT_TABLE_CAP = 100;
+
+interface SyncRunDetailLiveProps {
+    initialRun: SyncRun;
+    /** Null when the units fetch errored server-side; see initialUnitsError. */
+    initialSummary: SyncRunUnitSummary | null;
+    /** Server-side units-fetch error message, if any (render-only notice). */
+    initialUnitsError?: string | null;
+    /** When true, render the provided sample data and never poll a live API. */
+    testMode?: boolean;
+}
+
+/** Map a backend unit status string onto the shared badge status union. */
+function unitBadgeStatus(status: string): SyncStatus {
+    switch (status) {
+        case "success":
+            return "success";
+        case "failed":
+        case "cancelled":
+            return "failed";
+        case "running":
+        case "retrying":
+        case "dispatched":
+        case "dispatching":
+            return "running";
+        case "pending":
+        case "planned":
+            return "idle";
+        default:
+            return "idle";
+    }
+}
+
+function formatDuration(seconds: number | null): string {
+    if (seconds == null) return "—";
+    if (seconds < 60) return `${formatNumber(seconds)}s`;
+    const minutes = Math.floor(seconds / 60);
+    const remainder = Math.round(seconds % 60);
+    return `${formatNumber(minutes)}m ${formatNumber(remainder)}s`;
+}
+
+function StatBreakdown({ counts }: { counts: Record<string, number> }) {
+    const entries = Object.entries(counts);
+    if (entries.length === 0) {
+        return <p className="text-sm text-(--ink-muted)">No data yet.</p>;
+    }
+    return (
+        <ul className="space-y-1.5">
+            {entries.map(([key, count]) => (
+                <li key={key} className="flex items-center justify-between text-sm">
+                    <span className="text-foreground">{key}</span>
+                    <span className="font-medium text-(--ink-muted)">{formatNumber(count)}</span>
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+function NestedBreakdown({
+    groups,
+    labelFor,
+}: {
+    groups: Record<string, Record<string, number>>;
+    labelFor?: (key: string) => string;
+}) {
+    const entries = Object.entries(groups);
+    if (entries.length === 0) {
+        return <p className="text-sm text-(--ink-muted)">No data yet.</p>;
+    }
+    return (
+        <ul className="space-y-3">
+            {entries.map(([key, statuses]) => {
+                const total = Object.values(statuses).reduce((sum, n) => sum + n, 0);
+                return (
+                    <li key={key} className="space-y-1">
+                        <div className="flex items-center justify-between text-sm">
+                            <span className="font-medium text-foreground">
+                                {labelFor ? labelFor(key) : key}
+                            </span>
+                            <span className="text-(--ink-muted)">{formatNumber(total)}</span>
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">
+                            {Object.entries(statuses).map(([status, count]) => (
+                                <span
+                                    key={status}
+                                    className="rounded-full bg-(--card-70) px-2 py-0.5 text-xs text-(--ink-muted)"
+                                >
+                                    {status}: {formatNumber(count)}
+                                </span>
+                            ))}
+                        </div>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}
+
+export function SyncRunDetailLive({
+    initialRun,
+    initialSummary,
+    initialUnitsError = null,
+    testMode = false,
+}: SyncRunDetailLiveProps) {
+    const runId = initialRun.id;
+    const [run, setRun] = useState<SyncRun>(initialRun);
+    const [summary, setSummary] = useState<SyncRunUnitSummary | null>(initialSummary);
+    const [unitsError, setUnitsError] = useState<string | null>(initialUnitsError);
+
+    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Monotonic sequence: every tick and every stopPolling bumps it, so any
+    // in-flight response whose seq is no longer current (slow poll resolving
+    // after a later terminal tick, the safety timeout, or unmount) is ignored
+    // and can never overwrite terminal/cleared state (FIX 3).
+    const seqRef = useRef(0);
+    // Guard against overlapping ticks if a poll outlives the interval period.
+    const inFlightRef = useRef(false);
+
+    const stopPolling = useCallback(() => {
+        // Invalidate any in-flight response so it cannot mutate state post-stop.
+        seqRef.current += 1;
+        if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+        }
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
+        }
+    }, []);
+
+    // Poll run + unit state while the run is non-terminal, mirroring the
+    // cleanup/timeout discipline in useSyncTrigger.ts. State is only mutated
+    // inside the async interval callback (never synchronously in the effect
+    // body), so react-hooks/set-state-in-effect stays satisfied.
+    useEffect(() => {
+        if (testMode) return undefined;
+        if (isTerminalSyncStatus(mapPlannerRunStatus(initialRun.status))) return undefined;
+
+        let cancelled = false;
+
+        const tick = async () => {
+            // Skip overlapping ticks: only one request set in flight at a time.
+            if (inFlightRef.current) return;
+            inFlightRef.current = true;
+            const seq = (seqRef.current += 1);
+            try {
+                const [runRes, unitsRes] = await Promise.all([
+                    getSyncRunStatus(runId),
+                    getSyncRunUnits(runId),
+                ]);
+                // Ignore stale/unmounted/post-stop responses (FIX 3).
+                if (cancelled || seq !== seqRef.current) return;
+
+                // withErrorHandling RETURNS { error } (never throws), so a failed
+                // poll arrives as data:undefined. Do NOT apply blindly: stop and
+                // surface a non-fatal indicator instead of spinning or rendering
+                // stale/empty data (FIX 2).
+                if (runRes.error || unitsRes.error || !runRes.data || !unitsRes.data) {
+                    stopPolling();
+                    setUnitsError(
+                        runRes.error ?? unitsRes.error ?? "Live updates are unavailable.",
+                    );
+                    return;
+                }
+
+                setSummary(unitsRes.data);
+                setUnitsError(null);
+                const nextRun = runRes.data;
+                setRun(nextRun);
+                if (isTerminalSyncStatus(mapPlannerRunStatus(nextRun.status))) {
+                    stopPolling();
+                }
+            } finally {
+                inFlightRef.current = false;
+            }
+        };
+
+        intervalRef.current = setInterval(() => void tick(), POLL_INTERVAL_MS);
+        timeoutRef.current = setTimeout(() => stopPolling(), MAX_POLL_DURATION_MS);
+
+        return () => {
+            cancelled = true;
+            stopPolling();
+        };
+    }, [testMode, runId, initialRun.status, stopPolling]);
+
+    const liveStatus = mapPlannerRunStatus(run.status);
+    const isTerminal = isTerminalSyncStatus(liveStatus);
+
+    // Resolve source ids → display names from the units themselves. We NEVER
+    // surface a raw source id when a resolved name exists (web DoD / A7).
+    const sourceNameById = useMemo(() => {
+        const map: Record<string, string> = {};
+        for (const unit of summary?.units ?? []) {
+            const name = unit.source_full_name ?? unit.source_name;
+            if (name) map[unit.source_id] = name;
+        }
+        return map;
+    }, [summary]);
+
+    const sourceLabel = useCallback(
+        (sourceId: string) => sourceNameById[sourceId] ?? "Unresolved source",
+        [sourceNameById],
+    );
+
+    const total = run.total_units;
+    const completed = run.completed_units;
+    const failed = run.failed_units;
+    const settled = Math.min(total, completed + failed);
+    const percent = total > 0 ? Math.min(100, Math.round((settled / total) * 100)) : 0;
+
+    const attentionUnits = useMemo(
+        () =>
+            (summary?.units ?? []).filter(
+                (unit) => unit.status === "failed" || unit.status === "retrying",
+            ),
+        [summary],
+    );
+
+    const cappedUnits = (summary?.units ?? []).slice(0, UNIT_TABLE_CAP);
+    const overflow = (summary?.units.length ?? 0) - cappedUnits.length;
+
+    return (
+        <div className="space-y-6">
+            {/* Run header */}
+            <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div className="space-y-2">
+                        <div className="flex items-center gap-3">
+                            <SyncStatusBadge status={liveStatus} className="text-sm px-3 py-1" />
+                            <span className="text-sm text-(--ink-muted)">
+                                {isTerminal
+                                    ? "Run complete"
+                                    : unitsError
+                                      ? "Live updates paused"
+                                      : "Live — refreshing…"}
+                            </span>
+                        </div>
+                        <dl className="grid grid-cols-2 gap-x-8 gap-y-1 text-sm sm:grid-cols-4">
+                            <div>
+                                <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                    Status
+                                </dt>
+                                <dd className="text-foreground">{run.status}</dd>
+                            </div>
+                            <div>
+                                <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                    Mode
+                                </dt>
+                                <dd className="text-foreground">{run.mode}</dd>
+                            </div>
+                            <div>
+                                <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                    Triggered by
+                                </dt>
+                                <dd className="text-foreground">{run.triggered_by}</dd>
+                            </div>
+                            <div>
+                                <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                    Started
+                                </dt>
+                                <dd className="text-foreground">
+                                    <ClientTimestamp value={run.started_at} fallback="—" />
+                                </dd>
+                            </div>
+                            <div>
+                                <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                    Completed
+                                </dt>
+                                <dd className="text-foreground">
+                                    <ClientTimestamp value={run.completed_at} fallback="—" />
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+
+            {/* Overall progress */}
+            <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="mb-2 flex items-center justify-between text-sm">
+                    <span className="font-medium text-foreground">Overall progress</span>
+                    <span className="text-(--ink-muted)">
+                        {formatNumber(settled)} / {formatNumber(total)} ({formatPercent(percent)})
+                    </span>
+                </div>
+                <div className="h-2 w-full overflow-hidden rounded-full bg-(--card-70)">
+                    <div
+                        className="h-full bg-(--accent) transition-all duration-500 ease-out"
+                        style={{ width: `${percent}%` }}
+                    />
+                </div>
+                <div className="mt-3 grid grid-cols-3 gap-4 text-sm">
+                    <div>
+                        <div className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                            Completed
+                        </div>
+                        <div className="text-lg font-medium text-foreground">
+                            {formatNumber(completed)}
+                        </div>
+                    </div>
+                    <div>
+                        <div className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                            Failed
+                        </div>
+                        <div className="text-lg font-medium text-foreground">
+                            {formatNumber(failed)}
+                        </div>
+                    </div>
+                    <div>
+                        <div className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                            Total units
+                        </div>
+                        <div className="text-lg font-medium text-foreground">
+                            {formatNumber(total)}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* Non-fatal notice: units fetch errored server-side (FIX 1) or a
+                live poll failed (FIX 2). Render an explicit indicator rather
+                than fabricating empty units. */}
+            {unitsError && (
+                <div
+                    role="alert"
+                    className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6"
+                >
+                    <h3 className="text-sm font-medium text-red-500 uppercase tracking-wider">
+                        Unit details unavailable
+                    </h3>
+                    <p className="mt-2 text-sm text-(--ink-muted)">
+                        Failed to load unit details: {unitsError}
+                    </p>
+                </div>
+            )}
+
+            {summary ? (
+                <>
+                    {/* Breakdowns */}
+                    <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+                        <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                            <h3 className="mb-3 text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                                Unit status
+                            </h3>
+                            <StatBreakdown counts={summary.by_status} />
+                        </div>
+                        <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                            <h3 className="mb-3 text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                                By dataset
+                            </h3>
+                            <NestedBreakdown groups={summary.by_dataset} />
+                        </div>
+                        <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                            <h3 className="mb-3 text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                                By source
+                            </h3>
+                            <NestedBreakdown groups={summary.by_source} labelFor={sourceLabel} />
+                        </div>
+                        <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                            <h3 className="mb-3 text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                                By cost class
+                            </h3>
+                            <StatBreakdown counts={summary.by_cost_class} />
+                        </div>
+                    </div>
+
+                    {/* Failed / retrying summary */}
+                    {attentionUnits.length > 0 && (
+                        <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                                <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                                    Needs attention
+                                </h3>
+                                {summary.next_retry_at && (
+                                    <span className="text-xs text-(--ink-muted)">
+                                        Next retry{" "}
+                                        <ClientTimestamp
+                                            value={summary.next_retry_at}
+                                            fallback="—"
+                                        />
+                                    </span>
+                                )}
+                            </div>
+                            <ul className="space-y-3">
+                                {attentionUnits.map((unit) => (
+                                    <li
+                                        key={unit.id}
+                                        className="rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 text-sm"
+                                    >
+                                        <div className="flex flex-wrap items-center justify-between gap-2">
+                                            <span className="font-medium text-foreground">
+                                                {sourceLabel(unit.source_id)} · {unit.dataset_key}
+                                            </span>
+                                            <SyncStatusBadge
+                                                status={unitBadgeStatus(unit.status)}
+                                                label={unit.status}
+                                            />
+                                        </div>
+                                        <div className="mt-1 text-xs text-(--ink-muted)">
+                                            {unit.error_category && (
+                                                <span>Category: {unit.error_category}</span>
+                                            )}
+                                            {unit.error_category && unit.available_at && " · "}
+                                            {unit.available_at && (
+                                                <span>
+                                                    Retry at{" "}
+                                                    <ClientTimestamp
+                                                        value={unit.available_at}
+                                                        fallback="—"
+                                                    />
+                                                </span>
+                                            )}
+                                        </div>
+                                        {unit.error && (
+                                            <p className="mt-1 text-xs text-red-500">
+                                                {unit.error}
+                                            </p>
+                                        )}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    {/* Unit table */}
+                    <div className="space-y-3">
+                        <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                            Units ({formatNumber(summary.unit_count)})
+                        </h3>
+                        <div className="overflow-x-auto rounded-xl border border-(--card-stroke) bg-(--card-80)">
+                            <table className="min-w-full divide-y divide-(--card-stroke)">
+                                <thead className="bg-(--card-bg)">
+                                    <tr>
+                                        {[
+                                            "Unit",
+                                            "Source",
+                                            "Dataset",
+                                            "Cost class",
+                                            "Status",
+                                            "Attempts",
+                                            "Duration",
+                                            "Detail",
+                                        ].map((heading) => (
+                                            <th
+                                                key={heading}
+                                                scope="col"
+                                                className="px-4 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
+                                            >
+                                                {heading}
+                                            </th>
+                                        ))}
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-(--card-stroke)">
+                                    {cappedUnits.map((unit: SyncRunUnit) => (
+                                        <tr key={unit.id}>
+                                            <td className="px-4 py-3 font-mono text-xs text-(--ink-muted)">
+                                                {unit.id.slice(0, 8)}
+                                            </td>
+                                            <td className="px-4 py-3 text-sm text-foreground">
+                                                {sourceLabel(unit.source_id)}
+                                            </td>
+                                            <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                                {unit.dataset_key}
+                                            </td>
+                                            <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                                {unit.cost_class}
+                                            </td>
+                                            <td className="px-4 py-3">
+                                                <SyncStatusBadge
+                                                    status={unitBadgeStatus(unit.status)}
+                                                    label={unit.status}
+                                                />
+                                            </td>
+                                            <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                                {formatNumber(unit.attempts)}
+                                            </td>
+                                            <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                                {formatDuration(unit.duration_seconds)}
+                                            </td>
+                                            <td className="px-4 py-3 text-sm">
+                                                {unit.error ? (
+                                                    <span className="text-red-500">
+                                                        {unit.error}
+                                                    </span>
+                                                ) : unit.error_category ? (
+                                                    <span className="text-(--ink-muted)">
+                                                        {unit.error_category}
+                                                    </span>
+                                                ) : unit.available_at ? (
+                                                    <span className="text-(--ink-muted)">
+                                                        Retry{" "}
+                                                        <ClientTimestamp
+                                                            value={unit.available_at}
+                                                            fallback="—"
+                                                        />
+                                                    </span>
+                                                ) : (
+                                                    <span className="text-(--ink-muted)">—</span>
+                                                )}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                            {overflow > 0 && (
+                                <div className="border-t border-(--card-stroke) px-4 py-3 text-xs text-(--ink-muted)">
+                                    Showing first {formatNumber(UNIT_TABLE_CAP)} of{" "}
+                                    {formatNumber(summary.units.length)} units.
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </>
+            ) : null}
+        </div>
+    );
+}

--- a/src/data/syncRunDetailSample.ts
+++ b/src/data/syncRunDetailSample.ts
@@ -1,0 +1,163 @@
+// ── Deterministic sync-run detail sample data for DEV_HEALTH_TEST_MODE ────────
+//
+// Mirrors the AI/TestOps sample-data convention: typed constants returned in
+// test mode instead of hitting the admin API, so the run detail page renders a
+// realistic, deterministic mix of unit states (success / failed / retrying)
+// without a live backend. Values are CLEARLY SAMPLE — fixed dates, sample-*
+// ids — and resolve source NAMES (never bare source ids) per the web DoD.
+
+import type { SyncRun, SyncRunUnit, SyncRunUnitSummary } from "@/lib/admin/types";
+
+const SAMPLE_RUN_ID = "sample-run-2703";
+const SAMPLE_ORG_ID = "sample-org";
+const SAMPLE_INTEGRATION_ID = "sample-integration";
+const STARTED_AT = "2026-06-26T11:00:00.000Z";
+const COMPLETED_AT = "2026-06-26T11:04:30.000Z";
+const NEXT_RETRY_AT = "2026-06-26T11:10:00.000Z";
+
+/** Sample SyncRun used by the detail page in test mode. */
+export const SAMPLE_SYNC_RUN: SyncRun = {
+    id: SAMPLE_RUN_ID,
+    org_id: SAMPLE_ORG_ID,
+    integration_id: SAMPLE_INTEGRATION_ID,
+    triggered_by: "admin@devhealth.example",
+    mode: "incremental",
+    status: "partial_failed",
+    total_units: 4,
+    completed_units: 2,
+    failed_units: 1,
+    started_at: STARTED_AT,
+    completed_at: COMPLETED_AT,
+    result: { partial_failure_summary: { failed_datasets: ["prs"] } },
+    error: null,
+    created_at: STARTED_AT,
+};
+
+const SAMPLE_UNITS: SyncRunUnit[] = [
+    {
+        id: "sample-unit-aa11bb22",
+        org_id: SAMPLE_ORG_ID,
+        sync_run_id: SAMPLE_RUN_ID,
+        integration_id: SAMPLE_INTEGRATION_ID,
+        source_id: "sample-source-1",
+        source_name: "platform-api",
+        source_full_name: "fullchaos/platform-api",
+        provider: "github",
+        dataset_key: "git",
+        cost_class: "standard",
+        mode: "incremental",
+        since_at: null,
+        before_at: null,
+        status: "success",
+        attempts: 1,
+        available_at: null,
+        rate_limit_deferrals: 0,
+        duration_seconds: 42,
+        error: null,
+        error_category: null,
+        last_heartbeat_at: null,
+        result: { items_synced: 318 },
+        created_at: STARTED_AT,
+        updated_at: COMPLETED_AT,
+    },
+    {
+        id: "sample-unit-cc33dd44",
+        org_id: SAMPLE_ORG_ID,
+        sync_run_id: SAMPLE_RUN_ID,
+        integration_id: SAMPLE_INTEGRATION_ID,
+        source_id: "sample-source-1",
+        source_name: "platform-api",
+        source_full_name: "fullchaos/platform-api",
+        provider: "github",
+        dataset_key: "prs",
+        cost_class: "expensive",
+        mode: "incremental",
+        since_at: null,
+        before_at: null,
+        status: "success",
+        attempts: 1,
+        available_at: null,
+        rate_limit_deferrals: 1,
+        duration_seconds: 156,
+        error: null,
+        error_category: null,
+        last_heartbeat_at: null,
+        result: { items_synced: 87 },
+        created_at: STARTED_AT,
+        updated_at: COMPLETED_AT,
+    },
+    {
+        id: "sample-unit-ee55ff66",
+        org_id: SAMPLE_ORG_ID,
+        sync_run_id: SAMPLE_RUN_ID,
+        integration_id: SAMPLE_INTEGRATION_ID,
+        source_id: "sample-source-2",
+        source_name: "billing-service",
+        source_full_name: "fullchaos/billing-service",
+        provider: "github",
+        dataset_key: "prs",
+        cost_class: "expensive",
+        mode: "incremental",
+        since_at: null,
+        before_at: null,
+        status: "failed",
+        attempts: 3,
+        available_at: null,
+        rate_limit_deferrals: 0,
+        duration_seconds: 12,
+        error: "Upstream returned 500 while paginating pull requests",
+        error_category: "provider_error",
+        last_heartbeat_at: null,
+        result: null,
+        created_at: STARTED_AT,
+        updated_at: COMPLETED_AT,
+    },
+    {
+        id: "sample-unit-77aa88bb",
+        org_id: SAMPLE_ORG_ID,
+        sync_run_id: SAMPLE_RUN_ID,
+        integration_id: SAMPLE_INTEGRATION_ID,
+        source_id: "sample-source-2",
+        source_name: "billing-service",
+        source_full_name: "fullchaos/billing-service",
+        provider: "github",
+        dataset_key: "cicd",
+        cost_class: "standard",
+        mode: "incremental",
+        since_at: null,
+        before_at: null,
+        status: "retrying",
+        attempts: 2,
+        available_at: NEXT_RETRY_AT,
+        rate_limit_deferrals: 2,
+        duration_seconds: null,
+        error: "Secondary rate limit hit; backing off",
+        error_category: "rate_limit",
+        last_heartbeat_at: "2026-06-26T11:04:00.000Z",
+        result: null,
+        created_at: STARTED_AT,
+        updated_at: COMPLETED_AT,
+    },
+];
+
+/** Sample SyncRunUnitSummary used by the detail page in test mode. */
+export const SAMPLE_SYNC_RUN_UNIT_SUMMARY: SyncRunUnitSummary = {
+    by_status: { success: 2, failed: 1, retrying: 1 },
+    by_source: {
+        "sample-source-1": { success: 2 },
+        "sample-source-2": { failed: 1, retrying: 1 },
+    },
+    by_dataset: {
+        git: { success: 1 },
+        prs: { success: 1, failed: 1 },
+        cicd: { retrying: 1 },
+    },
+    by_cost_class: { standard: 2, expensive: 2 },
+    slowest_unit_ids: ["sample-unit-cc33dd44"],
+    failed_unit_ids: ["sample-unit-ee55ff66"],
+    failed_unit_count: 1,
+    unit_count: 4,
+    partial_failure_summary: { failed_datasets: ["prs"] },
+    next_retry_at: NEXT_RETRY_AT,
+    units: SAMPLE_UNITS,
+};

--- a/src/lib/admin/api/sync.ts
+++ b/src/lib/admin/api/sync.ts
@@ -12,6 +12,7 @@ import type {
     SyncConfigRepositorySelectionUpdate,
     SyncTriggerResult,
     SyncRun,
+    SyncRunUnitSummary,
 } from "../types";
 
 export const syncConfigsApi = {
@@ -66,6 +67,14 @@ export const syncConfigsApi = {
 
     getSyncRun: (runId: string, token?: string, orgId?: string) =>
         request<SyncRun>(`/sync-runs/${runId}`, { method: "GET" }, token, orgId),
+
+    getSyncRunUnits: (runId: string, token?: string, orgId?: string) =>
+        request<SyncRunUnitSummary>(
+            `/sync-runs/${runId}/units`,
+            { method: "GET" },
+            token,
+            orgId,
+        ),
 
     backfill: (
         id: string,

--- a/src/lib/admin/api/sync.ts
+++ b/src/lib/admin/api/sync.ts
@@ -69,12 +69,7 @@ export const syncConfigsApi = {
         request<SyncRun>(`/sync-runs/${runId}`, { method: "GET" }, token, orgId),
 
     getSyncRunUnits: (runId: string, token?: string, orgId?: string) =>
-        request<SyncRunUnitSummary>(
-            `/sync-runs/${runId}/units`,
-            { method: "GET" },
-            token,
-            orgId,
-        ),
+        request<SyncRunUnitSummary>(`/sync-runs/${runId}/units`, { method: "GET" }, token, orgId),
 
     backfill: (
         id: string,

--- a/src/lib/admin/server/sync.ts
+++ b/src/lib/admin/server/sync.ts
@@ -17,6 +17,7 @@ import type {
     SyncConfigRepositorySelectionUpdate,
     SyncTriggerResult,
     SyncRun,
+    SyncRunUnitSummary,
 } from "../types";
 import { getSessionContext, withErrorHandling } from "./_shared";
 
@@ -146,6 +147,15 @@ export async function getSyncRunStatus(runId: string): Promise<ActionResult<Sync
     return withErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
         return adminApi.syncConfigs.getSyncRun(runId, token, orgId);
+    });
+}
+
+export async function getSyncRunUnits(
+    runId: string,
+): Promise<ActionResult<SyncRunUnitSummary>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.syncConfigs.getSyncRunUnits(runId, token, orgId);
     });
 }
 

--- a/src/lib/admin/server/sync.ts
+++ b/src/lib/admin/server/sync.ts
@@ -150,9 +150,7 @@ export async function getSyncRunStatus(runId: string): Promise<ActionResult<Sync
     });
 }
 
-export async function getSyncRunUnits(
-    runId: string,
-): Promise<ActionResult<SyncRunUnitSummary>> {
+export async function getSyncRunUnits(runId: string): Promise<ActionResult<SyncRunUnitSummary>> {
     return withErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
         return adminApi.syncConfigs.getSyncRunUnits(runId, token, orgId);

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -198,6 +198,68 @@ export interface SyncRun {
     created_at: string;
 }
 
+/**
+ * A single unit of work within a planner sync run, returned inside
+ * SyncRunUnitSummary by GET /sync-runs/{run_id}/units. Mirrors
+ * dev-health-ops api/admin/schemas/integrations.py:SyncRunUnitResponse.
+ *
+ * Render-only: `source_full_name` / `source_name` are the resolved labels;
+ * never surface the raw `source_id` when a name exists.
+ */
+export interface SyncRunUnit {
+    id: string;
+    org_id: string;
+    sync_run_id: string;
+    integration_id: string;
+    source_id: string;
+    /** Resolved short source/repo name, or null when unresolved. */
+    source_name: string | null;
+    /** Resolved fully-qualified source name (e.g. org/repo), or null. */
+    source_full_name: string | null;
+    provider: string;
+    dataset_key: string;
+    cost_class: string;
+    mode: string;
+    since_at: string | null;
+    before_at: string | null;
+    status: string;
+    attempts: number;
+    /** Earliest retry timestamp for a retrying unit, else null. */
+    available_at: string | null;
+    rate_limit_deferrals: number;
+    duration_seconds: number | null;
+    error: string | null;
+    /** Extracted failure category (e.g. rate_limit), or null. */
+    error_category: string | null;
+    last_heartbeat_at: string | null;
+    result: Record<string, unknown> | null;
+    created_at: string;
+    updated_at: string;
+}
+
+/**
+ * Aggregate unit-level progress for a planner sync run, returned by
+ * GET /sync-runs/{run_id}/units. Mirrors
+ * dev-health-ops api/admin/schemas/integrations.py:SyncRunUnitSummary.
+ *
+ * Rollups are persisted backend state; the UI groups/displays them but never
+ * recomputes categories or source-of-truth.
+ */
+export interface SyncRunUnitSummary {
+    by_status: Record<string, number>;
+    by_source: Record<string, Record<string, number>>;
+    by_dataset: Record<string, Record<string, number>>;
+    by_cost_class: Record<string, number>;
+    slowest_unit_ids: string[];
+    failed_unit_ids: string[];
+    failed_unit_count: number;
+    unit_count: number;
+    partial_failure_summary: Record<string, unknown> | null;
+    /** Earliest available_at among retrying units, else null. */
+    next_retry_at: string | null;
+    units: SyncRunUnit[];
+}
+
 export interface SyncConfigCreate {
     name: string;
     provider: string;

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -1998,10 +1998,14 @@ export type WorkGraphArtifactRow = {
 export type WorkGraphArtifactsResult = {
   __typename?: 'WorkGraphArtifactsResult';
   degradedReason?: Maybe<Scalars['String']['output']>;
+  isPartial: Scalars['Boolean']['output'];
+  partialRepoIds: Array<Scalars['String']['output']>;
+  partialScope?: Maybe<Scalars['String']['output']>;
   rows: Array<WorkGraphArtifactRow>;
 };
 
 export type WorkGraphEdgeFilterInput = {
+  allowScopedPartial?: Scalars['Boolean']['input'];
   edgeType?: InputMaybe<WorkGraphEdgeTypeInput>;
   edgeTypes?: InputMaybe<Array<WorkGraphEdgeTypeInput>>;
   limit?: Scalars['Int']['input'];
@@ -2084,13 +2088,19 @@ export type WorkGraphEdgesResult = {
   __typename?: 'WorkGraphEdgesResult';
   degradedReason?: Maybe<Scalars['String']['output']>;
   edges: Array<WorkGraphEdgeResult>;
+  isPartial: Scalars['Boolean']['output'];
   pageInfo: PageInfo;
+  partialRepoIds: Array<Scalars['String']['output']>;
+  partialScope?: Maybe<Scalars['String']['output']>;
   totalCount: Scalars['Int']['output'];
 };
 
 export type WorkGraphFlowResult = {
   __typename?: 'WorkGraphFlowResult';
   degradedReason?: Maybe<Scalars['String']['output']>;
+  isPartial: Scalars['Boolean']['output'];
+  partialRepoIds: Array<Scalars['String']['output']>;
+  partialScope?: Maybe<Scalars['String']['output']>;
   rows: Array<WorkGraphFlowRow>;
 };
 

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1647,6 +1647,9 @@ type WorkGraphArtifactRow {
 type WorkGraphArtifactsResult {
   rows: [WorkGraphArtifactRow!]!
   degradedReason: String
+  isPartial: Boolean!
+  partialScope: String
+  partialRepoIds: [String!]!
 }
 
 input WorkGraphEdgeFilterInput {
@@ -1658,6 +1661,7 @@ input WorkGraphEdgeFilterInput {
   nodeId: String = null
   theme: String = null
   subcategory: String = null
+  allowScopedPartial: Boolean! = false
   limit: Int! = 1000
 }
 
@@ -1734,11 +1738,17 @@ type WorkGraphEdgesResult {
   totalCount: Int!
   pageInfo: PageInfo!
   degradedReason: String
+  isPartial: Boolean!
+  partialScope: String
+  partialRepoIds: [String!]!
 }
 
 type WorkGraphFlowResult {
   rows: [WorkGraphFlowRow!]!
   degradedReason: String
+  isPartial: Boolean!
+  partialScope: String
+  partialRepoIds: [String!]!
 }
 
 type WorkGraphFlowRow {


### PR DESCRIPTION
## CHAOS-2703 — Sync run detail page + clickable job history

Makes each planner-backed sync run in the admin job history click through to a new run-detail page showing unit-level progress: source/repo, dataset, cost class, status, retry/error detail, durations, and rollups. Renders persisted backend state only — no GraphQL subscriptions.

Linear: CHAOS-2703
Depends on dev-health-ops CHAOS-2703 (extends `GET /sync-runs/{run_id}/units`).

> Opened as **draft**: this is a rendered-UI change and visual evidence is still pending (the local `api` container is only reachable inside the docker network, so authenticated browser capture of this branch needs a preview/stack deploy). Screenshots will be attached to this PR and the Linear issue before marking ready.

### Changes
**Foundation**
- `src/lib/admin/types.ts` — `SyncRunUnit` + `SyncRunUnitSummary` (mirror the ops contract).
- `src/lib/admin/api/sync.ts` — `getSyncRunUnits(runId)`.
- `src/lib/admin/server/sync.ts` — `getSyncRunUnits` server action.

**Detail page**
- `src/app/(app)/org/admin/sync/[configId]/runs/[runId]/page.tsx` — server page: fetches run + units; on a units-fetch error it surfaces an explicit notice (no fabricated empty summary); test-mode renders the sample fixture.
- `src/components/admin/sync/SyncRunDetailLive.tsx` — run header, overall progress, status/dataset/source/cost-class breakdowns, failed/retrying summary (error category + next retry), capped unit table. Polls until terminal with an in-flight + monotonic-sequence guard and `ActionResult.error` handling. Source ids resolved to names — raw ids never surfaced.
- `src/data/syncRunDetailSample.ts` — deterministic test-mode fixture.

**Job history**
- `src/components/admin/sync/SyncJobHistory.tsx` — `configId` prop; planner rows (`result.sync_run_id`) navigate to `/org/admin/sync/{configId}/runs/{runId}` via a table-safe `useRouter` row click + a real focusable `Link` with a row-distinct aria-label; legacy rows stay non-clickable.
- `src/app/(app)/org/admin/sync/[configId]/page.tsx` — passes `configId`.

### Tests
- `SyncRunDetail.test.tsx` — progress/status counts, resolved source NAMES (not ids), error_category + next retry, unit rows, live poll-error stop (no stale spinner, last-good snapshot retained), server-side units-error notice.
- `SyncJobHistory.test.tsx` — planner row link href, whole-row navigation via a non-link cell, legacy rows non-clickable.

### Verification (combined branch)
- `pnpm typecheck` → clean
- `pnpm test:unit` → 236 files / 2235 tests passed
- `pnpm lint` → 0 errors (lone warning pre-existing in an untouched file)
- Branch composition verified: route present and job-history links resolve to it.

### Review
- Oracle-reviewed (read-only) per changeset: both initial FAILs fixed and re-reviewed to PASS-WITH-NITS; nits addressed.

## Visual evidence

**Run detail page** (`/org/admin/sync/[configId]/runs/[runId]`, test-mode sample) — header, 3/4 progress, status/dataset/source/cost-class breakdowns (resolved source names), failed/retrying attention panel with error category + next retry, and the unit table:

![Sync run detail page](https://github.com/user-attachments/assets/c477f54e-9231-4dea-9167-8070ff376aff)

**Clickable job history** — planner-backed run row navigates to the detail page:

![Clickable job history](https://github.com/user-attachments/assets/277b1a2c-b20a-458b-80c0-0a6b9f6c8549)

Captured via Playwright against the test-mode dev server (mock backend + storageState auth).
