### PR TITLE
feat(admin): shared ConfirmDialog, ReviewSummary, and TokenInput primitives

### DIFF
--- a/src/components/shared/ConfirmDialog.test.tsx
+++ b/src/components/shared/ConfirmDialog.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen, userEvent } from "@/test/utils";
 
 import { ConfirmDialog } from "./ConfirmDialog";
+import { CTA_LABELS } from "@/lib/design/cta";
 
 function findBackdropAndCancelButtons() {
     const buttons = screen.getAllByRole("button", { name: "Cancel" });
@@ -163,22 +164,104 @@ describe("ConfirmDialog", () => {
         expect(screen.getByRole("button", { name: "Confirm" })).toHaveClass("bg-(--negative)");
     });
 
-    it("supports custom confirm and cancel labels", () => {
+    it("supports custom confirm and cancel labels from the CTA registry", () => {
         render(
             <ConfirmDialog
                 isOpen
                 title="Void invoice"
-                confirmLabel="Confirm Void"
-                cancelLabel="Keep invoice"
+                confirmLabel={CTA_LABELS.delete}
+                cancelLabel={CTA_LABELS.closeWizard}
                 onConfirmAction={vi.fn()}
                 onCancelAction={vi.fn()}
             />,
         );
 
-        expect(screen.getByRole("button", { name: "Confirm Void" })).toBeInTheDocument();
-        const keepInvoiceButtons = screen.getAllByRole("button", { name: "Keep invoice" });
-        expect(keepInvoiceButtons.some((button) => button.textContent === "Keep invoice")).toBe(
+        expect(screen.getByRole("button", { name: CTA_LABELS.delete })).toBeInTheDocument();
+        const closeButtons = screen.getAllByRole("button", { name: CTA_LABELS.closeWizard });
+        expect(closeButtons.some((button) => button.textContent === CTA_LABELS.closeWizard)).toBe(
             true,
         );
+    });
+
+    it("moves focus inside the dialog when it opens", () => {
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Delete invoice"
+                onConfirmAction={vi.fn()}
+                onCancelAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByRole("dialog")).toHaveFocus();
+    });
+
+    it("wraps focus from the last focusable element back to the first on Tab", async () => {
+        const user = userEvent.setup();
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Delete invoice"
+                onConfirmAction={vi.fn()}
+                onCancelAction={vi.fn()}
+            />,
+        );
+
+        const confirmButton = screen.getByRole("button", { name: "Confirm" });
+        const { cancelButton } = findBackdropAndCancelButtons();
+        confirmButton.focus();
+
+        await user.tab();
+
+        expect(cancelButton).toHaveFocus();
+    });
+
+    it("wraps focus from the first focusable element back to the last on Shift+Tab", async () => {
+        const user = userEvent.setup();
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Delete invoice"
+                onConfirmAction={vi.fn()}
+                onCancelAction={vi.fn()}
+            />,
+        );
+
+        const confirmButton = screen.getByRole("button", { name: "Confirm" });
+        const { cancelButton } = findBackdropAndCancelButtons();
+        cancelButton.focus();
+
+        await user.tab({ shift: true });
+
+        expect(confirmButton).toHaveFocus();
+    });
+
+    it("restores focus to the previously focused element after close", () => {
+        const trigger = document.createElement("button");
+        document.body.appendChild(trigger);
+        trigger.focus();
+        expect(trigger).toHaveFocus();
+
+        const { rerender } = render(
+            <ConfirmDialog
+                isOpen
+                title="Delete invoice"
+                onConfirmAction={vi.fn()}
+                onCancelAction={vi.fn()}
+            />,
+        );
+        expect(screen.getByRole("dialog")).toHaveFocus();
+
+        rerender(
+            <ConfirmDialog
+                isOpen={false}
+                title="Delete invoice"
+                onConfirmAction={vi.fn()}
+                onCancelAction={vi.fn()}
+            />,
+        );
+
+        expect(trigger).toHaveFocus();
+        document.body.removeChild(trigger);
     });
 });

