### PR TITLE
fix(diagnose): normalize returned severity values

### DIFF
--- a/src/lib/areaSignals/__tests__/diagnose.test.ts
+++ b/src/lib/areaSignals/__tests__/diagnose.test.ts
@@ -220,6 +220,38 @@ describe("getDiagnoseSignals — source → AreaSignal mapping", () => {
                 value: "72%",
             });
         });
+
+        it("normalizes uppercase returned severities before rendering Diagnose cards", async () => {
+            mockGetHomeData.mockResolvedValue({
+                deltas: [
+                    { metric: "deploy_freq", value: 8, unit: "deploys" },
+                    { metric: "churn", value: 3200, unit: "loc" },
+                    { metric: "wip_saturation", value: 72, unit: "%" },
+                ],
+                signals: [
+                    { metric: "deploy_freq", severity: "HIGH" },
+                    { metric: "churn", severity: "MEDIUM" },
+                    { metric: "wip_saturation", severity: "LOW" },
+                ],
+            } as never);
+
+            const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+
+            expect(signals.flow).toMatchObject({ state: "high", value: "8" });
+            expect(signals.code).toMatchObject({ state: "medium", value: "3,200" });
+            expect(signals.bottleneck).toMatchObject({ state: "low", value: "72%" });
+        });
+
+        it("maps unknown returned severities to a defined neutral state", async () => {
+            mockGetHomeData.mockResolvedValue({
+                deltas: [{ metric: "deploy_freq", value: 8, unit: "deploys" }],
+                signals: [{ metric: "deploy_freq", severity: "UNKNOWN" }],
+            } as never);
+
+            const signals = byId(await getDiagnoseSignals(defaultMetricFilter));
+
+            expect(signals.flow).toMatchObject({ state: "neutral", value: "8" });
+        });
     });
 
     describe("DERIVE signals (Complexity)", () => {

--- a/src/lib/areaSignals/diagnose.ts
+++ b/src/lib/areaSignals/diagnose.ts
@@ -112,19 +112,11 @@ function buildSignal(
 /** The unavailable (honest-empty) resolution — no fabricated value. */
 const UNAVAILABLE = { state: "unavailable" as const, value: "" };
 
+const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
+
 function normalizeReturnedSeverity(severity: string | undefined): AreaSignalState {
-    switch (severity?.trim().toLowerCase()) {
-        case "critical":
-            return "critical";
-        case "high":
-            return "high";
-        case "medium":
-            return "medium";
-        case "low":
-            return "low";
-        default:
-            return "neutral";
-    }
+    const s = severity?.trim().toLowerCase() ?? "";
+    return VALID_SEVERITIES.has(s) ? (s as AreaSignalState) : "neutral";
 }
 
 /** Find a home `deltas[]` entry by its backend metric key. */

--- a/src/lib/areaSignals/diagnose.ts
+++ b/src/lib/areaSignals/diagnose.ts
@@ -112,6 +112,21 @@ function buildSignal(
 /** The unavailable (honest-empty) resolution — no fabricated value. */
 const UNAVAILABLE = { state: "unavailable" as const, value: "" };
 
+function normalizeReturnedSeverity(severity: string | undefined): AreaSignalState {
+    switch (severity?.trim().toLowerCase()) {
+        case "critical":
+            return "critical";
+        case "high":
+            return "high";
+        case "medium":
+            return "medium";
+        case "low":
+            return "low";
+        default:
+            return "neutral";
+    }
+}
+
 /** Find a home `deltas[]` entry by its backend metric key. */
 function homeDeltaValue(
     deltas: { metric: string; value: number; unit: string }[] | undefined,
@@ -127,7 +142,7 @@ function homeSignalByMetric(
     metric: string,
 ): { metric: string; severity: AreaSignalState } | undefined {
     const match = signals?.find((s) => s.metric === metric);
-    return match ? (match as { metric: string; severity: AreaSignalState }) : undefined;
+    return match ? { metric: match.metric, severity: normalizeReturnedSeverity(match.severity) } : undefined;
 }
 
 function meanCyclomaticPerKloc(result: ComplexityTimeseriesResult | undefined): number | undefined {

--- a/src/lib/areaSignals/diagnose.ts
+++ b/src/lib/areaSignals/diagnose.ts
@@ -142,7 +142,9 @@ function homeSignalByMetric(
     metric: string,
 ): { metric: string; severity: AreaSignalState } | undefined {
     const match = signals?.find((s) => s.metric === metric);
-    return match ? { metric: match.metric, severity: normalizeReturnedSeverity(match.severity) } : undefined;
+    return match
+        ? { metric: match.metric, severity: normalizeReturnedSeverity(match.severity) }
+        : undefined;
 }
 
 function meanCyclomaticPerKloc(result: ComplexityTimeseriesResult | undefined): number | undefined {


### PR DESCRIPTION
## Summary
- Normalize Diagnose home-signal severities at the resolver boundary before building area cards.
- Preserve canonical severities case-insensitively and fall back unknown/unrecognized values to the defined `neutral` state.
- Add regression coverage for uppercase and unknown returned severity values.

## Validation
- `pnpm vitest run src/lib/areaSignals/__tests__/diagnose.test.ts`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm build`

## Test governance
- Existing colocated resolver test updated: `src/lib/areaSignals/__tests__/diagnose.test.ts`

## Screenshots
Before:
![chaos-2247-diagnose-before.png](https://github.com/user-attachments/assets/b3bfa90f-38b2-4ada-b145-479069be9afa)

After:
![chaos-2247-diagnose-after.png](https://github.com/user-attachments/assets/da850656-b664-4b6e-8c6d-6b49bd76b84f)

## Oracle packet
- Goal: CHAOS-2247 Diagnose resolver no longer casts arbitrary backend severity strings directly into `AreaSignalState`.
- Constraints checked: resolver-boundary validation; uppercase severities normalize; unknown/unrecognized severities use defined `neutral`; no backend/schema changes; no UX-time recompute; tests and screenshots included; branch pushed; stop before merge.
- Risk notes: downstream AreaHub/AreaSignalCard now receive a known state, avoiding undefined severity tab classes and sort-rank drift.

Linear: CHAOS-2247