### PR TITLE
feat(backlog-risk): wire unestimated debt estimate coverage

### DIFF
--- a/src/app/(app)/plan/backlog-risk/_components.tsx
+++ b/src/app/(app)/plan/backlog-risk/_components.tsx
@@ -74,6 +74,10 @@ type StaleWipCardProps = {
     staleWip: ThroughputForecast["staleWip"];
 };
 
+type UnestimatedDebtCardProps = {
+    estimateCoverage: ThroughputForecast["estimateCoverage"];
+};
+
 function formatAgeHours(hours: number) {
     if (hours < 24) {
         const roundedHours = Math.round(hours);
@@ -118,6 +122,105 @@ export function StaleWipCard({ staleWip }: StaleWipCardProps) {
     );
 }
 
+function formatRatioAsPercent(ratio: number) {
+    return `${formatNumber(ratio * 100, { maximumFractionDigits: 0 })}%`;
+}
+
+export function UnestimatedDebtCard({ estimateCoverage }: UnestimatedDebtCardProps) {
+    if (!estimateCoverage) {
+        return (
+            <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
+                    Unestimated Debt
+                </h2>
+                <DataState
+                    variant="insufficient-confidence"
+                    className="mt-4"
+                    title="Estimate coverage unavailable"
+                    description="Sync open backlog estimate coverage to show how much work is planned without an estimate."
+                    data-testid="unestimated-debt-unavailable"
+                />
+            </div>
+        );
+    }
+
+    if (estimateCoverage.backlogSize === 0 && estimateCoverage.ratio == null) {
+        return (
+            <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
+                    Unestimated Debt
+                </h2>
+                <DataState
+                    variant="detector-enabled-no-findings"
+                    className="mt-4"
+                    title="No open backlog"
+                    description="Estimate coverage is connected, and there are no open backlog items in the selected scope."
+                    data-testid="unestimated-debt-empty-backlog"
+                />
+            </div>
+        );
+    }
+
+    if (estimateCoverage.ratio == null) {
+        return (
+            <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
+                    Unestimated Debt
+                </h2>
+                <DataState
+                    variant="insufficient-confidence"
+                    className="mt-4"
+                    title="Estimate coverage unavailable"
+                    description="The backlog exists, but estimate coverage was not computed for this scope."
+                    data-testid="unestimated-debt-ratio-unavailable"
+                />
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6"
+            data-testid="unestimated-debt-card"
+        >
+            <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
+                Unestimated Debt
+            </h2>
+            <div className="mt-4">
+                <p
+                    className="text-3xl font-semibold tabular-nums"
+                    data-testid="unestimated-debt-count"
+                >
+                    {formatNumber(estimateCoverage.unestimatedCount)} unestimated
+                </p>
+                <p className="mt-1 text-xs text-(--ink-muted)">
+                    {formatRatioAsPercent(estimateCoverage.ratio)} estimate coverage
+                </p>
+            </div>
+            <dl className="mt-5 grid gap-3 text-xs text-(--ink-muted) sm:grid-cols-3">
+                <div className="rounded-2xl border border-(--card-stroke)/60 bg-(--card-60) p-3">
+                    <dt className="uppercase tracking-[0.14em]">Estimated</dt>
+                    <dd className="mt-1 text-sm font-semibold text-foreground tabular-nums">
+                        {formatNumber(estimateCoverage.estimatedCount)}
+                    </dd>
+                </div>
+                <div className="rounded-2xl border border-(--card-stroke)/60 bg-(--card-60) p-3">
+                    <dt className="uppercase tracking-[0.14em]">Unestimated</dt>
+                    <dd className="mt-1 text-sm font-semibold text-foreground tabular-nums">
+                        {formatNumber(estimateCoverage.unestimatedCount)}
+                    </dd>
+                </div>
+                <div className="rounded-2xl border border-(--card-stroke)/60 bg-(--card-60) p-3">
+                    <dt className="uppercase tracking-[0.14em]">Open backlog</dt>
+                    <dd className="mt-1 text-sm font-semibold text-foreground tabular-nums">
+                        {formatNumber(estimateCoverage.backlogSize)}
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    );
+}
+
 // ── ForecastContent ───────────────────────────────────────────────────────────
 
 type ForecastContentProps = { forecast: ThroughputForecast };
@@ -133,17 +236,7 @@ export function ForecastContent({ forecast }: ForecastContentProps) {
             <section className="grid gap-4 md:grid-cols-2">
                 <StaleWipCard staleWip={forecast.staleWip} />
 
-                <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6">
-                    <h2 className="text-sm font-semibold uppercase tracking-[0.15em] text-(--ink-muted)">
-                        Unestimated Debt
-                    </h2>
-                    <DataState
-                        variant="detector-unavailable"
-                        className="mt-4"
-                        title="Estimate coverage not yet connected"
-                        description="The share of backlog items lacking estimates will appear here once estimate coverage data is connected."
-                    />
-                </div>
+                <UnestimatedDebtCard estimateCoverage={forecast.estimateCoverage} />
             </section>
         </>
     );
@@ -158,6 +251,19 @@ export function NoForecastState() {
                 variant="insufficient-confidence"
                 title="Not enough throughput history"
                 description="Widen the date range, select a different team, or sync more work-item history to populate WIP signals."
+            />
+        </section>
+    );
+}
+
+export function ForecastErrorState() {
+    return (
+        <section className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8">
+            <DataState
+                variant="error"
+                title="Backlog risk could not load"
+                message="The forecast request failed. Retry after the data service recovers; no placeholder backlog risk values are shown."
+                data-testid="backlog-risk-fetch-error"
             />
         </section>
     );

--- a/src/app/(app)/plan/backlog-risk/page.test.tsx
+++ b/src/app/(app)/plan/backlog-risk/page.test.tsx
@@ -1,14 +1,47 @@
 import { render, screen } from "@/test/utils";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Session } from "next-auth";
+
+const checkApiHealthMock = vi.fn();
+const requireSessionMock = vi.fn();
+const getThroughputForecastViaGraphQLMock = vi.fn();
+
+vi.mock("@/components/navigation/GlobalContextBar", () => ({
+    GlobalContextBar: () => <div data-testid="global-context-bar" />,
+}));
+
+vi.mock("@/components/navigation/PrimaryNav", () => ({
+    PrimaryNav: () => <nav data-testid="primary-nav" />,
+}));
+
+vi.mock("@/lib/api/system", () => ({
+    checkApiHealth: () => checkApiHealthMock(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+    requireSession: () => requireSessionMock(),
+}));
+
+vi.mock("@/lib/graphql/capacityFetchers", () => ({
+    getThroughputForecastViaGraphQL: (...args: unknown[]) =>
+        getThroughputForecastViaGraphQLMock(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+    logger: { warn: vi.fn() },
+}));
 
 import {
     ForecastContent,
+    ForecastErrorState,
     NoForecastState,
     StaleWipCard,
     StatusBadge,
+    UnestimatedDebtCard,
     WipCongestionCard,
 } from "./_components";
 import type { ThroughputForecast, ThroughputRiskOverlay } from "@/lib/graphql/types";
+import BacklogRiskPage from "./page";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -43,12 +76,38 @@ function makeForecast(overrides: Partial<ThroughputForecast> = {}): ThroughputFo
         primaryRisk: makeWipOverlay(),
         wipCongestion: makeWipOverlay(),
         staleWip: { p50AgeHours: 24, p90AgeHours: 96 },
+        estimateCoverage: {
+            ratio: 0.72,
+            estimatedCount: 72,
+            unestimatedCount: 28,
+            backlogSize: 100,
+        },
         reviewBottleneck: makeNeutralOverlay("review"),
         incidentLoad: makeNeutralOverlay("incident"),
         insufficientHistory: false,
         ...overrides,
     };
 }
+
+function makeSession(orgId = "org-1"): Session {
+    return {
+        access_token: "test-token",
+        user: { id: "user-1", org_id: orgId },
+        expires: "2026-07-01T00:00:00.000Z",
+    } satisfies Session;
+}
+
+async function renderPage(params: Record<string, string> = {}) {
+    const ui = await BacklogRiskPage({ searchParams: Promise.resolve(params) });
+    render(ui as React.ReactElement);
+}
+
+beforeEach(() => {
+    vi.resetAllMocks();
+    checkApiHealthMock.mockResolvedValue({ ok: true });
+    requireSessionMock.mockResolvedValue(makeSession());
+    getThroughputForecastViaGraphQLMock.mockResolvedValue(makeForecast());
+});
 
 // ── StatusBadge ───────────────────────────────────────────────────────────────
 
@@ -129,12 +188,65 @@ describe("StaleWipCard", () => {
     });
 });
 
