### PR TITLE
fix(work-graph): scope overview edge slices

### DIFF
--- a/src/components/work/GraphView.test.tsx
+++ b/src/components/work/GraphView.test.tsx
@@ -114,7 +114,11 @@ describe("GraphView", () => {
         expect(screen.getByText(/1 edges/i)).toBeInTheDocument();
         expect(mockUseWorkGraphEdges).toHaveBeenCalledWith({
             orgId: "org-1",
-            filters: { repoIds: ["repo-1"], limit: 1000 },
+            filters: {
+                repoIds: ["repo-1"],
+                limit: 1000,
+                edgeTypes: ["FIXES", "IMPLEMENTS", "REFERENCES"],
+            },
             pause: false,
         });
     });
@@ -247,7 +251,11 @@ describe("GraphView", () => {
         render(<GraphView filters={filters} />);
 
         const filtersArg = lastEdgeFilters();
-        expect(filtersArg).toEqual({ repoIds: ["repo-1"], limit: 1000 });
+        expect(filtersArg).toEqual({
+            repoIds: ["repo-1"],
+            limit: 1000,
+            edgeTypes: ["FIXES", "IMPLEMENTS", "REFERENCES"],
+        });
         expect(filtersArg).not.toHaveProperty("theme");
         expect(filtersArg).not.toHaveProperty("subcategory");
     });
@@ -1226,7 +1234,7 @@ describe("GraphView", () => {
         expect(filtersArg.edgeTypes).not.toContain("REFERENCES");
     });
 
-    it("overview tab does NOT carry edgeTypes (keeps the broad fetch)", () => {
+    it("overview tab carries the default connection slice edgeTypes before the backend limit", () => {
         mockUseWorkGraphEdges.mockReturnValue({
             edges: [],
             loading: false,
@@ -1236,6 +1244,44 @@ describe("GraphView", () => {
         });
 
         render(<GraphView filters={filters} activeTab="overview" />);
+
+        expect(lastEdgeFilters()).toMatchObject({
+            edgeTypes: ["FIXES", "IMPLEMENTS", "REFERENCES"],
+        });
+    });
+
+    it("overview tab sends the selected connection slice edgeTypes before the backend limit", async () => {
+        const user = userEvent.setup();
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="overview" />);
+
+        await user.selectOptions(screen.getByLabelText(/Connection type/i), "change-to-code");
+
+        expect(lastEdgeFilters()).toMatchObject({
+            edgeTypes: ["CONTAINS", "TOUCHES"],
+        });
+    });
+
+    it("overview tab omits edgeTypes for the All connections slice", async () => {
+        const user = userEvent.setup();
+        mockUseWorkGraphEdges.mockReturnValue({
+            edges: [],
+            loading: false,
+            error: null,
+            totalCount: 0,
+            refetch: vi.fn(),
+        });
+
+        render(<GraphView filters={filters} activeTab="overview" />);
+
+        await user.selectOptions(screen.getByLabelText(/Connection type/i), "all");
 
         expect(lastEdgeFilters()).not.toHaveProperty("edgeTypes");
     });

--- a/src/components/work/GraphView.tsx
+++ b/src/components/work/GraphView.tsx
@@ -326,6 +326,11 @@ export function GraphView({
 
     const contextOrgId = useOrgId();
     const orgId = filters.scope.ids[0] || contextOrgId || "";
+    // The Overview tab honours the in-explorer connection-type selector; the
+    // Dependencies / Review Network tabs ARE the filter, so they pin it.
+    const activeConnectionSlice =
+        CONNECTION_SLICES.find((slice) => slice.id === connectionSliceId) ?? CONNECTION_SLICES[0];
+
     // Theme / subcategory are filtered SERVER-SIDE (CHAOS-2431): the backend
     // applies them before the LIMIT, so a sparse theme's edges can't fall
     // outside the edge cap and produce a false-empty graph. We therefore pass
@@ -335,20 +340,32 @@ export function GraphView({
     // page; inflow-outflow / artifacts now fetch their own server-side
     // aggregates (CHAOS-2442) and review-network uses pre-fetched review edges.
     const graphTabActive = activeTab === "overview" || activeTab === "dependencies";
+    const activeOverviewEdgeTypes =
+        activeTab === "overview" && activeConnectionSlice.edgeTypes.length > 0
+            ? activeConnectionSlice.edgeTypes
+            : undefined;
+    const activeDependencyEdgeTypes =
+        activeTab === "dependencies" ? DEPENDENCY_EDGE_TYPES : undefined;
     const edgeFilters = useMemo<WorkGraphEdgeFilterInput>(
         () => ({
             repoIds: filters.what?.repos,
             limit: GRAPH_EDGE_QUERY_LIMIT,
             ...(theme !== "all" ? { theme } : {}),
             ...(subcategory !== "all" ? { subcategory } : {}),
-            // Dependencies tab (CHAOS-2442): scope the edge query to dependency
-            // edge types SERVER-SIDE so they arrive pre-filtered before the LIMIT
-            // and can never be starved by a reference-heavy capped page. The
-            // client-side DEPENDENCY_EDGE_TYPES filter below is kept only as a
-            // harmless safety net. The overview tab keeps the broad set.
-            ...(activeTab === "dependencies" ? { edgeTypes: DEPENDENCY_EDGE_TYPES } : {}),
+            // Explorer tabs scope their edge-type slices SERVER-SIDE so selected
+            // relationships arrive pre-filtered before LIMIT and cannot be
+            // starved by a reference-heavy capped page. The client-side filters
+            // below remain as harmless safety nets.
+            ...(activeOverviewEdgeTypes ? { edgeTypes: activeOverviewEdgeTypes } : {}),
+            ...(activeDependencyEdgeTypes ? { edgeTypes: activeDependencyEdgeTypes } : {}),
         }),
-        [filters.what?.repos, theme, subcategory, activeTab],
+        [
+            filters.what?.repos,
+            theme,
+            subcategory,
+            activeOverviewEdgeTypes,
+            activeDependencyEdgeTypes,
+        ],
     );
     const { edges, loading, error, totalCount, degradedReason } = useWorkGraphEdges({
         orgId,
@@ -391,11 +408,6 @@ export function GraphView({
         filters: artifactFilters,
         pause: !orgId || activeTab !== "artifacts",
     });
-
-    // The Overview tab honours the in-explorer connection-type selector; the
-    // Dependencies / Review Network tabs ARE the filter, so they pin it.
-    const activeConnectionSlice =
-        CONNECTION_SLICES.find((slice) => slice.id === connectionSliceId) ?? CONNECTION_SLICES[0];
 
     const tabEdges = useMemo(() => {
         // NB: theme/subcategory are filtered server-side (see edgeFilters above),


### PR DESCRIPTION
## Summary
- Scope Work Graph Overview edge queries to the selected connection slice edgeTypes before the backend LIMIT.
- Preserve broad fetching for the All connections slice.
- Add regression coverage for default, selected, and All connections Overview query variables.

## Verification
- pnpm exec vitest run src/components/work/GraphView.test.tsx
- pnpm exec eslint src/components/work/GraphView.tsx src/components/work/GraphView.test.tsx
- pnpm typecheck
- pnpm build
- Live browser QA: graph_connection=change-to-code request included edgeTypes [CONTAINS, TOUCHES].

## Visual evidence
Screenshot will be attached after PR creation.

Linear: CHAOS-2741

![work-graph-chaos-2741-change-to-code-live.png](https://github.com/user-attachments/assets/8c2ff039-7ed6-4684-bd04-00a3a675a84e)
