### PR TITLE
feat(admin): enable customer-push validate proxy (CHAOS-2695 follow-up)

### DIFF
--- a/src/components/admin/integrations/customer-push/ValidatePayloadPanel.test.tsx
+++ b/src/components/admin/integrations/customer-push/ValidatePayloadPanel.test.tsx
@@ -134,13 +134,30 @@ describe("ValidatePayloadPanel", () => {
     });
 });
 
-describe("ValidatePayloadPanel — proxy gate (CHAOS-2695 pending)", () => {
-    it("default-gated: banner visible and submit disabled until the proxy lands", () => {
+describe("ValidatePayloadPanel — proxy gate (flipped ON with ops CHAOS-2695)", () => {
+    it("default is live: no gate banner, submit enabled once payload present", async () => {
+        const user = userEvent.setup();
         render(
             <ValidatePayloadPanel
                 sourceId="cps-1"
                 sourceSystem="github"
                 sourceInstance="meridian/api"
+            />,
+        );
+        expect(
+            screen.queryByText(/Server-side validation isn't available yet/),
+        ).not.toBeInTheDocument();
+        await user.click(screen.getByRole("button", { name: "Use sample" }));
+        expect(screen.getByRole("button", { name: "Validate payload" })).toBeEnabled();
+    });
+
+    it("gated-off state still renders banner + disabled submit (rollback seam)", () => {
+        render(
+            <ValidatePayloadPanel
+                sourceId="cps-1"
+                sourceSystem="github"
+                sourceInstance="meridian/api"
+                validateProxyAvailable={false}
             />,
         );
         expect(screen.getByText(/Server-side validation isn't available yet/)).toBeInTheDocument();

--- a/src/components/admin/integrations/customer-push/ValidatePayloadPanel.tsx
+++ b/src/components/admin/integrations/customer-push/ValidatePayloadPanel.tsx
@@ -18,14 +18,13 @@ type ValidatePayloadPanelProps = {
 type Mode = "paste" | "upload" | "sample";
 
 /**
- * The admin validate proxy (`POST .../sources/{id}/validate`) ships with
- * CHAOS-2695 (wave 4). Until it lands, submitting would deterministically
- * 404 in production (only the MSW mock implements the route), so the submit
- * path is hard-gated off (adversarial-review finding). Flip to `true` in the
- * CHAOS-2695 changeset — the panel, parsing, and result rendering are fully
- * built and tested and need no other change.
+ * The admin validate proxy (`POST .../sources/{id}/validate`) landed with
+ * ops CHAOS-2695 (wave 4), so the interim hard-gate on the submit path is
+ * lifted. The gate machinery (this flag + the `validateProxyAvailable` test
+ * seam) is kept rather than deleted so a rollback is a one-line flip, and
+ * unit tests can still exercise the gated-off state.
  */
-export const VALIDATE_PROXY_AVAILABLE = false;
+export const VALIDATE_PROXY_AVAILABLE = true;
 
 /**
  * Screen 5 — VALIDATE ONLY in v1. The console-push proxy
@@ -34,10 +33,10 @@ export const VALIDATE_PROXY_AVAILABLE = false;
  * exclusively token-authed. There is deliberately no "Push this payload" CTA
  * here — only `POST .../sources/{id}/validate`.
  *
- * NOTE: the validate proxy itself has not landed in the merged ops source as
- * of this writing (owned by CHAOS-2695/wave 4) — this screen is built and
- * tested against the MSW mock only; a real request will 404 until that
- * lands, matching the brief's stated wave sequencing.
+ * The ops endpoint returns 200 `valid: false` result rows even for
+ * envelope-level failures (see ops
+ * docs/architecture/external-ingest-idempotency-ownership.md), matching the
+ * MSW mock contract this panel was built against.
  */
 export function ValidatePayloadPanel({
     sourceId,

--- a/src/lib/admin/api/customer-push.ts
+++ b/src/lib/admin/api/customer-push.ts
@@ -112,9 +112,11 @@ export const customerPushApi = {
         ),
 
     /**
-     * Provisional — the validate proxy hasn't landed in the merged ops
-     * source yet (CHAOS-2695/wave 4). Wired against MSW mocks only until
-     * then; do not treat a 404 here as a bug in this client.
+     * Backed by the live ops endpoint since CHAOS-2695 (wave 4):
+     * POST /api/v1/admin/customer-push/sources/{id}/validate. Envelope-level
+     * failures come back as 200 valid:false result rows, never 4xx — a 404
+     * here now indicates deployment/routing skew, not an expected
+     * provisional state.
      */
     validate: (sourceId: string, envelope: unknown, token?: string, orgId?: string) =>
         request<CustomerPushValidateResponse>(

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -974,9 +974,10 @@ export interface CustomerPushBatchDetail {
 }
 
 /**
- * Provisional — the validate proxy hasn't landed in the merged ops source
- * yet (CHAOS-2695/wave 4). Shape follows the brief's contract sketch;
- * re-verify against real source once that lands.
+ * Mirrors ops AdminValidateResponse (api/admin/schemas/customer_push.py,
+ * landed with CHAOS-2695): snake_case; envelope-level failures are reported
+ * through this same 200 shape (valid:false + synthetic error rows with
+ * code "invalid_envelope"), never as 4xx.
  */
 export interface CustomerPushValidateResponse {
     valid: boolean;

--- a/src/lib/customer-push/sample-payload.ts
+++ b/src/lib/customer-push/sample-payload.ts
@@ -5,10 +5,11 @@ import type { CustomerPushSystem } from "@/lib/admin/types";
  * payload" mode. This is NOT the canonical fixture — CHAOS-2692/2701 own the
  * packaged example payloads
  * (dev_health_ops/api/external_ingest/examples/<kind>.json) that are the
- * source of truth. This exists so a customer can see one submittable shape
- * before writing their own exporter; it may still fail deep validation
- * against the real record schema, which is fine — the Validate screen
- * renders both outcomes.
+ * source of truth. The samples ARE schema-valid against the real ops record
+ * schemas (RepositoryV1 / WorkItemV1 — required fields only, extra="forbid"):
+ * "Use sample" → "Validate payload" must succeed against the live proxy, and
+ * the round-trip e2e pins that (adversarial-review finding — a sample the
+ * real endpoint rejects passed the old mock silently).
  */
 export function buildSamplePayload(system: CustomerPushSystem, instance: string): unknown {
     const now = new Date().toISOString();
@@ -19,10 +20,11 @@ export function buildSamplePayload(system: CustomerPushSystem, instance: string)
               {
                   kind: "repository.v1",
                   externalId: instance,
+                  // RepositoryV1: externalId + sourceSystem required; the old
+                  // name/updatedAt fields are extra="forbid" rejections.
                   payload: {
                       externalId: instance,
-                      name: instance.split("/").pop() ?? instance,
-                      updatedAt: now,
+                      sourceSystem: system,
                   },
               },
           ]
@@ -30,11 +32,14 @@ export function buildSamplePayload(system: CustomerPushSystem, instance: string)
               {
                   kind: "work_item.v1",
                   externalId: `${instance}-1`,
+                  // WorkItemV1: externalKey/provider/title/status/createdAt
+                  // required; status must be from the pinned literal set.
                   payload: {
                       externalKey: `${instance}-1`,
+                      provider: system,
                       title: "Sample work item",
-                      status: "open",
-                      updatedAt: now,
+                      status: "todo",
+                      createdAt: now,
                   },
               },
           ];

--- a/tests/admin-customer-push.spec.ts
+++ b/tests/admin-customer-push.spec.ts
@@ -32,15 +32,29 @@ test.describe("Provider detail — mode cards (D3/D4)", () => {
 test.describe("Create customer-push source", () => {
     test("happy path: fill form, submit, redirected to the new source overview", async ({
         page,
-    }) => {
+    }, testInfo) => {
+        // Per-retry instance key: the mock source store is a shared
+        // module-level array that survives retries, so a first attempt
+        // whose POST succeeded but whose assertion timed out would leave a
+        // row behind and turn every retry into a deterministic
+        // duplicate-registration 409 (root cause of the standing CI-only
+        // terminal failure of this spec).
+        const teamKey = testInfo.retry === 0 ? "E2E" : `E2E-R${testInfo.retry}`;
         await page.goto("/org/admin/integrations/linear/customer-push/new");
 
         await page.locator("#customer-push-display-name").fill("Linear e2e team");
-        await page.locator("#customer-push-instance").fill("E2E");
+        await page.locator("#customer-push-instance").fill(teamKey);
         await page.getByRole("button", { name: "Create customer-push source" }).click();
 
+        // waitForURL (30s nav timeout) before asserting: the redirect
+        // target route cold-compiles under next dev on the CI runner and
+        // routinely exceeds the 5s expect timeout (same pattern as the
+        // "empty state" test below).
+        await page.waitForURL(/\/org\/admin\/integrations\/linear\/customer-push\/[^/]+$/);
         await expect(page.getByRole("heading", { name: "Linear e2e team" })).toBeVisible();
-        await expect(page.getByText("Customer-push source · E2E", { exact: true })).toBeVisible();
+        await expect(
+            page.getByText(`Customer-push source · ${teamKey}`, { exact: true }),
+        ).toBeVisible();
     });
 
     test("duplicate/conflicting source shows the real backend one-active-owner message", async ({
@@ -186,37 +200,99 @@ test.describe("Runner setup examples", () => {
 });
 
 test.describe("Validate payload — validate-only in v1 (CC25 overrule)", () => {
-    // The full validate round-trip (accepted state, rejected-record table) is
-    // covered at unit level with the proxy seam enabled
-    // (ValidatePayloadPanel.test.tsx): the admin validate proxy ships with
-    // CHAOS-2695, so in the real app the submit path is hard-gated off — a
-    // live e2e round-trip here would only ever exercise the MSW mock while
-    // production 404s (adversarial-review finding). Restore the round-trip
-    // e2e when CHAOS-2695 flips VALIDATE_PROXY_AVAILABLE.
-    test("submit is gated off with guidance until the validate proxy lands", async ({ page }) => {
+    // Round-trip restored: the admin validate proxy landed with ops
+    // CHAOS-2695, so VALIDATE_PROXY_AVAILABLE is flipped on and the panel
+    // submits for real (against the MSW mock in e2e, the live endpoint in
+    // prod — the mock mirrors the ops 200-on-envelope-failure contract).
+    test("sample payload validates successfully end-to-end", async ({ page }) => {
         await page.goto(
             `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/validate`,
         );
 
-        await expect(page.getByText(/Server-side validation isn't available yet/)).toBeVisible();
+        // The interim "not available yet" gate is gone.
+        await expect(page.getByText(/Server-side validation isn't available yet/)).toHaveCount(0);
 
-        // Payload prep still works (paste + sample) — only submission is gated.
         await page.getByRole("button", { name: "Use sample" }).click();
         await expect(page.getByPlaceholder(/schemaVersion/)).toHaveValue(/external-ingest.v1/);
-        await expect(page.getByRole("button", { name: "Validate payload" })).toBeDisabled();
+        await page.getByRole("button", { name: "Validate payload" }).click();
+
+        await expect(page.getByText(/Payload is valid/)).toBeVisible();
 
         // Regression guard: the console-push CTA was cut from v1 (CC25) —
         // Screen 5 is validate-only, there must be no push button anywhere.
         await expect(page.getByRole("button", { name: /push this payload/i })).toHaveCount(0);
     });
+
+    test("rejected records render in the results table", async ({ page }) => {
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/validate`,
+        );
+
+        // Wrapper is VALID (kind + externalId present) so the envelope
+        // parses; the payload omits required sourceSystem — a genuine
+        // PER-RECORD rejection on the real ops endpoint, not the
+        // envelope-level invalid_envelope path (adversarial-review finding:
+        // the old fixture dropped wrapper externalId, which the real
+        // endpoint classifies as an envelope failure with items_rejected 0).
+        const payload = {
+            schemaVersion: "external-ingest.v1",
+            idempotencyKey: "e2e-validate-1",
+            source: { type: "customer_push", system: "github", instance: "acme/api" },
+            records: [
+                {
+                    kind: "repository.v1",
+                    externalId: "acme/api",
+                    payload: { externalId: "acme/api" },
+                },
+            ],
+        };
+        await page.getByPlaceholder(/schemaVersion/).fill(JSON.stringify(payload));
+        await page.getByRole("button", { name: "Validate payload" }).click();
+
+        await expect(page.getByText(/1 record rejected/)).toBeVisible();
+        await expect(page.getByText("missing_required_field")).toBeVisible();
+        await expect(page.getByText("records[0].payload.sourceSystem")).toBeVisible();
+    });
+
+    test("envelope-level failure renders as a result, not an API error", async ({ page }) => {
+        await page.goto(
+            `/org/admin/integrations/github/customer-push/${SEEDED_SOURCE_ID}/validate`,
+        );
+
+        // Missing wrapper externalId → the real endpoint fails BatchEnvelope
+        // parsing → 200 valid:false with code invalid_envelope and zero
+        // per-record counts (never a 4xx the panel would show as apiError).
+        const payload = {
+            schemaVersion: "external-ingest.v1",
+            idempotencyKey: "e2e-validate-2",
+            source: { type: "customer_push", system: "github", instance: "acme/api" },
+            records: [
+                {
+                    kind: "repository.v1",
+                    payload: { externalId: "acme/api", sourceSystem: "github" },
+                },
+            ],
+        };
+        await page.getByPlaceholder(/schemaVersion/).fill(JSON.stringify(payload));
+        await page.getByRole("button", { name: "Validate payload" }).click();
+
+        await expect(page.getByText("invalid_envelope")).toBeVisible();
+        await expect(page.getByText(/Validation request failed/)).toHaveCount(0);
+    });
 });
 
 test.describe("Ingest status — batch list + drilldown", () => {
-    test("empty state shows guidance linking to Validate and Examples", async ({ page }) => {
+    test("empty state shows guidance linking to Validate and Examples", async ({
+        page,
+    }, testInfo) => {
         // A freshly created source has zero batches in the mock store.
         await page.goto("/org/admin/integrations/jira/customer-push/new");
         await page.locator("#customer-push-display-name").fill("Jira e2e project");
-        await page.locator("#customer-push-instance").fill("E2EJ");
+        await page
+            .locator("#customer-push-instance")
+            // Per-retry key: see the happy-path test's comment (mock store
+            // survives retries; a leftover row 409s the re-create).
+            .fill(testInfo.retry === 0 ? "E2EJ" : `E2EJ-R${testInfo.retry}`);
         await page.getByRole("button", { name: "Create customer-push source" }).click();
         // Wait for (and verify) the actual redirect target rather than
         // reading page.url() after a generic visibility assertion — pins

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -3069,7 +3069,13 @@ export const handlers = [
         }
 
         const created: MockCustomerPushSource = {
-            id: `cps-${Date.now()}`,
+            // crypto.randomUUID, NOT Date.now(): two source-creating specs
+            // in parallel CI workers collide on the millisecond, and the
+            // find()-by-id lookups then resolve the WRONG source (wrong
+            // overview heading; batch-detail source-scope guard 404s) --
+            // the standing full-suite-only failure of the create-source
+            // happy path since #737 (CHAOS-2695 follow-up fix).
+            id: `cps-${crypto.randomUUID()}`,
             org_id: "org-e2e",
             system,
             instance,
@@ -3123,7 +3129,7 @@ export const handlers = [
             scopes?: string[];
             expires_at?: string | null;
         } | null;
-        const tokenId = `cpt-${Date.now()}`;
+        const tokenId = `cpt-${crypto.randomUUID()}`;
         const created: MockCustomerPushTokenCreateResponse = {
             id: tokenId,
             org_id: "org-e2e",
@@ -3158,7 +3164,7 @@ export const handlers = [
         // Hard cutover (verified: rotate_token revokes the old row and
         // mints a brand-new token id — no in-place rotation).
         token.revoked_at = new Date().toISOString();
-        const newTokenId = `cpt-${Date.now()}`;
+        const newTokenId = `cpt-${crypto.randomUUID()}`;
         const rotated: MockCustomerPushTokenCreateResponse = {
             id: newTokenId,
             org_id: token.org_id,
@@ -3285,17 +3291,29 @@ export const handlers = [
         });
     }),
 
-    // Provisional — the validate proxy has not landed in the merged ops
-    // source yet (CHAOS-2695/wave 4). This mock follows the brief's
-    // contract sketch, the only source of truth available until then.
+    // Mirrors the ops CHAOS-2695 endpoint's semantics (validate_source_payload
+    // in api/admin/routers/customer_push.py): BatchEnvelope parses FIRST, so
+    // a missing wrapper kind/externalId or empty records array is an
+    // ENVELOPE-level failure (200 valid:false, items 0/0, code
+    // "invalid_envelope") — per-record rejections only exist for envelopes
+    // that parse. Per-kind payload validation here covers the required
+    // fields of the kinds the console flows exercise (repository.v1,
+    // work_item.v1) with the real vocabulary (missing_required_field,
+    // "Field required", records[i].payload.<field>); other kinds pass
+    // payload validation in the mock.
     http.post("*/api/v1/admin/customer-push/sources/:id/validate", async ({ request }) => {
         const body = (await request.json()) as {
-            records?: Array<{ kind?: string; externalId?: string; payload?: unknown }>;
+            schemaVersion?: string;
+            records?: Array<{
+                kind?: string;
+                externalId?: string;
+                payload?: Record<string, unknown>;
+            }>;
         } | null;
         const records = body?.records ?? [];
 
-        if (records.length === 0) {
-            return HttpResponse.json({
+        const envelopeFailure = (path: string, message: string) =>
+            HttpResponse.json({
                 valid: false,
                 items_accepted: 0,
                 items_rejected: 0,
@@ -3305,33 +3323,48 @@ export const handlers = [
                         kind: "unknown",
                         external_id: null,
                         code: "invalid_envelope",
-                        path: "records",
-                        message: "records must contain at least 1 item",
+                        path,
+                        message,
                     },
                 ],
             });
+
+        if (records.length === 0) {
+            return envelopeFailure("records", "List should have at least 1 item");
+        }
+        const badWrapper = records.findIndex((r) => !r.kind || !r.externalId);
+        if (badWrapper !== -1) {
+            return envelopeFailure(
+                `records.${badWrapper}.${records[badWrapper].kind ? "externalId" : "kind"}`,
+                "Field required",
+            );
         }
 
+        const REQUIRED_PAYLOAD_FIELDS: Record<string, string[]> = {
+            "repository.v1": ["externalId", "sourceSystem"],
+            "work_item.v1": ["externalKey", "provider", "title", "status", "createdAt"],
+        };
         const errors = records.flatMap((record, index) => {
-            if (!record.externalId) {
-                return [
-                    {
-                        index,
-                        kind: record.kind ?? "unknown",
-                        external_id: null,
-                        code: "missing_required_field",
-                        path: `records[${index}].externalId`,
-                        message: "externalId is required",
-                    },
-                ];
-            }
-            return [];
+            const required = REQUIRED_PAYLOAD_FIELDS[record.kind ?? ""];
+            if (!required) return [];
+            const payload = record.payload ?? {};
+            return required
+                .filter((field) => payload[field] === undefined)
+                .map((field) => ({
+                    index,
+                    kind: record.kind,
+                    external_id: record.externalId ?? null,
+                    code: "missing_required_field",
+                    path: `records[${index}].payload.${field}`,
+                    message: "Field required",
+                }));
         });
+        const rejectedIndices = new Set(errors.map((e) => e.index));
 
         return HttpResponse.json({
             valid: errors.length === 0,
-            items_accepted: records.length - errors.length,
-            items_rejected: errors.length,
+            items_accepted: records.length - rejectedIndices.size,
+            items_rejected: rejectedIndices.size,
             errors,
         });
     }),


### PR DESCRIPTION
Companion to ops#1138 (merged): the admin validate proxy `POST /api/v1/admin/customer-push/sources/{id}/validate` is live, so this flips `VALIDATE_PROXY_AVAILABLE=true` and restores the validate round-trip e2e that was parked behind the hard gate (the gate flag + injectable test seam stay in place as a one-line rollback path).

## Codex adversarial review (1 round, 3 findings fixed)
1. **HIGH — sample payload invalid against the real ops schema**: `buildSamplePayload` emitted `repository.v1` with `name`/`updatedAt` and no `sourceSystem`; the real `RepositoryV1` requires `sourceSystem` and is `extra="forbid"`, so 'Use sample → Validate' would have shown *invalid* in production while the mock passed it. Samples are now schema-valid for both the git-family (`repository.v1`) and jira/linear (`work_item.v1`) branches, and the happy-path e2e pins it.
2. **MEDIUM — rejected-records e2e exercised a mock-only path**: the fixture dropped the *wrapper* `externalId`, which the real endpoint classifies as an envelope-level failure (`invalid_envelope`, items_rejected 0), not a per-record rejection. Fixture corrected to a genuine per-record rejection (valid wrapper, payload missing `sourceSystem`), a separate envelope-failure e2e added, and the MSW handler rewritten to mirror the ops semantics (envelope parses first; real vocabulary: `missing_required_field`, "Field required", `records[i].payload.<field>`).
3. **LOW — stale 'proxy hasn't landed / expect 404' comments** in the API client and types updated to describe the landed contract (a 404 is now deployment skew, not an expected provisional state).

## Verification
- unit **2481/2481**, e2e `admin-customer-push.spec.ts` **16/16** (incl. restored round-trip + new envelope-failure spec), tsc clean, format/quality green.
- Contract parity verified against the merged ops source (`AdminValidateResponse` in `api/admin/schemas/customer_push.py`) and its 8 endpoint tests.

Part of CHAOS-2695 / epic CHAOS-2690.