+describe("UnestimatedDebtCard", () => {
+    it("renders populated estimate coverage from the frozen GraphQL response", () => {
+        render(
+            <UnestimatedDebtCard
+                estimateCoverage={{
+                    ratio: 0.72,
+                    estimatedCount: 72,
+                    unestimatedCount: 28,
+                    backlogSize: 100,
+                }}
+            />,
+        );
+
+        expect(screen.getByTestId("unestimated-debt-count")).toHaveTextContent("28 unestimated");
+        expect(screen.getByText("72% estimate coverage")).toBeInTheDocument();
+        expect(screen.getByText("Estimated")).toBeInTheDocument();
+        expect(screen.getByText("Unestimated")).toBeInTheDocument();
+        expect(screen.getByText("Open backlog")).toBeInTheDocument();
+    });
+
+    it("renders connected-but-zero backlog copy without showing 0%", () => {
+        render(
+            <UnestimatedDebtCard
+                estimateCoverage={{
+                    ratio: null,
+                    estimatedCount: 0,
+                    unestimatedCount: 0,
+                    backlogSize: 0,
+                }}
+            />,
+        );
+
+        expect(screen.getByText("No open backlog")).toBeInTheDocument();
+        expect(screen.getByText(/estimate coverage is connected/i)).toBeInTheDocument();
+        expect(screen.queryByText(/0%/)).not.toBeInTheDocument();
+    });
+
+    it("renders unavailable copy when estimate coverage is missing", () => {
+        render(<UnestimatedDebtCard estimateCoverage={null} />);
+
+        expect(screen.getByText("Estimate coverage unavailable")).toBeInTheDocument();
+        expect(screen.queryByText("Estimate coverage not yet connected")).not.toBeInTheDocument();
+    });
+});
+
 // ── NoForecastState ───────────────────────────────────────────────────────────
 
 describe("NoForecastState", () => {
     it("renders the insufficient-confidence empty state", () => {
         render(<NoForecastState />);
         expect(screen.getByText("Not enough throughput history")).toBeInTheDocument();
+    });
+});
+
+describe("ForecastErrorState", () => {
+    it("renders a visually distinct fetch-failure state", () => {
+        render(<ForecastErrorState />);
+        expect(screen.getByTestId("backlog-risk-fetch-error")).toBeInTheDocument();
+        expect(screen.getByText("Backlog risk could not load")).toBeInTheDocument();
     });
 });
 
