### PR TITLE
feat(prs): wire live PR detail page (CHAOS-2387)

### DIFF
--- a/src/app/(app)/prs/[pr_id]/page.test.tsx
+++ b/src/app/(app)/prs/[pr_id]/page.test.tsx
@@ -1,0 +1,214 @@
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const checkApiHealthMock = vi.fn();
+const getFlameMock = vi.fn();
+const requireSessionMock = vi.fn();
+const getPrDetailViaGraphQLMock = vi.fn();
+const getAIWorkflowDrilldownViaGraphQLMock = vi.fn();
+const getWorkUnitInvestmentDistributionMock = vi.fn();
+
+vi.mock("@/components/navigation/PrimaryNav", () => ({
+    PrimaryNav: () => <nav data-testid="primary-nav" />,
+}));
+
+vi.mock("@/components/charts/FlameDiagram", () => ({
+    FlameDiagram: () => <div data-testid="flame-diagram" />,
+}));
+
+vi.mock("@/components/ClientTimestamp", () => ({
+    ClientTimestamp: ({ value, suffix = "" }: { value: string; suffix?: string }) => (
+        <span>{`${value}${suffix}`}</span>
+    ),
+}));
+
+vi.mock("@/lib/api/system", () => ({
+    checkApiHealth: () => checkApiHealthMock(),
+}));
+
+vi.mock("@/lib/api/visuals", () => ({
+    getFlame: (...args: unknown[]) => getFlameMock(...args),
+}));
+
+vi.mock("@/lib/auth", () => ({
+    requireSession: () => requireSessionMock(),
+}));
+
+vi.mock("@/lib/graphql/workGraphFetchers", () => ({
+    getPrDetailViaGraphQL: (...args: unknown[]) => getPrDetailViaGraphQLMock(...args),
+    getAIWorkflowDrilldownViaGraphQL: (...args: unknown[]) =>
+        getAIWorkflowDrilldownViaGraphQLMock(...args),
+    getWorkUnitInvestmentDistribution: (...args: unknown[]) =>
+        getWorkUnitInvestmentDistributionMock(...args),
+}));
+
+import PrDetailPage from "./page";
+
+const prId = "11111111-1111-1111-1111-111111111111#pr42";
+
+const samplePr = {
+    id: prId,
+    orgId: "org-1",
+    repoId: "11111111-1111-1111-1111-111111111111",
+    repoName: "full-chaos/dev-health-web",
+    number: 42,
+    title: "Wire PR detail",
+    body: "body",
+    state: "merged",
+    authorName: "Ada",
+    authorEmail: "ada@example.com",
+    createdAt: "2026-06-01T12:00:00Z",
+    mergedAt: "2026-06-01T13:00:00Z",
+    closedAt: null,
+    headBranch: "feature/pr-detail",
+    baseBranch: "main",
+    additions: 12,
+    deletions: 3,
+    changedFiles: 4,
+    firstReviewAt: "2026-06-01T12:30:00Z",
+    firstCommentAt: "2026-06-01T12:10:00Z",
+    changesRequestedCount: 1,
+    reviewsCount: 2,
+    commentsCount: 5,
+    reviews: [
+        {
+            reviewId: "r1",
+            reviewer: "reviewer@example.com",
+            state: "APPROVED",
+            submittedAt: "2026-06-01T12:35:00Z",
+        },
+    ],
+    commits: [
+        {
+            hash: "abcdef1234567890",
+            message: "commit message",
+            authorName: "Ada",
+            authorEmail: "ada@example.com",
+            authorWhen: "2026-06-01T12:05:00Z",
+            confidence: 0.99,
+            provenance: "native",
+            evidence: "api_pr_commits",
+        },
+    ],
+    linkedIssues: [],
+};
+
+const emptyDrilldown = {
+    orgId: "org-1",
+    rootType: "PR",
+    rootId: prId,
+    nodes: [],
+    edges: [],
+    partial: false,
+    dataAvailable: false,
+};
+
+const demoInvestment = {
+    workUnitId: prId,
+    themeDistribution: { feature_delivery: 1 },
+    subcategoryDistribution: { "feature_delivery.roadmap": 1 },
+    evidenceQuotes: [{ quote: "demo quote", sourceType: "pr", sourceId: prId }],
+};
+
+async function renderPage(id = prId) {
+    const ui = await PrDetailPage({ params: Promise.resolve({ pr_id: id }) });
+    render(ui as React.ReactElement);
+}
+
+describe("PrDetailPage", () => {
+    beforeEach(() => {
+        vi.unstubAllEnvs();
+        checkApiHealthMock.mockReset();
+        getFlameMock.mockReset();
+        requireSessionMock.mockReset();
+        getPrDetailViaGraphQLMock.mockReset();
+        getAIWorkflowDrilldownViaGraphQLMock.mockReset();
+        getWorkUnitInvestmentDistributionMock.mockReset();
+        checkApiHealthMock.mockResolvedValue({ ok: true });
+        requireSessionMock.mockResolvedValue({ user: { org_id: "org-1" } });
+        getFlameMock.mockResolvedValue(null);
+        getPrDetailViaGraphQLMock.mockResolvedValue(samplePr);
+        getAIWorkflowDrilldownViaGraphQLMock.mockResolvedValue(emptyDrilldown);
+        getWorkUnitInvestmentDistributionMock.mockReturnValue(demoInvestment);
+    });
+
+    it("renders populated PR detail from live GraphQL data", async () => {
+        await renderPage();
+
+        expect(screen.getByRole("heading", { name: "PR detail" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "Wire PR detail" })).toBeInTheDocument();
+        expect(screen.getByText("full-chaos/dev-health-web · #42")).toBeInTheDocument();
+        expect(screen.getByText("reviewer@example.com")).toBeInTheDocument();
+        expect(screen.getByText(/abcdef12/)).toBeInTheDocument();
+        expect(getPrDetailViaGraphQLMock).toHaveBeenCalledWith({ orgId: "org-1", id: prId });
+        expect(getAIWorkflowDrilldownViaGraphQLMock).toHaveBeenCalledWith({
+            orgId: "org-1",
+            rootType: "PR",
+            rootId: prId,
+            useDemoFallback: false,
+        });
+        expect(getWorkUnitInvestmentDistributionMock).not.toHaveBeenCalled();
+    });
+
+    it("renders honest empty state without requesting live related entities for a missing PR", async () => {
+        getPrDetailViaGraphQLMock.mockResolvedValue(null);
+
+        await renderPage("bad-id");
+
+        expect(screen.getByText(/No PR detail found for this id/i)).toBeInTheDocument();
+        expect(screen.getByText("No data for related entities.")).toBeInTheDocument();
+        expect(getAIWorkflowDrilldownViaGraphQLMock).not.toHaveBeenCalled();
+    });
+
+    it("renders backend error state when the PR detail GraphQL query fails", async () => {
+        getPrDetailViaGraphQLMock.mockRejectedValue(new Error("boom"));
+
+        await renderPage();
+
+        expect(
+            screen.getByText(/PR detail could not be loaded from the backend/i),
+        ).toBeInTheDocument();
+        expect(getAIWorkflowDrilldownViaGraphQLMock).not.toHaveBeenCalled();
+    });
+
+    it("keeps demo fallback behind explicit test mode", async () => {
+        vi.stubEnv("DEV_HEALTH_TEST_MODE", "true");
+        getPrDetailViaGraphQLMock.mockResolvedValue(null);
+        getAIWorkflowDrilldownViaGraphQLMock.mockResolvedValue({
+            ...emptyDrilldown,
+            dataAvailable: true,
+            edges: [
+                {
+                    edgeId: "edge-1",
+                    sourceType: "PR",
+                    sourceId: prId,
+                    targetType: "COMMIT",
+                    targetId: "abcdef1234567890",
+                    edgeType: "CONTAINS",
+                    confidence: 0.99,
+                    source: "native",
+                    evidence: "api_pr_commits",
+                    provider: "github",
+                    repoId: samplePr.repoId,
+                },
+            ],
+        });
+
+        await renderPage();
+
+        expect(getAIWorkflowDrilldownViaGraphQLMock).toHaveBeenCalledWith({
+            orgId: "org-1",
+            rootType: "PR",
+            rootId: prId,
+            useDemoFallback: true,
+        });
+        expect(getWorkUnitInvestmentDistributionMock).toHaveBeenCalledWith({
+            rootType: "PR",
+            rootId: prId,
+        });
+        const evidence = screen.getByRole("heading", { name: "Commits" }).closest("div");
+        expect(evidence).not.toBeNull();
+        if (evidence === null) throw new Error("Expected commits evidence panel");
+        expect(within(evidence).getByText("abcdef1234567890")).toBeInTheDocument();
+    });
+});

