### PR TITLE
fix(risk): repoint compounding-risk Work Graph drilldown (CHAOS-2851)

### DIFF
--- a/src/components/risk/CompoundingRiskDashboard.test.tsx
+++ b/src/components/risk/CompoundingRiskDashboard.test.tsx
@@ -15,6 +15,8 @@ import { describe, expect, it } from "vitest";
 
 import { render, screen, within } from "@/test/utils";
 
+import { decodeFilter } from "@/lib/filters/encode";
+
 import {
     CompoundingRiskDashboard,
     type CompoundingRiskDashboardProps,
@@ -36,7 +38,6 @@ function makeRow(overrides: Partial<CompoundingRiskRowView> = {}): CompoundingRi
             reviewNorm: 0.5,
             reworkChurn: 0.18,
             complexityDelta: 0.12,
-            busFactor: 4,
             ownershipGini: 0.55,
             singleOwnerRatio: 0.65,
             reviewLatencyP90h: 30,
@@ -121,8 +122,11 @@ describe("CompoundingRiskDashboard", () => {
         expect(tableRows[1].getAttribute("data-severity")).toBe("low");
 
         const drilldownLinks = screen.getAllByTestId("open-in-work-graph");
-        expect(drilldownLinks[0].getAttribute("href")).toContain("risk_scope_id=repo-a");
-        expect(drilldownLinks[0].getAttribute("href")).toContain("risk_scope_kind=repo");
+        const href = drilldownLinks[0].getAttribute("href") ?? "";
+        expect(href).toMatch(/^\/diagnose\/work-graph\?f=/);
+        const filters = decodeFilter(new URL(href, "http://localhost").searchParams.get("f"));
+        expect(filters.scope).toEqual({ level: "repo", ids: ["repo-a"] });
+        expect(filters.what.repos).toEqual(["repo-a"]);
     });
 
     it("uses 'team' in the drilldown URL when breakout is team", () => {
@@ -137,8 +141,9 @@ describe("CompoundingRiskDashboard", () => {
         renderDashboard({ breakout: "team", rows });
 
         const drilldown = screen.getByTestId("open-in-work-graph");
-        expect(drilldown.getAttribute("href")).toContain("risk_scope_kind=team");
-        expect(drilldown.getAttribute("href")).toContain("risk_scope_id=team-x");
+        const href = drilldown.getAttribute("href") ?? "";
+        const filters = decodeFilter(new URL(href, "http://localhost").searchParams.get("f"));
+        expect(filters.scope).toEqual({ level: "team", ids: ["team-x"] });
     });
 
     it("renders the rich empty state when no rows are supplied (no compounding_risk_daily payload)", () => {

--- a/src/components/risk/CompoundingRiskDashboard.test.tsx
+++ b/src/components/risk/CompoundingRiskDashboard.test.tsx
@@ -129,7 +129,7 @@ describe("CompoundingRiskDashboard", () => {
         expect(filters.what.repos).toEqual(["repo-a"]);
     });
 
-    it("uses 'team' in the drilldown URL when breakout is team", () => {
+    it("renders a disabled indicator (not an active link) for team-scope rows, since Work Graph has no team\u2192repo resolution", () => {
         const rows = [
             makeRow({
                 scope: "team",
@@ -140,10 +140,10 @@ describe("CompoundingRiskDashboard", () => {
         ];
         renderDashboard({ breakout: "team", rows });
 
-        const drilldown = screen.getByTestId("open-in-work-graph");
-        const href = drilldown.getAttribute("href") ?? "";
-        const filters = decodeFilter(new URL(href, "http://localhost").searchParams.get("f"));
-        expect(filters.scope).toEqual({ level: "team", ids: ["team-x"] });
+        expect(screen.queryByTestId("open-in-work-graph")).not.toBeInTheDocument();
+        expect(screen.getByTestId("work-graph-drilldown-unavailable")).toHaveTextContent(
+            "Not available for team scope",
+        );
     });
 
     it("renders the rich empty state when no rows are supplied (no compounding_risk_daily payload)", () => {

--- a/src/components/risk/CompoundingRiskDashboard.tsx
+++ b/src/components/risk/CompoundingRiskDashboard.tsx
@@ -16,17 +16,30 @@
 
 import Link from "next/link";
 
+import { CTA_LABELS } from "@/lib/design/cta";
+import { defaultMetricFilter } from "@/lib/filters/defaults";
+import type { MetricFilter } from "@/lib/filters/types";
+import { withFilterParam } from "@/lib/filters/url";
+
+// Builds a direct `/diagnose/work-graph?f=…` link (bypassing the lossy
+// `/work` legacy-redirect, which drops any query param outside `tab`/`view`)
+// so the scope survives the drilldown (CHAOS-2851). Repo scope also seeds
+// `what.repos` because GraphView filters graph edges off that field, not
+// `scope.ids` — see `src/components/work/GraphView.tsx`.
 function buildRiskDrilldownUrl({
     scope,
 }: {
     scope: { kind: "repo" | "team"; id: string };
 }): string {
-    const params = new URLSearchParams({
-        tab: "graph",
-        risk_scope_kind: scope.kind,
-        risk_scope_id: scope.id,
-    });
-    return `/work?${params.toString()}`;
+    const filters: MetricFilter = {
+        ...defaultMetricFilter,
+        scope: { level: scope.kind, ids: [scope.id] },
+        what: {
+            ...defaultMetricFilter.what,
+            ...(scope.kind === "repo" ? { repos: [scope.id] } : {}),
+        },
+    };
+    return withFilterParam("/diagnose/work-graph", filters);
 }
 
 export type CompoundingRiskSeverity = "unknown" | "low" | "elevated" | "high";
@@ -40,7 +53,6 @@ export type CompoundingRiskComponentsView = {
     reviewNorm: number | null;
     reworkChurn: number | null;
     complexityDelta: number | null;
-    busFactor: number | null;
     ownershipGini: number | null;
     singleOwnerRatio: number | null;
     reviewLatencyP90h: number | null;
@@ -316,7 +328,7 @@ function ScopeTable({
                                         className="text-xs font-semibold uppercase tracking-[0.18em] text-(--accent) hover:underline"
                                         data-testid="open-in-work-graph"
                                     >
-                                        Open in Work Graph →
+                                        {CTA_LABELS.openWorkGraph} ↗
                                     </Link>
                                 </td>
                             </tr>

--- a/src/components/risk/CompoundingRiskDashboard.tsx
+++ b/src/components/risk/CompoundingRiskDashboard.tsx
@@ -23,21 +23,19 @@ import { withFilterParam } from "@/lib/filters/url";
 
 // Builds a direct `/diagnose/work-graph?f=…` link (bypassing the lossy
 // `/work` legacy-redirect, which drops any query param outside `tab`/`view`)
-// so the scope survives the drilldown (CHAOS-2851). Repo scope also seeds
-// `what.repos` because GraphView filters graph edges off that field, not
-// `scope.ids` — see `src/components/work/GraphView.tsx`.
-function buildRiskDrilldownUrl({
-    scope,
-}: {
-    scope: { kind: "repo" | "team"; id: string };
-}): string {
+// so the scope survives the drilldown (CHAOS-2851).
+//
+// Repo-scope only: `WorkGraphEdgeFilterInput` (and `GraphView`, which reads
+// `filters.what.repos`) only supports filtering graph edges by `repoIds` —
+// there is no team-repo resolution available client-side today. Team-scope
+// rows therefore render a disabled indicator instead of a drilldown link
+// (see `ScopeTable` below) rather than linking to an unscoped/misleading
+// "global" graph.
+function buildRiskDrilldownUrl({ repoId }: { repoId: string }): string {
     const filters: MetricFilter = {
         ...defaultMetricFilter,
-        scope: { level: scope.kind, ids: [scope.id] },
-        what: {
-            ...defaultMetricFilter.what,
-            ...(scope.kind === "repo" ? { repos: [scope.id] } : {}),
-        },
+        scope: { level: "repo", ids: [repoId] },
+        what: { ...defaultMetricFilter.what, repos: [repoId] },
     };
     return withFilterParam("/diagnose/work-graph", filters);
 }
@@ -287,12 +285,13 @@ function ScopeTable({
                 </thead>
                 <tbody>
                     {rows.map((row) => {
-                        const workGraphHref = buildRiskDrilldownUrl({
-                            scope:
-                                breakout === "team"
-                                    ? { kind: "team", id: row.scopeId }
-                                    : { kind: "repo", id: row.scopeId },
-                        });
+                        // Team-scope has no persisted team→repo resolution, so
+                        // Work Graph (repo-only filtering) can't be scoped to it —
+                        // only repo rows get an active drilldown.
+                        const workGraphHref =
+                            breakout === "repo"
+                                ? buildRiskDrilldownUrl({ repoId: row.scopeId })
+                                : null;
                         return (
                             <tr
                                 key={row.scopeId}
@@ -323,13 +322,23 @@ function ScopeTable({
                                     {fmtScore(row.components.reviewNorm)}
                                 </td>
                                 <td className="px-5 py-3">
-                                    <Link
-                                        href={workGraphHref}
-                                        className="text-xs font-semibold uppercase tracking-[0.18em] text-(--accent) hover:underline"
-                                        data-testid="open-in-work-graph"
-                                    >
-                                        {CTA_LABELS.openWorkGraph} ↗
-                                    </Link>
+                                    {workGraphHref ? (
+                                        <Link
+                                            href={workGraphHref}
+                                            className="text-xs font-semibold uppercase tracking-[0.18em] text-(--accent) hover:underline"
+                                            data-testid="open-in-work-graph"
+                                        >
+                                            {CTA_LABELS.openWorkGraph} ↗
+                                        </Link>
+                                    ) : (
+                                        <span
+                                            className="text-xs text-(--ink-muted)"
+                                            data-testid="work-graph-drilldown-unavailable"
+                                            title="Work Graph doesn't support team-level scoping yet; switch to the repo view to drill in."
+                                        >
+                                            Not available for team scope
+                                        </span>
+                                    )}
                                 </td>
                             </tr>
                         );

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -193,7 +193,6 @@ query CompoundingRisk(
         reviewNorm
         reworkChurn
         complexityDelta
-        busFactor
         ownershipGini
         singleOwnerRatio
         reviewLatencyP90h

--- a/tests/compounding-risk.spec.ts
+++ b/tests/compounding-risk.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { encodeFilter } from "../src/lib/filters/encode";
+import { decodeFilter, encodeFilter } from "../src/lib/filters/encode";
 import type { MetricFilter } from "../src/lib/filters/types";
 
 /**
@@ -64,12 +64,16 @@ test.describe("Compounding Risk surface", () => {
         await expect(rows.first()).toHaveAttribute("data-scope-id", "repo-a");
         await expect(rows.first()).toHaveAttribute("data-severity", "high");
 
-        // Drilldown link encodes the scope.
+        // Drilldown link encodes the scope directly for /diagnose/work-graph
+        // (CHAOS-2851) instead of the lossy /work?risk_scope_* redirect.
         const drilldown = page.getByTestId("open-in-work-graph").first();
-        await expect(drilldown).toHaveAttribute(
-            "href",
-            /risk_scope_kind=repo.*risk_scope_id=repo-a/,
+        const drilldownHref = await drilldown.getAttribute("href");
+        expect(drilldownHref).toMatch(/^\/diagnose\/work-graph\?f=/);
+        const drilldownFilters = decodeFilter(
+            new URL(drilldownHref ?? "", "http://localhost").searchParams.get("f"),
         );
+        expect(drilldownFilters.scope).toEqual({ level: "repo", ids: ["repo-a"] });
+        expect(drilldownFilters.what.repos).toEqual(["repo-a"]);
     });
 
     test("person scope is blocked with the no-surveillance guardrail", async ({ page }) => {

--- a/tests/compounding-risk.spec.ts
+++ b/tests/compounding-risk.spec.ts
@@ -76,6 +76,19 @@ test.describe("Compounding Risk surface", () => {
         expect(drilldownFilters.what.repos).toEqual(["repo-a"]);
     });
 
+    test("team-scope rows show a disabled Work Graph indicator, not an active link", async ({
+        page,
+    }) => {
+        // Work Graph only supports repo-scoped edge filtering (no persisted
+        // team\u2192repo resolution client-side), so team-breakout rows must not
+        // link to an unscoped/misleading "global" graph (CHAOS-2851).
+        await page.goto(`/risk/compounding?f=${encodeFilter(teamFilter)}&breakout=team`);
+
+        await expect(page.getByTestId("compounding-risk-dashboard")).toBeVisible();
+        await expect(page.getByTestId("open-in-work-graph")).toHaveCount(0);
+        await expect(page.getByTestId("work-graph-drilldown-unavailable")).toBeVisible();
+    });
+
     test("person scope is blocked with the no-surveillance guardrail", async ({ page }) => {
         await page.goto(`/risk/compounding?f=${encodeFilter(developerFilter)}`);
 


### PR DESCRIPTION
## CHAOS-2851 (P1): Fix inert "Open in Work Graph" drilldown on Compounding Risk dashboard

### Problem
`CompoundingRiskDashboard`'s per-row drilldown built a URL like
`/work?tab=graph&risk_scope_kind=repo&risk_scope_id=<id>`. `/work` redirects to
`/diagnose/work-graph` but only preserves params other than `tab`/`view` — since
`risk_scope_kind`/`risk_scope_id` aren't part of that allowlist logic path taken
by the redirect target resolution for this case, the destination never saw them,
so the drilldown silently lost scope. The CTA text was also hard-coded instead of
using the shared CTA registry, and the GraphQL query selected `busFactor` on
`compoundingRisk.rows[].components`, a field the UI never renders.

### Fix
- `buildRiskDrilldownUrl` now links **directly** to `/diagnose/work-graph` with
  an encoded `MetricFilter` (`f=…`, the same mechanism used by
  `FlowView/InspectPanel` and `workGraphDrilldownUrl.ts`), instead of going
  through the lossy `/work` redirect. Repo scope also seeds `what.repos`,
  which is the field `GraphView` actually filters graph edges on (`scope.ids`
  is not read for edge filtering).
- Replaced the hard-coded `"Open in Work Graph →"` string with
  `CTA_LABELS.openWorkGraph`, matching `InspectPanel.tsx` and
  `InvestmentMixSection.tsx`.
- Removed the unused `busFactor` field from `COMPOUNDING_RISK_QUERY` and
  `CompoundingRiskComponentsView` (dead selection, never rendered).

### Verification
- `pnpm typecheck` / `pnpm lint` / `pnpm test:unit` all pass.
- `pnpm design-lint`: no new violations (pre-existing, unrelated findings only).
- Manually verified against the local dev stack: clicking the drilldown now
  lands on `/diagnose/work-graph` with the `WorkGraphEdges` GraphQL query
  correctly scoped via `repoIds: ["<repo-id>"]` matching the clicked row.

### Screenshots

**Before** — inert link (`/work?tab=graph&risk_scope_kind=repo&risk_scope_id=…`, dropped by the redirect):

![chaos-2851-work-graph-drilldown-before.png](https://github.com/user-attachments/assets/9b59f2ef-ffe9-4947-a2e7-048d215b996a)

**After** — `Open Work Graph ↗` label from the CTA registry, linking to `/diagnose/work-graph?f=…`:

![chaos-2851-work-graph-drilldown-after.png](https://github.com/user-attachments/assets/a3e2e05b-c089-43eb-9e15-d745c84f48cd)

**Destination** — Work Graph correctly scoped to the clicked repo (`repoIds` filter confirmed in the GraphQL network request):

![chaos-2851-work-graph-drilldown-destination.png](https://github.com/user-attachments/assets/89a4552c-e3e6-4c36-b41f-3c1dce35d72e)

TEST-WAIVER: not applicable — `CompoundingRiskDashboard.test.tsx` updated in this PR to cover the new URL shape.

Refs CHAOS-2851.

---

### Update: team-scope rows

Oracle review flagged that the original fix seeded `what.repos` only for repo-scope rows; team-scope rows would otherwise fall back to an **unscoped/global** Work Graph query (misleading — looks scoped, isn't). Confirmed via investigation: `WorkGraphEdgeFilterInput` only supports `repoIds` (no `teamIds`), and there is no persisted team→repo resolution reachable client-side today.

Fix: team-scope rows now render a disabled **"Not available for team scope"** indicator instead of an active link, rather than linking to an unscoped graph. Repo-scope rows are unaffected. Added component-test and e2e coverage for the disabled state.

**Team-scope row (disabled indicator, no active link):**
![chaos-2851-team-scope-disabled-drilldown.png](https://github.com/user-attachments/assets/91c97be9-59f3-48df-93b5-5b28c171e1a9)
