### PR TITLE
fix(hub): render populated Govern/Diagnose/Improve signal cards in test mode (CHAOS-2223)

### DIFF
--- a/src/lib/areaSignals/__tests__/diagnose.test.ts
+++ b/src/lib/areaSignals/__tests__/diagnose.test.ts
@@ -537,27 +537,41 @@ describe("getDiagnoseSignals — source → AreaSignal mapping", () => {
         });
     });
 
-    it("test-mode skips graphql and resolves complexity as unavailable", async () => {
-        // In test mode, graphqlFetch is never called for complexity.
+    it("test-mode renders deterministic sample Complexity data (no GraphQL calls, CHAOS-2223)", async () => {
+        // In test mode, graphqlFetch is never called for complexity —
+        // SAMPLE_DIAGNOSE_COMPLEXITY flows through the SAME mean-cyclomaticPerKloc
+        // derivation above instead of the honest-empty "Not yet connected" tier.
         const signals = byId(await getDiagnoseSignals(defaultMetricFilter, true));
         expect(mockGraphql).not.toHaveBeenCalled();
         expect(signals.complexity).toMatchObject({
-            state: "unavailable",
-            value: "",
+            state: "medium",
+            value: "22",
         });
     });
 
-    it("test-mode skips bus factor and resolves landscape as unavailable", async () => {
-        // In test mode, getBusFactorData is never called for Landscape — it stays
-        // unavailable like the other GraphQL-backed Diagnose signals (complexity,
-        // cognitive-load). This stops a test-only BusFactor mock (added for the /code
-        // ownership card) from leaking an available Landscape hero into the Diagnose
-        // overview (CHAOS-2035 regression).
+    it("test-mode renders deterministic sample Landscape (bus factor) data (CHAOS-2223)", async () => {
+        // getBusFactorData is never called in test mode — SAMPLE_DIAGNOSE_BUS_FACTOR
+        // (a dedicated constant, NOT the shared /code-page MSW mock) flows through
+        // the same higher-is-better derivation instead. This no longer depends on
+        // (or can drift with) the /code ownership card's shared mock value, which
+        // is what caused the original CHAOS-2035 hero-leak regression.
         const signals = byId(await getDiagnoseSignals(defaultMetricFilter, true));
         expect(mockGetBusFactorData).not.toHaveBeenCalled();
         expect(signals.landscape).toMatchObject({
-            state: "unavailable",
-            value: "",
+            state: "high",
+            value: "1.8",
+        });
+    });
+
+    it("test-mode renders deterministic sample Cognitive Load data, scope-independent (CHAOS-2223)", async () => {
+        // Test-mode samples are scope-independent by convention (mirrors the AI
+        // hub): the isTestMode branch is checked BEFORE the scope gate, so this
+        // never depends on cognitiveLoadScopeSupported.
+        const signals = byId(await getDiagnoseSignals(defaultMetricFilter, true));
+        expect(mockGetCognitiveLoad).not.toHaveBeenCalled();
+        expect(signals["cognitive-load"]).toMatchObject({
+            state: "low",
+            value: "6",
         });
     });
 

--- a/src/lib/areaSignals/__tests__/diagnose.test.ts
+++ b/src/lib/areaSignals/__tests__/diagnose.test.ts
@@ -563,15 +563,35 @@ describe("getDiagnoseSignals — source → AreaSignal mapping", () => {
         });
     });
 
-    it("test-mode renders deterministic sample Cognitive Load data, scope-independent (CHAOS-2223)", async () => {
-        // Test-mode samples are scope-independent by convention (mirrors the AI
-        // hub): the isTestMode branch is checked BEFORE the scope gate, so this
-        // never depends on cognitiveLoadScopeSupported.
+    it("test-mode renders deterministic sample Cognitive Load data for a scope-supported filter (CHAOS-2223)", async () => {
+        // The isTestMode branch is checked BEFORE the scope gate in the FETCH, so
+        // no network call happens for any scope. But the CHAOS-2077 privacy gate
+        // downstream (cognitiveLoadScopeSupported ? avgInterruptionLoad(...) :
+        // undefined, further below) is untouched and still applies regardless of
+        // test mode — this test uses defaultMetricFilter's supported "team: all"
+        // scope. See the companion test below for the unsupported-scope case.
         const signals = byId(await getDiagnoseSignals(defaultMetricFilter, true));
         expect(mockGetCognitiveLoad).not.toHaveBeenCalled();
         expect(signals["cognitive-load"]).toMatchObject({
             state: "low",
             value: "6",
+        });
+    });
+
+    it("test-mode still honors the CHAOS-2077 scope-support privacy gate for Cognitive Load (developer scope stays unavailable)", async () => {
+        // The isTestMode fetch-level bypass above does NOT make Cognitive Load
+        // scope-independent end-to-end: the downstream render gate
+        // (cognitiveLoadScopeSupported) still discards the fetched sample under an
+        // unsupported scope, so a developer scope can never leak org-wide sample
+        // data under its self-only privacy framing — even in test mode.
+        const developerFilter = {
+            ...defaultMetricFilter,
+            scope: { ...defaultMetricFilter.scope, level: "developer" as const, ids: ["u1"] },
+        };
+        const signals = byId(await getDiagnoseSignals(developerFilter, true));
+        expect(signals["cognitive-load"]).toMatchObject({
+            state: "unavailable",
+            value: "",
         });
     });
 

--- a/src/lib/areaSignals/__tests__/govern.test.ts
+++ b/src/lib/areaSignals/__tests__/govern.test.ts
@@ -258,4 +258,25 @@ describe("getGovernSignals — source → AreaSignal mapping", () => {
             value: "95% success",
         });
     });
+
+    it("renders deterministic sample data for Security + Compounding Risk in isTestMode (no GraphQL calls, CHAOS-2223)", async () => {
+        // Security and Compounding Risk previously short-circuited to `undefined`
+        // in test mode (the graphql-direct sources), so the Govern hub could only
+        // ever render their honest-empty "Not yet connected" tier under Playwright.
+        // SAMPLE_GOVERN_SECURITY_OVERVIEW / SAMPLE_GOVERN_COMPOUNDING_RISK now flow
+        // through the SAME derivation logic above (never bypassing it).
+        const signals = byId(await getGovernSignals(defaultMetricFilter, true));
+
+        expect(signals.security).toMatchObject({
+            state: "high",
+            value: "9",
+            cluster: "Risk",
+        });
+        expect(signals["risk-compounding"]).toMatchObject({
+            state: "medium",
+            cluster: "Risk",
+        });
+        // Neither sample constant calls graphqlFetch — the network is bypassed.
+        expect(mockGraphql).not.toHaveBeenCalled();
+    });
 });