--- a/src/app/(app)/prs/[pr_id]/page.test.tsx
+++ b/src/app/(app)/prs/[pr_id]/page.test.tsx
@@ -211,4 +211,16 @@ describe("PrDetailPage", () => {
         if (evidence === null) throw new Error("Expected commits evidence panel");
         expect(within(evidence).getByText("abcdef1234567890")).toBeInTheDocument();
     });
+
+    it("renders a distinct error state when the related-entities fetch fails, not 'No data'", async () => {
+        getAIWorkflowDrilldownViaGraphQLMock.mockRejectedValue(
+            new Error("Work Graph drilldown unavailable"),
+        );
+
+        await renderPage();
+
+        expect(screen.getByTestId("related-entities-error")).toBeInTheDocument();
+        expect(screen.getByText(/Related work unavailable/i)).toBeInTheDocument();
+        expect(screen.queryByText("No data for related entities.")).not.toBeInTheDocument();
+    });
 });

--- a/src/app/(app)/prs/[pr_id]/page.test.tsx
+++ b/src/app/(app)/prs/[pr_id]/page.test.tsx
@@ -223,4 +223,21 @@ describe("PrDetailPage", () => {
         expect(screen.getByText(/Related work unavailable/i)).toBeInTheDocument();
         expect(screen.queryByText("No data for related entities.")).not.toBeInTheDocument();
     });
+
+    it("resolves and renders the repo_id:number colon-format PR id route", async () => {
+        const colonId = "11111111-1111-1111-1111-111111111111:42";
+        getPrDetailViaGraphQLMock.mockResolvedValue({ ...samplePr, id: colonId });
+
+        await renderPage(colonId);
+
+        expect(screen.getByRole("heading", { name: "PR detail" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "Wire PR detail" })).toBeInTheDocument();
+        expect(getPrDetailViaGraphQLMock).toHaveBeenCalledWith({ orgId: "org-1", id: colonId });
+        expect(getAIWorkflowDrilldownViaGraphQLMock).toHaveBeenCalledWith({
+            orgId: "org-1",
+            rootType: "PR",
+            rootId: colonId,
+            useDemoFallback: false,
+        });
+    });
 });

