### PR TITLE
Improve chart label contrast accessibility

### DIFF
--- a/src/components/charts/InvestmentMixSunburst.tsx
+++ b/src/components/charts/InvestmentMixSunburst.tsx
@@ -9,6 +9,7 @@ import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
 import { echarts } from "@/lib/echartsInit";
 import { buildTooltipHtml, calcPercent } from "@/lib/chartUtils";
+import { getAccessibleTextColor } from "@/lib/chartColorContrast";
 import { formatNumber, formatPercent } from "@/lib/formatters";
 import { titleCase, formatSubcategoryLabel } from "@/lib/investmentMix";
 
@@ -101,6 +102,12 @@ export function InvestmentMixSunburst({
             const themeLabel = titleCase(theme.key);
             const baseColor = themeColorMap.get(theme.key) ?? chartTheme.grid;
             const themeOpacity = evidenceQualityDistribution?.[theme.key];
+            const themeLabelColor = getAccessibleTextColor(
+                baseColor,
+                chartTheme.background,
+                chartTheme.text,
+                themeOpacity,
+            );
             const themeChildren =
                 focusedTheme && focusedTheme !== theme.key
                     ? undefined
@@ -109,15 +116,28 @@ export function InvestmentMixSunburst({
                           .sort((a, b) => b.value - a.value)
                           .map((entry, idx) => {
                               const childOpacity = evidenceQualityDistribution?.[entry.key];
+                              const childColor = adjustHex(baseColor, 18 + (idx % 3) * 10);
+                              const childLabelColor = getAccessibleTextColor(
+                                  childColor,
+                                  chartTheme.background,
+                                  chartTheme.text,
+                                  childOpacity,
+                              );
                               return {
                                   name: formatSubcategoryLabel(entry.key, true),
                                   value: entry.value,
                                   itemStyle: {
-                                      color: adjustHex(baseColor, 18 + (idx % 3) * 10),
+                                      color: childColor,
                                       opacity:
-                                          typeof childOpacity === "number"
-                                              ? childOpacity
-                                              : undefined,
+                                          typeof childOpacity === "number" ? childOpacity : undefined,
+                                  },
+                                  label: {
+                                      color: childLabelColor,
+                                  },
+                                  emphasis: {
+                                      label: {
+                                          color: childLabelColor,
+                                      },
                                   },
                                   nodeType: "subcategory",
                                   themeKey: theme.key,
@@ -132,13 +152,23 @@ export function InvestmentMixSunburst({
                     color: baseColor,
                     opacity: typeof themeOpacity === "number" ? themeOpacity : undefined,
                 },
+                label: {
+                    color: themeLabelColor,
+                },
+                emphasis: {
+                    label: {
+                        color: themeLabelColor,
+                    },
+                },
                 nodeType: "theme",
                 themeKey: theme.key,
                 children: themeChildren?.length ? themeChildren : undefined,
             };
         });
     }, [
+        chartTheme.background,
         chartTheme.grid,
+        chartTheme.text,
         evidenceQualityDistribution,
         focusedTheme,
         sortedThemes,
@@ -275,7 +305,7 @@ export function InvestmentMixSunburst({
                             r: "70%",
                             label: { show: false },
                             emphasis: {
-                                label: { show: true, color: chartTheme.text, fontSize: 11 },
+                                label: { show: true, fontSize: 11 },
                             },
                             itemStyle: { borderWidth: 2 },
                         },

--- a/src/components/charts/SunburstChart.tsx
+++ b/src/components/charts/SunburstChart.tsx
@@ -9,8 +9,18 @@ import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
 import { echarts } from "@/lib/echartsInit";
 import { buildTooltipHtml, calcPercent, lightenByDepth } from "@/lib/chartUtils";
+import { getAccessibleTextColor } from "@/lib/chartColorContrast";
 
 echarts.use([EChartsSunburstChart]);
+
+type SunburstTextStyle = {
+    color?: string;
+    fontSize?: number;
+    fontWeight?: number;
+    rotate?: number | string;
+    show?: boolean;
+    [key: string]: unknown;
+};
 
 export type SunburstNode = {
     name: string;
@@ -19,6 +29,11 @@ export type SunburstNode = {
     itemStyle?: {
         color?: string;
         opacity?: number;
+    };
+    label?: SunburstTextStyle;
+    emphasis?: {
+        label?: SunburstTextStyle;
+        [key: string]: unknown;
     };
     [key: string]: unknown;
 };
@@ -39,6 +54,39 @@ type SunburstChartProps = {
         percent: number;
         data?: SunburstNode;
     }) => void;
+};
+
+const applyAccessibleLabels = (
+    node: SunburstNode,
+    surfaceColor: string,
+    fallbackTextColor: string,
+    inheritedFillColor?: string,
+): SunburstNode => {
+    const fillColor = node.itemStyle?.color ?? inheritedFillColor;
+    const labelColor = getAccessibleTextColor(
+        fillColor,
+        surfaceColor,
+        fallbackTextColor,
+        node.itemStyle?.opacity,
+    );
+
+    return {
+        ...node,
+        label: {
+            ...node.label,
+            color: labelColor,
+        },
+        emphasis: {
+            ...node.emphasis,
+            label: {
+                ...node.emphasis?.label,
+                color: labelColor,
+            },
+        },
+        children: node.children?.map((child) =>
+            applyAccessibleLabels(child, surfaceColor, fallbackTextColor, fillColor),
+        ),
+    };
 };
 
 /**
@@ -63,7 +111,7 @@ export function SunburstChart({
 
     const totalValue = data.value || 0;
 
-    // Assign colors to top-level children
+    // Assign colors to top-level children.
     const coloredData = useMemo(() => {
         if (useInputColors || !data.children?.length) return data;
 
@@ -88,6 +136,11 @@ export function SunburstChart({
             children: data.children.map((child, idx) => assignColors(child, 0, idx)),
         };
     }, [data, chartColors, useInputColors]);
+
+    const accessibleData = useMemo(
+        () => applyAccessibleLabels(coloredData, chartTheme.background, chartTheme.text),
+        [chartTheme.background, chartTheme.text, coloredData],
+    );
 
     const handleClick = useCallback(
         (params: unknown) => {
@@ -129,8 +182,7 @@ export function SunburstChart({
                     const nodeData = entry.data;
                     if (!nodeData?.name) return "";
 
-                    const path =
-                        entry.treePathInfo?.map((p) => p.name).join(" → ") ?? nodeData.name;
+                    const path = entry.treePathInfo?.map((p) => p.name).join(" → ") ?? nodeData.name;
                     const value = nodeData.value ?? 0;
                     const percent = calcPercent(value, totalValue);
 
@@ -148,7 +200,7 @@ export function SunburstChart({
             series: [
                 {
                     type: "sunburst" as const,
-                    data: coloredData.children ?? [],
+                    data: accessibleData.children ?? [],
                     radius: ["15%", "90%"],
                     center: ["50%", "50%"],
                     sort: "desc" as const,
@@ -212,7 +264,7 @@ export function SunburstChart({
                 },
             ],
         }),
-        [coloredData, totalValue, unit, chartTheme, tooltipFormatter],
+        [accessibleData, totalValue, unit, chartTheme, tooltipFormatter],
     );
 
     return (

--- a/src/components/charts/TreemapChart.tsx
+++ b/src/components/charts/TreemapChart.tsx
@@ -2,7 +2,7 @@
 
 import type { CSSProperties } from "react";
 import { useCallback, useMemo } from "react";
-// Type-only import from full echarts package (erased at runtime — no bundle impact).
+// Type-only import from full echarts package (erased at runtime - no bundle impact).
 import type { EChartsOption } from "echarts";
 import { TreemapChart as EChartsTreemapChart } from "echarts/charts";
 
@@ -10,9 +10,18 @@ import { Chart } from "./Chart";
 import { useChartColors, useChartTheme } from "./chartTheme";
 import { echarts } from "@/lib/echartsInit";
 import { buildTooltipHtml, calcPercent, lightenByDepth } from "@/lib/chartUtils";
+import { getAccessibleTextColor } from "@/lib/chartColorContrast";
 import { formatPercent } from "@/lib/formatters";
 
 echarts.use([EChartsTreemapChart]);
+
+type TreemapTextStyle = {
+    color?: string;
+    fontSize?: number;
+    fontWeight?: number;
+    show?: boolean;
+    [key: string]: unknown;
+};
 
 export type TreemapNode = {
     name: string;
@@ -22,6 +31,8 @@ export type TreemapNode = {
         color?: string;
         opacity?: number;
     };
+    label?: TreemapTextStyle;
+    upperLabel?: TreemapTextStyle;
     [key: string]: unknown;
 };
 
@@ -43,6 +54,36 @@ type TreemapChartProps = {
         percent: number;
         data?: TreemapNode;
     }) => void;
+};
+
+const applyAccessibleLabels = (
+    node: TreemapNode,
+    surfaceColor: string,
+    fallbackTextColor: string,
+    inheritedFillColor?: string,
+): TreemapNode => {
+    const fillColor = node.itemStyle?.color ?? inheritedFillColor;
+    const labelColor = getAccessibleTextColor(
+        fillColor,
+        surfaceColor,
+        fallbackTextColor,
+        node.itemStyle?.opacity,
+    );
+
+    return {
+        ...node,
+        label: {
+            ...node.label,
+            color: labelColor,
+        },
+        upperLabel: {
+            ...node.upperLabel,
+            color: labelColor,
+        },
+        children: node.children?.map((child) =>
+            applyAccessibleLabels(child, surfaceColor, fallbackTextColor, fillColor),
+        ),
+    };
 };
 
 /**
@@ -68,7 +109,7 @@ export function TreemapChart({
 
     const totalValue = data.value || 0;
 
-    // Assign colors to top-level children
+    // Assign colors to top-level children.
     const coloredData = useMemo(() => {
         if (useInputColors || !data.children?.length) return data;
 
@@ -93,6 +134,11 @@ export function TreemapChart({
             children: data.children.map((child, idx) => assignColors(child, 0, idx)),
         };
     }, [data, chartColors, useInputColors]);
+
+    const accessibleData = useMemo(
+        () => applyAccessibleLabels(coloredData, chartTheme.background, chartTheme.text),
+        [chartTheme.background, chartTheme.text, coloredData],
+    );
 
     const handleClick = useCallback(
         (params: unknown) => {
@@ -163,7 +209,7 @@ export function TreemapChart({
                 series: [
                     {
                         type: "treemap" as const,
-                        data: coloredData.children ?? [],
+                        data: accessibleData.children ?? [],
                         top: 8,
                         left: 8,
                         right: 8,
@@ -243,7 +289,7 @@ export function TreemapChart({
                 ],
             }) as EChartsOption,
         [
-            coloredData,
+            accessibleData,
             totalValue,
             unit,
             chartTheme,

--- a/src/lib/chartColorContrast.ts
+++ b/src/lib/chartColorContrast.ts
@@ -1,0 +1,87 @@
+const DARK_TEXT = "#111827";
+const LIGHT_TEXT = "#f9fafb";
+
+const clamp = (value: number, min = 0, max = 1) => Math.max(min, Math.min(max, value));
+
+type Rgb = {
+    r: number;
+    g: number;
+    b: number;
+};
+
+const parseHexColor = (color: string): Rgb | null => {
+    const normalized = color.trim().replace(/^#/, "");
+    const hex =
+        normalized.length === 3
+            ? normalized
+                  .split("")
+                  .map((char) => `${char}${char}`)
+                  .join("")
+            : normalized;
+
+    if (!/^[0-9a-fA-F]{6}$/.test(hex)) {
+        return null;
+    }
+
+    const value = Number.parseInt(hex, 16);
+    return {
+        r: (value >> 16) & 0xff,
+        g: (value >> 8) & 0xff,
+        b: value & 0xff,
+    };
+};
+
+const blendRgb = (foreground: Rgb, background: Rgb, opacity = 1): Rgb => {
+    const alpha = clamp(opacity);
+    return {
+        r: foreground.r * alpha + background.r * (1 - alpha),
+        g: foreground.g * alpha + background.g * (1 - alpha),
+        b: foreground.b * alpha + background.b * (1 - alpha),
+    };
+};
+
+const relativeLuminance = ({ r, g, b }: Rgb) => {
+    const transform = (channel: number) => {
+        const srgb = channel / 255;
+        return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+    };
+
+    return 0.2126 * transform(r) + 0.7152 * transform(g) + 0.0722 * transform(b);
+};
+
+const contrastRatio = (foreground: Rgb, background: Rgb) => {
+    const foregroundLum = relativeLuminance(foreground);
+    const backgroundLum = relativeLuminance(background);
+    const lighter = Math.max(foregroundLum, backgroundLum);
+    const darker = Math.min(foregroundLum, backgroundLum);
+    return (lighter + 0.05) / (darker + 0.05);
+};
+
+export const getAccessibleTextColor = (
+    fillColor: string | undefined,
+    surfaceColor: string,
+    fallbackColor: string,
+    opacity?: number,
+) => {
+    if (!fillColor) {
+        return fallbackColor;
+    }
+
+    const fillRgb = parseHexColor(fillColor);
+    if (!fillRgb) {
+        return fallbackColor;
+    }
+
+    const surfaceRgb = parseHexColor(surfaceColor) ?? parseHexColor(DARK_TEXT);
+    const effectiveFill = surfaceRgb ? blendRgb(fillRgb, surfaceRgb, opacity ?? 1) : fillRgb;
+    const lightRgb = parseHexColor(LIGHT_TEXT);
+    const darkRgb = parseHexColor(DARK_TEXT);
+
+    if (!lightRgb || !darkRgb) {
+        return fallbackColor;
+    }
+
+    return contrastRatio(darkRgb, effectiveFill) >= contrastRatio(lightRgb, effectiveFill)
+        ? DARK_TEXT
+        : LIGHT_TEXT;
+};


### PR DESCRIPTION
## Summary
- Add a reusable chart color contrast helper that chooses readable label text against chart fills, including opacity blended over the chart surface.
- Apply accessible per-node label colors to treemap labels and upper labels.
- Apply the same contrast logic to both investment-specific and generic sunburst labels and hover labels.

## Why
The issue is broader than one investment treemap. The repo defines many palette-level `--chart-color-*` values and the chart system reads them globally through `useChartColors()`. Those colors are used across chart components, but chart labels were often inheriting a single global theme text color. That fails when labels sit directly on saturated or light chart fills.

This PR keeps the theme colors intact, but makes chart label foregrounds context-aware anywhere the label is rendered inside a colored region.

## Validation
- Not run locally in this environment.