### PR TITLE
fix(admin): stop /org/admin 500 on malformed admin list payloads

### DIFF
--- a/src/app/(app)/org/admin/page.test.tsx
+++ b/src/app/(app)/org/admin/page.test.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/test/utils";
+
+import type { User } from "@/lib/admin/types";
+import {
+    getPendingTeamChanges,
+    listCredentials,
+    listIdentities,
+    listSyncConfigs,
+    listTeams,
+    listUsers,
+} from "@/lib/admin/server";
+import AdminDashboardPage from "./page";
+
+vi.mock("next/link", () => ({
+    default: ({
+        href,
+        children,
+        ...props
+    }: {
+        href: string;
+        children: ReactNode;
+        [key: string]: unknown;
+    }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock("@/lib/auth", () => ({
+    auth: vi.fn(async () => ({ user: { email: "admin@test.com" } })),
+}));
+
+vi.mock("@/lib/admin/server", () => ({
+    listUsers: vi.fn(),
+    listTeams: vi.fn(),
+    listIdentities: vi.fn(),
+    listCredentials: vi.fn(),
+    listSyncConfigs: vi.fn(),
+    getPendingTeamChanges: vi.fn(),
+}));
+
+describe("AdminDashboardPage", () => {
+    beforeEach(() => {
+        vi.mocked(listUsers).mockResolvedValue({ data: [] });
+        vi.mocked(listTeams).mockResolvedValue({ data: [] });
+        vi.mocked(listIdentities).mockResolvedValue({ data: [] });
+        vi.mocked(listCredentials).mockResolvedValue({ data: [] });
+        vi.mocked(listSyncConfigs).mockResolvedValue({ data: [] });
+        vi.mocked(getPendingTeamChanges).mockResolvedValue({
+            data: { changes: [], total: 0 },
+        });
+    });
+
+    it("renders operational signals without the partial banner on the happy path", async () => {
+        render(await AdminDashboardPage());
+
+        expect(screen.getByText("Admin Dashboard")).toBeInTheDocument();
+        expect(screen.getByText("Organization roster")).toBeInTheDocument();
+        expect(screen.getByText("Setup progress")).toBeInTheDocument();
+        expect(screen.queryByText(/Some admin signals could not load/)).not.toBeInTheDocument();
+    });
+
+    it("degrades to the partial-signals banner when a list action returns a non-array payload", async () => {
+        // Reproduces the E2E mock envelope that 500'd /org/admin with
+        // `users.filter is not a function` — an out-of-contract payload, hence
+        // the double assertion.
+        vi.mocked(listUsers).mockResolvedValue({
+            data: { items: [], total: 1 } as unknown as User[],
+        });
+
+        render(await AdminDashboardPage());
+
+        expect(screen.getByText("Admin Dashboard")).toBeInTheDocument();
+        expect(screen.getByText(/Some admin signals could not load/)).toBeInTheDocument();
+    });
+
+    it("shows the partial-signals banner when an action reports an error", async () => {
+        vi.mocked(listCredentials).mockResolvedValue({ error: "backend unavailable" });
+
+        render(await AdminDashboardPage());
+
+        expect(screen.getByText(/Some admin signals could not load/)).toBeInTheDocument();
+    });
+});

--- a/src/app/(app)/org/admin/page.tsx
+++ b/src/app/(app)/org/admin/page.tsx
@@ -50,6 +50,19 @@ function SignalCard({
     );
 }
 
+/**
+ * Boundary guard: admin list actions are typed to return arrays, but a
+ * misbehaving backend/mock payload (e.g. a paginated envelope) must degrade
+ * to the partial-signals banner instead of throwing during RSC render.
+ */
+function asList<T>(value: T[] | undefined): T[] {
+    return Array.isArray(value) ? value : [];
+}
+
+function isMalformedList(value: unknown): boolean {
+    return value !== undefined && !Array.isArray(value);
+}
+
 export default async function AdminDashboardPage() {
     const [
         session,
@@ -69,12 +82,13 @@ export default async function AdminDashboardPage() {
         getPendingTeamChanges(),
     ]);
     const user = session?.user;
-    const users = usersResult.data ?? [];
-    const teams = teamsResult.data ?? [];
-    const identities = identitiesResult.data ?? [];
-    const credentials = credentialsResult.data ?? [];
-    const syncConfigs = syncResult.data ?? [];
-    const pendingTeamChanges = pendingResult.data?.total ?? 0;
+    const users = asList(usersResult.data);
+    const teams = asList(teamsResult.data);
+    const identities = asList(identitiesResult.data);
+    const credentials = asList(credentialsResult.data);
+    const syncConfigs = asList(syncResult.data);
+    const pendingTotal = pendingResult.data?.total;
+    const pendingTeamChanges = typeof pendingTotal === "number" ? pendingTotal : 0;
     const invitedUsers = users.filter((adminUser) => !adminUser.is_verified).length;
     const unassignedIdentities = identities.filter(
         (identity) => identity.team_ids.length === 0,
@@ -103,6 +117,13 @@ export default async function AdminDashboardPage() {
             : failingCredentials > 0
               ? CTA_LABELS.manageConnections
               : CTA_LABELS.reviewSyncHealth;
+    const malformedSignals = [
+        usersResult.data,
+        teamsResult.data,
+        identitiesResult.data,
+        credentialsResult.data,
+        syncResult.data,
+    ].filter(isMalformedList).length;
     const loadErrors = [
         usersResult.error,
         teamsResult.error,
@@ -111,6 +132,7 @@ export default async function AdminDashboardPage() {
         syncResult.error,
         pendingResult.error,
     ].filter(Boolean);
+    const hasPartialSignals = loadErrors.length > 0 || malformedSignals > 0;
 
     return (
         <div className="space-y-8">
@@ -120,7 +142,7 @@ export default async function AdminDashboardPage() {
                 breadcrumbs={[{ label: "Home", href: "/dashboard" }, { label: "Admin" }]}
             />
 
-            {loadErrors.length > 0 && (
+            {hasPartialSignals && (
                 <div className="rounded-2xl border border-amber-500/25 bg-amber-500/10 p-4 text-sm text-amber-200">
                     Some admin signals could not load. The available signals below may be partial.
                 </div>

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -2883,6 +2883,17 @@ export const handlers = [
             team_id: teamId,
             name: body?.name ?? "Team",
             source: body?.source ?? "github",
+            description: body?.description ?? null,
+            repo_patterns: body?.repo_patterns ?? [],
+            project_keys: body?.project_keys ?? [],
+            extra_data: body?.extra_data ?? {},
+            managed_fields: body?.managed_fields ?? [],
+            sync_policy: body?.sync_policy ?? 0,
+            flagged_changes: null,
+            last_drift_sync_at: null,
+            is_active: true,
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-01-01T00:00:00Z",
         };
         MOCK_TEAMS.push(created);
         return HttpResponse.json(created);
@@ -2908,8 +2919,17 @@ export const handlers = [
 
     http.post("*/api/v1/admin/identities", async ({ request }) => {
         const body = (await request.json()) as Partial<MockIdentity> | null;
+        const identityId = body?.id ?? body?.canonical_id ?? `identity-${Date.now()}`;
         const created: MockIdentity = {
-            id: body?.id ?? `identity-${Date.now()}`,
+            id: identityId,
+            canonical_id: body?.canonical_id ?? identityId,
+            display_name: body?.display_name ?? null,
+            email: body?.email ?? null,
+            provider_identities: body?.provider_identities ?? {},
+            team_ids: body?.team_ids ?? [],
+            is_active: true,
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-01-01T00:00:00Z",
             provider: body?.provider ?? "github",
             external_id: body?.external_id ?? `external-${Date.now()}`,
             user_id: body?.user_id ?? "e2e-user-1",
@@ -2918,18 +2938,27 @@ export const handlers = [
         return HttpResponse.json(created);
     }),
 
+    // The real backend returns a bare User[] array (see src/lib/admin/types.ts
+    // User + adminApi.users.list). A paginated envelope here previously made
+    // /org/admin throw `users.filter is not a function` during RSC render.
     http.get("*/api/v1/admin/users", () =>
-        HttpResponse.json({
-            items: [
-                {
-                    id: "e2e-user-1",
-                    email: "test@example.com",
-                    role: "owner",
-                    is_active: true,
-                },
-            ],
-            total: 1,
-        }),
+        HttpResponse.json([
+            {
+                id: "e2e-user-1",
+                email: "test@example.com",
+                username: "e2e-user",
+                full_name: "E2E User",
+                avatar_url: null,
+                auth_provider: "local",
+                is_active: true,
+                is_verified: true,
+                is_superuser: false,
+                role: "owner",
+                last_login_at: null,
+                created_at: "2025-01-01T00:00:00Z",
+                updated_at: "2025-01-01T00:00:00Z",
+            },
+        ]),
     ),
 
     http.get("*/api/v1/admin/settings/categories", () =>

--- a/tests/mocks/types.ts
+++ b/tests/mocks/types.ts
@@ -126,18 +126,49 @@ export interface MockSyncConfig {
     updated_at: string;
 }
 
+/**
+ * Mirrors the backend TeamMapping contract (src/lib/admin/types.ts) so admin
+ * surfaces that dereference array fields (repo_patterns, project_keys) never
+ * throw on mock-created rows. `source` is a legacy mock-only field kept for
+ * existing specs.
+ */
 export interface MockTeam {
     id: string;
     team_id: string;
     name: string;
-    source: string;
+    source?: string;
+    description: string | null;
+    repo_patterns: string[];
+    project_keys: string[];
+    extra_data: Record<string, unknown>;
+    managed_fields: string[];
+    sync_policy: number;
+    flagged_changes: Record<string, unknown> | null;
+    last_drift_sync_at: string | null;
+    is_active: boolean;
+    created_at: string;
+    updated_at: string;
 }
 
+/**
+ * Mirrors the backend IdentityMapping contract (src/lib/admin/types.ts) so
+ * admin surfaces that dereference team_ids/provider_identities never throw on
+ * mock-created rows. provider/external_id/user_id are legacy mock-only fields
+ * kept for existing specs.
+ */
 export interface MockIdentity {
     id: string;
-    provider: string;
-    external_id: string;
-    user_id: string;
+    canonical_id: string;
+    display_name: string | null;
+    email: string | null;
+    provider_identities: Record<string, string[]>;
+    team_ids: string[];
+    is_active: boolean;
+    created_at: string;
+    updated_at: string;
+    provider?: string;
+    external_id?: string;
+    user_id?: string;
 }
 
 /** Full credential response as returned by GET /api/v1/admin/credentials. */


### PR DESCRIPTION
## Summary

Hotfix for the E2E failure on `main` after #750 merged before CI finished: `tests/nav-reachability.spec.ts` hit `/org/admin` which returned 500 with `TypeError: users.filter is not a function`.

## Root cause

The MSW mock for `GET */api/v1/admin/users` returned a paginated envelope `{ items, total }`, while the real backend and the `User[]` type return a bare array. The new operational dashboard (#750) calls `.filter` on that payload during RSC render, so the mock-mode render threw.

## Fix

- `src/app/(app)/org/admin/page.tsx`: boundary-guard the five list results (`asList`) and the pending-changes total; malformed (non-array) payloads now count toward the existing partial-signals banner instead of throwing.
- `tests/mocks/handlers.ts` / `tests/mocks/types.ts`: align the admin users mock with the `User[]` contract, and make `MockTeam`/`MockIdentity` plus their POST handlers mirror the backend `TeamMapping`/`IdentityMapping` shapes (required array fields) so mock-created rows can never re-trigger the crash when mutation specs run before reachability.
- New colocated regression test `src/app/(app)/org/admin/page.test.tsx`: happy path renders without banner; envelope payload degrades to banner instead of throwing; action error shows banner.

## Verification

- `pnpm exec vitest run "src/app/(app)/org/admin/page.test.tsx"`: 3 passed.
- `pnpm exec playwright test tests/nav-reachability.spec.ts -g "former leaf"`: passed (previously failing spec).
- Deterministic mutation-before-reachability sequence: `pnpm exec playwright test tests/admin-teams.spec.ts tests/admin-identities.spec.ts tests/nav-reachability.spec.ts --workers=1`: 18 passed.
- `pnpm typecheck`: passed. Focused eslint + `DESIGN_LINT=true` eslint on changed files: passed (one pre-existing warning in `tests/mocks/handlers.ts` line 2640, untouched).
- Oracle review gate: PASS after mock-shape revisions.

SCREENSHOT-WAIVER: no rendered-output change on healthy data paths — the only visual delta is the existing partial-signals banner now also covering malformed payloads, which is locked by the colocated unit test and the E2E reachability spec.
