### PR TITLE
test(ai): stub aiAttributionOverview so attribution renders populated in test mode (CHAOS-2744)

### DIFF
--- a/tests/ai-journey.spec.ts
+++ b/tests/ai-journey.spec.ts
@@ -267,12 +267,18 @@ test.describe("AI area journey (CHAOS-2213)", () => {
         await expect(page.getByRole("heading", { name: "Attribution" })).toBeVisible();
 
         // CHAOS-2744 replaced the static preview stub (AITabPreview + preview
-        // badge) with the live aiAttributionOverview-backed dashboard. The
-        // Playwright mock backend does not yet stub aiAttributionOverview, so
-        // the honest "unavailable" DataState -- not the removed preview
-        // markers -- is the deterministic outcome here.
-        await expect(page.getByTestId("data-state-detector-unavailable")).toBeVisible();
-        await expect(page.getByText("AI attribution data unavailable")).toBeVisible();
+        // badge) with the live aiAttributionOverview-backed dashboard. This is a
+        // fix-forward for PR #731, which merged asserting the honest
+        // "unavailable" DataState as the happy path instead of adding the
+        // missing aiAttributionOverview mock stub -- the populated filter must
+        // render the populated mix + evidence dashboard, never the unavailable
+        // state, when the mock backend has data to serve.
+        const dashboard = page.getByTestId("ai-attribution-dashboard");
+        await expect(dashboard).toBeVisible();
+        await expect(dashboard.getByTestId("ai-attribution-mix-row")).not.toHaveCount(0);
+        await expect(dashboard.getByTestId("ai-attribution-evidence-row")).not.toHaveCount(0);
+        await expect(page.getByTestId("data-state-detector-unavailable")).toHaveCount(0);
+        await expect(page.getByText("AI attribution data unavailable")).toHaveCount(0);
         await expect(page.getByTitle("This feature is in preview.")).toHaveCount(0);
         await expect(page.getByTestId("ai-tab-preview")).toHaveCount(0);
     });

--- a/tests/mocks/aiSample.ts
+++ b/tests/mocks/aiSample.ts
@@ -688,6 +688,140 @@ export function aiGovernanceSummaryResponse(
     };
 }
 
