### PR TITLE
fix(admin/sync): defend against zombie backfill banners (CHAOS-2868)

### DIFF
--- a/src/components/admin/sync/BackfillStatus.test.tsx
+++ b/src/components/admin/sync/BackfillStatus.test.tsx
@@ -233,4 +233,53 @@ describe("BackfillStatus — live poll", () => {
         });
         expect(getBackfillJobStatus).toHaveBeenCalledTimes(callsAtGiveUp);
     });
+
+    it("never starts an overlapping poll while a request is in flight, so a slow response can't be resurrected after a terminal one (CHAOS-2868)", async () => {
+        let resolveSlowPoll: (result: { data: BackfillJob }) => void = () => {};
+        const slowPoll = new Promise<{ data: BackfillJob }>((resolve) => {
+            resolveSlowPoll = resolve;
+        });
+        vi.mocked(getBackfillJobStatus).mockReturnValue(slowPoll);
+
+        render(
+            <BackfillStatus
+                initialJob={{ ...RUNNING_JOB, status: "dispatching", progress_pct: 0 }}
+            />,
+        );
+
+        // First tick fires and is left unresolved, simulating a slow response.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+        expect(getBackfillJobStatus).toHaveBeenCalledTimes(1);
+
+        // Several more poll cycles elapse while that request is still in
+        // flight. The in-flight guard must skip every one of them rather than
+        // dispatching an overlapping request that could resolve out of order
+        // and be overwritten by — or overwrite — whatever the slow response
+        // eventually applies (the exact race that used to resurrect a stale
+        // zombie banner after a terminal result).
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000 * 3);
+        });
+        expect(getBackfillJobStatus).toHaveBeenCalledTimes(1);
+
+        // The slow request finally resolves with a terminal result.
+        await act(async () => {
+            resolveSlowPoll({
+                data: { ...RUNNING_JOB, status: "completed", progress_pct: 100 },
+            });
+            await vi.advanceTimersByTimeAsync(0);
+        });
+
+        expect(screen.getByText("Backfill complete")).toBeInTheDocument();
+        expect(screen.queryByText("Live — refreshing…")).not.toBeInTheDocument();
+        expect(screen.queryByText("Live updates paused")).not.toBeInTheDocument();
+
+        // No overlapping/late response can resurrect the banner afterward.
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000 * 4);
+        });
+        expect(getBackfillJobStatus).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/components/admin/sync/BackfillStatus.test.tsx
+++ b/src/components/admin/sync/BackfillStatus.test.tsx
@@ -80,6 +80,31 @@ describe("BackfillStatus", () => {
         expect(screen.getByText("Waiting to start...")).toBeInTheDocument();
         expect(screen.getByText("Live — refreshing…")).toBeInTheDocument();
     });
+
+    it("re-syncs local state when initialJob transitions to a terminal status on the SAME job id (CHAOS-2868)", () => {
+        const { rerender } = render(
+            <BackfillStatus
+                initialJob={{ ...RUNNING_JOB, status: "dispatching", progress_pct: 0 }}
+                testMode
+            />,
+        );
+
+        expect(screen.getByText("Dispatching work...")).toBeInTheDocument();
+        expect(screen.getByText("Live — refreshing…")).toBeInTheDocument();
+
+        // Same job id, status-only change — BackfillOperations keys by id alone,
+        // so a real remount would not happen here either; this re-renders the
+        // SAME component instance to prove the local state re-syncs from props.
+        rerender(
+            <BackfillStatus
+                initialJob={{ ...RUNNING_JOB, status: "completed", progress_pct: 100 }}
+                testMode
+            />,
+        );
+
+        expect(screen.getByText("Backfill complete")).toBeInTheDocument();
+        expect(screen.queryByText("Live — refreshing…")).not.toBeInTheDocument();
+    });
 });
 
 describe("BackfillStatus — live poll", () => {
@@ -181,5 +206,31 @@ describe("BackfillStatus — live poll", () => {
             await vi.advanceTimersByTimeAsync(3000 * 4);
         });
         expect(getBackfillJobStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives up polling and stops the Live indicator after a bounded zero-progress window (CHAOS-2868)", async () => {
+        vi.mocked(getBackfillJobStatus).mockResolvedValue({
+            data: { ...RUNNING_JOB, status: "dispatching", progress_pct: 0 },
+        });
+
+        render(
+            <BackfillStatus
+                initialJob={{ ...RUNNING_JOB, status: "dispatching", progress_pct: 0 }}
+            />,
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+        });
+
+        expect(screen.queryByText("Live — refreshing…")).not.toBeInTheDocument();
+        expect(screen.getByText("Live updates paused")).toBeInTheDocument();
+
+        // Polling stopped: advancing further triggers no additional calls.
+        const callsAtGiveUp = vi.mocked(getBackfillJobStatus).mock.calls.length;
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000 * 5);
+        });
+        expect(getBackfillJobStatus).toHaveBeenCalledTimes(callsAtGiveUp);
     });
 });

