### PR TITLE
feat(customer-push): web setup screens for customer-push source onboarding (CHAOS-2714)

### DIFF
--- a/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/batches/[ingestion_id]/page.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/batches/[ingestion_id]/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { BackLink } from "@/components/shared/BackLink";
+import { CustomerPushBatchDetailLive } from "@/components/admin/integrations/customer-push/CustomerPushBatchDetailLive";
+import { getCustomerPushBatch } from "@/lib/admin/server";
+
+export default async function CustomerPushBatchDetailPage({
+    params,
+}: {
+    params: Promise<{ provider: string; source_id: string; ingestion_id: string }>;
+}) {
+    const { provider, source_id: sourceId, ingestion_id: ingestionId } = await params;
+    const batchResult = await getCustomerPushBatch(ingestionId);
+
+    if (batchResult.error || !batchResult.data) {
+        notFound();
+    }
+
+    const basePath = `/org/admin/integrations/${provider}/customer-push/${sourceId}`;
+
+    return (
+        <div className="space-y-6">
+            <BackLink href={`${basePath}/batches`} area="Ingest status" />
+
+            <AdminHeader
+                title="Batch detail"
+                description="Status, record counts, and rejected records for this batch."
+            />
+
+            <CustomerPushBatchDetailLive initialBatch={batchResult.data} />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/batches/page.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/batches/page.tsx
@@ -1,0 +1,132 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { BackLink } from "@/components/shared/BackLink";
+import { CustomerPushBatchList } from "@/components/admin/integrations/customer-push/CustomerPushBatchList";
+import { getCustomerPushSource, listCustomerPushBatches } from "@/lib/admin/server";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { CustomerPushBatchStatus } from "@/lib/admin/types";
+
+const STATUSES: CustomerPushBatchStatus[] = [
+    "accepted",
+    "stream_unavailable",
+    "processing",
+    "completed",
+    "partial",
+    "failed",
+];
+
+export default async function CustomerPushBatchesPage({
+    params,
+    searchParams,
+}: {
+    params: Promise<{ provider: string; source_id: string }>;
+    searchParams: Promise<{ status?: string; from?: string; to?: string }>;
+}) {
+    const { provider, source_id: sourceId } = await params;
+    const filters = await searchParams;
+
+    const status =
+        filters.status && (STATUSES as string[]).includes(filters.status)
+            ? (filters.status as CustomerPushBatchStatus)
+            : undefined;
+
+    const [sourceResult, batchesResult] = await Promise.all([
+        getCustomerPushSource(sourceId),
+        listCustomerPushBatches(sourceId, {
+            status,
+            from: filters.from || undefined,
+            to: filters.to || undefined,
+            limit: 50,
+        }),
+    ]);
+
+    if (sourceResult.error || !sourceResult.data) {
+        notFound();
+    }
+
+    const basePath = `/org/admin/integrations/${provider}/customer-push/${sourceId}`;
+    const displayName = sourceResult.data.display_name || sourceResult.data.instance;
+    const batches = batchesResult.data?.items ?? [];
+
+    return (
+        <div className="space-y-6">
+            <BackLink href={basePath} area={displayName} />
+
+            <AdminHeader title="Ingest status" description={`Batches pushed for ${displayName}.`} />
+
+            {batchesResult.error && (
+                <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500">
+                    Failed to load batches: {batchesResult.error}
+                </div>
+            )}
+
+            <form method="GET" className="flex flex-wrap items-end gap-3">
+                <div>
+                    <label
+                        htmlFor="batch-status-filter"
+                        className="mb-1.5 block text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
+                    >
+                        Status
+                    </label>
+                    <select
+                        id="batch-status-filter"
+                        name="status"
+                        defaultValue={status ?? ""}
+                        className="rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-2 text-sm text-(--ink-base)"
+                    >
+                        <option value="">All statuses</option>
+                        {STATUSES.map((s) => (
+                            <option key={s} value={s}>
+                                {s}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div>
+                    <label
+                        htmlFor="batch-from-filter"
+                        className="mb-1.5 block text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
+                    >
+                        From
+                    </label>
+                    <input
+                        id="batch-from-filter"
+                        type="date"
+                        name="from"
+                        defaultValue={filters.from ?? ""}
+                        className="rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-2 text-sm text-(--ink-base)"
+                    />
+                </div>
+                <div>
+                    <label
+                        htmlFor="batch-to-filter"
+                        className="mb-1.5 block text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
+                    >
+                        To
+                    </label>
+                    <input
+                        id="batch-to-filter"
+                        type="date"
+                        name="to"
+                        defaultValue={filters.to ?? ""}
+                        className="rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-2 text-sm text-(--ink-base)"
+                    />
+                </div>
+                <button
+                    type="submit"
+                    className="rounded-md border border-(--border-subtle) bg-(--surface-base) px-4 py-2 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted)"
+                >
+                    {CTA_LABELS.applyFilters}
+                </button>
+            </form>
+
+            <CustomerPushBatchList
+                provider={provider}
+                sourceId={sourceId}
+                batches={batches}
+                validateHref={`${basePath}/validate`}
+                examplesHref={`${basePath}/examples`}
+            />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/credentials/new/page.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/credentials/new/page.tsx
@@ -1,0 +1,37 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { BackLink } from "@/components/shared/BackLink";
+import { CreateCustomerPushTokenForm } from "@/components/admin/integrations/customer-push/CreateCustomerPushTokenForm";
+import { getCustomerPushSource } from "@/lib/admin/server";
+
+export default async function NewCustomerPushTokenPage({
+    params,
+}: {
+    params: Promise<{ provider: string; source_id: string }>;
+}) {
+    const { provider, source_id: sourceId } = await params;
+    const sourceResult = await getCustomerPushSource(sourceId);
+
+    if (sourceResult.error || !sourceResult.data) {
+        notFound();
+    }
+
+    const basePath = `/org/admin/integrations/${provider}/customer-push/${sourceId}`;
+
+    return (
+        <div className="space-y-6">
+            <BackLink href={`${basePath}/credentials`} area="Credentials" />
+
+            <AdminHeader
+                title="Create ingest credential"
+                description={`Generate a token scoped to ${sourceResult.data.display_name || sourceResult.data.instance}.`}
+            />
+
+            <CreateCustomerPushTokenForm
+                sourceId={sourceId}
+                examplesHref={`${basePath}/examples`}
+                credentialsHref={`${basePath}/credentials`}
+            />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/credentials/page.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/credentials/page.tsx
@@ -1,0 +1,45 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { BackLink } from "@/components/shared/BackLink";
+import { CustomerPushTokenList } from "@/components/admin/integrations/customer-push/CustomerPushTokenList";
+import { getCustomerPushSource, listCustomerPushTokens } from "@/lib/admin/server";
+
+export default async function CustomerPushCredentialsPage({
+    params,
+}: {
+    params: Promise<{ provider: string; source_id: string }>;
+}) {
+    const { provider, source_id: sourceId } = await params;
+    const [sourceResult, tokensResult] = await Promise.all([
+        getCustomerPushSource(sourceId),
+        listCustomerPushTokens(sourceId),
+    ]);
+
+    if (sourceResult.error || !sourceResult.data) {
+        notFound();
+    }
+
+    const basePath = `/org/admin/integrations/${provider}/customer-push/${sourceId}`;
+    const displayName = sourceResult.data.display_name || sourceResult.data.instance;
+    const tokens = tokensResult.data ?? [];
+
+    return (
+        <div className="space-y-6">
+            <BackLink href={basePath} area={displayName} />
+
+            <AdminHeader title="Credentials" description={`Ingest tokens for ${displayName}.`} />
+
+            {tokensResult.error && (
+                <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500">
+                    Failed to load credentials: {tokensResult.error}
+                </div>
+            )}
+
+            <CustomerPushTokenList
+                tokens={tokens}
+                newTokenHref={`${basePath}/credentials/new`}
+                examplesHref={`${basePath}/examples`}
+            />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/examples/page.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/examples/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { BackLink } from "@/components/shared/BackLink";
+import { SetupExamplesTabs } from "@/components/admin/integrations/customer-push/SetupExamplesTabs";
+import { getCustomerPushSource } from "@/lib/admin/server";
+
+export default async function CustomerPushExamplesPage({
+    params,
+}: {
+    params: Promise<{ provider: string; source_id: string }>;
+}) {
+    const { provider, source_id: sourceId } = await params;
+    const sourceResult = await getCustomerPushSource(sourceId);
+
+    if (sourceResult.error || !sourceResult.data) {
+        notFound();
+    }
+
+    const source = sourceResult.data;
+    const basePath = `/org/admin/integrations/${provider}/customer-push/${sourceId}`;
+
+    return (
+        <div className="space-y-6">
+            <BackLink href={basePath} area={source.display_name || source.instance} />
+
+            <AdminHeader
+                title="Runner setup examples"
+                description={`Copy-pasteable commands for ${source.display_name || source.instance} (${source.instance}).`}
+            />
+
+            <SetupExamplesTabs sourceSystem={source.system} sourceInstance={source.instance} />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/page.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { BackLink } from "@/components/shared/BackLink";
+import { CustomerPushSourceOverview } from "@/components/admin/integrations/customer-push/CustomerPushSourceOverview";
+import { getCustomerPushSource } from "@/lib/admin/server";
+
+export default async function CustomerPushSourceOverviewPage({
+    params,
+}: {
+    params: Promise<{ provider: string; source_id: string }>;
+}) {
+    const { provider, source_id: sourceId } = await params;
+    const sourceResult = await getCustomerPushSource(sourceId);
+
+    if (sourceResult.error || !sourceResult.data) {
+        notFound();
+    }
+
+    const source = sourceResult.data;
+
+    return (
+        <div className="space-y-6">
+            <BackLink href={`/org/admin/integrations/${provider}`} area="Integrations" />
+
+            <AdminHeader
+                title={source.display_name || source.instance}
+                description={`Customer-push source · ${source.instance}`}
+            />
+
+            <CustomerPushSourceOverview provider={provider} source={source} />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/validate/page.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/customer-push/[source_id]/validate/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { BackLink } from "@/components/shared/BackLink";
+import { ValidatePayloadPanel } from "@/components/admin/integrations/customer-push/ValidatePayloadPanel";
+import { getCustomerPushSource } from "@/lib/admin/server";
+
+export default async function CustomerPushValidatePage({
+    params,
+}: {
+    params: Promise<{ provider: string; source_id: string }>;
+}) {
+    const { provider, source_id: sourceId } = await params;
+    const sourceResult = await getCustomerPushSource(sourceId);
+
+    if (sourceResult.error || !sourceResult.data) {
+        notFound();
+    }
+
+    const source = sourceResult.data;
+    const basePath = `/org/admin/integrations/${provider}/customer-push/${sourceId}`;
+
+    return (
+        <div className="space-y-6">
+            <BackLink href={basePath} area={source.display_name || source.instance} />
+
+            <AdminHeader
+                title="Validate payload"
+                description="Check a payload against the schema before your first push. This does not push data."
+            />
+
+            <ValidatePayloadPanel
+                sourceId={sourceId}
+                sourceSystem={source.system}
+                sourceInstance={source.instance}
+            />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/integrations/[provider]/customer-push/new/page.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/customer-push/new/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/AdminHeader";
+import { BackLink } from "@/components/shared/BackLink";
+import { CreateCustomerPushSourceForm } from "@/components/admin/integrations/customer-push/CreateCustomerPushSourceForm";
+
+const PROVIDER_NAMES: Record<string, string> = {
+    github: "GitHub",
+    gitlab: "GitLab",
+    jira: "Jira",
+    linear: "Linear",
+    custom: "Custom",
+};
+
+export default async function NewCustomerPushSourcePage({
+    params,
+}: {
+    params: Promise<{ provider: string }>;
+}) {
+    const { provider } = await params;
+    const providerName = PROVIDER_NAMES[provider];
+
+    if (!providerName) {
+        notFound();
+    }
+
+    return (
+        <div className="space-y-6">
+            <BackLink href={`/org/admin/integrations/${provider}`} area="Integrations" />
+
+            <AdminHeader
+                title={`Create ${providerName} customer-push source`}
+                description="Register a source instance that will push data instead of granting FullChaos provider credentials."
+            />
+
+            <CreateCustomerPushSourceForm provider={provider} providerName={providerName} />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/integrations/[provider]/page.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/page.tsx
@@ -5,16 +5,28 @@ import {
     GitHubAppConnect,
     type GitHubAppConnectResult,
 } from "@/components/admin/integrations/GitHubAppConnect";
-import { listCredentials, listSyncConfigs } from "@/lib/admin/server";
+import { ModeCards } from "@/components/admin/integrations/customer-push/ModeCards";
+import { CustomerPushSourceList } from "@/components/admin/integrations/customer-push/CustomerPushSourceList";
+import { listCredentials, listSyncConfigs, listCustomerPushSources } from "@/lib/admin/server";
 import type { Provider } from "@/lib/admin/types";
 
+// Intentionally drifted from `types.ts`'s `PROVIDERS`/`PROVIDER_LABELS` (see
+// docs/providers-integration.md) — this page-local map also carries the
+// customer-push-only `custom` pseudo-provider (D3), which must NOT be added
+// to the managed-sync `Provider` union.
 const PROVIDERS: Record<string, string> = {
     github: "GitHub",
     gitlab: "GitLab",
     jira: "Jira",
     linear: "Linear",
     launchdarkly: "LaunchDarkly",
+    custom: "Custom",
 };
+
+// LaunchDarkly has no customer-push mode in v1 (D4) — it isn't in the epic's
+// v1 source-system list, so the provider page renders only its managed-sync
+// form, unchanged.
+const CUSTOMER_PUSH_ENABLED_PROVIDERS = new Set(["github", "gitlab", "jira", "linear", "custom"]);
 
 export default async function IntegrationPage({
     params,
@@ -33,35 +45,73 @@ export default async function IntegrationPage({
         notFound();
     }
 
-    const [credentialsResult, syncConfigsResult] = await Promise.all([
+    const isCustomProvider = provider === "custom";
+    const supportsCustomerPush = CUSTOMER_PUSH_ENABLED_PROVIDERS.has(provider);
+
+    const [credentialsResult, syncConfigsResult, customerPushSourcesResult] = await Promise.all([
         listCredentials(),
         listSyncConfigs(),
+        supportsCustomerPush ? listCustomerPushSources(provider) : Promise.resolve(undefined),
     ]);
 
     const credentials = (credentialsResult.data ?? []).filter((c) => c.provider === provider);
     const syncConfigs = syncConfigsResult.data ?? [];
+    const customerPushSources = customerPushSourcesResult?.data ?? [];
 
     return (
         <div>
             <AdminHeader
                 title={`${providerName} Integration`}
-                description={`Manage your ${providerName} connections and credentials.`}
+                description={
+                    isCustomProvider
+                        ? "Manage your custom customer-push sources."
+                        : `Manage your ${providerName} connections and ingestion mode.`
+                }
             />
 
-            {credentialsResult.error && (
+            {credentialsResult.error && !isCustomProvider && (
                 <div className="mb-6 rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-red-500">
                     Failed to load credentials: {credentialsResult.error}
                 </div>
             )}
 
-            {provider === "github" && <GitHubAppConnect result={githubAppResult} />}
+            {customerPushSourcesResult?.error && (
+                <div className="mb-6 rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-red-500">
+                    Failed to load customer-push sources: {customerPushSourcesResult.error}
+                </div>
+            )}
 
-            <ProviderCredentialsList
-                provider={provider as Provider}
-                providerName={providerName}
-                credentials={credentials}
-                syncConfigs={syncConfigs}
-            />
+            {supportsCustomerPush && (
+                <ModeCards
+                    provider={provider}
+                    providerName={providerName}
+                    showManagedSync={!isCustomProvider}
+                    customerPushSourceCount={customerPushSources.length}
+                />
+            )}
+
+            {!isCustomProvider && (
+                <div id="managed-sync-credentials" className="space-y-8">
+                    {provider === "github" && <GitHubAppConnect result={githubAppResult} />}
+
+                    <ProviderCredentialsList
+                        provider={provider as Provider}
+                        providerName={providerName}
+                        credentials={credentials}
+                        syncConfigs={syncConfigs}
+                    />
+                </div>
+            )}
+
+            {supportsCustomerPush && (
+                <div className="mt-8">
+                    <CustomerPushSourceList
+                        provider={provider}
+                        providerName={providerName}
+                        sources={customerPushSources}
+                    />
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/admin/integrations/customer-push/CreateCustomerPushSourceForm.test.tsx
+++ b/src/components/admin/integrations/customer-push/CreateCustomerPushSourceForm.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render, screen, userEvent, waitFor } from "@/test/utils";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: mockPush, back: vi.fn() }),
+}));
+
+const mockCreateCustomerPushSource = vi.fn();
+vi.mock("@/lib/admin/server", () => ({
+    createCustomerPushSource: (...args: unknown[]) => mockCreateCustomerPushSource(...args),
+}));
+
+import { CreateCustomerPushSourceForm } from "./CreateCustomerPushSourceForm";
+
+describe("CreateCustomerPushSourceForm", () => {
+    afterEach(() => {
+        mockPush.mockReset();
+        mockCreateCustomerPushSource.mockReset();
+    });
+
+    it("shows a field error instead of submitting when instance is whitespace-only", async () => {
+        // The <input required> attribute already blocks a fully-empty
+        // submit natively; a whitespace-only value passes that native check
+        // so it reaches the component's own .trim() validation.
+        const user = userEvent.setup();
+        render(<CreateCustomerPushSourceForm provider="github" providerName="GitHub" />);
+        await user.type(screen.getByLabelText(/repository full name/i), "   ");
+        await user.click(screen.getByRole("button", { name: /create customer-push source/i }));
+        expect(screen.getByText(/enter a stable provider instance/i)).toBeInTheDocument();
+        expect(mockCreateCustomerPushSource).not.toHaveBeenCalled();
+    });
+
+    it("redirects to the new source's overview page on success", async () => {
+        mockCreateCustomerPushSource.mockResolvedValue({
+            data: { id: "cps-99", instance: "acme/api" },
+        });
+        const user = userEvent.setup();
+        render(<CreateCustomerPushSourceForm provider="github" providerName="GitHub" />);
+        await user.type(screen.getByLabelText(/repository full name/i), "acme/api");
+        await user.click(screen.getByRole("button", { name: /create customer-push source/i }));
+
+        await waitFor(() => {
+            expect(mockPush).toHaveBeenCalledWith(
+                "/org/admin/integrations/github/customer-push/cps-99",
+            );
+        });
+        expect(mockCreateCustomerPushSource).toHaveBeenCalledWith({
+            system: "github",
+            instance: "acme/api",
+            display_name: "acme/api",
+        });
+    });
+
+    it("renders the real backend's one-active-owner conflict message on a 409 (regression guard, not a generic error)", async () => {
+        // _request.ts's formatErrorDetail falls back to JSON.stringify for
+        // the real backend's {code, message} 409 detail shape (no top-level
+        // "error" key) — mirror that exactly, and assert the form unwraps it
+        // to clean prose rather than showing raw JSON.
+        const backendMessage =
+            "A managed github sync source already owns 'acme/api' in this organization; disable it before enabling customer-push for the same instance.";
+        mockCreateCustomerPushSource.mockResolvedValue({
+            error: JSON.stringify({
+                code: "source_owned_by_fullchaos_sync",
+                message: backendMessage,
+            }),
+        });
+        const user = userEvent.setup();
+        render(<CreateCustomerPushSourceForm provider="github" providerName="GitHub" />);
+        await user.type(screen.getByLabelText(/repository full name/i), "acme/api");
+        await user.click(screen.getByRole("button", { name: /create customer-push source/i }));
+
+        expect(await screen.findByText(backendMessage)).toBeInTheDocument();
+        expect(screen.getByText("One-active-owner conflict")).toBeInTheDocument();
+        expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("renders a generic error banner for a non-conflict failure", async () => {
+        mockCreateCustomerPushSource.mockResolvedValue({ error: "Something else went wrong" });
+        const user = userEvent.setup();
+        render(<CreateCustomerPushSourceForm provider="jira" providerName="Jira" />);
+        await user.type(screen.getByLabelText(/project key/i), "ABC");
+        await user.click(screen.getByRole("button", { name: /create customer-push source/i }));
+
+        expect(await screen.findByText("Something else went wrong")).toBeInTheDocument();
+    });
+
+    it("treats the plain-string duplicate-registration 409 as a generic error, distinct from the one-active-owner conflict", async () => {
+        // Real backend's IntegrityError path (registering the exact same
+        // source twice) is a plain string, not the {code,message} ownership
+        // shape — must not be mislabeled as "One-active-owner conflict".
+        const duplicateMessage =
+            "A source is already registered for system='github' instance='acme/api' in this organization";
+        mockCreateCustomerPushSource.mockResolvedValue({ error: duplicateMessage });
+        const user = userEvent.setup();
+        render(<CreateCustomerPushSourceForm provider="github" providerName="GitHub" />);
+        await user.type(screen.getByLabelText(/repository full name/i), "acme/api");
+        await user.click(screen.getByRole("button", { name: /create customer-push source/i }));
+
+        expect(await screen.findByText(duplicateMessage)).toBeInTheDocument();
+        expect(screen.queryByText("One-active-owner conflict")).not.toBeInTheDocument();
+        expect(mockPush).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/admin/integrations/customer-push/CreateCustomerPushSourceForm.tsx
+++ b/src/components/admin/integrations/customer-push/CreateCustomerPushSourceForm.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createCustomerPushSource } from "@/lib/admin/server";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { CustomerPushSystem } from "@/lib/admin/types";
+
+type CreateCustomerPushSourceFormProps = {
+    provider: string;
+    providerName: string;
+};
+
+const MISSING_INSTANCE_COPY =
+    "Enter a stable provider instance so incoming records can be scoped and deduplicated.";
+
+function instanceFieldCopy(system: CustomerPushSystem): { label: string; placeholder: string } {
+    switch (system) {
+        case "github":
+        case "gitlab":
+            return { label: "Repository full name (owner/repo)", placeholder: "acme/api" };
+        case "jira":
+            return { label: "Project key", placeholder: "ABC" };
+        case "linear":
+            return { label: "Team key", placeholder: "CHAOS" };
+        default:
+            return { label: "Stable source id", placeholder: "acme-internal-tracker" };
+    }
+}
+
+/** True when a create-source error message looks like the one-active-owner conflict (409). */
+function isOwnershipConflict(message: string): boolean {
+    const normalized = message.toLowerCase();
+    return (
+        normalized.includes("sync source already owns") ||
+        normalized.includes("owned_by_fullchaos_sync") ||
+        normalized.includes("owned by managed sync")
+    );
+}
+
+/**
+ * The real ops router's one-active-owner 409 raises `detail={code, message}`
+ * (no top-level `error` key) — `_request.ts`'s `formatErrorDetail` only
+ * unwraps `.message` for detail objects that DO carry an `error` key, so
+ * this shape falls through to its `JSON.stringify(raw)` fallback and
+ * `AdminApiError.detail` arrives here as a JSON string rather than clean
+ * prose. Unwrap it locally rather than widening that shared helper's
+ * behavior for every other admin domain that calls it.
+ */
+function extractErrorMessage(raw: string): { isConflict: boolean; message: string } {
+    try {
+        const parsed = JSON.parse(raw) as { code?: unknown; message?: unknown };
+        if (typeof parsed?.message === "string") {
+            const isConflict =
+                parsed.code === "source_owned_by_fullchaos_sync" ||
+                isOwnershipConflict(parsed.message);
+            return { isConflict, message: parsed.message };
+        }
+    } catch {
+        // Not JSON — already clean prose (or another domain's plain string).
+    }
+    return { isConflict: isOwnershipConflict(raw), message: raw };
+}
+
+export function CreateCustomerPushSourceForm({
+    provider,
+    providerName,
+}: CreateCustomerPushSourceFormProps) {
+    const router = useRouter();
+    const [isPending, startTransition] = useTransition();
+    const [displayName, setDisplayName] = useState("");
+    const [instance, setInstance] = useState("");
+    const [instanceError, setInstanceError] = useState<string | null>(null);
+    const [conflictError, setConflictError] = useState<string | null>(null);
+    const [genericError, setGenericError] = useState<string | null>(null);
+
+    const system = provider as CustomerPushSystem;
+    const { label: instanceLabel, placeholder: instancePlaceholder } = instanceFieldCopy(system);
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setInstanceError(null);
+        setConflictError(null);
+        setGenericError(null);
+
+        if (instance.trim().length === 0) {
+            setInstanceError(MISSING_INSTANCE_COPY);
+            return;
+        }
+
+        startTransition(async () => {
+            const result = await createCustomerPushSource({
+                system,
+                instance: instance.trim(),
+                display_name: displayName.trim() || instance.trim(),
+            });
+
+            if (result.error) {
+                const { isConflict, message } = extractErrorMessage(result.error);
+                if (isConflict) {
+                    setConflictError(message);
+                } else {
+                    setGenericError(message);
+                }
+                return;
+            }
+
+            if (result.data) {
+                router.push(`/org/admin/integrations/${provider}/customer-push/${result.data.id}`);
+            }
+        });
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="max-w-xl space-y-6">
+            {conflictError && (
+                <div
+                    role="alert"
+                    className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500"
+                >
+                    <p className="font-medium">One-active-owner conflict</p>
+                    <p className="mt-1">{conflictError}</p>
+                </div>
+            )}
+            {genericError && (
+                <div
+                    role="alert"
+                    className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500"
+                >
+                    {genericError}
+                </div>
+            )}
+
+            <div>
+                <label
+                    htmlFor="customer-push-display-name"
+                    className="mb-1.5 block text-sm font-medium text-(--ink-base)"
+                >
+                    Source display name
+                </label>
+                <input
+                    id="customer-push-display-name"
+                    type="text"
+                    value={displayName}
+                    onChange={(e) => setDisplayName(e.target.value)}
+                    placeholder={`${providerName} — ${instancePlaceholder}`}
+                    className="w-full rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-2 text-sm text-(--ink-base) focus:border-(--accent) focus:outline-none"
+                />
+            </div>
+
+            <div>
+                <label
+                    htmlFor="customer-push-instance"
+                    className="mb-1.5 block text-sm font-medium text-(--ink-base)"
+                >
+                    {instanceLabel}
+                </label>
+                <input
+                    id="customer-push-instance"
+                    type="text"
+                    required
+                    value={instance}
+                    onChange={(e) => setInstance(e.target.value)}
+                    placeholder={instancePlaceholder}
+                    className="w-full rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-2 text-sm text-(--ink-base) focus:border-(--accent) focus:outline-none"
+                />
+                {instanceError && <p className="mt-1.5 text-sm text-red-500">{instanceError}</p>}
+            </div>
+
+            <div className="rounded-lg border border-(--border-subtle) bg-(--surface-base) p-4 text-sm text-(--ink-muted)">
+                <p className="font-medium text-(--ink-base)">Ingestion mode: Customer push</p>
+                <p className="mt-1">
+                    Only one mode can own this source instance at a time. Managed sync and customer
+                    push cannot both own the same {instanceLabel.toLowerCase()}.
+                </p>
+            </div>
+
+            <div className="flex items-center gap-3">
+                <button
+                    type="submit"
+                    disabled={isPending}
+                    className="inline-flex items-center justify-center rounded-md bg-(--surface-inverted) px-4 py-2 text-sm font-medium text-(--ink-inverted) hover:bg-(--surface-inverted)/90 disabled:opacity-50"
+                >
+                    {isPending ? "Creating..." : CTA_LABELS.createCustomerPushSource}
+                </button>
+            </div>
+        </form>
+    );
+}

--- a/src/components/admin/integrations/customer-push/CreateCustomerPushTokenForm.test.tsx
+++ b/src/components/admin/integrations/customer-push/CreateCustomerPushTokenForm.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render, screen, userEvent, waitFor } from "@/test/utils";
+
+const mockCreateCustomerPushToken = vi.fn();
+vi.mock("@/lib/admin/server", () => ({
+    createCustomerPushToken: (...args: unknown[]) => mockCreateCustomerPushToken(...args),
+}));
+
+import { CreateCustomerPushTokenForm } from "./CreateCustomerPushTokenForm";
+
+describe("CreateCustomerPushTokenForm", () => {
+    afterEach(() => {
+        mockCreateCustomerPushToken.mockReset();
+    });
+
+    it("defaults all 3 v1 scopes to checked and shows disabled provider-specific scopes (D7)", () => {
+        render(
+            <CreateCustomerPushTokenForm
+                sourceId="cps-1"
+                examplesHref="/examples"
+                credentialsHref="/credentials"
+            />,
+        );
+        expect(screen.getByRole("checkbox", { name: /schema:read/i })).toBeChecked();
+        expect(screen.getByRole("checkbox", { name: /ingest:write/i })).toBeChecked();
+        expect(screen.getByRole("checkbox", { name: /ingest:status/i })).toBeChecked();
+
+        const providerScope = screen.getByText("ingest:github").closest("span");
+        const providerCheckbox = providerScope?.querySelector("input[type=checkbox]");
+        expect(providerCheckbox).toBeDisabled();
+    });
+
+    it("renders the one-time TokenRevealPanel after a successful create, replacing the form", async () => {
+        mockCreateCustomerPushToken.mockResolvedValue({
+            data: {
+                id: "cpt-1",
+                token: "fcpush_newtoken",
+                name: "CI runner",
+                source_id: "cps-1",
+                scopes: ["schema:read", "ingest:write", "ingest:status"],
+                expires_at: null,
+            },
+        });
+        const user = userEvent.setup();
+        render(
+            <CreateCustomerPushTokenForm
+                sourceId="cps-1"
+                examplesHref="/examples"
+                credentialsHref="/credentials"
+            />,
+        );
+        await user.click(screen.getByRole("button", { name: /create credential/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText("fcpush_newtoken")).toBeInTheDocument();
+        });
+        // The create form (with its scope checkboxes) must be gone now.
+        expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    });
+
+    it("disables submit when all scopes are unchecked", async () => {
+        const user = userEvent.setup();
+        render(
+            <CreateCustomerPushTokenForm
+                sourceId="cps-1"
+                examplesHref="/examples"
+                credentialsHref="/credentials"
+            />,
+        );
+        await user.click(screen.getByRole("checkbox", { name: /schema:read/i }));
+        await user.click(screen.getByRole("checkbox", { name: /ingest:write/i }));
+        await user.click(screen.getByRole("checkbox", { name: /ingest:status/i }));
+
+        expect(screen.getByRole("button", { name: /create credential/i })).toBeDisabled();
+    });
+});

--- a/src/components/admin/integrations/customer-push/CreateCustomerPushTokenForm.tsx
+++ b/src/components/admin/integrations/customer-push/CreateCustomerPushTokenForm.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { createCustomerPushToken } from "@/lib/admin/server";
+import { CTA_LABELS } from "@/lib/design/cta";
+import { TokenRevealPanel } from "./TokenRevealPanel";
+import type { CustomerPushScope, CustomerPushTokenCreateResponse } from "@/lib/admin/types";
+
+type CreateCustomerPushTokenFormProps = {
+    sourceId: string;
+    examplesHref: string;
+    credentialsHref: string;
+};
+
+const V1_SCOPES: { scope: CustomerPushScope; description: string }[] = [
+    { scope: "schema:read", description: "Read the record schema and validate payloads." },
+    { scope: "ingest:write", description: "Push batches of normalized records." },
+    { scope: "ingest:status", description: "Read ingest batch status and rejected records." },
+];
+
+// D7: provider-specific scopes are shown (so the intended scope model is
+// visible) but rendered disabled — they are not wired to any state and are
+// never sent to the API.
+const PROVIDER_SCOPES = ["ingest:github", "ingest:gitlab", "ingest:jira", "ingest:linear"];
+
+export function CreateCustomerPushTokenForm({
+    sourceId,
+    examplesHref,
+    credentialsHref,
+}: CreateCustomerPushTokenFormProps) {
+    const [isPending, startTransition] = useTransition();
+    const [name, setName] = useState("");
+    const [expiresAt, setExpiresAt] = useState("");
+    const [scopes, setScopes] = useState<CustomerPushScope[]>([
+        "schema:read",
+        "ingest:write",
+        "ingest:status",
+    ]);
+    const [error, setError] = useState<string | null>(null);
+    const [created, setCreated] = useState<CustomerPushTokenCreateResponse | null>(null);
+
+    const toggleScope = (scope: CustomerPushScope) => {
+        setScopes((prev) =>
+            prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope],
+        );
+    };
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setError(null);
+
+        startTransition(async () => {
+            const result = await createCustomerPushToken(sourceId, {
+                name: name.trim() || "CI runner",
+                scopes,
+                expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+            });
+
+            if (result.error) {
+                setError(result.error);
+                return;
+            }
+
+            if (result.data) {
+                setCreated(result.data);
+            }
+        });
+    };
+
+    if (created) {
+        return (
+            <TokenRevealPanel
+                token={created.token}
+                name={created.name}
+                scopes={created.scopes}
+                examplesHref={examplesHref}
+                onDismiss={() => setCreated(null)}
+            />
+        );
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="max-w-xl space-y-6">
+            {error && (
+                <div
+                    role="alert"
+                    className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500"
+                >
+                    {error}
+                </div>
+            )}
+
+            <div>
+                <label
+                    htmlFor="customer-push-token-name"
+                    className="mb-1.5 block text-sm font-medium text-(--ink-base)"
+                >
+                    Credential name
+                </label>
+                <input
+                    id="customer-push-token-name"
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="CI runner"
+                    className="w-full rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-2 text-sm text-(--ink-base) focus:border-(--accent) focus:outline-none"
+                />
+            </div>
+
+            <div>
+                <span className="mb-1.5 block text-sm font-medium text-(--ink-base)">Scopes</span>
+                <div className="space-y-2">
+                    {V1_SCOPES.map(({ scope, description }) => (
+                        <label
+                            key={scope}
+                            className="flex items-start gap-2.5 rounded-md border border-(--border-subtle) bg-(--surface-base) p-3"
+                        >
+                            <input
+                                type="checkbox"
+                                checked={scopes.includes(scope)}
+                                onChange={() => toggleScope(scope)}
+                                className="mt-0.5"
+                            />
+                            <span>
+                                <span className="block font-mono text-sm text-(--ink-base)">
+                                    {scope}
+                                </span>
+                                <span className="block text-xs text-(--ink-muted)">
+                                    {description}
+                                </span>
+                            </span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+
+            <div>
+                <span className="mb-1.5 block text-sm font-medium text-(--ink-muted)">
+                    Provider-specific scopes (coming soon)
+                </span>
+                <div className="flex flex-wrap gap-2">
+                    {PROVIDER_SCOPES.map((scope) => (
+                        <span
+                            key={scope}
+                            title="Coming soon"
+                            className="flex cursor-not-allowed items-center gap-1.5 rounded-full border border-(--border-subtle) px-3 py-1 text-xs font-mono text-(--ink-muted) opacity-50"
+                        >
+                            <input type="checkbox" disabled className="cursor-not-allowed" />
+                            {scope}
+                        </span>
+                    ))}
+                </div>
+            </div>
+
+            <div>
+                <label
+                    htmlFor="customer-push-token-expires"
+                    className="mb-1.5 block text-sm font-medium text-(--ink-base)"
+                >
+                    Expiration (optional)
+                </label>
+                <input
+                    id="customer-push-token-expires"
+                    type="date"
+                    value={expiresAt}
+                    onChange={(e) => setExpiresAt(e.target.value)}
+                    className="w-full rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-2 text-sm text-(--ink-base) focus:border-(--accent) focus:outline-none"
+                />
+            </div>
+
+            <div className="flex items-center gap-3">
+                <button
+                    type="submit"
+                    disabled={isPending || scopes.length === 0}
+                    className="inline-flex items-center justify-center rounded-md bg-(--surface-inverted) px-4 py-2 text-sm font-medium text-(--ink-inverted) hover:bg-(--surface-inverted)/90 disabled:opacity-50"
+                >
+                    {isPending ? "Creating..." : "Create credential"}
+                </button>
+                <a
+                    href={credentialsHref}
+                    className="text-sm text-(--ink-muted) hover:text-foreground"
+                >
+                    {CTA_LABELS.cancel}
+                </a>
+            </div>
+        </form>
+    );
+}

--- a/src/components/admin/integrations/customer-push/CustomerPushBatchDetailLive.test.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushBatchDetailLive.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/test/utils";
+import type { CustomerPushBatchDetail } from "@/lib/admin/types";
+
+const mockGetCustomerPushBatch = vi.fn();
+vi.mock("@/lib/admin/server", () => ({
+    getCustomerPushBatch: (...args: unknown[]) => mockGetCustomerPushBatch(...args),
+}));
+
+import { CustomerPushBatchDetailLive } from "./CustomerPushBatchDetailLive";
+
+const completedBatch: CustomerPushBatchDetail = {
+    ingestion_id: "batch-1",
+    org_id: "org-1",
+    status: "completed",
+    attempts: 1,
+    source_system: "github",
+    source_instance: "acme/api",
+    producer: "dev-hops-cli",
+    producer_version: "0.1.0",
+    schema_version: "external-ingest.v1",
+    window_started_at: "2026-06-25T00:00:00.000Z",
+    window_ended_at: "2026-06-26T00:00:00.000Z",
+    items_received: 10,
+    items_accepted: 10,
+    items_rejected: 0,
+    record_counts: { "pull_request.v1": 10 },
+    recompute_status: "dispatched",
+    error_summary: null,
+    created_at: "2026-06-26T00:01:00.000Z",
+    updated_at: "2026-06-26T00:01:00.000Z",
+    completed_at: "2026-06-26T00:02:00.000Z",
+    rejected_records: [],
+    rejected_records_total: 0,
+    rejected_records_limit: 50,
+    rejected_records_offset: 0,
+};
+
+const partialBatch: CustomerPushBatchDetail = {
+    ...completedBatch,
+    status: "partial",
+    items_accepted: 8,
+    items_rejected: 2,
+    error_summary: {
+        total_rejected: 2,
+        stored_rejections: 2,
+        truncated: false,
+        top_codes: [{ code: "missing_external_id", count: 2 }],
+    },
+    rejected_records_total: 1,
+    rejected_records: [
+        {
+            index: 1,
+            kind: "pull_request.v1",
+            external_id: "PR#1",
+            code: "missing_external_id",
+            path: "records[1].externalId",
+            message: "externalId is required",
+        },
+    ],
+};
+
+describe("CustomerPushBatchDetailLive", () => {
+    it("renders the clean 'No rejected records' empty state when items_rejected === 0", () => {
+        render(<CustomerPushBatchDetailLive initialBatch={completedBatch} testMode />);
+        expect(screen.getByText("No rejected records.")).toBeInTheDocument();
+    });
+
+    it("renders the rejected-records table when items_rejected > 0", () => {
+        render(<CustomerPushBatchDetailLive initialBatch={partialBatch} testMode />);
+        expect(screen.getByText("records[1].externalId")).toBeInTheDocument();
+        expect(screen.getByText("externalId is required")).toBeInTheDocument();
+    });
+
+    it("never polls in testMode, even for a non-terminal batch", async () => {
+        render(
+            <CustomerPushBatchDetailLive
+                initialBatch={{ ...completedBatch, status: "processing" }}
+                testMode
+            />,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(mockGetCustomerPushBatch).not.toHaveBeenCalled();
+    });
+
+    it("does not poll a batch that is already in a terminal status, even outside testMode", async () => {
+        render(<CustomerPushBatchDetailLive initialBatch={completedBatch} />);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(mockGetCustomerPushBatch).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/admin/integrations/customer-push/CustomerPushBatchDetailLive.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushBatchDetailLive.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getCustomerPushBatch } from "@/lib/admin/server";
+import { CustomerPushStatusBadge } from "./CustomerPushStatusBadge";
+import { RejectedRecordsTable } from "./RejectedRecordsTable";
+import { TruncatedId } from "./TruncatedId";
+import {
+    classifyProducer,
+    PRODUCER_BUCKET_LABELS,
+    isTerminalCustomerPushStatus,
+} from "@/lib/customer-push/producer";
+import type { CustomerPushBatchDetail } from "@/lib/admin/types";
+
+/** How often to refresh a non-terminal batch. Mirrors SyncRunDetailLive (D11). */
+const POLL_INTERVAL_MS = 3500;
+/** Safety cap so a stuck batch never polls forever (~10 min). */
+const MAX_POLL_DURATION_MS = 10 * 60 * 1000;
+
+interface CustomerPushBatchDetailLiveProps {
+    initialBatch: CustomerPushBatchDetail;
+    /** When true, render the provided sample data and never poll a live API. */
+    testMode?: boolean;
+}
+
+function formatTimestamp(value: string | null) {
+    if (!value) return "—";
+    return new Date(value).toLocaleString();
+}
+
+export function CustomerPushBatchDetailLive({
+    initialBatch,
+    testMode = false,
+}: CustomerPushBatchDetailLiveProps) {
+    const ingestionId = initialBatch.ingestion_id;
+    const [batch, setBatch] = useState<CustomerPushBatchDetail>(initialBatch);
+    const [pollError, setPollError] = useState<string | null>(null);
+
+    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Monotonic sequence: invalidates any in-flight response that resolves
+    // after a later terminal tick, the safety timeout, or unmount (mirrors
+    // SyncRunDetailLive's FIX 3).
+    const seqRef = useRef(0);
+    const inFlightRef = useRef(false);
+
+    const stopPolling = useCallback(() => {
+        seqRef.current += 1;
+        if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+        }
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
+        }
+    }, []);
+
+    useEffect(() => {
+        if (testMode) return undefined;
+        if (isTerminalCustomerPushStatus(initialBatch.status)) return undefined;
+
+        let cancelled = false;
+
+        const tick = async () => {
+            if (inFlightRef.current) return;
+            inFlightRef.current = true;
+            const seq = (seqRef.current += 1);
+            try {
+                const result = await getCustomerPushBatch(ingestionId);
+                if (cancelled || seq !== seqRef.current) return;
+
+                if (result.error || !result.data) {
+                    stopPolling();
+                    setPollError(result.error ?? "Live updates are unavailable.");
+                    return;
+                }
+
+                setBatch(result.data);
+                setPollError(null);
+                if (isTerminalCustomerPushStatus(result.data.status)) {
+                    stopPolling();
+                }
+            } finally {
+                inFlightRef.current = false;
+            }
+        };
+
+        intervalRef.current = setInterval(() => void tick(), POLL_INTERVAL_MS);
+        timeoutRef.current = setTimeout(() => stopPolling(), MAX_POLL_DURATION_MS);
+
+        return () => {
+            cancelled = true;
+            stopPolling();
+        };
+    }, [testMode, ingestionId, initialBatch.status, stopPolling]);
+
+    const isTerminal = isTerminalCustomerPushStatus(batch.status);
+    const recordCountEntries = Object.entries(batch.record_counts ?? {});
+
+    return (
+        <div className="space-y-6">
+            <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div className="space-y-2">
+                        <div className="flex items-center gap-3">
+                            <CustomerPushStatusBadge
+                                status={batch.status}
+                                className="text-sm px-3 py-1"
+                            />
+                            <span className="text-sm text-(--ink-muted)">
+                                {isTerminal
+                                    ? "Batch complete"
+                                    : pollError
+                                      ? "Live updates paused"
+                                      : "Live — refreshing…"}
+                            </span>
+                        </div>
+                        <dl className="grid grid-cols-2 gap-x-8 gap-y-1 text-sm sm:grid-cols-4">
+                            <div>
+                                <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                    Producer
+                                </dt>
+                                <dd className="text-foreground">
+                                    {PRODUCER_BUCKET_LABELS[classifyProducer(batch.producer ?? "")]}
+                                    {batch.producer ? ` · ${batch.producer}` : ""}
+                                </dd>
+                            </div>
+                            <div>
+                                <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                    Schema
+                                </dt>
+                                <dd className="text-foreground">{batch.schema_version}</dd>
+                            </div>
+                            <div>
+                                <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                    Created
+                                </dt>
+                                <dd className="text-foreground">
+                                    {formatTimestamp(batch.created_at)}
+                                </dd>
+                            </div>
+                            <div>
+                                <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                    Completed
+                                </dt>
+                                <dd className="text-foreground">
+                                    {formatTimestamp(batch.completed_at)}
+                                </dd>
+                            </div>
+                        </dl>
+                        <TruncatedId value={batch.ingestion_id} label="Ingestion ID" />
+                    </div>
+                </div>
+            </div>
+
+            {pollError && (
+                <div
+                    role="alert"
+                    className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6"
+                >
+                    <h3 className="text-sm font-medium text-red-500 uppercase tracking-wider">
+                        Live updates unavailable
+                    </h3>
+                    <p className="mt-2 text-sm text-(--ink-muted)">{pollError}</p>
+                </div>
+            )}
+
+            <div className="grid gap-6 md:grid-cols-3">
+                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                        Items
+                    </h3>
+                    <dl className="mt-3 space-y-1.5 text-sm">
+                        <div className="flex items-center justify-between">
+                            <dt className="text-foreground">Received</dt>
+                            <dd className="font-medium text-(--ink-muted)">
+                                {batch.items_received}
+                            </dd>
+                        </div>
+                        <div className="flex items-center justify-between">
+                            <dt className="text-foreground">Accepted</dt>
+                            <dd className="font-medium text-(--ink-muted)">
+                                {batch.items_accepted}
+                            </dd>
+                        </div>
+                        <div className="flex items-center justify-between">
+                            <dt className="text-foreground">Rejected</dt>
+                            <dd className="font-medium text-(--ink-muted)">
+                                {batch.items_rejected}
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+
+                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                        Record counts
+                    </h3>
+                    {recordCountEntries.length === 0 ? (
+                        <p className="mt-3 text-sm text-(--ink-muted)">No data yet.</p>
+                    ) : (
+                        <ul className="mt-3 space-y-1.5">
+                            {recordCountEntries.map(([kind, count]) => (
+                                <li
+                                    key={kind}
+                                    className="flex items-center justify-between text-sm"
+                                >
+                                    <span className="text-foreground">{kind}</span>
+                                    <span className="font-medium text-(--ink-muted)">{count}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+
+                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                        Recompute status
+                    </h3>
+                    <p className="mt-3 text-sm text-foreground">
+                        {batch.recompute_status ?? "Not available yet"}
+                    </p>
+                </div>
+            </div>
+
+            {batch.error_summary && (
+                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                        Error summary
+                    </h3>
+                    <dl className="mt-3 grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
+                        <div>
+                            <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                Total rejected
+                            </dt>
+                            <dd className="text-foreground">
+                                {batch.error_summary.total_rejected}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                Stored
+                            </dt>
+                            <dd className="text-foreground">
+                                {batch.error_summary.stored_rejections}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                                Truncated
+                            </dt>
+                            <dd className="text-foreground">
+                                {batch.error_summary.truncated ? "Yes" : "No"}
+                            </dd>
+                        </div>
+                    </dl>
+                    {batch.error_summary.top_codes.length > 0 && (
+                        <div className="mt-3 flex flex-wrap gap-1.5">
+                            {batch.error_summary.top_codes.map(({ code, count }) => (
+                                <span
+                                    key={code}
+                                    className="rounded-full bg-(--card-70) px-2 py-0.5 text-xs font-mono text-(--ink-muted)"
+                                >
+                                    {code}: {count}
+                                </span>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            )}
+
+            <div className="space-y-3">
+                <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                    Rejected records
+                </h3>
+                <RejectedRecordsTable records={batch.rejected_records} />
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/integrations/customer-push/CustomerPushBatchList.test.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushBatchList.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "@/test/utils";
+import type { CustomerPushBatchSummary } from "@/lib/admin/types";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: mockPush }),
+}));
+
+import { CustomerPushBatchList } from "./CustomerPushBatchList";
+
+const batches: CustomerPushBatchSummary[] = [
+    {
+        ingestion_id: "batch-1",
+        source_system: "github",
+        source_instance: "acme/api",
+        producer: "dev-hops-cli",
+        status: "completed",
+        items_received: 10,
+        items_accepted: 10,
+        items_rejected: 0,
+        created_at: "2026-06-26T00:01:00.000Z",
+        completed_at: "2026-06-26T00:02:00.000Z",
+    },
+    {
+        ingestion_id: "batch-2",
+        source_system: "github",
+        source_instance: "acme/api",
+        producer: "github-actions",
+        status: "partial",
+        items_received: 5,
+        items_accepted: 4,
+        items_rejected: 1,
+        created_at: "2026-06-28T00:01:00.000Z",
+        completed_at: "2026-06-28T00:02:00.000Z",
+    },
+];
+
+describe("CustomerPushBatchList", () => {
+    it("clicking anywhere on a row navigates to its drilldown (D11 — mirrors SyncJobHistory)", async () => {
+        mockPush.mockReset();
+        const user = userEvent.setup();
+        render(
+            <CustomerPushBatchList
+                provider="github"
+                sourceId="cps-1"
+                batches={batches}
+                validateHref="/validate"
+                examplesHref="/examples"
+            />,
+        );
+        await user.click(screen.getByText("Completed"));
+        expect(mockPush).toHaveBeenCalledWith(
+            "/org/admin/integrations/github/customer-push/cps-1/batches/batch-1",
+        );
+    });
+
+    it("shows the empty state linking to both Validate and examples when no batches exist", () => {
+        render(
+            <CustomerPushBatchList
+                provider="github"
+                sourceId="cps-1"
+                batches={[]}
+                validateHref="/validate"
+                examplesHref="/examples"
+            />,
+        );
+        expect(screen.getByText(/no batches yet/i)).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "Validate" })).toHaveAttribute("href", "/validate");
+        expect(screen.getByRole("link", { name: "CI job" })).toHaveAttribute("href", "/examples");
+    });
+
+    it("shows status badges and links each row to its drilldown", () => {
+        render(
+            <CustomerPushBatchList
+                provider="github"
+                sourceId="cps-1"
+                batches={batches}
+                validateHref="/validate"
+                examplesHref="/examples"
+            />,
+        );
+        expect(screen.getByText("Completed")).toBeInTheDocument();
+        expect(screen.getByText("Partial")).toBeInTheDocument();
+        const rowLink = screen.getByTitle("batch-1").closest("a");
+        expect(rowLink).toHaveAttribute(
+            "href",
+            "/org/admin/integrations/github/customer-push/cps-1/batches/batch-1",
+        );
+    });
+
+    it("filters by producer bucket via the chips", async () => {
+        const user = userEvent.setup();
+        render(
+            <CustomerPushBatchList
+                provider="github"
+                sourceId="cps-1"
+                batches={batches}
+                validateHref="/validate"
+                examplesHref="/examples"
+            />,
+        );
+        await user.click(screen.getByRole("button", { name: "CI" }));
+        expect(screen.queryByTitle("batch-1")).not.toBeInTheDocument();
+        expect(screen.getByTitle("batch-2")).toBeInTheDocument();
+    });
+});

--- a/src/components/admin/integrations/customer-push/CustomerPushBatchList.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushBatchList.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { CustomerPushStatusBadge } from "./CustomerPushStatusBadge";
+import { TruncatedId } from "./TruncatedId";
+import { CTA_LABELS } from "@/lib/design/cta";
+import {
+    classifyProducer,
+    PRODUCER_BUCKET_LABELS,
+    type ProducerBucket,
+} from "@/lib/customer-push/producer";
+import type { CustomerPushBatchSummary } from "@/lib/admin/types";
+
+type CustomerPushBatchListProps = {
+    provider: string;
+    sourceId: string;
+    batches: CustomerPushBatchSummary[];
+    validateHref: string;
+    examplesHref: string;
+};
+
+const BUCKETS: ProducerBucket[] = ["cli", "ci", "relay", "api"];
+
+function formatTimestamp(value: string | null) {
+    if (!value) return "—";
+    return new Date(value).toLocaleString();
+}
+
+export function CustomerPushBatchList({
+    provider,
+    sourceId,
+    batches,
+    validateHref,
+    examplesHref,
+}: CustomerPushBatchListProps) {
+    const router = useRouter();
+    const [activeBucket, setActiveBucket] = useState<ProducerBucket | null>(null);
+
+    const visibleBatches = useMemo(() => {
+        if (!activeBucket) return batches;
+        return batches.filter((batch) => classifyProducer(batch.producer ?? "") === activeBucket);
+    }, [batches, activeBucket]);
+
+    if (batches.length === 0) {
+        return (
+            <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-8 text-center">
+                <p className="text-sm text-(--ink-muted)">
+                    No batches yet — push your first payload from{" "}
+                    <Link href={validateHref} className="text-(--accent) hover:underline">
+                        {CTA_LABELS.goToValidate}
+                    </Link>{" "}
+                    or a{" "}
+                    <Link href={examplesHref} className="text-(--accent) hover:underline">
+                        {CTA_LABELS.goToCiJob}
+                    </Link>
+                    .
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+                <button
+                    type="button"
+                    onClick={() => setActiveBucket(null)}
+                    className={`rounded-full border px-3 py-1 text-xs font-medium ${
+                        activeBucket === null
+                            ? "border-(--accent) text-foreground"
+                            : "border-(--border-subtle) text-(--ink-muted) hover:text-foreground"
+                    }`}
+                >
+                    {CTA_LABELS.allProducers}
+                </button>
+                {BUCKETS.map((bucket) => (
+                    <button
+                        key={bucket}
+                        type="button"
+                        onClick={() => setActiveBucket(bucket)}
+                        className={`rounded-full border px-3 py-1 text-xs font-medium ${
+                            activeBucket === bucket
+                                ? "border-(--accent) text-foreground"
+                                : "border-(--border-subtle) text-(--ink-muted) hover:text-foreground"
+                        }`}
+                    >
+                        {PRODUCER_BUCKET_LABELS[bucket]}
+                    </button>
+                ))}
+            </div>
+
+            <div className="overflow-x-auto rounded-xl border border-(--card-stroke) bg-(--card-80)">
+                <table className="min-w-full divide-y divide-(--card-stroke)">
+                    <thead className="bg-(--card-bg)">
+                        <tr>
+                            {[
+                                "Batch",
+                                "Producer",
+                                "Status",
+                                "Received",
+                                "Accepted",
+                                "Rejected",
+                                "Created",
+                            ].map((heading) => (
+                                <th
+                                    key={heading}
+                                    scope="col"
+                                    className="px-4 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
+                                >
+                                    {heading}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-(--card-stroke)">
+                        {visibleBatches.map((batch) => {
+                            const href = `/org/admin/integrations/${provider}/customer-push/${sourceId}/batches/${batch.ingestion_id}`;
+                            return (
+                                <tr
+                                    key={batch.ingestion_id}
+                                    onClick={() => router.push(href)}
+                                    className="cursor-pointer transition-colors hover:bg-(--card-70)"
+                                >
+                                    <td className="px-4 py-3">
+                                        <Link
+                                            href={href}
+                                            onClick={(e) => e.stopPropagation()}
+                                            className="inline-flex rounded focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--accent)"
+                                        >
+                                            <TruncatedId
+                                                value={batch.ingestion_id}
+                                                label="Ingestion ID"
+                                                readOnly
+                                            />
+                                        </Link>
+                                    </td>
+                                    <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                        {
+                                            PRODUCER_BUCKET_LABELS[
+                                                classifyProducer(batch.producer ?? "")
+                                            ]
+                                        }
+                                        {batch.producer ? ` · ${batch.producer}` : ""}
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        <CustomerPushStatusBadge status={batch.status} />
+                                    </td>
+                                    <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                        {batch.items_received}
+                                    </td>
+                                    <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                        {batch.items_accepted}
+                                    </td>
+                                    <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                        {batch.items_rejected}
+                                    </td>
+                                    <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                        {formatTimestamp(batch.created_at)}
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/integrations/customer-push/CustomerPushSourceList.test.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushSourceList.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+import { CustomerPushSourceList } from "./CustomerPushSourceList";
+import type { CustomerPushSource } from "@/lib/admin/types";
+
+const source: CustomerPushSource = {
+    id: "cps-1",
+    org_id: "org-1",
+    system: "github",
+    instance: "acme/api",
+    display_name: "Acme API",
+    mode: "customer_push",
+    enabled: true,
+    webhook_mode: "disabled",
+    matched_integration_source_id: null,
+    warnings: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+describe("CustomerPushSourceList", () => {
+    it("shows the empty state only when there are truly no sources", () => {
+        render(<CustomerPushSourceList provider="github" providerName="GitHub" sources={[]} />);
+        expect(screen.getByText("No customer-push sources yet")).toBeInTheDocument();
+    });
+
+    it("does not render the empty state when sources exist", () => {
+        render(
+            <CustomerPushSourceList provider="github" providerName="GitHub" sources={[source]} />,
+        );
+        expect(screen.queryByText("No customer-push sources yet")).not.toBeInTheDocument();
+        expect(screen.getByText("Acme API")).toBeInTheDocument();
+        expect(screen.getByText("acme/api")).toBeInTheDocument();
+    });
+
+    it("links each source card to its overview page", () => {
+        render(
+            <CustomerPushSourceList provider="github" providerName="GitHub" sources={[source]} />,
+        );
+        expect(screen.getByText("Acme API").closest("a")).toHaveAttribute(
+            "href",
+            "/org/admin/integrations/github/customer-push/cps-1",
+        );
+    });
+
+    it("flags sources with backend warnings using the informational (not error) status", () => {
+        render(
+            <CustomerPushSourceList
+                provider="github"
+                providerName="GitHub"
+                sources={[
+                    {
+                        ...source,
+                        warnings: ["Managed sync is also configured for provider 'github'..."],
+                    },
+                ]}
+            />,
+        );
+        expect(screen.getByText("Connecting...")).toBeInTheDocument();
+    });
+});

--- a/src/components/admin/integrations/customer-push/CustomerPushSourceList.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushSourceList.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import { ConnectionStatus } from "@/components/admin/integrations/ConnectionStatus";
+import { TruncatedId } from "./TruncatedId";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { CustomerPushSource } from "@/lib/admin/types";
+
+type CustomerPushSourceListProps = {
+    provider: string;
+    providerName: string;
+    sources: CustomerPushSource[];
+};
+
+export function CustomerPushSourceList({
+    provider,
+    providerName,
+    sources,
+}: CustomerPushSourceListProps) {
+    return (
+        <div id="customer-push-sources" className="space-y-4">
+            <div className="flex items-center justify-between">
+                <h2 className="text-lg font-medium text-(--ink-base)">Customer-push sources</h2>
+                <Link
+                    href={`/org/admin/integrations/${provider}/customer-push/new`}
+                    className="inline-flex items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-base) px-4 py-2 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted)"
+                >
+                    {CTA_LABELS.createCustomerPushSource}
+                </Link>
+            </div>
+
+            {sources.length === 0 ? (
+                <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-(--border-subtle) bg-(--surface-base) py-12 text-center">
+                    <h3 className="mb-2 text-lg font-medium text-(--ink-base)">
+                        No customer-push sources yet
+                    </h3>
+                    <p className="mb-6 text-sm text-(--ink-muted)">
+                        Register a {providerName} source to push data without granting FullChaos
+                        long-lived credentials.
+                    </p>
+                    <Link
+                        href={`/org/admin/integrations/${provider}/customer-push/new`}
+                        className="inline-flex items-center justify-center rounded-md bg-(--surface-inverted) px-4 py-2 text-sm font-medium text-(--ink-inverted) hover:bg-(--surface-inverted)/90"
+                    >
+                        {CTA_LABELS.createCustomerPushSource}
+                    </Link>
+                </div>
+            ) : (
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                    {sources.map((source) => (
+                        <Link
+                            key={source.id}
+                            href={`/org/admin/integrations/${provider}/customer-push/${source.id}`}
+                            className="flex flex-col justify-between rounded-lg border border-(--border-subtle) bg-(--surface-base) p-6 shadow-sm transition-shadow hover:shadow-md"
+                        >
+                            <div>
+                                <div className="mb-3 flex items-center justify-between">
+                                    <h3 className="text-base font-semibold text-(--ink-base)">
+                                        {source.display_name || source.instance}
+                                    </h3>
+                                    <ConnectionStatus
+                                        status={
+                                            source.warnings.length > 0
+                                                ? "connecting"
+                                                : source.enabled
+                                                  ? "connected"
+                                                  : "not_configured"
+                                        }
+                                    />
+                                </div>
+                                <p className="text-sm text-(--ink-muted)">{source.instance}</p>
+                            </div>
+                            <div className="mt-4">
+                                <TruncatedId value={source.id} label="Source ID" readOnly />
+                            </div>
+                        </Link>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/admin/integrations/customer-push/CustomerPushSourceOverview.test.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushSourceOverview.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+import { CustomerPushSourceOverview } from "./CustomerPushSourceOverview";
+import type { CustomerPushSource } from "@/lib/admin/types";
+
+const source: CustomerPushSource = {
+    id: "cps-1",
+    org_id: "org-1",
+    system: "github",
+    instance: "acme/api",
+    display_name: "Acme API",
+    mode: "customer_push",
+    enabled: true,
+    webhook_mode: "disabled",
+    matched_integration_source_id: null,
+    warnings: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+describe("CustomerPushSourceOverview", () => {
+    it("renders the 4 link-cards to Credentials/Examples/Validate/Batches (D1)", () => {
+        render(<CustomerPushSourceOverview provider="github" source={source} />);
+        for (const [title, segment] of [
+            ["Credentials", "credentials"],
+            ["Runner setup examples", "examples"],
+            ["Validate payload", "validate"],
+            ["Ingest status", "batches"],
+        ]) {
+            const link = screen.getByText(title).closest("a");
+            expect(link).toHaveAttribute(
+                "href",
+                `/org/admin/integrations/github/customer-push/cps-1/${segment}`,
+            );
+        }
+    });
+
+    it("renders backend-authored warnings verbatim, only when present", () => {
+        const { rerender } = render(
+            <CustomerPushSourceOverview provider="github" source={source} />,
+        );
+        expect(screen.queryByText(/managed sync/i)).not.toBeInTheDocument();
+
+        const warning =
+            "Managed sync is also configured for provider 'github' in this organization -- verify this is a different repository/workspace.";
+        rerender(
+            <CustomerPushSourceOverview
+                provider="github"
+                source={{ ...source, warnings: [warning] }}
+            />,
+        );
+        expect(screen.getByText(warning)).toBeInTheDocument();
+    });
+});

--- a/src/components/admin/integrations/customer-push/CustomerPushSourceOverview.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushSourceOverview.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import { ConnectionStatus } from "@/components/admin/integrations/ConnectionStatus";
+import { TruncatedId } from "./TruncatedId";
+import type { CustomerPushSource } from "@/lib/admin/types";
+
+type CustomerPushSourceOverviewProps = {
+    provider: string;
+    source: CustomerPushSource;
+};
+
+const LINK_CARDS = [
+    {
+        segment: "credentials",
+        title: "Credentials",
+        description: "Create, rotate, and revoke ingest tokens for this source.",
+    },
+    {
+        segment: "examples",
+        title: "Runner setup examples",
+        description: "GitHub Actions, GitLab Runner, Docker/cron, cURL, and webhook relay.",
+    },
+    {
+        segment: "validate",
+        title: "Validate payload",
+        description: "Check a sample or real payload against the schema before your first push.",
+    },
+    {
+        segment: "batches",
+        title: "Ingest status",
+        description: "See accepted, processing, completed, and failed batches.",
+    },
+] as const;
+
+export function CustomerPushSourceOverview({ provider, source }: CustomerPushSourceOverviewProps) {
+    const basePath = `/org/admin/integrations/${provider}/customer-push/${source.id}`;
+
+    return (
+        <div className="space-y-6">
+            {source.warnings.map((warning) => (
+                <div
+                    key={warning}
+                    role="alert"
+                    className="rounded-lg border border-amber-500/20 bg-amber-500/10 p-4 text-sm text-amber-600"
+                >
+                    {warning}
+                </div>
+            ))}
+
+            <div className="grid gap-6 md:grid-cols-3">
+                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                        Instance
+                    </h3>
+                    <p className="mt-2 text-lg font-medium text-foreground">{source.instance}</p>
+                    <p className="mt-1 text-sm text-(--ink-muted)">
+                        {source.display_name || source.instance}
+                    </p>
+                </div>
+
+                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                        Mode
+                    </h3>
+                    <p className="mt-2 text-lg font-medium text-foreground">Customer push</p>
+                    <p className="mt-1 text-sm text-(--ink-muted)">
+                        Webhook relay: {source.webhook_mode === "disabled" ? "Disabled" : "Enabled"}
+                    </p>
+                </div>
+
+                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                        Status
+                    </h3>
+                    <div className="mt-2">
+                        <ConnectionStatus
+                            status={source.enabled ? "connected" : "not_configured"}
+                        />
+                    </div>
+                    <div className="mt-3">
+                        <TruncatedId value={source.id} label="Source ID" />
+                    </div>
+                </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+                {LINK_CARDS.map((card) => (
+                    <Link
+                        key={card.segment}
+                        href={`${basePath}/${card.segment}`}
+                        className="flex flex-col rounded-lg border border-(--border-subtle) bg-(--surface-base) p-6 shadow-sm transition-shadow hover:shadow-md"
+                    >
+                        <h3 className="text-base font-semibold text-(--ink-base)">{card.title}</h3>
+                        <p className="mt-1.5 text-sm text-(--ink-muted)">{card.description}</p>
+                    </Link>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/integrations/customer-push/CustomerPushStatusBadge.test.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushStatusBadge.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+import { CustomerPushStatusBadge } from "./CustomerPushStatusBadge";
+import type { CustomerPushBatchStatus } from "@/lib/admin/types";
+
+describe("CustomerPushStatusBadge", () => {
+    const cases: Array<[CustomerPushBatchStatus, string]> = [
+        ["accepted", "Accepted"],
+        ["stream_unavailable", "Stream unavailable"],
+        ["processing", "Processing…"],
+        ["completed", "Completed"],
+        ["partial", "Partial"],
+        ["failed", "Failed"],
+    ];
+
+    it.each(cases)("renders the correct label for status %s", (status, label) => {
+        render(<CustomerPushStatusBadge status={status} />);
+        expect(screen.getByText(label)).toBeInTheDocument();
+    });
+});

--- a/src/components/admin/integrations/customer-push/CustomerPushStatusBadge.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushStatusBadge.tsx
@@ -1,0 +1,37 @@
+import type { CustomerPushBatchStatus } from "@/lib/admin/types";
+
+interface CustomerPushStatusBadgeProps {
+    status: CustomerPushBatchStatus;
+    className?: string;
+}
+
+// Mirrors SyncStatusBadge's variant/label shape (CHAOS-2714 D11) for the
+// pinned batch status vocabulary (CC12): accepted -> (stream_unavailable) ->
+// processing -> completed | partial | failed.
+const VARIANTS: Record<CustomerPushBatchStatus, string> = {
+    accepted: "bg-blue-100 text-blue-700 border-blue-200",
+    stream_unavailable: "bg-orange-100 text-orange-700 border-orange-200",
+    processing: "bg-blue-100 text-blue-700 border-blue-200 animate-pulse",
+    completed: "bg-green-100 text-green-700 border-green-200",
+    partial: "bg-yellow-100 text-yellow-700 border-yellow-200",
+    failed: "bg-red-100 text-red-700 border-red-200",
+};
+
+const LABELS: Record<CustomerPushBatchStatus, string> = {
+    accepted: "Accepted",
+    stream_unavailable: "Stream unavailable",
+    processing: "Processing…",
+    completed: "Completed",
+    partial: "Partial",
+    failed: "Failed",
+};
+
+export function CustomerPushStatusBadge({ status, className = "" }: CustomerPushStatusBadgeProps) {
+    return (
+        <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors ${VARIANTS[status]} ${className}`}
+        >
+            {LABELS[status]}
+        </span>
+    );
+}

--- a/src/components/admin/integrations/customer-push/CustomerPushTokenList.test.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushTokenList.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render, screen, userEvent, waitFor } from "@/test/utils";
+import type { CustomerPushToken } from "@/lib/admin/types";
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+const mockRotateCustomerPushToken = vi.fn();
+const mockRevokeCustomerPushToken = vi.fn();
+vi.mock("@/lib/admin/server", () => ({
+    rotateCustomerPushToken: (...args: unknown[]) => mockRotateCustomerPushToken(...args),
+    revokeCustomerPushToken: (...args: unknown[]) => mockRevokeCustomerPushToken(...args),
+}));
+
+import { CustomerPushTokenList } from "./CustomerPushTokenList";
+
+const activeToken: CustomerPushToken = {
+    id: "cpt-1",
+    org_id: "org-1",
+    name: "CI runner",
+    source_id: "cps-1",
+    token_prefix: "fcpush_ab12",
+    scopes: ["schema:read", "ingest:write", "ingest:status"],
+    last_used_at: "2026-06-26T00:00:00.000Z",
+    expires_at: null,
+    revoked_at: null,
+    created_at: "2026-06-25T00:00:00.000Z",
+};
+
+describe("CustomerPushTokenList", () => {
+    afterEach(() => {
+        mockRotateCustomerPushToken.mockReset();
+        mockRevokeCustomerPushToken.mockReset();
+    });
+
+    it("shows the empty state with a CTA to create a credential", () => {
+        render(<CustomerPushTokenList tokens={[]} newTokenHref="/new" examplesHref="/examples" />);
+        expect(screen.getByText("No credentials yet for this source")).toBeInTheDocument();
+    });
+
+    it("renders the token_prefix for identification, but never the plaintext secret — the list response has no `token` field to leak", () => {
+        render(
+            <CustomerPushTokenList
+                tokens={[activeToken]}
+                newTokenHref="/new"
+                examplesHref="/examples"
+            />,
+        );
+        expect(screen.getByText("CI runner")).toBeInTheDocument();
+        expect(screen.getByText("Active")).toBeInTheDocument();
+        expect(screen.getByText(`${activeToken.token_prefix}…`)).toBeInTheDocument();
+    });
+
+    it("rotating a token shows the new one-time reveal panel", async () => {
+        mockRotateCustomerPushToken.mockResolvedValue({
+            data: {
+                id: "cpt-1",
+                token: "fcpush_rotated",
+                name: "CI runner",
+                source_id: "cps-1",
+                scopes: activeToken.scopes,
+                expires_at: null,
+            },
+        });
+        const user = userEvent.setup();
+        render(
+            <CustomerPushTokenList
+                tokens={[activeToken]}
+                newTokenHref="/new"
+                examplesHref="/examples"
+            />,
+        );
+        await user.click(screen.getByRole("button", { name: /rotate/i }));
+        await waitFor(() => {
+            expect(screen.getByText("fcpush_rotated")).toBeInTheDocument();
+        });
+    });
+
+    it("revoking a token requires confirmation, then disables rotate/revoke", async () => {
+        mockRevokeCustomerPushToken.mockResolvedValue({ data: undefined });
+        const user = userEvent.setup();
+        render(
+            <CustomerPushTokenList
+                tokens={[activeToken]}
+                newTokenHref="/new"
+                examplesHref="/examples"
+            />,
+        );
+        await user.click(screen.getByRole("button", { name: /^revoke$/i }));
+        expect(screen.getByText(/are you sure you want to revoke/i)).toBeInTheDocument();
+
+        await user.click(screen.getAllByRole("button", { name: /^revoke$/i })[1]);
+
+        await waitFor(() => {
+            expect(screen.getByText("Revoked")).toBeInTheDocument();
+        });
+        expect(screen.getByRole("button", { name: /rotate/i })).toBeDisabled();
+        expect(screen.getByRole("button", { name: /^revoke$/i })).toBeDisabled();
+    });
+});

--- a/src/components/admin/integrations/customer-push/CustomerPushTokenList.tsx
+++ b/src/components/admin/integrations/customer-push/CustomerPushTokenList.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { rotateCustomerPushToken, revokeCustomerPushToken } from "@/lib/admin/server";
+import { TokenRevealPanel } from "./TokenRevealPanel";
+import { TruncatedId } from "./TruncatedId";
+import { CTA_LABELS } from "@/lib/design/cta";
+import {
+    deriveTokenStatus,
+    TOKEN_STATUS_LABELS,
+    type CustomerPushTokenStatus,
+} from "@/lib/customer-push/token-status";
+import type { CustomerPushToken, CustomerPushTokenCreateResponse } from "@/lib/admin/types";
+
+type CustomerPushTokenListProps = {
+    tokens: CustomerPushToken[];
+    newTokenHref: string;
+    examplesHref: string;
+};
+
+const STATUS_STYLES: Record<CustomerPushTokenStatus, string> = {
+    active: "bg-green-100 text-green-700 border-green-200",
+    revoked: "bg-red-100 text-red-700 border-red-200",
+    expired: "bg-gray-100 text-gray-600 border-gray-200",
+    never_used: "bg-blue-100 text-blue-700 border-blue-200",
+};
+
+function TokenStatusBadge({ status }: { status: CustomerPushTokenStatus }) {
+    return (
+        <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${STATUS_STYLES[status]}`}
+        >
+            {TOKEN_STATUS_LABELS[status]}
+        </span>
+    );
+}
+
+function formatTimestamp(value: string | null) {
+    if (!value) return "—";
+    return new Date(value).toLocaleString();
+}
+
+function TokenRow({ token, examplesHref }: { token: CustomerPushToken; examplesHref: string }) {
+    const router = useRouter();
+    const [isRotating, startRotating] = useTransition();
+    const [isRevoking, startRevoking] = useTransition();
+    const [showRevokeConfirm, setShowRevokeConfirm] = useState(false);
+    const [rotated, setRotated] = useState<CustomerPushTokenCreateResponse | null>(null);
+    const [revoked, setRevoked] = useState(false);
+
+    const status = revoked ? "revoked" : deriveTokenStatus(token);
+    const isBusy = isRotating || isRevoking;
+
+    const handleRotate = () => {
+        startRotating(async () => {
+            const result = await rotateCustomerPushToken(token.id);
+            if (result.error) {
+                toast.error(result.error);
+            } else if (result.data) {
+                setRotated(result.data);
+                toast.success("Token rotated");
+            }
+        });
+    };
+
+    const handleRevoke = () => {
+        startRevoking(async () => {
+            const result = await revokeCustomerPushToken(token.id);
+            if (result.error) {
+                toast.error(result.error);
+            } else {
+                setRevoked(true);
+                setShowRevokeConfirm(false);
+                toast.success("Token revoked");
+            }
+        });
+    };
+
+    if (rotated) {
+        return (
+            <TokenRevealPanel
+                token={rotated.token}
+                name={rotated.name}
+                scopes={rotated.scopes}
+                examplesHref={examplesHref}
+                onDismiss={() => {
+                    setRotated(null);
+                    // Real backend hard-cutover (Design Decision 16): rotate
+                    // revokes this row and mints a NEW token id — refresh so
+                    // the list reflects the new row rather than staying on
+                    // the stale pre-rotation snapshot.
+                    router.refresh();
+                }}
+            />
+        );
+    }
+
+    return (
+        <div
+            data-testid={`token-row-${token.id}`}
+            className="flex flex-col gap-3 rounded-lg border border-(--border-subtle) bg-(--surface-base) p-4 sm:flex-row sm:items-center sm:justify-between"
+        >
+            <div>
+                <div className="flex items-center gap-2">
+                    <h3 className="text-sm font-semibold text-(--ink-base)">{token.name}</h3>
+                    <TokenStatusBadge status={status} />
+                </div>
+                <div className="mt-1 flex flex-wrap gap-1.5">
+                    {token.scopes.map((scope) => (
+                        <span
+                            key={scope}
+                            className="rounded-full bg-(--card-70) px-2 py-0.5 text-xs font-mono text-(--ink-muted)"
+                        >
+                            {scope}
+                        </span>
+                    ))}
+                </div>
+                <p className="mt-1.5 text-xs text-(--ink-muted)">
+                    Last used: {formatTimestamp(token.last_used_at)} · Created:{" "}
+                    {formatTimestamp(token.created_at)}
+                </p>
+                <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1">
+                    <span className="font-mono text-xs text-(--ink-muted)">
+                        {token.token_prefix}…
+                    </span>
+                    <TruncatedId value={token.id} label="Token ID" readOnly />
+                </div>
+            </div>
+            <div className="flex items-center gap-2">
+                <button
+                    type="button"
+                    onClick={handleRotate}
+                    disabled={isBusy || status === "revoked"}
+                    className="inline-flex items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-1.5 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted) disabled:opacity-50"
+                >
+                    {isRotating ? "Rotating..." : CTA_LABELS.rotate}
+                </button>
+                <button
+                    type="button"
+                    onClick={() => setShowRevokeConfirm(true)}
+                    disabled={isBusy || status === "revoked"}
+                    className="inline-flex items-center justify-center rounded-md border border-red-500/20 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-500/20 disabled:opacity-50"
+                >
+                    {CTA_LABELS.revoke}
+                </button>
+            </div>
+
+            {showRevokeConfirm && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+                    <div className="w-full max-w-md rounded-xl border border-(--card-stroke) bg-(--card) p-6 shadow-2xl">
+                        <h3 className="mb-4 text-lg font-semibold text-(--foreground)">
+                            Revoke credential
+                        </h3>
+                        <p className="mb-6 text-sm text-(--ink-muted)">
+                            Are you sure you want to revoke <strong>{token.name}</strong>? Any
+                            runner using this token will immediately lose access.
+                        </p>
+                        <div className="flex justify-end gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setShowRevokeConfirm(false)}
+                                disabled={isRevoking}
+                                className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm hover:bg-(--card-80) disabled:opacity-50"
+                            >
+                                {CTA_LABELS.cancel}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleRevoke}
+                                disabled={isRevoking}
+                                className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                            >
+                                {isRevoking ? "Revoking..." : CTA_LABELS.revoke}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function CustomerPushTokenList({
+    tokens,
+    newTokenHref,
+    examplesHref,
+}: CustomerPushTokenListProps) {
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center justify-between">
+                <h2 className="text-lg font-medium text-(--ink-base)">Credentials</h2>
+                <Link
+                    href={newTokenHref}
+                    className="inline-flex items-center justify-center rounded-md bg-(--surface-inverted) px-4 py-2 text-sm font-medium text-(--ink-inverted) hover:bg-(--surface-inverted)/90"
+                >
+                    {CTA_LABELS.createCredential}
+                </Link>
+            </div>
+
+            {tokens.length === 0 ? (
+                <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-(--border-subtle) bg-(--surface-base) py-12 text-center">
+                    <h3 className="mb-2 text-lg font-medium text-(--ink-base)">
+                        No credentials yet for this source
+                    </h3>
+                    <p className="mb-6 text-sm text-(--ink-muted)">
+                        Create an ingest credential so your CI/CD job or relay can push data.
+                    </p>
+                    <Link
+                        href={newTokenHref}
+                        className="inline-flex items-center justify-center rounded-md bg-(--surface-inverted) px-4 py-2 text-sm font-medium text-(--ink-inverted) hover:bg-(--surface-inverted)/90"
+                    >
+                        {CTA_LABELS.createCredential}
+                    </Link>
+                </div>
+            ) : (
+                <div className="space-y-3">
+                    {tokens.map((token) => (
+                        <TokenRow key={token.id} token={token} examplesHref={examplesHref} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/admin/integrations/customer-push/ModeCards.test.tsx
+++ b/src/components/admin/integrations/customer-push/ModeCards.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+import { ModeCards } from "./ModeCards";
+
+describe("ModeCards", () => {
+    it("renders both mode cards for a normal provider", () => {
+        render(
+            <ModeCards
+                provider="github"
+                providerName="GitHub"
+                showManagedSync
+                customerPushSourceCount={0}
+            />,
+        );
+        expect(screen.getByText("Managed sync")).toBeInTheDocument();
+        expect(screen.getByText("Customer push")).toBeInTheDocument();
+    });
+
+    it("omits the managed-sync card for the custom pseudo-provider (D3)", () => {
+        render(
+            <ModeCards
+                provider="custom"
+                providerName="Custom"
+                showManagedSync={false}
+                customerPushSourceCount={0}
+            />,
+        );
+        expect(screen.queryByText("Managed sync")).not.toBeInTheDocument();
+        expect(screen.getByText("Customer push")).toBeInTheDocument();
+    });
+
+    it("links the customer-push CTA to /new when there are no sources yet", () => {
+        render(
+            <ModeCards
+                provider="github"
+                providerName="GitHub"
+                showManagedSync
+                customerPushSourceCount={0}
+            />,
+        );
+        expect(screen.getByRole("link", { name: /set up customer push/i })).toHaveAttribute(
+            "href",
+            "/org/admin/integrations/github/customer-push/new",
+        );
+    });
+
+    it("scroll-anchors the customer-push CTA to the existing source list when sources exist", () => {
+        render(
+            <ModeCards
+                provider="github"
+                providerName="GitHub"
+                showManagedSync
+                customerPushSourceCount={2}
+            />,
+        );
+        expect(screen.getByRole("link", { name: /set up customer push/i })).toHaveAttribute(
+            "href",
+            "#customer-push-sources",
+        );
+    });
+});

--- a/src/components/admin/integrations/customer-push/ModeCards.tsx
+++ b/src/components/admin/integrations/customer-push/ModeCards.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { CTA_LABELS } from "@/lib/design/cta";
+
+type ModeCardsProps = {
+    provider: string;
+    providerName: string;
+    /** False for `custom` — there is no managed-sync equivalent (D3/D4). */
+    showManagedSync: boolean;
+    customerPushSourceCount: number;
+};
+
+/**
+ * Screen 1 mode-choice cards. Static/server-rendered — no client state.
+ * The managed-sync CTA scroll-anchors into the existing credentials section
+ * further down this same page (ProviderCredentialsList owns the actual
+ * add-connection flow); the customer-push CTA either starts a new source or
+ * scroll-anchors into the existing customer-push source list.
+ */
+export function ModeCards({
+    provider,
+    providerName,
+    showManagedSync,
+    customerPushSourceCount,
+}: ModeCardsProps) {
+    const customerPushHref =
+        customerPushSourceCount === 0
+            ? `/org/admin/integrations/${provider}/customer-push/new`
+            : "#customer-push-sources";
+
+    return (
+        <div className="mb-8 grid gap-6 md:grid-cols-2">
+            {showManagedSync && (
+                <div className="flex flex-col justify-between rounded-lg border border-(--border-subtle) bg-(--surface-base) p-6 shadow-sm">
+                    <div>
+                        <h3 className="text-lg font-semibold text-(--ink-base)">Managed sync</h3>
+                        <ul className="mt-3 space-y-1.5 text-sm text-(--ink-muted)">
+                            <li>FullChaos stores your {providerName} credentials.</li>
+                            <li>FullChaos schedules and runs {providerName} syncs.</li>
+                            <li>Best for fastest setup.</li>
+                        </ul>
+                    </div>
+                    <a
+                        href="#managed-sync-credentials"
+                        className="mt-6 inline-flex items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-base) px-4 py-2 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted)"
+                    >
+                        {CTA_LABELS.setUpManagedSync}
+                    </a>
+                </div>
+            )}
+
+            <div className="flex flex-col justify-between rounded-lg border border-(--border-subtle) bg-(--surface-base) p-6 shadow-sm">
+                <div>
+                    <div className="flex items-center gap-2">
+                        <h3 className="text-lg font-semibold text-(--ink-base)">Customer push</h3>
+                        <span className="rounded-full border border-(--border-subtle) px-2 py-0.5 text-xs font-medium text-(--ink-muted)">
+                            Webhook relay: Experimental
+                        </span>
+                    </div>
+                    <ul className="mt-3 space-y-1.5 text-sm text-(--ink-muted)">
+                        <li>You keep {providerName} credentials outside FullChaos.</li>
+                        <li>You send normalized data with an ingest token.</li>
+                        <li>Works from CI/CD, cron, ETL, or a webhook relay.</li>
+                        <li>Requires setting up a source, credential, and runner.</li>
+                    </ul>
+                </div>
+                <Link
+                    href={customerPushHref}
+                    className="mt-6 inline-flex items-center justify-center rounded-md bg-(--surface-inverted) px-4 py-2 text-sm font-medium text-(--ink-inverted) hover:bg-(--surface-inverted)/90"
+                >
+                    {CTA_LABELS.setUpCustomerPush}
+                </Link>
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/integrations/customer-push/RejectedRecordsTable.test.tsx
+++ b/src/components/admin/integrations/customer-push/RejectedRecordsTable.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+import { RejectedRecordsTable } from "./RejectedRecordsTable";
+
+describe("RejectedRecordsTable", () => {
+    it("renders a green empty state when there are no rejected records", () => {
+        const { container } = render(<RejectedRecordsTable records={[]} />);
+        expect(screen.getByText("No rejected records.")).toBeInTheDocument();
+        expect(container.querySelector(".text-green-600")).toBeInTheDocument();
+    });
+
+    it("renders index/kind/external_id/path/message columns for each record", () => {
+        render(
+            <RejectedRecordsTable
+                records={[
+                    {
+                        index: 12,
+                        kind: "pull_request.v1",
+                        external_id: "PR#88",
+                        code: "missing_external_id",
+                        path: "records[12].externalId",
+                        message: "externalId is required",
+                    },
+                ]}
+            />,
+        );
+        expect(screen.getByText("12")).toBeInTheDocument();
+        expect(screen.getByText("pull_request.v1")).toBeInTheDocument();
+        expect(screen.getByText("PR#88")).toBeInTheDocument();
+        expect(screen.getByText("missing_external_id")).toBeInTheDocument();
+        expect(screen.getByText("records[12].externalId")).toBeInTheDocument();
+        expect(screen.getByText("externalId is required")).toBeInTheDocument();
+    });
+
+    it("renders an em dash when external_id is null", () => {
+        render(
+            <RejectedRecordsTable
+                records={[
+                    {
+                        index: 1,
+                        kind: "work_item.v1",
+                        external_id: null,
+                        code: "unsupported_kind_for_system",
+                        path: "records[1].kind",
+                        message: "not supported",
+                    },
+                ]}
+            />,
+        );
+        expect(screen.getByText("—")).toBeInTheDocument();
+    });
+});

--- a/src/components/admin/integrations/customer-push/RejectedRecordsTable.tsx
+++ b/src/components/admin/integrations/customer-push/RejectedRecordsTable.tsx
@@ -1,0 +1,55 @@
+import type { CustomerPushRejectedRecord } from "@/lib/admin/types";
+
+type RejectedRecordsTableProps = {
+    records: CustomerPushRejectedRecord[];
+};
+
+const COLUMNS = ["Index", "Kind", "External ID", "Code", "Path", "Message"];
+
+export function RejectedRecordsTable({ records }: RejectedRecordsTableProps) {
+    if (records.length === 0) {
+        return (
+            <div className="rounded-xl border border-green-500/20 bg-green-500/5 p-6 text-center">
+                <p className="text-sm text-green-600">No rejected records.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="overflow-x-auto rounded-xl border border-(--card-stroke) bg-(--card-80)">
+            <table className="min-w-full divide-y divide-(--card-stroke)">
+                <thead className="bg-(--card-bg)">
+                    <tr>
+                        {COLUMNS.map((heading) => (
+                            <th
+                                key={heading}
+                                scope="col"
+                                className="px-4 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
+                            >
+                                {heading}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-(--card-stroke)">
+                    {records.map((record, i) => (
+                        <tr key={`${record.index}-${record.path}-${i}`}>
+                            <td className="px-4 py-3 text-sm text-(--ink-muted)">{record.index}</td>
+                            <td className="px-4 py-3 text-sm text-foreground">{record.kind}</td>
+                            <td className="px-4 py-3 font-mono text-xs text-(--ink-muted)">
+                                {record.external_id ?? "—"}
+                            </td>
+                            <td className="px-4 py-3 font-mono text-xs text-(--ink-muted)">
+                                {record.code}
+                            </td>
+                            <td className="px-4 py-3 font-mono text-xs text-(--ink-muted)">
+                                {record.path}
+                            </td>
+                            <td className="px-4 py-3 text-sm text-red-500">{record.message}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/src/components/admin/integrations/customer-push/SetupExamplesTabs.test.tsx
+++ b/src/components/admin/integrations/customer-push/SetupExamplesTabs.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "@/test/utils";
+import { SetupExamplesTabs } from "./SetupExamplesTabs";
+
+describe("SetupExamplesTabs", () => {
+    it("renders all 5 tabs and they are clickable", async () => {
+        const user = userEvent.setup();
+        render(<SetupExamplesTabs sourceSystem="github" sourceInstance="acme/api" />);
+
+        for (const label of [
+            "GitHub Actions",
+            "GitLab Runner",
+            "Generic Docker",
+            "cURL",
+            "Webhook relay",
+        ]) {
+            expect(screen.getByRole("button", { name: new RegExp(label) })).toBeInTheDocument();
+        }
+
+        await user.click(screen.getByRole("button", { name: /cURL/ }));
+        expect(screen.getByText(/\/api\/v1\/external-ingest\/batches/)).toBeInTheDocument();
+    });
+
+    it("shows the Experimental badge only on the webhook relay tab", () => {
+        render(<SetupExamplesTabs sourceSystem="github" sourceInstance="acme/api" />);
+        expect(screen.getByText("Experimental")).toBeInTheDocument();
+    });
+
+    it("copies the active tab's code to the clipboard", async () => {
+        const user = userEvent.setup();
+        const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+        render(<SetupExamplesTabs sourceSystem="github" sourceInstance="acme/api" />);
+        await user.click(screen.getByRole("button", { name: "Copy" }));
+        expect(writeText).toHaveBeenCalled();
+        expect(writeText.mock.calls[0][0]).toContain("dev-hops push export github");
+    });
+});

--- a/src/components/admin/integrations/customer-push/SetupExamplesTabs.tsx
+++ b/src/components/admin/integrations/customer-push/SetupExamplesTabs.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { buildExampleSnippets } from "@/lib/customer-push/examples";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { CustomerPushSystem } from "@/lib/admin/types";
+
+type SetupExamplesTabsProps = {
+    sourceSystem: CustomerPushSystem;
+    sourceInstance: string;
+};
+
+export function SetupExamplesTabs({ sourceSystem, sourceInstance }: SetupExamplesTabsProps) {
+    const tabs = useMemo(
+        () => buildExampleSnippets({ sourceSystem, sourceInstance }),
+        [sourceSystem, sourceInstance],
+    );
+    const [activeId, setActiveId] = useState(tabs[0].id);
+    const active = tabs.find((tab) => tab.id === activeId) ?? tabs[0];
+
+    const handleCopy = async () => {
+        if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(active.code);
+            toast.success("Copied to clipboard");
+        }
+    };
+
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-wrap gap-2 border-b border-(--card-stroke)">
+                {tabs.map((tab) => (
+                    <button
+                        key={tab.id}
+                        type="button"
+                        onClick={() => setActiveId(tab.id)}
+                        className={`inline-flex items-center gap-1.5 border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+                            tab.id === active.id
+                                ? "border-(--accent) text-foreground"
+                                : "border-transparent text-(--ink-muted) hover:text-foreground"
+                        }`}
+                    >
+                        {tab.label}
+                        {tab.badge && (
+                            <span className="rounded-full border border-(--border-subtle) px-1.5 py-0.5 text-xs font-medium text-(--ink-muted)">
+                                {tab.badge}
+                            </span>
+                        )}
+                    </button>
+                ))}
+            </div>
+
+            <div className="relative overflow-hidden rounded-xl border border-(--card-stroke) bg-(--card-80)">
+                <div className="flex items-center justify-between border-b border-(--card-stroke) px-4 py-2">
+                    <span className="text-xs text-(--ink-muted) uppercase tracking-wider">
+                        {active.language}
+                    </span>
+                    <button
+                        type="button"
+                        onClick={handleCopy}
+                        className="text-xs font-medium text-(--ink-muted) hover:text-foreground"
+                    >
+                        {CTA_LABELS.copy}
+                    </button>
+                </div>
+                <pre className="overflow-x-auto p-4 text-xs text-foreground">
+                    <code>{active.code}</code>
+                </pre>
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/integrations/customer-push/TokenRevealPanel.test.tsx
+++ b/src/components/admin/integrations/customer-push/TokenRevealPanel.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "@/test/utils";
+import { TokenRevealPanel } from "./TokenRevealPanel";
+
+describe("TokenRevealPanel", () => {
+    it("shows the plaintext token exactly once with the never-shown-again warning (D9)", () => {
+        render(
+            <TokenRevealPanel
+                token="fcpush_abc123"
+                name="CI runner"
+                scopes={["schema:read", "ingest:write"]}
+                examplesHref="/examples"
+                onDismiss={vi.fn()}
+            />,
+        );
+        expect(screen.getByText("fcpush_abc123")).toBeInTheDocument();
+        expect(screen.getByText(/will not show it again/i)).toBeInTheDocument();
+        expect(screen.getByText("schema:read")).toBeInTheDocument();
+        expect(screen.getByText("ingest:write")).toBeInTheDocument();
+    });
+
+    it("copies the token to the clipboard on click", async () => {
+        const user = userEvent.setup();
+        const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+        render(
+            <TokenRevealPanel
+                token="fcpush_abc123"
+                name="CI runner"
+                scopes={["schema:read"]}
+                examplesHref="/examples"
+                onDismiss={vi.fn()}
+            />,
+        );
+        await user.click(screen.getByRole("button", { name: "Copy" }));
+        expect(writeText).toHaveBeenCalledWith("fcpush_abc123");
+    });
+
+    it("calls onDismiss when Done is clicked", async () => {
+        const onDismiss = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <TokenRevealPanel
+                token="fcpush_abc123"
+                name="CI runner"
+                scopes={["schema:read"]}
+                examplesHref="/examples"
+                onDismiss={onDismiss}
+            />,
+        );
+        await user.click(screen.getByRole("button", { name: "Done" }));
+        expect(onDismiss).toHaveBeenCalledOnce();
+    });
+
+    it("never logs the token to the console", () => {
+        const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        render(
+            <TokenRevealPanel
+                token="fcpush_secret-value"
+                name="CI runner"
+                scopes={["schema:read"]}
+                examplesHref="/examples"
+                onDismiss={vi.fn()}
+            />,
+        );
+        const allLoggedArgs = [...consoleSpy.mock.calls, ...errorSpy.mock.calls].flat();
+        expect(allLoggedArgs.join(" ")).not.toContain("fcpush_secret-value");
+        consoleSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+});

--- a/src/components/admin/integrations/customer-push/TokenRevealPanel.tsx
+++ b/src/components/admin/integrations/customer-push/TokenRevealPanel.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { CustomerPushScope } from "@/lib/admin/types";
+
+type TokenRevealPanelProps = {
+    token: string;
+    name: string;
+    scopes: CustomerPushScope[];
+    examplesHref: string;
+    onDismiss: () => void;
+};
+
+/**
+ * One-time token reveal (CHAOS-2714 D9). `token` lives only in this
+ * component's props/local render tree — never written to
+ * localStorage/sessionStorage/the URL, and never passed whole into a
+ * console.* call or a toast that echoes full objects. Once the parent
+ * unmounts this panel (dismiss, navigation), React drops the value; there is
+ * no separate persistence to clear.
+ */
+export function TokenRevealPanel({
+    token,
+    name,
+    scopes,
+    examplesHref,
+    onDismiss,
+}: TokenRevealPanelProps) {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = async () => {
+        if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(token);
+            setCopied(true);
+            toast.success("Token copied");
+        }
+    };
+
+    return (
+        <div className="space-y-4 rounded-xl border border-amber-500/30 bg-amber-500/5 p-6">
+            <div>
+                <h3 className="text-base font-semibold text-(--ink-base)">
+                    {name} — token created
+                </h3>
+                <p className="mt-1 text-sm text-(--ink-muted)">
+                    Store this token in your CI/CD secret manager. FullChaos will not show it again.
+                </p>
+            </div>
+
+            <div className="flex items-center gap-2 rounded-md border border-(--border-subtle) bg-(--surface-base) p-3">
+                <code className="flex-1 overflow-x-auto font-mono text-sm text-(--ink-base)">
+                    {token}
+                </code>
+                <button
+                    type="button"
+                    onClick={handleCopy}
+                    className="shrink-0 rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-1.5 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted)"
+                >
+                    {copied ? "Copied" : "Copy"}
+                </button>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+                {scopes.map((scope) => (
+                    <span
+                        key={scope}
+                        className="rounded-full bg-(--card-70) px-3 py-1 text-xs font-medium text-foreground"
+                    >
+                        {scope}
+                    </span>
+                ))}
+            </div>
+
+            <div className="flex items-center gap-3">
+                <Link
+                    href={examplesHref}
+                    className="inline-flex items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-base) px-4 py-2 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted)"
+                >
+                    {CTA_LABELS.viewSetupExamples}
+                </Link>
+                <button
+                    type="button"
+                    onClick={onDismiss}
+                    className="inline-flex items-center justify-center rounded-md bg-(--surface-inverted) px-4 py-2 text-sm font-medium text-(--ink-inverted) hover:bg-(--surface-inverted)/90"
+                >
+                    {CTA_LABELS.done}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/integrations/customer-push/TruncatedId.test.tsx
+++ b/src/components/admin/integrations/customer-push/TruncatedId.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "@/test/utils";
+import { TruncatedId } from "./TruncatedId";
+
+describe("TruncatedId", () => {
+    it("renders a truncated value with the full id in the title attribute", () => {
+        render(<TruncatedId value="12345678-abcd-ef00-0000-000000000000" label="Source ID" />);
+        const span = screen.getByTitle("12345678-abcd-ef00-0000-000000000000");
+        expect(span).toHaveTextContent("12345678…");
+    });
+
+    it("copies the full value to the clipboard on click", async () => {
+        // user-event installs its own jsdom Clipboard stub on setup(); spy on
+        // its writeText rather than replacing navigator.clipboard ourselves.
+        const user = userEvent.setup();
+        const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+        render(<TruncatedId value="abcdefgh-1111" label="Source ID" />);
+        await user.click(screen.getByRole("button", { name: "Copy Source ID" }));
+        expect(writeText).toHaveBeenCalledWith("abcdefgh-1111");
+    });
+
+    it("omits the copy button in readOnly mode", () => {
+        render(<TruncatedId value="abcdefgh-1111" label="Ingestion ID" readOnly />);
+        expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+});

--- a/src/components/admin/integrations/customer-push/TruncatedId.tsx
+++ b/src/components/admin/integrations/customer-push/TruncatedId.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { toast } from "sonner";
+
+type TruncatedIdProps = {
+    value: string;
+    /** Accessible label, e.g. "Source ID", "Ingestion ID", "Token ID". */
+    label: string;
+    className?: string;
+    /** Omit the copy button — use inside an ancestor `<a>`/`<button>` where nesting interactive controls is invalid. */
+    readOnly?: boolean;
+};
+
+/**
+ * Renders a customer-push identifier (source_id/ingestion_id/token_id) as a
+ * truncated monospace value with the full id in a `title` attribute and a
+ * copy-to-clipboard action (CHAOS-2714 D10). These are not work-graph
+ * entities, so `resolveEntityLabel`/`EntityLabel` do not apply — there is no
+ * human-readable label to resolve, only the primary key the customer must
+ * correlate against their own CI logs.
+ */
+export function TruncatedId({ value, label, className, readOnly = false }: TruncatedIdProps) {
+    if (readOnly) {
+        return (
+            /* design-lint-disable-next-line no-raw-id-in-jsx -- source/ingestion/token identifiers are the primary key the customer must correlate against their own CI logs; no human label exists */
+            <span
+                title={value}
+                className={`font-mono text-xs text-(--ink-muted) ${className ?? ""}`.trim()}
+            >
+                {value.slice(0, 8)}…
+            </span>
+        );
+    }
+
+    const handleCopy = async () => {
+        if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(value);
+            toast.success(`${label} copied`);
+        }
+    };
+
+    return (
+        <span className={`inline-flex items-center gap-1.5 ${className ?? ""}`.trim()}>
+            {/* design-lint-disable-next-line no-raw-id-in-jsx -- source/ingestion/token identifiers are the primary key the customer must correlate against their own CI logs; no human label exists */}
+            <span title={value} className="font-mono text-xs text-(--ink-muted)">
+                {value.slice(0, 8)}…
+            </span>
+            <button
+                type="button"
+                onClick={handleCopy}
+                aria-label={`Copy ${label}`}
+                className="text-(--ink-muted) hover:text-foreground"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className="h-3.5 w-3.5"
+                    aria-hidden="true"
+                >
+                    <path d="M7 3.5A1.5 1.5 0 0 1 8.5 2h4A1.5 1.5 0 0 1 14 3.5v1h.5A1.5 1.5 0 0 1 16 6v9a1.5 1.5 0 0 1-1.5 1.5h-6A1.5 1.5 0 0 1 7 15V3.5Zm1.5-.5a.5.5 0 0 0-.5.5V15a.5.5 0 0 0 .5.5h6a.5.5 0 0 0 .5-.5V6a.5.5 0 0 0-.5-.5H14v7.5A1.5 1.5 0 0 1 12.5 14h-4a1.5 1.5 0 0 1-1.5-1.5v-9Z" />
+                    <path d="M4 5.5A1.5 1.5 0 0 1 5.5 4H6v9.5A1.5 1.5 0 0 0 7.5 15H12v.5a1.5 1.5 0 0 1-1.5 1.5h-6A1.5 1.5 0 0 1 3 15.5v-9A1.5 1.5 0 0 1 4.5 5H4Z" />
+                </svg>
+            </button>
+        </span>
+    );
+}

--- a/src/components/admin/integrations/customer-push/ValidatePayloadPanel.test.tsx
+++ b/src/components/admin/integrations/customer-push/ValidatePayloadPanel.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { fireEvent, render, screen, userEvent, waitFor } from "@/test/utils";
+
+const mockValidateCustomerPushPayload = vi.fn();
+vi.mock("@/lib/admin/server", () => ({
+    validateCustomerPushPayload: (...args: unknown[]) => mockValidateCustomerPushPayload(...args),
+}));
+
+import { ValidatePayloadPanel } from "./ValidatePayloadPanel";
+
+describe("ValidatePayloadPanel", () => {
+    afterEach(() => {
+        mockValidateCustomerPushPayload.mockReset();
+    });
+
+    it("never renders a Push/Push this payload CTA — validate-only in v1 (D6/CC25 overrule)", () => {
+        render(
+            <ValidatePayloadPanel
+                sourceId="cps-1"
+                sourceSystem="github"
+                sourceInstance="acme/api"
+            />,
+        );
+        expect(screen.queryByRole("button", { name: /push/i })).not.toBeInTheDocument();
+    });
+
+    it("renders the green valid state with accepted-record count", async () => {
+        mockValidateCustomerPushPayload.mockResolvedValue({
+            data: { valid: true, items_accepted: 3, items_rejected: 0, errors: [] },
+        });
+        const user = userEvent.setup();
+        render(
+            <ValidatePayloadPanel
+                sourceId="cps-1"
+                sourceSystem="github"
+                sourceInstance="acme/api"
+            />,
+        );
+        await user.click(screen.getByRole("button", { name: /use sample/i }));
+        await user.click(screen.getByRole("button", { name: /validate payload/i }));
+
+        expect(await screen.findByText(/payload is valid/i)).toBeInTheDocument();
+        expect(screen.getByText("No rejected records.")).toBeInTheDocument();
+    });
+
+    it("renders the rejected-record error table with index/kind/path/message on an invalid payload", async () => {
+        mockValidateCustomerPushPayload.mockResolvedValue({
+            data: {
+                valid: false,
+                items_accepted: 0,
+                items_rejected: 1,
+                errors: [
+                    {
+                        index: 0,
+                        kind: "repository.v1",
+                        external_id: null,
+                        code: "missing_required_field",
+                        path: "records[0].externalId",
+                        message: "externalId is required",
+                    },
+                ],
+            },
+        });
+        const user = userEvent.setup();
+        render(
+            <ValidatePayloadPanel
+                sourceId="cps-1"
+                sourceSystem="github"
+                sourceInstance="acme/api"
+            />,
+        );
+        await user.click(screen.getByRole("button", { name: /paste json/i }));
+        fireEvent.change(screen.getByPlaceholderText(/schemaVersion/), {
+            target: { value: '{"schemaVersion":"external-ingest.v1","records":[]}' },
+        });
+        await user.click(screen.getByRole("button", { name: /validate payload/i }));
+
+        expect(await screen.findByText(/record.*rejected/i)).toBeInTheDocument();
+        expect(screen.getByText("records[0].externalId")).toBeInTheDocument();
+        expect(screen.getByText("externalId is required")).toBeInTheDocument();
+    });
+
+    it("shows a JSON parse error distinct from an API/validation error", async () => {
+        const user = userEvent.setup();
+        render(
+            <ValidatePayloadPanel
+                sourceId="cps-1"
+                sourceSystem="github"
+                sourceInstance="acme/api"
+            />,
+        );
+        await user.click(screen.getByRole("button", { name: /paste json/i }));
+        fireEvent.change(screen.getByPlaceholderText(/schemaVersion/), {
+            target: { value: "{not valid json" },
+        });
+        await user.click(screen.getByRole("button", { name: /validate payload/i }));
+
+        expect(screen.getByText(/isn't valid json/i)).toBeInTheDocument();
+        expect(mockValidateCustomerPushPayload).not.toHaveBeenCalled();
+    });
+
+    it("distinguishes a network/API error from a schema-invalid (valid:false) result", async () => {
+        mockValidateCustomerPushPayload.mockResolvedValue({ error: "Network error" });
+        const user = userEvent.setup();
+        render(
+            <ValidatePayloadPanel
+                sourceId="cps-1"
+                sourceSystem="github"
+                sourceInstance="acme/api"
+            />,
+        );
+        await user.click(screen.getByRole("button", { name: /use sample/i }));
+        await user.click(screen.getByRole("button", { name: /validate payload/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/validation request failed/i)).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/admin/integrations/customer-push/ValidatePayloadPanel.tsx
+++ b/src/components/admin/integrations/customer-push/ValidatePayloadPanel.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { validateCustomerPushPayload } from "@/lib/admin/server";
+import { buildSamplePayload } from "@/lib/customer-push/sample-payload";
+import { RejectedRecordsTable } from "./RejectedRecordsTable";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { CustomerPushSystem, CustomerPushValidateResponse } from "@/lib/admin/types";
+
+type ValidatePayloadPanelProps = {
+    sourceId: string;
+    sourceSystem: CustomerPushSystem;
+    sourceInstance: string;
+};
+
+type Mode = "paste" | "upload" | "sample";
+
+/**
+ * Screen 5 — VALIDATE ONLY in v1. The console-push proxy
+ * (`POST .../sources/{id}/batches`, producer="web-console") was overruled
+ * post-critique (CC25 product decision): the ingestion write path stays
+ * exclusively token-authed. There is deliberately no "Push this payload" CTA
+ * here — only `POST .../sources/{id}/validate`.
+ */
+export function ValidatePayloadPanel({
+    sourceId,
+    sourceSystem,
+    sourceInstance,
+}: ValidatePayloadPanelProps) {
+    const [mode, setMode] = useState<Mode>("paste");
+    const [payloadText, setPayloadText] = useState("");
+    const [parseError, setParseError] = useState<string | null>(null);
+    const [apiError, setApiError] = useState<string | null>(null);
+    const [result, setResult] = useState<CustomerPushValidateResponse | null>(null);
+    const [isPending, startTransition] = useTransition();
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const resetOutcome = () => {
+        setParseError(null);
+        setApiError(null);
+        setResult(null);
+    };
+
+    const handleModeChange = (next: Mode) => {
+        setMode(next);
+        resetOutcome();
+        if (next === "sample") {
+            setPayloadText(
+                JSON.stringify(buildSamplePayload(sourceSystem, sourceInstance), null, 2),
+            );
+        } else if (next === "paste") {
+            setPayloadText("");
+        }
+    };
+
+    const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        const text = await file.text();
+        setPayloadText(text);
+        resetOutcome();
+    };
+
+    const handleValidate = () => {
+        resetOutcome();
+
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(payloadText);
+        } catch {
+            setParseError("This isn't valid JSON. Check for a trailing comma or unclosed brace.");
+            return;
+        }
+
+        startTransition(async () => {
+            const response = await validateCustomerPushPayload(sourceId, parsed);
+            if (response.error) {
+                setApiError(response.error);
+                return;
+            }
+            if (response.data) {
+                setResult(response.data);
+            }
+        });
+    };
+
+    return (
+        <div className="space-y-6">
+            <div className="flex flex-wrap gap-2 border-b border-(--card-stroke)">
+                {(["paste", "upload", "sample"] as Mode[]).map((m) => (
+                    <button
+                        key={m}
+                        type="button"
+                        onClick={() => handleModeChange(m)}
+                        className={`border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+                            mode === m
+                                ? "border-(--accent) text-foreground"
+                                : "border-transparent text-(--ink-muted) hover:text-foreground"
+                        }`}
+                    >
+                        {m === "paste"
+                            ? "Paste JSON"
+                            : m === "upload"
+                              ? "Upload file"
+                              : "Use sample"}
+                    </button>
+                ))}
+            </div>
+
+            {mode === "upload" && (
+                <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="application/json"
+                    onChange={handleFileUpload}
+                    className="block text-sm text-(--ink-muted)"
+                />
+            )}
+
+            <textarea
+                value={payloadText}
+                onChange={(e) => {
+                    setPayloadText(e.target.value);
+                    resetOutcome();
+                }}
+                rows={12}
+                placeholder='{"schemaVersion": "external-ingest.v1", "records": [...]}'
+                className="w-full rounded-md border border-(--border-subtle) bg-(--surface-base) p-3 font-mono text-xs text-(--ink-base) focus:border-(--accent) focus:outline-none"
+            />
+
+            {parseError && <p className="text-sm text-red-500">{parseError}</p>}
+
+            <div className="flex items-center gap-3">
+                <button
+                    type="button"
+                    onClick={handleValidate}
+                    disabled={isPending || payloadText.trim().length === 0}
+                    className="inline-flex items-center justify-center rounded-md bg-(--surface-inverted) px-4 py-2 text-sm font-medium text-(--ink-inverted) hover:bg-(--surface-inverted)/90 disabled:opacity-50"
+                >
+                    {isPending ? "Validating..." : CTA_LABELS.validatePayload}
+                </button>
+            </div>
+
+            {apiError && (
+                <div
+                    role="alert"
+                    className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500"
+                >
+                    Validation request failed: {apiError}
+                </div>
+            )}
+
+            {result && (
+                <div className="space-y-4">
+                    {result.valid ? (
+                        <div className="rounded-xl border border-green-500/20 bg-green-500/5 p-6">
+                            <p className="text-sm font-medium text-green-600">
+                                Payload is valid — {result.items_accepted} record
+                                {result.items_accepted === 1 ? "" : "s"} would be accepted.
+                            </p>
+                        </div>
+                    ) : (
+                        <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-6">
+                            <p className="text-sm font-medium text-red-600">
+                                {result.items_rejected} record
+                                {result.items_rejected === 1 ? "" : "s"} rejected,{" "}
+                                {result.items_accepted} would be accepted.
+                            </p>
+                        </div>
+                    )}
+                    <RejectedRecordsTable records={result.errors} />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/lib/admin/api.ts
+++ b/src/lib/admin/api.ts
@@ -14,11 +14,13 @@ import { retentionApi } from "./api/retention";
 import { llmSettingsApi } from "./api/llm-settings";
 import { platformApi, impersonationApi } from "./api/platform";
 import { setupApi } from "./api/setup";
+import { customerPushApi } from "./api/customer-push";
 
 export const adminApi = {
     settings: settingsApi,
     credentials: credentialsApi,
     syncConfigs: syncConfigsApi,
+    customerPush: customerPushApi,
     identities: identitiesApi,
     teams: teamsApi,
     users: usersApi,

--- a/src/lib/admin/api/__tests__/customer-push.test.ts
+++ b/src/lib/admin/api/__tests__/customer-push.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Contract tests: assert that customerPushApi calls request() with the
+ * correct backend paths, methods, and query-string shapes.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../_request", () => ({
+    request: vi.fn().mockResolvedValue({}),
+}));
+
+import { request } from "../_request";
+import { customerPushApi } from "../customer-push";
+
+const mockRequest = vi.mocked(request);
+
+beforeEach(() => {
+    mockRequest.mockClear();
+});
+
+describe("customerPushApi path contract", () => {
+    it("listSources never appends a system query string — the real endpoint has no server-side filter", async () => {
+        await customerPushApi.listSources();
+        expect(mockRequest.mock.calls[0][0]).toBe("/customer-push/sources");
+    });
+
+    it("createSource POSTs to /customer-push/sources", async () => {
+        await customerPushApi.createSource({
+            system: "github",
+            instance: "acme/api",
+            display_name: "Acme",
+        });
+        expect(mockRequest.mock.calls[0][0]).toBe("/customer-push/sources");
+        expect((mockRequest.mock.calls[0][1] as RequestInit).method).toBe("POST");
+    });
+
+    it("getSource/updateSource use /customer-push/sources/:id", async () => {
+        await customerPushApi.getSource("src-1");
+        expect(mockRequest.mock.calls[0][0]).toBe("/customer-push/sources/src-1");
+
+        await customerPushApi.updateSource("src-1", { enabled: false });
+        expect(mockRequest.mock.calls[1][0]).toBe("/customer-push/sources/src-1");
+        expect((mockRequest.mock.calls[1][1] as RequestInit).method).toBe("PATCH");
+    });
+
+    it("token endpoints use the pinned fcpush_-issuing routes", async () => {
+        await customerPushApi.listTokens("src-1");
+        expect(mockRequest.mock.calls[0][0]).toBe("/customer-push/sources/src-1/tokens");
+
+        await customerPushApi.createToken("src-1", {
+            name: "CI",
+            scopes: ["schema:read"],
+        });
+        expect(mockRequest.mock.calls[1][0]).toBe("/customer-push/sources/src-1/tokens");
+        expect((mockRequest.mock.calls[1][1] as RequestInit).method).toBe("POST");
+
+        await customerPushApi.rotateToken("tok-1");
+        expect(mockRequest.mock.calls[2][0]).toBe("/customer-push/tokens/tok-1/rotate");
+
+        await customerPushApi.revokeToken("tok-1");
+        expect(mockRequest.mock.calls[3][0]).toBe("/customer-push/tokens/tok-1/revoke");
+    });
+
+    it("listBatches builds the query string from only the provided filters", async () => {
+        await customerPushApi.listBatches("src-1", { status: "completed", producer: undefined });
+        expect(mockRequest.mock.calls[0][0]).toBe(
+            "/customer-push/sources/src-1/batches?status=completed",
+        );
+    });
+
+    it("listBatches omits the query string entirely when no filters are set", async () => {
+        await customerPushApi.listBatches("src-1", {});
+        expect(mockRequest.mock.calls[0][0]).toBe("/customer-push/sources/src-1/batches");
+    });
+
+    it("getBatch uses /customer-push/batches/:ingestion_id (not nested under sources)", async () => {
+        await customerPushApi.getBatch("batch-1");
+        expect(mockRequest.mock.calls[0][0]).toBe("/customer-push/batches/batch-1");
+    });
+
+    it("schemas endpoints are public-shaped reads", async () => {
+        await customerPushApi.listSchemas();
+        expect(mockRequest.mock.calls[0][0]).toBe("/customer-push/schemas");
+
+        await customerPushApi.getSchema("external-ingest.v1");
+        expect(mockRequest.mock.calls[1][0]).toBe("/customer-push/schemas/external-ingest.v1");
+    });
+
+    it("validate POSTs to /customer-push/sources/:id/validate", async () => {
+        await customerPushApi.validate("src-1", { records: [] });
+        expect(mockRequest.mock.calls[0][0]).toBe("/customer-push/sources/src-1/validate");
+        expect((mockRequest.mock.calls[0][1] as RequestInit).method).toBe("POST");
+    });
+
+    it("does not expose a console-push route (D6/CC25 overrule — validate-only in v1)", () => {
+        expect((customerPushApi as Record<string, unknown>).pushFromConsole).toBeUndefined();
+    });
+});

--- a/src/lib/admin/api/customer-push.ts
+++ b/src/lib/admin/api/customer-push.ts
@@ -1,0 +1,120 @@
+import { request } from "./_request";
+import type {
+    CustomerPushSource,
+    CustomerPushSourceCreate,
+    CustomerPushSourceUpdate,
+    CustomerPushToken,
+    CustomerPushTokenCreate,
+    CustomerPushTokenCreateResponse,
+    CustomerPushBatchDetail,
+    CustomerPushBatchListParams,
+    CustomerPushBatchListResponse,
+    CustomerPushValidateResponse,
+    CustomerPushSchemaListResponse,
+    CustomerPushSchemaDetailResponse,
+} from "../types";
+
+export const customerPushApi = {
+    /**
+     * GET /customer-push/sources has NO server-side system filter — it
+     * always returns every source for the org. Callers that need
+     * per-provider scoping must filter client-side (see
+     * server/customer-push.ts).
+     */
+    listSources: (token?: string, orgId?: string) =>
+        request<CustomerPushSource[]>("/customer-push/sources", {}, token, orgId),
+
+    createSource: (data: CustomerPushSourceCreate, token?: string, orgId?: string) =>
+        request<CustomerPushSource>(
+            "/customer-push/sources",
+            { method: "POST", body: JSON.stringify(data) },
+            token,
+            orgId,
+        ),
+
+    getSource: (sourceId: string, token?: string, orgId?: string) =>
+        request<CustomerPushSource>(`/customer-push/sources/${sourceId}`, {}, token, orgId),
+
+    updateSource: (
+        sourceId: string,
+        data: CustomerPushSourceUpdate,
+        token?: string,
+        orgId?: string,
+    ) =>
+        request<CustomerPushSource>(
+            `/customer-push/sources/${sourceId}`,
+            { method: "PATCH", body: JSON.stringify(data) },
+            token,
+            orgId,
+        ),
+
+    listTokens: (sourceId: string, token?: string, orgId?: string) =>
+        request<CustomerPushToken[]>(`/customer-push/sources/${sourceId}/tokens`, {}, token, orgId),
+
+    createToken: (
+        sourceId: string,
+        data: CustomerPushTokenCreate,
+        token?: string,
+        orgId?: string,
+    ) =>
+        request<CustomerPushTokenCreateResponse>(
+            `/customer-push/sources/${sourceId}/tokens`,
+            { method: "POST", body: JSON.stringify(data) },
+            token,
+            orgId,
+        ),
+
+    rotateToken: (tokenId: string, token?: string, orgId?: string) =>
+        request<CustomerPushTokenCreateResponse>(
+            `/customer-push/tokens/${tokenId}/rotate`,
+            { method: "POST" },
+            token,
+            orgId,
+        ),
+
+    revokeToken: (tokenId: string, token?: string, orgId?: string) =>
+        request<CustomerPushToken>(
+            `/customer-push/tokens/${tokenId}/revoke`,
+            { method: "POST" },
+            token,
+            orgId,
+        ),
+
+    listBatches: (
+        sourceId: string,
+        params: CustomerPushBatchListParams,
+        token?: string,
+        orgId?: string,
+    ) => {
+        const entries = Object.entries(params).filter(([, v]) => v !== undefined && v !== "");
+        const qs = new URLSearchParams(entries as [string, string][]).toString();
+        return request<CustomerPushBatchListResponse>(
+            `/customer-push/sources/${sourceId}/batches${qs ? `?${qs}` : ""}`,
+            {},
+            token,
+            orgId,
+        );
+    },
+
+    getBatch: (ingestionId: string, token?: string, orgId?: string) =>
+        request<CustomerPushBatchDetail>(`/customer-push/batches/${ingestionId}`, {}, token, orgId),
+
+    listSchemas: (token?: string, orgId?: string) =>
+        request<CustomerPushSchemaListResponse>("/customer-push/schemas", {}, token, orgId),
+
+    getSchema: (version: string, token?: string, orgId?: string) =>
+        request<CustomerPushSchemaDetailResponse>(
+            `/customer-push/schemas/${encodeURIComponent(version)}`,
+            {},
+            token,
+            orgId,
+        ),
+
+    validate: (sourceId: string, envelope: unknown, token?: string, orgId?: string) =>
+        request<CustomerPushValidateResponse>(
+            `/customer-push/sources/${sourceId}/validate`,
+            { method: "POST", body: JSON.stringify(envelope) },
+            token,
+            orgId,
+        ),
+};

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -9,3 +9,4 @@ export * from "./server/settings";
 export * from "./server/orgs";
 export * from "./server/billing";
 export * from "./server/setup";
+export * from "./server/customer-push";

--- a/src/lib/admin/server/customer-push.ts
+++ b/src/lib/admin/server/customer-push.ts
@@ -1,0 +1,157 @@
+"use server";
+
+import { adminApi } from "../api";
+import { revalidatePath } from "next/cache";
+import type { ActionResult } from "@/lib/result";
+import type {
+    CustomerPushSource,
+    CustomerPushSourceCreate,
+    CustomerPushSourceUpdate,
+    CustomerPushToken,
+    CustomerPushTokenCreate,
+    CustomerPushTokenCreateResponse,
+    CustomerPushBatchDetail,
+    CustomerPushBatchListParams,
+    CustomerPushBatchListResponse,
+    CustomerPushValidateResponse,
+    CustomerPushSchemaListResponse,
+    CustomerPushSchemaDetailResponse,
+} from "../types";
+import { getSessionContext, withErrorHandling } from "./_shared";
+
+/**
+ * GET /customer-push/sources has no server-side system filter (see
+ * api/customer-push.ts) — filter client-side here so every caller gets a
+ * correctly per-provider-scoped list without repeating the filter.
+ */
+export async function listCustomerPushSources(
+    system?: string,
+): Promise<ActionResult<CustomerPushSource[]>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        const sources = await adminApi.customerPush.listSources(token, orgId);
+        return system ? sources.filter((s) => s.system === system) : sources;
+    });
+}
+
+export async function createCustomerPushSource(
+    data: CustomerPushSourceCreate,
+): Promise<ActionResult<CustomerPushSource>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        const result = await adminApi.customerPush.createSource(data, token, orgId);
+        revalidatePath("/org/admin/integrations", "page");
+        return result;
+    });
+}
+
+export async function getCustomerPushSource(
+    sourceId: string,
+): Promise<ActionResult<CustomerPushSource>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.customerPush.getSource(sourceId, token, orgId);
+    });
+}
+
+export async function updateCustomerPushSource(
+    sourceId: string,
+    data: CustomerPushSourceUpdate,
+): Promise<ActionResult<CustomerPushSource>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        const result = await adminApi.customerPush.updateSource(sourceId, data, token, orgId);
+        revalidatePath("/org/admin/integrations", "page");
+        return result;
+    });
+}
+
+export async function listCustomerPushTokens(
+    sourceId: string,
+): Promise<ActionResult<CustomerPushToken[]>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.customerPush.listTokens(sourceId, token, orgId);
+    });
+}
+
+export async function createCustomerPushToken(
+    sourceId: string,
+    data: CustomerPushTokenCreate,
+): Promise<ActionResult<CustomerPushTokenCreateResponse>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        const result = await adminApi.customerPush.createToken(sourceId, data, token, orgId);
+        revalidatePath("/org/admin/integrations", "page");
+        return result;
+    });
+}
+
+export async function rotateCustomerPushToken(
+    tokenId: string,
+): Promise<ActionResult<CustomerPushTokenCreateResponse>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        const result = await adminApi.customerPush.rotateToken(tokenId, token, orgId);
+        revalidatePath("/org/admin/integrations", "page");
+        return result;
+    });
+}
+
+export async function revokeCustomerPushToken(
+    tokenId: string,
+): Promise<ActionResult<CustomerPushToken>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        const result = await adminApi.customerPush.revokeToken(tokenId, token, orgId);
+        revalidatePath("/org/admin/integrations", "page");
+        return result;
+    });
+}
+
+export async function listCustomerPushBatches(
+    sourceId: string,
+    params: CustomerPushBatchListParams = {},
+): Promise<ActionResult<CustomerPushBatchListResponse>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.customerPush.listBatches(sourceId, params, token, orgId);
+    });
+}
+
+export async function getCustomerPushBatch(
+    ingestionId: string,
+): Promise<ActionResult<CustomerPushBatchDetail>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.customerPush.getBatch(ingestionId, token, orgId);
+    });
+}
+
+export async function listCustomerPushSchemas(): Promise<
+    ActionResult<CustomerPushSchemaListResponse>
+> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.customerPush.listSchemas(token, orgId);
+    });
+}
+
+export async function getCustomerPushSchema(
+    version: string,
+): Promise<ActionResult<CustomerPushSchemaDetailResponse>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.customerPush.getSchema(version, token, orgId);
+    });
+}
+
+export async function validateCustomerPushPayload(
+    sourceId: string,
+    envelope: unknown,
+): Promise<ActionResult<CustomerPushValidateResponse>> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.customerPush.validate(sourceId, envelope, token, orgId);
+    });
+}

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -802,3 +802,205 @@ export interface DeletionPlan {
     credentialDeletionCount: number;
     warnings: string[];
 }
+
+// ---- Customer Push (CHAOS-2690/2714) ----
+//
+// Mirrors dev-health-ops/api/admin/routers/customer_push.py and
+// api/admin/schemas/customer_push.py EXACTLY — verified 2026-07-02 against
+// the real router/schema source in the ops chaos-2690-integration branch
+// (CHAOS-2696/2712/2694 are merged there), not just the design-doc sketch.
+// Real-backend corrections vs. the earlier design-doc-only draft of this
+// section:
+//   - source rows use `id`, not `source_id`; there is NO
+//     `conflicting_managed_sync` boolean — the backend returns
+//     `matched_integration_source_id` (the CC5-matched managed source, if
+//     any) plus a `warnings` string array to render verbatim.
+//   - `GET /customer-push/sources` has NO server-side `?system=` filter —
+//     it always returns every source for the org; filter client-side.
+//   - token rows carry `token_prefix` (always present) and NO
+//     `status`/`last_result` field — status is derived client-side from
+//     revoked_at/expires_at/last_used_at, see
+//     src/lib/customer-push/token-status.ts. Token prefix is `fcpush_`.
+//   - `POST .../tokens` request body has no `source_id` — it's implied by
+//     the URL (`/sources/{id}/tokens` vs. the org-wide `/tokens`).
+//   - batch LIST items (`GET .../sources/{id}/batches`) are wrapped in a
+//     paginated envelope `{items, total, limit, offset}`, NOT a bare array,
+//     and carry `source_system`/`source_instance` (no `source_id`,
+//     `producer_version`, or window_started_at/ended_at — those only exist
+//     on the single-batch detail response).
+//   - batch DETAIL (`GET .../batches/{id}`) additionally carries `attempts`,
+//     `updated_at`, and `rejected_records_total/limit/offset` (the rejected-
+//     records sub-list is itself paginated, default limit 50). It has NO
+//     `recompute_status` field yet in this branch — CHAOS-2699 adds that in
+//     wave 3; treat it as optional until then.
+//   - `error_summary.top_codes` is an array of `{code, count}` sorted
+//     descending by count, NOT a `Record<string, number>`.
+//   - `GET .../schemas` returns `{schemaVersions, recordKinds, limits}`
+//     (camelCase — a pass-through of the data-plane schema shape), not a
+//     `schemas: [...]` list of per-version entries.
+
+export type CustomerPushSystem = Provider | "custom";
+export type CustomerPushMode = "fullchaos_sync" | "customer_push" | "disabled";
+export type CustomerPushWebhookMode = "disabled" | "customer_relay" | "fullchaos_hosted";
+export type CustomerPushBatchStatus =
+    "accepted" | "stream_unavailable" | "processing" | "completed" | "partial" | "failed";
+export type CustomerPushScope = "schema:read" | "ingest:write" | "ingest:status";
+export type CustomerPushRecomputeStatus =
+    "not_applicable" | "pending" | "dispatched" | "skipped_no_scope" | "failed";
+
+export interface CustomerPushSource {
+    id: string;
+    org_id: string;
+    system: CustomerPushSystem;
+    instance: string;
+    display_name: string | null;
+    mode: CustomerPushMode;
+    enabled: boolean;
+    webhook_mode: CustomerPushWebhookMode;
+    /** CC5-matched managed-sync source id, whether or not it's actively enabled. */
+    matched_integration_source_id: string | null;
+    /** Non-blocking, backend-authored warning copy — render verbatim. */
+    warnings: string[];
+    created_at: string;
+    updated_at: string;
+}
+
+export interface CustomerPushSourceCreate {
+    system: CustomerPushSystem;
+    instance: string;
+    display_name?: string;
+}
+
+export interface CustomerPushSourceUpdate {
+    enabled?: boolean;
+    display_name?: string;
+}
+
+/** List/detail item — never includes the plaintext token. */
+export interface CustomerPushToken {
+    id: string;
+    org_id: string;
+    name: string;
+    source_id: string | null;
+    token_prefix: string;
+    scopes: CustomerPushScope[];
+    last_used_at: string | null;
+    expires_at: string | null;
+    revoked_at: string | null;
+    created_at: string;
+}
+
+export interface CustomerPushTokenCreate {
+    name: string;
+    scopes: CustomerPushScope[];
+    expires_at?: string | null;
+}
+
+/** Create/rotate response only — the plaintext token is shown exactly once. */
+export interface CustomerPushTokenCreateResponse {
+    id: string;
+    org_id: string;
+    token: string;
+    token_prefix: string;
+    name: string;
+    source_id: string | null;
+    scopes: CustomerPushScope[];
+    expires_at: string | null;
+    created_at: string;
+}
+
+/** GET .../sources/{id}/batches list item — a deliberately thinner shape than the detail response. */
+export interface CustomerPushBatchSummary {
+    ingestion_id: string;
+    source_system: CustomerPushSystem;
+    source_instance: string;
+    producer: string | null;
+    status: CustomerPushBatchStatus;
+    items_received: number;
+    items_accepted: number;
+    items_rejected: number;
+    created_at: string;
+    completed_at: string | null;
+}
+
+export interface CustomerPushBatchListResponse {
+    items: CustomerPushBatchSummary[];
+    total: number;
+    limit: number;
+    offset: number;
+}
+
+export interface CustomerPushRejectedRecord {
+    index: number;
+    kind: string;
+    external_id: string | null;
+    code: string;
+    path: string | null;
+    message: string;
+}
+
+export interface CustomerPushErrorSummary {
+    total_rejected: number;
+    stored_rejections: number;
+    truncated: boolean;
+    top_codes: Array<{ code: string; count: number }>;
+}
+
+export interface CustomerPushBatchDetail {
+    ingestion_id: string;
+    org_id: string;
+    status: CustomerPushBatchStatus;
+    attempts: number;
+    source_system: CustomerPushSystem;
+    source_instance: string;
+    producer: string | null;
+    producer_version: string | null;
+    schema_version: string;
+    window_started_at: string | null;
+    window_ended_at: string | null;
+    items_received: number;
+    items_accepted: number;
+    items_rejected: number;
+    record_counts: Record<string, number> | null;
+    error_summary: CustomerPushErrorSummary | null;
+    created_at: string;
+    updated_at: string;
+    completed_at: string | null;
+    rejected_records: CustomerPushRejectedRecord[];
+    rejected_records_total: number;
+    rejected_records_limit: number;
+    rejected_records_offset: number;
+    /** Not surfaced by this branch's status.py yet — CHAOS-2699 (wave 3) adds it. */
+    recompute_status?: CustomerPushRecomputeStatus;
+}
+
+export interface CustomerPushValidateResponse {
+    valid: boolean;
+    items_accepted: number;
+    items_rejected: number;
+    errors: CustomerPushRejectedRecord[];
+}
+
+/** GET .../schemas — camelCase pass-through of the data-plane schema shape. */
+export interface CustomerPushSchemaListResponse {
+    schemaVersions: string[];
+    recordKinds: string[];
+    limits: { maxRecordsPerBatch: number; maxBodyBytes: number };
+}
+
+/** GET .../schemas/{version} — camelCase pass-through, JSON-Schema bodies. */
+export interface CustomerPushSchemaDetailResponse {
+    schemaVersion: string;
+    envelope: Record<string, unknown>;
+    recordKinds: Record<string, Record<string, unknown>>;
+    limits: { maxRecordsPerBatch: number; maxBodyBytes: number };
+}
+
+export interface CustomerPushBatchListParams {
+    status?: CustomerPushBatchStatus;
+    producer?: string;
+    from?: string;
+    to?: string;
+    limit?: number;
+    offset?: number;
+}

--- a/src/lib/customer-push/__tests__/examples.test.ts
+++ b/src/lib/customer-push/__tests__/examples.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { buildExampleSnippets } from "../examples";
+
+describe("buildExampleSnippets", () => {
+    const args = {
+        sourceSystem: "github" as const,
+        sourceInstance: "acme/api",
+    };
+
+    it("returns all 5 tabs in the documented order", () => {
+        const tabs = buildExampleSnippets(args);
+        expect(tabs.map((t) => t.id)).toEqual([
+            "github-actions",
+            "gitlab-runner",
+            "docker",
+            "curl",
+            "webhook-relay",
+        ]);
+    });
+
+    it("the cURL tab contains the real external-ingest batches path — regression guard against pointing at the admin proxy", () => {
+        const tabs = buildExampleSnippets(args);
+        const curl = tabs.find((t) => t.id === "curl");
+        expect(curl?.code).toContain("/api/v1/external-ingest/batches");
+        expect(curl?.code).not.toContain("/api/v1/admin/customer-push");
+    });
+
+    it("marks only the webhook relay tab Experimental", () => {
+        const tabs = buildExampleSnippets(args);
+        const badges = Object.fromEntries(tabs.map((t) => [t.id, t.badge]));
+        expect(badges["webhook-relay"]).toBe("Experimental");
+        expect(badges["github-actions"]).toBeUndefined();
+        expect(badges["curl"]).toBeUndefined();
+    });
+
+    it("interpolates the source system and instance into every snippet", () => {
+        const tabs = buildExampleSnippets({ sourceSystem: "gitlab", sourceInstance: "group/proj" });
+        for (const tab of tabs) {
+            expect(tab.code).toContain("gitlab");
+        }
+    });
+
+    it("uses --repo for github and --project for gitlab in the export command", () => {
+        const githubTabs = buildExampleSnippets({ sourceSystem: "github", sourceInstance: "a/b" });
+        const gitlabTabs = buildExampleSnippets({ sourceSystem: "gitlab", sourceInstance: "a/b" });
+        expect(githubTabs.find((t) => t.id === "github-actions")?.code).toContain(
+            '--repo "$GITHUB_REPOSITORY"',
+        );
+        expect(gitlabTabs.find((t) => t.id === "gitlab-runner")?.code).toContain(
+            '--project "$CI_PROJECT_PATH"',
+        );
+    });
+});

--- a/src/lib/customer-push/__tests__/producer.test.ts
+++ b/src/lib/customer-push/__tests__/producer.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { classifyProducer, isTerminalCustomerPushStatus } from "../producer";
+
+describe("classifyProducer", () => {
+    it("classifies dev-hops CLI producers", () => {
+        expect(classifyProducer("dev-hops-cli")).toBe("cli");
+        expect(classifyProducer("dev-hops")).toBe("cli");
+    });
+
+    it("classifies CI producers", () => {
+        expect(classifyProducer("github-actions")).toBe("ci");
+        expect(classifyProducer("gitlab-ci")).toBe("ci");
+        expect(classifyProducer("acme.ci.runner")).toBe("ci");
+    });
+
+    it("classifies relay producers", () => {
+        expect(classifyProducer("customer-relay")).toBe("relay");
+    });
+
+    it("falls through unrecognized producers — including the cut web-console leg — to api", () => {
+        expect(classifyProducer("web-console")).toBe("api");
+        expect(classifyProducer("some-custom-etl")).toBe("api");
+    });
+
+    it("is case-insensitive", () => {
+        expect(classifyProducer("DEV-HOPS-CLI")).toBe("cli");
+    });
+});
+
+describe("isTerminalCustomerPushStatus", () => {
+    it("treats completed, partial, and failed as terminal", () => {
+        expect(isTerminalCustomerPushStatus("completed")).toBe(true);
+        expect(isTerminalCustomerPushStatus("partial")).toBe(true);
+        expect(isTerminalCustomerPushStatus("failed")).toBe(true);
+    });
+
+    it("treats accepted, stream_unavailable, and processing as non-terminal", () => {
+        expect(isTerminalCustomerPushStatus("accepted")).toBe(false);
+        expect(isTerminalCustomerPushStatus("stream_unavailable")).toBe(false);
+        expect(isTerminalCustomerPushStatus("processing")).toBe(false);
+    });
+});

--- a/src/lib/customer-push/__tests__/sample-payload.test.ts
+++ b/src/lib/customer-push/__tests__/sample-payload.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { buildSamplePayload } from "../sample-payload";
+
+describe("buildSamplePayload", () => {
+    it("builds a git-family repository record for github/gitlab/custom", () => {
+        for (const system of ["github", "gitlab", "custom"] as const) {
+            const payload = buildSamplePayload(system, "acme/api") as {
+                schemaVersion: string;
+                records: Array<{ kind: string; externalId: string; payload: unknown }>;
+            };
+            expect(payload.schemaVersion).toBe("external-ingest.v1");
+            expect(payload.records).toHaveLength(1);
+            expect(payload.records[0].kind).toBe("repository.v1");
+            expect(payload.records[0].externalId).toBe("acme/api");
+        }
+    });
+
+    it("builds a work_item record for jira/linear", () => {
+        for (const system of ["jira", "linear"] as const) {
+            const payload = buildSamplePayload(system, "CHAOS") as {
+                records: Array<{ kind: string; externalId: string }>;
+            };
+            expect(payload.records).toHaveLength(1);
+            expect(payload.records[0].kind).toBe("work_item.v1");
+            expect(payload.records[0].externalId).toBe("CHAOS-1");
+        }
+    });
+
+    it("stamps the source system and instance onto the envelope", () => {
+        const payload = buildSamplePayload("github", "acme/api") as {
+            source: { system: string; instance: string; type: string };
+        };
+        expect(payload.source.system).toBe("github");
+        expect(payload.source.instance).toBe("acme/api");
+        expect(payload.source.type).toBe("customer_push");
+    });
+
+    it("every record carries a non-empty externalId (required by the validate mock/backend)", () => {
+        const payload = buildSamplePayload("github", "acme/api") as {
+            records: Array<{ externalId: string }>;
+        };
+        for (const record of payload.records) {
+            expect(record.externalId).toBeTruthy();
+        }
+    });
+});

--- a/src/lib/customer-push/__tests__/token-status.test.ts
+++ b/src/lib/customer-push/__tests__/token-status.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { deriveTokenStatus } from "../token-status";
+
+describe("deriveTokenStatus", () => {
+    it("revoked takes precedence over everything else", () => {
+        expect(
+            deriveTokenStatus({
+                revoked_at: "2026-01-01T00:00:00.000Z",
+                expires_at: null,
+                last_used_at: "2026-01-01T00:00:00.000Z",
+            }),
+        ).toBe("revoked");
+    });
+
+    it("expired when expires_at is in the past and not revoked", () => {
+        expect(
+            deriveTokenStatus({
+                revoked_at: null,
+                expires_at: "2000-01-01T00:00:00.000Z",
+                last_used_at: "2001-01-01T00:00:00.000Z",
+            }),
+        ).toBe("expired");
+    });
+
+    it("never_used when last_used_at is null and not revoked/expired", () => {
+        expect(deriveTokenStatus({ revoked_at: null, expires_at: null, last_used_at: null })).toBe(
+            "never_used",
+        );
+    });
+
+    it("active when used, not revoked, and not expired", () => {
+        expect(
+            deriveTokenStatus({
+                revoked_at: null,
+                expires_at: null,
+                last_used_at: "2026-01-01T00:00:00.000Z",
+            }),
+        ).toBe("active");
+    });
+
+    it("a future expires_at does not mark the token expired", () => {
+        const future = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+        expect(
+            deriveTokenStatus({
+                revoked_at: null,
+                expires_at: future,
+                last_used_at: "2026-01-01T00:00:00.000Z",
+            }),
+        ).toBe("active");
+    });
+});

--- a/src/lib/customer-push/examples.ts
+++ b/src/lib/customer-push/examples.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure content builder for the runner-setup examples screen (Screen 4).
+ * Snippets are reused verbatim from docs/customer-push-ingestion-setup-design.md
+ * so the in-product tabs stay byte-identical to CHAOS-2713's eventual docs.
+ *
+ * The `dev-hops push` CLI (CHAOS-2700) does not exist yet as of this writing
+ * (its flags here are illustrative, matching the design doc). Re-verify the
+ * literal flag names against CHAOS-2700's implementation before treating
+ * these as ground truth for customer-facing docs.
+ */
+
+import type { CustomerPushSystem } from "@/lib/admin/types";
+
+export interface ExampleTab {
+    id: string;
+    label: string;
+    language: "yaml" | "bash";
+    code: string;
+    badge?: "Experimental";
+}
+
+export interface BuildExampleSnippetsArgs {
+    apiUrl?: string;
+    sourceSystem: CustomerPushSystem;
+    sourceInstance: string;
+    tokenPlaceholder?: string;
+}
+
+/** `dev-hops push export` flag used to scope the export to one instance, per source system. */
+function exportInstanceFlag(sourceSystem: CustomerPushSystem, sourceInstance: string): string {
+    switch (sourceSystem) {
+        case "github":
+            return '--repo "$GITHUB_REPOSITORY"';
+        case "gitlab":
+            return '--project "$CI_PROJECT_PATH"';
+        default:
+            return `--instance "${sourceInstance}"`;
+    }
+}
+
+export function buildExampleSnippets({
+    apiUrl = "$FULLCHAOS_API_URL",
+    sourceSystem,
+    sourceInstance,
+    tokenPlaceholder = "$FULLCHAOS_INGEST_TOKEN",
+}: BuildExampleSnippetsArgs): ExampleTab[] {
+    const instanceComment = `# Source: ${sourceSystem} — ${sourceInstance}`;
+
+    const githubActions: ExampleTab = {
+        id: "github-actions",
+        label: "GitHub Actions",
+        language: "yaml",
+        code: `${instanceComment}
+name: Push Dev Health Data
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+jobs:
+  push-dev-health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate payload
+        run: dev-hops push export ${sourceSystem} ${exportInstanceFlag(sourceSystem, sourceInstance)} --since "$SINCE" --until "$UNTIL" > payload.json
+      - name: Validate payload
+        run: dev-hops push validate payload.json --schema external-ingest.v1
+      - name: Push payload
+        run: dev-hops push batch payload.json --api-url "$FULLCHAOS_API_URL" --token "$FULLCHAOS_INGEST_TOKEN" --org "$FULLCHAOS_ORG_ID" --poll
+        env:
+          FULLCHAOS_API_URL: ${apiUrl}
+          FULLCHAOS_ORG_ID: \${{ vars.FULLCHAOS_ORG_ID }}
+          FULLCHAOS_INGEST_TOKEN: \${{ secrets.FULLCHAOS_INGEST_TOKEN }}`,
+    };
+
+    const gitlabRunner: ExampleTab = {
+        id: "gitlab-runner",
+        label: "GitLab Runner",
+        language: "yaml",
+        code: `${instanceComment}
+push_dev_health:
+  image: ghcr.io/full-chaos/dev-hops:latest
+  script:
+    - dev-hops push export ${sourceSystem} ${exportInstanceFlag(sourceSystem, sourceInstance)} --since "$SINCE" --until "$UNTIL" > payload.json
+    - dev-hops push validate payload.json --schema external-ingest.v1
+    - dev-hops push batch payload.json --api-url "$FULLCHAOS_API_URL" --token "$FULLCHAOS_INGEST_TOKEN" --org "$FULLCHAOS_ORG_ID" --poll
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"`,
+    };
+
+    const docker: ExampleTab = {
+        id: "docker",
+        label: "Generic Docker",
+        language: "bash",
+        code: `${instanceComment}
+docker run --rm \\
+  -e FULLCHAOS_API_URL="${apiUrl}" \\
+  -e FULLCHAOS_ORG_ID="$FULLCHAOS_ORG_ID" \\
+  -e FULLCHAOS_INGEST_TOKEN="${tokenPlaceholder}" \\
+  ghcr.io/full-chaos/dev-hops:latest \\
+  push export ${sourceSystem} ${exportInstanceFlag(sourceSystem, sourceInstance)} --since "$SINCE" --until "$UNTIL" \\
+  | dev-hops push batch - --api-url "$FULLCHAOS_API_URL" --token "$FULLCHAOS_INGEST_TOKEN" --org "$FULLCHAOS_ORG_ID" --poll
+
+# Cron/systemd-timer equivalent: run the same command on a schedule (e.g. every 30 minutes).`,
+    };
+
+    const curl: ExampleTab = {
+        id: "curl",
+        label: "cURL",
+        language: "bash",
+        code: `${instanceComment}
+curl -sS -X POST "${apiUrl}/api/v1/external-ingest/batches" \\
+  -H "Authorization: Bearer ${tokenPlaceholder}" \\
+  -H "Content-Type: application/json" \\
+  -H "Idempotency-Key: $IDEMPOTENCY_KEY" \\
+  --data-binary @payload.json`,
+    };
+
+    const webhookRelay: ExampleTab = {
+        id: "webhook-relay",
+        label: "Webhook relay",
+        language: "bash",
+        badge: "Experimental",
+        code: `${instanceComment}
+# Webhooks can reduce latency but do not replace scheduled reconciliation.
+# Use a relay when you want provider webhooks to stay inside your environment.
+#
+# The relay listens for ${sourceSystem} webhook events, normalizes them into
+# the external-ingest envelope, and forwards each batch the same way the
+# cURL example does:
+curl -sS -X POST "${apiUrl}/api/v1/external-ingest/batches" \\
+  -H "Authorization: Bearer ${tokenPlaceholder}" \\
+  -H "Content-Type: application/json" \\
+  -H "Idempotency-Key: $IDEMPOTENCY_KEY" \\
+  --data-binary @relayed-payload.json
+
+# Still run a scheduled reconciliation job (see the other tabs) — webhooks
+# accelerate updates, they do not replace it.`,
+    };
+
+    return [githubActions, gitlabRunner, docker, curl, webhookRelay];
+}

--- a/src/lib/customer-push/producer.ts
+++ b/src/lib/customer-push/producer.ts
@@ -1,0 +1,38 @@
+/**
+ * Client-side producer-type bucketing for the batch status list/filters
+ * (CHAOS-2714 design decision D8). The batch envelope only carries a
+ * free-text `source.producer` string — there is no backend `producer_type`
+ * enum — so this is a pure prefix/substring heuristic used only for filter
+ * chips and badge coloring. Never send the derived value back to the API.
+ *
+ * The design brief's original heuristic included a "console" bucket for
+ * producer === "web-console" (in-product push). That leg is CUT: the
+ * console-push proxy was overruled post-critique (Screen 5 is validate-only
+ * in v1), so "web-console" now falls through to the "api" bucket like any
+ * other unrecognized producer string.
+ */
+
+import type { CustomerPushBatchStatus } from "@/lib/admin/types";
+
+export type ProducerBucket = "cli" | "ci" | "relay" | "api";
+
+export function classifyProducer(producer: string): ProducerBucket {
+    const value = producer.toLowerCase();
+    if (value.startsWith("dev-hops")) return "cli";
+    if (value.includes("github-actions") || value.includes("gitlab-ci") || value.includes(".ci."))
+        return "ci";
+    if (value.includes("relay")) return "relay";
+    return "api";
+}
+
+export const PRODUCER_BUCKET_LABELS: Record<ProducerBucket, string> = {
+    cli: "CLI",
+    ci: "CI",
+    relay: "Relay",
+    api: "API",
+};
+
+/** Terminal batch statuses — polling/refresh stops once one of these is reached (CC12). */
+export function isTerminalCustomerPushStatus(status: CustomerPushBatchStatus): boolean {
+    return status === "completed" || status === "partial" || status === "failed";
+}

--- a/src/lib/customer-push/sample-payload.ts
+++ b/src/lib/customer-push/sample-payload.ts
@@ -1,0 +1,55 @@
+import type { CustomerPushSystem } from "@/lib/admin/types";
+
+/**
+ * Minimal illustrative sample envelope for the Validate screen's "use sample
+ * payload" mode. This is NOT the canonical fixture — CHAOS-2692/2701 own the
+ * packaged example payloads
+ * (dev_health_ops/api/external_ingest/examples/<kind>.json) that are the
+ * source of truth. This exists so a customer can see one submittable shape
+ * before writing their own exporter; it may still fail deep validation
+ * against the real record schema, which is fine — the Validate screen
+ * renders both outcomes.
+ */
+export function buildSamplePayload(system: CustomerPushSystem, instance: string): unknown {
+    const now = new Date().toISOString();
+    const gitFamily = system === "github" || system === "gitlab" || system === "custom";
+
+    const records = gitFamily
+        ? [
+              {
+                  kind: "repository.v1",
+                  externalId: instance,
+                  payload: {
+                      externalId: instance,
+                      name: instance.split("/").pop() ?? instance,
+                      updatedAt: now,
+                  },
+              },
+          ]
+        : [
+              {
+                  kind: "work_item.v1",
+                  externalId: `${instance}-1`,
+                  payload: {
+                      externalKey: `${instance}-1`,
+                      title: "Sample work item",
+                      status: "open",
+                      updatedAt: now,
+                  },
+              },
+          ];
+
+    return {
+        schemaVersion: "external-ingest.v1",
+        idempotencyKey: `sample-validate-${instance}-${now}`,
+        source: {
+            type: "customer_push",
+            system,
+            instance,
+            producer: "validate-screen-sample",
+            producerVersion: "0.0.0",
+        },
+        window: { startedAt: now, endedAt: now },
+        records,
+    };
+}

--- a/src/lib/customer-push/token-status.ts
+++ b/src/lib/customer-push/token-status.ts
@@ -1,0 +1,26 @@
+/**
+ * Client-derived token status. `CustomerPushToken` carries no `status` or
+ * `last_result` field from the backend (SYNTHESIZER RECONCILIATION #2) —
+ * status is derived here from `revoked_at`/`expires_at`/`last_used_at` so
+ * every list/card in the UI applies the same precedence.
+ */
+
+import type { CustomerPushToken } from "@/lib/admin/types";
+
+export type CustomerPushTokenStatus = "active" | "revoked" | "expired" | "never_used";
+
+export function deriveTokenStatus(
+    token: Pick<CustomerPushToken, "revoked_at" | "expires_at" | "last_used_at">,
+): CustomerPushTokenStatus {
+    if (token.revoked_at) return "revoked";
+    if (token.expires_at && new Date(token.expires_at).getTime() <= Date.now()) return "expired";
+    if (!token.last_used_at) return "never_used";
+    return "active";
+}
+
+export const TOKEN_STATUS_LABELS: Record<CustomerPushTokenStatus, string> = {
+    active: "Active",
+    revoked: "Revoked",
+    expired: "Expired",
+    never_used: "Never used",
+};

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -84,6 +84,30 @@ export const CTA_LABELS = {
     darkTheme: "Dark",
     enabled: "Enabled",
     disabled: "Disabled",
+    /** Start the managed-sync connection flow from the provider mode-choice card (CHAOS-2714). */
+    setUpManagedSync: "Set up managed sync",
+    /** Start the customer-push source setup flow from the provider mode-choice card (CHAOS-2714). */
+    setUpCustomerPush: "Set up customer push",
+    /** Submit the customer-push source registration form (CHAOS-2714). */
+    createCustomerPushSource: "Create customer-push source",
+    /** Submit the customer-push ingest credential creation form (CHAOS-2714). */
+    createCredential: "Create credential",
+    /** Revoke a customer-push ingest credential (CHAOS-2714). */
+    revoke: "Revoke",
+    /** Rotate a customer-push ingest credential, issuing a new one-time token (CHAOS-2714). */
+    rotate: "Rotate",
+    /** Dismiss the one-time token reveal panel (CHAOS-2714 D9). */
+    done: "Done",
+    /** Jump from the token reveal panel to the runner setup examples (CHAOS-2714). */
+    viewSetupExamples: "View setup examples",
+    /** Submit the customer-push payload validation form (CHAOS-2714, validate-only in v1). */
+    validatePayload: "Validate payload",
+    /** Clear the active producer-bucket filter chip on the batch list (CHAOS-2714 D8). */
+    allProducers: "All producers",
+    /** Inline link to the Validate screen from the empty batch-list state (CHAOS-2714). */
+    goToValidate: "Validate",
+    /** Inline link to the runner setup examples from the empty batch-list state (CHAOS-2714). */
+    goToCiJob: "CI job",
 } as const;
 
 export type CtaKey = keyof typeof CTA_LABELS;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -59,6 +59,17 @@ const ROUTE_LIMITS: Array<{
             maxRequests: 10,
         },
     },
+    {
+        // Token issuance abuse guard (CHAOS-2714): covers both
+        // POST .../sources/:id/tokens (create) and POST .../tokens/:id/rotate.
+        match: (method, pathname) => method === "POST" && isCustomerPushTokenIssuancePath(pathname),
+        opts: {
+            failClosed: true,
+            namespace: "admin-customer-push-token-issue",
+            windowMs: 60 * 60_000,
+            maxRequests: 20,
+        },
+    },
 ];
 
 const EXACT_PUBLIC_PATHS = [
@@ -129,6 +140,13 @@ function buildCspHeader(nonce: string): string {
     ].join("; ");
 }
 
+function isCustomerPushTokenIssuancePath(pathname: string): boolean {
+    return (
+        pathname.startsWith("/api/v1/admin/customer-push/") &&
+        (/\/sources\/[^/]+\/tokens$/.test(pathname) || /\/tokens\/[^/]+\/rotate$/.test(pathname))
+    );
+}
+
 function pathBucket(pathname: string): string {
     if (pathname.startsWith("/api/v1/auth/login")) return "auth-login";
     if (
@@ -140,6 +158,9 @@ function pathBucket(pathname: string): string {
     if (pathname.startsWith("/api/v1/auth/")) return "auth-other";
     if (pathname.startsWith("/api/v1/admin/credentials/test-connection"))
         return "admin-credentials-test-connection";
+    // Bucket by route shape, not the dynamic source/token id in the path —
+    // otherwise rotating across ids would reset the counter per id.
+    if (isCustomerPushTokenIssuancePath(pathname)) return "admin-customer-push-token-issue";
     return pathname;
 }
 
@@ -161,9 +182,10 @@ async function enforceProxyRateLimit(
     const env = getServerEnv();
     const clientIp = getClientIp(request, { trustProxy: isTrustProxyEnabled(env.TRUST_PROXY) });
     const bucket = pathBucket(pathname);
-    const identity = pathname.startsWith("/api/v1/admin/credentials/test-connection")
-        ? `user:${sessionUserId ?? `ip:${clientIp}`}`
-        : `ip:${clientIp}`;
+    const isUserKeyed =
+        pathname.startsWith("/api/v1/admin/credentials/test-connection") ||
+        isCustomerPushTokenIssuancePath(pathname);
+    const identity = isUserKeyed ? `user:${sessionUserId ?? `ip:${clientIp}`}` : `ip:${clientIp}`;
     const key = `proxy:${method}:${bucket}:${identity}`;
     const result = await checkRateLimit(key, routeLimit.opts);
 

--- a/tests/admin-customer-push.spec.ts
+++ b/tests/admin-customer-push.spec.ts
@@ -1,0 +1,298 @@
+import { expect, test } from "@playwright/test";
+
+// Seeded in tests/mocks/handlers.ts MOCK_CUSTOMER_PUSH_SOURCES/_TOKENS/_BATCHES.
+const SEEDED_SOURCE_ID = "cps-github-1";
+const SEEDED_SOURCE_INSTANCE = "meridian/api";
+const SEEDED_TOKEN_NAME = "CI runner";
+const SEEDED_TOKEN_ID = "cpt-1";
+const COMPLETED_BATCH_ID = "batch-completed-1";
+const PARTIAL_BATCH_ID = "batch-partial-1";
+
+test.describe("Provider detail — mode cards (D3/D4)", () => {
+    test("provider detail page renders both Managed sync and Customer push cards", async ({
+        page,
+    }) => {
+        await page.goto("/org/admin/integrations/github");
+
+        await expect(page.getByRole("heading", { name: "Managed sync" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Customer push" })).toBeVisible();
+    });
+
+    test("custom provider renders only the Customer push card, no managed-sync form", async ({
+        page,
+    }) => {
+        await page.goto("/org/admin/integrations/custom");
+
+        await expect(page.getByRole("heading", { name: "Customer push" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Managed sync" })).toHaveCount(0);
+        await expect(page.getByRole("heading", { name: "Saved Credentials" })).toHaveCount(0);
+    });
+});
+
+test.describe("Create customer-push source", () => {
+    test("happy path: fill form, submit, redirected to the new source overview", async ({
+        page,
+    }) => {
+        await page.goto("/org/admin/integrations/linear/customer-push/new");
+
+        await page.locator("#customer-push-display-name").fill("Linear e2e team");
+        await page.locator("#customer-push-instance").fill("E2E");
+        await page.getByRole("button", { name: "Create customer-push source" }).click();
+
+        await expect(page).toHaveURL(/\/customer-push\/[^/]+$/);
+        await expect(page.getByRole("heading", { name: "Linear e2e team" })).toBeVisible();
+        await expect(page.getByText("Customer-push source · E2E", { exact: true })).toBeVisible();
+    });
+
+    test("one-active-owner conflict (managed sync already owns this instance) shows the ownership validation message", async ({
+        page,
+    }) => {
+        await page.goto("/org/admin/integrations/github/customer-push/new");
+
+        await page.locator("#customer-push-display-name").fill("Owned by managed sync");
+        // Mock sentinel simulating a matching, enabled managed-sync source (CC5).
+        await page.locator("#customer-push-instance").fill("owned-by-managed-sync");
+        await page.getByRole("button", { name: "Create customer-push source" }).click();
+
+        await expect(page.getByText("One-active-owner conflict")).toBeVisible();
+        await expect(
+            page.getByText(
+                "A managed github sync source already owns 'owned-by-managed-sync' in this organization; disable it before enabling customer-push for the same instance.",
+            ),
+        ).toBeVisible();
+        // Stays on the form — no redirect on conflict.
+        await expect(page).toHaveURL(/\/customer-push\/new$/);
+    });
+
+    test("registering the same source instance twice shows the distinct duplicate-registration message", async ({
+        page,
+    }) => {
+        await page.goto("/org/admin/integrations/github/customer-push/new");
+
+        await page.locator("#customer-push-display-name").fill("Duplicate source");
+        await page.locator("#customer-push-instance").fill(SEEDED_SOURCE_INSTANCE);
+        await page.getByRole("button", { name: "Create customer-push source" }).click();
+
+        await expect(
+            page.getByText(
+                `A source is already registered for system='github' instance='${SEEDED_SOURCE_INSTANCE}' in this organization`,
+            ),
+        ).toBeVisible();
+        // This is a plain duplicate-registration error, not the
+        // one-active-owner conflict — it must not show that heading.
+        await expect(page.getByText("One-active-owner conflict")).toHaveCount(0);
+        await expect(page).toHaveURL(/\/customer-push\/new$/);
+    });
+});
+
+test.describe("Credential creation — one-time token display (D9)", () => {
+    test("create token flow: one-time panel renders, then the plaintext is never shown again", async ({
+        page,
+    }) => {
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/credentials/new`,
+        );
+
+        await page.locator("#customer-push-token-name").fill("e2e runner token");
+        await page.getByRole("button", { name: "Create credential" }).click();
+
+        await expect(page.getByText("e2e runner token — token created")).toBeVisible();
+        const tokenCode = page.locator("code");
+        await expect(tokenCode).toContainText("fcpush_");
+        const tokenText = (await tokenCode.textContent())?.trim() ?? "";
+        expect(tokenText.startsWith("fcpush_")).toBe(true);
+
+        await page.getByRole("button", { name: "Done" }).click();
+
+        // Navigate to the credentials list — the new token must appear by
+        // name/metadata only, never with the plaintext secret rendered.
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/credentials`,
+        );
+        await expect(page.getByText("e2e runner token", { exact: true })).toBeVisible();
+        await expect(page.getByText(tokenText)).toHaveCount(0);
+    });
+});
+
+test.describe("Credential management — rotate/revoke", () => {
+    test("rotate shows a new one-time token and hard-cuts-over the old row (Design Decision 16)", async ({
+        page,
+    }) => {
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/credentials`,
+        );
+
+        // Scope to the seeded token's row via data-testid — other tests in
+        // this file create additional tokens against the same seeded source,
+        // so an unscoped "Rotate"/"Revoke" button lookup is ambiguous.
+        const row = page.getByTestId(`token-row-${SEEDED_TOKEN_ID}`);
+        await row.getByRole("button", { name: "Rotate" }).click();
+
+        await expect(page.getByText(`${SEEDED_TOKEN_NAME} — token created`)).toBeVisible();
+        await expect(page.locator("code")).toContainText("fcpush_");
+        await page.getByRole("button", { name: "Done" }).click();
+
+        // Real backend: rotate is a hard, immediate cutover — it revokes
+        // this row and mints a NEW token id, so the ORIGINAL row (same
+        // testid) must now show revoked/disabled once the page refreshes.
+        const rowAfterRotate = page.getByTestId(`token-row-${SEEDED_TOKEN_ID}`);
+        await expect(rowAfterRotate.getByText("Revoked", { exact: true })).toBeVisible();
+        await expect(rowAfterRotate.getByRole("button", { name: "Rotate" })).toBeDisabled();
+        await expect(rowAfterRotate.getByRole("button", { name: "Revoke" })).toBeDisabled();
+
+        // ...and a second "CI runner" row now exists for the new token.
+        await expect(page.getByText("CI runner")).toHaveCount(2);
+    });
+
+    test("revoke requires confirmation and disables the row", async ({ page }) => {
+        // Create a fresh token so this test doesn't depend on rotate's
+        // dynamic new-row id from the test above.
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/credentials/new`,
+        );
+        await page.locator("#customer-push-token-name").fill("Revoke-me token");
+        await page.getByRole("button", { name: "Create credential" }).click();
+        await expect(page.getByText("Revoke-me token — token created")).toBeVisible();
+        await page.getByRole("button", { name: "Done" }).click();
+
+        // "Done" on the create form just clears local state back to a blank
+        // form (no navigation) — visit the list page to find the new row.
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/credentials`,
+        );
+        const row = page
+            .locator('[data-testid^="token-row-"]')
+            .filter({ hasText: "Revoke-me token" });
+        // The confirm dialog renders inside the row's own subtree, so
+        // "Revoke" resolves to two buttons here: the trigger (first) and
+        // the modal's confirm action (last).
+        await row.getByRole("button", { name: "Revoke" }).first().click();
+        await expect(page.getByRole("heading", { name: "Revoke credential" })).toBeVisible();
+        await row.getByRole("button", { name: "Revoke" }).last().click();
+
+        // Exact match — a substring match also hits the "Token revoked" toast.
+        await expect(row.getByText("Revoked", { exact: true })).toBeVisible();
+        await expect(row.getByRole("button", { name: "Rotate" })).toBeDisabled();
+        await expect(row.getByRole("button", { name: "Revoke" }).first()).toBeDisabled();
+    });
+});
+
+test.describe("Runner setup examples", () => {
+    test("all 5 tabs render; cURL tab uses the real external-ingest data-plane path", async ({
+        page,
+    }) => {
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/examples`,
+        );
+
+        for (const label of [
+            "GitHub Actions",
+            "GitLab Runner",
+            "Generic Docker",
+            "cURL",
+            "Webhook relay",
+        ]) {
+            await expect(page.getByRole("button", { name: label, exact: false })).toBeVisible();
+        }
+
+        await page.getByRole("button", { name: "cURL", exact: false }).click();
+        await expect(page.locator("pre code")).toContainText("/api/v1/external-ingest/batches");
+    });
+});
+
+test.describe("Validate payload — validate-only in v1 (CC25 overrule)", () => {
+    test("invalid payload renders the rejected-record error table", async ({ page }) => {
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/validate`,
+        );
+
+        const invalidPayload = JSON.stringify({
+            schemaVersion: "external-ingest.v1",
+            idempotencyKey: "e2e-invalid",
+            source: { type: "customer_push", system: "github", instance: SEEDED_SOURCE_INSTANCE },
+            window: { startedAt: "2026-01-01T00:00:00Z", endedAt: "2026-01-01T01:00:00Z" },
+            records: [{ kind: "pull_request.v1", payload: {} }],
+        });
+        await page.getByPlaceholder(/schemaVersion/).fill(invalidPayload);
+        await page.getByRole("button", { name: "Validate payload" }).click();
+
+        await expect(page.getByRole("columnheader", { name: "Index" })).toBeVisible();
+        await expect(page.getByRole("columnheader", { name: "Path" })).toBeVisible();
+        await expect(page.getByRole("columnheader", { name: "Message" })).toBeVisible();
+        await expect(page.getByText("externalId is required")).toBeVisible();
+
+        // Regression guard: the console-push CTA was cut from v1 (CC25) —
+        // Screen 5 is validate-only, there must be no push button anywhere.
+        await expect(page.getByRole("button", { name: /push this payload/i })).toHaveCount(0);
+    });
+
+    test("valid payload renders the accepted-count success state", async ({ page }) => {
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/validate`,
+        );
+
+        const validPayload = JSON.stringify({
+            schemaVersion: "external-ingest.v1",
+            idempotencyKey: "e2e-valid",
+            source: { type: "customer_push", system: "github", instance: SEEDED_SOURCE_INSTANCE },
+            window: { startedAt: "2026-01-01T00:00:00Z", endedAt: "2026-01-01T01:00:00Z" },
+            records: [
+                {
+                    kind: "repository.v1",
+                    externalId: SEEDED_SOURCE_INSTANCE,
+                    payload: { externalId: SEEDED_SOURCE_INSTANCE, name: "api" },
+                },
+            ],
+        });
+        await page.getByPlaceholder(/schemaVersion/).fill(validPayload);
+        await page.getByRole("button", { name: "Validate payload" }).click();
+
+        await expect(page.getByText(/Payload is valid/)).toBeVisible();
+        await expect(page.getByRole("button", { name: /push this payload/i })).toHaveCount(0);
+    });
+});
+
+test.describe("Ingest status — batch list + drilldown", () => {
+    test("empty state shows guidance linking to Validate and Examples", async ({ page }) => {
+        // A freshly created source has zero batches in the mock store.
+        await page.goto("/org/admin/integrations/jira/customer-push/new");
+        await page.locator("#customer-push-display-name").fill("Jira e2e project");
+        await page.locator("#customer-push-instance").fill("E2EJ");
+        await page.getByRole("button", { name: "Create customer-push source" }).click();
+        await expect(page.getByRole("heading", { name: "Jira e2e project" })).toBeVisible();
+        await expect(page).not.toHaveURL(/\/customer-push\/new$/);
+        const sourceUrl = page.url();
+
+        await page.goto(`${sourceUrl}/batches`);
+        await expect(page.getByText(/No batches yet/)).toBeVisible();
+        await expect(page.getByRole("link", { name: "Validate" })).toBeVisible();
+        await expect(page.getByRole("link", { name: "CI job" })).toBeVisible();
+    });
+
+    test("seeded batches show status badges and link to their drilldown", async ({ page }) => {
+        await page.goto(`/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/batches`);
+
+        await expect(page.getByText("Completed", { exact: true })).toBeVisible();
+        await expect(page.getByText("Partial", { exact: true })).toBeVisible();
+
+        await page.getByText("Completed", { exact: true }).click();
+        await expect(page).toHaveURL(new RegExp(`/batches/${COMPLETED_BATCH_ID}$`));
+    });
+
+    test("batch detail renders rejected records with the correct empty-state copy", async ({
+        page,
+    }) => {
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/batches/${PARTIAL_BATCH_ID}`,
+        );
+        await expect(page.getByRole("columnheader", { name: "Index" })).toBeVisible();
+        await expect(
+            page.getByRole("cell", { name: "missing_external_id", exact: true }),
+        ).toBeVisible();
+
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/batches/${COMPLETED_BATCH_ID}`,
+        );
+        await expect(page.getByText("No rejected records.")).toBeVisible();
+    });
+});

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -19,6 +19,10 @@ import type {
     MockSyncConfig,
     MockTeam,
     MockIdentity,
+    MockCustomerPushSource,
+    MockCustomerPushToken,
+    MockCustomerPushTokenCreateResponse,
+    MockCustomerPushBatch,
 } from "./types";
 
 import {
@@ -793,6 +797,199 @@ const MOCK_REPOSITORY_SELECTIONS = new Map<string, { owner: string; repos: strin
 ]);
 const MOCK_TEAMS: MockTeam[] = [];
 const MOCK_IDENTITIES: MockIdentity[] = [];
+
+// ---- Customer Push (CHAOS-2690/2714) ----
+// Vocabulary (field names, enum values) mirrors the real ops backend
+// contract exactly — verified against dev-health-ops
+// api/admin/routers/customer_push.py + api/admin/schemas/customer_push.py
+// source (CHAOS-2696/2712/2694, merged into chaos-2690-integration), not
+// just the design doc's illustrative sketch. See src/lib/admin/types.ts's
+// "Customer Push" section for the same corrections.
+
+const MOCK_CUSTOMER_PUSH_SOURCES: MockCustomerPushSource[] = [
+    {
+        id: "cps-github-1",
+        org_id: "org-e2e",
+        system: "github",
+        instance: "meridian/api",
+        display_name: "Meridian API (GitHub)",
+        mode: "customer_push",
+        enabled: true,
+        webhook_mode: "disabled",
+        matched_integration_source_id: null,
+        created_at: "2026-06-25T00:00:00.000Z",
+        updated_at: "2026-06-25T00:00:00.000Z",
+        warnings: [],
+    },
+];
+
+const MOCK_CUSTOMER_PUSH_TOKENS: MockCustomerPushToken[] = [
+    {
+        id: "cpt-1",
+        org_id: "org-e2e",
+        name: "CI runner",
+        source_id: "cps-github-1",
+        token_prefix: "fcpush_ab12cd34",
+        scopes: ["schema:read", "ingest:write", "ingest:status"],
+        last_used_at: "2026-06-26T00:00:00.000Z",
+        expires_at: null,
+        revoked_at: null,
+        created_at: "2026-06-25T00:00:00.000Z",
+    },
+];
+
+const MOCK_CUSTOMER_PUSH_BATCHES: MockCustomerPushBatch[] = [
+    {
+        ingestion_id: "batch-completed-1",
+        org_id: "org-e2e",
+        status: "completed",
+        attempts: 1,
+        source_system: "github",
+        source_instance: "meridian/api",
+        producer: "dev-hops-cli",
+        producer_version: "0.12.0",
+        schema_version: "external-ingest.v1",
+        window_started_at: "2026-06-25T00:00:00.000Z",
+        window_ended_at: "2026-06-26T00:00:00.000Z",
+        items_received: 500,
+        items_accepted: 500,
+        items_rejected: 0,
+        record_counts: { "pull_request.v1": 300, "review.v1": 200 },
+        error_summary: null,
+        created_at: "2026-06-26T00:01:00.000Z",
+        updated_at: "2026-06-26T00:03:00.000Z",
+        completed_at: "2026-06-26T00:03:00.000Z",
+        rejected_records: [],
+        rejected_records_total: 0,
+        rejected_records_limit: 50,
+        rejected_records_offset: 0,
+    },
+    {
+        ingestion_id: "batch-partial-1",
+        org_id: "org-e2e",
+        status: "partial",
+        attempts: 1,
+        source_system: "github",
+        source_instance: "meridian/api",
+        producer: "github-actions",
+        producer_version: "0.12.0",
+        schema_version: "external-ingest.v1",
+        window_started_at: "2026-06-26T00:00:00.000Z",
+        window_ended_at: "2026-06-27T00:00:00.000Z",
+        items_received: 100,
+        items_accepted: 92,
+        items_rejected: 8,
+        record_counts: { "pull_request.v1": 100 },
+        error_summary: {
+            total_rejected: 8,
+            stored_rejections: 8,
+            truncated: false,
+            top_codes: [
+                { code: "missing_external_id", count: 5 },
+                { code: "unsupported_kind_for_system", count: 3 },
+            ],
+        },
+        created_at: "2026-06-27T00:01:00.000Z",
+        updated_at: "2026-06-27T00:02:30.000Z",
+        completed_at: "2026-06-27T00:02:30.000Z",
+        rejected_records: [
+            {
+                index: 12,
+                kind: "pull_request.v1",
+                external_id: "PR#88",
+                code: "missing_external_id",
+                path: "records[12].externalId",
+                message: "externalId is required",
+            },
+            {
+                index: 47,
+                kind: "work_item.v1",
+                external_id: null,
+                code: "unsupported_kind_for_system",
+                path: "records[47].kind",
+                message: "work_item.v1 is not supported for source system github",
+            },
+        ],
+        rejected_records_total: 8,
+        rejected_records_limit: 50,
+        rejected_records_offset: 0,
+    },
+    {
+        ingestion_id: "batch-processing-1",
+        org_id: "org-e2e",
+        status: "processing",
+        attempts: 1,
+        source_system: "github",
+        source_instance: "meridian/api",
+        producer: "relay-customer-owned",
+        producer_version: "0.3.0",
+        schema_version: "external-ingest.v1",
+        window_started_at: "2026-06-28T00:00:00.000Z",
+        window_ended_at: "2026-06-28T00:30:00.000Z",
+        items_received: 50,
+        items_accepted: 0,
+        items_rejected: 0,
+        record_counts: null,
+        error_summary: null,
+        created_at: "2026-06-28T00:31:00.000Z",
+        updated_at: "2026-06-28T00:31:00.000Z",
+        completed_at: null,
+        rejected_records: [],
+        rejected_records_total: 0,
+        rejected_records_limit: 50,
+        rejected_records_offset: 0,
+    },
+];
+
+// Mirrors GET /customer-push/schemas — a camelCase pass-through of the
+// data-plane schema shape ({schemaVersions, recordKinds, limits}), NOT a
+// `schemas: [...]` list of per-version entries.
+const MOCK_CUSTOMER_PUSH_SCHEMAS = {
+    schemaVersions: ["external-ingest.v1"],
+    recordKinds: [
+        "repository.v1",
+        "pull_request.v1",
+        "review.v1",
+        "commit.v1",
+        "work_item.v1",
+        "work_item_transition.v1",
+        "work_item_dependency.v1",
+        "team.v1",
+        "identity.v1",
+    ],
+    limits: { maxRecordsPerBatch: 1000, maxBodyBytes: 10_000_000 },
+};
+
+/** Mirrors _resolve_ownership's 409 detail={code, message} shape exactly. */
+function customerPushOwnershipConflict(system: string, instance: string) {
+    return HttpResponse.json(
+        {
+            detail: {
+                code: "source_owned_by_fullchaos_sync",
+                message: `A managed ${system} sync source already owns '${instance}' in this organization; disable it before enabling customer-push for the same instance.`,
+            },
+        },
+        { status: 409 },
+    );
+}
+
+/**
+ * Mirrors the real router's OTHER 409 path: the (org_id, system, instance)
+ * unique-constraint IntegrityError when the exact same customer-push source
+ * is registered twice. Distinct plain-string detail (no {code,message})
+ * from the ownership-conflict 409 above — a real, different failure mode.
+ */
+function customerPushDuplicateSourceConflict(system: string, instance: string) {
+    return HttpResponse.json(
+        {
+            detail: `A source is already registered for system='${system}' instance='${instance}' in this organization`,
+        },
+        { status: 409 },
+    );
+}
+
+/** Special-case instance value that simulates a matching, enabled managed-sync source (CC5). */
+const MOCK_MANAGED_SYNC_OWNED_INSTANCE = "owned-by-managed-sync";
 
 const buildDeploymentFlameResponse = (deploymentId: string) => ({
     entity: {
@@ -2871,6 +3068,247 @@ export const handlers = [
             return HttpResponse.json(MOCK_SYNC_JOBS);
         }
         return HttpResponse.json([]);
+    }),
+
+    // ---- Customer Push (CHAOS-2690/2714) ----
+
+    // GET /customer-push/sources has NO server-side system filter in the
+    // real router — it always returns every source for the org.
+    http.get("*/api/v1/admin/customer-push/sources", () =>
+        HttpResponse.json<MockCustomerPushSource[]>(MOCK_CUSTOMER_PUSH_SOURCES),
+    ),
+
+    http.post("*/api/v1/admin/customer-push/sources", async ({ request }) => {
+        const body = (await request.json()) as Partial<MockCustomerPushSource> | null;
+        const system = body?.system ?? "github";
+        const instance = body?.instance ?? "";
+        if (instance === MOCK_MANAGED_SYNC_OWNED_INSTANCE) {
+            return customerPushOwnershipConflict(system, instance);
+        }
+        const duplicate = MOCK_CUSTOMER_PUSH_SOURCES.some(
+            (s) => s.system === system && s.instance === instance,
+        );
+        if (duplicate) {
+            return customerPushDuplicateSourceConflict(system, instance);
+        }
+        const created: MockCustomerPushSource = {
+            id: `cps-${Date.now()}`,
+            org_id: "org-e2e",
+            system,
+            instance,
+            display_name: body?.display_name ?? null,
+            mode: "customer_push",
+            enabled: true,
+            webhook_mode: "disabled",
+            matched_integration_source_id: null,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            warnings: [],
+        };
+        MOCK_CUSTOMER_PUSH_SOURCES.push(created);
+        return HttpResponse.json<MockCustomerPushSource>(created, { status: 201 });
+    }),
+
+    http.get("*/api/v1/admin/customer-push/sources/:id", ({ params }) => {
+        const source = MOCK_CUSTOMER_PUSH_SOURCES.find((s) => s.id === params.id);
+        if (!source) {
+            return HttpResponse.json({ detail: "Source not found" }, { status: 404 });
+        }
+        return HttpResponse.json<MockCustomerPushSource>(source);
+    }),
+
+    http.patch("*/api/v1/admin/customer-push/sources/:id", async ({ params, request }) => {
+        const source = MOCK_CUSTOMER_PUSH_SOURCES.find((s) => s.id === params.id);
+        if (!source) {
+            return HttpResponse.json({ detail: "Source not found" }, { status: 404 });
+        }
+        const body = (await request.json()) as { enabled?: boolean; display_name?: string } | null;
+        if (typeof body?.enabled === "boolean") source.enabled = body.enabled;
+        if (body?.display_name) source.display_name = body.display_name;
+        source.updated_at = new Date().toISOString();
+        return HttpResponse.json<MockCustomerPushSource>(source);
+    }),
+
+    http.get("*/api/v1/admin/customer-push/sources/:id/tokens", ({ params }) => {
+        const tokens = MOCK_CUSTOMER_PUSH_TOKENS.filter((t) => t.source_id === params.id);
+        return HttpResponse.json<MockCustomerPushToken[]>(tokens);
+    }),
+
+    http.post("*/api/v1/admin/customer-push/sources/:id/tokens", async ({ params, request }) => {
+        const body = (await request.json()) as {
+            name?: string;
+            scopes?: string[];
+            expires_at?: string | null;
+        } | null;
+        const tokenPrefix = `fcpush_${Math.random().toString(36).slice(2, 10)}`;
+        const created: MockCustomerPushTokenCreateResponse = {
+            id: `cpt-${Date.now()}`,
+            org_id: "org-e2e",
+            name: body?.name ?? "Ingest token",
+            source_id: params.id as string,
+            token_prefix: tokenPrefix,
+            scopes: body?.scopes ?? ["schema:read", "ingest:write", "ingest:status"],
+            last_used_at: null,
+            expires_at: body?.expires_at ?? null,
+            revoked_at: null,
+            created_at: new Date().toISOString(),
+            token: `${tokenPrefix}${Date.now().toString(36)}`,
+        };
+        MOCK_CUSTOMER_PUSH_TOKENS.push(created);
+        return HttpResponse.json<MockCustomerPushTokenCreateResponse>(created, { status: 201 });
+    }),
+
+    http.post("*/api/v1/admin/customer-push/tokens/:id/rotate", ({ params }) => {
+        const token = MOCK_CUSTOMER_PUSH_TOKENS.find((t) => t.id === params.id);
+        if (!token) {
+            return HttpResponse.json({ detail: "Token not found" }, { status: 404 });
+        }
+        // Real backend: hard cutover — revokes the old token and mints a new
+        // one with a NEW id (not a same-id refresh).
+        token.revoked_at = new Date().toISOString();
+        const tokenPrefix = `fcpush_${Math.random().toString(36).slice(2, 10)}`;
+        const rotated: MockCustomerPushTokenCreateResponse = {
+            id: `cpt-${Date.now()}`,
+            org_id: token.org_id,
+            name: token.name,
+            source_id: token.source_id,
+            token_prefix: tokenPrefix,
+            scopes: token.scopes,
+            last_used_at: null,
+            expires_at: token.expires_at,
+            revoked_at: null,
+            created_at: new Date().toISOString(),
+            token: `${tokenPrefix}${Date.now().toString(36)}`,
+        };
+        MOCK_CUSTOMER_PUSH_TOKENS.push(rotated);
+        return HttpResponse.json<MockCustomerPushTokenCreateResponse>(rotated);
+    }),
+
+    http.post("*/api/v1/admin/customer-push/tokens/:id/revoke", ({ params }) => {
+        const token = MOCK_CUSTOMER_PUSH_TOKENS.find((t) => t.id === params.id);
+        if (!token) {
+            return HttpResponse.json({ detail: "Token not found" }, { status: 404 });
+        }
+        token.revoked_at = new Date().toISOString();
+        return HttpResponse.json<MockCustomerPushToken>(token);
+    }),
+
+    // Real endpoint returns a paginated envelope {items, total, limit,
+    // offset}, not a bare array.
+    http.get("*/api/v1/admin/customer-push/sources/:id/batches", ({ params, request }) => {
+        const url = new URL(request.url);
+        const status = url.searchParams.get("status");
+        const producer = url.searchParams.get("producer");
+        const limit = Number(url.searchParams.get("limit") ?? "50");
+        const offset = Number(url.searchParams.get("offset") ?? "0");
+        const source = MOCK_CUSTOMER_PUSH_SOURCES.find((s) => s.id === params.id);
+        let batches = source
+            ? MOCK_CUSTOMER_PUSH_BATCHES.filter(
+                  (b) => b.source_system === source.system && b.source_instance === source.instance,
+              )
+            : [];
+        if (status) batches = batches.filter((b) => b.status === status);
+        if (producer) batches = batches.filter((b) => b.producer === producer);
+        const total = batches.length;
+        const page = batches
+            .slice(offset, offset + limit)
+            .map(
+                ({
+                    org_id: _org_id,
+                    attempts: _attempts,
+                    producer_version: _producer_version,
+                    schema_version: _schema_version,
+                    window_started_at: _window_started_at,
+                    window_ended_at: _window_ended_at,
+                    record_counts: _record_counts,
+                    error_summary: _error_summary,
+                    updated_at: _updated_at,
+                    rejected_records: _rejected_records,
+                    rejected_records_total: _rejected_records_total,
+                    rejected_records_limit: _rejected_records_limit,
+                    rejected_records_offset: _rejected_records_offset,
+                    recompute_status: _recompute_status,
+                    ...listItem
+                }) => listItem,
+            );
+        return HttpResponse.json({ items: page, total, limit, offset });
+    }),
+
+    http.get("*/api/v1/admin/customer-push/batches/:id", ({ params }) => {
+        const batch = MOCK_CUSTOMER_PUSH_BATCHES.find((b) => b.ingestion_id === params.id);
+        if (!batch) {
+            return HttpResponse.json({ detail: "Batch not found" }, { status: 404 });
+        }
+        return HttpResponse.json<MockCustomerPushBatch>(batch);
+    }),
+
+    http.get("*/api/v1/admin/customer-push/schemas", () =>
+        HttpResponse.json(MOCK_CUSTOMER_PUSH_SCHEMAS),
+    ),
+
+    http.get("*/api/v1/admin/customer-push/schemas/:version", ({ params }) => {
+        if (params.version !== MOCK_CUSTOMER_PUSH_SCHEMAS.schemaVersions[0]) {
+            return HttpResponse.json(
+                { detail: `Unknown schema version: '${params.version}'` },
+                { status: 404 },
+            );
+        }
+        return HttpResponse.json({
+            schemaVersion: MOCK_CUSTOMER_PUSH_SCHEMAS.schemaVersions[0],
+            envelope: { type: "object" },
+            recordKinds: Object.fromEntries(
+                MOCK_CUSTOMER_PUSH_SCHEMAS.recordKinds.map((kind) => [kind, { type: "object" }]),
+            ),
+            limits: MOCK_CUSTOMER_PUSH_SCHEMAS.limits,
+        });
+    }),
+
+    http.post("*/api/v1/admin/customer-push/sources/:id/validate", async ({ request }) => {
+        const body = (await request.json()) as {
+            records?: Array<{ kind?: string; externalId?: string; payload?: unknown }>;
+        } | null;
+        const records = body?.records ?? [];
+
+        if (records.length === 0) {
+            return HttpResponse.json({
+                valid: false,
+                items_accepted: 0,
+                items_rejected: 0,
+                errors: [
+                    {
+                        index: 0,
+                        kind: "unknown",
+                        external_id: null,
+                        code: "invalid_envelope",
+                        path: "records",
+                        message: "records must contain at least 1 item",
+                    },
+                ],
+            });
+        }
+
+        const errors = records.flatMap((record, index) => {
+            if (!record.externalId) {
+                return [
+                    {
+                        index,
+                        kind: record.kind ?? "unknown",
+                        external_id: null,
+                        code: "missing_required_field",
+                        path: `records[${index}].externalId`,
+                        message: "externalId is required",
+                    },
+                ];
+            }
+            return [];
+        });
+
+        return HttpResponse.json({
+            valid: errors.length === 0,
+            items_accepted: records.length - errors.length,
+            items_rejected: errors.length,
+            errors,
+        });
     }),
 
     http.get("*/api/v1/admin/teams", () => HttpResponse.json(MOCK_TEAMS)),

--- a/tests/mocks/types.ts
+++ b/tests/mocks/types.ts
@@ -140,6 +140,101 @@ export interface MockIdentity {
     user_id: string;
 }
 
+/**
+ * Mirrors IngestSourceResponse (dev-health-ops
+ * api/admin/schemas/customer_push.py, CHAOS-2696) — verified against the
+ * real router source, NOT the CHAOS-2714 design doc's illustrative sketch.
+ * No `conflicting_managed_sync` field exists; the backend returns
+ * `matched_integration_source_id` + a `warnings` string array instead.
+ */
+export interface MockCustomerPushSource {
+    id: string;
+    org_id: string;
+    system: string;
+    instance: string;
+    display_name: string | null;
+    mode: "fullchaos_sync" | "customer_push" | "disabled";
+    enabled: boolean;
+    webhook_mode: "disabled" | "customer_relay" | "fullchaos_hosted";
+    matched_integration_source_id: string | null;
+    created_at: string;
+    updated_at: string;
+    warnings: string[];
+}
+
+/** Mirrors IngestTokenResponse — no status/last_result field, derived client-side. */
+export interface MockCustomerPushToken {
+    id: string;
+    org_id: string;
+    name: string;
+    source_id: string | null;
+    token_prefix: string;
+    scopes: string[];
+    last_used_at: string | null;
+    expires_at: string | null;
+    revoked_at: string | null;
+    created_at: string;
+}
+
+/** Mirrors IngestTokenCreateResponse — one-time plaintext token. */
+export interface MockCustomerPushTokenCreateResponse extends MockCustomerPushToken {
+    token: string;
+}
+
+/** Mirrors AdminBatchListItemResponse — the LIST shape is deliberately thinner than the detail. */
+export interface MockCustomerPushBatchListItem {
+    ingestion_id: string;
+    status: "accepted" | "stream_unavailable" | "processing" | "completed" | "partial" | "failed";
+    source_system: string;
+    source_instance: string;
+    producer: string | null;
+    items_received: number;
+    items_accepted: number;
+    items_rejected: number;
+    created_at: string;
+    completed_at: string | null;
+}
+
+/** Mirrors AdminBatchResponse (detail) — has no `source_id`; no `recompute_status` yet in this branch. */
+export interface MockCustomerPushBatch {
+    ingestion_id: string;
+    org_id: string;
+    status: "accepted" | "stream_unavailable" | "processing" | "completed" | "partial" | "failed";
+    attempts: number;
+    source_system: string;
+    source_instance: string;
+    producer: string | null;
+    producer_version: string | null;
+    schema_version: string;
+    window_started_at: string | null;
+    window_ended_at: string | null;
+    items_received: number;
+    items_accepted: number;
+    items_rejected: number;
+    record_counts: Record<string, number> | null;
+    error_summary: {
+        total_rejected: number;
+        stored_rejections: number;
+        truncated: boolean;
+        top_codes: Array<{ code: string; count: number }>;
+    } | null;
+    created_at: string;
+    updated_at: string;
+    completed_at: string | null;
+    rejected_records: Array<{
+        index: number;
+        kind: string;
+        external_id: string | null;
+        code: string;
+        path: string | null;
+        message: string;
+    }>;
+    rejected_records_total: number;
+    rejected_records_limit: number;
+    rejected_records_offset: number;
+    recompute_status?: "not_applicable" | "pending" | "dispatched" | "skipped_no_scope" | "failed";
+}
+
 /** Full credential response as returned by GET /api/v1/admin/credentials. */
 export type IntegrationCredentialResponse = MockCredential;
 


### PR DESCRIPTION
## Summary

Implements the 7-screen customer-push source onboarding UI under `/org/admin/integrations/[provider]/customer-push/*`, per [CHAOS-2714](https://linear.app/fullchaos/issue/CHAOS-2714) and its implementation brief:

1. **Mode-choice cards** — Managed sync vs Customer push, on the provider detail page
2. **Create customer-push source** — with the one-active-owner (CC5) 409 conflict surfaced verbatim
3. **Source overview** — 4 link-cards into Credentials/Examples/Validate/Batches
4. **Credential creation** — one-time token reveal (D9), never persisted to storage or logged
5. **Runner setup examples** — GitHub Actions / GitLab Runner / Docker / cURL / webhook-relay tabs
6. **Validate payload** — validate-only in v1 (CC25 product decision cut the console-push write path)
7. **Ingest batch status** — list + drilldown, mirrors `SyncJobHistory`/`SyncRunDetailLive`'s poll pattern (D11)
8. **Credential management** — list/rotate/revoke, rotate is a hard cutover per the real backend

`custom` is a customer-push-only pseudo-provider (D3); `launchdarkly` gets no customer-push card (D4).

### Contract correctness

The type contract, API client, server actions, and MSW mocks were verified against the **real** `dev-health-ops` `customer_push` admin router/schema source (CHAOS-2696/2712/2694, already merged into `chaos-2690-integration`), not just the design doc's illustrative sketch. This caught and fixed real drift:
- No `conflicting_managed_sync` field exists — real shape is `matched_integration_source_id` + a `warnings` string array, rendered verbatim
- Batch list is a paginated `{items,total,limit,offset}` envelope, not a bare array
- Batch rows carry `source_system`/`source_instance`, not `source_id`; window fields only exist on the detail response
- `error_summary.top_codes` is an array of `{code,count}`, not a `Record`
- Tokens carry `token_prefix` (now rendered in the credentials list)
- The real one-active-owner 409 message text differs from the design doc's placeholder copy — the UI now shows the backend's actual message

**Known, expected gap:** `POST .../sources/{id}/validate` isn't live yet in this branch — it's owned by CHAOS-2695 (wave 4) per master-spec CC25. Screen 6 (Validate) is built and tested against MSW mocks only until that lands; this matches the brief's explicit wave plan.

### Codex review

Two rounds of adversarial review (full findings in `/tmp/claude/codex-review-chaos-2714*.md`). Round 1 found the contract drift above; round 2 confirmed those fixes and found: `token_prefix` never rendered (fixed), a copy-paste bug in `examples.ts` where non-GitHub/GitLab source systems' generated CLI commands used the provider name instead of the actual source instance (fixed — real functional bug), `revokeToken()` discarding the real response type (fixed), and the mock's duplicate-source path reusing the ownership-conflict message instead of the real distinct one (fixed, with new tests covering both paths). D9 token-handling security was verified clean by both passes.

## Test plan

- [x] `bash ci/run_tests.sh format` — pass
- [x] `bash ci/run_tests.sh quality` (audit/codegen/lint/typecheck) — pass
- [x] `pnpm typecheck` — clean
- [x] Unit: 85 new tests, all passing (2502/2507 full suite green — the only failure is the pre-existing, unrelated `rate-limit.test.ts`, confirmed via `git stash` isolation to fail identically without this branch's changes)
- [x] E2E: `tests/admin-customer-push.spec.ts`, 15/15 passing against MSW mocks (source create/conflict happy paths, one-time token display, rotate/revoke, examples tabs, validate accept/reject, batch list/drilldown empty+seeded states)
- [x] Visual evidence (Tier 1, MSW-mock-backed, dark theme) — screenshots attached below
- [ ] Live verification against the real ops backend (Tier 2) — **not completed**: I could not obtain safe Postgres credentials for an isolated scratch DB in this session (repeated safety-guardrail blocks on credential access); flagging for the coordinator/reviewer to run before merge, or to explicitly accept Tier-1-only for this PR

## Screenshots

![Provider mode cards](https://github.com/user-attachments/assets/4b023528-e669-40fd-a77e-06387aa5853f)
![Create source](https://github.com/user-attachments/assets/a44e0d50-3274-4cd2-8675-8539d9ec11cc)
![Source overview](https://github.com/user-attachments/assets/d82c721d-b455-4113-bf30-ff0f8e633a1d)
![Token reveal (one-time)](https://github.com/user-attachments/assets/8ec64be5-eab0-47b1-b3d0-2160567374e2)
![Credentials list](https://github.com/user-attachments/assets/ac6fda06-4cf1-40b7-b4a3-8cf8ab5290c2)
![Runner setup examples](https://github.com/user-attachments/assets/30c09097-8f2d-476a-831e-3c9e6bce31fa)
![Validate — valid payload](https://github.com/user-attachments/assets/0b4f64a8-b31f-42e0-a367-596e9ab02ff5)
![Batch list](https://github.com/user-attachments/assets/98dde9e1-9af1-4999-bf89-d758adaea992)
![Batch detail — rejected records](https://github.com/user-attachments/assets/c9830bb3-ff5a-4af5-b433-44308c2dba5a)
