### PR TITLE
fix(testops): render coverage fetch failures distinctly

### DIFF
--- a/src/app/(app)/testops/coverage/page.test.tsx
+++ b/src/app/(app)/testops/coverage/page.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@/test/utils";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCheckApiHealth, mockFetchCoverageMetrics } = vi.hoisted(() => ({
+    mockCheckApiHealth: vi.fn(),
+    mockFetchCoverageMetrics: vi.fn(),
+}));
+
+vi.mock("@/lib/api/system", () => ({
+    checkApiHealth: mockCheckApiHealth,
+}));
+
+vi.mock("@/lib/testops/fetchers", () => ({
+    fetchCoverageMetrics: mockFetchCoverageMetrics,
+}));
+
+vi.mock("@/lib/config", () => ({
+    getServerEnv: () => ({}),
+}));
+
+vi.mock("@/lib/labels/entityLabel", () => ({
+    resolveEntityLabels: (ids: string[]) => ({ labels: ids, titles: ids }),
+}));
+
+vi.mock("@/components/navigation/PrimaryNav", () => ({
+    PrimaryNav: () => <nav data-testid="primary-nav" />,
+}));
+
+vi.mock("@/components/navigation/GlobalContextBar", () => ({
+    GlobalContextBar: () => <div data-testid="global-context" />,
+}));
+
+vi.mock("@/components/filters/FilterBar", () => ({
+    FilterBar: () => <div data-testid="filter-bar" />,
+}));
+
+vi.mock("@/components/shared/BackLink", () => ({
+    BackLink: () => <a href="/">Back</a>,
+}));
+
+vi.mock("../TestOpsTabs", () => ({
+    TestOpsTabs: () => <div data-testid="testops-tabs" />,
+}));
+
+vi.mock("@/components/metrics/MetricCard", () => ({
+    MetricCard: ({ label }: { label: string }) => <article>{label}</article>,
+}));
+
+vi.mock("@/components/charts/TimeseriesChart", () => ({
+    TimeseriesChart: () => <div data-testid="timeseries-chart" />,
+}));
+
+vi.mock("@/components/charts/HorizontalBarChart", () => ({
+    HorizontalBarChart: () => <div data-testid="horizontal-bar-chart" />,
+}));
+
+vi.mock("@/components/charts/ChartFrame", () => ({
+    ChartFrame: ({
+        children,
+        isError,
+        isEmpty,
+        stateMessage,
+        stateDescription,
+        stateTitle,
+        title,
+    }: {
+        children: ReactNode;
+        isError?: boolean;
+        isEmpty?: boolean;
+        stateMessage?: string;
+        stateDescription?: string;
+        stateTitle?: string;
+        title: string;
+    }) => (
+        <section
+            data-testid="coverage-chart-frame"
+            data-is-error={String(Boolean(isError))}
+            data-is-empty={String(Boolean(isEmpty))}
+        >
+            <h2>{title}</h2>
+            {isError ? <p>{stateMessage}</p> : isEmpty ? <p>{stateDescription ?? stateTitle}</p> : children}
+        </section>
+    ),
+}));
+
+import CoveragePage from "./page";
+
+describe("CoveragePage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockCheckApiHealth.mockResolvedValue({ ok: true });
+    });
+
+    it("renders GraphQL fetch failures as an error state instead of empty coverage", async () => {
+        mockFetchCoverageMetrics.mockResolvedValue({ timeseries: [], breakdowns: [], fetchFailed: true });
+
+        render(await CoveragePage({ searchParams: Promise.resolve({}) }));
+
+        const chartFrame = screen.getByTestId("coverage-chart-frame");
+        expect(chartFrame).toHaveAttribute("data-is-error", "true");
+        expect(chartFrame).toHaveAttribute("data-is-empty", "true");
+        expect(screen.getByText(/Coverage analytics could not be loaded/i)).toBeInTheDocument();
+    });
+
+    it("renders genuine empty coverage as a not-populated state", async () => {
+        mockFetchCoverageMetrics.mockResolvedValue({ timeseries: [], breakdowns: [] });
+
+        render(await CoveragePage({ searchParams: Promise.resolve({}) }));
+
+        const chartFrame = screen.getByTestId("coverage-chart-frame");
+        expect(chartFrame).toHaveAttribute("data-is-error", "false");
+        expect(chartFrame).toHaveAttribute("data-is-empty", "true");
+        expect(screen.getByText(/connected CI coverage data is available/i)).toBeInTheDocument();
+    });
+});