+/**
+ * AI Attribution overview (CHAOS-2744). Reads mirror the resolver's
+ * `ai_attribution_resolved` contract: kind is one of ai_assisted /
+ * agent_created / ai_review (`AIAttributionKind` in
+ * `ops/src/dev_health_ops/models/ai_attribution.py`), source is one of the
+ * seven precedence-ordered `AIAttributionSource` values, and subjectType is
+ * the raw persisted literal (pull_request / commit / issue / workflow_run /
+ * review) -- never the uppercase workflow-graph node-type vocabulary used by
+ * `aiWorkflowDrilldown`.
+ */
+export function aiAttributionOverviewResponse(
+    orgId: string,
+    startDate: string,
+    endDate: string,
+    mode: AIMode,
+    limit = 50,
+    offset = 0,
+) {
+    if (mode === "missing") {
+        return {
+            orgId,
+            startDate,
+            endDate,
+            mix: [],
+            totalAttributed: 0,
+            rows: [],
+            hasMore: false,
+            dataAvailable: false,
+        };
+    }
+    if (mode === "empty") {
+        return {
+            orgId,
+            startDate,
+            endDate,
+            mix: [],
+            totalAttributed: 0,
+            rows: [],
+            hasMore: false,
+            dataAvailable: true,
+        };
+    }
+
+    const allRows = [
+        {
+            subjectType: "pull_request",
+            subjectId: "201",
+            repoId: "repo-web-app",
+            provider: "github",
+            kind: "ai_assisted",
+            source: "pr_label",
+            confidence: 0.95,
+            actor: "github-copilot",
+            evidence: "PR labeled 'ai-assisted' at open.",
+            observedAt: `${endDate}T15:00:00Z`,
+            teamId: "team-platform",
+        },
+        {
+            subjectType: "pull_request",
+            subjectId: "198",
+            repoId: "repo-web-app",
+            provider: "github",
+            kind: "agent_created",
+            source: "bot_author",
+            confidence: 0.92,
+            actor: "claude-code[bot]",
+            evidence: "PR authored by claude-code[bot].",
+            observedAt: `${endDate}T09:30:00Z`,
+            teamId: "team-platform",
+        },
+        {
+            subjectType: "commit",
+            subjectId: "abc123",
+            repoId: "repo-api",
+            provider: "github",
+            kind: "ai_assisted",
+            source: "commit_trailer",
+            confidence: 0.88,
+            actor: "octocat",
+            evidence: "Commit trailer: AI-Assisted-By: GitHub Copilot.",
+            observedAt: `${endDate}T08:15:00Z`,
+            teamId: "team-platform",
+        },
+        {
+            subjectType: "pull_request",
+            subjectId: "154",
+            repoId: "repo-api",
+            provider: "github",
+            kind: "ai_review",
+            source: "ci_annotation",
+            confidence: 0.81,
+            actor: "code-review-bot",
+            evidence: "CI annotation: automated review pass completed.",
+            observedAt: `${endDate}T07:05:00Z`,
+            teamId: "team-product",
+        },
+        {
+            subjectType: "issue",
+            subjectId: "PROJ-101",
+            repoId: null,
+            provider: "jira",
+            kind: "agent_created",
+            source: "branch_name",
+            confidence: 0.6,
+            actor: null,
+            evidence: "Branch name matched pattern agent/*.",
+            observedAt: `${endDate}T06:40:00Z`,
+            teamId: null,
+        },
+    ];
+
+    const totalAttributed = allRows.length;
+    const mixCounts = new Map<string, number>();
+    for (const row of allRows) {
+        mixCounts.set(row.kind, (mixCounts.get(row.kind) ?? 0) + 1);
+    }
+    const mix = Array.from(mixCounts.entries()).map(([kind, count]) => ({
+        kind,
+        count,
+        share: totalAttributed ? count / totalAttributed : 0,
+    }));
+
+    return {
+        orgId,
+        startDate,
+        endDate,
+        mix,
+        totalAttributed,
+        rows: allRows.slice(offset, offset + limit),
+        hasMore: offset + limit < allRows.length,
+        dataAvailable: true,
+    };
+}
+
 export function catalogValuesResponse(dimension: string) {
     const values: Record<string, Array<{ value: string; count: number }>> = {
         TEAM: [

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -36,6 +36,7 @@ import {
 
 import {
     aiAttributedPrsResponse,
+    aiAttributionOverviewResponse,
     aiComparisonResponse,
     aiGovernanceSummaryResponse,
     aiImpactSummaryResponse,
@@ -1366,6 +1367,22 @@ function dispatchGraphQL(query: string, variables: Record<string, unknown>): Res
                     limit,
                     offset,
                     vars.scope ?? null,
+                ),
+            },
+        });
+    }
+    if (query.includes("AIAttributionOverview")) {
+        const limit = typeof variables.limit === "number" ? variables.limit : 50;
+        const offset = typeof variables.offset === "number" ? variables.offset : 0;
+        return HttpResponse.json({
+            data: {
+                aiAttributionOverview: aiAttributionOverviewResponse(
+                    orgId,
+                    startDate,
+                    endDate,
+                    aiMode,
+                    limit,
+                    offset,
                 ),
             },
         });


### PR DESCRIPTION
## Fix-forward for #731

PR #731 (CHAOS-2744) wired `/ai/attribution` to the live `aiAttributionOverview`
resolver but never added the corresponding mock-backend stub in
`tests/mocks/handlers.ts`. The merged spec then asserted the resulting
"AI attribution data unavailable" `DataState` as the **happy path** for the
populated-filter test, instead of catching the missing stub — so on `main`,
`/ai/attribution` renders the unavailable state in test/demo mode, violating
the web test-mode contract ("components must render sample data without live
APIs").

This PR does not touch production code — it only adds the missing test
double and corrects the spec's assertion.

### What changed

- **`tests/mocks/aiSample.ts`**: new `aiAttributionOverviewResponse()`,
  mirroring the sibling AI query stubs (`aiImpactSummaryResponse`,
  `aiAttributedPrsResponse`, etc.) and keyed off the same `resolveAIMode`
  convention (`missing` → `dataAvailable: false`, `empty` → empty populated
  result, default → populated). The populated payload has 3 mix rows
  (`ai_assisted` / `agent_created` / `ai_review` — the exact
  `AIAttributionKind` vocabulary from `ops/.../models/ai_attribution.py`) and
  5 evidence rows spanning `github`/`jira` providers and multiple
  `AIAttributionSource` values (`pr_label`, `bot_author`, `commit_trailer`,
  `ci_annotation`, `branch_name`), matching the real
  `AIAttributionEvidenceRow`/`AIAttributionOverviewResult` schema fields
  exactly (verified against `src/lib/graphql/__generated__/types.ts` and the
  ops resolver in `api/graphql/resolvers/ai.py`).
- **`tests/mocks/handlers.ts`**: wires the `AIAttributionOverview` GraphQL
  operation to the new response, following the same `query.includes(...)`
  dispatch pattern as the neighboring AI handlers.
- **`tests/ai-journey.spec.ts`**: the CHAOS-2744 test
  ("attribution renders the live resolver-backed dashboard") now asserts the
  **populated** dashboard — `ai-attribution-dashboard` visible, at least one
  `ai-attribution-mix-row` and one `ai-attribution-evidence-row` — and
  asserts the unavailable `DataState`/text is **absent**, replacing the
  previous (incorrect) assertions that treated "unavailable" as the expected
  outcome.

### Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm run format:check:changed` — clean
- `pnpm exec eslint` on the 3 changed files — 0 errors (1 pre-existing
  unrelated warning at a line below our insertion, present on `main` too)
- `pnpm run codegen:check` — no drift (schema already has
  `AIAttributionScopeInput`/`AIAttributionOverviewResult` from #731)
- `pnpm exec vitest run` (AIAttributionDashboard + useAIAttributionOverview
  suites) — 12/12 passed
- `pnpm exec playwright test tests/ai-journey.spec.ts tests/ai-tabs.spec.ts`
  — **12/12 passed**, including the corrected CHAOS-2744 test, on the first
  run (no rerun needed)
- Manual Playwright screenshot of `/ai/attribution` in test mode confirms the
  populated Attribution mix (AI Assisted 2 · 40%, Agent Created 2 · 40%, AI
  Review 1 · 20%) and Attribution evidence table (5 rows) — screenshot
  attached below.

### Screenshot

Populated `/ai/attribution` dashboard in test mode:

![attribution populated](https://github.com/user-attachments/assets/2ab26461-c7ea-4570-b713-04dbc42b7d63)