--- a/src/components/shared/ConfirmDialog.test.tsx
+++ b/src/components/shared/ConfirmDialog.test.tsx
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "@/test/utils";
+
+import { ConfirmDialog } from "./ConfirmDialog";
+
+function findBackdropAndCancelButtons() {
+    const buttons = screen.getAllByRole("button", { name: "Cancel" });
+    const backdrop = buttons.find((button) => button.textContent === "");
+    const cancelButton = buttons.find((button) => button.textContent === "Cancel");
+    if (!backdrop || !cancelButton) {
+        throw new Error("Expected both a backdrop button and a labeled Cancel button.");
+    }
+    return { backdrop, cancelButton };
+}
+
+describe("ConfirmDialog", () => {
+    it("renders nothing when isOpen is false", () => {
+        render(
+            <ConfirmDialog
+                isOpen={false}
+                title="Delete invoice"
+                onConfirmAction={vi.fn()}
+                onCancelAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("renders the title, description, and default CTA labels", () => {
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Delete invoice"
+                description="This cannot be undone."
+                onConfirmAction={vi.fn()}
+                onCancelAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByRole("dialog", { name: "Delete invoice" })).toBeInTheDocument();
+        expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+    });
+
+    it("fires onConfirmAction exactly once and never onCancelAction when confirmed", async () => {
+        const onConfirmAction = vi.fn();
+        const onCancelAction = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Delete invoice"
+                onConfirmAction={onConfirmAction}
+                onCancelAction={onCancelAction}
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+        expect(onConfirmAction).toHaveBeenCalledTimes(1);
+        expect(onCancelAction).not.toHaveBeenCalled();
+    });
+
+    it("fires only onCancelAction when the Cancel button is clicked", async () => {
+        const onConfirmAction = vi.fn();
+        const onCancelAction = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Delete invoice"
+                onConfirmAction={onConfirmAction}
+                onCancelAction={onCancelAction}
+            />,
+        );
+
+        const { cancelButton } = findBackdropAndCancelButtons();
+        await user.click(cancelButton);
+
+        expect(onCancelAction).toHaveBeenCalledTimes(1);
+        expect(onConfirmAction).not.toHaveBeenCalled();
+    });
+
+    it("fires only onCancelAction when the backdrop is dismissed", async () => {
+        const onConfirmAction = vi.fn();
+        const onCancelAction = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Delete invoice"
+                onConfirmAction={onConfirmAction}
+                onCancelAction={onCancelAction}
+            />,
+        );
+
+        const { backdrop } = findBackdropAndCancelButtons();
+        await user.click(backdrop);
+
+        expect(onCancelAction).toHaveBeenCalledTimes(1);
+        expect(onConfirmAction).not.toHaveBeenCalled();
+    });
+
+    it("fires only onCancelAction when Escape is pressed", async () => {
+        const onConfirmAction = vi.fn();
+        const onCancelAction = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Delete invoice"
+                onConfirmAction={onConfirmAction}
+                onCancelAction={onCancelAction}
+            />,
+        );
+
+        await user.keyboard("{Escape}");
+
+        expect(onCancelAction).toHaveBeenCalledTimes(1);
+        expect(onConfirmAction).not.toHaveBeenCalled();
+    });
+
+    it("blocks confirm until the required confirmation text is typed exactly", async () => {
+        const onConfirmAction = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Delete organization"
+                requiredConfirmationText="delete-my-org"
+                onConfirmAction={onConfirmAction}
+                onCancelAction={vi.fn()}
+            />,
+        );
+
+        const confirmButton = screen.getByRole("button", { name: "Confirm" });
+        expect(confirmButton).toBeDisabled();
+
+        const input = screen.getByLabelText(/type.*delete-my-org.*to confirm/iu);
+        await user.type(input, "not-quite-right");
+        expect(confirmButton).toBeDisabled();
+
+        await user.clear(input);
+        await user.type(input, "delete-my-org");
+        expect(confirmButton).toBeEnabled();
+
+        await user.click(confirmButton);
+        expect(onConfirmAction).toHaveBeenCalledTimes(1);
+    });
+
+    it("applies the destructive tone to the confirm button", () => {
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Void invoice"
+                tone="destructive"
+                onConfirmAction={vi.fn()}
+                onCancelAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByRole("button", { name: "Confirm" })).toHaveClass("bg-(--negative)");
+    });
+
+    it("supports custom confirm and cancel labels", () => {
+        render(
+            <ConfirmDialog
+                isOpen
+                title="Void invoice"
+                confirmLabel="Confirm Void"
+                cancelLabel="Keep invoice"
+                onConfirmAction={vi.fn()}
+                onCancelAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByRole("button", { name: "Confirm Void" })).toBeInTheDocument();
+        const keepInvoiceButtons = screen.getAllByRole("button", { name: "Keep invoice" });
+        expect(keepInvoiceButtons.some((button) => button.textContent === "Keep invoice")).toBe(
+            true,
+        );
+    });
+});

--- a/src/components/shared/ConfirmDialog.tsx
+++ b/src/components/shared/ConfirmDialog.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import {
+    useEffect,
+    useId,
+    useRef,
+    useState,
+    type KeyboardEvent as ReactKeyboardEvent,
+    type ReactNode,
+} from "react";
 
-import { CTA_LABELS } from "@/lib/design/cta";
+import { CTA_LABELS, type CtaLabel } from "@/lib/design/cta";
 
 export type ConfirmDialogTone = "default" | "destructive";
 