--- a/src/app/(app)/testops/coverage/page.test.tsx
+++ b/src/app/(app)/testops/coverage/page.test.tsx
@@ -36,7 +36,7 @@ vi.mock("@/components/filters/FilterBar", () => ({
 }));
 
 vi.mock("@/components/shared/BackLink", () => ({
-    BackLink: () => <a href="/">Back</a>,
+    BackLink: () => <button type="button">Back</button>,
 }));
 
 vi.mock("../TestOpsTabs", () => ({

--- a/src/app/(app)/testops/coverage/page.tsx
+++ b/src/app/(app)/testops/coverage/page.tsx
@@ -113,6 +113,7 @@ export default async function CoveragePage({
 
 	const coverageTimeseries = coverageData.timeseries || [];
 	const coverageBreakdowns = coverageData.breakdowns || [];
+	const fetchFailed = Boolean(coverageData.fetchFailed);
 
 	const measures = [
 		{ id: "COVERAGE_LINE_PCT", ts: coverageTimeseries },
@@ -213,9 +214,11 @@ export default async function CoveragePage({
 								value: `${COVERAGE_LINE_TARGET_PCT}%`,
 								tone: "info",
 							}}
+							isError={fetchFailed}
+							stateMessage="Coverage analytics could not be loaded. Coverage history will reappear once the data service recovers."
 							isEmpty={timeseriesData.length === 0}
 							stateTitle="Coverage trend not populated"
-							stateDescription="Coverage history appears here once CI coverage data is connected for this scope."
+							stateDescription="Coverage history appears here once connected CI coverage data is available for this scope."
 						>
 							<div className="h-64">
 								<TimeseriesChart

--- a/src/lib/testops/__tests__/fetchers.test.ts
+++ b/src/lib/testops/__tests__/fetchers.test.ts
@@ -126,7 +126,16 @@ describe("fetchCoverageMetrics schema hardening (CHAOS-2078)", () => {
 
         const result = await fetchCoverageMetrics({ timeseries: [], breakdowns: [] }, false);
 
-        expect(result).toEqual(emptyAnalytics);
+        expect(result).toEqual({ ...emptyAnalytics, fetchFailed: true });
+    });
+
+    it("marks GraphQL errors as fetch failures instead of genuine empty coverage", async () => {
+        mockAuth({ user: { org_id: "org-1" } });
+        vi.mocked(graphqlFetch).mockRejectedValue(new Error("GraphQL unavailable"));
+
+        const result = await fetchCoverageMetrics({ timeseries: [], breakdowns: [] }, false);
+
+        expect(result).toEqual({ ...emptyAnalytics, fetchFailed: true });
     });
 
     it("returns parsed analytics for a well-formed response", async () => {

--- a/src/lib/testops/fetchers.ts
+++ b/src/lib/testops/fetchers.ts
@@ -23,6 +23,8 @@ import {
 
 const EMPTY_ANALYTICS: AnalyticsResult = { timeseries: [], breakdowns: [] };
 
+export type CoverageMetricsResult = AnalyticsResult & { fetchFailed?: boolean };
+
 // Duration measures whose backend buckets are stored in seconds. Sample data is
 // already in minutes, so this normalisation is applied only in real (non-test) mode.
 const DURATION_MEASURES_SECONDS = new Set([
@@ -110,7 +112,7 @@ export async function fetchCoverageMetrics(
     batch: AnalyticsRequestInput,
     isTestMode: boolean = false,
     orgIdOverride?: string,
-): Promise<AnalyticsResult> {
+): Promise<CoverageMetricsResult> {
     if (isTestMode) {
         return SAMPLE_COVERAGE_DATA;
     }
@@ -127,12 +129,12 @@ export async function fetchCoverageMetrics(
                 { err: parsed.error },
                 "Coverage analytics failed schema validation; returning empty result",
             );
-            return EMPTY_ANALYTICS;
+            return { ...EMPTY_ANALYTICS, fetchFailed: true };
         }
         return parsed.data;
     } catch (error) {
         logger.error({ err: error }, "Failed to fetch coverage metrics");
-        return EMPTY_ANALYTICS;
+        return { ...EMPTY_ANALYTICS, fetchFailed: true };
     }
 }
 


### PR DESCRIPTION
## Summary
- Propagate coverage analytics GraphQL/schema failures as `fetchFailed` instead of genuine empty data.
- Render the coverage trend card with the existing `ChartFrame` error state when coverage analytics cannot load.
- Add fetcher and page tests covering fetch failures separately from true empty coverage.

## Validation
- `pnpm vitest run src/lib/testops/__tests__/fetchers.test.ts 'src/app/(app)/testops/coverage/page.test.tsx'`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm build`

## Test governance
- Colocated tests added: `src/app/(app)/testops/coverage/page.test.tsx`
- Existing fetcher tests updated: `src/lib/testops/__tests__/fetchers.test.ts`

## Screenshots
Forced coverage GraphQL/schema failure evidence (backend health OK; coverage analytics response malformed):

Before (`origin/main`, same forced failure; old swallowed empty state):
![chaos-2245-before-forced-coverage-failure.png](https://github.com/user-attachments/assets/6332c37e-a8b5-48fa-a4aa-858ee2cb7564)

After (this branch, same forced failure; new error state):
![chaos-2245-after-forced-coverage-failure.png](https://github.com/user-attachments/assets/4e928e16-d66a-4bf4-9d1f-0f1d83f4f3d1)

## Oracle packet
- Goal: CHAOS-2245 coverage page distinguishes unavailable analytics from genuinely empty coverage data.
- Constraints checked: frontend-only; no backend behavior change; no UX-time recompute; tests included; screenshots attached; branch pushed; stop before merge.
- Risk notes: uses existing optional result metadata and existing `ChartFrame` error path; empty-state copy remains available for true empty data.

Linear: CHAOS-2245
