### PR TITLE
feat(admin/sync): coverage-first config detail, gaps timeline, job history redesign (CHAOS-2791/2792/2793)

### DIFF
--- a/src/app/(app)/org/admin/sync/[configId]/edit/page.tsx
+++ b/src/app/(app)/org/admin/sync/[configId]/edit/page.tsx
@@ -6,10 +6,13 @@ import { RunBackfill } from "@/components/admin/sync/RunBackfill";
 
 interface EditSyncConfigPageProps {
     params: Promise<{ configId: string }>;
+    /** Gap-driven backfill deep link from the coverage timeline (CHAOS-2793). */
+    searchParams: Promise<{ backfill_from?: string; backfill_to?: string }>;
 }
 
-export default async function EditSyncConfigPage({ params }: EditSyncConfigPageProps) {
+export default async function EditSyncConfigPage({ params, searchParams }: EditSyncConfigPageProps) {
     const { configId } = await params;
+    const { backfill_from: backfillFrom, backfill_to: backfillTo } = await searchParams;
     const [configResult, credentialsResult, repositorySelectionResult] = await Promise.all([
         getSyncConfig(configId),
         listCredentials(),
@@ -37,7 +40,7 @@ export default async function EditSyncConfigPage({ params }: EditSyncConfigPageP
             />
 
             <div className="max-w-2xl">
-                <RunBackfill configId={configId} />
+                <RunBackfill configId={configId} initialSince={backfillFrom} initialBefore={backfillTo} />
             </div>
         </div>
     );

--- a/src/app/(app)/org/admin/sync/[configId]/edit/page.tsx
+++ b/src/app/(app)/org/admin/sync/[configId]/edit/page.tsx
@@ -7,12 +7,21 @@ import { RunBackfill } from "@/components/admin/sync/RunBackfill";
 interface EditSyncConfigPageProps {
     params: Promise<{ configId: string }>;
     /** Gap-driven backfill deep link from the coverage timeline (CHAOS-2793). */
-    searchParams: Promise<{ backfill_from?: string; backfill_to?: string }>;
+    searchParams: Promise<{ backfill_from?: string | string[]; backfill_to?: string | string[] }>;
 }
 
-export default async function EditSyncConfigPage({ params, searchParams }: EditSyncConfigPageProps) {
+function firstParam(value: string | string[] | undefined): string | undefined {
+    return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function EditSyncConfigPage({
+    params,
+    searchParams,
+}: EditSyncConfigPageProps) {
     const { configId } = await params;
-    const { backfill_from: backfillFrom, backfill_to: backfillTo } = await searchParams;
+    const { backfill_from: backfillFromParam, backfill_to: backfillToParam } = await searchParams;
+    const backfillFrom = firstParam(backfillFromParam);
+    const backfillTo = firstParam(backfillToParam);
     const [configResult, credentialsResult, repositorySelectionResult] = await Promise.all([
         getSyncConfig(configId),
         listCredentials(),
@@ -40,7 +49,11 @@ export default async function EditSyncConfigPage({ params, searchParams }: EditS
             />
 
             <div className="max-w-2xl">
-                <RunBackfill configId={configId} initialSince={backfillFrom} initialBefore={backfillTo} />
+                <RunBackfill
+                    configId={configId}
+                    initialSince={backfillFrom}
+                    initialBefore={backfillTo}
+                />
             </div>
         </div>
     );

--- a/src/app/(app)/org/admin/sync/[configId]/loading.tsx
+++ b/src/app/(app)/org/admin/sync/[configId]/loading.tsx
@@ -1,0 +1,12 @@
+import { SkeletonLine, SkeletonCard, SkeletonTable } from "@/components/ui/Skeleton";
+
+export default function Loading() {
+    return (
+        <div className="space-y-8">
+            <SkeletonLine width="w-64" height="h-8" />
+            <SkeletonCard lines={2} />
+            <SkeletonCard lines={4} />
+            <SkeletonTable rows={6} cols={10} />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/sync/[configId]/page.tsx
+++ b/src/app/(app)/org/admin/sync/[configId]/page.tsx
@@ -20,12 +20,17 @@ import type { SyncConfig, SyncCoverageSummary, SyncJob } from "@/lib/admin/types
 interface PageProps {
     params: Promise<{ configId: string }>;
     /** `coverage_scenario` selects a sample scenario in DEV_HEALTH_TEST_MODE only. */
-    searchParams: Promise<{ coverage_scenario?: string }>;
+    searchParams: Promise<{ coverage_scenario?: string | string[] }>;
+}
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+    return Array.isArray(value) ? value[0] : value;
 }
 
 export default async function SyncConfigDetailPage({ params, searchParams }: PageProps) {
     const { configId } = await params;
     const { coverage_scenario: coverageScenario } = await searchParams;
+    const coverageScenarioParam = firstParam(coverageScenario);
 
     const env = getServerEnv();
     const isTestMode =
@@ -42,7 +47,7 @@ export default async function SyncConfigDetailPage({ params, searchParams }: Pag
         // page is exercisable in Playwright/test mode (web AGENTS test-mode rule).
         config = SAMPLE_SYNC_CONFIG;
         jobs = SAMPLE_SYNC_JOBS;
-        coverage = SYNC_COVERAGE_SAMPLES[resolveSyncCoverageSampleScenario(coverageScenario)];
+        coverage = SYNC_COVERAGE_SAMPLES[resolveSyncCoverageSampleScenario(coverageScenarioParam)];
         orgId = "sample-org";
     } else {
         const [configResult, jobsResult, coverageResult, orgResult] = await Promise.all([
@@ -80,7 +85,10 @@ export default async function SyncConfigDetailPage({ params, searchParams }: Pag
     return (
         <div className="space-y-8">
             <AdminHeader title={config.name} description={`Provider: ${config.provider}`}>
-                <TestConnectionButton provider={config.provider} credentialId={config.credential_id} />
+                <TestConnectionButton
+                    provider={config.provider}
+                    credentialId={config.credential_id}
+                />
             </AdminHeader>
 
             <SyncProgressBar configId={config.id} provider={config.provider} orgId={orgId} />
@@ -148,7 +156,8 @@ export default async function SyncConfigDetailPage({ params, searchParams }: Pag
 
                 {config.last_sync_error && (
                     <div className="mt-6 rounded-lg border border-(--negative)/20 bg-(--negative)/10 p-4 text-sm text-(--negative)">
-                        <span className="font-medium">Last sync error:</span> {config.last_sync_error}
+                        <span className="font-medium">Last sync error:</span>{" "}
+                        {config.last_sync_error}
                     </div>
                 )}
             </details>

--- a/src/app/(app)/org/admin/sync/[configId]/page.tsx
+++ b/src/app/(app)/org/admin/sync/[configId]/page.tsx
@@ -1,33 +1,76 @@
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import { ClientTimestamp } from "@/components/ClientTimestamp";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { SyncStatusBadge } from "@/components/admin/sync/SyncStatusBadge";
+import { SyncCoverageSummaryCard } from "@/components/admin/sync/SyncCoverageSummaryCard";
+import { SyncCoverageTimeline } from "@/components/admin/sync/SyncCoverageTimeline";
 import { SyncJobHistory } from "@/components/admin/sync/SyncJobHistory";
 import { SyncProgressBar } from "@/components/admin/sync/SyncProgressBar";
-import { SyncNowButton } from "@/components/admin/sync/SyncNowButton";
 import { TestConnectionButton } from "@/components/admin/sync/TestConnectionButton";
-import { getSyncConfig, getSyncJobs, getCurrentOrg } from "@/lib/admin/server";
+import { getServerEnv } from "@/lib/config";
+import { getSyncConfig, getSyncJobs, getSyncCoverage, getCurrentOrg } from "@/lib/admin/server";
+import {
+    SAMPLE_SYNC_CONFIG,
+    SAMPLE_SYNC_JOBS,
+    SYNC_COVERAGE_SAMPLES,
+    resolveSyncCoverageSampleScenario,
+} from "@/data/syncCoverageSample";
+import type { SyncConfig, SyncCoverageSummary, SyncJob } from "@/lib/admin/types";
 
 interface PageProps {
     params: Promise<{ configId: string }>;
+    /** `coverage_scenario` selects a sample scenario in DEV_HEALTH_TEST_MODE only. */
+    searchParams: Promise<{ coverage_scenario?: string }>;
 }
 
-export default async function SyncConfigDetailPage({ params }: PageProps) {
+export default async function SyncConfigDetailPage({ params, searchParams }: PageProps) {
     const { configId } = await params;
-    const [configResult, jobsResult, orgResult] = await Promise.all([
-        getSyncConfig(configId),
-        getSyncJobs(configId),
-        getCurrentOrg(),
-    ]);
+    const { coverage_scenario: coverageScenario } = await searchParams;
 
-    if (configResult.error || !configResult.data) {
-        notFound();
+    const env = getServerEnv();
+    const isTestMode =
+        env.DEV_HEALTH_TEST_MODE === "true" || env.NEXT_PUBLIC_DEV_HEALTH_TEST_MODE === "true";
+
+    let config: SyncConfig;
+    let jobs: SyncJob[];
+    let coverage: SyncCoverageSummary | null;
+    let coverageError: string | null = null;
+    let orgId: string;
+
+    if (isTestMode) {
+        // Render deterministic sample data without hitting the admin API so the
+        // page is exercisable in Playwright/test mode (web AGENTS test-mode rule).
+        config = SAMPLE_SYNC_CONFIG;
+        jobs = SAMPLE_SYNC_JOBS;
+        coverage = SYNC_COVERAGE_SAMPLES[resolveSyncCoverageSampleScenario(coverageScenario)];
+        orgId = "sample-org";
+    } else {
+        const [configResult, jobsResult, coverageResult, orgResult] = await Promise.all([
+            getSyncConfig(configId),
+            getSyncJobs(configId),
+            getSyncCoverage(configId),
+            getCurrentOrg(),
+        ]);
+
+        if (configResult.error || !configResult.data) {
+            notFound();
+        }
+
+        config = configResult.data;
+        jobs = jobsResult.data ?? [];
+        orgId = orgResult.data?.id ?? "";
+
+        // withErrorHandling RETURNS { error } (never throws), so a failed
+        // coverage fetch surfaces here. Do NOT fabricate an empty summary —
+        // pass the error through so the coverage card/timeline render an
+        // explicit notice while the rest of the page still renders.
+        if (coverageResult.error || !coverageResult.data) {
+            coverage = null;
+            coverageError = coverageResult.error ?? "Coverage summary is unavailable.";
+        } else {
+            coverage = coverageResult.data;
+        }
     }
-
-    const config = configResult.data;
-    const jobs = jobsResult.data || [];
-    const orgId = orgResult.data?.id || "";
 
     const getStatus = () => {
         if (!config.last_sync_at) return "never";
@@ -36,82 +79,83 @@ export default async function SyncConfigDetailPage({ params }: PageProps) {
 
     return (
         <div className="space-y-8">
-            <div className="flex items-center justify-between">
-                <AdminHeader title={config.name} description={`Provider: ${config.provider}`}>
-                    <div className="flex items-center gap-3">
-                        <TestConnectionButton
-                            provider={config.provider}
-                            credentialId={config.credential_id}
-                        />
-                        <Link
-                            href={`/org/admin/sync/${config.id}/edit`}
-                            className="rounded-md border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground hover:border-(--accent) hover:text-(--accent)"
-                        >
-                            Edit Config
-                        </Link>
-                        <SyncNowButton configId={config.id} />
-                    </div>
-                </AdminHeader>
-            </div>
+            <AdminHeader title={config.name} description={`Provider: ${config.provider}`}>
+                <TestConnectionButton provider={config.provider} credentialId={config.credential_id} />
+            </AdminHeader>
 
             <SyncProgressBar configId={config.id} provider={config.provider} orgId={orgId} />
 
-            <div className="grid gap-6 md:grid-cols-3">
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
-                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
-                        Current Status
-                    </h3>
-                    <div className="mt-2">
-                        <SyncStatusBadge status={getStatus()} className="text-sm px-3 py-1" />
+            <SyncCoverageSummaryCard
+                configId={config.id}
+                coverage={coverage}
+                error={coverageError}
+                isActive={config.is_active}
+            />
+
+            <SyncCoverageTimeline configId={config.id} coverage={coverage} error={coverageError} />
+
+            <details className="group space-y-4 rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <summary className="cursor-pointer text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                    Sync details
+                </summary>
+
+                <div className="mt-4 grid gap-6 md:grid-cols-3">
+                    <div>
+                        <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                            Current Status
+                        </h3>
+                        <div className="mt-2">
+                            <SyncStatusBadge status={getStatus()} className="text-sm px-3 py-1" />
+                        </div>
+                    </div>
+
+                    <div>
+                        <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                            Last Sync
+                        </h3>
+                        <p className="mt-2 text-lg font-medium text-foreground">
+                            <ClientTimestamp value={config.last_sync_at} fallback="Never" />
+                        </p>
+                    </div>
+
+                    <div>
+                        <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                            Active
+                        </h3>
+                        <p className="mt-2 text-lg font-medium text-foreground">
+                            {config.is_active ? "Yes" : "No"}
+                        </p>
                     </div>
                 </div>
 
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
-                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
-                        Last Sync
-                    </h3>
-                    <p className="mt-2 text-lg font-medium text-foreground">
-                        <ClientTimestamp value={config.last_sync_at} fallback="Never" />
-                    </p>
-                </div>
-
-                <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
-                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
-                        Active
-                    </h3>
-                    <p className="mt-2 text-lg font-medium text-foreground">
-                        {config.is_active ? "Yes" : "No"}
-                    </p>
-                </div>
-            </div>
-
-            {config.sync_targets.length > 0 && (
-                <div className="space-y-2">
-                    <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
-                        Sync Targets
-                    </h3>
-                    <div className="flex flex-wrap gap-2">
-                        {config.sync_targets.map((target) => (
-                            <span
-                                key={target}
-                                className="rounded-full bg-(--card-70) px-3 py-1 text-xs font-medium text-foreground"
-                            >
-                                {target}
-                            </span>
-                        ))}
+                {config.sync_targets.length > 0 && (
+                    <div className="mt-6 space-y-2">
+                        <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                            Sync Targets
+                        </h3>
+                        <div className="flex flex-wrap gap-2">
+                            {config.sync_targets.map((target) => (
+                                <span
+                                    key={target}
+                                    className="rounded-full bg-(--card-70) px-3 py-1 text-xs font-medium text-foreground"
+                                >
+                                    {target}
+                                </span>
+                            ))}
+                        </div>
                     </div>
-                </div>
-            )}
+                )}
 
-            {config.last_sync_error && (
-                <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-500">
-                    <span className="font-medium">Last sync error:</span> {config.last_sync_error}
-                </div>
-            )}
+                {config.last_sync_error && (
+                    <div className="mt-6 rounded-lg border border-(--negative)/20 bg-(--negative)/10 p-4 text-sm text-(--negative)">
+                        <span className="font-medium">Last sync error:</span> {config.last_sync_error}
+                    </div>
+                )}
+            </details>
 
             <div className="space-y-4">
                 <h2 className="text-lg font-medium text-foreground">Job History</h2>
-                <SyncJobHistory jobs={jobs} configId={config.id} />
+                <SyncJobHistory jobs={jobs} configId={config.id} testMode={isTestMode} />
             </div>
         </div>
     );

--- a/src/components/admin/sync/CoverageBadge.test.tsx
+++ b/src/components/admin/sync/CoverageBadge.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+import {
+    CoverageBadge,
+    healthLabel,
+    healthTone,
+    jobCoverageLabel,
+    jobCoverageTone,
+    statusLabel,
+    statusTone,
+} from "./CoverageBadge";
+
+describe("CoverageBadge", () => {
+    it("renders the label text alongside a decorative glyph", () => {
+        render(<CoverageBadge tone="positive" label="Healthy" />);
+
+        expect(screen.getByText("Healthy")).toBeInTheDocument();
+    });
+
+    it("maps every coverage health to a distinct tone with deterministic precedence", () => {
+        expect(healthTone("failed")).toBe("negative");
+        expect(healthTone("gaps")).toBe("caution");
+        expect(healthTone("stale")).toBe("caution");
+        expect(healthTone("healthy")).toBe("positive");
+        expect(healthTone("insufficient_data")).toBe("info");
+    });
+
+    it("never renders the literal word 'unknown' for any health label", () => {
+        const healths: Array<Parameters<typeof healthLabel>[0]> = [
+            "healthy",
+            "stale",
+            "gaps",
+            "failed",
+            "insufficient_data",
+        ];
+        for (const health of healths) {
+            expect(healthLabel(health).toLowerCase()).not.toContain("unknown");
+        }
+    });
+
+    it("maps dataset/source status tones including scheduling states", () => {
+        expect(statusTone("paused")).toBe("muted");
+        expect(statusTone("not_scheduled")).toBe("muted");
+        expect(statusTone("running")).toBe("info");
+        expect(statusLabel("not_scheduled")).toBe("Not scheduled");
+    });
+
+    it("maps job coverage results derived from persisted unit counts", () => {
+        expect(jobCoverageTone("complete")).toBe("positive");
+        expect(jobCoverageTone("partial")).toBe("caution");
+        expect(jobCoverageTone("gap")).toBe("caution");
+        expect(jobCoverageTone("failed")).toBe("negative");
+        expect(jobCoverageLabel("gap")).toBe("Gap");
+    });
+});

--- a/src/components/admin/sync/CoverageBadge.tsx
+++ b/src/components/admin/sync/CoverageBadge.tsx
@@ -1,0 +1,143 @@
+import type { SyncCoverageHealth, SyncCoverageStatus } from "@/lib/admin/types";
+
+/**
+ * Shared semantic-tone vocabulary for coverage/gap surfaces (CHAOS-2791/2792/2793).
+ *
+ * Color is never the only signal (web AGENTS a11y rule): every tone pairs a
+ * design-system status token with a glyph AND a text label, so a colorblind
+ * or non-visual reader gets the same information as a sighted one.
+ */
+export type CoverageTone = "positive" | "caution" | "negative" | "info" | "muted";
+
+const TONE_CLASSES: Record<CoverageTone, string> = {
+    positive: "border-(--positive)/30 bg-(--positive)/15 text-(--positive)",
+    caution: "border-(--caution)/30 bg-(--caution)/15 text-(--caution)",
+    negative: "border-(--negative)/30 bg-(--negative)/15 text-(--negative)",
+    info: "border-(--info)/30 bg-(--info)/15 text-(--info)",
+    muted: "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)",
+};
+
+const TONE_GLYPH: Record<CoverageTone, string> = {
+    positive: "\u2713", // check
+    caution: "\u26A0", // warning triangle
+    negative: "\u2715", // x
+    info: "\u2139", // info
+    muted: "\u2022", // bullet
+};
+
+interface CoverageBadgeProps {
+    tone: CoverageTone;
+    label: string;
+    className?: string;
+}
+
+export function CoverageBadge({ tone, label, className = "" }: CoverageBadgeProps) {
+    return (
+        <span
+            className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${TONE_CLASSES[tone]} ${className}`}
+        >
+            <span aria-hidden="true">{TONE_GLYPH[tone]}</span>
+            {label}
+        </span>
+    );
+}
+
+/** Overall coverage health tone (deterministic precedence: failed > gaps > stale > healthy). */
+export function healthTone(health: SyncCoverageHealth): CoverageTone {
+    switch (health) {
+        case "healthy":
+            return "positive";
+        case "stale":
+            return "caution";
+        case "gaps":
+            return "caution";
+        case "failed":
+            return "negative";
+        case "insufficient_data":
+            return "info";
+        default:
+            return "muted";
+    }
+}
+
+const HEALTH_LABEL: Record<SyncCoverageHealth, string> = {
+    healthy: "Healthy",
+    stale: "Stale",
+    gaps: "Gaps detected",
+    failed: "Failed",
+    insufficient_data: "Insufficient data",
+};
+
+export function healthLabel(health: SyncCoverageHealth): string {
+    return HEALTH_LABEL[health] ?? "Insufficient data";
+}
+
+/** Per-dataset / per-source coverage status tone, widening health with scheduling context. */
+export function statusTone(status: SyncCoverageStatus): CoverageTone {
+    switch (status) {
+        case "healthy":
+            return "positive";
+        case "stale":
+        case "gaps":
+            return "caution";
+        case "failed":
+            return "negative";
+        case "insufficient_data":
+            return "info";
+        case "running":
+            return "info";
+        case "paused":
+        case "not_scheduled":
+            return "muted";
+        default:
+            return "muted";
+    }
+}
+
+const STATUS_LABEL: Record<SyncCoverageStatus, string> = {
+    healthy: "Healthy",
+    stale: "Stale",
+    gaps: "Gaps",
+    failed: "Failed",
+    insufficient_data: "Insufficient data",
+    paused: "Paused",
+    not_scheduled: "Not scheduled",
+    running: "Running",
+};
+
+export function statusLabel(status: SyncCoverageStatus): string {
+    return STATUS_LABEL[status] ?? "Insufficient data";
+}
+
+/**
+ * Job-level coverage-result vocabulary (CHAOS-2792), derived ONLY from
+ * persisted job status + sync_run unit counts — never from client-side
+ * interval/coverage math.
+ */
+export type JobCoverageResult = "complete" | "partial" | "gap" | "failed";
+
+export function jobCoverageTone(result: JobCoverageResult): CoverageTone {
+    switch (result) {
+        case "complete":
+            return "positive";
+        case "partial":
+            return "caution";
+        case "gap":
+            return "caution";
+        case "failed":
+            return "negative";
+        default:
+            return "muted";
+    }
+}
+
+const JOB_RESULT_LABEL: Record<JobCoverageResult, string> = {
+    complete: "Complete",
+    partial: "Partial",
+    gap: "Gap",
+    failed: "Failed",
+};
+
+export function jobCoverageLabel(result: JobCoverageResult): string {
+    return JOB_RESULT_LABEL[result];
+}

--- a/src/components/admin/sync/RunBackfill.tsx
+++ b/src/components/admin/sync/RunBackfill.tsx
@@ -7,12 +7,16 @@ import type { BackfillJob } from "@/lib/admin/types";
 
 interface RunBackfillProps {
     configId: string;
+    /** Pre-fill from a gap-driven deep link (?backfill_from=YYYY-MM-DD), CHAOS-2793. */
+    initialSince?: string;
+    /** Pre-fill from a gap-driven deep link (?backfill_to=YYYY-MM-DD), CHAOS-2793. */
+    initialBefore?: string;
 }
 
-export function RunBackfill({ configId }: RunBackfillProps) {
+export function RunBackfill({ configId, initialSince = "", initialBefore = "" }: RunBackfillProps) {
     const [isPending, startTransition] = useTransition();
-    const [since, setSince] = useState("");
-    const [before, setBefore] = useState("");
+    const [since, setSince] = useState(initialSince);
+    const [before, setBefore] = useState(initialBefore);
     const [activeJob, setActiveJob] = useState<BackfillJob | null>(null);
     const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -91,7 +95,10 @@ export function RunBackfill({ configId }: RunBackfillProps) {
     const isTerminal = activeJob?.status === "completed" || activeJob?.status === "failed";
 
     return (
-        <div className="space-y-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6 mt-6">
+        <div
+            id="backfill"
+            className="space-y-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6 mt-6 scroll-mt-24"
+        >
             <div>
                 <h3 className="text-sm font-medium">Run Historical Backfill</h3>
                 <p className="mt-1 text-xs text-(--ink-muted)">

--- a/src/components/admin/sync/SyncCoverageSummaryCard.test.tsx
+++ b/src/components/admin/sync/SyncCoverageSummaryCard.test.tsx
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/test/utils";
+import { SyncCoverageSummaryCard } from "./SyncCoverageSummaryCard";
+import {
+    COMPLETE_COVERAGE_SUMMARY,
+    LEGACY_INSUFFICIENT_DATA_SUMMARY,
+    PARTIAL_COVERAGE_SUMMARY,
+} from "@/lib/admin/__tests__/syncCoverageFixtures";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: mockPush, refresh: vi.fn() }),
+}));
+vi.mock("@/lib/admin/server", () => ({
+    triggerSync: vi.fn(),
+    getSyncRunStatus: vi.fn(),
+    getSyncJobs: vi.fn(),
+}));
+
+beforeEach(() => {
+    mockPush.mockClear();
+});
+
+describe("SyncCoverageSummaryCard", () => {
+    it("renders a loading state when coverage has not resolved yet", () => {
+        render(
+            <SyncCoverageSummaryCard configId="cfg-1" coverage={null} isActive error={undefined} />,
+        );
+
+        expect(screen.getByTestId("coverage-summary-loading")).toBeInTheDocument();
+    });
+
+    it("renders an explicit error state instead of fabricating a summary", () => {
+        render(
+            <SyncCoverageSummaryCard
+                configId="cfg-1"
+                coverage={null}
+                error="Request failed with 500"
+                isActive
+            />,
+        );
+
+        expect(screen.getByTestId("coverage-summary-error")).toBeInTheDocument();
+        expect(screen.getByText("Request failed with 500")).toBeInTheDocument();
+    });
+
+    it("renders the healthy health badge and key stats", () => {
+        render(
+            <SyncCoverageSummaryCard
+                configId="cfg-1"
+                coverage={COMPLETE_COVERAGE_SUMMARY}
+                isActive
+                error={undefined}
+            />,
+        );
+
+        expect(screen.getByText("Healthy")).toBeInTheDocument();
+        expect(screen.getByText("Active")).toBeInTheDocument();
+        expect(screen.getByText("Sync Now")).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "Edit config" })).toHaveAttribute(
+            "href",
+            "/org/admin/sync/cfg-1/edit",
+        );
+        expect(screen.getByRole("link", { name: "Backfill" })).toHaveAttribute(
+            "href",
+            "/org/admin/sync/cfg-1/edit#backfill",
+        );
+    });
+
+    it("renders gap-detected health without the literal word unknown", () => {
+        render(
+            <SyncCoverageSummaryCard
+                configId="cfg-1"
+                coverage={PARTIAL_COVERAGE_SUMMARY}
+                isActive
+                error={undefined}
+            />,
+        );
+
+        expect(screen.getByText("Gaps detected")).toBeInTheDocument();
+        expect(screen.queryByText(/unknown/i)).not.toBeInTheDocument();
+    });
+
+    it("shows an explanatory legacy notice for insufficient_data + legacy data_basis", () => {
+        render(
+            <SyncCoverageSummaryCard
+                configId="cfg-1"
+                coverage={LEGACY_INSUFFICIENT_DATA_SUMMARY}
+                isActive={false}
+                error={undefined}
+            />,
+        );
+
+        expect(screen.getByText("Insufficient data")).toBeInTheDocument();
+        expect(screen.getByTestId("coverage-legacy-notice")).toBeInTheDocument();
+        expect(screen.getByText("Inactive")).toBeInTheDocument();
+        expect(screen.queryByText(/^unknown$/i)).not.toBeInTheDocument();
+    });
+});

--- a/src/components/admin/sync/SyncCoverageSummaryCard.tsx
+++ b/src/components/admin/sync/SyncCoverageSummaryCard.tsx
@@ -1,0 +1,133 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { ClientTimestamp } from "@/components/ClientTimestamp";
+import { DataState } from "@/components/ui/DataState";
+import { formatNumber } from "@/lib/formatters";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { SyncCoverageSummary } from "@/lib/admin/types";
+import { CoverageBadge, healthLabel, healthTone } from "./CoverageBadge";
+import { SyncNowButton } from "./SyncNowButton";
+
+interface SyncCoverageSummaryCardProps {
+    configId: string;
+    /** Null while the coverage summary is loading (page.tsx fetches synchronously; kept for reuse). */
+    coverage: SyncCoverageSummary | null;
+    /** UI-safe error message when the coverage fetch failed (never a raw exception). */
+    error?: string | null;
+    isActive: boolean;
+}
+
+function StatBlock({ label, value }: { label: string; value: ReactNode }) {
+    return (
+        <div>
+            <dt className="text-xs font-medium text-(--ink-muted) uppercase tracking-wider">
+                {label}
+            </dt>
+            <dd className="mt-1 text-lg font-medium text-foreground">{value}</dd>
+        </div>
+    );
+}
+
+export function SyncCoverageSummaryCard({
+    configId,
+    coverage,
+    error,
+    isActive,
+}: SyncCoverageSummaryCardProps) {
+    const editHref = `/org/admin/sync/${configId}/edit`;
+    const backfillHref = `${editHref}#backfill`;
+
+    if (error) {
+        return (
+            <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <DataState
+                    variant="error"
+                    title="Coverage summary unavailable"
+                    message={error}
+                    data-testid="coverage-summary-error"
+                />
+            </div>
+        );
+    }
+
+    if (!coverage) {
+        return (
+            <div
+                className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6"
+                data-testid="coverage-summary-loading"
+            >
+                <DataState variant="loading" title="Loading coverage summary…" />
+            </div>
+        );
+    }
+
+    const { overall, data_basis: dataBasis } = coverage;
+    const isLegacyInsufficientData = overall.health === "insufficient_data" && dataBasis === "legacy";
+
+    return (
+        <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="space-y-2">
+                    <div className="flex items-center gap-3">
+                        <CoverageBadge
+                            tone={healthTone(overall.health)}
+                            label={healthLabel(overall.health)}
+                            className="text-sm px-3 py-1"
+                        />
+                        <span className="text-sm text-(--ink-muted)">
+                            {isActive ? "Active" : "Inactive"}
+                        </span>
+                    </div>
+                    {isLegacyInsufficientData && (
+                        <p
+                            className="max-w-xl text-sm text-(--ink-muted)"
+                            data-testid="coverage-legacy-notice"
+                        >
+                            This configuration has no planner-tracked sync runs yet, so detailed
+                            coverage cannot be computed. Coverage will populate once a planner-backed
+                            sync completes.
+                        </p>
+                    )}
+                </div>
+                <div className="flex items-center gap-3">
+                    <Link
+                        href={backfillHref}
+                        className="rounded-md border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground hover:border-(--accent) hover:text-(--accent)"
+                    >
+                        {CTA_LABELS.backfill}
+                    </Link>
+                    <Link
+                        href={editHref}
+                        className="rounded-md border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground hover:border-(--accent) hover:text-(--accent)"
+                    >
+                        {CTA_LABELS.editConfig}
+                    </Link>
+                    <SyncNowButton configId={configId} />
+                </div>
+            </div>
+
+            <dl className="mt-6 grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-6">
+                <StatBlock
+                    label="Last successful run"
+                    value={<ClientTimestamp value={overall.latest_successful_run_at} fallback="Never" />}
+                />
+                <StatBlock
+                    label="Next scheduled run"
+                    value={
+                        <ClientTimestamp
+                            value={overall.next_scheduled_run_at}
+                            fallback="Not scheduled"
+                        />
+                    }
+                />
+                <StatBlock
+                    label="Covered through"
+                    value={<ClientTimestamp value={overall.latest_covered_through} fallback="—" />}
+                />
+                <StatBlock label="Gaps" value={formatNumber(overall.gap_count)} />
+                <StatBlock label="Stale datasets" value={formatNumber(overall.stale_dataset_count)} />
+                <StatBlock label="Failed ranges" value={formatNumber(overall.failed_range_count)} />
+            </dl>
+        </div>
+    );
+}

--- a/src/components/admin/sync/SyncCoverageSummaryCard.tsx
+++ b/src/components/admin/sync/SyncCoverageSummaryCard.tsx
@@ -62,7 +62,8 @@ export function SyncCoverageSummaryCard({
     }
 
     const { overall, data_basis: dataBasis } = coverage;
-    const isLegacyInsufficientData = overall.health === "insufficient_data" && dataBasis === "legacy";
+    const isLegacyInsufficientData =
+        overall.health === "insufficient_data" && dataBasis === "legacy";
 
     return (
         <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
@@ -84,8 +85,8 @@ export function SyncCoverageSummaryCard({
                             data-testid="coverage-legacy-notice"
                         >
                             This configuration has no planner-tracked sync runs yet, so detailed
-                            coverage cannot be computed. Coverage will populate once a planner-backed
-                            sync completes.
+                            coverage cannot be computed. Coverage will populate once a
+                            planner-backed sync completes.
                         </p>
                     )}
                 </div>
@@ -109,7 +110,12 @@ export function SyncCoverageSummaryCard({
             <dl className="mt-6 grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-6">
                 <StatBlock
                     label="Last successful run"
-                    value={<ClientTimestamp value={overall.latest_successful_run_at} fallback="Never" />}
+                    value={
+                        <ClientTimestamp
+                            value={overall.latest_successful_run_at}
+                            fallback="Never"
+                        />
+                    }
                 />
                 <StatBlock
                     label="Next scheduled run"
@@ -125,7 +131,10 @@ export function SyncCoverageSummaryCard({
                     value={<ClientTimestamp value={overall.latest_covered_through} fallback="—" />}
                 />
                 <StatBlock label="Gaps" value={formatNumber(overall.gap_count)} />
-                <StatBlock label="Stale datasets" value={formatNumber(overall.stale_dataset_count)} />
+                <StatBlock
+                    label="Stale datasets"
+                    value={formatNumber(overall.stale_dataset_count)}
+                />
                 <StatBlock label="Failed ranges" value={formatNumber(overall.failed_range_count)} />
             </dl>
         </div>

--- a/src/components/admin/sync/SyncCoverageTimeline.test.tsx
+++ b/src/components/admin/sync/SyncCoverageTimeline.test.tsx
@@ -6,6 +6,10 @@ import {
     LEGACY_INSUFFICIENT_DATA_SUMMARY,
     PARTIAL_COVERAGE_SUMMARY,
 } from "@/lib/admin/__tests__/syncCoverageFixtures";
+import {
+    SAMPLE_COVERAGE_CONCURRENT_CONFIG,
+    SAMPLE_COVERAGE_OVERLAPPING_RETRY,
+} from "@/data/syncCoverageSample";
 
 describe("SyncCoverageTimeline", () => {
     it("renders a loading state when coverage has not resolved yet", () => {
@@ -84,5 +88,32 @@ describe("SyncCoverageTimeline", () => {
         const tables = screen.getAllByRole("table");
         expect(tables.length).toBeGreaterThan(0);
         expect(within(tables[0]).getByText("Window")).toBeInTheDocument();
+    });
+
+    it("renders the overlapping-retry sample scenario with both a failed window and a later overlapping covered window (CHAOS-2791 D3)", () => {
+        render(
+            <SyncCoverageTimeline
+                configId="sample-sync-config"
+                coverage={SAMPLE_COVERAGE_OVERLAPPING_RETRY}
+            />,
+        );
+
+        const table = screen.getAllByRole("table")[0];
+        expect(within(table).getByText("Covered")).toBeInTheDocument();
+        expect(within(table).getByText("Failed")).toBeInTheDocument();
+        expect(within(table).getAllByText("fullchaos/platform-api").length).toBeGreaterThan(0);
+    });
+
+    it("renders the concurrent-config sample scenario with its own resolved source name (CHAOS-2791 D3)", () => {
+        render(
+            <SyncCoverageTimeline
+                configId="sample-sync-config-secondary"
+                coverage={SAMPLE_COVERAGE_CONCURRENT_CONFIG}
+            />,
+        );
+
+        const table = screen.getAllByRole("table")[0];
+        expect(within(table).getAllByText("fullchaos/second-repo").length).toBeGreaterThan(0);
+        expect(screen.queryByText(/sample-source-secondary-repo/)).not.toBeInTheDocument();
     });
 });

--- a/src/components/admin/sync/SyncCoverageTimeline.test.tsx
+++ b/src/components/admin/sync/SyncCoverageTimeline.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, userEvent, within } from "@/test/utils";
+import { SyncCoverageTimeline } from "./SyncCoverageTimeline";
+import {
+    COMPLETE_COVERAGE_SUMMARY,
+    LEGACY_INSUFFICIENT_DATA_SUMMARY,
+    PARTIAL_COVERAGE_SUMMARY,
+} from "@/lib/admin/__tests__/syncCoverageFixtures";
+
+describe("SyncCoverageTimeline", () => {
+    it("renders a loading state when coverage has not resolved yet", () => {
+        render(<SyncCoverageTimeline configId="cfg-1" coverage={null} />);
+
+        expect(screen.getByTestId("coverage-timeline-loading")).toBeInTheDocument();
+    });
+
+    it("renders an explicit error state instead of fabricating a timeline", () => {
+        render(
+            <SyncCoverageTimeline
+                configId="cfg-1"
+                coverage={null}
+                error="Coverage endpoint returned 500"
+            />,
+        );
+
+        expect(screen.getByText("Coverage timeline unavailable")).toBeInTheDocument();
+        expect(screen.getByText("Coverage endpoint returned 500")).toBeInTheDocument();
+    });
+
+    it("renders a legacy-aware empty state for insufficient_data + legacy data_basis", () => {
+        render(
+            <SyncCoverageTimeline configId="cfg-1" coverage={LEGACY_INSUFFICIENT_DATA_SUMMARY} />,
+        );
+
+        expect(screen.getByText("No planner-tracked coverage yet")).toBeInTheDocument();
+        expect(screen.queryByText(/^unknown$/i)).not.toBeInTheDocument();
+    });
+
+    it("renders dataset rows with resolved source names, never raw source ids", () => {
+        render(<SyncCoverageTimeline configId="cfg-1" coverage={PARTIAL_COVERAGE_SUMMARY} />);
+
+        expect(screen.getAllByText("commits").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("acme/repo").length).toBeGreaterThan(0);
+        expect(screen.queryByText(/src-repo/)).not.toBeInTheDocument();
+    });
+
+    it("exposes a 'Backfill this gap' action deep-linking to the edit page with date query params", () => {
+        render(<SyncCoverageTimeline configId="cfg-1" coverage={PARTIAL_COVERAGE_SUMMARY} />);
+
+        const link = screen.getByRole("link", { name: "Backfill this gap" });
+        expect(link).toHaveAttribute(
+            "href",
+            "/org/admin/sync/cfg-1/edit?backfill_from=2026-01-02&backfill_to=2026-01-03#backfill",
+        );
+    });
+
+    it("filters rendered datasets by the dataset filter", async () => {
+        render(<SyncCoverageTimeline configId="cfg-1" coverage={COMPLETE_COVERAGE_SUMMARY} />);
+
+        expect(screen.getAllByText("commits").length).toBeGreaterThan(0);
+
+        const [datasetSelect] = screen.getAllByRole("combobox");
+        await userEvent.selectOptions(datasetSelect, "commits");
+
+        expect(screen.getAllByText("commits").length).toBeGreaterThan(0);
+    });
+
+    it("filters the accessible table rows by the source filter", async () => {
+        render(<SyncCoverageTimeline configId="cfg-1" coverage={PARTIAL_COVERAGE_SUMMARY} />);
+
+        const selects = screen.getAllByRole("combobox");
+        const sourceSelect = selects[1];
+        await userEvent.selectOptions(sourceSelect, "src-repo");
+
+        // Every dataset in the fixture references the single source, so rows
+        // should still be present after filtering to that source.
+        const table = screen.getAllByRole("table")[0];
+        expect(within(table).getAllByText("acme/repo").length).toBeGreaterThan(0);
+    });
+
+    it("renders an accessible table fallback alongside the CSS bands", () => {
+        render(<SyncCoverageTimeline configId="cfg-1" coverage={PARTIAL_COVERAGE_SUMMARY} />);
+
+        const tables = screen.getAllByRole("table");
+        expect(tables.length).toBeGreaterThan(0);
+        expect(within(tables[0]).getByText("Window")).toBeInTheDocument();
+    });
+});

--- a/src/components/admin/sync/SyncCoverageTimeline.tsx
+++ b/src/components/admin/sync/SyncCoverageTimeline.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { DataState } from "@/components/ui/DataState";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { SyncCoverageDataset, SyncCoverageRange, SyncCoverageSummary } from "@/lib/admin/types";
+import { CoverageBadge, statusLabel, statusTone, type CoverageTone } from "./CoverageBadge";
+
+interface SyncCoverageTimelineProps {
+    configId: string;
+    coverage: SyncCoverageSummary | null;
+    error?: string | null;
+}
+
+type BandKind = "covered" | "gap" | "stale" | "failed";
+
+const BAND_TONE: Record<BandKind, CoverageTone> = {
+    covered: "positive",
+    gap: "negative",
+    stale: "caution",
+    failed: "negative",
+};
+
+const BAND_LABEL: Record<BandKind, string> = {
+    covered: "Covered",
+    gap: "Gap",
+    stale: "Stale",
+    failed: "Failed",
+};
+
+const BAND_BAR_CLASS: Record<BandKind, string> = {
+    covered: "bg-(--positive)",
+    gap: "border border-dashed border-(--negative) bg-(--negative)/40",
+    stale: "bg-(--caution)",
+    failed: "bg-(--negative)",
+};
+
+interface TimelineRow {
+    kind: BandKind;
+    range: SyncCoverageRange;
+    datasetKey: string;
+}
+
+function formatDate(value: string): string {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+    });
+}
+
+function toDateInput(value: string): string {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "";
+    return date.toISOString().slice(0, 10);
+}
+
+function rangeIncludesSource(range: SyncCoverageRange, sourceId: string | null): boolean {
+    if (!sourceId) return true;
+    return range.source_ids.includes(sourceId);
+}
+
+/** Compute the [start, end] extent (ms epoch) spanning every range in a dataset. */
+function datasetExtent(dataset: SyncCoverageDataset): [number, number] | null {
+    const allRanges = [
+        ...dataset.requested_ranges,
+        ...dataset.covered_ranges,
+        ...dataset.gaps,
+        ...dataset.stale_ranges,
+        ...dataset.failed_ranges,
+    ];
+    if (allRanges.length === 0) return null;
+    let start = Number.POSITIVE_INFINITY;
+    let end = Number.NEGATIVE_INFINITY;
+    for (const r of allRanges) {
+        const since = new Date(r.since).getTime();
+        const before = new Date(r.before).getTime();
+        if (!Number.isNaN(since)) start = Math.min(start, since);
+        if (!Number.isNaN(before)) end = Math.max(end, before);
+    }
+    if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return null;
+    return [start, end];
+}
+
+function bandStyle(range: SyncCoverageRange, extent: [number, number]): { left: string; width: string } {
+    const [start, end] = extent;
+    const span = end - start;
+    const since = new Date(range.since).getTime();
+    const before = new Date(range.before).getTime();
+    const left = span > 0 ? Math.max(0, Math.min(100, ((since - start) / span) * 100)) : 0;
+    const rawWidth = span > 0 ? ((before - since) / span) * 100 : 100;
+    const width = Math.max(1, Math.min(100 - left, rawWidth));
+    return { left: `${left}%`, width: `${width}%` };
+}
+
+/**
+ * Coverage & gaps timeline (CHAOS-2793). Renders ONLY persisted dataset/source
+ * coverage ranges from the API — no client-side interval recomputation. CSS
+ * horizontal bands are a decorative supplement (aria-hidden); the table below
+ * is the authoritative, screen-reader-friendly rendering of the same rows.
+ */
+export function SyncCoverageTimeline({ configId, coverage, error }: SyncCoverageTimelineProps) {
+    const [datasetFilter, setDatasetFilter] = useState<string>("all");
+    const [sourceFilter, setSourceFilter] = useState<string>("all");
+
+    const sourceNameById = useMemo(() => {
+        const map: Record<string, string> = {};
+        for (const source of coverage?.sources ?? []) {
+            map[source.source_id] = source.source_name;
+        }
+        return map;
+    }, [coverage]);
+
+    const sourceLabel = (sourceId: string) => sourceNameById[sourceId] ?? "Unresolved source";
+
+    const datasets = useMemo(() => {
+        const all = coverage?.datasets ?? [];
+        if (datasetFilter === "all") return all;
+        return all.filter((dataset) => dataset.dataset_key === datasetFilter);
+    }, [coverage, datasetFilter]);
+
+    const backfillGapHref = (range: SyncCoverageRange): string => {
+        const from = toDateInput(range.since);
+        const to = toDateInput(range.before);
+        const params = new URLSearchParams();
+        if (from) params.set("backfill_from", from);
+        if (to) params.set("backfill_to", to);
+        return `/org/admin/sync/${configId}/edit?${params.toString()}#backfill`;
+    };
+
+    if (error) {
+        return (
+            <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <DataState variant="error" title="Coverage timeline unavailable" message={error} />
+            </div>
+        );
+    }
+
+    if (!coverage) {
+        return (
+            <div
+                className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6"
+                data-testid="coverage-timeline-loading"
+            >
+                <DataState variant="loading" title="Loading coverage timeline…" />
+            </div>
+        );
+    }
+
+    const hasAnyRangeData = coverage.datasets.some(
+        (dataset) =>
+            dataset.requested_ranges.length +
+                dataset.covered_ranges.length +
+                dataset.gaps.length +
+                dataset.stale_ranges.length +
+                dataset.failed_ranges.length >
+            0,
+    );
+
+    if (!hasAnyRangeData) {
+        return (
+            <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                <DataState
+                    variant={coverage.data_basis === "legacy" ? "detector-unavailable" : "no-data-connected"}
+                    title={
+                        coverage.data_basis === "legacy"
+                            ? "No planner-tracked coverage yet"
+                            : "No coverage data yet"
+                    }
+                    description={
+                        coverage.data_basis === "legacy"
+                            ? "This configuration predates planner-tracked syncs, so dataset-level coverage cannot be shown yet."
+                            : "Coverage will populate once the first sync run completes."
+                    }
+                />
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-4 rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                    Coverage &amp; gaps
+                </h3>
+                <div className="flex flex-wrap items-center gap-3">
+                    <label className="flex items-center gap-2 text-sm text-(--ink-muted)">
+                        Dataset
+                        <select
+                            value={datasetFilter}
+                            onChange={(event) => setDatasetFilter(event.target.value)}
+                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-2 py-1 text-sm text-foreground"
+                        >
+                            <option value="all">{CTA_LABELS.allDatasets}</option>
+                            {coverage.datasets.map((dataset) => (
+                                <option key={dataset.dataset_key} value={dataset.dataset_key}>
+                                    {dataset.dataset_key}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-(--ink-muted)">
+                        Source
+                        <select
+                            value={sourceFilter}
+                            onChange={(event) => setSourceFilter(event.target.value)}
+                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-2 py-1 text-sm text-foreground"
+                        >
+                            <option value="all">{CTA_LABELS.allSources}</option>
+                            {coverage.sources.map((source) => (
+                                <option key={source.source_id} value={source.source_id}>
+                                    {source.source_name}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                </div>
+            </div>
+
+            <div className="space-y-6">
+                {datasets.map((dataset) => {
+                    const extent = datasetExtent(dataset);
+                    const activeSourceId = sourceFilter === "all" ? null : sourceFilter;
+                    const filterBySource = (ranges: SyncCoverageRange[]) =>
+                        ranges.filter((r) => rangeIncludesSource(r, activeSourceId));
+
+                    const rows: TimelineRow[] = [
+                        ...filterBySource(dataset.covered_ranges).map((range) => ({
+                            kind: "covered" as const,
+                            range,
+                            datasetKey: dataset.dataset_key,
+                        })),
+                        ...filterBySource(dataset.gaps).map((range) => ({
+                            kind: "gap" as const,
+                            range,
+                            datasetKey: dataset.dataset_key,
+                        })),
+                        ...filterBySource(dataset.stale_ranges).map((range) => ({
+                            kind: "stale" as const,
+                            range,
+                            datasetKey: dataset.dataset_key,
+                        })),
+                        ...filterBySource(dataset.failed_ranges).map((range) => ({
+                            kind: "failed" as const,
+                            range,
+                            datasetKey: dataset.dataset_key,
+                        })),
+                    ];
+
+                    if (activeSourceId && rows.length === 0) return null;
+
+                    return (
+                        <div
+                            key={dataset.dataset_key}
+                            className="space-y-3 rounded-lg border border-(--card-stroke) bg-(--card-70) p-4"
+                        >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                                <span className="font-medium text-foreground">{dataset.dataset_key}</span>
+                                <CoverageBadge
+                                    tone={statusTone(dataset.status)}
+                                    label={statusLabel(dataset.status)}
+                                />
+                            </div>
+
+                            {/* Decorative CSS band view — purely visual, mirrored by the table below. */}
+                            {extent && (
+                                <div aria-hidden="true" className="space-y-1.5">
+                                    {(["covered", "gap", "stale", "failed"] as BandKind[]).map((kind) => {
+                                        const kindRanges = rows.filter((row) => row.kind === kind);
+                                        if (kindRanges.length === 0) return null;
+                                        return (
+                                            <div key={kind} className="flex items-center gap-2">
+                                                <span className="w-16 shrink-0 text-xs text-(--ink-muted)">
+                                                    {BAND_LABEL[kind]}
+                                                </span>
+                                                <div className="relative h-3 flex-1 overflow-hidden rounded-full bg-(--card-stroke)">
+                                                    {kindRanges.map((row, index) => (
+                                                        <div
+                                                            key={`${kind}-${index}`}
+                                                            className={`absolute top-0 h-full rounded-full ${BAND_BAR_CLASS[kind]}`}
+                                                            style={bandStyle(row.range, extent)}
+                                                        />
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+
+                            {/* Accessible table fallback — the authoritative rendering. */}
+                            <div className="overflow-x-auto">
+                                <table className="min-w-full divide-y divide-(--card-stroke) text-sm">
+                                    <caption className="sr-only">
+                                        Coverage windows for dataset {dataset.dataset_key}
+                                    </caption>
+                                    <thead>
+                                        <tr>
+                                            <th scope="col" className="px-2 py-2 text-left font-medium text-(--ink-muted)">
+                                                Window
+                                            </th>
+                                            <th scope="col" className="px-2 py-2 text-left font-medium text-(--ink-muted)">
+                                                From
+                                            </th>
+                                            <th scope="col" className="px-2 py-2 text-left font-medium text-(--ink-muted)">
+                                                To
+                                            </th>
+                                            <th scope="col" className="px-2 py-2 text-left font-medium text-(--ink-muted)">
+                                                Source(s)
+                                            </th>
+                                            <th scope="col" className="px-2 py-2 text-left font-medium text-(--ink-muted)">
+                                                Action
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody className="divide-y divide-(--card-stroke)">
+                                        {rows.length === 0 ? (
+                                            <tr>
+                                                <td colSpan={5} className="px-2 py-3 text-(--ink-muted)">
+                                                    No windows recorded for this dataset yet.
+                                                </td>
+                                            </tr>
+                                        ) : (
+                                            rows.map((row, index) => (
+                                                <tr key={`${row.kind}-${index}`}>
+                                                    <td className="px-2 py-2">
+                                                        <CoverageBadge
+                                                            tone={BAND_TONE[row.kind]}
+                                                            label={BAND_LABEL[row.kind]}
+                                                        />
+                                                    </td>
+                                                    <td className="px-2 py-2 text-foreground">
+                                                        {formatDate(row.range.since)}
+                                                    </td>
+                                                    <td className="px-2 py-2 text-foreground">
+                                                        {formatDate(row.range.before)}
+                                                    </td>
+                                                    <td className="px-2 py-2 text-(--ink-muted)">
+                                                        {row.range.source_ids.length === 0
+                                                            ? "—"
+                                                            : row.range.source_ids
+                                                                  .map((id) => sourceLabel(id))
+                                                                  .join(", ")}
+                                                    </td>
+                                                    <td className="px-2 py-2">
+                                                        {row.kind === "gap" ? (
+                                                            <Link
+                                                                href={backfillGapHref(row.range)}
+                                                                className="text-(--accent) hover:underline"
+                                                            >
+                                                                {CTA_LABELS.backfillThisGap}
+                                                            </Link>
+                                                        ) : (
+                                                            <span className="text-(--ink-muted)">—</span>
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                            ))
+                                        )}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/sync/SyncCoverageTimeline.tsx
+++ b/src/components/admin/sync/SyncCoverageTimeline.tsx
@@ -4,7 +4,12 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import { DataState } from "@/components/ui/DataState";
 import { CTA_LABELS } from "@/lib/design/cta";
-import type { SyncCoverageDataset, SyncCoverageRange, SyncCoverageSummary } from "@/lib/admin/types";
+import { formatDateUTC } from "@/lib/formatters";
+import type {
+    SyncCoverageDataset,
+    SyncCoverageRange,
+    SyncCoverageSummary,
+} from "@/lib/admin/types";
 import { CoverageBadge, statusLabel, statusTone, type CoverageTone } from "./CoverageBadge";
 
 interface SyncCoverageTimelineProps {
@@ -42,15 +47,9 @@ interface TimelineRow {
     datasetKey: string;
 }
 
-function formatDate(value: string): string {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return value;
-    return date.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        timeZone: "UTC",
-    });
+/** Content-derived row/band key — stable across re-renders, unlike array index. */
+function rangeKey(kind: BandKind, range: SyncCoverageRange): string {
+    return `${kind}-${range.since}-${range.before}-${range.source_ids.join(",")}`;
 }
 
 function toDateInput(value: string): string {
@@ -86,7 +85,10 @@ function datasetExtent(dataset: SyncCoverageDataset): [number, number] | null {
     return [start, end];
 }
 
-function bandStyle(range: SyncCoverageRange, extent: [number, number]): { left: string; width: string } {
+function bandStyle(
+    range: SyncCoverageRange,
+    extent: [number, number],
+): { left: string; width: string } {
     const [start, end] = extent;
     const span = end - start;
     const since = new Date(range.since).getTime();
@@ -165,7 +167,11 @@ export function SyncCoverageTimeline({ configId, coverage, error }: SyncCoverage
         return (
             <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
                 <DataState
-                    variant={coverage.data_basis === "legacy" ? "detector-unavailable" : "no-data-connected"}
+                    variant={
+                        coverage.data_basis === "legacy"
+                            ? "detector-unavailable"
+                            : "no-data-connected"
+                    }
                     title={
                         coverage.data_basis === "legacy"
                             ? "No planner-tracked coverage yet"
@@ -259,7 +265,9 @@ export function SyncCoverageTimeline({ configId, coverage, error }: SyncCoverage
                             className="space-y-3 rounded-lg border border-(--card-stroke) bg-(--card-70) p-4"
                         >
                             <div className="flex flex-wrap items-center justify-between gap-2">
-                                <span className="font-medium text-foreground">{dataset.dataset_key}</span>
+                                <span className="font-medium text-foreground">
+                                    {dataset.dataset_key}
+                                </span>
                                 <CoverageBadge
                                     tone={statusTone(dataset.status)}
                                     label={statusLabel(dataset.status)}
@@ -269,26 +277,30 @@ export function SyncCoverageTimeline({ configId, coverage, error }: SyncCoverage
                             {/* Decorative CSS band view — purely visual, mirrored by the table below. */}
                             {extent && (
                                 <div aria-hidden="true" className="space-y-1.5">
-                                    {(["covered", "gap", "stale", "failed"] as BandKind[]).map((kind) => {
-                                        const kindRanges = rows.filter((row) => row.kind === kind);
-                                        if (kindRanges.length === 0) return null;
-                                        return (
-                                            <div key={kind} className="flex items-center gap-2">
-                                                <span className="w-16 shrink-0 text-xs text-(--ink-muted)">
-                                                    {BAND_LABEL[kind]}
-                                                </span>
-                                                <div className="relative h-3 flex-1 overflow-hidden rounded-full bg-(--card-stroke)">
-                                                    {kindRanges.map((row, index) => (
-                                                        <div
-                                                            key={`${kind}-${index}`}
-                                                            className={`absolute top-0 h-full rounded-full ${BAND_BAR_CLASS[kind]}`}
-                                                            style={bandStyle(row.range, extent)}
-                                                        />
-                                                    ))}
+                                    {(["covered", "gap", "stale", "failed"] as BandKind[]).map(
+                                        (kind) => {
+                                            const kindRanges = rows.filter(
+                                                (row) => row.kind === kind,
+                                            );
+                                            if (kindRanges.length === 0) return null;
+                                            return (
+                                                <div key={kind} className="flex items-center gap-2">
+                                                    <span className="w-16 shrink-0 text-xs text-(--ink-muted)">
+                                                        {BAND_LABEL[kind]}
+                                                    </span>
+                                                    <div className="relative h-3 flex-1 overflow-hidden rounded-full bg-(--card-stroke)">
+                                                        {kindRanges.map((row) => (
+                                                            <div
+                                                                key={rangeKey(kind, row.range)}
+                                                                className={`absolute top-0 h-full rounded-full ${BAND_BAR_CLASS[kind]}`}
+                                                                style={bandStyle(row.range, extent)}
+                                                            />
+                                                        ))}
+                                                    </div>
                                                 </div>
-                                            </div>
-                                        );
-                                    })}
+                                            );
+                                        },
+                                    )}
                                 </div>
                             )}
 
@@ -300,19 +312,34 @@ export function SyncCoverageTimeline({ configId, coverage, error }: SyncCoverage
                                     </caption>
                                     <thead>
                                         <tr>
-                                            <th scope="col" className="px-2 py-2 text-left font-medium text-(--ink-muted)">
+                                            <th
+                                                scope="col"
+                                                className="px-2 py-2 text-left font-medium text-(--ink-muted)"
+                                            >
                                                 Window
                                             </th>
-                                            <th scope="col" className="px-2 py-2 text-left font-medium text-(--ink-muted)">
+                                            <th
+                                                scope="col"
+                                                className="px-2 py-2 text-left font-medium text-(--ink-muted)"
+                                            >
                                                 From
                                             </th>
-                                            <th scope="col" className="px-2 py-2 text-left font-medium text-(--ink-muted)">
+                                            <th
+                                                scope="col"
+                                                className="px-2 py-2 text-left font-medium text-(--ink-muted)"
+                                            >
                                                 To
                                             </th>
-                                            <th scope="col" className="px-2 py-2 text-left font-medium text-(--ink-muted)">
+                                            <th
+                                                scope="col"
+                                                className="px-2 py-2 text-left font-medium text-(--ink-muted)"
+                                            >
                                                 Source(s)
                                             </th>
-                                            <th scope="col" className="px-2 py-2 text-left font-medium text-(--ink-muted)">
+                                            <th
+                                                scope="col"
+                                                className="px-2 py-2 text-left font-medium text-(--ink-muted)"
+                                            >
                                                 Action
                                             </th>
                                         </tr>
@@ -320,13 +347,16 @@ export function SyncCoverageTimeline({ configId, coverage, error }: SyncCoverage
                                     <tbody className="divide-y divide-(--card-stroke)">
                                         {rows.length === 0 ? (
                                             <tr>
-                                                <td colSpan={5} className="px-2 py-3 text-(--ink-muted)">
+                                                <td
+                                                    colSpan={5}
+                                                    className="px-2 py-3 text-(--ink-muted)"
+                                                >
                                                     No windows recorded for this dataset yet.
                                                 </td>
                                             </tr>
                                         ) : (
-                                            rows.map((row, index) => (
-                                                <tr key={`${row.kind}-${index}`}>
+                                            rows.map((row) => (
+                                                <tr key={rangeKey(row.kind, row.range)}>
                                                     <td className="px-2 py-2">
                                                         <CoverageBadge
                                                             tone={BAND_TONE[row.kind]}
@@ -334,10 +364,10 @@ export function SyncCoverageTimeline({ configId, coverage, error }: SyncCoverage
                                                         />
                                                     </td>
                                                     <td className="px-2 py-2 text-foreground">
-                                                        {formatDate(row.range.since)}
+                                                        {formatDateUTC(row.range.since)}
                                                     </td>
                                                     <td className="px-2 py-2 text-foreground">
-                                                        {formatDate(row.range.before)}
+                                                        {formatDateUTC(row.range.before)}
                                                     </td>
                                                     <td className="px-2 py-2 text-(--ink-muted)">
                                                         {row.range.source_ids.length === 0
@@ -355,7 +385,9 @@ export function SyncCoverageTimeline({ configId, coverage, error }: SyncCoverage
                                                                 {CTA_LABELS.backfillThisGap}
                                                             </Link>
                                                         ) : (
-                                                            <span className="text-(--ink-muted)">—</span>
+                                                            <span className="text-(--ink-muted)">
+                                                                —
+                                                            </span>
                                                         )}
                                                     </td>
                                                 </tr>

--- a/src/components/admin/sync/SyncJobHistory.test.tsx
+++ b/src/components/admin/sync/SyncJobHistory.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, userEvent } from "@/test/utils";
+import { render, screen, userEvent, waitFor } from "@/test/utils";
 import type { SyncJob } from "@/lib/admin/types";
+import { SYNC_JOB_WITH_RUN } from "@/lib/admin/__tests__/syncCoverageFixtures";
 import { SyncJobHistory } from "./SyncJobHistory";
 
 const mockPush = vi.fn();
@@ -8,8 +9,14 @@ vi.mock("next/navigation", () => ({
     useRouter: () => ({ push: mockPush }),
 }));
 
+const mockGetSyncJobs = vi.fn();
+vi.mock("@/lib/admin/server", () => ({
+    getSyncJobs: (...args: unknown[]) => mockGetSyncJobs(...args),
+}));
+
 beforeEach(() => {
     mockPush.mockClear();
+    mockGetSyncJobs.mockReset();
 });
 
 function buildJobs(count: number): SyncJob[] {
@@ -21,58 +28,73 @@ function buildJobs(count: number): SyncJob[] {
         completed_at: `2024-01-01T00:${String(index).padStart(2, "0")}:30.000Z`,
         duration_seconds: 30,
         items_synced: index + 1,
-        error: `error-${index + 1}`,
     }));
 }
 
 describe("SyncJobHistory", () => {
-    it("renders first page with 10 jobs", () => {
-        render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" />);
+    it("shows empty state when there are no jobs", () => {
+        render(<SyncJobHistory jobs={[]} configId="cfg-1" />);
 
-        expect(screen.getByText("Completed / Last Activity")).toBeInTheDocument();
-        expect(screen.getByText("error-1")).toBeInTheDocument();
-        expect(screen.getByText("error-10")).toBeInTheDocument();
-        expect(screen.queryByText("error-11")).not.toBeInTheDocument();
-        expect(screen.getByText("Showing 1-10 of 12")).toBeInTheDocument();
+        expect(screen.getByText("No sync history available.")).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
     });
 
-    it("disables Previous on first page", () => {
-        render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" />);
+    it("renders the redesigned column headings", () => {
+        render(<SyncJobHistory jobs={[SYNC_JOB_WITH_RUN]} configId="cfg-1" testMode />);
 
-        expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+        for (const heading of [
+            "Trigger",
+            "Mode",
+            "Requested range",
+            "Covered range",
+            "Status",
+            "Scope",
+            "Units",
+            "Started",
+            "Duration",
+            "Actions",
+        ]) {
+            expect(screen.getByText(heading)).toBeInTheDocument();
+        }
     });
 
-    it("disables Next on last page", async () => {
-        render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" />);
+    it("derives a partial coverage-result badge from persisted sync_run unit counts only", () => {
+        render(<SyncJobHistory jobs={[SYNC_JOB_WITH_RUN]} configId="cfg-1" testMode />);
 
-        await userEvent.click(screen.getByRole("button", { name: "Next" }));
-
-        expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
-        expect(screen.getByText("Showing 11-12 of 12")).toBeInTheDocument();
+        // SYNC_JOB_WITH_RUN: total_units=2, completed_units=1, failed_units=1.
+        expect(screen.getByText("Partial")).toBeInTheDocument();
+        expect(screen.getByText("1 done · 1 failed · 2 total")).toBeInTheDocument();
     });
 
-    it("clicking Next shows next page", async () => {
-        render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" />);
+    it("renders requested/covered ranges and links planner-backed rows to run detail", () => {
+        render(<SyncJobHistory jobs={[SYNC_JOB_WITH_RUN]} configId="cfg-1" testMode />);
 
-        await userEvent.click(screen.getByRole("button", { name: "Next" }));
-
-        expect(screen.queryByText("error-1")).not.toBeInTheDocument();
-        expect(screen.getByText("error-11")).toBeInTheDocument();
-        expect(screen.getByText("error-12")).toBeInTheDocument();
+        const link = screen.getByRole("link", { name: /View run details/ });
+        expect(link).toHaveAttribute("href", "/org/admin/sync/cfg-1/runs/run-coverage");
+        expect(screen.getByText("Jan 1, 2026 → Jan 3, 2026")).toBeInTheDocument();
     });
 
-    it("clicking Previous returns to previous page", async () => {
-        render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" />);
+    it("renders legacy rows (no sync_run block) readably with em-dashes, never a fabricated coverage result", () => {
+        const legacyJob: SyncJob = {
+            id: "job-legacy",
+            config_id: "cfg-1",
+            status: "success",
+            started_at: "2024-01-01T00:00:00.000Z",
+            completed_at: "2024-01-01T00:00:30.000Z",
+            duration_seconds: 30,
+            items_synced: 5,
+        };
 
-        await userEvent.click(screen.getByRole("button", { name: "Next" }));
-        await userEvent.click(screen.getByRole("button", { name: "Previous" }));
+        render(<SyncJobHistory jobs={[legacyJob]} configId="cfg-1" testMode />);
 
-        expect(screen.getByText("error-1")).toBeInTheDocument();
-        expect(screen.queryByText("error-11")).not.toBeInTheDocument();
-        expect(screen.getByText("Showing 1-10 of 12")).toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: /View run details/ })).not.toBeInTheDocument();
+        expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+        // Legacy rows fall back to the plain job-status badge, not the
+        // complete/partial/gap/failed coverage vocabulary.
+        expect(screen.getByText("Success")).toBeInTheDocument();
     });
 
-    it("renders an em dash for pending jobs with null started_at, not the epoch date", () => {
+    it("renders a fallback badge for pending jobs with null started_at, never the epoch date", () => {
         const pendingJob: SyncJob = {
             id: "job-pending",
             config_id: "cfg-1",
@@ -82,150 +104,67 @@ describe("SyncJobHistory", () => {
             duration_seconds: null,
             items_synced: 0,
         };
-        render(<SyncJobHistory jobs={[pendingJob]} configId="cfg-1" />);
 
-        expect(screen.getAllByText("Queued").length).toBeGreaterThan(0);
-        expect(screen.getAllByText("—").length).toBeGreaterThan(0);
-        // new Date(null) coerces to epoch 0; the 1969/1970 date must never render.
+        render(<SyncJobHistory jobs={[pendingJob]} configId="cfg-1" testMode />);
+
+        expect(screen.getByText("Queued")).toBeInTheDocument();
         expect(screen.queryByText(/19[67]\d/)).not.toBeInTheDocument();
     });
 
-    it("shows completed activity and structured failure context", () => {
-        const failedJob: SyncJob = {
-            id: "job-failed",
-            config_id: "cfg-1",
-            status: "failed",
-            started_at: "2024-01-01T00:00:00.000Z",
-            completed_at: "2024-01-01T00:00:45.000Z",
-            duration_seconds: null,
-            items_synced: 4,
-            error: "Sync run completed with failed units",
-            result: {
-                dataset_key: "work-items",
-                error_category: "rate_limit",
-                failed_unit_count: 2,
-                total_units: 5,
-                failed_unit_ids: ["unit-1", "unit-2"],
-            },
-        };
+    describe("test-mode client-side pagination", () => {
+        it("renders first page with 10 jobs", () => {
+            render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" testMode />);
 
-        render(<SyncJobHistory jobs={[failedJob]} configId="cfg-1" />);
+            expect(screen.getByText("Showing 1-10")).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+        });
 
-        expect(screen.getByText("Completed")).toBeInTheDocument();
-        expect(screen.getByText("45s")).toBeInTheDocument();
-        expect(screen.getByText("Sync run completed with failed units")).toBeInTheDocument();
-        expect(
-            screen.getByText(/Part: work-items · Category: rate_limit · Failed units: 2 of 5/),
-        ).toBeInTheDocument();
+        it("clicking Next shows the next page and disables Next on the last page", async () => {
+            render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" testMode />);
+
+            await userEvent.click(screen.getByRole("button", { name: "Next" }));
+
+            expect(screen.getByText("Showing 11-12")).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+        });
+
+        it("clicking Previous returns to the previous page", async () => {
+            render(<SyncJobHistory jobs={buildJobs(12)} configId="cfg-1" testMode />);
+
+            await userEvent.click(screen.getByRole("button", { name: "Next" }));
+            await userEvent.click(screen.getByRole("button", { name: "Previous" }));
+
+            expect(screen.getByText("Showing 1-10")).toBeInTheDocument();
+        });
     });
 
-    it("marks running jobs as still running when completed_at is not stamped", () => {
-        const runningJob: SyncJob = {
-            id: "job-running",
-            config_id: "cfg-1",
-            status: "running",
-            started_at: "2024-01-01T00:00:00.000Z",
-            completed_at: null,
-            duration_seconds: null,
-            items_synced: 3,
-        };
+    describe("server-backed pagination (non-test-mode)", () => {
+        it("fetches the next page via getSyncJobs with limit/offset params", async () => {
+            const firstPage = buildJobs(11); // PAGE_SIZE + 1 => hasMore
+            const secondPage = buildJobs(5).map((job, i) => ({ ...job, id: `page2-job-${i}` }));
+            mockGetSyncJobs.mockResolvedValueOnce({ data: secondPage });
 
-        render(<SyncJobHistory jobs={[runningJob]} configId="cfg-1" />);
+            render(<SyncJobHistory jobs={firstPage} configId="cfg-1" />);
 
-        expect(screen.getAllByText("Still running").length).toBeGreaterThan(0);
-        expect(screen.getAllByText(/Started /).length).toBeGreaterThan(0);
-    });
+            await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
-    it("shows cancelled jobs and object-shaped partial failure summaries", () => {
-        const cancelledJob: SyncJob = {
-            id: "job-cancelled",
-            config_id: "cfg-1",
-            status: "cancelled",
-            started_at: "2024-01-01T00:00:00.000Z",
-            completed_at: "2024-01-01T00:00:10.000Z",
-            duration_seconds: 10,
-            items_synced: 1,
-            result: {
-                partial_failure_summary: {
-                    failed_datasets: ["prs", "work-items"],
-                    error_categories: ["rate_limit"],
-                },
-            },
-        };
+            await waitFor(() => {
+                expect(mockGetSyncJobs).toHaveBeenCalledWith("cfg-1", 11, 10);
+            });
+            expect(screen.getByText("Showing 11-15")).toBeInTheDocument();
+        });
 
-        render(<SyncJobHistory jobs={[cancelledJob]} configId="cfg-1" />);
+        it("shows an inline error and keeps the current page when the fetch fails", async () => {
+            mockGetSyncJobs.mockResolvedValueOnce({ error: "Request failed with 500" });
 
-        expect(screen.getAllByText("Cancelled")).toHaveLength(2);
-        expect(
-            screen.getByText(/failed_datasets: prs, work-items; error_categories: rate_limit/),
-        ).toBeInTheDocument();
-    });
+            render(<SyncJobHistory jobs={buildJobs(11)} configId="cfg-1" />);
 
-    it("shows empty state when there are no jobs", () => {
-        render(<SyncJobHistory jobs={[]} configId="cfg-1" />);
+            await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
-        expect(screen.getByText("No sync history available.")).toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
-    });
-
-    it("links planner-backed rows to the run detail page", () => {
-        const plannerJob: SyncJob = {
-            id: "job-planner",
-            config_id: "cfg-1",
-            status: "success",
-            started_at: "2024-01-01T00:00:00.000Z",
-            completed_at: "2024-01-01T00:00:30.000Z",
-            duration_seconds: 30,
-            items_synced: 5,
-            result: {
-                sync_run_id: "run-123",
-            },
-        };
-
-        render(<SyncJobHistory jobs={[plannerJob]} configId="cfg-1" />);
-
-        const link = screen.getByRole("link", { name: /View run details/ });
-        expect(link).toHaveAttribute("href", "/org/admin/sync/cfg-1/runs/run-123");
-    });
-
-    it("navigates to the run detail page when a planner-backed row is clicked", async () => {
-        const plannerJob: SyncJob = {
-            id: "job-planner",
-            config_id: "cfg-1",
-            status: "success",
-            started_at: "2024-01-01T00:00:00.000Z",
-            completed_at: "2024-01-01T00:00:30.000Z",
-            duration_seconds: 30,
-            items_synced: 5,
-            result: {
-                sync_run_id: "run-123",
-            },
-        };
-
-        render(<SyncJobHistory jobs={[plannerJob]} configId="cfg-1" />);
-
-        // Click a NON-link cell (duration) to prove whole-row navigation, not link bubbling.
-        await userEvent.click(screen.getByText("30s"));
-
-        expect(mockPush).toHaveBeenCalledWith("/org/admin/sync/cfg-1/runs/run-123");
-    });
-
-    it("does not link legacy rows without a sync_run_id", () => {
-        const legacyJob: SyncJob = {
-            id: "job-legacy",
-            config_id: "cfg-1",
-            status: "success",
-            started_at: "2024-01-01T00:00:00.000Z",
-            completed_at: "2024-01-01T00:00:30.000Z",
-            duration_seconds: 30,
-            items_synced: 5,
-            result: {
-                dataset_key: "work-items",
-            },
-        };
-
-        render(<SyncJobHistory jobs={[legacyJob]} configId="cfg-1" />);
-
-        expect(screen.queryByRole("link", { name: "View run details" })).not.toBeInTheDocument();
+            await waitFor(() => {
+                expect(screen.getByRole("alert")).toHaveTextContent("Request failed with 500");
+            });
+            expect(screen.getByText("Showing 1-10")).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/admin/sync/SyncJobHistory.test.tsx
+++ b/src/components/admin/sync/SyncJobHistory.test.tsx
@@ -195,4 +195,77 @@ describe("SyncJobHistory", () => {
             expect(screen.getByText("999")).toBeInTheDocument();
         });
     });
+
+    describe("coverage-result precedence (CHAOS-2792 contract: failed > partial > gap > complete)", () => {
+        function jobWithRun(overrides: {
+            status: SyncJob["status"];
+            total_units: number;
+            completed_units: number;
+            failed_units: number;
+        }): SyncJob {
+            return {
+                id: `job-${overrides.status}-${overrides.completed_units}-${overrides.failed_units}`,
+                config_id: "cfg-1",
+                status: overrides.status,
+                started_at: "2026-01-01T00:00:00.000Z",
+                completed_at: "2026-01-01T00:05:00.000Z",
+                duration_seconds: 300,
+                items_synced: 0,
+                sync_run: {
+                    mode: "incremental",
+                    triggered_by: "scheduled",
+                    requested_range: null,
+                    covered_range: null,
+                    total_units: overrides.total_units,
+                    completed_units: overrides.completed_units,
+                    failed_units: overrides.failed_units,
+                    sync_run_id: "run-precedence",
+                },
+            };
+        }
+
+        it("reports 'partial', never 'gap', for a terminal failed run with unsettled units and some completed work", () => {
+            // settled=3 < total=5 (unsettled units remain) on a FAILED run.
+            const job = jobWithRun({
+                status: "failed",
+                total_units: 5,
+                completed_units: 2,
+                failed_units: 1,
+            });
+
+            render(<SyncJobHistory jobs={[job]} configId="cfg-1" testMode />);
+
+            expect(screen.getByText("Partial")).toBeInTheDocument();
+            expect(screen.queryByText("Gap")).not.toBeInTheDocument();
+        });
+
+        it("reports 'failed', never 'gap', for a terminal failed run with unsettled units and zero completed work", () => {
+            // settled=1 < total=5 (unsettled units remain) on a FAILED run.
+            const job = jobWithRun({
+                status: "failed",
+                total_units: 5,
+                completed_units: 0,
+                failed_units: 1,
+            });
+
+            render(<SyncJobHistory jobs={[job]} configId="cfg-1" testMode />);
+
+            expect(screen.getByText("Failed")).toBeInTheDocument();
+            expect(screen.queryByText("Gap")).not.toBeInTheDocument();
+        });
+
+        it("reports 'gap' for a terminal success run with unsettled units and zero failures", () => {
+            // settled=3 < total=5, no failures, terminal SUCCESS => gap.
+            const job = jobWithRun({
+                status: "success",
+                total_units: 5,
+                completed_units: 3,
+                failed_units: 0,
+            });
+
+            render(<SyncJobHistory jobs={[job]} configId="cfg-1" testMode />);
+
+            expect(screen.getByText("Gap")).toBeInTheDocument();
+        });
+    });
 });

--- a/src/components/admin/sync/SyncJobHistory.test.tsx
+++ b/src/components/admin/sync/SyncJobHistory.test.tsx
@@ -167,4 +167,32 @@ describe("SyncJobHistory", () => {
             expect(screen.getByText("Showing 1-10")).toBeInTheDocument();
         });
     });
+
+    describe("offset-0 page reactivity (regression: CHAOS-2791 stale Sync Now/Backfill refresh)", () => {
+        it("shows a newly-prepended job immediately on rerender, without requiring a pagination click", () => {
+            const initialJobs = buildJobs(3);
+            const { rerender } = render(<SyncJobHistory jobs={initialJobs} configId="cfg-1" />);
+
+            expect(screen.getByText("Showing 1-3")).toBeInTheDocument();
+            expect(screen.queryByText("999")).not.toBeInTheDocument();
+
+            const freshJob: SyncJob = {
+                id: "job-fresh",
+                config_id: "cfg-1",
+                status: "success",
+                started_at: "2024-02-01T00:00:00.000Z",
+                completed_at: "2024-02-01T00:00:30.000Z",
+                duration_seconds: 30,
+                items_synced: 999,
+            };
+
+            // Simulates Sync Now / Backfill triggering router.refresh(), which
+            // delivers a fresh `jobs` prop on the SAME render — no pagination
+            // click involved.
+            rerender(<SyncJobHistory jobs={[freshJob, ...initialJobs]} configId="cfg-1" />);
+
+            expect(screen.getByText("Showing 1-4")).toBeInTheDocument();
+            expect(screen.getByText("999")).toBeInTheDocument();
+        });
+    });
 });

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -156,16 +156,22 @@ export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHist
     const router = useRouter();
     const [isPending, startTransition] = useTransition();
     const [offset, setOffset] = useState(0);
-    const [pageJobs, setPageJobs] = useState<SyncJob[]>(() => jobs.slice(0, PAGE_SIZE));
-    const [hasMore, setHasMore] = useState(() => jobs.length > PAGE_SIZE);
+    // Fetched-page state is used ONLY for offset > 0 (server-backed mode).
+    // The offset-0 page is derived reactively from `jobs` below (see
+    // firstPageJobs) so a Sync Now / Backfill refresh — router.refresh()
+    // delivering a fresh `jobs` prop — is reflected immediately, without
+    // requiring a pagination click (regression: CHAOS-2791).
+    const [fetchedPageJobs, setFetchedPageJobs] = useState<SyncJob[]>([]);
+    const [fetchedHasMore, setFetchedHasMore] = useState(false);
     const [fetchError, setFetchError] = useState<string | null>(null);
 
-    const clientPageJobs = useMemo(
-        () => jobs.slice(offset, offset + PAGE_SIZE),
-        [jobs, offset],
-    );
+    const clientPageJobs = useMemo(() => jobs.slice(offset, offset + PAGE_SIZE), [jobs, offset]);
 
-    const visibleJobs = testMode ? clientPageJobs : pageJobs;
+    const firstPageJobs = useMemo(() => jobs.slice(0, PAGE_SIZE), [jobs]);
+    const firstPageHasMore = jobs.length > PAGE_SIZE;
+
+    const visibleJobs = testMode ? clientPageJobs : offset === 0 ? firstPageJobs : fetchedPageJobs;
+    const hasMore = offset === 0 ? firstPageHasMore : fetchedHasMore;
 
     if (jobs.length === 0) {
         return (
@@ -182,6 +188,12 @@ export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHist
             return;
         }
         setFetchError(null);
+        if (safeOffset === 0) {
+            // No fetch needed — the offset-0 page always derives from the
+            // current `jobs` prop (see firstPageJobs above).
+            setOffset(0);
+            return;
+        }
         startTransition(async () => {
             const result = await getSyncJobs(configId, PAGE_SIZE + 1, safeOffset);
             if (result.error || !result.data) {
@@ -189,8 +201,8 @@ export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHist
                 return;
             }
             setOffset(safeOffset);
-            setPageJobs(result.data.slice(0, PAGE_SIZE));
-            setHasMore(result.data.length > PAGE_SIZE);
+            setFetchedPageJobs(result.data.slice(0, PAGE_SIZE));
+            setFetchedHasMore(result.data.length > PAGE_SIZE);
         });
     };
 
@@ -200,7 +212,10 @@ export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHist
     return (
         <div className="overflow-x-auto rounded-xl border border-(--card-stroke) bg-(--card-80)">
             {fetchError && (
-                <div role="alert" className="border-b border-(--card-stroke) px-6 py-3 text-sm text-(--negative)">
+                <div
+                    role="alert"
+                    className="border-b border-(--card-stroke) px-6 py-3 text-sm text-(--negative)"
+                >
                     {fetchError}
                 </div>
             )}
@@ -229,7 +244,11 @@ export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHist
                             <tr
                                 key={job.id}
                                 onClick={href ? () => router.push(href) : undefined}
-                                className={href ? "cursor-pointer transition-colors hover:bg-(--card-70)" : undefined}
+                                className={
+                                    href
+                                        ? "cursor-pointer transition-colors hover:bg-(--card-70)"
+                                        : undefined
+                                }
                             >
                                 <td className="px-4 py-3 whitespace-nowrap text-sm text-foreground">
                                     {sr?.triggered_by ?? job.triggered_by ?? "—"}

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -6,9 +6,14 @@ import { useRouter } from "next/navigation";
 import { getSyncJobs } from "@/lib/admin/server";
 import type { SyncJob } from "@/lib/admin/types";
 import { CTA_LABELS } from "@/lib/design/cta";
-import { formatNumber } from "@/lib/formatters";
+import { formatDateUTC, formatNumber } from "@/lib/formatters";
 import { SyncStatusBadge } from "./SyncStatusBadge";
-import { CoverageBadge, jobCoverageLabel, jobCoverageTone, type JobCoverageResult } from "./CoverageBadge";
+import {
+    CoverageBadge,
+    jobCoverageLabel,
+    jobCoverageTone,
+    type JobCoverageResult,
+} from "./CoverageBadge";
 
 const PAGE_SIZE = 10;
 
@@ -27,26 +32,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function formatTimestamp(value: string | null | undefined): string {
-    if (!value) return "—";
-    return new Date(value).toLocaleString();
-}
+// Locked UTC-anchored formatter: bare toLocaleString() drifts between Node
+// and browser locales/timezones (hydration + CI mismatches). Module-level
+// so we don't allocate a new Intl.DateTimeFormat per render.
+const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+});
 
-function formatDateOnly(value: string | null | undefined): string {
+function formatTimestamp(value: string | null | undefined): string {
     if (!value) return "—";
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return "—";
-    return date.toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        timeZone: "UTC",
-    });
+    return TIMESTAMP_FORMATTER.format(date);
 }
 
 function formatRange(range: { since: string; before: string } | null | undefined): string {
     if (!range) return "—";
-    return `${formatDateOnly(range.since)} → ${formatDateOnly(range.before)}`;
+    return `${formatDateUTC(range.since)} → ${formatDateUTC(range.before)}`;
 }
 
 function getDuration(job: SyncJob): string {

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -96,6 +96,12 @@ function getBadgeLabel(status: SyncJob["status"]) {
  * from range/interval comparisons (platform ban on client-side coverage math).
  * Returns null for non-terminal jobs or legacy rows (no sync_run block) —
  * those render the plain job status badge instead.
+ *
+ * Precedence is deliberate and pinned by tests: failed > partial > gap >
+ * complete. A terminal failed/cancelled run is a STRONGER signal than an
+ * unsettled-units gap — so a failed/cancelled run with unsettled units
+ * (settled < total_units) still reports "failed"/"partial", never "gap".
+ * Only a terminal SUCCESS run with unsettled units reports "gap".
  */
 function deriveJobCoverageResult(job: SyncJob): JobCoverageResult | null {
     const sr = job.sync_run;
@@ -104,6 +110,8 @@ function deriveJobCoverageResult(job: SyncJob): JobCoverageResult | null {
 
     const settled = sr.completed_units + sr.failed_units;
 
+    // failed/cancelled precedence: a stronger signal than "gap" (see doc
+    // comment above) — reported regardless of how many units settled.
     if (job.status === "failed" || job.status === "cancelled") {
         return sr.completed_units === 0 ? "failed" : "partial";
     }
@@ -126,9 +134,10 @@ function getRunId(job: SyncJob): string | null {
 function getScopeLabel(job: SyncJob): string {
     const sr = job.sync_run;
     if (!sr) {
-        const datasetKey = isRecord(job.result) && typeof job.result.dataset_key === "string"
-            ? job.result.dataset_key
-            : null;
+        const datasetKey =
+            isRecord(job.result) && typeof job.result.dataset_key === "string"
+                ? job.result.dataset_key
+                : null;
         return datasetKey ?? "—";
     }
     const sourceIds = new Set<string>([

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -1,24 +1,167 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { SyncJob } from "@/lib/admin/types";
+import { getSyncJobs } from "@/lib/admin/server";
+import type { SyncJob } from "@/lib/admin/types";
 import { CTA_LABELS } from "@/lib/design/cta";
+import { formatNumber } from "@/lib/formatters";
 import { SyncStatusBadge } from "./SyncStatusBadge";
+import { CoverageBadge, jobCoverageLabel, jobCoverageTone, type JobCoverageResult } from "./CoverageBadge";
+
+const PAGE_SIZE = 10;
 
 interface SyncJobHistoryProps {
     jobs: SyncJob[];
     configId: string;
-    totalJobs?: number;
+    /**
+     * When true, paginate purely client-side over the full `jobs` array
+     * instead of calling the `getSyncJobs` server action (test-mode / sample
+     * data rendering — mirrors SyncRunDetailLive's `testMode` convention).
+     */
+    testMode?: boolean;
 }
 
-export function SyncJobHistory({ jobs, configId, totalJobs }: SyncJobHistoryProps) {
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function formatTimestamp(value: string | null | undefined): string {
+    if (!value) return "—";
+    return new Date(value).toLocaleString();
+}
+
+function formatDateOnly(value: string | null | undefined): string {
+    if (!value) return "—";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "—";
+    return date.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+    });
+}
+
+function formatRange(range: { since: string; before: string } | null | undefined): string {
+    if (!range) return "—";
+    return `${formatDateOnly(range.since)} → ${formatDateOnly(range.before)}`;
+}
+
+function getDuration(job: SyncJob): string {
+    if (job.duration_seconds != null) return `${Math.round(job.duration_seconds)}s`;
+    if (job.completed_at && job.started_at) {
+        return `${Math.round(
+            (new Date(job.completed_at).getTime() - new Date(job.started_at).getTime()) / 1000,
+        )}s`;
+    }
+    return "—";
+}
+
+function getBadgeStatus(status: SyncJob["status"]) {
+    switch (status) {
+        case "success":
+            return "success" as const;
+        case "failed":
+        case "cancelled":
+            return "failed" as const;
+        case "running":
+            return "running" as const;
+        case "pending":
+            return "idle" as const;
+        default:
+            return "never" as const;
+    }
+}
+
+function getBadgeLabel(status: SyncJob["status"]) {
+    switch (status) {
+        case "pending":
+            return "Queued";
+        case "cancelled":
+            return "Cancelled";
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Derive the coverage-result label for a planner-backed job (CHAOS-2792),
+ * using ONLY persisted job status + sync_run unit counts. Never re-derives
+ * from range/interval comparisons (platform ban on client-side coverage math).
+ * Returns null for non-terminal jobs or legacy rows (no sync_run block) —
+ * those render the plain job status badge instead.
+ */
+function deriveJobCoverageResult(job: SyncJob): JobCoverageResult | null {
+    const sr = job.sync_run;
+    if (!sr) return null;
+    if (job.status === "pending" || job.status === "running") return null;
+
+    const settled = sr.completed_units + sr.failed_units;
+
+    if (job.status === "failed" || job.status === "cancelled") {
+        return sr.completed_units === 0 ? "failed" : "partial";
+    }
+    // job.status === "success"
+    if (sr.total_units === 0) return "complete";
+    if (sr.failed_units > 0 && sr.completed_units > 0) return "partial";
+    if (sr.failed_units > 0 && sr.completed_units === 0) return "failed";
+    if (settled < sr.total_units) return "gap";
+    return "complete";
+}
+
+function getRunId(job: SyncJob): string | null {
+    if (job.sync_run?.sync_run_id) return job.sync_run.sync_run_id;
+    if (isRecord(job.result) && typeof job.result.sync_run_id === "string") {
+        return job.result.sync_run_id;
+    }
+    return null;
+}
+
+function getScopeLabel(job: SyncJob): string {
+    const sr = job.sync_run;
+    if (!sr) {
+        const datasetKey = isRecord(job.result) && typeof job.result.dataset_key === "string"
+            ? job.result.dataset_key
+            : null;
+        return datasetKey ?? "—";
+    }
+    const sourceIds = new Set<string>([
+        ...(sr.requested_range?.source_ids ?? []),
+        ...(sr.covered_range?.source_ids ?? []),
+    ]);
+    if (sourceIds.size === 0) return "—";
+    return `${formatNumber(sourceIds.size)} source${sourceIds.size === 1 ? "" : "s"}`;
+}
+
+const HEADINGS = [
+    "Trigger",
+    "Mode",
+    "Requested range",
+    "Covered range",
+    "Status",
+    "Scope",
+    "Units",
+    "Started",
+    "Duration",
+    "Actions",
+];
+
+export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHistoryProps) {
     const router = useRouter();
+    const [isPending, startTransition] = useTransition();
     const [offset, setOffset] = useState(0);
-    const limit = 10;
-    const total = totalJobs ?? jobs.length;
-    const paginatedJobs = useMemo(() => jobs.slice(offset, offset + limit), [jobs, offset]);
+    const [pageJobs, setPageJobs] = useState<SyncJob[]>(() => jobs.slice(0, PAGE_SIZE));
+    const [hasMore, setHasMore] = useState(() => jobs.length > PAGE_SIZE);
+    const [fetchError, setFetchError] = useState<string | null>(null);
+
+    const clientPageJobs = useMemo(
+        () => jobs.slice(offset, offset + PAGE_SIZE),
+        [jobs, offset],
+    );
+
+    const visibleJobs = testMode ? clientPageJobs : pageJobs;
 
     if (jobs.length === 0) {
         return (
@@ -28,229 +171,80 @@ export function SyncJobHistory({ jobs, configId, totalJobs }: SyncJobHistoryProp
         );
     }
 
-    const getBadgeStatus = (status: SyncJob["status"]) => {
-        switch (status) {
-            case "success":
-                return "success";
-            case "failed":
-            case "cancelled":
-                return "failed";
-            case "running":
-                return "running";
-            case "pending":
-                return "idle";
-            default:
-                return "never";
+    const goToOffset = (nextOffset: number) => {
+        const safeOffset = Math.max(0, nextOffset);
+        if (testMode) {
+            setOffset(safeOffset);
+            return;
         }
+        setFetchError(null);
+        startTransition(async () => {
+            const result = await getSyncJobs(configId, PAGE_SIZE + 1, safeOffset);
+            if (result.error || !result.data) {
+                setFetchError(result.error ?? "Failed to load more jobs.");
+                return;
+            }
+            setOffset(safeOffset);
+            setPageJobs(result.data.slice(0, PAGE_SIZE));
+            setHasMore(result.data.length > PAGE_SIZE);
+        });
     };
 
-    const getBadgeLabel = (status: SyncJob["status"]) => {
-        switch (status) {
-            case "pending":
-                return "Queued";
-            case "cancelled":
-                return "Cancelled";
-            default:
-                return undefined;
-        }
-    };
-
-    const formatTimestamp = (value: string | null | undefined) => {
-        if (!value) return "—";
-        return new Date(value).toLocaleString();
-    };
-
-    const getDuration = (job: SyncJob) => {
-        if (job.duration_seconds != null) return `${Math.round(job.duration_seconds)}s`;
-        if (job.completed_at && job.started_at) {
-            return `${Math.round(
-                (new Date(job.completed_at).getTime() - new Date(job.started_at).getTime()) / 1000,
-            )}s`;
-        }
-        return "-";
-    };
-
-    const getActivityLabel = (job: SyncJob) => {
-        if (job.status === "cancelled") return "Cancelled";
-        if (job.completed_at) return "Completed";
-        if (job.status === "running") return "Still running";
-        if (job.status === "pending") return "Queued";
-        return "Last activity";
-    };
-
-    const getActivityTimestamp = (job: SyncJob) =>
-        job.completed_at ?? job.started_at ?? job.created_at ?? null;
-
-    const isRecord = (value: unknown): value is Record<string, unknown> =>
-        value !== null && typeof value === "object" && !Array.isArray(value);
-
-    const stringifyValue = (value: unknown): string | null => {
-        if (typeof value === "string" && value.trim().length > 0) return value;
-        if (typeof value === "number" || typeof value === "boolean") return String(value);
-        if (Array.isArray(value)) {
-            const items = value.map((item) => stringifyValue(item)).filter((item) => item != null);
-            return items.length > 0 ? items.join(", ") : null;
-        }
-        if (isRecord(value)) {
-            const entries = Object.entries(value)
-                .map(([key, item]) => {
-                    const text = stringifyValue(item);
-                    return text ? `${key}: ${text}` : null;
-                })
-                .filter((item) => item != null);
-            return entries.length > 0 ? entries.join("; ") : null;
-        }
-        return null;
-    };
-
-    const getResultValue = (result: Record<string, unknown> | null | undefined, key: string) =>
-        result ? stringifyValue(result[key]) : null;
-
-    const getResultDetails = (job: SyncJob) => {
-        const result = isRecord(job.result) ? job.result : null;
-        const details: string[] = [];
-        const part =
-            getResultValue(result, "sync_part") ??
-            getResultValue(result, "phase") ??
-            getResultValue(result, "dataset_key") ??
-            getResultValue(result, "provider") ??
-            getResultValue(result, "mode");
-        const category = getResultValue(result, "error_category");
-        const reason =
-            getResultValue(result, "partial_failure_summary") ??
-            getResultValue(result, "reason") ??
-            getResultValue(result, "message") ??
-            getResultValue(result, "error");
-        const failedUnits =
-            getResultValue(result, "failed_unit_count") ?? getResultValue(result, "failed_units");
-        const totalUnits = getResultValue(result, "total_units");
-        const failedUnitIds = result?.failed_unit_ids;
-
-        if (part) details.push(`Part: ${part}`);
-        if (category) details.push(`Category: ${category}`);
-        if (reason && reason !== job.error) details.push(reason);
-        if (failedUnits) {
-            details.push(
-                totalUnits
-                    ? `Failed units: ${failedUnits} of ${totalUnits}`
-                    : `Failed units: ${failedUnits}`,
-            );
-        }
-        if (Array.isArray(failedUnitIds) && failedUnitIds.length > 0) {
-            details.push(`Unit IDs: ${failedUnitIds.slice(0, 3).join(", ")}`);
-        }
-
-        return details;
-    };
-
-    const getJobDetails = (job: SyncJob) => {
-        const resultDetails = getResultDetails(job);
-        if (job.error) return { primary: job.error, secondary: resultDetails, tone: "error" };
-        if (job.status === "failed") {
-            return {
-                primary: resultDetails[0] ?? "Sync failed without a stored reason",
-                secondary: resultDetails.slice(1),
-                tone: "error",
-            };
-        }
-        if (job.status === "cancelled") {
-            return {
-                primary: resultDetails[0] ?? "Sync was cancelled before completion",
-                secondary: resultDetails.slice(1),
-                tone: "error",
-            };
-        }
-        if (job.status === "running") {
-            return {
-                primary: "Still running",
-                secondary: [`Started ${formatTimestamp(job.started_at)}`],
-                tone: "muted",
-            };
-        }
-        if (job.status === "pending") {
-            return { primary: "Queued", secondary: [], tone: "muted" };
-        }
-        return { primary: "-", secondary: [], tone: "muted" };
-    };
+    const canGoPrevious = offset > 0;
+    const canGoNext = testMode ? offset + PAGE_SIZE < jobs.length : hasMore;
 
     return (
         <div className="overflow-x-auto rounded-xl border border-(--card-stroke) bg-(--card-80)">
+            {fetchError && (
+                <div role="alert" className="border-b border-(--card-stroke) px-6 py-3 text-sm text-(--negative)">
+                    {fetchError}
+                </div>
+            )}
             <table className="min-w-full divide-y divide-(--card-stroke)">
                 <thead className="bg-(--card-bg)">
                     <tr>
-                        <th
-                            scope="col"
-                            className="px-6 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
-                        >
-                            Status
-                        </th>
-                        <th
-                            scope="col"
-                            className="px-6 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
-                        >
-                            Started At
-                        </th>
-                        <th
-                            scope="col"
-                            className="px-6 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
-                        >
-                            Completed / Last Activity
-                        </th>
-                        <th
-                            scope="col"
-                            className="px-6 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
-                        >
-                            Duration
-                        </th>
-                        <th
-                            scope="col"
-                            className="px-6 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
-                        >
-                            Items Synced
-                        </th>
-                        <th
-                            scope="col"
-                            className="px-6 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
-                        >
-                            Details
-                        </th>
+                        {HEADINGS.map((heading) => (
+                            <th
+                                key={heading}
+                                scope="col"
+                                className="px-4 py-3 text-left text-xs font-medium text-(--ink-muted) uppercase tracking-wider"
+                            >
+                                {heading}
+                            </th>
+                        ))}
                     </tr>
                 </thead>
                 <tbody className="divide-y divide-(--card-stroke) bg-(--card-80)">
-                    {paginatedJobs.map((job) => {
-                        const duration = getDuration(job);
-                        const activityTimestamp = getActivityTimestamp(job);
-                        const details = getJobDetails(job);
-                        const runId =
-                            isRecord(job.result) && typeof job.result.sync_run_id === "string"
-                                ? job.result.sync_run_id
-                                : null;
+                    {visibleJobs.map((job) => {
+                        const runId = getRunId(job);
                         const href = runId ? `/org/admin/sync/${configId}/runs/${runId}` : null;
+                        const coverageResult = deriveJobCoverageResult(job);
+                        const sr = job.sync_run;
 
                         return (
                             <tr
                                 key={job.id}
                                 onClick={href ? () => router.push(href) : undefined}
-                                className={
-                                    href
-                                        ? "cursor-pointer transition-colors hover:bg-(--card-70)"
-                                        : undefined
-                                }
+                                className={href ? "cursor-pointer transition-colors hover:bg-(--card-70)" : undefined}
                             >
-                                <td className="px-6 py-4 whitespace-nowrap">
-                                    {href ? (
-                                        <Link
-                                            href={href}
-                                            aria-label={`View run details for sync run started ${formatTimestamp(
-                                                job.started_at,
-                                            )}`}
-                                            className="inline-flex rounded-xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--accent)"
-                                        >
-                                            <SyncStatusBadge
-                                                status={getBadgeStatus(job.status)}
-                                                label={getBadgeLabel(job.status)}
-                                            />
-                                        </Link>
+                                <td className="px-4 py-3 whitespace-nowrap text-sm text-foreground">
+                                    {sr?.triggered_by ?? job.triggered_by ?? "—"}
+                                </td>
+                                <td className="px-4 py-3 whitespace-nowrap text-sm text-(--ink-muted)">
+                                    {sr?.mode ?? "—"}
+                                </td>
+                                <td className="px-4 py-3 whitespace-nowrap text-sm text-(--ink-muted)">
+                                    {formatRange(sr?.requested_range)}
+                                </td>
+                                <td className="px-4 py-3 whitespace-nowrap text-sm text-(--ink-muted)">
+                                    {formatRange(sr?.covered_range)}
+                                </td>
+                                <td className="px-4 py-3 whitespace-nowrap">
+                                    {coverageResult ? (
+                                        <CoverageBadge
+                                            tone={jobCoverageTone(coverageResult)}
+                                            label={jobCoverageLabel(coverageResult)}
+                                        />
                                     ) : (
                                         <SyncStatusBadge
                                             status={getBadgeStatus(job.status)}
@@ -258,43 +252,33 @@ export function SyncJobHistory({ jobs, configId, totalJobs }: SyncJobHistoryProp
                                         />
                                     )}
                                 </td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
+                                <td className="px-4 py-3 whitespace-nowrap text-sm text-(--ink-muted)">
+                                    {getScopeLabel(job)}
+                                </td>
+                                <td className="px-4 py-3 whitespace-nowrap text-sm text-(--ink-muted)">
+                                    {sr
+                                        ? `${formatNumber(sr.completed_units)} done · ${formatNumber(sr.failed_units)} failed · ${formatNumber(sr.total_units)} total`
+                                        : (job.items_synced ?? "—")}
+                                </td>
+                                <td className="px-4 py-3 whitespace-nowrap text-sm text-foreground">
                                     {formatTimestamp(job.started_at)}
                                 </td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
-                                    <div>{formatTimestamp(activityTimestamp)}</div>
-                                    <div className="text-xs text-(--ink-muted)">
-                                        {getActivityLabel(job)}
-                                    </div>
+                                <td className="px-4 py-3 whitespace-nowrap text-sm text-(--ink-muted)">
+                                    {getDuration(job)}
                                 </td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-(--ink-muted)">
-                                    {duration}
-                                </td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-(--ink-muted)">
-                                    {job.items_synced ?? "-"}
-                                </td>
-                                <td
-                                    className={`px-6 py-4 text-sm ${
-                                        details.tone === "error"
-                                            ? "text-red-500"
-                                            : "text-(--ink-muted)"
-                                    }`}
-                                >
-                                    {details.primary !== "-" ? (
-                                        <div
-                                            title={[details.primary, ...details.secondary].join(
-                                                " · ",
-                                            )}
+                                <td className="px-4 py-3 whitespace-nowrap text-sm">
+                                    {href ? (
+                                        <Link
+                                            href={href}
+                                            aria-label={`View run details for sync run started ${formatTimestamp(
+                                                job.started_at,
+                                            )}`}
+                                            className="text-(--accent) hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--accent)"
                                         >
-                                            <div className="line-clamp-2">{details.primary}</div>
-                                            {details.secondary.length > 0 && (
-                                                <div className="mt-1 line-clamp-2 text-xs text-(--ink-muted)">
-                                                    {details.secondary.join(" · ")}
-                                                </div>
-                                            )}
-                                        </div>
+                                            {CTA_LABELS.viewRun}
+                                        </Link>
                                     ) : (
-                                        <span className="text-(--ink-muted)">-</span>
+                                        <span className="text-(--ink-muted)">—</span>
                                     )}
                                 </td>
                             </tr>
@@ -305,21 +289,22 @@ export function SyncJobHistory({ jobs, configId, totalJobs }: SyncJobHistoryProp
 
             <div className="flex items-center justify-between border-t border-(--card-stroke) px-6 py-4">
                 <span className="text-sm text-(--ink-muted)">
-                    Showing {offset + 1}-{Math.min(offset + limit, total)} of {total}
+                    Showing {offset + 1}-{offset + visibleJobs.length}
+                    {isPending ? " · Loading…" : ""}
                 </span>
                 <div className="flex items-center gap-2">
                     <button
                         type="button"
-                        onClick={() => setOffset((prev) => Math.max(0, prev - limit))}
-                        disabled={offset === 0}
+                        onClick={() => goToOffset(offset - PAGE_SIZE)}
+                        disabled={!canGoPrevious || isPending}
                         className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium hover:bg-(--card-70) disabled:cursor-not-allowed disabled:opacity-50"
                     >
                         {CTA_LABELS.previousPage}
                     </button>
                     <button
                         type="button"
-                        onClick={() => setOffset((prev) => prev + limit)}
-                        disabled={offset + limit >= total}
+                        onClick={() => goToOffset(offset + PAGE_SIZE)}
+                        disabled={!canGoNext || isPending}
                         className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium hover:bg-(--card-70) disabled:cursor-not-allowed disabled:opacity-50"
                     >
                         {CTA_LABELS.nextPage}

--- a/src/data/syncCoverageSample.ts
+++ b/src/data/syncCoverageSample.ts
@@ -1,0 +1,518 @@
+// ── Deterministic sync-coverage sample data for DEV_HEALTH_TEST_MODE ─────────
+//
+// Mirrors the run-detail sample-data convention (data/syncRunDetailSample.ts):
+// typed constants rendered in test mode instead of hitting the admin API, so
+// the coverage-first config detail page (CHAOS-2791/2792/2793) is exercisable
+// in Playwright/unit tests without a live backend. Values are CLEARLY SAMPLE
+// (fixed dates, sample-* ids) and resolve source NAMES (never bare source
+// ids) per the web DoD. Scenario shapes intentionally mirror the frozen
+// contract fixtures in lib/admin/__tests__/syncCoverageFixtures.ts (CHAOS-2790)
+// so sample-mode rendering and the API contract never drift apart.
+
+import type { SyncConfig, SyncCoverageRange, SyncCoverageSummary, SyncJob } from "@/lib/admin/types";
+
+const CONFIG_ID = "sample-sync-config";
+const PROVIDER = "github";
+const SOURCE_PLATFORM = "sample-source-platform-api";
+const SOURCE_BILLING = "sample-source-billing-service";
+const RUN_HEALTHY = "sample-run-healthy";
+const RUN_GAPS = "sample-run-gaps";
+const RUN_FAILED = "sample-run-failed";
+const RUN_STALE = "sample-run-stale";
+
+const GENERATED_AT = "2026-07-02T15:00:00.000Z";
+const TRUNCATED_BEFORE = "2026-01-03T00:00:00.000Z";
+
+function range(
+    since: string,
+    before: string,
+    sourceIds: string[],
+    runIds: string[] = [],
+): SyncCoverageRange {
+    return { since, before, source_ids: sourceIds, run_ids: runIds };
+}
+
+/** Sample sync config matching the coverage/job samples below (test-mode only). */
+export const SAMPLE_SYNC_CONFIG: SyncConfig = {
+    id: CONFIG_ID,
+    name: "fullchaos/platform-api (sample)",
+    provider: PROVIDER,
+    credential_id: "sample-credential",
+    sync_targets: ["git", "prs", "cicd", "work-items"],
+    sync_options: {},
+    is_active: true,
+    schedule_cron: "0 * * * *",
+    timezone: "UTC",
+    initial_sync_depth: 90,
+    last_sync_at: "2026-07-02T13:00:00.000Z",
+    last_sync_success: true,
+    last_sync_error: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-07-02T13:00:00.000Z",
+    parent_id: null,
+};
+
+// ---- Coverage summary scenarios ----
+
+export const SAMPLE_COVERAGE_HEALTHY: SyncCoverageSummary = {
+    config_id: CONFIG_ID,
+    provider: PROVIDER,
+    generated_at: GENERATED_AT,
+    data_basis: "planner",
+    history_lookback_days: 180,
+    truncated_before: TRUNCATED_BEFORE,
+    overall: {
+        health: "healthy",
+        latest_successful_run_at: "2026-07-02T13:00:00.000Z",
+        latest_covered_through: "2026-07-02T13:00:00.000Z",
+        next_scheduled_run_at: "2026-07-02T14:00:00.000Z",
+        gap_count: 0,
+        stale_dataset_count: 0,
+        failed_range_count: 0,
+    },
+    datasets: [
+        {
+            dataset_key: "git",
+            status: "healthy",
+            covered_through: "2026-07-02T13:00:00.000Z",
+            requested_ranges: [
+                range("2026-06-01T00:00:00.000Z", "2026-07-02T13:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_HEALTHY,
+                ]),
+            ],
+            covered_ranges: [
+                range("2026-06-01T00:00:00.000Z", "2026-07-02T13:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_HEALTHY,
+                ]),
+            ],
+            gaps: [],
+            stale_ranges: [],
+            failed_ranges: [],
+        },
+        {
+            dataset_key: "prs",
+            status: "healthy",
+            covered_through: "2026-07-02T13:00:00.000Z",
+            requested_ranges: [
+                range("2026-06-01T00:00:00.000Z", "2026-07-02T13:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_HEALTHY,
+                ]),
+            ],
+            covered_ranges: [
+                range("2026-06-01T00:00:00.000Z", "2026-07-02T13:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_HEALTHY,
+                ]),
+            ],
+            gaps: [],
+            stale_ranges: [],
+            failed_ranges: [],
+        },
+    ],
+    sources: [
+        {
+            source_id: SOURCE_PLATFORM,
+            source_name: "fullchaos/platform-api",
+            status: "healthy",
+            covered_through: "2026-07-02T13:00:00.000Z",
+            gap_count: 0,
+            failed_range_count: 0,
+        },
+    ],
+};
+
+export const SAMPLE_COVERAGE_GAPS: SyncCoverageSummary = {
+    config_id: CONFIG_ID,
+    provider: PROVIDER,
+    generated_at: GENERATED_AT,
+    data_basis: "planner",
+    history_lookback_days: 180,
+    truncated_before: TRUNCATED_BEFORE,
+    overall: {
+        health: "gaps",
+        latest_successful_run_at: "2026-07-01T09:00:00.000Z",
+        latest_covered_through: "2026-06-28T00:00:00.000Z",
+        next_scheduled_run_at: "2026-07-02T16:00:00.000Z",
+        gap_count: 2,
+        stale_dataset_count: 1,
+        failed_range_count: 1,
+    },
+    datasets: [
+        {
+            dataset_key: "git",
+            status: "gaps",
+            covered_through: "2026-06-28T00:00:00.000Z",
+            requested_ranges: [
+                range("2026-06-20T00:00:00.000Z", "2026-07-01T09:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_GAPS,
+                ]),
+            ],
+            covered_ranges: [
+                range("2026-06-20T00:00:00.000Z", "2026-06-24T00:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_GAPS,
+                ]),
+                range("2026-06-26T00:00:00.000Z", "2026-06-28T00:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_GAPS,
+                ]),
+            ],
+            gaps: [
+                range("2026-06-24T00:00:00.000Z", "2026-06-26T00:00:00.000Z", [SOURCE_PLATFORM]),
+                range("2026-06-28T00:00:00.000Z", "2026-07-01T09:00:00.000Z", [SOURCE_PLATFORM]),
+            ],
+            stale_ranges: [],
+            failed_ranges: [],
+        },
+        {
+            dataset_key: "prs",
+            status: "failed",
+            covered_through: "2026-06-25T00:00:00.000Z",
+            requested_ranges: [
+                range(
+                    "2026-06-20T00:00:00.000Z",
+                    "2026-07-01T09:00:00.000Z",
+                    [SOURCE_PLATFORM, SOURCE_BILLING],
+                    [RUN_GAPS],
+                ),
+            ],
+            covered_ranges: [
+                range("2026-06-20T00:00:00.000Z", "2026-06-25T00:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_GAPS,
+                ]),
+            ],
+            gaps: [],
+            stale_ranges: [],
+            failed_ranges: [
+                range("2026-06-25T00:00:00.000Z", "2026-06-27T00:00:00.000Z", [SOURCE_BILLING], [
+                    RUN_GAPS,
+                ]),
+            ],
+        },
+        {
+            dataset_key: "cicd",
+            status: "stale",
+            covered_through: "2026-06-15T00:00:00.000Z",
+            requested_ranges: [
+                range("2026-06-01T00:00:00.000Z", "2026-06-15T00:00:00.000Z", [SOURCE_BILLING], [
+                    RUN_GAPS,
+                ]),
+            ],
+            covered_ranges: [
+                range("2026-06-01T00:00:00.000Z", "2026-06-15T00:00:00.000Z", [SOURCE_BILLING], [
+                    RUN_GAPS,
+                ]),
+            ],
+            gaps: [],
+            stale_ranges: [
+                range("2026-06-15T00:00:00.000Z", "2026-07-02T15:00:00.000Z", [SOURCE_BILLING]),
+            ],
+            failed_ranges: [],
+        },
+    ],
+    sources: [
+        {
+            source_id: SOURCE_PLATFORM,
+            source_name: "fullchaos/platform-api",
+            status: "gaps",
+            covered_through: "2026-06-28T00:00:00.000Z",
+            gap_count: 2,
+            failed_range_count: 0,
+        },
+        {
+            source_id: SOURCE_BILLING,
+            source_name: "fullchaos/billing-service",
+            status: "failed",
+            covered_through: "2026-06-25T00:00:00.000Z",
+            gap_count: 0,
+            failed_range_count: 1,
+        },
+    ],
+};
+
+export const SAMPLE_COVERAGE_FAILED: SyncCoverageSummary = {
+    config_id: CONFIG_ID,
+    provider: PROVIDER,
+    generated_at: GENERATED_AT,
+    data_basis: "planner",
+    history_lookback_days: 180,
+    truncated_before: TRUNCATED_BEFORE,
+    overall: {
+        health: "failed",
+        latest_successful_run_at: "2026-06-20T00:00:00.000Z",
+        latest_covered_through: "2026-06-20T00:00:00.000Z",
+        next_scheduled_run_at: "2026-07-02T16:00:00.000Z",
+        gap_count: 0,
+        stale_dataset_count: 0,
+        failed_range_count: 1,
+    },
+    datasets: [
+        {
+            dataset_key: "work-items",
+            status: "failed",
+            covered_through: "2026-06-20T00:00:00.000Z",
+            requested_ranges: [
+                range("2026-06-20T00:00:00.000Z", "2026-07-02T00:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_FAILED,
+                ]),
+            ],
+            covered_ranges: [
+                range("2026-06-18T00:00:00.000Z", "2026-06-20T00:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_FAILED,
+                ]),
+            ],
+            gaps: [],
+            stale_ranges: [],
+            failed_ranges: [
+                range("2026-06-20T00:00:00.000Z", "2026-07-02T00:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_FAILED,
+                ]),
+            ],
+        },
+    ],
+    sources: [
+        {
+            source_id: SOURCE_PLATFORM,
+            source_name: "fullchaos/platform-api",
+            status: "failed",
+            covered_through: "2026-06-20T00:00:00.000Z",
+            gap_count: 0,
+            failed_range_count: 1,
+        },
+    ],
+};
+
+export const SAMPLE_COVERAGE_STALE: SyncCoverageSummary = {
+    config_id: CONFIG_ID,
+    provider: PROVIDER,
+    generated_at: GENERATED_AT,
+    data_basis: "planner",
+    history_lookback_days: 180,
+    truncated_before: TRUNCATED_BEFORE,
+    overall: {
+        health: "stale",
+        latest_successful_run_at: "2026-06-10T00:00:00.000Z",
+        latest_covered_through: "2026-06-10T00:00:00.000Z",
+        next_scheduled_run_at: null,
+        gap_count: 0,
+        stale_dataset_count: 2,
+        failed_range_count: 0,
+    },
+    datasets: [
+        {
+            dataset_key: "git",
+            status: "stale",
+            covered_through: "2026-06-10T00:00:00.000Z",
+            requested_ranges: [
+                range("2026-05-01T00:00:00.000Z", "2026-06-10T00:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_STALE,
+                ]),
+            ],
+            covered_ranges: [
+                range("2026-05-01T00:00:00.000Z", "2026-06-10T00:00:00.000Z", [SOURCE_PLATFORM], [
+                    RUN_STALE,
+                ]),
+            ],
+            gaps: [],
+            stale_ranges: [
+                range("2026-06-10T00:00:00.000Z", "2026-07-02T15:00:00.000Z", [SOURCE_PLATFORM]),
+            ],
+            failed_ranges: [],
+        },
+    ],
+    sources: [
+        {
+            source_id: SOURCE_PLATFORM,
+            source_name: "fullchaos/platform-api",
+            status: "stale",
+            covered_through: "2026-06-10T00:00:00.000Z",
+            gap_count: 0,
+            failed_range_count: 0,
+        },
+    ],
+};
+
+export const SAMPLE_COVERAGE_INSUFFICIENT_DATA: SyncCoverageSummary = {
+    config_id: CONFIG_ID,
+    provider: PROVIDER,
+    generated_at: GENERATED_AT,
+    data_basis: "legacy",
+    history_lookback_days: 180,
+    truncated_before: TRUNCATED_BEFORE,
+    overall: {
+        health: "insufficient_data",
+        latest_successful_run_at: null,
+        latest_covered_through: null,
+        next_scheduled_run_at: null,
+        gap_count: 0,
+        stale_dataset_count: 0,
+        failed_range_count: 0,
+    },
+    datasets: [],
+    sources: [],
+};
+
+/** Named scenarios selectable via the `?coverage_scenario=` test-mode query param. */
+export const SYNC_COVERAGE_SAMPLES = {
+    healthy: SAMPLE_COVERAGE_HEALTHY,
+    gaps: SAMPLE_COVERAGE_GAPS,
+    failed: SAMPLE_COVERAGE_FAILED,
+    stale: SAMPLE_COVERAGE_STALE,
+    insufficient_data: SAMPLE_COVERAGE_INSUFFICIENT_DATA,
+} satisfies Record<string, SyncCoverageSummary>;
+
+export type SyncCoverageSampleScenario = keyof typeof SYNC_COVERAGE_SAMPLES;
+
+export const DEFAULT_SYNC_COVERAGE_SCENARIO: SyncCoverageSampleScenario = "gaps";
+
+export function resolveSyncCoverageSampleScenario(value: string | undefined): SyncCoverageSampleScenario {
+    if (value && Object.hasOwn(SYNC_COVERAGE_SAMPLES, value)) {
+        return value as SyncCoverageSampleScenario;
+    }
+    return DEFAULT_SYNC_COVERAGE_SCENARIO;
+}
+
+// ---- Job history sample (mix of planner-enriched + legacy rows) ----
+
+function jobRange(since: string, before: string, sourceIds: string[]): SyncCoverageRange {
+    return { since, before, source_ids: sourceIds, run_ids: [] };
+}
+
+export const SAMPLE_SYNC_JOBS: SyncJob[] = [
+    {
+        id: "sample-job-1",
+        job_id: "sample-job-1",
+        status: "success",
+        started_at: "2026-07-02T13:00:00.000Z",
+        completed_at: "2026-07-02T13:04:00.000Z",
+        duration_seconds: 240,
+        items_synced: 412,
+        triggered_by: "scheduled",
+        created_at: "2026-07-02T13:00:00.000Z",
+        sync_run: {
+            mode: "incremental",
+            triggered_by: "scheduled",
+            requested_range: jobRange(
+                "2026-07-02T12:00:00.000Z",
+                "2026-07-02T13:00:00.000Z",
+                [SOURCE_PLATFORM],
+            ),
+            covered_range: jobRange(
+                "2026-07-02T12:00:00.000Z",
+                "2026-07-02T13:00:00.000Z",
+                [SOURCE_PLATFORM],
+            ),
+            total_units: 4,
+            completed_units: 4,
+            failed_units: 0,
+            sync_run_id: RUN_HEALTHY,
+        },
+    },
+    {
+        id: "sample-job-2",
+        job_id: "sample-job-2",
+        status: "success",
+        started_at: "2026-07-01T09:00:00.000Z",
+        completed_at: "2026-07-01T09:06:12.000Z",
+        duration_seconds: 372,
+        items_synced: 88,
+        triggered_by: "manual",
+        created_at: "2026-07-01T09:00:00.000Z",
+        sync_run: {
+            mode: "incremental",
+            triggered_by: "admin@devhealth.example",
+            requested_range: jobRange(
+                "2026-06-20T00:00:00.000Z",
+                "2026-07-01T09:00:00.000Z",
+                [SOURCE_PLATFORM, SOURCE_BILLING],
+            ),
+            covered_range: jobRange(
+                "2026-06-20T00:00:00.000Z",
+                "2026-06-28T00:00:00.000Z",
+                [SOURCE_PLATFORM, SOURCE_BILLING],
+            ),
+            total_units: 6,
+            completed_units: 4,
+            failed_units: 1,
+            sync_run_id: RUN_GAPS,
+        },
+    },
+    {
+        id: "sample-job-3",
+        job_id: "sample-job-3",
+        status: "failed",
+        started_at: "2026-06-20T00:00:00.000Z",
+        completed_at: "2026-06-20T00:03:40.000Z",
+        duration_seconds: 220,
+        items_synced: 0,
+        error: "Upstream returned 500 while paginating work items",
+        triggered_by: "scheduled",
+        created_at: "2026-06-20T00:00:00.000Z",
+        sync_run: {
+            mode: "full_resync",
+            triggered_by: "scheduled",
+            requested_range: jobRange(
+                "2026-06-20T00:00:00.000Z",
+                "2026-07-02T00:00:00.000Z",
+                [SOURCE_PLATFORM],
+            ),
+            covered_range: null,
+            total_units: 3,
+            completed_units: 0,
+            failed_units: 3,
+            sync_run_id: RUN_FAILED,
+        },
+    },
+    {
+        id: "sample-job-4",
+        job_id: "sample-job-4",
+        status: "success",
+        started_at: "2026-06-10T00:00:00.000Z",
+        completed_at: "2026-06-10T00:05:00.000Z",
+        duration_seconds: 300,
+        items_synced: 210,
+        triggered_by: "scheduled",
+        created_at: "2026-06-10T00:00:00.000Z",
+        sync_run: {
+            mode: "incremental",
+            triggered_by: "scheduled",
+            requested_range: jobRange(
+                "2026-05-01T00:00:00.000Z",
+                "2026-06-10T00:00:00.000Z",
+                [SOURCE_PLATFORM],
+            ),
+            covered_range: jobRange(
+                "2026-05-01T00:00:00.000Z",
+                "2026-06-10T00:00:00.000Z",
+                [SOURCE_PLATFORM],
+            ),
+            total_units: 2,
+            completed_units: 2,
+            failed_units: 0,
+            sync_run_id: RUN_STALE,
+        },
+    },
+    // Legacy rows: no planner sync_run enrichment block. Must render readable
+    // with em-dashes, never fabricate a complete/partial/gap/failed label.
+    {
+        id: "sample-job-legacy-1",
+        job_id: "sample-job-legacy-1",
+        status: "success",
+        started_at: "2026-05-15T00:00:00.000Z",
+        completed_at: "2026-05-15T00:02:30.000Z",
+        duration_seconds: 150,
+        items_synced: 63,
+        triggered_by: "scheduled",
+        created_at: "2026-05-15T00:00:00.000Z",
+        result: { dataset_key: "work-items" },
+    },
+    {
+        id: "sample-job-legacy-2",
+        job_id: "sample-job-legacy-2",
+        status: "failed",
+        started_at: "2026-05-01T00:00:00.000Z",
+        completed_at: "2026-05-01T00:01:10.000Z",
+        duration_seconds: 70,
+        items_synced: 0,
+        error: "Credential expired",
+        triggered_by: "scheduled",
+        created_at: "2026-05-01T00:00:00.000Z",
+    },
+];

--- a/src/data/syncCoverageSample.ts
+++ b/src/data/syncCoverageSample.ts
@@ -9,7 +9,12 @@
 // contract fixtures in lib/admin/__tests__/syncCoverageFixtures.ts (CHAOS-2790)
 // so sample-mode rendering and the API contract never drift apart.
 
-import type { SyncConfig, SyncCoverageRange, SyncCoverageSummary, SyncJob } from "@/lib/admin/types";
+import type {
+    SyncConfig,
+    SyncCoverageRange,
+    SyncCoverageSummary,
+    SyncJob,
+} from "@/lib/admin/types";
 
 const CONFIG_ID = "sample-sync-config";
 const PROVIDER = "github";
@@ -19,6 +24,10 @@ const RUN_HEALTHY = "sample-run-healthy";
 const RUN_GAPS = "sample-run-gaps";
 const RUN_FAILED = "sample-run-failed";
 const RUN_STALE = "sample-run-stale";
+const RUN_RETRY = "sample-run-retry";
+const RUN_CONCURRENT = "sample-run-concurrent";
+const SOURCE_SECONDARY = "sample-source-secondary-repo";
+const CONFIG_ID_SECONDARY = "sample-sync-config-secondary";
 
 const GENERATED_AT = "2026-07-02T15:00:00.000Z";
 const TRUNCATED_BEFORE = "2026-01-03T00:00:00.000Z";
@@ -76,14 +85,20 @@ export const SAMPLE_COVERAGE_HEALTHY: SyncCoverageSummary = {
             status: "healthy",
             covered_through: "2026-07-02T13:00:00.000Z",
             requested_ranges: [
-                range("2026-06-01T00:00:00.000Z", "2026-07-02T13:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_HEALTHY,
-                ]),
+                range(
+                    "2026-06-01T00:00:00.000Z",
+                    "2026-07-02T13:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_HEALTHY],
+                ),
             ],
             covered_ranges: [
-                range("2026-06-01T00:00:00.000Z", "2026-07-02T13:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_HEALTHY,
-                ]),
+                range(
+                    "2026-06-01T00:00:00.000Z",
+                    "2026-07-02T13:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_HEALTHY],
+                ),
             ],
             gaps: [],
             stale_ranges: [],
@@ -94,14 +109,20 @@ export const SAMPLE_COVERAGE_HEALTHY: SyncCoverageSummary = {
             status: "healthy",
             covered_through: "2026-07-02T13:00:00.000Z",
             requested_ranges: [
-                range("2026-06-01T00:00:00.000Z", "2026-07-02T13:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_HEALTHY,
-                ]),
+                range(
+                    "2026-06-01T00:00:00.000Z",
+                    "2026-07-02T13:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_HEALTHY],
+                ),
             ],
             covered_ranges: [
-                range("2026-06-01T00:00:00.000Z", "2026-07-02T13:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_HEALTHY,
-                ]),
+                range(
+                    "2026-06-01T00:00:00.000Z",
+                    "2026-07-02T13:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_HEALTHY],
+                ),
             ],
             gaps: [],
             stale_ranges: [],
@@ -142,17 +163,26 @@ export const SAMPLE_COVERAGE_GAPS: SyncCoverageSummary = {
             status: "gaps",
             covered_through: "2026-06-28T00:00:00.000Z",
             requested_ranges: [
-                range("2026-06-20T00:00:00.000Z", "2026-07-01T09:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_GAPS,
-                ]),
+                range(
+                    "2026-06-20T00:00:00.000Z",
+                    "2026-07-01T09:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_GAPS],
+                ),
             ],
             covered_ranges: [
-                range("2026-06-20T00:00:00.000Z", "2026-06-24T00:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_GAPS,
-                ]),
-                range("2026-06-26T00:00:00.000Z", "2026-06-28T00:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_GAPS,
-                ]),
+                range(
+                    "2026-06-20T00:00:00.000Z",
+                    "2026-06-24T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_GAPS],
+                ),
+                range(
+                    "2026-06-26T00:00:00.000Z",
+                    "2026-06-28T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_GAPS],
+                ),
             ],
             gaps: [
                 range("2026-06-24T00:00:00.000Z", "2026-06-26T00:00:00.000Z", [SOURCE_PLATFORM]),
@@ -174,16 +204,22 @@ export const SAMPLE_COVERAGE_GAPS: SyncCoverageSummary = {
                 ),
             ],
             covered_ranges: [
-                range("2026-06-20T00:00:00.000Z", "2026-06-25T00:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_GAPS,
-                ]),
+                range(
+                    "2026-06-20T00:00:00.000Z",
+                    "2026-06-25T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_GAPS],
+                ),
             ],
             gaps: [],
             stale_ranges: [],
             failed_ranges: [
-                range("2026-06-25T00:00:00.000Z", "2026-06-27T00:00:00.000Z", [SOURCE_BILLING], [
-                    RUN_GAPS,
-                ]),
+                range(
+                    "2026-06-25T00:00:00.000Z",
+                    "2026-06-27T00:00:00.000Z",
+                    [SOURCE_BILLING],
+                    [RUN_GAPS],
+                ),
             ],
         },
         {
@@ -191,14 +227,20 @@ export const SAMPLE_COVERAGE_GAPS: SyncCoverageSummary = {
             status: "stale",
             covered_through: "2026-06-15T00:00:00.000Z",
             requested_ranges: [
-                range("2026-06-01T00:00:00.000Z", "2026-06-15T00:00:00.000Z", [SOURCE_BILLING], [
-                    RUN_GAPS,
-                ]),
+                range(
+                    "2026-06-01T00:00:00.000Z",
+                    "2026-06-15T00:00:00.000Z",
+                    [SOURCE_BILLING],
+                    [RUN_GAPS],
+                ),
             ],
             covered_ranges: [
-                range("2026-06-01T00:00:00.000Z", "2026-06-15T00:00:00.000Z", [SOURCE_BILLING], [
-                    RUN_GAPS,
-                ]),
+                range(
+                    "2026-06-01T00:00:00.000Z",
+                    "2026-06-15T00:00:00.000Z",
+                    [SOURCE_BILLING],
+                    [RUN_GAPS],
+                ),
             ],
             gaps: [],
             stale_ranges: [
@@ -249,21 +291,30 @@ export const SAMPLE_COVERAGE_FAILED: SyncCoverageSummary = {
             status: "failed",
             covered_through: "2026-06-20T00:00:00.000Z",
             requested_ranges: [
-                range("2026-06-20T00:00:00.000Z", "2026-07-02T00:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_FAILED,
-                ]),
+                range(
+                    "2026-06-20T00:00:00.000Z",
+                    "2026-07-02T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_FAILED],
+                ),
             ],
             covered_ranges: [
-                range("2026-06-18T00:00:00.000Z", "2026-06-20T00:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_FAILED,
-                ]),
+                range(
+                    "2026-06-18T00:00:00.000Z",
+                    "2026-06-20T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_FAILED],
+                ),
             ],
             gaps: [],
             stale_ranges: [],
             failed_ranges: [
-                range("2026-06-20T00:00:00.000Z", "2026-07-02T00:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_FAILED,
-                ]),
+                range(
+                    "2026-06-20T00:00:00.000Z",
+                    "2026-07-02T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_FAILED],
+                ),
             ],
         },
     ],
@@ -301,14 +352,20 @@ export const SAMPLE_COVERAGE_STALE: SyncCoverageSummary = {
             status: "stale",
             covered_through: "2026-06-10T00:00:00.000Z",
             requested_ranges: [
-                range("2026-05-01T00:00:00.000Z", "2026-06-10T00:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_STALE,
-                ]),
+                range(
+                    "2026-05-01T00:00:00.000Z",
+                    "2026-06-10T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_STALE],
+                ),
             ],
             covered_ranges: [
-                range("2026-05-01T00:00:00.000Z", "2026-06-10T00:00:00.000Z", [SOURCE_PLATFORM], [
-                    RUN_STALE,
-                ]),
+                range(
+                    "2026-05-01T00:00:00.000Z",
+                    "2026-06-10T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_STALE],
+                ),
             ],
             gaps: [],
             stale_ranges: [
@@ -349,6 +406,131 @@ export const SAMPLE_COVERAGE_INSUFFICIENT_DATA: SyncCoverageSummary = {
     sources: [],
 };
 
+export const SAMPLE_COVERAGE_OVERLAPPING_RETRY: SyncCoverageSummary = {
+    config_id: CONFIG_ID,
+    provider: PROVIDER,
+    generated_at: GENERATED_AT,
+    data_basis: "planner",
+    history_lookback_days: 180,
+    truncated_before: TRUNCATED_BEFORE,
+    overall: {
+        health: "healthy",
+        latest_successful_run_at: "2026-06-27T00:00:00.000Z",
+        latest_covered_through: "2026-06-27T00:00:00.000Z",
+        next_scheduled_run_at: "2026-07-02T16:00:00.000Z",
+        gap_count: 0,
+        stale_dataset_count: 0,
+        failed_range_count: 1,
+    },
+    datasets: [
+        {
+            dataset_key: "git",
+            status: "healthy",
+            covered_through: "2026-06-27T00:00:00.000Z",
+            requested_ranges: [
+                range(
+                    "2026-06-20T00:00:00.000Z",
+                    "2026-06-27T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_FAILED, RUN_RETRY],
+                ),
+            ],
+            covered_ranges: [
+                // A successful retry (RUN_RETRY) re-covers and extends past
+                // the window an earlier run (RUN_FAILED) failed on — the
+                // failed and covered ranges below deliberately OVERLAP
+                // (CHAOS-2791 D3: "overlapping-retry" scenario).
+                range(
+                    "2026-06-22T00:00:00.000Z",
+                    "2026-06-27T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_RETRY],
+                ),
+            ],
+            gaps: [],
+            stale_ranges: [],
+            failed_ranges: [
+                range(
+                    "2026-06-20T00:00:00.000Z",
+                    "2026-06-24T00:00:00.000Z",
+                    [SOURCE_PLATFORM],
+                    [RUN_FAILED],
+                ),
+            ],
+        },
+    ],
+    sources: [
+        {
+            source_id: SOURCE_PLATFORM,
+            source_name: "fullchaos/platform-api",
+            status: "healthy",
+            covered_through: "2026-06-27T00:00:00.000Z",
+            gap_count: 0,
+            failed_range_count: 1,
+        },
+    ],
+};
+
+/**
+ * Second GitHub config's coverage (CHAOS-2791 D3: "concurrent same-provider
+ * configs"). Demonstrates that coverage summaries are scoped per config_id
+ * even when two configs share a provider — a distinct config_id/source pair
+ * from the primary sample config above.
+ */
+export const SAMPLE_COVERAGE_CONCURRENT_CONFIG: SyncCoverageSummary = {
+    config_id: CONFIG_ID_SECONDARY,
+    provider: PROVIDER,
+    generated_at: GENERATED_AT,
+    data_basis: "planner",
+    history_lookback_days: 180,
+    truncated_before: TRUNCATED_BEFORE,
+    overall: {
+        health: "healthy",
+        latest_successful_run_at: "2026-07-02T12:30:00.000Z",
+        latest_covered_through: "2026-07-02T12:30:00.000Z",
+        next_scheduled_run_at: "2026-07-02T13:30:00.000Z",
+        gap_count: 0,
+        stale_dataset_count: 0,
+        failed_range_count: 0,
+    },
+    datasets: [
+        {
+            dataset_key: "git",
+            status: "healthy",
+            covered_through: "2026-07-02T12:30:00.000Z",
+            requested_ranges: [
+                range(
+                    "2026-06-01T00:00:00.000Z",
+                    "2026-07-02T12:30:00.000Z",
+                    [SOURCE_SECONDARY],
+                    [RUN_CONCURRENT],
+                ),
+            ],
+            covered_ranges: [
+                range(
+                    "2026-06-01T00:00:00.000Z",
+                    "2026-07-02T12:30:00.000Z",
+                    [SOURCE_SECONDARY],
+                    [RUN_CONCURRENT],
+                ),
+            ],
+            gaps: [],
+            stale_ranges: [],
+            failed_ranges: [],
+        },
+    ],
+    sources: [
+        {
+            source_id: SOURCE_SECONDARY,
+            source_name: "fullchaos/second-repo",
+            status: "healthy",
+            covered_through: "2026-07-02T12:30:00.000Z",
+            gap_count: 0,
+            failed_range_count: 0,
+        },
+    ],
+};
+
 /** Named scenarios selectable via the `?coverage_scenario=` test-mode query param. */
 export const SYNC_COVERAGE_SAMPLES = {
     healthy: SAMPLE_COVERAGE_HEALTHY,
@@ -356,13 +538,17 @@ export const SYNC_COVERAGE_SAMPLES = {
     failed: SAMPLE_COVERAGE_FAILED,
     stale: SAMPLE_COVERAGE_STALE,
     insufficient_data: SAMPLE_COVERAGE_INSUFFICIENT_DATA,
+    overlapping_retry: SAMPLE_COVERAGE_OVERLAPPING_RETRY,
+    concurrent_config: SAMPLE_COVERAGE_CONCURRENT_CONFIG,
 } satisfies Record<string, SyncCoverageSummary>;
 
 export type SyncCoverageSampleScenario = keyof typeof SYNC_COVERAGE_SAMPLES;
 
 export const DEFAULT_SYNC_COVERAGE_SCENARIO: SyncCoverageSampleScenario = "gaps";
 
-export function resolveSyncCoverageSampleScenario(value: string | undefined): SyncCoverageSampleScenario {
+export function resolveSyncCoverageSampleScenario(
+    value: string | undefined,
+): SyncCoverageSampleScenario {
     if (value && Object.hasOwn(SYNC_COVERAGE_SAMPLES, value)) {
         return value as SyncCoverageSampleScenario;
     }
@@ -389,16 +575,12 @@ export const SAMPLE_SYNC_JOBS: SyncJob[] = [
         sync_run: {
             mode: "incremental",
             triggered_by: "scheduled",
-            requested_range: jobRange(
-                "2026-07-02T12:00:00.000Z",
-                "2026-07-02T13:00:00.000Z",
-                [SOURCE_PLATFORM],
-            ),
-            covered_range: jobRange(
-                "2026-07-02T12:00:00.000Z",
-                "2026-07-02T13:00:00.000Z",
-                [SOURCE_PLATFORM],
-            ),
+            requested_range: jobRange("2026-07-02T12:00:00.000Z", "2026-07-02T13:00:00.000Z", [
+                SOURCE_PLATFORM,
+            ]),
+            covered_range: jobRange("2026-07-02T12:00:00.000Z", "2026-07-02T13:00:00.000Z", [
+                SOURCE_PLATFORM,
+            ]),
             total_units: 4,
             completed_units: 4,
             failed_units: 0,
@@ -418,16 +600,14 @@ export const SAMPLE_SYNC_JOBS: SyncJob[] = [
         sync_run: {
             mode: "incremental",
             triggered_by: "admin@devhealth.example",
-            requested_range: jobRange(
-                "2026-06-20T00:00:00.000Z",
-                "2026-07-01T09:00:00.000Z",
-                [SOURCE_PLATFORM, SOURCE_BILLING],
-            ),
-            covered_range: jobRange(
-                "2026-06-20T00:00:00.000Z",
-                "2026-06-28T00:00:00.000Z",
-                [SOURCE_PLATFORM, SOURCE_BILLING],
-            ),
+            requested_range: jobRange("2026-06-20T00:00:00.000Z", "2026-07-01T09:00:00.000Z", [
+                SOURCE_PLATFORM,
+                SOURCE_BILLING,
+            ]),
+            covered_range: jobRange("2026-06-20T00:00:00.000Z", "2026-06-28T00:00:00.000Z", [
+                SOURCE_PLATFORM,
+                SOURCE_BILLING,
+            ]),
             total_units: 6,
             completed_units: 4,
             failed_units: 1,
@@ -448,11 +628,9 @@ export const SAMPLE_SYNC_JOBS: SyncJob[] = [
         sync_run: {
             mode: "full_resync",
             triggered_by: "scheduled",
-            requested_range: jobRange(
-                "2026-06-20T00:00:00.000Z",
-                "2026-07-02T00:00:00.000Z",
-                [SOURCE_PLATFORM],
-            ),
+            requested_range: jobRange("2026-06-20T00:00:00.000Z", "2026-07-02T00:00:00.000Z", [
+                SOURCE_PLATFORM,
+            ]),
             covered_range: null,
             total_units: 3,
             completed_units: 0,
@@ -473,16 +651,12 @@ export const SAMPLE_SYNC_JOBS: SyncJob[] = [
         sync_run: {
             mode: "incremental",
             triggered_by: "scheduled",
-            requested_range: jobRange(
-                "2026-05-01T00:00:00.000Z",
-                "2026-06-10T00:00:00.000Z",
-                [SOURCE_PLATFORM],
-            ),
-            covered_range: jobRange(
-                "2026-05-01T00:00:00.000Z",
-                "2026-06-10T00:00:00.000Z",
-                [SOURCE_PLATFORM],
-            ),
+            requested_range: jobRange("2026-05-01T00:00:00.000Z", "2026-06-10T00:00:00.000Z", [
+                SOURCE_PLATFORM,
+            ]),
+            covered_range: jobRange("2026-05-01T00:00:00.000Z", "2026-06-10T00:00:00.000Z", [
+                SOURCE_PLATFORM,
+            ]),
             total_units: 2,
             completed_units: 2,
             failed_units: 0,

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -84,6 +84,18 @@ export const CTA_LABELS = {
     darkTheme: "Dark",
     enabled: "Enabled",
     disabled: "Disabled",
+    /** Edit a sync configuration from its detail page (CHAOS-2791). */
+    editConfig: "Edit config",
+    /** Generic backfill entry point from the coverage summary header (CHAOS-2791). */
+    backfill: "Backfill",
+    /** Gap-scoped backfill deep-link from the coverage timeline (CHAOS-2793). */
+    backfillThisGap: "Backfill this gap",
+    /** Toggle between the CSS band view and the accessible table view (CHAOS-2793). */
+    showAsTable: "Show as table",
+    showAsTimeline: "Show as timeline",
+    allDatasets: "All datasets",
+    allSources: "All sources",
+    viewRun: "View run",
 } as const;
 
 export type CtaKey = keyof typeof CTA_LABELS;

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -90,9 +90,6 @@ export const CTA_LABELS = {
     backfill: "Backfill",
     /** Gap-scoped backfill deep-link from the coverage timeline (CHAOS-2793). */
     backfillThisGap: "Backfill this gap",
-    /** Toggle between the CSS band view and the accessible table view (CHAOS-2793). */
-    showAsTable: "Show as table",
-    showAsTimeline: "Show as timeline",
     allDatasets: "All datasets",
     allSources: "All sources",
     viewRun: "View run",

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -99,3 +99,21 @@ export const formatTimestamp = (value?: string | null) => {
     const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
     return `${get("month")} ${get("day")}, ${get("hour")}:${get("minute")} ${get("dayPeriod")}`;
 };
+
+/**
+ * Date-only formatter locked to UTC (CHAOS-2791 D3): avoids hydration/CI
+ * drift from bare toLocaleDateString() calls that pick up the runtime's
+ * local timezone. Shared by SyncJobHistory and SyncCoverageTimeline so the
+ * two coverage surfaces never drift apart on date-only formatting.
+ */
+export const formatDateUTC = (value: string | null | undefined): string => {
+    if (!value) return "—";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "—";
+    return date.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+    });
+};

--- a/tests/admin-sync.spec.ts
+++ b/tests/admin-sync.spec.ts
@@ -63,15 +63,40 @@ test("editing sync config repositories updates selected repos", async ({ page })
     await expect(page).toHaveURL(/\/org\/admin\/sync$/);
 });
 
-test("sync config history exposes completion and failure context", async ({ page }) => {
+test("sync config history exposes coverage-first job columns and results", async ({ page }) => {
     await page.goto("/org/admin/sync/sync-config-edit-repos");
 
-    await expect(page.getByRole("heading", { name: /editable repos/i })).toBeVisible();
-    await expect(page.getByText("Completed / Last Activity")).toBeVisible();
-    await expect(page.getByText("Sync run completed with failed units")).toBeVisible();
-    await expect(page.getByText(/Part: work-items · Category: rate_limit/)).toBeVisible();
-    await expect(page.getByText(/Failed units: 2 of 6/)).toBeVisible();
-    await expect(page.getByText("Still running").first()).toBeVisible();
+    // DEV_HEALTH_TEST_MODE renders the deterministic sample config/coverage/
+    // job data regardless of the configId in the URL (see [configId]/page.tsx).
+    await expect(
+        page.getByRole("heading", { name: "fullchaos/platform-api (sample)" }),
+    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Job History" })).toBeVisible();
+
+    const jobTable = page.getByRole("table").filter({ hasText: "Trigger" });
+    for (const heading of [
+        "Trigger",
+        "Mode",
+        "Requested range",
+        "Covered range",
+        "Status",
+        "Scope",
+        "Units",
+        "Started",
+        "Duration",
+        "Actions",
+    ]) {
+        await expect(jobTable.getByRole("columnheader", { name: heading })).toBeVisible();
+    }
+
+    // Coverage-result badges derive from persisted sync_run unit counts only
+    // (CHAOS-2792) — never from client-side range/interval recomputation.
+    await expect(jobTable.getByRole("cell", { name: "Partial", exact: true })).toBeVisible();
+    await expect(jobTable.getByRole("cell", { name: "4 done · 1 failed · 6 total" })).toBeVisible();
+    await expect(jobTable.getByRole("cell", { name: "2 sources", exact: true })).toBeVisible();
+    await expect(
+        jobTable.getByRole("link", { name: /View run details for sync run started/ }).first(),
+    ).toBeVisible();
 });
 
 test("provider selection filters sync targets", async ({ page }) => {


### PR DESCRIPTION
## Summary

Coverage-first redesign of the sync admin surface (CHAOS-2791, CHAOS-2792, CHAOS-2793):

- **CHAOS-2791 — config detail** (`/org/admin/sync/[configId]`): new `SyncCoverageSummaryCard` leads the page — health badge (`healthy | stale | gaps | failed | insufficient_data`), last successful run, next scheduled run, latest covered-through, gap/stale/failed counts, active state, and primary actions. Old status cards demoted into a collapsible section. Explicit loading / error / legacy (`insufficient_data` + `data_basis`) states; the word "unknown" never renders.
- **CHAOS-2793 — coverage & gaps timeline**: new `SyncCoverageTimeline` renders covered / gap / stale / failed windows per dataset as CSS bands (decorative, `aria-hidden`) with an accessible table as the authoritative view; dataset + source filters; each gap exposes a "Backfill this gap" deep-link (pre-fills the backfill range; a follow-up PR relocates backfill into a wizard on this page).
- **CHAOS-2792 — job history**: columns are now Trigger · Mode · Requested range · Covered range · Status (complete/partial/gap/failed — derived only from persisted `job.status` + `sync_run` unit counts, precedence documented and pinned by tests) · Scope · Units · Started · Duration · Actions. Server-backed pagination via `limit`/`offset`; planner rows clickable; legacy rows readable.
- Test-mode sample scenarios (`?coverage_scenario=`): healthy, gaps, failed, stale, insufficient_data/legacy, overlapping-retry, concurrent same-provider configs.

All rendering is from persisted API data — no client-side coverage recomputation.

## Review gates

Reviewed by two independent agents (architecture + implementation); all findings fixed in follow-up commits on this branch, including: first job-history page now reacts to `router.refresh()` after Sync Now/Backfill (regression test), UTC-locked timestamp formatting (shared `formatDateUTC` in `lib/formatters`), coverage-result precedence contract documented + tested, e2e spec updated to the new columns.

## Testing

- Unit: 262 files / 2456 tests pass (`pnpm test:unit`); new/updated suites for SyncCoverageSummaryCard, SyncCoverageTimeline (incl. new sample scenarios), SyncJobHistory (pagination reactivity, precedence), CoverageBadge.
- Playwright: `tests/admin-sync.spec.ts` updated and passing against the redesigned job history.
- `pnpm typecheck` / `pnpm lint` / `prettier --check` clean on touched files; design-lint: 0 new violations (repo baseline pre-existing errors untouched).

## Depends on

- full-chaos/dev-health-web#741 (CHAOS-2790, base branch of this PR) — merge that first.
- Backend contract: full-chaos/dev-health-ops#1150 (CHAOS-2789).

Part of CHAOS-2788 (sync observability UX epic).

## Screenshots

### Before (old status-card layout)
![before](https://github.com/user-attachments/assets/34340fd0-d27a-43f5-a35d-870d47a7f868)

### After — coverage-first detail (healthy)
![healthy](https://github.com/user-attachments/assets/ca053cab-d4b7-497e-ac71-7cc9dfb69936)

### After — coverage-first detail (gaps scenario)
![gaps](https://github.com/user-attachments/assets/a82d10e6-a1d5-439d-9b2a-94f14560ba85)

### Coverage & gaps timeline
![timeline](https://github.com/user-attachments/assets/6f074b2e-fc60-44e7-8fc4-edec6159e1de)

### Redesigned job history
![job history](https://github.com/user-attachments/assets/cd3c5409-9df1-4695-a65e-079f9b740a00)
