### PR TITLE
feat(backlog-risk): render stale WIP signal (CHAOS-2729)

### DIFF
--- a/src/app/(app)/plan/backlog-risk/_components.tsx
+++ b/src/app/(app)/plan/backlog-risk/_components.tsx
@@ -70,6 +70,54 @@ export function WipCongestionCard({ overlay, backlogSize }: WipCongestionCardPro
     );
 }
 
+type StaleWipCardProps = {
+    staleWip: ThroughputForecast["staleWip"];
+};
+
+function formatAgeHours(hours: number) {
+    if (hours < 24) {
+        const roundedHours = Math.round(hours);
+        return `${formatNumber(roundedHours, { maximumFractionDigits: 0 })} ${roundedHours === 1 ? "hour" : "hours"}`;
+    }
+
+    const days = hours / 24;
+    const roundedDays = Math.round(days * 10) / 10;
+    const dayLabel = roundedDays === 1 ? "day" : "days";
+    return `${formatNumber(roundedDays, { maximumFractionDigits: 1 })} ${dayLabel}`;
+}
+
+export function StaleWipCard({ staleWip }: StaleWipCardProps) {
+    const p90AgeHours = staleWip?.p90AgeHours;
+
+    return (
+        <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
+                Stale WIP
+            </h2>
+            {p90AgeHours == null ? (
+                <DataState
+                    variant="insufficient-confidence"
+                    className="mt-4"
+                    title="WIP age unavailable"
+                    description="Sync in-progress work item age data to show how long current WIP has been open."
+                />
+            ) : (
+                <div className="mt-4">
+                    <p className="text-3xl font-semibold">{formatAgeHours(p90AgeHours)}</p>
+                    <p className="mt-1 text-xs text-(--ink-muted)">
+                        90th percentile age of in-progress items
+                    </p>
+                    {staleWip?.p50AgeHours != null ? (
+                        <p className="mt-4 text-xs text-(--ink-muted)">
+                            Median in-progress age: {formatAgeHours(staleWip.p50AgeHours)}
+                        </p>
+                    ) : null}
+                </div>
+            )}
+        </div>
+    );
+}
+
 // ── ForecastContent ───────────────────────────────────────────────────────────
 
 type ForecastContentProps = { forecast: ThroughputForecast };
@@ -83,17 +131,7 @@ export function ForecastContent({ forecast }: ForecastContentProps) {
             />
 
             <section className="grid gap-4 md:grid-cols-2">
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
-                    <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
-                        Stale WIP
-                    </h2>
-                    <DataState
-                        variant="detector-unavailable"
-                        className="mt-4"
-                        title="WIP age not yet connected"
-                        description="Items that appear stuck in progress will surface here once work item age data is connected."
-                    />
-                </div>
+                <StaleWipCard staleWip={forecast.staleWip} />
 
                 <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
                     <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">

--- a/src/app/(app)/plan/backlog-risk/page.test.tsx
+++ b/src/app/(app)/plan/backlog-risk/page.test.tsx
@@ -1,7 +1,13 @@
 import { render, screen } from "@/test/utils";
 import { describe, expect, it } from "vitest";
 
-import { ForecastContent, NoForecastState, StatusBadge, WipCongestionCard } from "./_components";
+import {
+    ForecastContent,
+    NoForecastState,
+    StaleWipCard,
+    StatusBadge,
+    WipCongestionCard,
+} from "./_components";
 import type { ThroughputForecast, ThroughputRiskOverlay } from "@/lib/graphql/types";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -36,6 +42,7 @@ function makeForecast(overrides: Partial<ThroughputForecast> = {}): ThroughputFo
         rollingWindows: [],
         primaryRisk: makeWipOverlay(),
         wipCongestion: makeWipOverlay(),
+        staleWip: { p50AgeHours: 24, p90AgeHours: 96 },
         reviewBottleneck: makeNeutralOverlay("review"),
         incidentLoad: makeNeutralOverlay("incident"),
         insufficientHistory: false,
@@ -100,6 +107,28 @@ describe("WipCongestionCard — ratio semantics", () => {
     });
 });
 
