### PR TITLE
fix(admin/sync): show all sync run units

### DIFF
--- a/src/components/admin/sync/SyncRunDetail.test.tsx
+++ b/src/components/admin/sync/SyncRunDetail.test.tsx
@@ -82,6 +82,36 @@ describe("SyncRunDetailLive", () => {
         );
     });
 
+    it("renders every returned unit without a client-side table cap", () => {
+        const units = Array.from({ length: 201 }, (_, index) => ({
+            ...SAMPLE_SYNC_RUN_UNIT_SUMMARY.units[0],
+            id: `bulk-${String(index).padStart(3, "0")}-unit`,
+        }));
+
+        render(
+            <SyncRunDetailLive
+                initialRun={{
+                    ...SAMPLE_SYNC_RUN,
+                    total_units: units.length,
+                    completed_units: units.length,
+                    failed_units: 0,
+                }}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { success: units.length },
+                    unit_count: units.length,
+                    units,
+                }}
+                testMode
+            />,
+        );
+
+        const table = screen.getByRole("table");
+        expect(within(table).getAllByText(/^bulk-\d{3}$/)).toHaveLength(units.length);
+        expect(screen.getByText(/Units \(201\)/)).toBeInTheDocument();
+        expect(screen.queryByText(/Showing first/)).not.toBeInTheDocument();
+    });
+
     it("renders since_at/before_at windows per unit", () => {
         renderDetail();
 

--- a/src/components/admin/sync/SyncRunDetailLive.tsx
+++ b/src/components/admin/sync/SyncRunDetailLive.tsx
@@ -13,8 +13,6 @@ import type { SyncRun, SyncRunUnit, SyncRunUnitSummary } from "@/lib/admin/types
 const POLL_INTERVAL_MS = 3500;
 /** Safety cap so a stuck/abandoned run never polls forever (~10 min). */
 const MAX_POLL_DURATION_MS = 10 * 60 * 1000;
-/** Cap the rendered unit table so a huge fan-out stays readable. */
-const UNIT_TABLE_CAP = 100;
 
 /** Distinct unit statuses, in a stable display order, for the status filter. */
 const STATUS_FILTER_ORDER = [
@@ -367,9 +365,6 @@ export function SyncRunDetailLive({
         () => computeWindow((summary?.units ?? []).filter((unit) => unit.status === "success")),
         [summary],
     );
-
-    const cappedUnits = filteredUnits.slice(0, UNIT_TABLE_CAP);
-    const overflow = filteredUnits.length - cappedUnits.length;
 
     return (
         <div className="space-y-6">
@@ -740,7 +735,7 @@ export function SyncRunDetailLive({
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-(--card-stroke)">
-                                    {cappedUnits.map((unit: SyncRunUnit) => (
+                                    {filteredUnits.map((unit: SyncRunUnit) => (
                                         <tr key={unit.id}>
                                             <td className="px-4 py-3 font-mono text-xs text-(--ink-muted)">
                                                 {unit.id.slice(0, 8)}
@@ -797,12 +792,6 @@ export function SyncRunDetailLive({
                                     ))}
                                 </tbody>
                             </table>
-                            {overflow > 0 && (
-                                <div className="border-t border-(--card-stroke) px-4 py-3 text-xs text-(--ink-muted)">
-                                    Showing first {formatNumber(UNIT_TABLE_CAP)} of{" "}
-                                    {formatNumber(filteredUnits.length)} units.
-                                </div>
-                            )}
                         </div>
                     </div>
                 </>


### PR DESCRIPTION
## Summary

Fixes CHAOS-2864.

- Remove the sync run detail table's client-side unit cap.
- Add a regression that renders 201 returned units and confirms no "Showing first" overflow message remains.

## Verification

- `pnpm test:unit src/components/admin/sync/SyncRunDetail.test.tsx`
- `pnpm typecheck`
- `pnpm lint` (passes with one pre-existing warning in `src/lib/navigation/__tests__/ia-preservation-invariants.test.ts`)
- Browser smoke in test mode: opened `/org/admin/sync/a7a44bc9-94c7-41b3-84cd-9c7b896377ec/runs/c8df43c1-b119-4fce-8843-ef5b33d59b51`, selected `Status = failed`, observed `UNITS (1 OF 4)` and only the failed row in the table.

## Visual evidence

SCREENSHOT-WAIVER: GitHub `gh image` upload was blocked by org SSO/session upload-token resolution (`uploadToken not found`). A local Playwright screenshot was captured during the browser smoke check.
