### PR TITLE
docs(auth): clarify GitHub OAuth setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,15 +62,19 @@ AUTH_SECRET=
 # Set to the full URL where the app is hosted (e.g., https://app.example.com)
 # Required for CSRF origin validation — without this, sign-in/sign-up will fail
 # with a 'request origin validation' error in Docker, reverse proxy, or production.
-# In local dev on localhost:3000, Auth.js auto-detects this, so it's optional.
+# In local dev on localhost:3000, Auth.js auto-detects this, but Docker/reverse
+# proxy setups should set it explicitly so GitHub redirect_uri uses the right host.
 # AUTH_URL=http://localhost:3000
 
 # Deprecated alias for AUTH_SECRET (kept for backward compatibility)
 # NEXTAUTH_SECRET=
 
 # Social Login (OAuth provider credentials)
-# NOTE: The same OAuth app credentials must also be set in the ops repo
-# (.env: SOCIAL_GITHUB_CLIENT_ID/SECRET, SOCIAL_GOOGLE_CLIENT_ID/SECRET, etc.).
+# GitHub: use the GitHub App Client ID/secret if you want one app to power both
+# Connect GitHub App and Sign in with GitHub. Register this callback on the
+# GitHub App: http://localhost:3000/api/auth/callback/github
+# NOTE: The same OAuth credentials must also be set in ops/.env
+# (SOCIAL_GITHUB_CLIENT_ID/SECRET, SOCIAL_GOOGLE_CLIENT_ID/SECRET, etc.).
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
 AUTH_GOOGLE_ID=

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -24,9 +24,10 @@ All fields are `optional()` in the Zod schema — the app applies its own defaul
 | `BASE_PATH`             | string | —       | Next.js `basePath` for sub-path deployments. Also used as `assetPrefix` in static export mode.                                                            |
 | `AUTH_SECRET`           | string | —       | NextAuth v5 secret. Required in production; falls back to `NEXTAUTH_SECRET`, then a dev default.                                                          |
 | `NEXTAUTH_SECRET`       | string | —       | Legacy NextAuth secret alias. Superseded by `AUTH_SECRET`.                                                                                                |