@@ -153,10 +265,11 @@ describe("ForecastContent", () => {
         expect(screen.getByText("Elevated")).toBeInTheDocument();
     });
 
-    it("renders live Stale WIP and leaves Unestimated Debt unavailable", () => {
+    it("renders live Stale WIP and live Unestimated Debt", () => {
         render(<ForecastContent forecast={makeForecast()} />);
         expect(screen.getByText("4 days")).toBeInTheDocument();
-        expect(screen.getByText("Estimate coverage not yet connected")).toBeInTheDocument();
+        expect(screen.getByText("28 unestimated")).toBeInTheDocument();
+        expect(screen.getByText("72% estimate coverage")).toBeInTheDocument();
     });
 
     it("does not leak internal metric field names in empty-state copy", () => {
@@ -164,5 +277,59 @@ describe("ForecastContent", () => {
         // DataState detail copy must never expose implementation vocabulary
         expect(screen.queryByText(/wip_age_p90_hours/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/rollup/i)).not.toBeInTheDocument();
+    });
+});
+
+describe("BacklogRiskPage GraphQL states", () => {
+    it("renders populated estimate coverage from a mocked GraphQL forecast", async () => {
+        getThroughputForecastViaGraphQLMock.mockResolvedValue(
+            makeForecast({
+                estimateCoverage: {
+                    ratio: 0.6,
+                    estimatedCount: 30,
+                    unestimatedCount: 20,
+                    backlogSize: 50,
+                },
+            }),
+        );
+
+        await renderPage();
+
+        expect(getThroughputForecastViaGraphQLMock).toHaveBeenCalledWith("org-1", {
+            teamIds: null,
+            workScopeId: null,
+            historyWeeks: 12,
+        });
+        expect(screen.getByText("20 unestimated")).toBeInTheDocument();
+        expect(screen.getByText("60% estimate coverage")).toBeInTheDocument();
+    });
+
+    it("renders connected-but-zero backlog from a mocked GraphQL forecast without 0%", async () => {
+        getThroughputForecastViaGraphQLMock.mockResolvedValue(
+            makeForecast({
+                backlogSize: 0,
+                estimateCoverage: {
+                    ratio: null,
+                    estimatedCount: 0,
+                    unestimatedCount: 0,
+                    backlogSize: 0,
+                },
+            }),
+        );
+
+        await renderPage();
+
+        expect(screen.getByText("No open backlog")).toBeInTheDocument();
+        expect(screen.queryByText(/0%/)).not.toBeInTheDocument();
+    });
+
+    it("renders error copy when the mocked GraphQL forecast rejects", async () => {
+        getThroughputForecastViaGraphQLMock.mockRejectedValue(new Error("GraphQL failed"));
+
+        await renderPage();
+
+        expect(screen.getByTestId("backlog-risk-fetch-error")).toBeInTheDocument();
+        expect(screen.getByText("Backlog risk could not load")).toBeInTheDocument();
+        expect(screen.queryByText("Not enough throughput history")).not.toBeInTheDocument();
     });
 });

--- a/src/app/(app)/plan/backlog-risk/page.tsx
+++ b/src/app/(app)/plan/backlog-risk/page.tsx
@@ -4,12 +4,13 @@ import { ServiceUnavailable } from "@/components/ServiceUnavailable";
 import { BackLink } from "@/components/shared/BackLink";
 import { checkApiHealth } from "@/lib/api/system";
 import { requireSession } from "@/lib/auth";
-import { fetchOrNull } from "@/lib/fetchOrNull";
 import { decodeFilter, filterFromQueryParams } from "@/lib/filters/encode";
 import { withFilterParam } from "@/lib/filters/url";
 import { getThroughputForecastViaGraphQL } from "@/lib/graphql/capacityFetchers";
+import type { ThroughputForecast } from "@/lib/graphql/types";
+import { logger } from "@/lib/logger";
 
-import { ForecastContent, NoForecastState } from "./_components";
+import { ForecastContent, ForecastErrorState, NoForecastState } from "./_components";
 
 type BacklogRiskPageProps = {
     searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -34,14 +35,21 @@ export default async function BacklogRiskPage({ searchParams }: BacklogRiskPageP
     if (!health.ok) return <ServiceUnavailable />;
 
     const orgId = session.user.org_id ?? "default-org";
-    const forecast = await fetchOrNull(
-        getThroughputForecastViaGraphQL(orgId, {
+    let forecast: ThroughputForecast | null = null;
+    let forecastFetchFailed = false;
+    try {
+        forecast = await getThroughputForecastViaGraphQL(orgId, {
             teamIds,
             workScopeId: workScopeId ?? null,
             historyWeeks: 12,
-        }),
-        "plan/backlog-risk/throughput-forecast",
-    );
+        });
+    } catch (err: unknown) {
+        forecastFetchFailed = true;
+        logger.warn(
+            { err, label: "plan/backlog-risk/throughput-forecast" },
+            "Backlog risk forecast fetch failed",
+        );
+    }
 
     return (
         <div className="min-h-screen bg-background text-foreground">
@@ -64,7 +72,13 @@ export default async function BacklogRiskPage({ searchParams }: BacklogRiskPageP
 
                     <GlobalContextBar filters={filters} origin={originParam} />
 
-                    {forecast ? <ForecastContent forecast={forecast} /> : <NoForecastState />}
+                    {forecastFetchFailed ? (
+                        <ForecastErrorState />
+                    ) : forecast ? (
+                        <ForecastContent forecast={forecast} />
+                    ) : (
+                        <NoForecastState />
+                    )}
                 </main>
             </div>
         </div>

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -1197,6 +1197,64 @@ export type ProductTelemetryTopOrgType = {
   sessions: Scalars['Int']['output'];
 };
 
+export type PullRequestCommit = {
+  __typename?: 'PullRequestCommit';
+  authorEmail?: Maybe<Scalars['String']['output']>;
+  authorName?: Maybe<Scalars['String']['output']>;
+  authorWhen?: Maybe<Scalars['DateTime']['output']>;
+  confidence?: Maybe<Scalars['Float']['output']>;
+  evidence?: Maybe<Scalars['String']['output']>;
+  hash: Scalars['String']['output'];
+  message?: Maybe<Scalars['String']['output']>;
+  provenance?: Maybe<Scalars['String']['output']>;
+};
+
+export type PullRequestDetail = {
+  __typename?: 'PullRequestDetail';
+  additions?: Maybe<Scalars['Int']['output']>;
+  authorEmail?: Maybe<Scalars['String']['output']>;
+  authorName?: Maybe<Scalars['String']['output']>;
+  baseBranch?: Maybe<Scalars['String']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  changedFiles?: Maybe<Scalars['Int']['output']>;
+  changesRequestedCount: Scalars['Int']['output'];
+  closedAt?: Maybe<Scalars['DateTime']['output']>;
+  commentsCount: Scalars['Int']['output'];
+  commits: Array<PullRequestCommit>;
+  createdAt: Scalars['DateTime']['output'];
+  deletions?: Maybe<Scalars['Int']['output']>;
+  firstCommentAt?: Maybe<Scalars['DateTime']['output']>;
+  firstReviewAt?: Maybe<Scalars['DateTime']['output']>;
+  headBranch?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  linkedIssues: Array<PullRequestIssueLink>;
+  mergedAt?: Maybe<Scalars['DateTime']['output']>;
+  number: Scalars['Int']['output'];
+  orgId: Scalars['String']['output'];
+  repoId: Scalars['ID']['output'];
+  repoName?: Maybe<Scalars['String']['output']>;
+  reviews: Array<PullRequestReview>;
+  reviewsCount: Scalars['Int']['output'];
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type PullRequestIssueLink = {
+  __typename?: 'PullRequestIssueLink';
+  confidence: Scalars['Float']['output'];
+  evidence: Scalars['String']['output'];
+  provenance: Scalars['String']['output'];
+  workItemId: Scalars['String']['output'];
+};
+
+export type PullRequestReview = {
+  __typename?: 'PullRequestReview';
+  reviewId: Scalars['String']['output'];
+  reviewer: Scalars['String']['output'];
+  state: Scalars['String']['output'];
+  submittedAt: Scalars['DateTime']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   /** List AI-attributed pull requests in the requested window so the UI can offer a concrete drilldown selector. Rows come from ai_attribution_resolved joined to git_pull_requests; no aggregation, no fabrication. */
@@ -1247,6 +1305,8 @@ export type Query = {
   improveOpportunities: ImproveOpportunitiesResult;
   /** Weekly Engineering Operating Review */
   operatingReview: OperatingReview;
+  /** Pull request detail by stable id ({repo_id}#pr{number}) from persisted ClickHouse PR, review, commit, and Work Graph tables. */
+  pr?: Maybe<PullRequestDetail>;
   /** Get first-party product telemetry dashboard metrics */
   productTelemetryDashboard: ProductTelemetryDashboardType;
   /** Cross-org product telemetry dashboard for platform/super admins. Requires is_superuser. Returns global aggregates plus a top-orgs rollup with org names resolved from Postgres. */
@@ -1436,6 +1496,12 @@ export type QueryImproveOpportunitiesArgs = {
 
 export type QueryOperatingReviewArgs = {
   input: OperatingReviewInput;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryPrArgs = {
+  id: Scalars['ID']['input'];
   orgId: Scalars['String']['input'];
 };
 

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -1864,6 +1864,7 @@ export type ThroughputForecast = {
   __typename?: 'ThroughputForecast';
   backlogSize: Scalars['Int']['output'];
   computedAt: Scalars['String']['output'];
+  estimateCoverage?: Maybe<ThroughputEstimateCoverage>;
   forecastId: Scalars['String']['output'];
   historyWeeks: Scalars['Int']['output'];
   incidentLoad: ThroughputRiskOverlay;
@@ -1878,6 +1879,14 @@ export type ThroughputForecast = {
   teamId?: Maybe<Scalars['String']['output']>;
   wipCongestion: ThroughputRiskOverlay;
   workScopeId?: Maybe<Scalars['String']['output']>;
+};
+
+export type ThroughputEstimateCoverage = {
+  __typename?: 'ThroughputEstimateCoverage';
+  backlogSize: Scalars['Int']['output'];
+  estimatedCount: Scalars['Int']['output'];
+  ratio?: Maybe<Scalars['Float']['output']>;
+  unestimatedCount: Scalars['Int']['output'];
 };
 
 export type ThroughputForecastInput = {

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -1860,6 +1860,14 @@ export type TeamAttributionSource =
   | 'REPO_OWNERSHIP'
   | 'UNASSIGNED';
 
+export type ThroughputEstimateCoverage = {
+  __typename?: 'ThroughputEstimateCoverage';
+  backlogSize: Scalars['Int']['output'];
+  estimatedCount: Scalars['Int']['output'];
+  ratio?: Maybe<Scalars['Float']['output']>;
+  unestimatedCount: Scalars['Int']['output'];
+};
+
 export type ThroughputForecast = {
   __typename?: 'ThroughputForecast';
   backlogSize: Scalars['Int']['output'];
@@ -1879,14 +1887,6 @@ export type ThroughputForecast = {
   teamId?: Maybe<Scalars['String']['output']>;
   wipCongestion: ThroughputRiskOverlay;
   workScopeId?: Maybe<Scalars['String']['output']>;
-};
-
-export type ThroughputEstimateCoverage = {
-  __typename?: 'ThroughputEstimateCoverage';
-  backlogSize: Scalars['Int']['output'];
-  estimatedCount: Scalars['Int']['output'];
-  ratio?: Maybe<Scalars['Float']['output']>;
-  unestimatedCount: Scalars['Int']['output'];
 };
 
 export type ThroughputForecastInput = {

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -269,6 +269,12 @@ query ThroughputForecast($orgId: String!, $input: ThroughputForecastInput!) {
       p50AgeHours
       p90AgeHours
     }
+    estimateCoverage {
+      ratio
+      estimatedCount
+      unestimatedCount
+      backlogSize
+    }
     reviewBottleneck {
       kind
       score

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1074,6 +1074,60 @@ type ProductTelemetryTopOrgType {
   orgSlug: String
 }
 
+type PullRequestCommit {
+  hash: String!
+  message: String
+  authorName: String
+  authorEmail: String
+  authorWhen: DateTime
+  confidence: Float
+  provenance: String
+  evidence: String
+}
+
+type PullRequestDetail {
+  id: ID!
+  orgId: String!
+  repoId: ID!
+  repoName: String
+  number: Int!
+  title: String
+  body: String
+  state: String
+  authorName: String
+  authorEmail: String
+  createdAt: DateTime!
+  mergedAt: DateTime
+  closedAt: DateTime
+  headBranch: String
+  baseBranch: String
+  additions: Int
+  deletions: Int
+  changedFiles: Int
+  firstReviewAt: DateTime
+  firstCommentAt: DateTime
+  changesRequestedCount: Int!
+  reviewsCount: Int!
+  commentsCount: Int!
+  reviews: [PullRequestReview!]!
+  commits: [PullRequestCommit!]!
+  linkedIssues: [PullRequestIssueLink!]!
+}
+
+type PullRequestIssueLink {
+  workItemId: String!
+  confidence: Float!
+  provenance: String!
+  evidence: String!
+}
+
+type PullRequestReview {
+  reviewId: String!
+  reviewer: String!
+  state: String!
+  submittedAt: DateTime!
+}
+
 type Query {
   """Get catalog of available dimensions, measures, and limits"""
   catalog(orgId: String!, dimension: DimensionInput = null, filters: FilterInput = null): CatalogResult!
@@ -1094,6 +1148,11 @@ type Query {
 
   """Query work graph edges with optional filters"""
   workGraphEdges(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphEdgesResult!
+
+  """
+  Pull request detail by stable id ({repo_id}#pr{number}) from persisted ClickHouse PR, review, commit, and Work Graph tables.
+  """
+  pr(orgId: String!, id: ID!): PullRequestDetail
 
   """Per-node-type inflow/outflow over the full work graph"""
   workGraphFlow(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphFlowResult!
@@ -1516,6 +1575,13 @@ enum TeamAttributionSource {
   UNASSIGNED
 }
 
+type ThroughputEstimateCoverage {
+  ratio: Float
+  estimatedCount: Int!
+  unestimatedCount: Int!
+  backlogSize: Int!
+}
+
 type ThroughputForecast {
   forecastId: String!
   computedAt: String!
@@ -1562,13 +1628,6 @@ type ThroughputRollingWindow {
 type ThroughputStaleWip {
   p50AgeHours: Float
   p90AgeHours: Float
-}
-
-type ThroughputEstimateCoverage {
-  ratio: Float
-  estimatedCount: Int!
-  unestimatedCount: Int!
-  backlogSize: Int!
 }
 
 enum TimeGranularity {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -1530,6 +1530,7 @@ type ThroughputForecast {
   primaryRisk: ThroughputRiskOverlay!
   wipCongestion: ThroughputRiskOverlay!
   staleWip: ThroughputStaleWip
+  estimateCoverage: ThroughputEstimateCoverage
   reviewBottleneck: ThroughputRiskOverlay!
   incidentLoad: ThroughputRiskOverlay!
   insufficientHistory: Boolean!
@@ -1561,6 +1562,13 @@ type ThroughputRollingWindow {
 type ThroughputStaleWip {
   p50AgeHours: Float
   p90AgeHours: Float
+}
+
+type ThroughputEstimateCoverage {
+  ratio: Float
+  estimatedCount: Int!
+  unestimatedCount: Int!
+  backlogSize: Int!
 }
 
 enum TimeGranularity {

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -375,6 +375,13 @@ export interface ThroughputStaleWip {
     p90AgeHours?: number | null;
 }
 
+export interface ThroughputEstimateCoverage {
+    ratio?: number | null;
+    estimatedCount: number;
+    unestimatedCount: number;
+    backlogSize: number;
+}
+
 export interface ThroughputForecast {
     forecastId: string;
     computedAt: string;
@@ -389,6 +396,7 @@ export interface ThroughputForecast {
     primaryRisk: ThroughputRiskOverlay;
     wipCongestion: ThroughputRiskOverlay;
     staleWip?: ThroughputStaleWip | null;
+    estimateCoverage?: ThroughputEstimateCoverage | null;
     reviewBottleneck: ThroughputRiskOverlay;
     incidentLoad: ThroughputRiskOverlay;
     insufficientHistory: boolean;


### PR DESCRIPTION
## Summary
- Mirrors the frozen `ThroughputForecast.estimateCoverage { ratio, estimatedCount, unestimatedCount, backlogSize }` contract into the web schema/types and forecast query.
- Replaces the Unestimated Debt placeholder with persisted estimate coverage values.
- Adds distinct states for populated data, connected-but-zero backlog (`backlogSize=0`, `ratio=null`, no `0%`), and forecast fetch failure.
- Expands colocated Backlog Risk tests with mocked GraphQL forecasts for populated, zero-backlog, and error states.

Linear: CHAOS-2730

## Verification
- `pnpm vitest run "src/app/(app)/plan/backlog-risk/page.test.tsx"`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warning in `src/lib/navigation/__tests__/ia-preservation-invariants.test.ts`)
- `pnpm format:check:changed`
- `pnpm build`

## Screenshots
Before placeholder:

![chaos-2730-backlog-risk-before.png](https://github.com/user-attachments/assets/0a221244-efd7-46ee-a6fc-9ddec0e841d1)

After estimateCoverage wiring:

![chaos-2730-backlog-risk-after.png](https://github.com/user-attachments/assets/be4b152d-d319-409e-b334-eb1e8e767a7c)