--- a/src/lib/areaSignals/__tests__/govern.test.ts
+++ b/src/lib/areaSignals/__tests__/govern.test.ts
@@ -274,6 +274,7 @@ describe("getGovernSignals — source → AreaSignal mapping", () => {
         });
         expect(signals["risk-compounding"]).toMatchObject({
             state: "medium",
+            value: "0.6",
             cluster: "Risk",
         });
         // Neither sample constant calls graphqlFetch — the network is bypassed.

--- a/src/lib/areaSignals/__tests__/improve.test.ts
+++ b/src/lib/areaSignals/__tests__/improve.test.ts
@@ -427,15 +427,19 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
     });
 
     it("degrades the 3 sub-areas to UNAVAILABLE (no top signal) when ALL sources fail (CHAOS-2219 + CHAOS-2220)", async () => {
-        // The genuine "not connected" path: all three fetches throw → safe()
-        // swallows to undefined → all sub-areas unavailable, no top signal.
+        // The genuine "not connected" path (production, isTestMode=false): all
+        // three fetches throw → safe() swallows to undefined → all sub-areas
+        // unavailable, no top signal. (In isTestMode, Automations now short-
+        // circuits to deterministic sample data instead of calling graphqlFetch
+        // at all — see the CHAOS-2223 test below — so this genuine-failure
+        // scenario is exercised with isTestMode=false.)
         // Both Experiments (CHAOS-2219) and Automations (CHAOS-2220) have real
         // routes, so neither degrades to "preview" even when unavailable.
         mockGetOpportunities.mockRejectedValue(new Error("opps down"));
         mockGetHomeData.mockRejectedValue(new Error("home down"));
         mockGraphqlFetch.mockRejectedValue(new Error("graphql down"));
 
-        const signals = await getImproveSignals(defaultMetricFilter, true);
+        const signals = await getImproveSignals(defaultMetricFilter, false);
         expect(signals).toHaveLength(3);
         expect(signals.find((s) => s.id === "improve-top-signal")).toBeUndefined();
         for (const signal of signals) {
@@ -447,5 +451,19 @@ describe("getImproveSignals — Improve area signals (CHAOS-2217)", () => {
         expect(byIdMap.experiments.preview).not.toBe(true);
         expect(byIdMap["improve-automations"].preview).not.toBe(true);
         expect(byIdMap.opportunities.preview).not.toBe(true);
+    });
+
+    it("renders deterministic sample Automations data in isTestMode (no GraphQL calls, CHAOS-2223)", async () => {
+        // Automations was the one Improve source still short-circuiting to an
+        // honest-empty card in test mode (the shared mock GraphQL server has no
+        // `improveOpportunities` handler). SAMPLE_IMPROVE_AUTOMATIONS now flows
+        // through the SAME detectorReady/totalCount derivation instead of calling
+        // graphqlFetch.
+        const signals = byId(await getImproveSignals(defaultMetricFilter, true));
+        expect(mockGraphqlFetch).not.toHaveBeenCalled();
+        expect(signals["improve-automations"]).toMatchObject({
+            state: "neutral",
+            value: "3 detected",
+        });
     });
 });

--- a/src/lib/areaSignals/diagnose-sample-data.ts
+++ b/src/lib/areaSignals/diagnose-sample-data.ts
@@ -1,0 +1,104 @@
+// ── Deterministic Diagnose sample data for DEV_HEALTH_TEST_MODE (CHAOS-2223) ──
+//
+// Mirrors the established TestOps/AI convention: typed constants returned by
+// the resolver instead of hitting the network, flowing through the REAL
+// severity derivation in areaSignals/diagnose.ts (never bypassing it):
+//
+//   complexity     → "medium" (mean cyclomaticPerKloc 22 → >=15, <25)
+//   landscape      → "high"   (bus factor 1.8 → >=1.5, <2, higherIsBetter)
+//   cognitive-load → "low"    (avg interruption load 6 → <8)
+//
+// Bus factor previously short-circuited to `null` in test mode (CHAOS-2035: a
+// shared MSW `BusFactor` mock, reused by the /code ownership card, leaked an
+// available Landscape hero into the Diagnose overview at a time when no
+// deterministic-sample-data convention existed). Providing our OWN typed
+// constant here — never touching `getBusFactorData` or the shared mock —
+// sidesteps that regression: Diagnose test-mode data no longer depends on (or
+// can drift with) the /code page's mock value.
+
+import type { ComplexityTimeseriesResult } from "@/lib/graphql/__generated__/types";
+import type { BusFactor } from "@/lib/graphql/types";
+import type { CognitiveLoadResult } from "@/lib/graphql/cognitiveLoadFetchers";
+
+const SAMPLE_ORG_ID = "default-org";
+const SAMPLE_DATE = "2026-06-09";
+
+export const SAMPLE_DIAGNOSE_COMPLEXITY: ComplexityTimeseriesResult = {
+    points: [
+        {
+            date: SAMPLE_DATE,
+            scopeId: "sample-repo-web",
+            scopeName: "sample/web-app",
+            cyclomaticPerKloc: 28,
+            cyclomaticAvg: 14,
+            cyclomaticTotal: 280,
+            locTotal: 10000,
+            highComplexityFunctions: 12,
+            veryHighComplexityFunctions: 2,
+        },
+        {
+            date: SAMPLE_DATE,
+            scopeId: "sample-repo-api",
+            scopeName: "sample/api",
+            cyclomaticPerKloc: 16,
+            cyclomaticAvg: 9,
+            cyclomaticTotal: 96,
+            locTotal: 6000,
+            highComplexityFunctions: 5,
+            veryHighComplexityFunctions: 0,
+        },
+    ],
+    totalScope: 2,
+};
+
+export const SAMPLE_DIAGNOSE_BUS_FACTOR: BusFactor = {
+    orgId: SAMPLE_ORG_ID,
+    scope: { repoId: null, teamId: null },
+    value: 1.8,
+    topMaintainers: [
+        { author: "sample-maintainer-1@example.com", sharePercent: 64.5 },
+        { author: "sample-maintainer-2@example.com", sharePercent: 35.5 },
+    ],
+    repos: [
+        {
+            repoId: "sample-repo-web",
+            repoName: "sample/web-app",
+            value: 1.8,
+            topMaintainers: [{ author: "sample-maintainer-1@example.com", sharePercent: 64.5 }],
+            evidenceSampleCount: 420,
+        },
+    ],
+    evidenceSampleCount: 420,
+};
+
+export const SAMPLE_DIAGNOSE_COGNITIVE_LOAD: CognitiveLoadResult = {
+    orgId: SAMPLE_ORG_ID,
+    teamId: null,
+    totalDays: 3,
+    signals: [
+        {
+            day: "2026-06-07",
+            prInterruptionLoad: 6,
+            contextSpreadCount: 20,
+            reviewRequestLoad: 3,
+            afterHoursCommitRatio: 0.1,
+            weekendCommitRatio: 0.05,
+        },
+        {
+            day: "2026-06-08",
+            prInterruptionLoad: 7,
+            contextSpreadCount: 22,
+            reviewRequestLoad: 4,
+            afterHoursCommitRatio: 0.12,
+            weekendCommitRatio: 0.06,
+        },
+        {
+            day: SAMPLE_DATE,
+            prInterruptionLoad: 5,
+            contextSpreadCount: 18,
+            reviewRequestLoad: 2,
+            afterHoursCommitRatio: 0.08,
+            weekendCommitRatio: 0.04,
+        },
+    ],
+};

--- a/src/lib/areaSignals/diagnose.ts
+++ b/src/lib/areaSignals/diagnose.ts
@@ -35,6 +35,11 @@ import {
 } from "@/lib/complexity/filters";
 import { getCognitiveLoadViaGraphQL } from "@/lib/graphql/cognitiveLoadFetchers";
 import type { CognitiveLoadResult } from "@/lib/graphql/cognitiveLoadFetchers";
+import {
+    SAMPLE_DIAGNOSE_BUS_FACTOR,
+    SAMPLE_DIAGNOSE_COGNITIVE_LOAD,
+    SAMPLE_DIAGNOSE_COMPLEXITY,
+} from "./diagnose-sample-data";
 import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
 import type { MetricFilter } from "@/lib/filters/types";
 import { formatNumber } from "@/lib/formatters";
@@ -248,7 +253,7 @@ export async function getDiagnoseSignals(
         safe(
             () =>
                 isTestMode
-                    ? Promise.resolve(undefined)
+                    ? Promise.resolve(SAMPLE_DIAGNOSE_COMPLEXITY)
                     : graphqlFetch<{
                           complexityTimeseries: ComplexityTimeseriesResult;
                       }>(
@@ -268,17 +273,25 @@ export async function getDiagnoseSignals(
                       ).then((r) => r.complexityTimeseries),
             "complexity",
         ),
-        safe(() => (isTestMode ? Promise.resolve(null) : getBusFactorData(filters)), "bus-factor"),
         safe(
             () =>
-                isTestMode || !cognitiveLoadScopeSupported
-                    ? Promise.resolve(undefined)
-                    : getCognitiveLoadViaGraphQL({
-                          orgId,
-                          sinceDate,
-                          untilDate,
-                          teamId: cognitiveLoadTeamId,
-                      }),
+                isTestMode
+                    ? Promise.resolve(SAMPLE_DIAGNOSE_BUS_FACTOR)
+                    : getBusFactorData(filters),
+            "bus-factor",
+        ),
+        safe(
+            () =>
+                isTestMode
+                    ? Promise.resolve(SAMPLE_DIAGNOSE_COGNITIVE_LOAD)
+                    : !cognitiveLoadScopeSupported
+                      ? Promise.resolve(undefined)
+                      : getCognitiveLoadViaGraphQL({
+                            orgId,
+                            sinceDate,
+                            untilDate,
+                            teamId: cognitiveLoadTeamId,
+                        }),
             "cognitive-load",
         ),
     ]);

--- a/src/lib/areaSignals/govern-sample-data.ts
+++ b/src/lib/areaSignals/govern-sample-data.ts
@@ -1,0 +1,100 @@
+// ── Deterministic Govern sample data for DEV_HEALTH_TEST_MODE (CHAOS-2223) ────
+//
+// Mirrors the established TestOps/AI convention (src/lib/testops/sample-data.ts,
+// src/lib/ai/sample-data.ts): typed constants returned by the resolver instead of
+// hitting the network, so the Govern hub renders realistic, deterministic card
+// states in test mode. The values are CLEARLY SAMPLE — fixed dates, sample-* ids
+// — and flow through the REAL severity derivation in areaSignals/govern.ts
+// (never bypassing it):
+//
+//   security         → "high"   (0 critical, 2 high, 9 open → high>=1 ladder)
+//   risk-compounding → "medium" (worst row severity ELEVATED → medium)
+
+import type { CompoundingRiskResult, SecurityOverview } from "@/lib/graphql/__generated__/types";
+
+const SAMPLE_START_DATE = "2026-05-26";
+const SAMPLE_END_DATE = "2026-06-09";
+const SAMPLE_ORG_ID = "default-org";
+
+export const SAMPLE_GOVERN_SECURITY_OVERVIEW: SecurityOverview = {
+    kpis: {
+        critical: 0,
+        high: 2,
+        meanDaysToFix30d: 4.5,
+        openDelta30d: -3,
+        openTotal: 9,
+    },
+    severityBreakdown: [
+        { severity: "HIGH", count: 2 },
+        { severity: "MEDIUM", count: 4 },
+        { severity: "LOW", count: 3 },
+    ],
+    topRepos: [
+        { repoId: "sample-repo-web", repoName: "sample/web-app", count: 5, repoUrl: null },
+        { repoId: "sample-repo-api", repoName: "sample/api", count: 4, repoUrl: null },
+    ],
+    trend: [
+        { day: SAMPLE_START_DATE, opened: 2, fixed: 1 },
+        { day: SAMPLE_END_DATE, opened: 1, fixed: 3 },
+    ],
+};
+
+export const SAMPLE_GOVERN_COMPOUNDING_RISK: CompoundingRiskResult = {
+    orgId: SAMPLE_ORG_ID,
+    generatedAt: `${SAMPLE_END_DATE}T06:00:00Z`,
+    breakout: "REPO",
+    rows: [
+        {
+            day: SAMPLE_END_DATE,
+            scope: "REPO",
+            scopeId: "sample-repo-web",
+            scopeLabel: "sample/web-app",
+            scopeEntity: { id: "sample-repo-web", displayName: "sample/web-app" },
+            computedAt: `${SAMPLE_END_DATE}T06:00:00Z`,
+            score: 0.6,
+            severity: "ELEVATED",
+            components: {
+                busFactor: 1.8,
+                churnNorm: 0.5,
+                complexityDelta: 0.1,
+                complexityNorm: 0.4,
+                ownershipGini: 0.55,
+                ownershipNorm: 0.5,
+                reviewLatencyP90h: 36,
+                reviewNorm: 0.3,
+                reworkChurn: 0.2,
+                singleOwnerRatio: 0.6,
+            },
+            thresholds: { elevated: 0.4, high: 0.7 },
+            weights: { churn: 0.25, complexity: 0.25, ownership: 0.25, review: 0.25 },
+        },
+        {
+            day: SAMPLE_END_DATE,
+            scope: "REPO",
+            scopeId: "sample-repo-api",
+            scopeLabel: "sample/api",
+            scopeEntity: { id: "sample-repo-api", displayName: "sample/api" },
+            computedAt: `${SAMPLE_END_DATE}T06:00:00Z`,
+            score: 0.18,
+            severity: "LOW",
+            components: {
+                busFactor: 3.2,
+                churnNorm: 0.1,
+                complexityDelta: 0.02,
+                complexityNorm: 0.15,
+                ownershipGini: 0.3,
+                ownershipNorm: 0.2,
+                reviewLatencyP90h: 10,
+                reviewNorm: 0.1,
+                reworkChurn: 0.05,
+                singleOwnerRatio: 0.25,
+            },
+            thresholds: { elevated: 0.4, high: 0.7 },
+            weights: { churn: 0.25, complexity: 0.25, ownership: 0.25, review: 0.25 },
+        },
+    ],
+    trend: [
+        { day: SAMPLE_START_DATE, score: 0.3, severity: "LOW" },
+        { day: SAMPLE_END_DATE, score: 0.6, severity: "ELEVATED" },
+    ],
+};

--- a/src/lib/areaSignals/govern.ts
+++ b/src/lib/areaSignals/govern.ts
@@ -27,6 +27,10 @@ import type {
     CompoundingRiskSeverity,
     SecurityOverview,
 } from "@/lib/graphql/__generated__/types";
+import {
+    SAMPLE_GOVERN_COMPOUNDING_RISK,
+    SAMPLE_GOVERN_SECURITY_OVERVIEW,
+} from "./govern-sample-data";
 import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
 import { fetchCoverageMetrics, fetchRiskMetrics, fetchTestOpsData } from "@/lib/testops/fetchers";
 import type { AnalyticsRequestInput, TimeseriesResult } from "@/lib/graphql/schemas/analytics";
@@ -212,7 +216,7 @@ export async function getGovernSignals(
             safe(
                 () =>
                     isTestMode
-                        ? Promise.resolve(undefined)
+                        ? Promise.resolve(SAMPLE_GOVERN_SECURITY_OVERVIEW)
                         : graphqlFetch<{ securityOverview: SecurityOverview }>(
                               SECURITY_OVERVIEW_QUERY,
                               { orgId, filters: { openOnly: true } },
@@ -223,7 +227,7 @@ export async function getGovernSignals(
             safe(
                 () =>
                     isTestMode
-                        ? Promise.resolve(undefined)
+                        ? Promise.resolve(SAMPLE_GOVERN_COMPOUNDING_RISK)
                         : graphqlFetch<{ compoundingRisk: CompoundingRiskResult }>(
                               COMPOUNDING_RISK_QUERY,
                               { orgId, filter: null },

--- a/src/lib/areaSignals/improve-sample-data.ts
+++ b/src/lib/areaSignals/improve-sample-data.ts
@@ -1,0 +1,47 @@
+// ── Deterministic Improve Automations sample data for DEV_HEALTH_TEST_MODE ────
+// (CHAOS-2223)
+//
+// Opportunities + home (Improve's other two sources) are already MSW-mockable
+// REST, fetched unconditionally regardless of isTestMode (see improve.ts) —
+// they render real mock-backend data in test mode already. Automations was the
+// one GraphQL-direct source that still short-circuited to an honest-empty card
+// because the shared mock GraphQL server has no `improveOpportunities` handler.
+// This constant follows the Govern/Diagnose/AI convention instead: a typed
+// sample flowing through the REAL derivation in areaSignals/improve.ts (never
+// bypassing it) — detectorReady + totalCount 3 → "neutral", "3 detected".
+
+import type { ImproveOpportunitiesResult } from "@/lib/graphql/__generated__/types";
+
+const SAMPLE_ORG_ID = "default-org";
+
+export const SAMPLE_IMPROVE_AUTOMATIONS: ImproveOpportunitiesResult = {
+    orgId: SAMPLE_ORG_ID,
+    detectorReady: true,
+    totalCount: 3,
+    opportunities: [
+        {
+            opportunityId: "sample-improve-opp-1",
+            entityId: "sample-repo-web",
+            entityType: "repo",
+            kind: "HIGH_CHURN",
+            title: "Automate churn reduction in sample/web-app",
+            rationale: "Recurring high-churn files match the automation heuristic.",
+            recommendedAction: "Auto-flag files with 3+ reworks/week for a dedicated cleanup pass.",
+            score: 0.72,
+            severity: "medium",
+            evidenceRefs: ["git_pull_requests:sample-repo-web:512"],
+        },
+        {
+            opportunityId: "sample-improve-opp-2",
+            entityId: "sample-repo-api",
+            entityType: "repo",
+            kind: "SLOW_CYCLE_TIME",
+            title: "Automate cycle-time triage in sample/api",
+            rationale: "Cycle time regressions cluster around review latency.",
+            recommendedAction: "Route slow PRs to a fast-track reviewer queue.",
+            score: 0.58,
+            severity: "low",
+            evidenceRefs: ["git_pull_requests:sample-repo-api:88"],
+        },
+    ],
+};

--- a/src/lib/areaSignals/improve.ts
+++ b/src/lib/areaSignals/improve.ts
@@ -36,12 +36,16 @@
 //   - Automations (CHAOS-2220): REAL — count of flow opportunities from
 //     FlowOpportunityDetector via `improveOpportunities` GraphQL query.
 //     "neutral" when detectorReady (even zero is a valid "all green" state).
-//     "unavailable" when the fetch fails or the detector is not ready.
+//     "unavailable" when the fetch fails or the detector is not ready. In
+//     isTestMode this source short-circuits to a deterministic sample constant
+//     (CHAOS-2223) — the shared mock GraphQL server has no `improveOpportunities`
+//     handler, so without this the card degraded to a false "not connected".
 
 import { getHomeData, getOpportunities } from "@/lib/api/home";
 import { graphqlFetch } from "@/lib/graphql/server";
 import { IMPROVE_OPPORTUNITIES_QUERY } from "@/lib/graphql/queries";
 import type { ImproveOpportunitiesResult } from "@/lib/graphql/__generated__/types";
+import { SAMPLE_IMPROVE_AUTOMATIONS } from "./improve-sample-data";
 import { getAreaById, type NavAreaHubItem } from "@/lib/navigation/areas";
 import type { MetricFilter } from "@/lib/filters/types";
 import type { MetricDelta } from "@/lib/types";
@@ -140,10 +144,13 @@ async function safe<T>(fn: () => Promise<T>, source: string): Promise<T | undefi
  * Resolve the Improve area's signal cards.
  *
  * @param filters  Active metric filter (drives the home/opportunities date range).
- * @param isTestMode  Accepted for dispatcher-signature parity with the other area
- *   resolvers. NOT used as a fetch gate: both sources are MSW-mockable REST and
- *   are fetched unconditionally (see the fetch block) so the Overview renders
- *   real cards under Playwright's mock backend, matching Diagnose/Govern.
+ * @param isTestMode  Opportunities/home are MSW-mockable REST and are fetched
+ *   unconditionally regardless of this flag (see the fetch block) so the
+ *   Overview renders real cards under Playwright's mock backend, matching
+ *   Diagnose/Govern. Automations, the one GraphQL-direct source, DOES gate on
+ *   this flag: it short-circuits to a deterministic sample constant in test
+ *   mode (CHAOS-2223) instead of calling the mock backend, which has no
+ *   `improveOpportunities` handler.
  */
 export async function getImproveSignals(
     filters: MetricFilter,
@@ -167,6 +174,11 @@ export async function getImproveSignals(
         safe(() => getOpportunities(filters), "opportunities"),
         safe(() => getHomeData(filters), "home"),
         safe(() => {
+            // Test mode: deterministic sample data (CHAOS-2223), same convention as
+            // Govern/Diagnose's GraphQL-direct sources — bypasses the network so the
+            // Overview renders a real Automations card without depending on the mock
+            // backend having an `improveOpportunities` handler.
+            if (isTestMode) return Promise.resolve(SAMPLE_IMPROVE_AUTOMATIONS);
             // Guard: without an org in session, require_org_id will reject the
             // request server-side. Short-circuit here so safe() → UNAVAILABLE
             // rather than a false "0 detected / all green" (Warning 4, CHAOS-2220).

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -573,6 +573,7 @@ export type CloneSavedReportInput = {
 
 export type CognitiveLoadInput = {
   orgId: Scalars['String']['input'];
+  repoId?: InputMaybe<Scalars['String']['input']>;
   sinceDate: Scalars['Date']['input'];
   teamId?: InputMaybe<Scalars['String']['input']>;
   untilDate: Scalars['Date']['input'];

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -56,6 +56,12 @@ export type AiAttributionOverviewResult = {
   totalAttributed: Scalars['Int']['output'];
 };
 
+export type AiAttributionScopeInput = {
+  buckets?: InputMaybe<Array<AiAttributionBucketInput>>;
+  repoId?: InputMaybe<Scalars['String']['input']>;
+  teamId?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type AiComparison = {
   __typename?: 'AIComparison';
   aiSide: AiComparisonSide;
@@ -1390,7 +1396,7 @@ export type QueryAiAttributionOverviewArgs = {
   limit?: Scalars['Int']['input'];
   offset?: Scalars['Int']['input'];
   orgId: Scalars['String']['input'];
-  scope?: InputMaybe<AiScopeInput>;
+  scope?: InputMaybe<AiAttributionScopeInput>;
 };
 
 

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -37,6 +37,12 @@ type AIAttributionOverviewResult {
   dataAvailable: Boolean!
 }
 
+input AIAttributionScopeInput {
+  repoId: String = null
+  teamId: String = null
+  buckets: [AIAttributionBucketInput!] = null
+}
+
 type AIComparison {
   orgId: String!
   startDate: Date!
@@ -1311,7 +1317,7 @@ type Query {
   """
   AI attribution mix and provenance evidence for the requested window. Reads ai_attribution_resolved only - the highest-precedence, non-superseded signal per subject - so every row carries source, confidence, and evidence. Does not include a synthesized human bucket; use aiImpactSummary for the full AI-vs-human PR split.
   """
-  aiAttributionOverview(orgId: String!, dateRange: AIDateRangeInput!, scope: AIScopeInput = null, limit: Int! = 50, offset: Int! = 0): AIAttributionOverviewResult!
+  aiAttributionOverview(orgId: String!, dateRange: AIDateRangeInput!, scope: AIAttributionScopeInput = null, limit: Int! = 50, offset: Int! = 0): AIAttributionOverviewResult!
 }
 
 type Recommendation {

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -519,6 +519,7 @@ input CognitiveLoadInput {
   sinceDate: Date!
   untilDate: Date!
   teamId: String = null
+  repoId: String = null
 }
 
 type CognitiveLoadResult {

--- a/tests/cognitive-load.spec.ts
+++ b/tests/cognitive-load.spec.ts
@@ -24,7 +24,13 @@ test.describe("IA rejection regressions", () => {
         await expect(grid).toBeVisible();
         await expect(grid.getByTestId("area-signal-unavailable")).not.toHaveCount(0);
         await expect(grid.getByRole("link", { name: "People" })).not.toBeVisible();
-        await expect(grid.getByRole("link", { name: "Landscape" })).toBeVisible();
+        // CHAOS-2223: Landscape now renders deterministic sample bus-factor data in
+        // test mode and derives "high" severity — the most severe available Diagnose
+        // signal — so AreaOverview promotes it to the HERO slot, not the grid. Assert
+        // page-level visibility rather than scoping to `grid`.
+        await expect(
+            page.getByTestId("area-overview-hero").getByRole("heading", { name: "Landscape" }),
+        ).toBeVisible();
         await expect(grid.getByRole("link", { name: "Cognitive Load" })).toBeVisible();
 
         // People remains reachable via the active Diagnose sidebar navigation

--- a/tests/diagnose-overview.spec.ts
+++ b/tests/diagnose-overview.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+// ── Diagnose Overview hub cards render in test mode (CHAOS-2223) ─────────────
+// Complexity, Landscape (bus factor), and Cognitive Load previously short-
+// circuited to undefined/null in DEV_HEALTH_TEST_MODE, so these cards could
+// only ever render the honest-empty "Not yet connected" tier under Playwright.
+// SAMPLE_DIAGNOSE_* constants now flow through the real derivation instead
+// (src/lib/areaSignals/diagnose-sample-data.ts).
+
+test.describe("Diagnose Overview hub cards (CHAOS-2223)", () => {
+    test("Complexity, Landscape, and Cognitive Load render populated signal values in test mode", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await expect(page.getByTestId("area-overview")).toBeVisible();
+
+        const card = (id: string) => page.locator(`[data-signal-id="${id}"]`);
+
+        await expect(card("complexity")).toHaveAttribute("data-state", "medium");
+        await expect(card("complexity").getByTestId("area-signal-value")).toHaveText("22");
+
+        await expect(card("landscape")).toHaveAttribute("data-state", "high");
+        await expect(card("landscape").getByTestId("area-signal-value")).toHaveText("1.8");
+
+        await expect(card("cognitive-load")).toHaveAttribute("data-state", "low");
+        await expect(card("cognitive-load").getByTestId("area-signal-value")).toHaveText("6");
+    });
+});

--- a/tests/govern-overview.spec.ts
+++ b/tests/govern-overview.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+// ── Govern Overview hub cards render in test mode (CHAOS-2223) ───────────────
+// Security + Compounding Risk previously short-circuited to `undefined` in
+// DEV_HEALTH_TEST_MODE (the graphql-direct sources), so these cards could only
+// ever render the honest-empty "Not yet connected" tier under Playwright.
+// SAMPLE_GOVERN_SECURITY_OVERVIEW / SAMPLE_GOVERN_COMPOUNDING_RISK now flow
+// through the real derivation instead (src/lib/areaSignals/govern-sample-data.ts).
+
+test.describe("Govern Overview hub cards (CHAOS-2223)", () => {
+    test("Security and Compounding Risk render populated signal values in test mode", async ({
+        page,
+    }) => {
+        await page.goto("/govern", { waitUntil: "domcontentloaded" });
+        await expect(page.getByTestId("area-overview")).toBeVisible();
+
+        const card = (id: string) => page.locator(`[data-signal-id="${id}"]`);
+
+        await expect(card("security")).toHaveAttribute("data-state", "high");
+        await expect(card("security").getByTestId("area-signal-value")).toHaveText("9");
+
+        await expect(card("risk-compounding")).toHaveAttribute("data-state", "medium");
+
+        // Neither card collapsed into the honest-unavailable tier.
+        await expect(card("security")).not.toHaveAttribute("data-state", "unavailable");
+        await expect(card("risk-compounding")).not.toHaveAttribute("data-state", "unavailable");
+    });
+});

--- a/tests/improve-overview.spec.ts
+++ b/tests/improve-overview.spec.ts
@@ -94,6 +94,13 @@ test.describe("Improve Overview landing", () => {
             "href",
             /\/improve\/automations/,
         );
+
+        // CHAOS-2223: Automations renders deterministic sample data in test mode
+        // (previously short-circuited to the honest-empty "Not yet connected" tier —
+        // the shared mock GraphQL server has no `improveOpportunities` handler).
+        const automationsCard = grid.locator('[data-signal-id="improve-automations"]');
+        await expect(automationsCard).toHaveAttribute("data-state", "neutral");
+        await expect(automationsCard.getByTestId("area-signal-value")).toHaveText("3 detected");
     });
 
     test("marks Improve as the single selected area on /improve", async ({ page }) => {


### PR DESCRIPTION
## Summary

Govern (security, compounding risk), Diagnose (complexity, bus factor, cognitive load), and Improve (automations) area-signal resolvers short-circuited their graphql-direct sources to `undefined`/`null` in `DEV_HEALTH_TEST_MODE`, so their hub cards could only ever render the honest-empty "Not yet connected" tier under the e2e harness / demo mode — contradicting the established test-mode contract (components must render sample data without live APIs).

Same bug class as the AI-area fix in CHAOS-2180 Wave 2 (`src/lib/ai/sample-data.ts`).

## Fix

Follows the established testops/AI sample-data convention: deterministic `SAMPLE_*` constants that flow through the **real** severity-derivation logic (never bypassing it):

- `src/lib/areaSignals/govern-sample-data.ts` — security (`high`), compounding risk (`medium`)
- `src/lib/areaSignals/diagnose-sample-data.ts` — complexity (`medium`), landscape/bus-factor (`high`), cognitive load (`low`)
- `src/lib/areaSignals/improve-sample-data.ts` — automations (`neutral`, "3 detected")

Each area gets a deliberate severity mix (not all-critical, not all-green), matching the CHAOS-2180 precedent.

### Diagnose bus-factor note (CHAOS-2035)

Bus factor previously short-circuited to `null` in test mode entirely. That was a workaround for CHAOS-2035: a shared MSW `BusFactor` mock (reused by the `/code` ownership card) once leaked an available Landscape hero into the Diagnose overview. Providing a **dedicated** sample constant here — never touching `getBusFactorData` or the shared mock — sidesteps that regression instead of re-disabling the card.

### Improve automations note

Improve's `opportunities`/`home` sources were already fixed in a prior wave (unconditional REST fetch against the mock backend). Automations was the one remaining GraphQL-direct source: the shared mock GraphQL server has no `improveOpportunities` handler, so without a test-mode sample constant it silently degraded to "Not yet connected" even though the resolver code looked "REAL".

## Tests

- Flipped the unit tests that encoded the gap (`diagnose.test.ts`: complexity + bus-factor test-mode assertions; `improve.test.ts`: the "all sources fail" test now runs with `isTestMode=false` since Automations no longer touches the network in test mode).
- Added new unit tests pinning the sample-data derivation for all three areas (Govern, Diagnose, Improve).
- Added `tests/govern-overview.spec.ts` and `tests/diagnose-overview.spec.ts` (new e2e journeys asserting populated hub-card values in test mode); extended `tests/improve-overview.spec.ts`'s Automations assertion from "link exists" to real `data-state`/value assertions.

## Gates

- `pnpm exec tsc --noEmit` — clean
- `pnpm format:check:changed` — clean
- `pnpm exec eslint` on changed files — clean
- Scoped `pnpm exec vitest run src/lib/areaSignals` — 123/123 passed
- `pnpm exec playwright test tests/govern-overview.spec.ts tests/diagnose-overview.spec.ts tests/improve-overview.spec.ts` — 8/8 passed
- `enforce-src-test-governance.mjs` — passed

## Visual evidence

Screenshots of all three hub pages rendering populated cards in test mode below.

### Govern (Security + Compounding Risk populated)

![Govern hub after](https://github.com/user-attachments/assets/8aeda1a5-1377-451f-89ac-da7d66cdae31)

### Diagnose (Complexity + Landscape + Cognitive Load populated)

![Diagnose hub after](https://github.com/user-attachments/assets/126c9512-e65d-431c-903d-4f1239ec1d25)

### Improve (Automations populated)

![Improve hub after](https://github.com/user-attachments/assets/dccde4bb-4507-4de0-b2b9-78bb22efaf16)
