### PR TITLE
chore(security): scanner triage for epic branch (CHAOS-2690)

### DIFF
--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -3141,7 +3141,10 @@ export const handlers = [
             revoked_at: null,
             created_at: new Date().toISOString(),
             token_prefix: `fcpush_${tokenId.slice(0, 4)}`,
-            token: `fcpush_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`,
+            // Cryptographically secure even though this is mock/test-only data —
+            // avoids CodeQL js/insecure-randomness flagging Math.random() as a
+            // security-sensitive token generator (see CHAOS-2690 scanner triage).
+            token: `fcpush_${crypto.randomUUID().replace(/-/g, "")}`,
         };
         // One-time-display contract (adversarial-review finding): the plaintext
         // `token` exists ONLY in the immediate POST response — the stored list
@@ -3176,7 +3179,8 @@ export const handlers = [
             revoked_at: null,
             created_at: new Date().toISOString(),
             token_prefix: `fcpush_${newTokenId.slice(0, 4)}`,
-            token: `fcpush_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`,
+            // See rationale on the create-token handler above.
+            token: `fcpush_${crypto.randomUUID().replace(/-/g, "")}`,
         };
         // Same one-time-display contract as token creation: list store never
         // holds the plaintext.


### PR DESCRIPTION
Triages the security-scanner findings on the CHAOS-2690 epic-integration PR (#739).

## Triage table

| Finding | Verdict | Action |
|---|---|---|
| CodeQL `js/insecure-randomness` #24 — `tests/mocks/handlers.ts:3144` (create customer-push token mock) | Real (technically), no security impact | Fixed: `Math.random()` → `crypto.randomUUID()` |
| CodeQL `js/insecure-randomness` #25 — `tests/mocks/handlers.ts:3177` (rotate customer-push token mock) | Real (technically), no security impact | Fixed: `Math.random()` → `crypto.randomUUID()` |
| gitleaks findings | N/A | **Doesn't run on this repo** — no workflow, no `.gitleaks.toml`, no alerts anywhere in the repo. That's a dev-health-ops PR #1145 pattern, not applicable here. No action taken. |
| Semgrep OSS findings | N/A | **Doesn't run on this repo** — no workflow, zero code-scanning alerts from that tool anywhere in the repo (checked repo-wide, not just this PR). Same as above, not applicable here. No action taken. |

## Details on the 2 real findings

Both alerts are in `tests/mocks/handlers.ts`, an MSW mock-server handler file used only
by unit/e2e tests (never shipped or executed in production). They flag `Math.random()`
used to build the fake `token` value returned by the mock "create customer-push API
token" / "rotate token" endpoints. GitHub itself classifies both alert locations as
`test`. There is no real security impact — the value is never a real credential, it only
exists in the mock server's in-memory store so Playwright/vitest specs can exercise the
one-time-display / list-redaction UI contract.

Even so, since the fix is a trivial one-line swap with no downside, I fixed the code
rather than suppressing the alert: replaced `Math.random()` with `crypto.randomUUID()`
at both call sites. This is consistent with the id-mint style PR #738 already introduced
nearby in the same file (`cps-${crypto.randomUUID()}`, `cpt-${crypto.randomUUID()}`).
No inline suppression comment/mechanism was added — this repo has no existing
`codeql[...]`/`lgtm[...]`/`nosemgrep` precedent to follow, and none is needed once the
code itself is fixed.

Verified no test asserts the exact token format (only the `fcpush_` prefix, in
`tests/admin-customer-push.spec.ts` and `src/lib/admin/api/__tests__/customer-push.test.ts`),
so this is a safe, behavior-preserving change.

## Gates

Rebased onto `chaos-2690-external-ingest` @ `afc829024` (post PR #738 merge) before
running gates, since #738 touched the same file.

- `format` — PASS
- `quality` (audit/codegen/lint/typecheck) — PASS
- `pnpm run typecheck` — PASS
- `unit` — 3 failures, all in `src/lib/__tests__/rate-limit.test.ts` (in-memory
  rate-limiter timing, unrelated to this change). **Reproduced identically on the base
  commit with this fix NOT applied** — pre-existing, and this same file was reported
  green 2481/2481 on unrelated same-tree runs earlier today. Machine-load timing flake.
- `e2e` (full suite incl. onboarding) — 3 failures: `admin-customer-push.spec.ts` (batch
  drilldown nav), `admin-sync.spec.ts` (repo-edit nav), `filter-propagation.spec.ts`
  (diagnose child-route filter retention). This is a known navigation-timeout flake class
  already seen intermittently in PR #738's CI (which retries; local Playwright config
  does not retry). **None reproduced when re-run in isolation against the base commit**
  (2/2 passes each) — no plausible causal link to a mock token-generator string change.

None of the 6 failures touch `tests/mocks/handlers.ts` semantics or the customer-push
token flows this change modifies.