--- a/src/components/admin/sync/BackfillStatus.tsx
+++ b/src/components/admin/sync/BackfillStatus.tsx
@@ -112,40 +112,55 @@ export function BackfillStatus({ initialJob, testMode = false }: BackfillStatusP
         if (!initialJob || TERMINAL_STATUSES.has(initialJob.status)) return undefined;
 
         let cancelled = false;
+        // Skip overlapping ticks: only one request in flight at a time, so a
+        // slow response can never resolve AFTER a later tick's response
+        // already reached a terminal/stalled conclusion and overwrite it
+        // (out-of-order poll race — mirrors SyncRunDetailLive's inFlightRef).
+        let inFlight = false;
         const jobId = initialJob.id;
         const pollStartedAt = Date.now();
 
         const tick = async () => {
-            const result = await getBackfillJobStatus(jobId);
-            if (cancelled) return;
-            if (result.error || !result.data) {
-                stopPolling();
-                return;
-            }
-            setJob(result.data);
-            if (TERMINAL_STATUSES.has(result.data.status)) {
-                stopPolling();
-                if (result.data.status === "completed" || result.data.status === "success") {
-                    toast.success("Backfill completed successfully");
-                } else if (result.data.status === "partial_failed") {
-                    toast.warning(
-                        result.data.error_message || "Backfill completed with some failures",
-                    );
-                } else {
-                    toast.error(result.data.error_message || "Backfill failed");
+            if (inFlight) return;
+            inFlight = true;
+            try {
+                const result = await getBackfillJobStatus(jobId);
+                if (cancelled) return;
+                if (result.error || !result.data) {
+                    stopPolling();
+                    return;
                 }
-                return;
-            }
-            // Bounded liveness (CHAOS-2868): a stranded zombie reports a
-            // non-terminal status with 0% progress forever. Give up once
-            // that has held for the whole window rather than polling and
-            // claiming "Live" indefinitely.
-            if (
-                result.data.progress_pct === 0 &&
-                Date.now() - pollStartedAt >= MAX_ZERO_PROGRESS_POLL_MS
-            ) {
-                stopPolling();
-                setPollStalled(true);
+                setJob(result.data);
+                if (TERMINAL_STATUSES.has(result.data.status)) {
+                    stopPolling();
+                    setPollStalled(false);
+                    if (result.data.status === "completed" || result.data.status === "success") {
+                        toast.success("Backfill completed successfully");
+                    } else if (result.data.status === "partial_failed") {
+                        toast.warning(
+                            result.data.error_message || "Backfill completed with some failures",
+                        );
+                    } else {
+                        toast.error(result.data.error_message || "Backfill failed");
+                    }
+                    return;
+                }
+                if (result.data.progress_pct > 0) {
+                    // Real forward progress: never leave a stale "paused"
+                    // label behind from an earlier zero-progress window.
+                    setPollStalled(false);
+                    return;
+                }
+                // Bounded liveness (CHAOS-2868): a stranded zombie reports a
+                // non-terminal status with 0% progress forever. Give up once
+                // that has held for the whole window rather than polling and
+                // claiming "Live" indefinitely.
+                if (Date.now() - pollStartedAt >= MAX_ZERO_PROGRESS_POLL_MS) {
+                    stopPolling();
+                    setPollStalled(true);
+                }
+            } finally {
+                inFlight = false;
             }
         };
 

--- a/src/components/admin/sync/BackfillStatus.tsx
+++ b/src/components/admin/sync/BackfillStatus.tsx
@@ -17,14 +17,23 @@ const POLL_INTERVAL_MS = 3000;
  */
 const TERMINAL_STATUSES = new Set(["completed", "failed", "success", "partial_failed"]);
 
+/**
+ * Bounded liveness window (CHAOS-2868): mirrors SyncRunDetailLive's
+ * MAX_POLL_DURATION_MS safety cap. A live job reports forward progress
+ * within minutes; one still pinned at 0% after this long is presumed a
+ * stranded zombie, so polling gives up instead of claiming "Live" forever.
+ */
+const MAX_ZERO_PROGRESS_POLL_MS = 10 * 60 * 1000;
+
 interface BackfillStatusProps {
     /**
      * Backfill job resolved server-side from PERSISTED state (live
      * `getActiveBackfillJob` fetch, or a test-mode sample) — never derived
      * client-side, so an in-progress backfill survives navigation (CHAOS-2795).
-     * Render this component with `key={initialJob?.id ?? "none"}` from the
-     * parent so a newly-submitted job resets local poll state on mount
-     * instead of needing an effect to resync a changed prop.
+     * The parent renders this with `key={initialJob?.id ?? "none"}` so a
+     * newly-submitted job resets local poll state on mount; local state also
+     * re-syncs from this prop directly (see `backfillJobSyncKey` below) as
+     * defense in depth for a status change on the SAME job id (CHAOS-2868).
      */
     initialJob: BackfillJob | null;
     /** When true, render the provided sample job and never poll a live API. */
@@ -61,8 +70,29 @@ function progressBarClassName(status: string): string {
     return "bg-(--accent)";
 }
 
+/** Resync key: local state re-syncs whenever the job identity OR its status changes. */
+function backfillJobSyncKey(job: BackfillJob | null): string {
+    return job ? `${job.id}:${job.status}` : "none";
+}
+
 export function BackfillStatus({ initialJob, testMode = false }: BackfillStatusProps) {
     const [job, setJob] = useState<BackfillJob | null>(initialJob);
+    const [pollStalled, setPollStalled] = useState(false);
+    // Defense in depth (CHAOS-2868): re-sync local state whenever the parent
+    // passes a job with a new id OR a new status, even if BackfillOperations'
+    // `key={activeBackfillJob?.id}` doesn't remount this component (e.g. a
+    // status-only change on the same job id). Adjusting state during render
+    // rather than inside an effect mirrors the documented React pattern for
+    // resetting state from props and keeps `react-hooks/set-state-in-effect`
+    // satisfied.
+    const [syncedJobKey, setSyncedJobKey] = useState(() => backfillJobSyncKey(initialJob));
+    const initialJobKey = backfillJobSyncKey(initialJob);
+    if (initialJobKey !== syncedJobKey) {
+        setSyncedJobKey(initialJobKey);
+        setJob(initialJob);
+        setPollStalled(false);
+    }
+
     const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
     const stopPolling = useCallback(() => {
@@ -83,6 +113,7 @@ export function BackfillStatus({ initialJob, testMode = false }: BackfillStatusP
 
         let cancelled = false;
         const jobId = initialJob.id;
+        const pollStartedAt = Date.now();
 
         const tick = async () => {
             const result = await getBackfillJobStatus(jobId);
@@ -103,6 +134,18 @@ export function BackfillStatus({ initialJob, testMode = false }: BackfillStatusP
                 } else {
                     toast.error(result.data.error_message || "Backfill failed");
                 }
+                return;
+            }
+            // Bounded liveness (CHAOS-2868): a stranded zombie reports a
+            // non-terminal status with 0% progress forever. Give up once
+            // that has held for the whole window rather than polling and
+            // claiming "Live" indefinitely.
+            if (
+                result.data.progress_pct === 0 &&
+                Date.now() - pollStartedAt >= MAX_ZERO_PROGRESS_POLL_MS
+            ) {
+                stopPolling();
+                setPollStalled(true);
             }
         };
 
@@ -132,7 +175,9 @@ export function BackfillStatus({ initialJob, testMode = false }: BackfillStatusP
                     </p>
                 </div>
                 {!isTerminal && (
-                    <span className="text-xs text-(--ink-muted)">Live — refreshing…</span>
+                    <span className="text-xs text-(--ink-muted)">
+                        {pollStalled ? "Live updates paused" : "Live — refreshing…"}
+                    </span>
                 )}
             </div>
 

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -41,6 +41,11 @@ function mockSession() {
     mockAuth({ user: { id: "u-1", org_id: "org-1" } });
 }
 
+/** ISO timestamp `hours` in the past, for getActiveBackfillJob staleness fixtures. */
+function hoursAgoIso(hours: number): string {
+    return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+}
+
 describe("admin/server credential actions", () => {
     beforeEach(() => {
         vi.resetAllMocks();
@@ -315,9 +320,9 @@ describe("admin/server sync config actions", () => {
                     failed_chunks: 0,
                     progress_pct: 50,
                     error_message: null,
-                    started_at: "2026-06-20T00:00:00Z",
+                    started_at: hoursAgoIso(1),
                     completed_at: null,
-                    created_at: "2026-06-20T00:00:00Z",
+                    created_at: hoursAgoIso(1),
                 },
             ];
             const fetchSpy = vi
@@ -367,7 +372,7 @@ describe("admin/server sync config actions", () => {
                     error_message: null,
                     started_at: null,
                     completed_at: null,
-                    created_at: "2026-06-20T00:00:00Z",
+                    created_at: hoursAgoIso(1),
                 },
             ];
             const fetchSpy = vi
@@ -382,6 +387,74 @@ describe("admin/server sync config actions", () => {
             const result = await getActiveBackfillJob("cfg-coverage");
 
             expect(result.data?.id).toBe("job-planned");
+            fetchSpy.mockRestore();
+        });
+
+        it("excludes a non-terminal job older than the staleness cutoff (zombie backfill, CHAOS-2868)", async () => {
+            mockSession();
+            const jobs = [
+                {
+                    id: "job-zombie",
+                    sync_config_id: "cfg-coverage",
+                    status: "dispatching",
+                    since_date: "2026-06-01",
+                    before_date: "2026-06-05",
+                    total_chunks: 0,
+                    completed_chunks: 0,
+                    failed_chunks: 0,
+                    progress_pct: 0,
+                    error_message: null,
+                    started_at: null,
+                    completed_at: null,
+                    created_at: hoursAgoIso(48),
+                },
+            ];
+            const fetchSpy = vi
+                .spyOn(global, "fetch")
+                .mockResolvedValue(
+                    new Response(
+                        JSON.stringify({ items: jobs, total: jobs.length, limit: 50, offset: 0 }),
+                        { status: 200 },
+                    ),
+                );
+
+            const result = await getActiveBackfillJob("cfg-coverage");
+
+            expect(result.data).toBeNull();
+            fetchSpy.mockRestore();
+        });
+
+        it("treats a job as active when it recently started even if it was created long ago", async () => {
+            mockSession();
+            const jobs = [
+                {
+                    id: "job-late-dispatch",
+                    sync_config_id: "cfg-coverage",
+                    status: "running",
+                    since_date: "2026-06-01",
+                    before_date: "2026-06-05",
+                    total_chunks: 4,
+                    completed_chunks: 1,
+                    failed_chunks: 0,
+                    progress_pct: 25,
+                    error_message: null,
+                    started_at: hoursAgoIso(1),
+                    completed_at: null,
+                    created_at: hoursAgoIso(48),
+                },
+            ];
+            const fetchSpy = vi
+                .spyOn(global, "fetch")
+                .mockResolvedValue(
+                    new Response(
+                        JSON.stringify({ items: jobs, total: jobs.length, limit: 50, offset: 0 }),
+                        { status: 200 },
+                    ),
+                );
+
+            const result = await getActiveBackfillJob("cfg-coverage");
+
+            expect(result.data?.id).toBe("job-late-dispatch");
             fetchSpy.mockRestore();
         });
     });

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -424,19 +424,19 @@ describe("admin/server sync config actions", () => {
             fetchSpy.mockRestore();
         });
 
-        it("treats a job as active when it recently started even if it was created long ago", async () => {
+        it("treats a zero-progress job as active when it recently started even if it was created long ago", async () => {
             mockSession();
             const jobs = [
                 {
                     id: "job-late-dispatch",
                     sync_config_id: "cfg-coverage",
-                    status: "running",
+                    status: "dispatching",
                     since_date: "2026-06-01",
                     before_date: "2026-06-05",
-                    total_chunks: 4,
-                    completed_chunks: 1,
+                    total_chunks: 0,
+                    completed_chunks: 0,
                     failed_chunks: 0,
-                    progress_pct: 25,
+                    progress_pct: 0,
                     error_message: null,
                     started_at: hoursAgoIso(1),
                     completed_at: null,
@@ -455,6 +455,74 @@ describe("admin/server sync config actions", () => {
             const result = await getActiveBackfillJob("cfg-coverage");
 
             expect(result.data?.id).toBe("job-late-dispatch");
+            fetchSpy.mockRestore();
+        });
+
+        it("keeps a job with real progress visible past the staleness cutoff (CHAOS-2868 review: age alone must not hide progressed jobs)", async () => {
+            mockSession();
+            const jobs = [
+                {
+                    id: "job-long-running",
+                    sync_config_id: "cfg-coverage",
+                    status: "running",
+                    since_date: "2026-06-01",
+                    before_date: "2026-06-05",
+                    total_chunks: 5,
+                    completed_chunks: 3,
+                    failed_chunks: 0,
+                    progress_pct: 60,
+                    error_message: null,
+                    started_at: hoursAgoIso(48),
+                    completed_at: null,
+                    created_at: hoursAgoIso(48),
+                },
+            ];
+            const fetchSpy = vi
+                .spyOn(global, "fetch")
+                .mockResolvedValue(
+                    new Response(
+                        JSON.stringify({ items: jobs, total: jobs.length, limit: 50, offset: 0 }),
+                        { status: 200 },
+                    ),
+                );
+
+            const result = await getActiveBackfillJob("cfg-coverage");
+
+            expect(result.data?.id).toBe("job-long-running");
+            fetchSpy.mockRestore();
+        });
+
+        it("treats a zero-progress job with no parseable timestamps as not stale (defensive against a malformed row, CHAOS-2868 review)", async () => {
+            mockSession();
+            const jobs = [
+                {
+                    id: "job-no-timestamps",
+                    sync_config_id: "cfg-coverage",
+                    status: "pending",
+                    since_date: "2026-06-01",
+                    before_date: "2026-06-05",
+                    total_chunks: 0,
+                    completed_chunks: 0,
+                    failed_chunks: 0,
+                    progress_pct: 0,
+                    error_message: null,
+                    started_at: null,
+                    completed_at: null,
+                    created_at: null,
+                },
+            ];
+            const fetchSpy = vi
+                .spyOn(global, "fetch")
+                .mockResolvedValue(
+                    new Response(
+                        JSON.stringify({ items: jobs, total: jobs.length, limit: 50, offset: 0 }),
+                        { status: 200 },
+                    ),
+                );
+
+            const result = await getActiveBackfillJob("cfg-coverage");
+
+            expect(result.data?.id).toBe("job-no-timestamps");
             fetchSpy.mockRestore();
         });
     });

--- a/src/lib/admin/server/sync.ts
+++ b/src/lib/admin/server/sync.ts
@@ -132,18 +132,40 @@ export async function triggerBackfill(
 const ACTIVE_BACKFILL_STATUSES = new Set(["pending", "planned", "dispatching", "running"]);
 
 /**
- * Non-terminal jobs whose most recent activity timestamp is older than this
- * are treated as stranded zombies and excluded from discovery (CHAOS-2868):
- * the backend merges a linked SyncRun's status over the stored BackfillJob
- * row, so a job whose run got stuck/lost reports pending|dispatching forever
- * with 0% progress. Re-surfacing a week-old zombie on every page load would
- * otherwise pin the "Backfill in progress" banner on indefinitely.
+ * Non-terminal jobs with ZERO recorded progress whose most recent activity
+ * timestamp is older than this are treated as stranded zombies and excluded
+ * from discovery (CHAOS-2868): the backend merges a linked SyncRun's status
+ * over the stored BackfillJob row, so a job whose run got stuck/lost reports
+ * pending|dispatching forever with 0% progress. Re-surfacing a week-old
+ * zombie on every page load would otherwise pin the "Backfill in progress"
+ * banner on indefinitely. Jobs with real progress are NEVER excluded by age
+ * alone — a legitimate long-running backfill must stay visible.
  */
 const ACTIVE_BACKFILL_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
-/** True when a non-terminal job's activity is older than ACTIVE_BACKFILL_MAX_AGE_MS. */
+/** True when a job has recorded any forward progress (chunks or percent). */
+function hasBackfillProgress(job: BackfillJob): boolean {
+    return job.progress_pct > 0 || job.completed_chunks > 0 || job.failed_chunks > 0;
+}
+
+/**
+ * True when a non-terminal, zero-progress job's activity is older than
+ * ACTIVE_BACKFILL_MAX_AGE_MS. A job with any recorded progress is never
+ * stale regardless of age (see ACTIVE_BACKFILL_MAX_AGE_MS doc).
+ */
 function isStaleBackfillJob(job: BackfillJob, now: number): boolean {
-    const referenceTime = new Date(job.started_at ?? job.created_at).getTime();
+    if (hasBackfillProgress(job)) return false;
+
+    // Falsy/missing timestamps (defensive against a malformed row despite
+    // the response type) are treated as NOT stale — age can't be judged, so
+    // err on the side of keeping the job visible rather than hiding it.
+    const timestamp = job.started_at || job.created_at;
+    if (!timestamp) return false;
+
+    // Backend datetimes are stored `DateTime(timezone=True)` and always
+    // serialize with an explicit UTC offset (ops models/integrations.py), so
+    // `new Date(...)` here never falls back to local-time parsing.
+    const referenceTime = new Date(timestamp).getTime();
     if (Number.isNaN(referenceTime)) return false;
     return now - referenceTime > ACTIVE_BACKFILL_MAX_AGE_MS;
 }

--- a/src/lib/admin/server/sync.ts
+++ b/src/lib/admin/server/sync.ts
@@ -132,6 +132,23 @@ export async function triggerBackfill(
 const ACTIVE_BACKFILL_STATUSES = new Set(["pending", "planned", "dispatching", "running"]);
 
 /**
+ * Non-terminal jobs whose most recent activity timestamp is older than this
+ * are treated as stranded zombies and excluded from discovery (CHAOS-2868):
+ * the backend merges a linked SyncRun's status over the stored BackfillJob
+ * row, so a job whose run got stuck/lost reports pending|dispatching forever
+ * with 0% progress. Re-surfacing a week-old zombie on every page load would
+ * otherwise pin the "Backfill in progress" banner on indefinitely.
+ */
+const ACTIVE_BACKFILL_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/** True when a non-terminal job's activity is older than ACTIVE_BACKFILL_MAX_AGE_MS. */
+function isStaleBackfillJob(job: BackfillJob, now: number): boolean {
+    const referenceTime = new Date(job.started_at ?? job.created_at).getTime();
+    if (Number.isNaN(referenceTime)) return false;
+    return now - referenceTime > ACTIVE_BACKFILL_MAX_AGE_MS;
+}
+
+/**
  * Discover a persisted in-progress backfill for `configId` so its status
  * survives navigation (CHAOS-2795). The `/backfill-jobs` endpoint has no
  * server-side sync_config_id filter, so this fetches the most recent org-wide
@@ -145,8 +162,12 @@ export async function getActiveBackfillJob(
     return withErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
         const result = await adminApi.syncConfigs.listBackfillJobs(token, orgId, { limit: 50 });
+        const now = Date.now();
         const active = result.items.find(
-            (job) => job.sync_config_id === configId && ACTIVE_BACKFILL_STATUSES.has(job.status),
+            (job) =>
+                job.sync_config_id === configId &&
+                ACTIVE_BACKFILL_STATUSES.has(job.status) &&
+                !isStaleBackfillJob(job, now),
         );
         return active ?? null;
     });


### PR DESCRIPTION
Fixes CHAOS-2868

## Problem

On `org/admin/sync/<configId>`, the "BACKFILL IN PROGRESS / Dispatching work... / 0% / Live — refreshing..." banner renders forever for zombie backfill jobs. The backend merges a linked SyncRun's status over the stored BackfillJob row, so a stranded run can report `pending`/`dispatching` with 0% progress indefinitely (existing rows; fixed forward for new runs by CHAOS-2867). A parallel ops PR adds a reconciler repair sweep for stranded rows, but the web needs to be robust regardless of backend state.

## Fix — three web-side defenses (defense in depth)

1. **Staleness filter** (`src/lib/admin/server/sync.ts`, `getActiveBackfillJob`): non-terminal jobs whose `started_at ?? created_at` is older than 24h are excluded from discovery, so a week-old zombie is never re-surfaced on page load. A job that started recently is still treated as active even if it was created long ago (late-dispatch case).
2. **Prop re-sync** (`src/components/admin/sync/BackfillStatus.tsx`): local `job` state now re-syncs from the `initialJob` prop whenever its id OR status changes, via the documented React "adjust state during render" pattern (not an effect, so `react-hooks/set-state-in-effect` stays satisfied). Previously a parent re-render with a terminal status was silently ignored if `BackfillOperations`' `key={id}` didn't remount the component.
3. **Bounded liveness** (`src/components/admin/sync/BackfillStatus.tsx` polling loop): after a 10-minute window with progress pinned at 0% and status still non-terminal, polling stops and the "Live — refreshing…" text swaps to "Live updates paused" — mirrors the existing `MAX_POLL_DURATION_MS` safety-cap pattern already used in `SyncRunDetailLive`/`useSyncTrigger`.

## Tests

Extended the existing colocated test suites:
- `src/lib/admin/__tests__/server.test.ts`: stale zombie job excluded from discovery; a job with a recent `started_at` stays active despite an old `created_at`.
- `src/components/admin/sync/BackfillStatus.test.tsx`: prop transition to a terminal status on the same job id stops the live banner; polling gives up and swaps to "Live updates paused" after the bounded zero-progress window, with no further polling afterward.

All 4 changed files' quality gates green: `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` (266 files / 2536 tests passing).

SCREENSHOT-WAIVER: logic-only change to backfill job discovery/polling termination; no visual redesign — behavior locked by component tests