### PR TITLE
Add cosmic nebula web theme

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -94,14 +94,14 @@ The platform uses **Tailwind CSS v4** via `@tailwindcss/postcss`.
 Appearance is controlled by two HTML attributes on the `<html>` element:
 
 1. **`data-theme`**: Controls the color mode (`light` or `dark`).
-2. **`data-palette`**: Controls the color scheme (`fullchaos`, `material`, `echarts`, `fullchaos-cosmic-train`, `fullchaos-infinity-knot`, `flat`).
+2. **`data-palette`**: Controls the color scheme (`fullchaos`, `material`, `echarts`, `fullchaos-cosmic-train`, `fullchaos-cosmic-nebula`, `fullchaos-infinity-knot`, `fullchaos-infinity-knot-redux`, `flat`).
 
 #### Default State
 
 The default configuration is:
 
 - `data-theme="dark"`
-- `data-palette="fullchaos"`
+- `data-palette="fullchaos-infinity-knot-redux"`
 
 #### Initialization
 

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -11,6 +11,7 @@
       normalizedPalette === "echarts" ||
       normalizedPalette === "fullchaos" ||
       normalizedPalette === "fullchaos-cosmic-train" ||
+      normalizedPalette === "fullchaos-cosmic-nebula" ||
       normalizedPalette === "fullchaos-infinity-knot" ||
       normalizedPalette === "fullchaos-infinity-knot-redux" ||
       normalizedPalette === "flat"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -518,6 +518,89 @@
 }
 
 /* ============================================================
+ * PALETTE: fullchaos-cosmic-nebula
+ *
+ * Built from the supplied Cosmic palette: deep navy and ink
+ * surfaces, plum/wine depth, coral-red action, and cyan signal.
+ * ============================================================ */
+:root[data-palette="fullchaos-cosmic-nebula"][data-theme="light"] {
+    color-scheme: light;
+    --background: #e5d6c8;
+    --foreground: #111722;
+    --ink-muted: #543559;
+    --accent: #812645;
+    --accent-2: #345e7d;
+    --accent-3: #ae5079;
+    --accent-negative: #c23041;
+    --accent-highlight: #e16068;
+    --card: color-mix(in srgb, #e5d6c8 76%, white);
+    --card-stroke: color-mix(in srgb, #df9399 58%, #543559);
+    --chart-muted: #55213f;
+    --chart-color-1: #812645;
+    --chart-color-2: #345e7d;
+    --chart-color-3: #c23041;
+    --chart-color-4: #50a1ad;
+    --chart-color-5: #804770;
+    --chart-color-6: #272e4b;
+    --chart-color-7: #ae5079;
+    --chart-color-8: #371e37;
+    --chart-color-9: #e16068;
+    --chart-color-10: #111722;
+    --hero-gradient: radial-gradient(
+        circle_at_top,
+        #e5d6c8 0%,
+        #df9399 24%,
+        #ae5079 42%,
+        #50a1ad 68%,
+        #111722 100%
+    );
+    --app-gradient: radial-gradient(
+        ellipse at 14% 0%,
+        color-mix(in srgb, var(--accent-highlight) 12%, var(--background)) 0%,
+        color-mix(in srgb, var(--accent-2) 8%, var(--background)) 36%,
+        var(--background) 74%
+    );
+}
+
+:root[data-palette="fullchaos-cosmic-nebula"][data-theme="dark"] {
+    color-scheme: dark;
+    --background: #111722;
+    --foreground: #e5d6c8;
+    --ink-muted: #df9399;
+    --accent: #e16068;
+    --accent-2: #70dbd6;
+    --accent-3: #ae5079;
+    --accent-negative: #c23041;
+    --accent-highlight: #50a1ad;
+    --card: #1d1d2f;
+    --card-stroke: #272e4b;
+    --chart-color-1: #e16068;
+    --chart-color-2: #70dbd6;
+    --chart-color-3: #ae5079;
+    --chart-color-4: #50a1ad;
+    --chart-color-5: #c23041;
+    --chart-color-6: #804770;
+    --chart-color-7: #df9399;
+    --chart-color-8: #345e7d;
+    --chart-color-9: #55213f;
+    --chart-color-10: #e5d6c8;
+    --hero-gradient: radial-gradient(
+        circle_at_top,
+        #371e37 0%,
+        #812645 22%,
+        #e16068 42%,
+        #70dbd6 68%,
+        #111722 100%
+    );
+    --app-gradient: radial-gradient(
+        ellipse at 50% -10%,
+        color-mix(in srgb, var(--accent) 10%, var(--background)) 0%,
+        color-mix(in srgb, var(--accent-2) 7%, var(--background)) 38%,
+        var(--background) 70%
+    );
+}
+
+/* ============================================================
  * PALETTE: flat
  * ============================================================ */
 :root[data-palette="flat"][data-theme="light"] {

--- a/src/components/ThemeToggle.test.tsx
+++ b/src/components/ThemeToggle.test.tsx
@@ -42,6 +42,15 @@ describe("ThemeToggle", () => {
         expect(screen.getByRole("option", { name: "Fullchaos Infinity Knot" })).toBeInTheDocument();
     });
 
+    it("renders the cosmic nebula palette option when expanded", async () => {
+        const user = userEvent.setup();
+        render(<ThemeToggle />);
+
+        await user.click(screen.getByRole("button", { name: /expand settings/i }));
+
+        expect(screen.getByRole("option", { name: "Fullchaos Cosmic Nebula" })).toBeInTheDocument();
+    });
+
     it("persists the infinity knot palette selection", async () => {
         const user = userEvent.setup();
         render(<ThemeToggle />);
@@ -54,5 +63,19 @@ describe("ThemeToggle", () => {
 
         expect(document.documentElement.dataset.palette).toBe("fullchaos-infinity-knot");
         expect(localStorage.getItem("palette")).toBe("fullchaos-infinity-knot");
+    });
+
+    it("persists the cosmic nebula palette selection", async () => {
+        const user = userEvent.setup();
+        render(<ThemeToggle />);
+
+        await user.click(screen.getByRole("button", { name: /expand settings/i }));
+        await user.selectOptions(
+            screen.getByLabelText(/theme palette/i),
+            "fullchaos-cosmic-nebula",
+        );
+
+        expect(document.documentElement.dataset.palette).toBe("fullchaos-cosmic-nebula");
+        expect(localStorage.getItem("palette")).toBe("fullchaos-cosmic-nebula");
     });
 });

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -10,6 +10,7 @@ type Palette =
     | "echarts"
     | "fullchaos"
     | "fullchaos-cosmic-train"
+    | "fullchaos-cosmic-nebula"
     | "fullchaos-infinity-knot"
     | "fullchaos-infinity-knot-redux"
     | "flat";
@@ -39,6 +40,7 @@ const normalizePalette = (value: string | null): Palette | null => {
         value === "echarts" ||
         value === "fullchaos" ||
         value === "fullchaos-cosmic-train" ||
+        value === "fullchaos-cosmic-nebula" ||
         value === "fullchaos-infinity-knot" ||
         value === "fullchaos-infinity-knot-redux" ||
         value === "flat"
@@ -141,7 +143,7 @@ export function ThemeToggle() {
 
     return (
         <div
-            className={`group inline-flex items-center gap-2 rounded-full border border-(--card-stroke) bg-(--card-80) p-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted) shadow-[0_12px_30px_-20px_rgba(0,0,0,0.45)] transition-all duration-300 ${
+            className={`group inline-flex items-center gap-2 rounded-full border border-(--card-stroke) bg-(--card-80) p-1 text-label-caps font-semibold uppercase tracking-[0.2em] text-(--ink-muted) shadow-[0_12px_30px_-20px_rgba(0,0,0,0.45)] transition-all duration-300 ${
                 isCollapsed ? "w-10 overflow-hidden" : "px-3 py-2"
             }`}
         >
@@ -152,12 +154,13 @@ export function ThemeToggle() {
                         aria-label="Theme palette"
                         value={palette}
                         onChange={handlePaletteChange}
-                        className="bg-transparent text-[11px] font-semibold uppercase tracking-[0.2em] text-(--ink-muted) focus:text-foreground focus:outline-none"
+                        className="bg-transparent text-label-caps font-semibold uppercase tracking-[0.2em] text-(--ink-muted) focus:text-foreground focus:outline-none"
                     >
                         <option value="material">Material</option>
                         <option value="echarts">ECharts</option>
                         <option value="fullchaos">Full Chaos</option>
                         <option value="fullchaos-cosmic-train">Fullchaos Cosmic Train</option>
+                        <option value="fullchaos-cosmic-nebula">Fullchaos Cosmic Nebula</option>
                         <option value="fullchaos-infinity-knot">Fullchaos Infinity Knot</option>
                         <option value="fullchaos-infinity-knot-redux">Infinity Knot Redux</option>
                         <option value="flat">Flat UI</option>
@@ -166,7 +169,7 @@ export function ThemeToggle() {
                         type="button"
                         onClick={handleToggle}
                         aria-label="Toggle light/dark"
-                        className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-foreground transition hover:-translate-y-0.5"
+                        className="rounded-full border border-(--card-stroke) bg-(--card-70) px-2.5 py-1 text-label-caps font-semibold uppercase tracking-[0.2em] text-foreground transition hover:-translate-y-0.5"
                     >
                         {theme === "dark" ? "Dark" : "Light"}
                     </button>

--- a/src/components/settings/PreferencesSettings.test.tsx
+++ b/src/components/settings/PreferencesSettings.test.tsx
@@ -45,6 +45,12 @@ describe("PreferencesSettings", () => {
         expect(screen.getByRole("button", { name: "Infinity Knot Redux" })).toBeInTheDocument();
     });
 
+    it("shows the cosmic nebula palette in preferences", () => {
+        render(<PreferencesSettings />);
+
+        expect(screen.getByRole("button", { name: "Cosmic Nebula" })).toBeInTheDocument();
+    });
+
     it("applies the infinity knot palette from preferences", async () => {
         const user = userEvent.setup();
         render(<PreferencesSettings />);
@@ -63,6 +69,16 @@ describe("PreferencesSettings", () => {
 
         expect(document.documentElement.dataset.palette).toBe("fullchaos-infinity-knot-redux");
         expect(localStorage.getItem("palette")).toBe("fullchaos-infinity-knot-redux");
+    });
+
+    it("applies the cosmic nebula palette from preferences", async () => {
+        const user = userEvent.setup();
+        render(<PreferencesSettings />);
+
+        await user.click(screen.getByRole("button", { name: "Cosmic Nebula" }));
+
+        expect(document.documentElement.dataset.palette).toBe("fullchaos-cosmic-nebula");
+        expect(localStorage.getItem("palette")).toBe("fullchaos-cosmic-nebula");
     });
 
     it("persists the product telemetry opt-out preference", async () => {

--- a/src/components/settings/PreferencesSettings.tsx
+++ b/src/components/settings/PreferencesSettings.tsx
@@ -2,6 +2,7 @@
 
 import { useSyncExternalStore } from "react";
 import { SettingsSection } from "./SettingsSection";
+import { CTA_LABELS } from "@/lib/design/cta";
 import { isServer, getLocalStorage, getWindow } from "@/lib/env";
 import { isTelemetryOptedOut, setTelemetryOptOut } from "@/lib/telemetry/config";
 
@@ -11,6 +12,7 @@ type Palette =
     | "echarts"
     | "fullchaos"
     | "fullchaos-cosmic-train"
+    | "fullchaos-cosmic-nebula"
     | "fullchaos-infinity-knot"
     | "fullchaos-infinity-knot-redux"
     | "flat";
@@ -41,6 +43,7 @@ const normalizePalette = (value: string | null): Palette | null => {
         "echarts",
         "fullchaos",
         "fullchaos-cosmic-train",
+        "fullchaos-cosmic-nebula",
         "fullchaos-infinity-knot",
         "fullchaos-infinity-knot-redux",
         "flat",
@@ -98,6 +101,7 @@ const getTelemetryServerSnapshot = (): boolean => false;
 const PALETTES: { value: Palette; label: string }[] = [
     { value: "fullchaos", label: "Full Chaos" },
     { value: "fullchaos-cosmic-train", label: "Cosmic Train" },
+    { value: "fullchaos-cosmic-nebula", label: "Cosmic Nebula" },
     { value: "fullchaos-infinity-knot", label: "Infinity Knot" },
     { value: "fullchaos-infinity-knot-redux", label: "Infinity Knot Redux" },
     { value: "material", label: "Material" },
@@ -138,7 +142,7 @@ export function PreferencesSettings() {
                             }`}
                         >
                             <span className="block text-lg mb-1">☀️</span>
-                            Light
+                            {CTA_LABELS.lightTheme}
                         </button>
                         <button
                             type="button"
@@ -150,7 +154,7 @@ export function PreferencesSettings() {
                             }`}
                         >
                             <span className="block text-lg mb-1">🌙</span>
-                            Dark
+                            {CTA_LABELS.darkTheme}
                         </button>
                     </div>
                 </div>
@@ -198,7 +202,7 @@ export function PreferencesSettings() {
                                     : "border-(--card-stroke) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
                             }`}
                         >
-                            Enabled
+                            {CTA_LABELS.enabled}
                         </button>
                         <button
                             type="button"
@@ -210,7 +214,7 @@ export function PreferencesSettings() {
                                     : "border-(--card-stroke) bg-(--card-70) text-(--ink-muted) hover:border-(--accent)/50"
                             }`}
                         >
-                            Disabled
+                            {CTA_LABELS.disabled}
                         </button>
                     </div>
                 </div>

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -80,6 +80,10 @@ export const CTA_LABELS = {
     selectRepositories: "Select repositories",
     /** Begin the first repository sync after explicit confirmation (CHAOS-2681). */
     startSync: "Start sync",
+    lightTheme: "Light",
+    darkTheme: "Dark",
+    enabled: "Enabled",
+    disabled: "Disabled",
 } as const;
 
 export type CtaKey = keyof typeof CTA_LABELS;


### PR DESCRIPTION
## Summary

- Add the `fullchaos-cosmic-nebula` palette with light and dark token mappings from the supplied cosmic colors.
- Register the palette in the FOUC-safe theme initializer, header theme toggle, and Preferences settings.
- Update palette coverage tests and the design-system palette reference.
- Tokenize touched theme-toggle text sizing and route preference state labels through the CTA registry so touched files pass design-lint.

## Validation

- `pnpm test:unit src/components/ThemeToggle.test.tsx src/components/settings/PreferencesSettings.test.tsx`
- `pnpm typecheck`
- `DESIGN_LINT=true pnpm exec eslint src/components/ThemeToggle.tsx src/components/ThemeToggle.test.tsx src/components/settings/PreferencesSettings.tsx src/components/settings/PreferencesSettings.test.tsx src/lib/design/cta.ts`
- `pnpm format:check:changed`
- `git diff --check`

`pnpm design-lint` still fails on the existing repo-wide backlog, mostly CTA registry and hardcoded-size violations outside this change.

## Screenshots

Dark:
![cosmic-nebula-dark-marketing.png](https://github.com/user-attachments/assets/1c1b5e3d-8a38-48df-a952-10f04f8c03cd)

Light:
![cosmic-nebula-light-marketing.png](https://github.com/user-attachments/assets/d75f4a94-f2a2-4304-afbf-b02b9f121008)