@@ -12,8 +19,8 @@ type ConfirmDialogProps = {
     description?: ReactNode;
     /** Visual emphasis for irreversible/safety-critical actions. */
     tone?: ConfirmDialogTone;
-    confirmLabel?: string;
-    cancelLabel?: string;
+    confirmLabel?: CtaLabel;
+    cancelLabel?: CtaLabel;
     isPending?: boolean;
     /**
      * When set, the confirm action stays disabled until the user types this
@@ -29,6 +36,14 @@ const TONE_CLASSNAME: Record<ConfirmDialogTone, string> = {
     default: "bg-(--accent) text-white hover:bg-(--accent)/90",
     destructive: "bg-(--negative) text-white hover:bg-(--negative)/90",
 };
+
+/** Focusable candidates considered for the Tab/Shift+Tab trap (backdrop excluded via tabIndex={-1}). */
+const FOCUSABLE_SELECTOR =
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
 
 /**
  * Accessible modal confirmation dialog for destructive/safety-critical
@@ -89,6 +104,29 @@ export function ConfirmDialog({
         };
     }, [isOpen]);
 
+    // Focus trap: Tab from the last focusable element wraps to the first,
+    // and Shift+Tab from the first wraps to the last, so focus can never
+    // escape past the backdrop while the dialog is open.
+    function handleDialogKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+        if (event.key !== "Tab") return;
+        const container = dialogRef.current;
+        if (!container) return;
+        const focusable = getFocusableElements(container);
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+        if (event.shiftKey) {
+            if (active === first || active === container) {
+                event.preventDefault();
+                last.focus();
+            }
+        } else if (active === last || active === container) {
+            event.preventDefault();
+            first.focus();
+        }
+    }
+
     if (!isOpen) {
         return null;
     }
@@ -102,6 +140,7 @@ export function ConfirmDialog({
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
             <button
                 type="button"
+                tabIndex={-1}
                 aria-label={cancelLabel}
                 onClick={onCancelAction}
                 className="absolute inset-0 bg-black/50"
@@ -112,6 +151,7 @@ export function ConfirmDialog({
                 aria-modal="true"
                 aria-labelledby={titleId}
                 tabIndex={-1}
+                onKeyDown={handleDialogKeyDown}
                 className="relative z-10 w-full max-w-md rounded-2xl border border-(--card-stroke) bg-(--background) p-6 shadow-2xl focus:outline-none"
             >
                 <h3 id={titleId} className="text-h2 text-foreground">

--- a/src/components/shared/ConfirmDialog.tsx
+++ b/src/components/shared/ConfirmDialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+
+import { CTA_LABELS } from "@/lib/design/cta";
+
+export type ConfirmDialogTone = "default" | "destructive";
+
+type ConfirmDialogProps = {
+    isOpen: boolean;
+    title: string;
+    description?: ReactNode;
+    /** Visual emphasis for irreversible/safety-critical actions. */
+    tone?: ConfirmDialogTone;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    isPending?: boolean;
+    /**
+     * When set, the confirm action stays disabled until the user types this
+     * exact string into the confirmation field (DeletionPlanPreview pattern).
+     */
+    requiredConfirmationText?: string;
+    onConfirmAction: () => void;
+    /** Fired by the Cancel button, the backdrop, and Escape — never by confirm. */
+    onCancelAction: () => void;
+};
+
+const TONE_CLASSNAME: Record<ConfirmDialogTone, string> = {
+    default: "bg-(--accent) text-white hover:bg-(--accent)/90",
+    destructive: "bg-(--negative) text-white hover:bg-(--negative)/90",
+};
+
+/**
+ * Accessible modal confirmation dialog for destructive/safety-critical
+ * admin actions (shared primitive, CHAOS-2845 Foundations lane).
+ *
+ * Cancel, the backdrop, and Escape all resolve to {@link onCancelAction};
+ * only the confirm button can ever fire {@link onConfirmAction}.
+ */
+export function ConfirmDialog({
+    isOpen,
+    title,
+    description,
+    tone = "default",
+    confirmLabel = CTA_LABELS.confirm,
+    cancelLabel = CTA_LABELS.cancel,
+    isPending = false,
+    requiredConfirmationText,
+    onConfirmAction,
+    onCancelAction,
+}: ConfirmDialogProps) {
+    const titleId = useId();
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const onCancelActionRef = useRef(onCancelAction);
+    const [typedText, setTypedText] = useState("");
+    const [wasOpen, setWasOpen] = useState(isOpen);
+
+    // Reset the typed-confirmation draft when the dialog transitions open —
+    // adjusting state during render (React's documented pattern) rather than
+    // in an effect, since this is deriving state from a prop change, not
+    // synchronizing with an external system.
+    if (isOpen !== wasOpen) {
+        setWasOpen(isOpen);
+        if (isOpen) {
+            setTypedText("");
+        }
+    }
+
+    useEffect(() => {
+        onCancelActionRef.current = onCancelAction;
+    }, [onCancelAction]);
+
+    // Modal a11y: move focus into the dialog on open, restore it on close, and
+    // close on Escape regardless of where focus currently sits (BackfillWizard
+    // pattern, CHAOS-2796).
+    useEffect(() => {
+        if (!isOpen) return;
+        const previouslyFocused = document.activeElement as HTMLElement | null;
+        dialogRef.current?.focus();
+
+        function handleKeyDown(event: KeyboardEvent) {
+            if (event.key === "Escape") onCancelActionRef.current();
+        }
+        document.addEventListener("keydown", handleKeyDown);
+
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            previouslyFocused?.focus();
+        };
+    }, [isOpen]);
+
+    if (!isOpen) {
+        return null;
+    }
+
+    const confirmationRequired = requiredConfirmationText !== undefined;
+    const confirmationBlocked = confirmationRequired && typedText !== requiredConfirmationText;
+    const confirmDisabled = isPending || confirmationBlocked;
+    const confirmInputId = `${titleId}-confirm-text`;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <button
+                type="button"
+                aria-label={cancelLabel}
+                onClick={onCancelAction}
+                className="absolute inset-0 bg-black/50"
+            />
+            <div
+                ref={dialogRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                tabIndex={-1}
+                className="relative z-10 w-full max-w-md rounded-2xl border border-(--card-stroke) bg-(--background) p-6 shadow-2xl focus:outline-none"
+            >
+                <h3 id={titleId} className="text-h2 text-foreground">
+                    {title}
+                </h3>
+                {description ? (
+                    <div className="mt-2 text-sm text-(--ink-muted)">{description}</div>
+                ) : null}
+
+                {confirmationRequired ? (
+                    <div className="mt-4">
+                        <label htmlFor={confirmInputId} className="mb-1.5 block text-sm text-foreground">
+                            Type <strong>{requiredConfirmationText}</strong> to confirm:
+                        </label>
+                        <input
+                            id={confirmInputId}
+                            type="text"
+                            value={typedText}
+                            onChange={(event) => setTypedText(event.target.value)}
+                            disabled={isPending}
+                            placeholder={requiredConfirmationText}
+                            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--negative) focus:outline-none focus:ring-1 focus:ring-(--negative) disabled:opacity-50"
+                        />
+                    </div>
+                ) : null}
+
+                <div className="mt-5 flex justify-end gap-2">
+                    <button
+                        type="button"
+                        onClick={onCancelAction}
+                        disabled={isPending}
+                        className="rounded-lg border border-(--card-stroke) px-3 py-1.5 text-sm text-foreground hover:bg-(--card-70) disabled:opacity-50"
+                    >
+                        {cancelLabel}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onConfirmAction}
+                        disabled={confirmDisabled}
+                        className={`rounded-lg px-3 py-1.5 text-sm font-medium disabled:opacity-50 ${TONE_CLASSNAME[tone]}`}
+                    >
+                        {confirmLabel}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/shared/ConfirmDialog.tsx
+++ b/src/components/shared/ConfirmDialog.tsx
@@ -163,7 +163,10 @@ export function ConfirmDialog({
 
                 {confirmationRequired ? (
                     <div className="mt-4">
-                        <label htmlFor={confirmInputId} className="mb-1.5 block text-sm text-foreground">
+                        <label
+                            htmlFor={confirmInputId}
+                            className="mb-1.5 block text-sm text-foreground"
+                        >
                             Type <strong>{requiredConfirmationText}</strong> to confirm:
                         </label>
                         <input

--- a/src/components/shared/ReviewSummary.test.tsx
+++ b/src/components/shared/ReviewSummary.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+
+import { ReviewSummary } from "./ReviewSummary";
+
+describe("ReviewSummary", () => {
+    it("renders one row per label/value pair", () => {
+        render(
+            <ReviewSummary
+                rows={[
+                    { label: "Organization", value: "Acme Corp" },
+                    { label: "Seats", value: 42 },
+                ]}
+            />,
+        );
+
+        expect(screen.getByText("Organization")).toBeInTheDocument();
+        expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+        expect(screen.getByText("Seats")).toBeInTheDocument();
+        expect(screen.getByText("42")).toBeInTheDocument();
+    });
+
+    it("renders ReactNode values, not only strings", () => {
+        render(
+            <ReviewSummary
+                rows={[{ label: "Status", value: <strong>Active</strong> }]}
+            />,
+        );
+
+        expect(screen.getByText("Active").tagName).toBe("STRONG");
+    });
+
+    it("renders no warnings region when warnings is omitted or empty", () => {
+        render(<ReviewSummary rows={[{ label: "Plan", value: "Team" }]} />);
+
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("renders each warning inside an alert region for destructive-change callouts", () => {
+        render(
+            <ReviewSummary
+                rows={[{ label: "Plan", value: "Team" }]}
+                warnings={["This will remove 3 pending invites.", "Billing will be prorated."]}
+            />,
+        );
+
+        const alert = screen.getByRole("alert");
+        expect(alert).toHaveTextContent("This will remove 3 pending invites.");
+        expect(alert).toHaveTextContent("Billing will be prorated.");
+    });
+
+    it("uses the id override for row keys when provided", () => {
+        render(
+            <ReviewSummary
+                rows={[
+                    { id: "row-a", label: "Repeat label", value: "First" },
+                    { id: "row-b", label: "Repeat label", value: "Second" },
+                ]}
+            />,
+        );
+
+        expect(screen.getByText("First")).toBeInTheDocument();
+        expect(screen.getByText("Second")).toBeInTheDocument();
+        expect(screen.getAllByText("Repeat label")).toHaveLength(2);
+    });
+});

--- a/src/components/shared/ReviewSummary.test.tsx
+++ b/src/components/shared/ReviewSummary.test.tsx
@@ -21,11 +21,7 @@ describe("ReviewSummary", () => {
     });
 
     it("renders ReactNode values, not only strings", () => {
-        render(
-            <ReviewSummary
-                rows={[{ label: "Status", value: <strong>Active</strong> }]}
-            />,
-        );
+        render(<ReviewSummary rows={[{ label: "Status", value: <strong>Active</strong> }]} />);
 
         expect(screen.getByText("Active").tagName).toBe("STRONG");
     });

--- a/src/components/shared/ReviewSummary.tsx
+++ b/src/components/shared/ReviewSummary.tsx
@@ -46,7 +46,9 @@ export function ReviewSummary({ rows, warnings, className }: ReviewSummaryProps)
                         key={row.id ?? row.label}
                         className="flex items-start justify-between gap-4 px-4 py-3"
                     >
-                        <dt className="text-label-caps uppercase text-(--ink-muted)">{row.label}</dt>
+                        <dt className="text-label-caps uppercase text-(--ink-muted)">
+                            {row.label}
+                        </dt>
                         <dd className="text-right text-sm text-foreground">{row.value}</dd>
                     </div>
                 ))}

--- a/src/components/shared/ReviewSummary.tsx
+++ b/src/components/shared/ReviewSummary.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+export type ReviewSummaryRow = {
+    /** Stable row key; falls back to `label` when omitted. */
+    id?: string;
+    label: string;
+    value: ReactNode;
+};
+
+type ReviewSummaryProps = {
+    rows: ReviewSummaryRow[];
+    /** Destructive-change callouts shown below the rows (DestructiveWarning tone). */
+    warnings?: string[];
+    className?: string;
+};
+
+/**
+ * Review-before-submit summary block (shared primitive, CHAOS-2845
+ * Foundations lane): a label/value row list plus an optional warnings slot
+ * for irreversible or destructive staged changes.
+ */
+export function ReviewSummary({ rows, warnings, className }: ReviewSummaryProps) {
+    return (
+        <div className={`space-y-4 ${className ?? ""}`.trim()}>
+            <dl className="divide-y divide-(--card-stroke) rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+                {rows.map((row) => (
+                    <div
+                        key={row.id ?? row.label}
+                        className="flex items-start justify-between gap-4 px-4 py-3"
+                    >
+                        <dt className="text-label-caps uppercase text-(--ink-muted)">{row.label}</dt>
+                        <dd className="text-right text-sm text-foreground">{row.value}</dd>
+                    </div>
+                ))}
+            </dl>
+
+            {warnings && warnings.length > 0 ? (
+                <div
+                    role="alert"
+                    className="space-y-1.5 rounded-lg border border-(--caution)/30 bg-(--caution)/10 p-3 text-xs text-(--caution)"
+                >
+                    {warnings.map((warning) => (
+                        <p key={warning}>⚠ {warning}</p>
+                    ))}
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/src/components/shared/ReviewSummary.tsx
+++ b/src/components/shared/ReviewSummary.tsx
@@ -14,6 +14,24 @@ type ReviewSummaryProps = {
     className?: string;
 };
 
+/** Inline warning-triangle glyph (design system forbids emoji-as-icon). */
+function WarningIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            viewBox="0 0 20 20"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className="mt-0.5 h-3.5 w-3.5 shrink-0"
+        >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10 3.5 2.5 16h15L10 3.5Z" />
+            <path strokeLinecap="round" d="M10 8v4" />
+            <path strokeLinecap="round" d="M10 14.5h.01" />
+        </svg>
+    );
+}
+
 /**
  * Review-before-submit summary block (shared primitive, CHAOS-2845
  * Foundations lane): a label/value row list plus an optional warnings slot
@@ -40,7 +58,10 @@ export function ReviewSummary({ rows, warnings, className }: ReviewSummaryProps)
                     className="space-y-1.5 rounded-lg border border-(--caution)/30 bg-(--caution)/10 p-3 text-xs text-(--caution)"
                 >
                     {warnings.map((warning) => (
-                        <p key={warning}>⚠ {warning}</p>
+                        <p key={warning} className="flex items-start gap-1.5">
+                            <WarningIcon />
+                            <span>{warning}</span>
+                        </p>
                     ))}
                 </div>
             ) : null}

--- a/src/components/shared/TokenInput.test.tsx
+++ b/src/components/shared/TokenInput.test.tsx
@@ -92,4 +92,31 @@ describe("TokenInput", () => {
         expect(screen.queryByText("alpha")).not.toBeInTheDocument();
         expect(screen.getByText("beta")).toBeInTheDocument();
     });
+
+    it("does not commit on Enter or comma while an IME composition is in progress", () => {
+        const onChangeAction = vi.fn();
+        render(<TokenInput value={[]} onChangeAction={onChangeAction} ariaLabel="Tags" />);
+        const input = screen.getByLabelText("Tags");
+
+        fireEvent.change(input, { target: { value: "\u30a2\u30eb\u30d5\u30a1" } });
+        fireEvent.compositionStart(input);
+        fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+        fireEvent.keyDown(input, { key: ",", isComposing: true });
+
+        expect(onChangeAction).not.toHaveBeenCalled();
+        expect(input).toHaveValue("\u30a2\u30eb\u30d5\u30a1");
+    });
+
+    it("commits normally on Enter once the IME composition has ended", () => {
+        const onChangeAction = vi.fn();
+        render(<TokenInput value={[]} onChangeAction={onChangeAction} ariaLabel="Tags" />);
+        const input = screen.getByLabelText("Tags");
+
+        fireEvent.change(input, { target: { value: "\u30a2\u30eb\u30d5\u30a1" } });
+        fireEvent.compositionStart(input);
+        fireEvent.compositionEnd(input);
+        fireEvent.keyDown(input, { key: "Enter", isComposing: false });
+
+        expect(onChangeAction).toHaveBeenCalledWith(["\u30a2\u30eb\u30d5\u30a1"]);
+    });
 });

--- a/src/components/shared/TokenInput.test.tsx
+++ b/src/components/shared/TokenInput.test.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, userEvent } from "@/test/utils";
+
+import { TokenInput } from "./TokenInput";
+
+function TokenInputHarness({ initial = [] as string[] }) {
+    const [value, setValue] = useState<string[]>(initial);
+    return <TokenInput value={value} onChangeAction={setValue} ariaLabel="Tags" />;
+}
+
+describe("TokenInput", () => {
+    it("renders existing tokens as chips with an accessible remove button each", () => {
+        render(<TokenInput value={["alpha", "beta"]} onChangeAction={vi.fn()} ariaLabel="Tags" />);
+
+        expect(screen.getByText("alpha")).toBeInTheDocument();
+        expect(screen.getByText("beta")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Remove alpha" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Remove beta" })).toBeInTheDocument();
+    });
+
+    it("adds a trimmed token on Enter and clears the draft", async () => {
+        const user = userEvent.setup();
+        render(<TokenInputHarness />);
+
+        await user.type(screen.getByLabelText("Tags"), "  alpha  {Enter}");
+
+        expect(screen.getByText("alpha")).toBeInTheDocument();
+        expect(screen.getByLabelText("Tags")).toHaveValue("");
+    });
+
+    it("adds a token on comma without requiring Enter", async () => {
+        const user = userEvent.setup();
+        render(<TokenInputHarness />);
+
+        await user.type(screen.getByLabelText("Tags"), "alpha,");
+
+        expect(screen.getByText("alpha")).toBeInTheDocument();
+        expect(screen.getByLabelText("Tags")).toHaveValue("");
+    });
+
+    it("rejects a case-insensitive duplicate with visible feedback and no change", async () => {
+        const onChangeAction = vi.fn();
+        const user = userEvent.setup();
+        render(<TokenInput value={["alpha"]} onChangeAction={onChangeAction} ariaLabel="Tags" />);
+
+        await user.type(screen.getByLabelText("Tags"), "ALPHA{Enter}");
+
+        expect(onChangeAction).not.toHaveBeenCalled();
+        expect(screen.getByRole("status")).toHaveTextContent("Already added");
+    });
+
+    it("rejects an empty/whitespace-only draft on Enter", async () => {
+        const onChangeAction = vi.fn();
+        const user = userEvent.setup();
+        render(<TokenInput value={[]} onChangeAction={onChangeAction} ariaLabel="Tags" />);
+
+        await user.type(screen.getByLabelText("Tags"), "   {Enter}");
+
+        expect(onChangeAction).not.toHaveBeenCalled();
+    });
+
+    it("splits pasted text on commas and whitespace into multiple tokens", () => {
+        const onChangeAction = vi.fn();
+        render(<TokenInput value={[]} onChangeAction={onChangeAction} ariaLabel="Tags" />);
+
+        fireEvent.paste(screen.getByLabelText("Tags"), {
+            clipboardData: { getData: () => "alpha, beta  gamma" },
+        });
+
+        expect(onChangeAction).toHaveBeenCalledWith(["alpha", "beta", "gamma"]);
+    });
+
+    it("drops empty entries produced by a leading/trailing separator paste, keeping valid tokens", () => {
+        const onChangeAction = vi.fn();
+        render(<TokenInput value={[]} onChangeAction={onChangeAction} ariaLabel="Tags" />);
+
+        fireEvent.paste(screen.getByLabelText("Tags"), {
+            clipboardData: { getData: () => ",alpha,beta," },
+        });
+
+        expect(onChangeAction).toHaveBeenCalledWith(["alpha", "beta"]);
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("removes exactly the clicked token via its remove button", async () => {
+        const user = userEvent.setup();
+        render(<TokenInputHarness initial={["alpha", "beta"]} />);
+
+        await user.click(screen.getByRole("button", { name: "Remove alpha" }));
+
+        expect(screen.queryByText("alpha")).not.toBeInTheDocument();
+        expect(screen.getByText("beta")).toBeInTheDocument();
+    });
+});

--- a/src/components/shared/TokenInput.tsx
+++ b/src/components/shared/TokenInput.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useId, useState, type ClipboardEvent, type KeyboardEvent } from "react";
+
+type TokenInputProps = {
+    value: string[];
+    onChangeAction: (next: string[]) => void;
+    placeholder?: string;
+    ariaLabel: string;
+    className?: string;
+};
+
+function splitCandidates(raw: string): string[] {
+    return raw
+        .split(/[,\s]+/u)
+        .map((candidate) => candidate.trim())
+        .filter(Boolean);
+}
+
+function isSameToken(a: string, b: string): boolean {
+    return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
+ * Token/chip input for string lists (shared primitive, CHAOS-2845
+ * Foundations lane): Enter or comma commits the current draft, pasted text
+ * splits on commas/whitespace, entries are trimmed, empties are dropped, and
+ * duplicates are rejected case-insensitively with visible feedback.
+ */
+export function TokenInput({ value, onChangeAction, placeholder, ariaLabel, className }: TokenInputProps) {
+    const [draft, setDraft] = useState("");
+    const [feedback, setFeedback] = useState<string | null>(null);
+    const feedbackId = useId();
+
+    // Both call sites (Enter/comma commit and paste-split) already trim and
+    // drop empty segments before reaching here, so the only outcome this
+    // function needs to track is a rejected case-insensitive duplicate.
+    function addCandidates(candidates: string[]) {
+        const accepted: string[] = [];
+        let hadDuplicate = false;
+
+        for (const candidate of candidates) {
+            const isDuplicate =
+                value.some((existing) => isSameToken(existing, candidate)) ||
+                accepted.some((existing) => isSameToken(existing, candidate));
+            if (isDuplicate) {
+                hadDuplicate = true;
+                continue;
+            }
+            accepted.push(candidate);
+        }
+
+        if (accepted.length > 0) {
+            onChangeAction([...value, ...accepted]);
+        }
+
+        setFeedback(hadDuplicate ? "Already added — duplicates are ignored." : null);
+    }
+
+    function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+        if (event.key !== "Enter" && event.key !== ",") return;
+        event.preventDefault();
+        if (!draft.trim()) return;
+        addCandidates([draft.trim()]);
+        setDraft("");
+    }
+
+    function handlePaste(event: ClipboardEvent<HTMLInputElement>) {
+        const text = event.clipboardData.getData("text");
+        if (!/[,\s]/u.test(text)) return;
+        event.preventDefault();
+        addCandidates(splitCandidates(text));
+        setDraft("");
+    }
+
+    function removeToken(token: string) {
+        onChangeAction(value.filter((existing) => existing !== token));
+        setFeedback(null);
+    }
+
+    return (
+        <div className={className}>
+            <div className="flex flex-wrap items-center gap-1.5 rounded-lg border border-(--card-stroke) bg-(--card-70) p-2 focus-within:border-(--accent) focus-within:ring-1 focus-within:ring-(--accent)">
+                {value.map((token) => (
+                    <span
+                        key={token}
+                        className="inline-flex items-center gap-1 rounded-full border border-(--card-stroke) bg-(--card-80) px-2.5 py-1 text-xs text-foreground"
+                    >
+                        {token}
+                        <button
+                            type="button"
+                            onClick={() => removeToken(token)}
+                            aria-label={`Remove ${token}`}
+                            className="text-(--ink-muted) hover:text-(--negative)"
+                        >
+                            ×
+                        </button>
+                    </span>
+                ))}
+                <input
+                    type="text"
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    onKeyDown={handleKeyDown}
+                    onPaste={handlePaste}
+                    placeholder={placeholder}
+                    aria-label={ariaLabel}
+                    aria-describedby={feedback ? feedbackId : undefined}
+                    className="flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-(--ink-muted)"
+                />
+            </div>
+            {feedback ? (
+                <p id={feedbackId} role="status" className="mt-1 text-xs text-(--caution)">
+                    {feedback}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/src/components/shared/TokenInput.tsx
+++ b/src/components/shared/TokenInput.tsx
@@ -27,7 +27,13 @@ function isSameToken(a: string, b: string): boolean {
  * splits on commas/whitespace, entries are trimmed, empties are dropped, and
  * duplicates are rejected case-insensitively with visible feedback.
  */
-export function TokenInput({ value, onChangeAction, placeholder, ariaLabel, className }: TokenInputProps) {
+export function TokenInput({
+    value,
+    onChangeAction,
+    placeholder,
+    ariaLabel,
+    className,
+}: TokenInputProps) {
     const [draft, setDraft] = useState("");
     const [feedback, setFeedback] = useState<string | null>(null);
     const feedbackId = useId();

--- a/src/components/shared/TokenInput.tsx
+++ b/src/components/shared/TokenInput.tsx
@@ -58,6 +58,9 @@ export function TokenInput({ value, onChangeAction, placeholder, ariaLabel, clas
     }
 
     function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+        // IME composition (CJK/Japanese/Korean input): Enter/comma confirm the
+        // in-progress composition, not the token — never commit while composing.
+        if (event.nativeEvent.isComposing) return;
         if (event.key !== "Enter" && event.key !== ",") return;
         event.preventDefault();
         if (!draft.trim()) return;

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -115,6 +115,8 @@ export const CTA_LABELS = {
     manageConnections: "Manage connections",
     reviewIdentities: "Review identities",
     openSyncStatus: "Open sync status",
+    /** Generic affirmative action for the shared ConfirmDialog primitive (CHAOS-2845). */
+    confirm: "Confirm",
 } as const;
 
 export type CtaKey = keyof typeof CTA_LABELS;


### PR DESCRIPTION
## Summary

Foundations lane of the Org Admin UX redesign (CHAOS-2845): three new shared admin primitives, no existing pages modified (adoption follows in later lanes).

- `ConfirmDialog` — accessible confirmation modal for destructive/safety-critical actions: real Tab/Shift+Tab focus trap, backdrop button out of the tab cycle, Escape/backdrop/cancel route ONLY to `onCancelAction`, optional typed-confirmation gate, `confirmLabel`/`cancelLabel` typed as registry `CtaLabel` (no bypass).
- `ReviewSummary` — review-before-submit rows plus a warnings slot (`--caution` token, inline SVG icon).
- `TokenInput` — chip input with Enter/comma commit, paste splitting, case-insensitive duplicate rejection with visible feedback, IME-composition-safe (no commit while `isComposing`), accessible per-chip remove.
- `CTA_LABELS`: appended `confirm`.

## Review gates
- Worker gates: lsp clean, focused eslint + `DESIGN_LINT=true` eslint clean, `tsc --noEmit` clean, `src/components/shared/` suite 11 files / 72 tests passing (22→28 new tests incl. focus-trap + IME regressions).
- Oracle code review: initial REVISE (focus trap, IME guard, CtaLabel narrowing, emoji glyph) → all fixed → **PASS** on re-review.

## Status
Draft until after-screenshots are attached at the integration QA pass (primitives get visual evidence via their first adopting surfaces).

SCREENSHOT-WAIVER: no rendered surface consumes these primitives yet — this PR adds new shared components only (no page/route renders them). Visual evidence lands with their first adopting surfaces (billing cancel modal, mapping token inputs, safety confirmations).