+describe("StaleWipCard", () => {
+    it("renders p90 WIP age as an age signal, not a count", () => {
+        render(<StaleWipCard staleWip={{ p50AgeHours: 24, p90AgeHours: 96 }} />);
+        expect(screen.getByText("4 days")).toBeInTheDocument();
+        expect(screen.getByText("90th percentile age of in-progress items")).toBeInTheDocument();
+        expect(screen.getByText("Median in-progress age: 1 day")).toBeInTheDocument();
+        expect(screen.queryByText(/items stuck/i)).not.toBeInTheDocument();
+    });
+
+    it("pluralizes rounded day labels from the displayed value", () => {
+        render(<StaleWipCard staleWip={{ p50AgeHours: null, p90AgeHours: 24.1 }} />);
+        expect(screen.getByText("1 day")).toBeInTheDocument();
+        expect(screen.queryByText("1 days")).not.toBeInTheDocument();
+    });
+
+    it("renders a genuine no-data state when WIP age is missing", () => {
+        render(<StaleWipCard staleWip={null} />);
+        expect(screen.getByText("WIP age unavailable")).toBeInTheDocument();
+        expect(screen.queryByText("WIP age not yet connected")).not.toBeInTheDocument();
+    });
+});
+
 // ── NoForecastState ───────────────────────────────────────────────────────────
 
 describe("NoForecastState", () => {
@@ -124,9 +153,9 @@ describe("ForecastContent", () => {
         expect(screen.getByText("Elevated")).toBeInTheDocument();
     });
 
-    it("renders Stale WIP and Unestimated Debt unavailable panels", () => {
+    it("renders live Stale WIP and leaves Unestimated Debt unavailable", () => {
         render(<ForecastContent forecast={makeForecast()} />);
-        expect(screen.getByText("WIP age not yet connected")).toBeInTheDocument();
+        expect(screen.getByText("4 days")).toBeInTheDocument();
         expect(screen.getByText("Estimate coverage not yet connected")).toBeInTheDocument();
     });
 

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -1874,6 +1874,7 @@ export type ThroughputForecast = {
   primaryRisk: ThroughputRiskOverlay;
   reviewBottleneck: ThroughputRiskOverlay;
   rollingWindows: Array<ThroughputRollingWindow>;
+  staleWip?: Maybe<ThroughputStaleWip>;
   teamId?: Maybe<Scalars['String']['output']>;
   wipCongestion: ThroughputRiskOverlay;
   workScopeId?: Maybe<Scalars['String']['output']>;
@@ -1902,6 +1903,12 @@ export type ThroughputRollingWindow = {
   meanWeeklyThroughput: Scalars['Float']['output'];
   sampleCount: Scalars['Int']['output'];
   windowWeeks: Scalars['Int']['output'];
+};
+
+export type ThroughputStaleWip = {
+  __typename?: 'ThroughputStaleWip';
+  p50AgeHours?: Maybe<Scalars['Float']['output']>;
+  p90AgeHours?: Maybe<Scalars['Float']['output']>;
 };
 
 export type TimeGranularity =

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -265,6 +265,10 @@ query ThroughputForecast($orgId: String!, $input: ThroughputForecastInput!) {
       threshold
       active
     }
+    staleWip {
+      p50AgeHours
+      p90AgeHours
+    }
     reviewBottleneck {
       kind
       score

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1535,11 +1535,6 @@ type ThroughputForecast {
   insufficientHistory: Boolean!
 }
 
-type ThroughputStaleWip {
-  p50AgeHours: Float
-  p90AgeHours: Float
-}
-
 input ThroughputForecastInput {
   teamIds: [String!] = null
   workScopeId: String = null
@@ -1561,6 +1556,11 @@ type ThroughputRollingWindow {
   meanWeeklyThroughput: Float!
   sampleCount: Int!
   insufficientHistory: Boolean!
+}
+
+type ThroughputStaleWip {
+  p50AgeHours: Float
+  p90AgeHours: Float
 }
 
 enum TimeGranularity {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1529,9 +1529,15 @@ type ThroughputForecast {
   rollingWindows: [ThroughputRollingWindow!]!
   primaryRisk: ThroughputRiskOverlay!
   wipCongestion: ThroughputRiskOverlay!
+  staleWip: ThroughputStaleWip
   reviewBottleneck: ThroughputRiskOverlay!
   incidentLoad: ThroughputRiskOverlay!
   insufficientHistory: Boolean!
+}
+
+type ThroughputStaleWip {
+  p50AgeHours: Float
+  p90AgeHours: Float
 }
 
 input ThroughputForecastInput {

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -370,6 +370,11 @@ export interface ThroughputRiskOverlay {
     active: boolean;
 }
 
+export interface ThroughputStaleWip {
+    p50AgeHours?: number | null;
+    p90AgeHours?: number | null;
+}
+
 export interface ThroughputForecast {
     forecastId: string;
     computedAt: string;
@@ -383,6 +388,7 @@ export interface ThroughputForecast {
     rollingWindows: ThroughputRollingWindow[];
     primaryRisk: ThroughputRiskOverlay;
     wipCongestion: ThroughputRiskOverlay;
+    staleWip?: ThroughputStaleWip | null;
     reviewBottleneck: ThroughputRiskOverlay;
     incidentLoad: ThroughputRiskOverlay;
     insufficientHistory: boolean;


### PR DESCRIPTION
## Summary
- Adds stale WIP forecast fields to generated GraphQL types and backlog-risk query types.
- Renders the stale WIP card in Backlog Risk with unavailable/no-data handling.

## Verification
- Focused unit tests passed.
- `pnpm typecheck` passed.
- `pnpm build` passed.
- GraphQL codegen drift check passed.
- Focused design lint passed.

## Manual QA
- Browser QA verified `/plan/backlog-risk` renders the WIP age unavailable no-data state.
- Network response returned 200.
- Known Next dev CSP `eval` warning only.

## Screenshot
![chaos-2729-backlog-risk-stale-wip.png](https://github.com/user-attachments/assets/f2ea566b-03b3-4173-80d9-3c9f514739eb)

## Phase Context
- CHAOS-2729 stale WIP slice only.
- Remaining forecast cockpit phases continue in CHAOS-2730, CHAOS-2731, CHAOS-2732, CHAOS-2733, and Phase 4.

## Linear
- https://linear.app/fullchaos/issue/CHAOS-2729/backlog-risk-wire-stale-wip-card-to-existing-wip-age-data