--- a/src/app/(app)/prs/[pr_id]/page.tsx
+++ b/src/app/(app)/prs/[pr_id]/page.tsx
@@ -185,7 +185,7 @@ export default async function PrDetailPage({ params }: PrDetailPageProps) {
         );
     }
     const shouldLoadRelatedEntities = prResult.pr !== null || demoMode;
-    const [flame, drilldown] = await Promise.all([
+    const [flame, relatedEntitiesResult] = await Promise.all([
         fetchOrNull(getFlame({ entity_type: "pr", entity_id: prId }), "pr-flame"),
         shouldLoadRelatedEntities
             ? getAIWorkflowDrilldownViaGraphQL({
@@ -193,9 +193,18 @@ export default async function PrDetailPage({ params }: PrDetailPageProps) {
                   rootType: "PR",
                   rootId: prId,
                   useDemoFallback: demoMode,
-              }).catch(() => emptyDrilldown(orgId, prId))
-            : Promise.resolve(emptyDrilldown(orgId, prId)),
+              })
+                  .then((drilldown) => ({ drilldown, relatedEntitiesError: false }))
+                  .catch(() => ({
+                      drilldown: emptyDrilldown(orgId, prId),
+                      relatedEntitiesError: true,
+                  }))
+            : Promise.resolve({
+                  drilldown: emptyDrilldown(orgId, prId),
+                  relatedEntitiesError: false,
+              }),
     ]);
+    const { drilldown, relatedEntitiesError } = relatedEntitiesResult;
     const investment = demoMode
         ? getWorkUnitInvestmentDistribution({ rootType: "PR", rootId: prId })
         : emptyInvestment(prId);
@@ -254,6 +263,7 @@ export default async function PrDetailPage({ params }: PrDetailPageProps) {
                         rootId={prId}
                         drilldown={drilldown}
                         investment={investment}
+                        relatedEntitiesError={relatedEntitiesError}
                     />
                 </main>
             </div>

--- a/src/app/(app)/prs/[pr_id]/page.tsx
+++ b/src/app/(app)/prs/[pr_id]/page.tsx
@@ -10,14 +10,150 @@ import { ClientTimestamp } from "@/components/ClientTimestamp";
 import { fetchOrNull } from "@/lib/fetchOrNull";
 import { RelatedEntitiesPanel } from "@/components/work/RelatedEntitiesPanel";
 import { requireSession } from "@/lib/auth";
+import { formatNumber } from "@/lib/formatters";
+import { getServerEnv } from "@/lib/config";
 import {
     getAIWorkflowDrilldownViaGraphQL,
+    getPrDetailViaGraphQL,
     getWorkUnitInvestmentDistribution,
 } from "@/lib/graphql/workGraphFetchers";
+import type {
+    AIWorkflowDrilldownResult,
+    PullRequestDetail,
+    WorkUnitInvestmentDistribution,
+} from "@/lib/graphql/types";
 
 type PrDetailPageProps = {
     params: Promise<{ pr_id: string }>;
 };
+
+function isExplicitDemoMode(): boolean {
+    const env = getServerEnv();
+    return (
+        env.DEV_HEALTH_TEST_MODE === "true" ||
+        env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true" ||
+        env.NEXT_PUBLIC_DEMO_MODE === "true"
+    );
+}
+
+function emptyInvestment(rootId: string): WorkUnitInvestmentDistribution {
+    return {
+        workUnitId: rootId,
+        themeDistribution: {},
+        subcategoryDistribution: {},
+        evidenceQuotes: [],
+        uncertainty: "No persisted investment distribution returned for this PR.",
+    };
+}
+
+function emptyDrilldown(orgId: string, rootId: string): AIWorkflowDrilldownResult {
+    return {
+        orgId,
+        rootType: "PR",
+        rootId,
+        nodes: [],
+        edges: [],
+        partial: false,
+        dataAvailable: false,
+    };
+}
+
+function metricValue(value: number | null | undefined): string {
+    return typeof value === "number" ? formatNumber(value) : "No data";
+}
+
+function PrDetailSummary({ pr }: { pr: PullRequestDetail }) {
+    return (
+        <section className="rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                    <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                        {pr.repoName ?? pr.repoId} · #{pr.number}
+                    </p>
+                    <h2 className="mt-2 font-(--font-display) text-2xl">
+                        {pr.title ?? "Untitled pull request"}
+                    </h2>
+                    <p className="mt-2 text-sm text-(--ink-muted)">
+                        {pr.authorName ?? pr.authorEmail ?? "Unknown author"} opened{" "}
+                        <ClientTimestamp value={pr.createdAt} />
+                    </p>
+                </div>
+                <span className="rounded-full border border-(--card-stroke) px-3 py-1 text-xs uppercase tracking-[0.18em] text-(--ink-muted)">
+                    {pr.state ?? "No state"}
+                </span>
+            </div>
+            <dl className="mt-6 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+                <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <dt className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
+                        Changed files
+                    </dt>
+                    <dd className="mt-2 font-medium">{metricValue(pr.changedFiles)}</dd>
+                </div>
+                <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <dt className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
+                        Additions
+                    </dt>
+                    <dd className="mt-2 font-medium">{metricValue(pr.additions)}</dd>
+                </div>
+                <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <dt className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
+                        Deletions
+                    </dt>
+                    <dd className="mt-2 font-medium">{metricValue(pr.deletions)}</dd>
+                </div>
+                <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <dt className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
+                        Reviews
+                    </dt>
+                    <dd className="mt-2 font-medium">{formatNumber(pr.reviewsCount)}</dd>
+                </div>
+            </dl>
+            <div className="mt-6 grid gap-4 lg:grid-cols-2">
+                <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-(--ink-muted)">
+                        Reviews
+                    </h3>
+                    {pr.reviews.length === 0 ? (
+                        <p className="mt-3 text-sm text-(--ink-muted)">
+                            No persisted reviews for this PR.
+                        </p>
+                    ) : (
+                        <ul className="mt-3 space-y-2 text-sm text-(--ink-muted)">
+                            {pr.reviews.map((review) => (
+                                <li key={review.reviewId}>
+                                    <span className="text-foreground">{review.reviewer}</span> ·{" "}
+                                    {review.state} · <ClientTimestamp value={review.submittedAt} />
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+                <div className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4">
+                    <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-(--ink-muted)">
+                        Commits
+                    </h3>
+                    {pr.commits.length === 0 ? (
+                        <p className="mt-3 text-sm text-(--ink-muted)">
+                            No persisted commit links for this PR.
+                        </p>
+                    ) : (
+                        <ul className="mt-3 space-y-2 text-sm text-(--ink-muted)">
+                            {pr.commits.map((commit) => (
+                                <li key={commit.hash}>
+                                    <span className="text-foreground">
+                                        {commit.hash.slice(0, 8)}
+                                    </span>{" "}
+                                    · {commit.message ?? "No message"}
+                                    {commit.provenance ? ` · ${commit.provenance}` : ""}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            </div>
+        </section>
+    );
+}
 
 export default async function PrDetailPage({ params }: PrDetailPageProps) {
     const health = await checkApiHealth();
@@ -28,39 +164,57 @@ export default async function PrDetailPage({ params }: PrDetailPageProps) {
     const { pr_id: prId } = await params;
     const session = await requireSession();
     const orgId = session.user.org_id ?? "default-org";
+    const demoMode = isExplicitDemoMode();
+    const prResult = await getPrDetailViaGraphQL({ orgId, id: prId })
+        .then((pr) => ({ pr, error: null }))
+        .catch((error: unknown) => ({ pr: null, error }));
+    if (prResult.error) {
+        return (
+            <div className="min-h-screen bg-background text-foreground">
+                <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
+                    <PrimaryNav filters={defaultMetricFilter} />
+                    <main className="flex min-w-0 flex-1 flex-col gap-8">
+                        <PrHeader />
+                        <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
+                            PR detail could not be loaded from the backend. Try again after the data
+                            service is healthy.
+                        </div>
+                    </main>
+                </div>
+            </div>
+        );
+    }
+    const shouldLoadRelatedEntities = prResult.pr !== null || demoMode;
     const [flame, drilldown] = await Promise.all([
         fetchOrNull(getFlame({ entity_type: "pr", entity_id: prId }), "pr-flame"),
-        getAIWorkflowDrilldownViaGraphQL({
-            orgId,
-            rootType: "PR",
-            rootId: prId,
-            useDemoFallback: true,
-        }),
+        shouldLoadRelatedEntities
+            ? getAIWorkflowDrilldownViaGraphQL({
+                  orgId,
+                  rootType: "PR",
+                  rootId: prId,
+                  useDemoFallback: demoMode,
+              }).catch(() => emptyDrilldown(orgId, prId))
+            : Promise.resolve(emptyDrilldown(orgId, prId)),
     ]);
-    const investment = getWorkUnitInvestmentDistribution({ rootType: "PR", rootId: prId });
+    const investment = demoMode
+        ? getWorkUnitInvestmentDistribution({ rootType: "PR", rootId: prId })
+        : emptyInvestment(prId);
 
     return (
         <div className="min-h-screen bg-background text-foreground">
             <div className="flex w-full flex-col gap-6 px-6 pb-16 pt-10 md:flex-row">
                 <PrimaryNav filters={defaultMetricFilter} />
                 <main className="flex min-w-0 flex-1 flex-col gap-8">
-                    <header className="flex flex-wrap items-start justify-between gap-4">
-                        <div>
-                            <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
-                                Pull Request
-                            </p>
-                            <h1 className="mt-2 font-(--font-display) text-3xl">Flame Diagram</h1>
-                            <p className="mt-2 text-sm text-(--ink-muted)">
-                                Visualize review waits, rework loops, and merge timing.
-                            </p>
+                    <PrHeader />
+
+                    {prResult.pr ? (
+                        <PrDetailSummary pr={prResult.pr} />
+                    ) : (
+                        <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
+                            No PR detail found for this id. Check that the URL uses a persisted PR
+                            id such as repo_id#prnumber.
                         </div>
-                        <Link
-                            href="/explore"
-                            className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
-                        >
-                            Back to Explore
-                        </Link>
-                    </header>
+                    )}
 
                     {!flame?.entity || !flame.timeline || !flame.frames ? (
                         <div className="rounded-3xl border border-dashed border-(--card-stroke) bg-(--card-70) p-6 text-sm text-(--ink-muted)">
@@ -104,5 +258,27 @@ export default async function PrDetailPage({ params }: PrDetailPageProps) {
                 </main>
             </div>
         </div>
+    );
+}
+
+function PrHeader() {
+    return (
+        <header className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+                <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
+                    Pull Request
+                </p>
+                <h1 className="mt-2 font-(--font-display) text-3xl">PR detail</h1>
+                <p className="mt-2 text-sm text-(--ink-muted)">
+                    Review persisted PR details, reviews, commits, and Work Graph evidence.
+                </p>
+            </div>
+            <Link
+                href="/explore"
+                className="rounded-full border border-(--card-stroke) px-4 py-2 text-xs uppercase tracking-[0.2em]"
+            >
+                Back to Explore
+            </Link>
+        </header>
     );
 }

--- a/src/components/work/RelatedEntitiesPanel.tsx
+++ b/src/components/work/RelatedEntitiesPanel.tsx
@@ -14,6 +14,8 @@ type RelatedEntitiesPanelProps = {
     rootId: string;
     drilldown: AIWorkflowDrilldownResult;
     investment: WorkUnitInvestmentDistribution;
+    /** True when the related-entities/Work Graph evidence fetch failed (distinct from a genuine empty result). */
+    relatedEntitiesError?: boolean;
 };
 
 const entityLabels: Record<string, string> = {
@@ -91,6 +93,7 @@ export function RelatedEntitiesPanel({
     rootId,
     drilldown,
     investment,
+    relatedEntitiesError = false,
 }: RelatedEntitiesPanelProps) {
     const theme = topDistributionEntry(investment.themeDistribution);
     const subcategory = topDistributionEntry(investment.subcategoryDistribution);
@@ -125,7 +128,15 @@ export function RelatedEntitiesPanel({
                 </div>
             </div>
 
-            {relatedEdges.length === 0 ? (
+            {relatedEntitiesError ? (
+                <div
+                    data-testid="related-entities-error"
+                    className="mt-6 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)"
+                >
+                    Related work unavailable. Work Graph evidence could not be loaded from the
+                    backend; try again once the data service recovers.
+                </div>
+            ) : relatedEdges.length === 0 ? (
                 <div className="mt-6 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) p-5 text-sm text-(--ink-muted)">
                     No data for related entities.
                 </div>

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -22,6 +22,40 @@ export type AiAttributionBucketInput =
   | 'HUMAN'
   | 'UNKNOWN';
 
+export type AiAttributionEvidenceRow = {
+  __typename?: 'AIAttributionEvidenceRow';
+  actor?: Maybe<Scalars['String']['output']>;
+  confidence: Scalars['Float']['output'];
+  evidence: Scalars['String']['output'];
+  kind: Scalars['String']['output'];
+  observedAt: Scalars['DateTime']['output'];
+  provider: Scalars['String']['output'];
+  repoId?: Maybe<Scalars['String']['output']>;
+  source: Scalars['String']['output'];
+  subjectId: Scalars['String']['output'];
+  subjectType: Scalars['String']['output'];
+  teamId?: Maybe<Scalars['String']['output']>;
+};
+
+export type AiAttributionMixRow = {
+  __typename?: 'AIAttributionMixRow';
+  count: Scalars['Int']['output'];
+  kind: Scalars['String']['output'];
+  share: Scalars['Float']['output'];
+};
+
+export type AiAttributionOverviewResult = {
+  __typename?: 'AIAttributionOverviewResult';
+  dataAvailable: Scalars['Boolean']['output'];
+  endDate: Scalars['Date']['output'];
+  hasMore: Scalars['Boolean']['output'];
+  mix: Array<AiAttributionMixRow>;
+  orgId: Scalars['String']['output'];
+  rows: Array<AiAttributionEvidenceRow>;
+  startDate: Scalars['Date']['output'];
+  totalAttributed: Scalars['Int']['output'];
+};
+
 export type AiComparison = {
   __typename?: 'AIComparison';
   aiSide: AiComparisonSide;
@@ -1197,10 +1231,70 @@ export type ProductTelemetryTopOrgType = {
   sessions: Scalars['Int']['output'];
 };
 
+export type PullRequestCommit = {
+  __typename?: 'PullRequestCommit';
+  authorEmail?: Maybe<Scalars['String']['output']>;
+  authorName?: Maybe<Scalars['String']['output']>;
+  authorWhen?: Maybe<Scalars['DateTime']['output']>;
+  confidence?: Maybe<Scalars['Float']['output']>;
+  evidence?: Maybe<Scalars['String']['output']>;
+  hash: Scalars['String']['output'];
+  message?: Maybe<Scalars['String']['output']>;
+  provenance?: Maybe<Scalars['String']['output']>;
+};
+
+export type PullRequestDetail = {
+  __typename?: 'PullRequestDetail';
+  additions?: Maybe<Scalars['Int']['output']>;
+  authorEmail?: Maybe<Scalars['String']['output']>;
+  authorName?: Maybe<Scalars['String']['output']>;
+  baseBranch?: Maybe<Scalars['String']['output']>;
+  body?: Maybe<Scalars['String']['output']>;
+  changedFiles?: Maybe<Scalars['Int']['output']>;
+  changesRequestedCount: Scalars['Int']['output'];
+  closedAt?: Maybe<Scalars['DateTime']['output']>;
+  commentsCount: Scalars['Int']['output'];
+  commits: Array<PullRequestCommit>;
+  createdAt: Scalars['DateTime']['output'];
+  deletions?: Maybe<Scalars['Int']['output']>;
+  firstCommentAt?: Maybe<Scalars['DateTime']['output']>;
+  firstReviewAt?: Maybe<Scalars['DateTime']['output']>;
+  headBranch?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  linkedIssues: Array<PullRequestIssueLink>;
+  mergedAt?: Maybe<Scalars['DateTime']['output']>;
+  number: Scalars['Int']['output'];
+  orgId: Scalars['String']['output'];
+  repoId: Scalars['ID']['output'];
+  repoName?: Maybe<Scalars['String']['output']>;
+  reviews: Array<PullRequestReview>;
+  reviewsCount: Scalars['Int']['output'];
+  state?: Maybe<Scalars['String']['output']>;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type PullRequestIssueLink = {
+  __typename?: 'PullRequestIssueLink';
+  confidence: Scalars['Float']['output'];
+  evidence: Scalars['String']['output'];
+  provenance: Scalars['String']['output'];
+  workItemId: Scalars['String']['output'];
+};
+
+export type PullRequestReview = {
+  __typename?: 'PullRequestReview';
+  reviewId: Scalars['String']['output'];
+  reviewer: Scalars['String']['output'];
+  state: Scalars['String']['output'];
+  submittedAt: Scalars['DateTime']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   /** List AI-attributed pull requests in the requested window so the UI can offer a concrete drilldown selector. Rows come from ai_attribution_resolved joined to git_pull_requests; no aggregation, no fabrication. */
   aiAttributedPrs: AiAttributedPrsResult;
+  /** AI attribution mix and provenance evidence for the requested window. Reads ai_attribution_resolved only - the highest-precedence, non-superseded signal per subject - so every row carries source, confidence, and evidence. Does not include a synthesized human bucket; use aiImpactSummary for the full AI-vs-human PR split. */
+  aiAttributionOverview: AiAttributionOverviewResult;
   /** Side-by-side AI-assisted vs non-AI baseline comparison. */
   aiComparison: AiComparison;
   /** AI governance coverage and recent policy violations. */
@@ -1247,6 +1341,8 @@ export type Query = {
   improveOpportunities: ImproveOpportunitiesResult;
   /** Weekly Engineering Operating Review */
   operatingReview: OperatingReview;
+  /** Pull request detail by stable id ({repo_id}#pr{number}) from persisted ClickHouse PR, review, commit, and Work Graph tables. */
+  pr?: Maybe<PullRequestDetail>;
   /** Get first-party product telemetry dashboard metrics */
   productTelemetryDashboard: ProductTelemetryDashboardType;
   /** Cross-org product telemetry dashboard for platform/super admins. Requires is_superuser. Returns global aggregates plus a top-orgs rollup with org names resolved from Postgres. */
@@ -1281,6 +1377,15 @@ export type Query = {
 
 
 export type QueryAiAttributedPrsArgs = {
+  dateRange: AiDateRangeInput;
+  limit?: Scalars['Int']['input'];
+  offset?: Scalars['Int']['input'];
+  orgId: Scalars['String']['input'];
+  scope?: InputMaybe<AiScopeInput>;
+};
+
+
+export type QueryAiAttributionOverviewArgs = {
   dateRange: AiDateRangeInput;
   limit?: Scalars['Int']['input'];
   offset?: Scalars['Int']['input'];
@@ -1436,6 +1541,12 @@ export type QueryImproveOpportunitiesArgs = {
 
 export type QueryOperatingReviewArgs = {
   input: OperatingReviewInput;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryPrArgs = {
+  id: Scalars['ID']['input'];
   orgId: Scalars['String']['input'];
 };
 
@@ -1860,10 +1971,19 @@ export type TeamAttributionSource =
   | 'REPO_OWNERSHIP'
   | 'UNASSIGNED';
 
+export type ThroughputEstimateCoverage = {
+  __typename?: 'ThroughputEstimateCoverage';
+  backlogSize: Scalars['Int']['output'];
+  estimatedCount: Scalars['Int']['output'];
+  ratio?: Maybe<Scalars['Float']['output']>;
+  unestimatedCount: Scalars['Int']['output'];
+};
+
 export type ThroughputForecast = {
   __typename?: 'ThroughputForecast';
   backlogSize: Scalars['Int']['output'];
   computedAt: Scalars['String']['output'];
+  estimateCoverage?: Maybe<ThroughputEstimateCoverage>;
   forecastId: Scalars['String']['output'];
   historyWeeks: Scalars['Int']['output'];
   incidentLoad: ThroughputRiskOverlay;

--- a/src/lib/graphql/__tests__/workGraphFetchers.test.ts
+++ b/src/lib/graphql/__tests__/workGraphFetchers.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../server", () => ({
+    graphqlFetch: vi.fn(),
+}));
+
+import { graphqlFetch } from "../server";
+import { getPrDetailViaGraphQL } from "../workGraphFetchers";
+
+const mockedFetch = vi.mocked(graphqlFetch);
+
+describe("getPrDetailViaGraphQL", () => {
+    beforeEach(() => {
+        mockedFetch.mockReset();
+    });
+
+    it("returns the pr(id) payload from GraphQL", async () => {
+        const pr = {
+            id: "repo#pr1",
+            orgId: "org-1",
+            repoId: "repo",
+            number: 1,
+            title: "PR",
+            createdAt: "2026-06-01T12:00:00Z",
+            changesRequestedCount: 0,
+            reviewsCount: 0,
+            commentsCount: 0,
+            reviews: [],
+            commits: [],
+            linkedIssues: [],
+        };
+        mockedFetch.mockResolvedValueOnce({ pr });
+
+        const result = await getPrDetailViaGraphQL({ orgId: "org-1", id: "repo#pr1" });
+
+        expect(result).toEqual(pr);
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+        expect(mockedFetch.mock.calls[0][1]).toEqual({ orgId: "org-1", id: "repo#pr1" });
+        expect(mockedFetch.mock.calls[0][2]).toEqual({ orgId: "org-1" });
+    });
+
+    it("returns null when GraphQL has no PR for the id", async () => {
+        mockedFetch.mockResolvedValueOnce({ pr: null });
+
+        const result = await getPrDetailViaGraphQL({ orgId: "org-1", id: "missing" });
+
+        expect(result).toBeNull();
+    });
+});

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -112,6 +112,58 @@ query BusFactor($orgId: String!, $scope: BusFactorScopeInput = null) {
 }
 `;
 
+export const PR_DETAIL_QUERY = `
+query PrDetail($orgId: String!, $id: ID!) {
+  pr(orgId: $orgId, id: $id) {
+    id
+    orgId
+    repoId
+    repoName
+    number
+    title
+    body
+    state
+    authorName
+    authorEmail
+    createdAt
+    mergedAt
+    closedAt
+    headBranch
+    baseBranch
+    additions
+    deletions
+    changedFiles
+    firstReviewAt
+    firstCommentAt
+    changesRequestedCount
+    reviewsCount
+    commentsCount
+    reviews {
+      reviewId
+      reviewer
+      state
+      submittedAt
+    }
+    commits {
+      hash
+      message
+      authorName
+      authorEmail
+      authorWhen
+      confidence
+      provenance
+      evidence
+    }
+    linkedIssues {
+      workItemId
+      confidence
+      provenance
+      evidence
+    }
+  }
+}
+`;
+
 // Compounding Risk surface (CHAOS-1642)
 //
 // Reads from compounding_risk_daily (CHAOS-1641). Every field carries enough

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -6,6 +6,37 @@ enum AIAttributionBucketInput {
   UNKNOWN
 }
 
+type AIAttributionEvidenceRow {
+  subjectType: String!
+  subjectId: String!
+  repoId: String
+  provider: String!
+  kind: String!
+  source: String!
+  confidence: Float!
+  actor: String
+  evidence: String!
+  observedAt: DateTime!
+  teamId: String
+}
+
+type AIAttributionMixRow {
+  kind: String!
+  count: Int!
+  share: Float!
+}
+
+type AIAttributionOverviewResult {
+  orgId: String!
+  startDate: Date!
+  endDate: Date!
+  mix: [AIAttributionMixRow!]!
+  totalAttributed: Int!
+  rows: [AIAttributionEvidenceRow!]!
+  hasMore: Boolean!
+  dataAvailable: Boolean!
+}
+
 type AIComparison {
   orgId: String!
   startDate: Date!
@@ -1074,6 +1105,60 @@ type ProductTelemetryTopOrgType {
   orgSlug: String
 }
 
+type PullRequestCommit {
+  hash: String!
+  message: String
+  authorName: String
+  authorEmail: String
+  authorWhen: DateTime
+  confidence: Float
+  provenance: String
+  evidence: String
+}
+
+type PullRequestDetail {
+  id: ID!
+  orgId: String!
+  repoId: ID!
+  repoName: String
+  number: Int!
+  title: String
+  body: String
+  state: String
+  authorName: String
+  authorEmail: String
+  createdAt: DateTime!
+  mergedAt: DateTime
+  closedAt: DateTime
+  headBranch: String
+  baseBranch: String
+  additions: Int
+  deletions: Int
+  changedFiles: Int
+  firstReviewAt: DateTime
+  firstCommentAt: DateTime
+  changesRequestedCount: Int!
+  reviewsCount: Int!
+  commentsCount: Int!
+  reviews: [PullRequestReview!]!
+  commits: [PullRequestCommit!]!
+  linkedIssues: [PullRequestIssueLink!]!
+}
+
+type PullRequestIssueLink {
+  workItemId: String!
+  confidence: Float!
+  provenance: String!
+  evidence: String!
+}
+
+type PullRequestReview {
+  reviewId: String!
+  reviewer: String!
+  state: String!
+  submittedAt: DateTime!
+}
+
 type Query {
   """Get catalog of available dimensions, measures, and limits"""
   catalog(orgId: String!, dimension: DimensionInput = null, filters: FilterInput = null): CatalogResult!
@@ -1094,6 +1179,11 @@ type Query {
 
   """Query work graph edges with optional filters"""
   workGraphEdges(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphEdgesResult!
+
+  """
+  Pull request detail by stable id ({repo_id}#pr{number}) from persisted ClickHouse PR, review, commit, and Work Graph tables.
+  """
+  pr(orgId: String!, id: ID!): PullRequestDetail
 
   """Per-node-type inflow/outflow over the full work graph"""
   workGraphFlow(orgId: String!, filters: WorkGraphEdgeFilterInput = null): WorkGraphFlowResult!
@@ -1217,6 +1307,11 @@ type Query {
   List AI-attributed pull requests in the requested window so the UI can offer a concrete drilldown selector. Rows come from ai_attribution_resolved joined to git_pull_requests; no aggregation, no fabrication.
   """
   aiAttributedPrs(orgId: String!, dateRange: AIDateRangeInput!, scope: AIScopeInput = null, limit: Int! = 50, offset: Int! = 0): AiAttributedPrsResult!
+
+  """
+  AI attribution mix and provenance evidence for the requested window. Reads ai_attribution_resolved only - the highest-precedence, non-superseded signal per subject - so every row carries source, confidence, and evidence. Does not include a synthesized human bucket; use aiImpactSummary for the full AI-vs-human PR split.
+  """
+  aiAttributionOverview(orgId: String!, dateRange: AIDateRangeInput!, scope: AIScopeInput = null, limit: Int! = 50, offset: Int! = 0): AIAttributionOverviewResult!
 }
 
 type Recommendation {
@@ -1516,6 +1611,13 @@ enum TeamAttributionSource {
   UNASSIGNED
 }
 
+type ThroughputEstimateCoverage {
+  ratio: Float
+  estimatedCount: Int!
+  unestimatedCount: Int!
+  backlogSize: Int!
+}
+
 type ThroughputForecast {
   forecastId: String!
   computedAt: String!
@@ -1530,6 +1632,7 @@ type ThroughputForecast {
   primaryRisk: ThroughputRiskOverlay!
   wipCongestion: ThroughputRiskOverlay!
   staleWip: ThroughputStaleWip
+  estimateCoverage: ThroughputEstimateCoverage
   reviewBottleneck: ThroughputRiskOverlay!
   incidentLoad: ThroughputRiskOverlay!
   insufficientHistory: Boolean!

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -247,6 +247,64 @@ export interface BusFactorScopeInput {
     teamId?: string | null;
 }
 
+export interface PullRequestReview {
+    reviewId: string;
+    reviewer: string;
+    state: string;
+    submittedAt: string;
+}
+
+export interface PullRequestCommit {
+    hash: string;
+    message?: string | null;
+    authorName?: string | null;
+    authorEmail?: string | null;
+    authorWhen?: string | null;
+    confidence?: number | null;
+    provenance?: string | null;
+    evidence?: string | null;
+}
+
+export interface PullRequestIssueLink {
+    workItemId: string;
+    confidence: number;
+    provenance: string;
+    evidence: string;
+}
+
+export interface PullRequestDetail {
+    id: string;
+    orgId: string;
+    repoId: string;
+    repoName?: string | null;
+    number: number;
+    title?: string | null;
+    body?: string | null;
+    state?: string | null;
+    authorName?: string | null;
+    authorEmail?: string | null;
+    createdAt: string;
+    mergedAt?: string | null;
+    closedAt?: string | null;
+    headBranch?: string | null;
+    baseBranch?: string | null;
+    additions?: number | null;
+    deletions?: number | null;
+    changedFiles?: number | null;
+    firstReviewAt?: string | null;
+    firstCommentAt?: string | null;
+    changesRequestedCount: number;
+    reviewsCount: number;
+    commentsCount: number;
+    reviews: PullRequestReview[];
+    commits: PullRequestCommit[];
+    linkedIssues: PullRequestIssueLink[];
+}
+
+export interface PrDetailQueryResponse {
+    pr: PullRequestDetail | null;
+}
+
 export interface MaintainerShare {
     author: string;
     sharePercent: number;

--- a/src/lib/graphql/workGraphFetchers.ts
+++ b/src/lib/graphql/workGraphFetchers.ts
@@ -1,9 +1,11 @@
 import { graphqlFetch } from "./server";
-import { AI_WORKFLOW_DRILLDOWN_QUERY, WORK_GRAPH_EDGES_QUERY } from "./queries";
+import { AI_WORKFLOW_DRILLDOWN_QUERY, PR_DETAIL_QUERY, WORK_GRAPH_EDGES_QUERY } from "./queries";
 import type {
     AIWorkflowDrilldownQueryResponse,
     AIWorkflowDrilldownResult,
     AIWorkflowRootTypeInput,
+    PrDetailQueryResponse,
+    PullRequestDetail,
     WorkGraphEdgeFilterInput,
     WorkGraphEdgesQueryResponse,
     WorkGraphEdgesResult,
@@ -49,6 +51,18 @@ export async function getAIWorkflowDrilldownViaGraphQL(params: {
         if (!params.useDemoFallback) throw new Error("Work Graph drilldown unavailable");
     }
     return demoWorkflowDrilldown(params.rootType, params.rootId, params.orgId);
+}
+
+export async function getPrDetailViaGraphQL(params: {
+    orgId: string;
+    id: string;
+}): Promise<PullRequestDetail | null> {
+    const response = await graphqlFetch<PrDetailQueryResponse>(
+        PR_DETAIL_QUERY,
+        { orgId: params.orgId, id: params.id },
+        { orgId: params.orgId },
+    );
+    return response.pr;
 }
 
 export function getWorkUnitInvestmentDistribution(params: {


### PR DESCRIPTION
## Summary
- query live PR detail data for /prs/[pr_id]
- render persisted PR metadata, reviews, commits, and honest empty/error states
- keep demo/static fallback behind explicit demo/test mode only

## Screenshots
Before: https://github.com/user-attachments/assets/e98a414a-f1ab-4d7d-a125-bdadad1c8d02
After: https://github.com/user-attachments/assets/d69b868d-4827-4087-81f4-6844634ecb48

## Oracle NO-GO findings addressed
1. **Honest error state** — related-entities/Work Graph evidence GraphQL failures now render a distinct "Related work unavailable" state instead of silently reusing the "No data" empty-result copy. Covered by a new page test asserting the rejected-fetch path.
2. **Schema drift** — `src/lib/graphql/schema.graphql` regenerated from ops main (`dev_health_ops.api.graphql.export_schema`) + `pnpm codegen`; now includes the `pr` query and `PullRequestDetail`/`PullRequestCommit`/`PullRequestReview`/`PullRequestIssueLink` types.
3. **repo_id:number id format** — added a page test asserting the colon-format PR id (used by `workflowRootId.ts` / `explore/page.tsx`) resolves and renders; no production route-parsing change was needed.

![chaos-2387-related-entities-error-after.png](https://github.com/user-attachments/assets/a558c1aa-e44f-495a-8190-472fecb28d79)

## Validation
- pnpm typecheck
- pnpm lint
- pnpm format:check:changed
- pnpm test:unit

Linear: CHAOS-2387