-| `NEXTAUTH_URL`          | string | —       | Canonical URL for NextAuth callbacks.                                                                                                                     |
-| `AUTH_GITHUB_ID`        | string | —       | GitHub OAuth App client ID. Enables GitHub social login when set.                                                                                         |
-| `AUTH_GITHUB_SECRET`    | string | —       | GitHub OAuth App client secret. Required when `AUTH_GITHUB_ID` is set.                                                                                    |
+| `AUTH_URL`              | string | —       | Canonical public URL for Auth.js callbacks. Set this in Docker, reverse proxy, and production environments so provider `redirect_uri` values use the expected origin. |
+| `NEXTAUTH_URL`          | string | —       | Legacy canonical URL alias for NextAuth callbacks. Prefer `AUTH_URL`.                                                                                     |
+| `AUTH_GITHUB_ID`        | string | —       | GitHub OAuth Client ID. Enables GitHub social login when set; may reuse the GitHub App Client ID from ops.                                                |
+| `AUTH_GITHUB_SECRET`    | string | —       | GitHub OAuth Client secret. Required when `AUTH_GITHUB_ID` is set; may reuse the GitHub App Client secret from ops.                                      |
 | `AUTH_GOOGLE_ID`        | string | —       | Google OAuth client ID. Enables Google social login when set.                                                                                             |
 | `AUTH_GOOGLE_SECRET`    | string | —       | Google OAuth client secret. Required when `AUTH_GOOGLE_ID` is set.                                                                                        |
 | `AUTH_GITLAB_ID`        | string | —       | GitLab OAuth client ID. Enables GitLab social login when set.                                                                                             |

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -15,30 +15,30 @@ All fields are `optional()` in the Zod schema — the app applies its own defaul
 
 ([`config.ts:74–103`](../src/lib/config.ts#L74))
 
-| Variable                | Type   | Default | Description                                                                                                                                               |
-| ----------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NODE_ENV`              | string | —       | Node environment (`development`, `production`, `test`).                                                                                                   |
-| `LOG_LEVEL`             | string | —       | Pino log level (`trace`, `debug`, `info`, `warn`, `error`).                                                                                               |
-| `LOG_FORMAT`            | string | —       | Log format (`json` or `pretty`).                                                                                                                          |
-| `BACKEND_URL`           | string | —       | Base URL of the dev-health-ops backend API (e.g. `http://localhost:8800`).                                                                                |
-| `BASE_PATH`             | string | —       | Next.js `basePath` for sub-path deployments. Also used as `assetPrefix` in static export mode.                                                            |
-| `AUTH_SECRET`           | string | —       | NextAuth v5 secret. Required in production; falls back to `NEXTAUTH_SECRET`, then a dev default.                                                          |
-| `NEXTAUTH_SECRET`       | string | —       | Legacy NextAuth secret alias. Superseded by `AUTH_SECRET`.                                                                                                |
+| Variable                | Type   | Default | Description                                                                                                                                                           |
+| ----------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NODE_ENV`              | string | —       | Node environment (`development`, `production`, `test`).                                                                                                               |
+| `LOG_LEVEL`             | string | —       | Pino log level (`trace`, `debug`, `info`, `warn`, `error`).                                                                                                           |
+| `LOG_FORMAT`            | string | —       | Log format (`json` or `pretty`).                                                                                                                                      |
+| `BACKEND_URL`           | string | —       | Base URL of the dev-health-ops backend API (e.g. `http://localhost:8800`).                                                                                            |
+| `BASE_PATH`             | string | —       | Next.js `basePath` for sub-path deployments. Also used as `assetPrefix` in static export mode.                                                                        |
+| `AUTH_SECRET`           | string | —       | NextAuth v5 secret. Required in production; falls back to `NEXTAUTH_SECRET`, then a dev default.                                                                      |
+| `NEXTAUTH_SECRET`       | string | —       | Legacy NextAuth secret alias. Superseded by `AUTH_SECRET`.                                                                                                            |
 | `AUTH_URL`              | string | —       | Canonical public URL for Auth.js callbacks. Set this in Docker, reverse proxy, and production environments so provider `redirect_uri` values use the expected origin. |
-| `NEXTAUTH_URL`          | string | —       | Legacy canonical URL alias for NextAuth callbacks. Prefer `AUTH_URL`.                                                                                     |
-| `AUTH_GITHUB_ID`        | string | —       | GitHub OAuth Client ID. Enables GitHub social login when set; may reuse the GitHub App Client ID from ops.                                                |
-| `AUTH_GITHUB_SECRET`    | string | —       | GitHub OAuth Client secret. Required when `AUTH_GITHUB_ID` is set; may reuse the GitHub App Client secret from ops.                                      |
-| `AUTH_GOOGLE_ID`        | string | —       | Google OAuth client ID. Enables Google social login when set.                                                                                             |
-| `AUTH_GOOGLE_SECRET`    | string | —       | Google OAuth client secret. Required when `AUTH_GOOGLE_ID` is set.                                                                                        |
-| `AUTH_GITLAB_ID`        | string | —       | GitLab OAuth client ID. Enables GitLab social login when set.                                                                                             |
-| `AUTH_GITLAB_SECRET`    | string | —       | GitLab OAuth client secret. Required when `AUTH_GITLAB_ID` is set.                                                                                        |
-| `LINEAR_API_KEY`        | string | —       | Linear API key for Linear integration features.                                                                                                           |
-| `LINEAR_TEAM_ID`        | string | —       | Linear team ID scoping Linear API calls.                                                                                                                  |
-| `REDIS_URL`             | string | —       | Redis/Valkey connection URL. Required for distributed rate limiting (`failClosed` routes). Without it, rate limiting falls back to per-process in-memory. |
-| `TRUST_PROXY`           | string | —       | Set to `"true"` to trust `X-Forwarded-For` for client IP detection (needed behind a load balancer).                                                       |
-| `USE_GRAPHQL_ANALYTICS` | string | —       | Server-side override for GraphQL analytics. Defaults to `true` unless set to `"false"`.                                                                   |
-| `DEV_HEALTH_TEST_MODE`  | string | —       | Enables test mode (bypasses rate limiting, uses sample data). **Must not be `"true"` in production.**                                                     |
-| `DEMO_EXPORT`           | string | —       | Set to `"true"` to build a static demo export. Changes Next.js output mode and page extensions.                                                           |
+| `NEXTAUTH_URL`          | string | —       | Legacy canonical URL alias for NextAuth callbacks. Prefer `AUTH_URL`.                                                                                                 |
+| `AUTH_GITHUB_ID`        | string | —       | GitHub OAuth Client ID. Enables GitHub social login when set; may reuse the GitHub App Client ID from ops.                                                            |
+| `AUTH_GITHUB_SECRET`    | string | —       | GitHub OAuth Client secret. Required when `AUTH_GITHUB_ID` is set; may reuse the GitHub App Client secret from ops.                                                   |
+| `AUTH_GOOGLE_ID`        | string | —       | Google OAuth client ID. Enables Google social login when set.                                                                                                         |
+| `AUTH_GOOGLE_SECRET`    | string | —       | Google OAuth client secret. Required when `AUTH_GOOGLE_ID` is set.                                                                                                    |
+| `AUTH_GITLAB_ID`        | string | —       | GitLab OAuth client ID. Enables GitLab social login when set.                                                                                                         |
+| `AUTH_GITLAB_SECRET`    | string | —       | GitLab OAuth client secret. Required when `AUTH_GITLAB_ID` is set.                                                                                                    |
+| `LINEAR_API_KEY`        | string | —       | Linear API key for Linear integration features.                                                                                                                       |
+| `LINEAR_TEAM_ID`        | string | —       | Linear team ID scoping Linear API calls.                                                                                                                              |
+| `REDIS_URL`             | string | —       | Redis/Valkey connection URL. Required for distributed rate limiting (`failClosed` routes). Without it, rate limiting falls back to per-process in-memory.             |
+| `TRUST_PROXY`           | string | —       | Set to `"true"` to trust `X-Forwarded-For` for client IP detection (needed behind a load balancer).                                                                   |
+| `USE_GRAPHQL_ANALYTICS` | string | —       | Server-side override for GraphQL analytics. Defaults to `true` unless set to `"false"`.                                                                               |
+| `DEV_HEALTH_TEST_MODE`  | string | —       | Enables test mode (bypasses rate limiting, uses sample data). **Must not be `"true"` in production.**                                                                 |
+| `DEMO_EXPORT`           | string | —       | Set to `"true"` to build a static demo export. Changes Next.js output mode and page extensions.                                                                       |
 
 ---
 

--- a/docs/github-app-auth.md
+++ b/docs/github-app-auth.md
@@ -18,11 +18,11 @@ GitHub social login is an optional provider in NextAuth.js v5. It is enabled onl
 
 See [`src/lib/config.ts`](../src/lib/config.ts) for the runtime env schema.
 
-| Variable             | Required                           | Description                                                                                  |
-| -------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------- |
+| Variable             | Required                           | Description                                                                                     |
+| -------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `AUTH_URL`           | Yes outside simple localhost dev   | Public web origin Auth.js uses to derive `redirect_uri`, for example `https://app.example.com`. |
-| `AUTH_GITHUB_ID`     | Yes (to enable)                    | GitHub OAuth Client ID. Can be the same value as `GITHUB_APP_CLIENT_ID` in `ops/.env`.        |
-| `AUTH_GITHUB_SECRET` | Yes (when `AUTH_GITHUB_ID` is set) | GitHub OAuth Client secret. Can be the same value as `GITHUB_APP_CLIENT_SECRET` in `ops/.env`. |
+| `AUTH_GITHUB_ID`     | Yes (to enable)                    | GitHub OAuth Client ID. Can be the same value as `GITHUB_APP_CLIENT_ID` in `ops/.env`.          |
+| `AUTH_GITHUB_SECRET` | Yes (when `AUTH_GITHUB_ID` is set) | GitHub OAuth Client secret. Can be the same value as `GITHUB_APP_CLIENT_SECRET` in `ops/.env`.  |
 
 The ops backend must also know the same OAuth credentials so `/api/v1/auth/social-login`
 can verify the GitHub access token before issuing a Dev Health session:

--- a/docs/github-app-auth.md
+++ b/docs/github-app-auth.md
@@ -2,11 +2,11 @@
 
 **Source of Truth:** [`src/lib/auth.ts`](../src/lib/auth.ts) · [`src/lib/config.ts`](../src/lib/config.ts)
 
-> **Note:** This document covers **GitHub OAuth (social login)** via NextAuth.js. The app uses a standard GitHub OAuth App — not a GitHub App with installation tokens or private-key JWTs. There is no GitHub App installation flow in this codebase.
+> **Note:** This document covers **GitHub OAuth (social login)** via Auth.js/NextAuth. Dev Health can use the same GitHub App for both social login and the one-click GitHub App install flow documented in `ops/docs/user-guide/github-app-setup.md`; you do not need a separate GitHub OAuth App unless you want to manage login and installation as separate GitHub applications.
 
 ## Overview
 
-GitHub social login is an optional provider in NextAuth.js v5. It is enabled only when `AUTH_GITHUB_ID` is set in the environment. ([`auth.ts:119`](../src/lib/auth.ts#L119))
+GitHub social login is an optional provider in NextAuth.js v5. It is enabled only when `AUTH_GITHUB_ID` is set in the environment. See [`src/lib/auth.ts`](../src/lib/auth.ts).
 
 ```ts
 ...(authEnv.AUTH_GITHUB_ID
@@ -16,12 +16,22 @@ GitHub social login is an optional provider in NextAuth.js v5. It is enabled onl
 
 ## Configuration
 
-([`config.ts:83–84`](../src/lib/config.ts#L83))
+See [`src/lib/config.ts`](../src/lib/config.ts) for the runtime env schema.
 
-| Variable             | Required                           | Description                                                      |
-| -------------------- | ---------------------------------- | ---------------------------------------------------------------- |
-| `AUTH_GITHUB_ID`     | Yes (to enable)                    | GitHub OAuth App client ID. If absent, GitHub login is disabled. |
-| `AUTH_GITHUB_SECRET` | Yes (when `AUTH_GITHUB_ID` is set) | GitHub OAuth App client secret.                                  |
+| Variable             | Required                           | Description                                                                                  |
+| -------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------- |
+| `AUTH_URL`           | Yes outside simple localhost dev   | Public web origin Auth.js uses to derive `redirect_uri`, for example `https://app.example.com`. |
+| `AUTH_GITHUB_ID`     | Yes (to enable)                    | GitHub OAuth Client ID. Can be the same value as `GITHUB_APP_CLIENT_ID` in `ops/.env`.        |
+| `AUTH_GITHUB_SECRET` | Yes (when `AUTH_GITHUB_ID` is set) | GitHub OAuth Client secret. Can be the same value as `GITHUB_APP_CLIENT_SECRET` in `ops/.env`. |
+
+The ops backend must also know the same OAuth credentials so `/api/v1/auth/social-login`
+can verify the GitHub access token before issuing a Dev Health session:
+
+```dotenv
+# ops/.env
+SOCIAL_GITHUB_CLIENT_ID=<same Client ID>
+SOCIAL_GITHUB_CLIENT_SECRET=<same client secret>
+```
 
 See [`docs/env-vars.md`](env-vars.md) for the full environment variable reference.
 
@@ -40,7 +50,7 @@ User clicks "Sign in with GitHub"
   → NextAuth stores backend JWT + user metadata in its own session token
 ```
 
-([`auth.ts:138–174`](../src/lib/auth.ts#L138))
+See [`src/lib/auth.ts`](../src/lib/auth.ts) for the JWT callback that exchanges the provider token for a backend session.
 
 ## Session data after GitHub login
 
@@ -62,21 +72,29 @@ import { getAvailableSocialProviders } from "@/lib/auth";
 const providers = getAvailableSocialProviders();
 ```
 
-([`auth.ts:369–376`](../src/lib/auth.ts#L369))
+See [`getAvailableSocialProviders()`](../src/lib/auth.ts) for the provider list.
 
-## Registering a GitHub OAuth App for local dev
+## Registering GitHub callbacks for local dev
 
-1. Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**.
-2. Set **Homepage URL** to `http://localhost:3000`.
-3. Set **Authorization callback URL** to `http://localhost:3000/api/auth/callback/github`.
-4. Copy the **Client ID** and generate a **Client secret**.
-5. Add to your `.env.local`:
+You may either reuse the Dev Health GitHub App's Client ID/secret or create a
+separate GitHub OAuth App. Reuse is the default for local development.
+
+1. In the GitHub App's **Callback URLs**, add `http://localhost:3000/api/auth/callback/github`.
+2. If using the GitHub App install/connect flow too, also add `http://localhost:3000/org/admin/integrations/github-app/callback`.
+3. Copy the GitHub App **Client ID** and **Client secret**.
+4. Add to `web/.env`:
     ```
+    AUTH_URL=http://localhost:3000
     AUTH_GITHUB_ID=<client_id>
     AUTH_GITHUB_SECRET=<client_secret>
     ```
-6. Restart the dev server. The GitHub button will appear on the sign-in page.
+5. Add the same values to `ops/.env`:
+    ```
+    SOCIAL_GITHUB_CLIENT_ID=<client_id>
+    SOCIAL_GITHUB_CLIENT_SECRET=<client_secret>
+    ```
+6. Restart the web and ops services. The GitHub button will appear on the sign-in page.
 
 ## Error handling
 
-If the backend `/api/v1/auth/social-login` call fails or returns a non-OK response, `token.error` is set to `"social_login_failed"` and the session is marked as errored. ([`auth.ts:163–173`](../src/lib/auth.ts#L163))
+If the backend `/api/v1/auth/social-login` call fails or returns a non-OK response, `token.error` is set to `"social_login_failed"` and the session is marked as errored. See [`src/lib/auth.ts`](../src/lib/auth.ts).


### PR DESCRIPTION
## Summary

- Document reusing the GitHub App Client ID/secret for Auth.js GitHub login

- Add AUTH_URL guidance for Docker/reverse proxy redirect_uri generation

- Update env docs/examples with the matching ops SOCIAL_GITHUB_* requirements



## Verification

- git diff --check



SCREENSHOT-WAIVER: docs/env-only change; no rendered UI changed.