### PR TITLE
feat(admin/audit-logs): investigation-oriented audit log surface

### DIFF
--- a/src/app/(app)/org/admin/audit-logs/AuditIdentityLabel.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditIdentityLabel.test.tsx
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { render, screen, cleanup } from "@/test/utils";
+import { AuditIdentityLabel } from "./AuditIdentityLabel";
+
+const UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("AuditIdentityLabel", () => {
+    afterEach(() => cleanup());
+
+    it("renders the empty label when id is null (e.g. a system-initiated action)", () => {
+        render(<AuditIdentityLabel id={null} emptyLabel="System" copyLabel="actor ID" />);
+        expect(screen.getByText("System")).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: /copy/i })).not.toBeInTheDocument();
+    });
+
+    it("shows an explicit Unresolved primary label for an id with no known name", () => {
+        render(<AuditIdentityLabel id={UUID} emptyLabel="System" copyLabel="actor ID" />);
+        expect(screen.getByText("Unresolved")).toBeInTheDocument();
+    });
+
+    it("never renders the raw id as the primary label", () => {
+        render(<AuditIdentityLabel id={UUID} emptyLabel="System" copyLabel="actor ID" />);
+        const primary = screen.getByText("Unresolved").closest("span");
+        expect(primary).not.toHaveTextContent(UUID);
+    });
+
+    it("shows the full id as secondary, copyable text", () => {
+        render(<AuditIdentityLabel id={UUID} emptyLabel="System" copyLabel="actor ID" />);
+        expect(screen.getByText(UUID)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /copy actor id/i })).toBeInTheDocument();
+    });
+});

--- a/src/app/(app)/org/admin/audit-logs/AuditIdentityLabel.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditIdentityLabel.tsx
@@ -33,7 +33,8 @@ export function AuditIdentityLabel({
         return <span className="text-xs text-(--ink-muted)">{emptyLabel}</span>;
     }
 
-    const containerClass = layout === "stacked" ? "flex flex-col gap-1" : "flex flex-wrap items-center gap-2";
+    const containerClass =
+        layout === "stacked" ? "flex flex-col gap-1" : "flex flex-wrap items-center gap-2";
 
     return (
         <div className={containerClass}>

--- a/src/app/(app)/org/admin/audit-logs/AuditIdentityLabel.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditIdentityLabel.tsx
@@ -1,0 +1,47 @@
+import { EntityLabel } from "@/components/labels/EntityLabel";
+import { CopyIdButton } from "./CopyIdButton";
+
+type AuditIdentityLabelProps = {
+    /** Raw actor/resource identifier from the audit-log API. */
+    id: string | null;
+    /** Rendered when `id` is null — e.g. "System" for an unattributed action. */
+    emptyLabel: string;
+    /** Description passed to the copy affordance, e.g. "actor ID". */
+    copyLabel: string;
+    /** "stacked" for compact table cells, "inline" for the wider detail drawer. */
+    layout?: "stacked" | "inline";
+};
+
+/**
+ * Resolved actor/resource identity display (CHAOS-2843, design system A7).
+ *
+ * The audit-log API currently returns only a bare id for `user_id` and
+ * `resource_id` — no display name field exists on `AuditLog` yet. `EntityLabel`
+ * is still the canonical primitive: it renders the name when one IS available
+ * (once the API adds one) and otherwise shows the explicit "Unresolved"
+ * treatment rather than a raw id as the primary label. The full id is always
+ * shown as secondary, copyable text alongside it so investigators can still
+ * trace the record without the id ever being the primary label.
+ */
+export function AuditIdentityLabel({
+    id,
+    emptyLabel,
+    copyLabel,
+    layout = "stacked",
+}: AuditIdentityLabelProps) {
+    if (!id) {
+        return <span className="text-xs text-(--ink-muted)">{emptyLabel}</span>;
+    }
+
+    const containerClass = layout === "stacked" ? "flex flex-col gap-1" : "flex flex-wrap items-center gap-2";
+
+    return (
+        <div className={containerClass}>
+            <EntityLabel id={id} className="text-xs font-medium" />
+            <div className="flex items-center gap-1.5">
+                <span className="font-mono text-xs text-(--ink-muted)">{id}</span>
+                <CopyIdButton value={id} label={copyLabel} />
+            </div>
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, userEvent } from "@/test/utils";
+import { AuditLogDetailDrawer } from "./AuditLogDetailDrawer";
+import type { AuditLog } from "@/lib/admin/types";
+
+function makeEntry(overrides: Partial<AuditLog> = {}): AuditLog {
+    return {
+        id: "al-1",
+        org_id: "org-1",
+        user_id: "550e8400-e29b-41d4-a716-446655440000",
+        action: "team.role_change",
+        resource_type: "team_member",
+        resource_id: "660e8400-e29b-41d4-a716-446655440111",
+        description: "Promoted a member to admin",
+        changes: { old_role: "member", new_role: "admin" },
+        request_metadata: { ip: "203.0.113.4" },
+        status: "success",
+        error_message: null,
+        created_at: "2025-01-01T12:00:00Z",
+        ...overrides,
+    };
+}
+
+describe("AuditLogDetailDrawer", () => {
+    beforeEach(() => {
+        userEvent.setup();
+    });
+    afterEach(() => cleanup());
+
+    it("renders nothing when closed", () => {
+        render(<AuditLogDetailDrawer entry={makeEntry()} isOpen={false} onCloseAction={vi.fn()} />);
+        expect(screen.queryByTestId("audit-log-detail-drawer")).not.toBeInTheDocument();
+    });
+
+    it("renders nothing when there is no selected entry", () => {
+        render(<AuditLogDetailDrawer entry={null} isOpen={true} onCloseAction={vi.fn()} />);
+        expect(screen.queryByTestId("audit-log-detail-drawer")).not.toBeInTheDocument();
+    });
+
+    it("shows timestamp, actor, resource, action, and status when open", () => {
+        render(<AuditLogDetailDrawer entry={makeEntry()} isOpen={true} onCloseAction={vi.fn()} />);
+
+        expect(screen.getByTestId("audit-log-detail-drawer")).toBeInTheDocument();
+        expect(screen.getByText("Jan 1, 2025, 12:00 PM UTC")).toBeInTheDocument();
+        expect(screen.getByText("team.role_change")).toBeInTheDocument();
+        expect(screen.getByText("team_member")).toBeInTheDocument();
+        expect(screen.getByText("Success")).toBeInTheDocument();
+        expect(screen.getAllByText("Unresolved")).toHaveLength(2);
+    });
+
+    it("renders the payload and context as typed, labeled fields — never a raw JSON dump", () => {
+        render(<AuditLogDetailDrawer entry={makeEntry()} isOpen={true} onCloseAction={vi.fn()} />);
+
+        expect(screen.getByText("Old Role")).toBeInTheDocument();
+        expect(screen.getByText("member")).toBeInTheDocument();
+        expect(screen.getByText("Ip")).toBeInTheDocument();
+        expect(screen.getByText("203.0.113.4")).toBeInTheDocument();
+        expect(screen.queryByText(/"old_role":"member"/)).not.toBeInTheDocument();
+    });
+
+    it("shows an empty-payload message when changes and request context are both null", () => {
+        render(
+            <AuditLogDetailDrawer
+                entry={makeEntry({ changes: null, request_metadata: null })}
+                isOpen={true}
+                onCloseAction={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.getByText("No change payload was returned for this event."),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText("No request context was returned for this event."),
+        ).toBeInTheDocument();
+    });
+
+    it("offers a copy affordance for the audit entry's own id", () => {
+        render(<AuditLogDetailDrawer entry={makeEntry()} isOpen={true} onCloseAction={vi.fn()} />);
+        expect(screen.getByRole("button", { name: /copy audit entry id/i })).toBeInTheDocument();
+    });
+
+    it("calls onCloseAction when the close button is clicked", async () => {
+        const onCloseAction = vi.fn();
+        const user = userEvent.setup();
+        render(<AuditLogDetailDrawer entry={makeEntry()} isOpen={true} onCloseAction={onCloseAction} />);
+
+        await user.click(screen.getByTitle(/close panel/i));
+
+        expect(onCloseAction).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onCloseAction when the backdrop is clicked", async () => {
+        const onCloseAction = vi.fn();
+        const user = userEvent.setup();
+        render(<AuditLogDetailDrawer entry={makeEntry()} isOpen={true} onCloseAction={onCloseAction} />);
+
+        await user.click(screen.getByRole("button", { name: /close panel/i }));
+
+        expect(onCloseAction).toHaveBeenCalled();
+    });
+});

--- a/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.test.tsx
@@ -48,7 +48,7 @@ describe("AuditLogDetailDrawer", () => {
         expect(screen.getAllByText("Unresolved")).toHaveLength(2);
     });
 
-    it("renders the payload and context as typed, labeled fields — never a raw JSON dump", () => {
+    it("renders Changes and Request details as typed, labeled fields — never a raw JSON dump", () => {
         render(<AuditLogDetailDrawer entry={makeEntry()} isOpen={true} onCloseAction={vi.fn()} />);
 
         expect(screen.getByText("Old Role")).toBeInTheDocument();
@@ -58,7 +58,7 @@ describe("AuditLogDetailDrawer", () => {
         expect(screen.queryByText(/"old_role":"member"/)).not.toBeInTheDocument();
     });
 
-    it("shows an empty-payload message when changes and request context are both null", () => {
+    it("shows customer-safe empty messages when Changes and Request details are both empty", () => {
         render(
             <AuditLogDetailDrawer
                 entry={makeEntry({ changes: null, request_metadata: null })}
@@ -68,10 +68,10 @@ describe("AuditLogDetailDrawer", () => {
         );
 
         expect(
-            screen.getByText("No change payload was returned for this event."),
+            screen.getByText("No changes were recorded for this event."),
         ).toBeInTheDocument();
         expect(
-            screen.getByText("No request context was returned for this event."),
+            screen.getByText("No request details were recorded for this event."),
         ).toBeInTheDocument();
     });
 

--- a/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.test.tsx
@@ -67,9 +67,7 @@ describe("AuditLogDetailDrawer", () => {
             />,
         );
 
-        expect(
-            screen.getByText("No changes were recorded for this event."),
-        ).toBeInTheDocument();
+        expect(screen.getByText("No changes were recorded for this event.")).toBeInTheDocument();
         expect(
             screen.getByText("No request details were recorded for this event."),
         ).toBeInTheDocument();
@@ -83,7 +81,13 @@ describe("AuditLogDetailDrawer", () => {
     it("calls onCloseAction when the close button is clicked", async () => {
         const onCloseAction = vi.fn();
         const user = userEvent.setup();
-        render(<AuditLogDetailDrawer entry={makeEntry()} isOpen={true} onCloseAction={onCloseAction} />);
+        render(
+            <AuditLogDetailDrawer
+                entry={makeEntry()}
+                isOpen={true}
+                onCloseAction={onCloseAction}
+            />,
+        );
 
         await user.click(screen.getByTitle(/close panel/i));
 
@@ -93,7 +97,13 @@ describe("AuditLogDetailDrawer", () => {
     it("calls onCloseAction when the backdrop is clicked", async () => {
         const onCloseAction = vi.fn();
         const user = userEvent.setup();
-        render(<AuditLogDetailDrawer entry={makeEntry()} isOpen={true} onCloseAction={onCloseAction} />);
+        render(
+            <AuditLogDetailDrawer
+                entry={makeEntry()}
+                isOpen={true}
+                onCloseAction={onCloseAction}
+            />,
+        );
 
         await user.click(screen.getByRole("button", { name: /close panel/i }));
 

--- a/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.tsx
@@ -30,7 +30,7 @@ function DetailRow({ label, children }: { label: string; children: ReactNode }) 
  * Row detail surface for the org audit-logs investigation page (CHAOS-2843).
  * A drawer, not a new route — modeled on {@link EvidencePanel}'s slide-over
  * pattern. Every field the audit-log API returns is shown as a typed,
- * labeled row; payload/context objects render through {@link PayloadFieldList}
+ * labeled row; the Changes/Request details sections render through {@link PayloadFieldList}
  * instead of a raw JSON dump.
  */
 export function AuditLogDetailDrawer({ entry, isOpen, onCloseAction }: AuditLogDetailDrawerProps) {
@@ -106,14 +106,14 @@ export function AuditLogDetailDrawer({ entry, isOpen, onCloseAction }: AuditLogD
                     </DetailRow>
 
                     <PayloadFieldList
-                        title="Change payload"
+                        title="Changes"
                         data={entry.changes}
-                        emptyMessage="No change payload was returned for this event."
+                        emptyMessage="No changes were recorded for this event."
                     />
                     <PayloadFieldList
-                        title="Request context"
+                        title="Request details"
                         data={entry.request_metadata}
-                        emptyMessage="No request context was returned for this event."
+                        emptyMessage="No request details were recorded for this event."
                     />
                 </div>
             </div>

--- a/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { AuditLog } from "@/lib/admin/types";
+import { formatDateTimeUTC } from "@/lib/formatters";
+import { CTA_LABELS } from "@/lib/design/cta";
+import { AuditIdentityLabel } from "./AuditIdentityLabel";
+import { AuditStatusBadge } from "./AuditStatusBadge";
+import { CopyIdButton } from "./CopyIdButton";
+import { PayloadFieldList } from "./PayloadFieldList";
+
+type AuditLogDetailDrawerProps = {
+    entry: AuditLog | null;
+    isOpen: boolean;
+    onCloseAction: () => void;
+};
+
+function DetailRow({ label, children }: { label: string; children: ReactNode }) {
+    return (
+        <div className="flex gap-3 text-sm">
+            <span className="w-28 shrink-0 pt-0.5 text-xs uppercase tracking-wide text-(--ink-muted)">
+                {label}
+            </span>
+            <div className="min-w-0 flex-1">{children}</div>
+        </div>
+    );
+}
+
+/**
+ * Row detail surface for the org audit-logs investigation page (CHAOS-2843).
+ * A drawer, not a new route — modeled on {@link EvidencePanel}'s slide-over
+ * pattern. Every field the audit-log API returns is shown as a typed,
+ * labeled row; payload/context objects render through {@link PayloadFieldList}
+ * instead of a raw JSON dump.
+ */
+export function AuditLogDetailDrawer({ entry, isOpen, onCloseAction }: AuditLogDetailDrawerProps) {
+    if (!isOpen || !entry) return null;
+
+    return (
+        <div className="fixed inset-0 z-50 flex justify-end" data-testid="audit-log-detail-drawer">
+            <button
+                type="button"
+                aria-label={CTA_LABELS.closePanel}
+                className="absolute inset-0 bg-black/50"
+                onClick={onCloseAction}
+            />
+            <div className="relative z-10 flex h-full w-full flex-col rounded-l-3xl border-l border-(--card-stroke) bg-card shadow-2xl md:max-w-lg">
+                <header className="flex items-center justify-between border-b border-(--card-stroke) bg-(--card-90) p-6">
+                    <div>
+                        <p className="text-xs uppercase tracking-widest text-(--ink-muted)">
+                            Audit event
+                        </p>
+                        <h2 className="mt-1 font-mono text-lg font-semibold text-foreground">
+                            {entry.action}
+                        </h2>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onCloseAction}
+                        title={CTA_LABELS.closePanel}
+                        className="rounded-full border border-(--card-stroke) p-2 text-xs uppercase tracking-widest text-(--ink-muted) transition-colors hover:bg-(--card-70) hover:text-foreground"
+                    >
+                        ✕
+                    </button>
+                </header>
+
+                <div className="flex-1 space-y-4 overflow-y-auto p-6">
+                    <DetailRow label="Timestamp">{formatDateTimeUTC(entry.created_at)}</DetailRow>
+                    <DetailRow label="Status">
+                        <AuditStatusBadge status={entry.status} />
+                    </DetailRow>
+                    <DetailRow label="Actor">
+                        <AuditIdentityLabel
+                            id={entry.user_id}
+                            emptyLabel="System"
+                            copyLabel="actor ID"
+                            layout="inline"
+                        />
+                    </DetailRow>
+                    <DetailRow label="Resource">
+                        <div className="space-y-1">
+                            <span className="text-xs uppercase tracking-wide text-(--ink-muted)">
+                                {entry.resource_type}
+                            </span>
+                            <AuditIdentityLabel
+                                id={entry.resource_id}
+                                emptyLabel="—"
+                                copyLabel="resource ID"
+                                layout="inline"
+                            />
+                        </div>
+                    </DetailRow>
+                    {entry.description && (
+                        <DetailRow label="Description">{entry.description}</DetailRow>
+                    )}
+                    {entry.error_message && (
+                        <DetailRow label="Error">
+                            <span className="text-(--negative)">{entry.error_message}</span>
+                        </DetailRow>
+                    )}
+                    <DetailRow label="Entry ID">
+                        <div className="flex items-center gap-2">
+                            <span className="font-mono text-xs text-(--ink-muted)">{entry.id}</span>
+                            <CopyIdButton value={entry.id} label="audit entry ID" />
+                        </div>
+                    </DetailRow>
+
+                    <PayloadFieldList
+                        title="Change payload"
+                        data={entry.changes}
+                        emptyMessage="No change payload was returned for this event."
+                    />
+                    <PayloadFieldList
+                        title="Request context"
+                        data={entry.request_metadata}
+                        emptyMessage="No request context was returned for this event."
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/audit-logs/AuditLogEmptyState.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogEmptyState.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, userEvent } from "@/test/utils";
+import { AuditLogEmptyState } from "./AuditLogEmptyState";
+
+describe("AuditLogEmptyState", () => {
+    afterEach(() => cleanup());
+
+    it("shows a distinct initial empty state with no reset action when no filters are applied", () => {
+        render(<AuditLogEmptyState hasActiveFilters={false} onResetAction={vi.fn()} />);
+
+        expect(screen.getByTestId("audit-log-empty-initial")).toBeInTheDocument();
+        expect(screen.getByText("No audit events recorded yet")).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: /reset filters/i })).not.toBeInTheDocument();
+    });
+
+    it("shows a distinct filtered empty state with a reset action when filters are applied", () => {
+        render(<AuditLogEmptyState hasActiveFilters={true} onResetAction={vi.fn()} />);
+
+        expect(screen.getByTestId("audit-log-empty-filtered")).toBeInTheDocument();
+        expect(screen.getByText("No audit events match these filters")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /reset filters/i })).toBeInTheDocument();
+    });
+
+    it("renders different titles for the initial vs filtered states", () => {
+        const { rerender } = render(
+            <AuditLogEmptyState hasActiveFilters={false} onResetAction={vi.fn()} />,
+        );
+        const initialTitle = screen.getByText("No audit events recorded yet").textContent;
+
+        rerender(<AuditLogEmptyState hasActiveFilters={true} onResetAction={vi.fn()} />);
+        const filteredTitle = screen.getByText("No audit events match these filters").textContent;
+
+        expect(initialTitle).not.toBe(filteredTitle);
+    });
+
+    it("calls onResetAction when the Reset filters action is clicked", async () => {
+        const onResetAction = vi.fn();
+        const user = userEvent.setup();
+        render(<AuditLogEmptyState hasActiveFilters={true} onResetAction={onResetAction} />);
+
+        await user.click(screen.getByRole("button", { name: /reset filters/i }));
+
+        expect(onResetAction).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/app/(app)/org/admin/audit-logs/AuditLogEmptyState.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogEmptyState.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { DataState } from "@/components/ui/DataState";
+import { Button } from "@/components/shared/Button";
+import { CTA_LABELS } from "@/lib/design/cta";
+
+type AuditLogEmptyStateProps = {
+    /** Whether the current query has any non-empty filter applied. */
+    hasActiveFilters: boolean;
+    onResetAction: () => void;
+};
+
+/**
+ * Customer-safe "no rows" states for the audit-logs investigation page
+ * (CHAOS-2843, design system A11): a filtered zero-result state is visually
+ * and textually distinct from the initial "nothing recorded yet" state, and
+ * the filtered state offers a one-click way back to an unfiltered view.
+ */
+export function AuditLogEmptyState({ hasActiveFilters, onResetAction }: AuditLogEmptyStateProps) {
+    if (hasActiveFilters) {
+        return (
+            <DataState
+                variant="detector-enabled-no-findings"
+                title="No audit events match these filters"
+                description="Try widening the date range or clearing a filter to see more activity."
+                data-testid="audit-log-empty-filtered"
+                action={
+                    <Button variant="secondary" onClick={onResetAction}>
+                        {CTA_LABELS.resetFilters}
+                    </Button>
+                }
+            />
+        );
+    }
+
+    return (
+        <DataState
+            variant="detector-enabled-no-findings"
+            title="No audit events recorded yet"
+            description="Audit events appear here as members take actions in your organization."
+            data-testid="audit-log-empty-initial"
+        />
+    );
+}

--- a/src/app/(app)/org/admin/audit-logs/AuditLogRows.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogRows.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, userEvent } from "@/test/utils";
+import { AuditLogRows } from "./AuditLogRows";
+import type { AuditLog } from "@/lib/admin/types";
+
+function makeEntry(overrides: Partial<AuditLog> = {}): AuditLog {
+    return {
+        id: "al-1",
+        org_id: "org-1",
+        user_id: "550e8400-e29b-41d4-a716-446655440000",
+        action: "user.login",
+        resource_type: "user",
+        resource_id: "660e8400-e29b-41d4-a716-446655440111",
+        description: null,
+        changes: null,
+        request_metadata: null,
+        status: "success",
+        error_message: null,
+        created_at: "2025-01-01T12:00:00Z",
+        ...overrides,
+    };
+}
+
+describe("AuditLogRows", () => {
+    beforeEach(() => {
+        // AuditIdentityLabel's copy affordance uses navigator.clipboard, which
+        // user-event's clipboard stub supplies once setup() has run.
+        userEvent.setup();
+    });
+    afterEach(() => cleanup());
+
+    it("renders the investigation column headers", () => {
+        render(<AuditLogRows entries={[makeEntry()]} onRowSelectAction={vi.fn()} />);
+        expect(screen.getByText("Timestamp")).toBeInTheDocument();
+        expect(screen.getByText("Action")).toBeInTheDocument();
+        expect(screen.getByText("Resource")).toBeInTheDocument();
+        expect(screen.getByText("Actor")).toBeInTheDocument();
+        expect(screen.getByText("Status")).toBeInTheDocument();
+    });
+
+    it("formats the timestamp deterministically in UTC", () => {
+        render(<AuditLogRows entries={[makeEntry()]} onRowSelectAction={vi.fn()} />);
+        expect(screen.getByText("Jan 1, 2025, 12:00 PM UTC")).toBeInTheDocument();
+    });
+
+    it("shows System when the entry has no actor", () => {
+        render(<AuditLogRows entries={[makeEntry({ user_id: null })]} onRowSelectAction={vi.fn()} />);
+        expect(screen.getByText("System")).toBeInTheDocument();
+    });
+
+    it("shows an Unresolved treatment for actor and resource ids with no known name", () => {
+        render(<AuditLogRows entries={[makeEntry()]} onRowSelectAction={vi.fn()} />);
+        expect(screen.getAllByText("Unresolved")).toHaveLength(2);
+    });
+
+    it("calls onRowSelectAction with the clicked entry", async () => {
+        const onRowSelectAction = vi.fn();
+        const user = userEvent.setup();
+        const entry = makeEntry();
+        render(<AuditLogRows entries={[entry]} onRowSelectAction={onRowSelectAction} />);
+
+        await user.click(screen.getByRole("button", { name: /user\.login/i }));
+
+        expect(onRowSelectAction).toHaveBeenCalledWith(entry);
+    });
+
+    it("calls onRowSelectAction on Enter key when a row is focused", async () => {
+        const onRowSelectAction = vi.fn();
+        const user = userEvent.setup();
+        const entry = makeEntry();
+        render(<AuditLogRows entries={[entry]} onRowSelectAction={onRowSelectAction} />);
+
+        screen.getByRole("button", { name: /user\.login/i }).focus();
+        await user.keyboard("{Enter}");
+
+        expect(onRowSelectAction).toHaveBeenCalledWith(entry);
+    });
+
+    it("does not open the row when a copy affordance inside it is clicked", async () => {
+        const onRowSelectAction = vi.fn();
+        const user = userEvent.setup();
+        render(<AuditLogRows entries={[makeEntry()]} onRowSelectAction={onRowSelectAction} />);
+
+        await user.click(screen.getAllByRole("button", { name: /copy resource id/i })[0]);
+
+        expect(onRowSelectAction).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/(app)/org/admin/audit-logs/AuditLogRows.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogRows.test.tsx
@@ -22,10 +22,13 @@ function makeEntry(overrides: Partial<AuditLog> = {}): AuditLog {
 }
 
 describe("AuditLogRows", () => {
+    let user: ReturnType<typeof userEvent.setup>;
+
     beforeEach(() => {
-        // AuditIdentityLabel's copy affordance uses navigator.clipboard, which
-        // user-event's clipboard stub supplies once setup() has run.
-        userEvent.setup();
+        // userEvent.setup() installs its own jsdom-friendly clipboard stub, so
+        // AuditIdentityLabel's copy affordance has something real to write to.
+        user = userEvent.setup();
+        vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
     });
     afterEach(() => cleanup());
 
@@ -53,35 +56,60 @@ describe("AuditLogRows", () => {
         expect(screen.getAllByText("Unresolved")).toHaveLength(2);
     });
 
-    it("calls onRowSelectAction with the clicked entry", async () => {
+    it("calls onRowSelectAction when the explicit Open details button is clicked", async () => {
         const onRowSelectAction = vi.fn();
-        const user = userEvent.setup();
         const entry = makeEntry();
         render(<AuditLogRows entries={[entry]} onRowSelectAction={onRowSelectAction} />);
 
-        await user.click(screen.getByRole("button", { name: /user\.login/i }));
+        await user.click(screen.getByRole("button", { name: /open details/i }));
+
+        expect(onRowSelectAction).toHaveBeenCalledTimes(1);
+        expect(onRowSelectAction).toHaveBeenCalledWith(entry);
+    });
+
+    it("calls onRowSelectAction on Enter when the Open details button is focused", async () => {
+        const onRowSelectAction = vi.fn();
+        const entry = makeEntry();
+        render(<AuditLogRows entries={[entry]} onRowSelectAction={onRowSelectAction} />);
+
+        screen.getByRole("button", { name: /open details/i }).focus();
+        await user.keyboard("{Enter}");
 
         expect(onRowSelectAction).toHaveBeenCalledWith(entry);
     });
 
-    it("calls onRowSelectAction on Enter key when a row is focused", async () => {
+    it("also opens the row as a pointer-only enhancement when clicking elsewhere in the row", async () => {
         const onRowSelectAction = vi.fn();
-        const user = userEvent.setup();
         const entry = makeEntry();
         render(<AuditLogRows entries={[entry]} onRowSelectAction={onRowSelectAction} />);
 
-        screen.getByRole("button", { name: /user\.login/i }).focus();
-        await user.keyboard("{Enter}");
+        await user.click(screen.getByText("user.login"));
 
         expect(onRowSelectAction).toHaveBeenCalledWith(entry);
     });
 
     it("does not open the row when a copy affordance inside it is clicked", async () => {
         const onRowSelectAction = vi.fn();
-        const user = userEvent.setup();
         render(<AuditLogRows entries={[makeEntry()]} onRowSelectAction={onRowSelectAction} />);
 
         await user.click(screen.getAllByRole("button", { name: /copy resource id/i })[0]);
+
+        expect(onRowSelectAction).not.toHaveBeenCalled();
+    });
+
+    it("copies without opening the drawer when a focused copy button is triggered via Enter or Space", async () => {
+        const onRowSelectAction = vi.fn();
+        const writeText = vi.spyOn(navigator.clipboard, "writeText");
+        render(<AuditLogRows entries={[makeEntry()]} onRowSelectAction={onRowSelectAction} />);
+
+        const copyButton = screen.getAllByRole("button", { name: /copy resource id/i })[0];
+        copyButton.focus();
+        await user.keyboard("{Enter}");
+
+        expect(writeText).toHaveBeenCalled();
+        expect(onRowSelectAction).not.toHaveBeenCalled();
+
+        await user.keyboard(" ");
 
         expect(onRowSelectAction).not.toHaveBeenCalled();
     });

--- a/src/app/(app)/org/admin/audit-logs/AuditLogRows.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogRows.test.tsx
@@ -47,7 +47,9 @@ describe("AuditLogRows", () => {
     });
 
     it("shows System when the entry has no actor", () => {
-        render(<AuditLogRows entries={[makeEntry({ user_id: null })]} onRowSelectAction={vi.fn()} />);
+        render(
+            <AuditLogRows entries={[makeEntry({ user_id: null })]} onRowSelectAction={vi.fn()} />,
+        );
         expect(screen.getByText("System")).toBeInTheDocument();
     });
 

--- a/src/app/(app)/org/admin/audit-logs/AuditLogRows.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogRows.tsx
@@ -1,32 +1,30 @@
 "use client";
 
-import type { KeyboardEvent } from "react";
 import type { AuditLog } from "@/lib/admin/types";
 import { formatDateTimeUTC } from "@/lib/formatters";
+import { CTA_LABELS } from "@/lib/design/cta";
 import { AuditIdentityLabel } from "./AuditIdentityLabel";
 import { AuditStatusBadge } from "./AuditStatusBadge";
 
 type AuditLogRowsProps = {
     entries: AuditLog[];
-    /** Opens the investigation detail surface for the clicked row. */
+    /** Opens the investigation detail surface for the selected row. */
     onRowSelectAction: (entry: AuditLog) => void;
 };
 
 /**
- * Investigation-oriented audit-log table (CHAOS-2843). Rows are clickable —
- * opening the detail drawer — and actor/resource cells render through
- * {@link AuditIdentityLabel} so an unresolved id never becomes the primary
- * label. Compact by design: the fuller record (description, payload,
- * context) lives in the detail drawer, not crammed into this row.
+ * Investigation-oriented audit-log table (CHAOS-2843). Actor/resource cells
+ * render through {@link AuditIdentityLabel} so an unresolved id never becomes
+ * the primary label. Compact by design: the fuller record (description,
+ * Changes, Request details) lives in the detail drawer, not this row.
+ *
+ * Each row exposes an explicit "Open details" button rather than making the
+ * whole `<tr>` a synthetic button — nested real buttons (the id copy
+ * affordances) inside a row-level `role="button"` would make Enter/Space on
+ * the copy button bubble up and also open the drawer. Clicking anywhere else
+ * in the row still opens it as a pointer-only enhancement.
  */
 export function AuditLogRows({ entries, onRowSelectAction }: AuditLogRowsProps) {
-    const handleKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, entry: AuditLog) => {
-        if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            onRowSelectAction(entry);
-        }
-    };
-
     return (
         <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
             <table className="w-full text-left text-sm">
@@ -37,17 +35,17 @@ export function AuditLogRows({ entries, onRowSelectAction }: AuditLogRowsProps) 
                         <th className="px-6 py-4 font-medium">Resource</th>
                         <th className="px-6 py-4 font-medium">Actor</th>
                         <th className="px-6 py-4 font-medium">Status</th>
+                        <th className="px-6 py-4 font-medium">
+                            <span className="sr-only">Details</span>
+                        </th>
                     </tr>
                 </thead>
                 <tbody className="divide-y divide-(--card-stroke)">
                     {entries.map((entry) => (
                         <tr
                             key={entry.id}
-                            role="button"
-                            tabIndex={0}
                             onClick={() => onRowSelectAction(entry)}
-                            onKeyDown={(event) => handleKeyDown(event, entry)}
-                            className="cursor-pointer hover:bg-(--card-70)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+                            className="cursor-pointer hover:bg-(--card-70)/50"
                         >
                             <td className="px-6 py-4 text-(--ink-muted)">
                                 {formatDateTimeUTC(entry.created_at)}
@@ -74,6 +72,18 @@ export function AuditLogRows({ entries, onRowSelectAction }: AuditLogRowsProps) 
                             </td>
                             <td className="px-6 py-4">
                                 <AuditStatusBadge status={entry.status} />
+                            </td>
+                            <td className="px-6 py-4 text-right">
+                                <button
+                                    type="button"
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+                                        onRowSelectAction(entry);
+                                    }}
+                                    className="rounded-full border border-(--card-stroke) px-3 py-1.5 text-xs font-medium text-(--ink-muted) transition-colors hover:border-(--ink-muted) hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+                                >
+                                    {CTA_LABELS.openDetails}
+                                </button>
                             </td>
                         </tr>
                     ))}

--- a/src/app/(app)/org/admin/audit-logs/AuditLogRows.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogRows.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { KeyboardEvent } from "react";
+import type { AuditLog } from "@/lib/admin/types";
+import { formatDateTimeUTC } from "@/lib/formatters";
+import { AuditIdentityLabel } from "./AuditIdentityLabel";
+import { AuditStatusBadge } from "./AuditStatusBadge";
+
+type AuditLogRowsProps = {
+    entries: AuditLog[];
+    /** Opens the investigation detail surface for the clicked row. */
+    onRowSelectAction: (entry: AuditLog) => void;
+};
+
+/**
+ * Investigation-oriented audit-log table (CHAOS-2843). Rows are clickable —
+ * opening the detail drawer — and actor/resource cells render through
+ * {@link AuditIdentityLabel} so an unresolved id never becomes the primary
+ * label. Compact by design: the fuller record (description, payload,
+ * context) lives in the detail drawer, not crammed into this row.
+ */
+export function AuditLogRows({ entries, onRowSelectAction }: AuditLogRowsProps) {
+    const handleKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, entry: AuditLog) => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onRowSelectAction(entry);
+        }
+    };
+
+    return (
+        <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+            <table className="w-full text-left text-sm">
+                <thead className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+                    <tr>
+                        <th className="px-6 py-4 font-medium">Timestamp</th>
+                        <th className="px-6 py-4 font-medium">Action</th>
+                        <th className="px-6 py-4 font-medium">Resource</th>
+                        <th className="px-6 py-4 font-medium">Actor</th>
+                        <th className="px-6 py-4 font-medium">Status</th>
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-(--card-stroke)">
+                    {entries.map((entry) => (
+                        <tr
+                            key={entry.id}
+                            role="button"
+                            tabIndex={0}
+                            onClick={() => onRowSelectAction(entry)}
+                            onKeyDown={(event) => handleKeyDown(event, entry)}
+                            className="cursor-pointer hover:bg-(--card-70)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+                        >
+                            <td className="px-6 py-4 text-(--ink-muted)">
+                                {formatDateTimeUTC(entry.created_at)}
+                            </td>
+                            <td className="px-6 py-4 font-mono text-xs">{entry.action}</td>
+                            <td className="px-6 py-4">
+                                <div className="flex flex-col gap-1">
+                                    <span className="text-xs uppercase tracking-wide text-(--ink-muted)">
+                                        {entry.resource_type}
+                                    </span>
+                                    <AuditIdentityLabel
+                                        id={entry.resource_id}
+                                        emptyLabel="—"
+                                        copyLabel="resource ID"
+                                    />
+                                </div>
+                            </td>
+                            <td className="px-6 py-4">
+                                <AuditIdentityLabel
+                                    id={entry.user_id}
+                                    emptyLabel="System"
+                                    copyLabel="actor ID"
+                                />
+                            </td>
+                            <td className="px-6 py-4">
+                                <AuditStatusBadge status={entry.status} />
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/audit-logs/AuditStatusBadge.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditStatusBadge.test.tsx
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { render, screen, cleanup } from "@/test/utils";
+import { AuditStatusBadge } from "./AuditStatusBadge";
+
+describe("AuditStatusBadge", () => {
+    afterEach(() => cleanup());
+
+    it("renders a positive tone for a success status", () => {
+        render(<AuditStatusBadge status="success" />);
+        expect(screen.getByText("Success")).toHaveClass("text-(--positive)");
+    });
+
+    it("renders a negative tone for any non-success status", () => {
+        render(<AuditStatusBadge status="failure" />);
+        expect(screen.getByText("Failure")).toHaveClass("text-(--negative)");
+    });
+
+    it("renders a muted 'Unknown' tone when status is missing", () => {
+        render(<AuditStatusBadge status={null} />);
+        expect(screen.getByText("Unknown")).toHaveClass("text-(--ink-muted)");
+    });
+
+    it("is case-insensitive when detecting success", () => {
+        render(<AuditStatusBadge status="SUCCESS" />);
+        expect(screen.getByText("SUCCESS")).toHaveClass("text-(--positive)");
+    });
+});

--- a/src/app/(app)/org/admin/audit-logs/AuditStatusBadge.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditStatusBadge.tsx
@@ -1,0 +1,33 @@
+type AuditStatusBadgeProps = {
+    status: string | null | undefined;
+};
+
+const TONE_CLASSES = {
+    positive: "border-(--positive)/30 bg-(--positive)/15 text-(--positive)",
+    negative: "border-(--negative)/30 bg-(--negative)/15 text-(--negative)",
+    muted: "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)",
+} as const;
+
+function capitalize(value: string): string {
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/**
+ * Token-based status badge for audit-log rows/detail (CHAOS-2843, design
+ * system Part C2: semantic status tokens, not raw hex). The API only
+ * documents a `status` string, so any non-"success" value is treated as
+ * negative rather than assuming a fixed enum the backend hasn't committed to.
+ */
+export function AuditStatusBadge({ status }: AuditStatusBadgeProps) {
+    const normalized = status?.trim().toLowerCase();
+    const tone = normalized === "success" ? "positive" : normalized ? "negative" : "muted";
+    const label = status?.trim() ? capitalize(status.trim()) : "Unknown";
+
+    return (
+        <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold ${TONE_CLASSES[tone]}`}
+        >
+            {label}
+        </span>
+    );
+}

--- a/src/app/(app)/org/admin/audit-logs/CopyIdButton.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/CopyIdButton.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, userEvent } from "@/test/utils";
+import { CopyIdButton } from "./CopyIdButton";
+
+let user: ReturnType<typeof userEvent.setup>;
+let writeText: ReturnType<typeof vi.spyOn>;
+
+describe("CopyIdButton", () => {
+    beforeEach(() => {
+        // userEvent.setup() installs its own jsdom-friendly clipboard stub
+        // (navigator.clipboard) the first time it runs, so the spy must be
+        // attached to that stub afterwards rather than pre-defining the
+        // property ourselves.
+        user = userEvent.setup();
+        writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+    });
+    afterEach(() => cleanup());
+    it("renders the copy affordance using the CTA registry label", () => {
+        render(<CopyIdButton value="entity-123" label="resource ID" />);
+        expect(screen.getByRole("button", { name: /copy resource id/i })).toBeInTheDocument();
+    });
+
+    it("copies the given value to the clipboard on click", async () => {
+        render(<CopyIdButton value="entity-123" label="resource ID" />);
+        await user.click(screen.getByRole("button", { name: /copy resource id/i }));
+
+        expect(writeText).toHaveBeenCalledWith("entity-123");
+    });
+
+    it("shows a copied acknowledgement after a successful copy", async () => {
+        render(<CopyIdButton value="entity-123" label="actor ID" />);
+        const button = screen.getByRole("button", { name: /copy actor id/i });
+        await user.click(button);
+
+        expect(button).toHaveAttribute("title", "Copied to clipboard");
+    });
+
+    it("stops the click from bubbling to a parent row handler", async () => {
+        const onRowClick = vi.fn();
+
+        render(
+            <div onClick={onRowClick}>
+                <CopyIdButton value="entity-123" label="resource ID" />
+            </div>,
+        );
+        await user.click(screen.getByRole("button", { name: /copy resource id/i }));
+
+        expect(onRowClick).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/(app)/org/admin/audit-logs/CopyIdButton.tsx
+++ b/src/app/(app)/org/admin/audit-logs/CopyIdButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState, type MouseEvent } from "react";
+import { Button } from "@/components/shared/Button";
+import { CTA_LABELS } from "@/lib/design/cta";
+
+type CopyIdButtonProps = {
+    /** Full identifier value to place on the clipboard. */
+    value: string;
+    /** Human-readable description of what is being copied, e.g. "actor ID". */
+    label: string;
+    className?: string;
+};
+
+const COPIED_RESET_DELAY_MS = 1500;
+
+/**
+ * Copy affordance for an audit-log identifier (CHAOS-2843, A7). Only ever
+ * rendered next to an id that actually exists — never invented as a
+ * placeholder. Visible text always comes from the CTA registry; the
+ * "copied" acknowledgement is conveyed through a non-text glyph and the
+ * `title`/`aria-label` so no ad-hoc CTA phrasing is introduced.
+ */
+export function CopyIdButton({ value, label, className }: CopyIdButtonProps) {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+        if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(value);
+        }
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), COPIED_RESET_DELAY_MS);
+    };
+
+    return (
+        <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleCopy}
+            aria-label={`Copy ${label}`}
+            title={copied ? "Copied to clipboard" : `Copy ${label}`}
+            className={className}
+        >
+            {copied && <span aria-hidden="true">✓ </span>}
+            {CTA_LABELS.copy}
+        </Button>
+    );
+}

--- a/src/app/(app)/org/admin/audit-logs/PayloadFieldList.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/PayloadFieldList.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { render, screen, cleanup } from "@/test/utils";
+import { PayloadFieldList } from "./PayloadFieldList";
+
+describe("PayloadFieldList", () => {
+    afterEach(() => cleanup());
+
+    it("shows the empty message when data is null", () => {
+        render(
+            <PayloadFieldList title="Change payload" data={null} emptyMessage="No payload returned." />,
+        );
+        expect(screen.getByText("No payload returned.")).toBeInTheDocument();
+    });
+
+    it("shows the empty message when data is an empty object", () => {
+        render(
+            <PayloadFieldList title="Change payload" data={{}} emptyMessage="No payload returned." />,
+        );
+        expect(screen.getByText("No payload returned.")).toBeInTheDocument();
+    });
+
+    it("renders each field as a humanized, labeled row instead of a raw dump", () => {
+        render(
+            <PayloadFieldList
+                title="Change payload"
+                data={{ old_role: "member", new_role: "admin" }}
+                emptyMessage="No payload returned."
+            />,
+        );
+        expect(screen.getByText("Old Role")).toBeInTheDocument();
+        expect(screen.getByText("member")).toBeInTheDocument();
+        expect(screen.getByText("New Role")).toBeInTheDocument();
+        expect(screen.getByText("admin")).toBeInTheDocument();
+        expect(screen.queryByText(/"old_role":"member"/)).not.toBeInTheDocument();
+    });
+
+    it("formats booleans and null leaf values", () => {
+        render(
+            <PayloadFieldList
+                title="Request context"
+                data={{ is_automated: true, previous_value: null }}
+                emptyMessage="No context returned."
+            />,
+        );
+        expect(screen.getByText("Yes")).toBeInTheDocument();
+        expect(screen.getByText("—")).toBeInTheDocument();
+    });
+
+    it("stringifies a nested object as one field's leaf value", () => {
+        render(
+            <PayloadFieldList
+                title="Change payload"
+                data={{ role: { old: "member", new: "admin" } }}
+                emptyMessage="No payload returned."
+            />,
+        );
+        expect(screen.getByText('{"old":"member","new":"admin"}')).toBeInTheDocument();
+    });
+});

--- a/src/app/(app)/org/admin/audit-logs/PayloadFieldList.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/PayloadFieldList.test.tsx
@@ -6,25 +6,21 @@ describe("PayloadFieldList", () => {
     afterEach(() => cleanup());
 
     it("shows the empty message when data is null", () => {
-        render(
-            <PayloadFieldList title="Change payload" data={null} emptyMessage="No payload returned." />,
-        );
-        expect(screen.getByText("No payload returned.")).toBeInTheDocument();
+        render(<PayloadFieldList title="Changes" data={null} emptyMessage="No changes recorded." />);
+        expect(screen.getByText("No changes recorded.")).toBeInTheDocument();
     });
 
     it("shows the empty message when data is an empty object", () => {
-        render(
-            <PayloadFieldList title="Change payload" data={{}} emptyMessage="No payload returned." />,
-        );
-        expect(screen.getByText("No payload returned.")).toBeInTheDocument();
+        render(<PayloadFieldList title="Changes" data={{}} emptyMessage="No changes recorded." />);
+        expect(screen.getByText("No changes recorded.")).toBeInTheDocument();
     });
 
-    it("renders each field as a humanized, labeled row instead of a raw dump", () => {
+    it("renders each flat field as a humanized, labeled row instead of a raw dump", () => {
         render(
             <PayloadFieldList
-                title="Change payload"
+                title="Changes"
                 data={{ old_role: "member", new_role: "admin" }}
-                emptyMessage="No payload returned."
+                emptyMessage="No changes recorded."
             />,
         );
         expect(screen.getByText("Old Role")).toBeInTheDocument();
@@ -37,23 +33,63 @@ describe("PayloadFieldList", () => {
     it("formats booleans and null leaf values", () => {
         render(
             <PayloadFieldList
-                title="Request context"
+                title="Request details"
                 data={{ is_automated: true, previous_value: null }}
-                emptyMessage="No context returned."
+                emptyMessage="No request details recorded."
             />,
         );
         expect(screen.getByText("Yes")).toBeInTheDocument();
         expect(screen.getByText("—")).toBeInTheDocument();
     });
 
-    it("stringifies a nested object as one field's leaf value", () => {
+    it("flattens a nested object into dotted-path labeled rows instead of a raw dump", () => {
         render(
             <PayloadFieldList
-                title="Change payload"
+                title="Changes"
                 data={{ role: { old: "member", new: "admin" } }}
-                emptyMessage="No payload returned."
+                emptyMessage="No changes recorded."
             />,
         );
-        expect(screen.getByText('{"old":"member","new":"admin"}')).toBeInTheDocument();
+        expect(screen.getByText("Role \u203A Old")).toBeInTheDocument();
+        expect(screen.getByText("member")).toBeInTheDocument();
+        expect(screen.getByText("Role \u203A New")).toBeInTheDocument();
+        expect(screen.getByText("admin")).toBeInTheDocument();
+        expect(screen.queryByText(/"old":"member"/)).not.toBeInTheDocument();
+    });
+
+    it("renders an array of primitives as comma-joined text", () => {
+        render(
+            <PayloadFieldList
+                title="Changes"
+                data={{ tags: ["urgent", "billing"] }}
+                emptyMessage="No changes recorded."
+            />,
+        );
+        expect(screen.getByText("Tags")).toBeInTheDocument();
+        expect(screen.getByText("urgent, billing")).toBeInTheDocument();
+    });
+
+    it("summarizes an array of objects as a count instead of dumping them", () => {
+        render(
+            <PayloadFieldList
+                title="Changes"
+                data={{ members: [{ id: "1" }, { id: "2" }, { id: "3" }] }}
+                emptyMessage="No changes recorded."
+            />,
+        );
+        expect(screen.getByText("Members")).toBeInTheDocument();
+        expect(screen.getByText("3 nested values")).toBeInTheDocument();
+    });
+
+    it("summarizes structures nested beyond the flattening depth instead of dumping them", () => {
+        render(
+            <PayloadFieldList
+                title="Changes"
+                data={{ a: { b: { c: { d: "x", e: "y" } } } }}
+                emptyMessage="No changes recorded."
+            />,
+        );
+        expect(screen.getByText("A \u203A B \u203A C")).toBeInTheDocument();
+        expect(screen.getByText("2 nested values")).toBeInTheDocument();
     });
 });

--- a/src/app/(app)/org/admin/audit-logs/PayloadFieldList.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/PayloadFieldList.test.tsx
@@ -6,7 +6,9 @@ describe("PayloadFieldList", () => {
     afterEach(() => cleanup());
 
     it("shows the empty message when data is null", () => {
-        render(<PayloadFieldList title="Changes" data={null} emptyMessage="No changes recorded." />);
+        render(
+            <PayloadFieldList title="Changes" data={null} emptyMessage="No changes recorded." />,
+        );
         expect(screen.getByText("No changes recorded.")).toBeInTheDocument();
     });
 

--- a/src/app/(app)/org/admin/audit-logs/PayloadFieldList.tsx
+++ b/src/app/(app)/org/admin/audit-logs/PayloadFieldList.tsx
@@ -35,11 +35,7 @@ function summarizeArray(items: unknown[]): string {
  * as readable text; anything deeper or an array of objects becomes a count
  * summary instead of a blob.
  */
-function flattenPayload(
-    data: Record<string, unknown>,
-    prefix = "",
-    depth = 0,
-): FlattenedField[] {
+function flattenPayload(data: Record<string, unknown>, prefix = "", depth = 0): FlattenedField[] {
     return Object.entries(data).flatMap(([key, value]): FlattenedField[] => {
         const path = prefix ? `${prefix}.${key}` : key;
 
@@ -85,7 +81,9 @@ export function PayloadFieldList({ title, data, emptyMessage }: PayloadFieldList
                 <dl className="grid gap-2 text-sm">
                     {fields.map(({ path, value }) => (
                         <div key={path} className="flex gap-2">
-                            <dt className="w-36 shrink-0 text-(--ink-muted)">{humanizePath(path)}</dt>
+                            <dt className="w-36 shrink-0 text-(--ink-muted)">
+                                {humanizePath(path)}
+                            </dt>
                             <dd className="min-w-0 break-words font-mono text-xs">
                                 {formatFieldValue(value)}
                             </dd>

--- a/src/app/(app)/org/admin/audit-logs/PayloadFieldList.tsx
+++ b/src/app/(app)/org/admin/audit-logs/PayloadFieldList.tsx
@@ -1,48 +1,91 @@
 type PayloadFieldListProps = {
     title: string;
     data: Record<string, unknown> | null;
-    /** Customer-safe message when the API returned no payload for this section. */
+    /** Customer-safe message shown when the API recorded nothing for this section. */
     emptyMessage: string;
 };
 
-function humanizeKey(key: string): string {
-    return key
+type FlattenedField = { path: string; value: unknown };
+
+/** Recursion stops after this many levels of nesting — deeper structures summarize instead. */
+const MAX_NESTING_DEPTH = 2;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPrimitive(value: unknown): boolean {
+    return value === null || value === undefined || typeof value !== "object";
+}
+
+function countLabel(count: number): string {
+    return `${count} nested value${count === 1 ? "" : "s"}`;
+}
+
+function summarizeArray(items: unknown[]): string {
+    if (items.length === 0) return "(none)";
+    if (items.every(isPrimitive)) return items.map((item) => formatFieldValue(item)).join(", ");
+    return countLabel(items.length);
+}
+
+/**
+ * Flattens a payload object into labeled leaf rows (CHAOS-2843, design
+ * system A9) — never a raw JSON dump. Nested objects become dotted-path rows
+ * (e.g. `role.old`) up to {@link MAX_NESTING_DEPTH}; arrays of primitives join
+ * as readable text; anything deeper or an array of objects becomes a count
+ * summary instead of a blob.
+ */
+function flattenPayload(
+    data: Record<string, unknown>,
+    prefix = "",
+    depth = 0,
+): FlattenedField[] {
+    return Object.entries(data).flatMap(([key, value]): FlattenedField[] => {
+        const path = prefix ? `${prefix}.${key}` : key;
+
+        if (Array.isArray(value)) {
+            return [{ path, value: summarizeArray(value) }];
+        }
+        if (isPlainObject(value)) {
+            if (depth >= MAX_NESTING_DEPTH) {
+                return [{ path, value: countLabel(Object.keys(value).length) }];
+            }
+            return flattenPayload(value, path, depth + 1);
+        }
+        return [{ path, value }];
+    });
+}
+
+function humanizeSegment(segment: string): string {
+    return segment
         .split("_")
         .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
         .join(" ");
 }
 
+function humanizePath(path: string): string {
+    return path.split(".").map(humanizeSegment).join(" \u203A ");
+}
+
 function formatFieldValue(value: unknown): string {
     if (value === null || value === undefined) return "—";
     if (typeof value === "boolean") return value ? "Yes" : "No";
-    if (typeof value === "string" || typeof value === "number") return String(value);
-    try {
-        return JSON.stringify(value);
-    } catch {
-        return String(value);
-    }
+    return String(value);
 }
 
-/**
- * Renders an audit-log payload/context object as typed, labeled fields
- * (CHAOS-2843, design system A9) — never a raw JSON dump as the primary
- * content. Only a value that is itself a nested object/array falls back to
- * a compact `JSON.stringify` for that ONE field's leaf value, which stays a
- * labeled secondary detail rather than the section's primary content.
- */
 export function PayloadFieldList({ title, data, emptyMessage }: PayloadFieldListProps) {
-    const entries = data ? Object.entries(data) : [];
+    const fields = data ? flattenPayload(data) : [];
 
     return (
         <section className="space-y-2 rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4">
             <p className="text-xs uppercase tracking-widest text-(--ink-muted)">{title}</p>
-            {entries.length === 0 ? (
+            {fields.length === 0 ? (
                 <p className="text-sm text-(--ink-muted)">{emptyMessage}</p>
             ) : (
                 <dl className="grid gap-2 text-sm">
-                    {entries.map(([key, value]) => (
-                        <div key={key} className="flex gap-2">
-                            <dt className="w-36 shrink-0 text-(--ink-muted)">{humanizeKey(key)}</dt>
+                    {fields.map(({ path, value }) => (
+                        <div key={path} className="flex gap-2">
+                            <dt className="w-36 shrink-0 text-(--ink-muted)">{humanizePath(path)}</dt>
                             <dd className="min-w-0 break-words font-mono text-xs">
                                 {formatFieldValue(value)}
                             </dd>

--- a/src/app/(app)/org/admin/audit-logs/PayloadFieldList.tsx
+++ b/src/app/(app)/org/admin/audit-logs/PayloadFieldList.tsx
@@ -1,0 +1,55 @@
+type PayloadFieldListProps = {
+    title: string;
+    data: Record<string, unknown> | null;
+    /** Customer-safe message when the API returned no payload for this section. */
+    emptyMessage: string;
+};
+
+function humanizeKey(key: string): string {
+    return key
+        .split("_")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ");
+}
+
+function formatFieldValue(value: unknown): string {
+    if (value === null || value === undefined) return "—";
+    if (typeof value === "boolean") return value ? "Yes" : "No";
+    if (typeof value === "string" || typeof value === "number") return String(value);
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}
+
+/**
+ * Renders an audit-log payload/context object as typed, labeled fields
+ * (CHAOS-2843, design system A9) — never a raw JSON dump as the primary
+ * content. Only a value that is itself a nested object/array falls back to
+ * a compact `JSON.stringify` for that ONE field's leaf value, which stays a
+ * labeled secondary detail rather than the section's primary content.
+ */
+export function PayloadFieldList({ title, data, emptyMessage }: PayloadFieldListProps) {
+    const entries = data ? Object.entries(data) : [];
+
+    return (
+        <section className="space-y-2 rounded-2xl border border-(--card-stroke) bg-(--card-90) p-4">
+            <p className="text-xs uppercase tracking-widest text-(--ink-muted)">{title}</p>
+            {entries.length === 0 ? (
+                <p className="text-sm text-(--ink-muted)">{emptyMessage}</p>
+            ) : (
+                <dl className="grid gap-2 text-sm">
+                    {entries.map(([key, value]) => (
+                        <div key={key} className="flex gap-2">
+                            <dt className="w-36 shrink-0 text-(--ink-muted)">{humanizeKey(key)}</dt>
+                            <dd className="min-w-0 break-words font-mono text-xs">
+                                {formatFieldValue(value)}
+                            </dd>
+                        </div>
+                    ))}
+                </dl>
+            )}
+        </section>
+    );
+}

--- a/src/app/(app)/org/admin/audit-logs/page.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/page.test.tsx
@@ -1,0 +1,100 @@
+/** OrgAuditLogPage integration tests — CHAOS-2843. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, userEvent, waitFor, within } from "@/test/utils";
+import type { AuditLog, AuditLogFilter } from "@/lib/admin/types";
+import OrgAuditLogPage from "./page";
+
+const mockListAuditLogs = vi.fn();
+vi.mock("@/lib/admin/server", () => ({
+    listAuditLogs: (...args: unknown[]) => mockListAuditLogs(...args),
+}));
+
+vi.mock("@/components/admin/AdminTierContext", () => ({
+    useAdminTier: () => ({
+        tier: "enterprise",
+        features: { audit_log: true },
+        minSyncIntervalHours: 0.25,
+        limits: {},
+    }),
+}));
+
+function makeEntry(overrides: Partial<AuditLog> = {}): AuditLog {
+    return {
+        id: "al-1",
+        org_id: "org-1",
+        user_id: null,
+        action: "org.create",
+        resource_type: "organization",
+        resource_id: "org-1",
+        description: "Created the organization",
+        changes: null,
+        request_metadata: null,
+        status: "success",
+        error_message: null,
+        created_at: "2025-01-01T12:00:00Z",
+        ...overrides,
+    };
+}
+
+function respondWith(items: AuditLog[]) {
+    return { data: { items, total: items.length, limit: 50, offset: 0 }, error: undefined };
+}
+
+describe("OrgAuditLogPage", () => {
+    beforeEach(() => {
+        mockListAuditLogs.mockReset();
+    });
+    afterEach(() => cleanup());
+
+    it("loads and renders audit rows on mount", async () => {
+        mockListAuditLogs.mockResolvedValue(respondWith([makeEntry()]));
+
+        render(<OrgAuditLogPage />);
+
+        await waitFor(() => expect(screen.getByText("org.create")).toBeInTheDocument());
+    });
+
+    it("supports apply \u2192 reset \u2192 apply-with-no-results with a customer-safe empty state distinct from the initial state", async () => {
+        mockListAuditLogs.mockResolvedValueOnce(respondWith([makeEntry()]));
+        const user = userEvent.setup();
+        render(<OrgAuditLogPage />);
+        await waitFor(() => expect(screen.getByText("org.create")).toBeInTheDocument());
+
+        // Apply a filter that matches nothing.
+        mockListAuditLogs.mockResolvedValueOnce(respondWith([]));
+        await user.type(screen.getByLabelText(/action/i), "user.invite");
+        await user.click(screen.getByRole("button", { name: /apply filters/i }));
+
+        await waitFor(() =>
+            expect(screen.getByTestId("audit-log-empty-filtered")).toBeInTheDocument(),
+        );
+        expect(screen.queryByTestId("audit-log-empty-initial")).not.toBeInTheDocument();
+
+        const lastFilterCall = mockListAuditLogs.mock.calls.at(-1)?.[0] as AuditLogFilter;
+        expect(lastFilterCall.action).toBe("user.invite");
+
+        // Reset clears the filter and re-queries immediately.
+        mockListAuditLogs.mockResolvedValueOnce(respondWith([makeEntry({ action: "user.invite" })]));
+        const emptyState = screen.getByTestId("audit-log-empty-filtered");
+        await user.click(within(emptyState).getByRole("button", { name: /reset filters/i }));
+
+        await waitFor(() => expect(screen.getByText("user.invite")).toBeInTheDocument());
+        expect(screen.getByLabelText(/action/i)).toHaveValue("");
+    });
+
+    it("opens the detail drawer on row click and closes it cleanly", async () => {
+        mockListAuditLogs.mockResolvedValue(respondWith([makeEntry()]));
+        const user = userEvent.setup();
+        render(<OrgAuditLogPage />);
+        await waitFor(() => expect(screen.getByText("org.create")).toBeInTheDocument());
+
+        await user.click(screen.getByRole("button", { name: /org\.create/i }));
+
+        expect(await screen.findByTestId("audit-log-detail-drawer")).toBeInTheDocument();
+        expect(screen.getByText("Created the organization")).toBeInTheDocument();
+
+        await user.click(screen.getByTitle(/close panel/i));
+
+        expect(screen.queryByTestId("audit-log-detail-drawer")).not.toBeInTheDocument();
+    });
+});

--- a/src/app/(app)/org/admin/audit-logs/page.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/page.test.tsx
@@ -74,7 +74,9 @@ describe("OrgAuditLogPage", () => {
         expect(lastFilterCall.action).toBe("user.invite");
 
         // Reset clears the filter and re-queries immediately.
-        mockListAuditLogs.mockResolvedValueOnce(respondWith([makeEntry({ action: "user.invite" })]));
+        mockListAuditLogs.mockResolvedValueOnce(
+            respondWith([makeEntry({ action: "user.invite" })]),
+        );
         const emptyState = screen.getByTestId("audit-log-empty-filtered");
         await user.click(within(emptyState).getByRole("button", { name: /reset filters/i }));
 

--- a/src/app/(app)/org/admin/audit-logs/page.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/page.test.tsx
@@ -88,7 +88,7 @@ describe("OrgAuditLogPage", () => {
         render(<OrgAuditLogPage />);
         await waitFor(() => expect(screen.getByText("org.create")).toBeInTheDocument());
 
-        await user.click(screen.getByRole("button", { name: /org\.create/i }));
+        await user.click(screen.getByRole("button", { name: /open details/i }));
 
         expect(await screen.findByTestId("audit-log-detail-drawer")).toBeInTheDocument();
         expect(screen.getByText("Created the organization")).toBeInTheDocument();

--- a/src/app/(app)/org/admin/audit-logs/page.tsx
+++ b/src/app/(app)/org/admin/audit-logs/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { AdminHeader } from "@/components/admin/AdminHeader";
-import { AuditLogTable } from "@/components/shared/AuditLogTable";
 import { AuditLogFilters } from "@/components/shared/AuditLogFilters";
 import { listAuditLogs } from "@/lib/admin/server";
 import type { AuditLog, AuditLogFilter } from "@/lib/admin/types";
 import { UpgradeGate } from "@/components/billing/UpgradeGate";
+import { CTA_LABELS } from "@/lib/design/cta";
+import { AuditLogRows } from "./AuditLogRows";
+import { AuditLogDetailDrawer } from "./AuditLogDetailDrawer";
+import { AuditLogEmptyState } from "./AuditLogEmptyState";
 
 export default function OrgAuditLogPage() {
     const [logs, setLogs] = useState<AuditLog[]>([]);
@@ -14,6 +17,12 @@ export default function OrgAuditLogPage() {
     const [error, setError] = useState<string | null>(null);
     const [filters, setFilters] = useState<AuditLogFilter>({});
     const [offset, setOffset] = useState(0);
+    const [selectedEntry, setSelectedEntry] = useState<AuditLog | null>(null);
+    const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+    // Remounts AuditLogFilters (via `key`) so a reset triggered from OUTSIDE
+    // the filter form — the empty-state action — also clears its inputs;
+    // the form's own Reset button already clears them directly.
+    const [filterResetKey, setFilterResetKey] = useState(0);
     const limit = 50;
 
     const fetchLogs = useCallback(async () => {
@@ -38,9 +47,20 @@ export default function OrgAuditLogPage() {
         fetchLogs();
     }, [fetchLogs]);
 
+    const hasActiveFilters = useMemo(
+        () => Object.values(filters).some((value) => Boolean(value)),
+        [filters],
+    );
+
     const handleFilter = (newFilters: AuditLogFilter) => {
         setFilters(newFilters);
         setOffset(0);
+    };
+
+    const handleResetFilters = () => {
+        setFilters({});
+        setOffset(0);
+        setFilterResetKey((key) => key + 1);
     };
 
     const handleNextPage = () => {
@@ -51,6 +71,15 @@ export default function OrgAuditLogPage() {
         setOffset((prev) => Math.max(0, prev - limit));
     };
 
+    const handleRowSelect = (entry: AuditLog) => {
+        setSelectedEntry(entry);
+        setIsDrawerOpen(true);
+    };
+
+    const handleCloseDrawer = () => {
+        setIsDrawerOpen(false);
+    };
+
     return (
         <UpgradeGate feature="audit_log" requiredTier="enterprise">
             <div>
@@ -59,10 +88,10 @@ export default function OrgAuditLogPage() {
                     description="Browse and filter audit events for your organization."
                 />
 
-                <AuditLogFilters variant="admin" onFilter={handleFilter} />
+                <AuditLogFilters key={filterResetKey} variant="admin" onFilter={handleFilter} />
 
                 {error && (
-                    <div className="mb-6 rounded-2xl border border-red-500/20 bg-red-500/10 p-4 text-red-500">
+                    <div className="mb-6 rounded-2xl border border-(--negative)/20 bg-(--negative)/10 p-4 text-(--negative)">
                         Error loading audit logs: {error}
                     </div>
                 )}
@@ -71,9 +100,14 @@ export default function OrgAuditLogPage() {
                     <div className="py-12 text-center text-(--ink-muted)">
                         Loading audit logs...
                     </div>
+                ) : error ? null : logs.length === 0 ? (
+                    <AuditLogEmptyState
+                        hasActiveFilters={hasActiveFilters}
+                        onResetAction={handleResetFilters}
+                    />
                 ) : (
                     <>
-                        <AuditLogTable variant="admin" entries={logs} />
+                        <AuditLogRows entries={logs} onRowSelectAction={handleRowSelect} />
                         <div className="mt-4 flex items-center justify-between">
                             <button
                                 type="button"
@@ -81,7 +115,7 @@ export default function OrgAuditLogPage() {
                                 disabled={offset === 0}
                                 className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
-                                Previous
+                                {CTA_LABELS.previousPage}
                             </button>
                             <span className="text-sm text-(--ink-muted)">
                                 Showing {offset + 1}-{offset + logs.length}
@@ -92,11 +126,17 @@ export default function OrgAuditLogPage() {
                                 disabled={logs.length < limit}
                                 className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
-                                Next
+                                {CTA_LABELS.nextPage}
                             </button>
                         </div>
                     </>
                 )}
+
+                <AuditLogDetailDrawer
+                    entry={selectedEntry}
+                    isOpen={isDrawerOpen}
+                    onCloseAction={handleCloseDrawer}
+                />
             </div>
         </UpgradeGate>
     );

--- a/src/components/shared/AuditLogFilters.test.tsx
+++ b/src/components/shared/AuditLogFilters.test.tsx
@@ -4,10 +4,11 @@ import userEvent from "@testing-library/user-event";
 import { AuditLogFilters } from "./AuditLogFilters";
 
 describe("AuditLogFilters — admin variant", () => {
-    it("renders labelled action and resource type inputs", () => {
+    it("renders labelled action, resource type, status, and date inputs", () => {
         render(<AuditLogFilters variant="admin" onFilter={vi.fn()} />);
         expect(screen.getByLabelText(/action/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/resource type/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/^status$/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
     });
@@ -32,14 +33,52 @@ describe("AuditLogFilters — admin variant", () => {
         expect(onFilter).toHaveBeenCalledWith({
             action: undefined,
             resource_type: undefined,
+            status: undefined,
             start_date: undefined,
             end_date: undefined,
         });
     });
 
-    it("renders the Search button", () => {
+    it("renders the Apply filters and Reset filters buttons", () => {
         render(<AuditLogFilters variant="admin" onFilter={vi.fn()} />);
-        expect(screen.getByRole("button", { name: /search/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /apply filters/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /reset filters/i })).toBeInTheDocument();
+    });
+
+    it("Reset immediately clears an empty filter without waiting for Apply", async () => {
+        const onFilter = vi.fn();
+        const user = userEvent.setup();
+        render(<AuditLogFilters variant="admin" onFilter={onFilter} />);
+
+        await user.type(screen.getByLabelText(/action/i), "org.create");
+        await user.selectOptions(screen.getByLabelText(/^status$/i), "success");
+        await user.click(screen.getByRole("button", { name: /reset filters/i }));
+
+        expect(onFilter).toHaveBeenCalledWith({
+            action: undefined,
+            resource_type: undefined,
+            status: undefined,
+            start_date: undefined,
+            end_date: undefined,
+        });
+        expect(screen.getByLabelText(/action/i)).toHaveValue("");
+        expect(screen.getByLabelText(/^status$/i)).toHaveValue("");
+    });
+
+    it("applies again cleanly after a reset (apply \u2192 reset \u2192 apply)", async () => {
+        const onFilter = vi.fn();
+        const user = userEvent.setup();
+        render(<AuditLogFilters variant="admin" onFilter={onFilter} />);
+
+        await user.type(screen.getByLabelText(/action/i), "org.create");
+        await user.click(screen.getByRole("button", { name: /apply filters/i }));
+        await user.click(screen.getByRole("button", { name: /reset filters/i }));
+        await user.type(screen.getByLabelText(/action/i), "user.invite");
+        await user.click(screen.getByRole("button", { name: /apply filters/i }));
+
+        expect(onFilter).toHaveBeenNthCalledWith(1, expect.objectContaining({ action: "org.create" }));
+        expect(onFilter).toHaveBeenNthCalledWith(2, expect.objectContaining({ action: undefined }));
+        expect(onFilter).toHaveBeenNthCalledWith(3, expect.objectContaining({ action: "user.invite" }));
     });
 });
 

--- a/src/components/shared/AuditLogFilters.test.tsx
+++ b/src/components/shared/AuditLogFilters.test.tsx
@@ -76,9 +76,15 @@ describe("AuditLogFilters — admin variant", () => {
         await user.type(screen.getByLabelText(/action/i), "user.invite");
         await user.click(screen.getByRole("button", { name: /apply filters/i }));
 
-        expect(onFilter).toHaveBeenNthCalledWith(1, expect.objectContaining({ action: "org.create" }));
+        expect(onFilter).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ action: "org.create" }),
+        );
         expect(onFilter).toHaveBeenNthCalledWith(2, expect.objectContaining({ action: undefined }));
-        expect(onFilter).toHaveBeenNthCalledWith(3, expect.objectContaining({ action: "user.invite" }));
+        expect(onFilter).toHaveBeenNthCalledWith(
+            3,
+            expect.objectContaining({ action: "user.invite" }),
+        );
     });
 });
 

--- a/src/components/shared/AuditLogFilters.tsx
+++ b/src/components/shared/AuditLogFilters.tsx
@@ -9,11 +9,17 @@
  *   - src/components/admin/billing/AuditLogFilters.tsx (variant="billing")
  *
  * Differences handled by variant:
- *   - "admin":   onFilter callback, fields: action / resource_type / start_date / end_date
+ *   - "admin":   onFilter callback, fields: action / resource_type / status / start_date / end_date
  *   - "billing": onApply callback, fields: action / resource_type / reconciliation_status / from_date / to_date
+ *
+ * Admin variant (CHAOS-2843): the Apply/Reset controls are explicit and
+ * independent — Reset clears every field and immediately re-queries with an
+ * empty filter (it does not wait for a follow-up Apply), matching the
+ * Apply-then-Reset-then-Apply investigation flow.
  */
 
 import { useState } from "react";
+import { CTA_LABELS } from "@/lib/design/cta";
 
 // ============================================================================
 // Shared filter shapes
@@ -22,6 +28,7 @@ import { useState } from "react";
 export type AdminAuditFilter = {
     action?: string;
     resource_type?: string;
+    status?: string;
     start_date?: string;
     end_date?: string;
 };
@@ -34,15 +41,33 @@ export type BillingAuditFilter = {
     to_date?: string;
 };
 
+const EMPTY_ADMIN_FILTER: AdminAuditFilter = {
+    action: undefined,
+    resource_type: undefined,
+    status: undefined,
+    start_date: undefined,
+    end_date: undefined,
+};
+
 // ============================================================================
-// Variant: admin — labelled inputs, full-width button
+// Variant: admin — labelled inputs, explicit Apply + Reset controls
 // ============================================================================
 
 function AdminAuditLogFilters({ onFilter }: { onFilter: (f: AdminAuditFilter) => void }) {
     const [action, setAction] = useState("");
     const [resourceType, setResourceType] = useState("");
+    const [status, setStatus] = useState("");
     const [startDate, setStartDate] = useState("");
     const [endDate, setEndDate] = useState("");
+
+    const handleReset = () => {
+        setAction("");
+        setResourceType("");
+        setStatus("");
+        setStartDate("");
+        setEndDate("");
+        onFilter(EMPTY_ADMIN_FILTER);
+    };
 
     return (
         <form
@@ -51,11 +76,12 @@ function AdminAuditLogFilters({ onFilter }: { onFilter: (f: AdminAuditFilter) =>
                 onFilter({
                     action: action || undefined,
                     resource_type: resourceType || undefined,
+                    status: status || undefined,
                     start_date: startDate || undefined,
                     end_date: endDate || undefined,
                 });
             }}
-            className="mb-6 grid gap-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4 sm:grid-cols-2 lg:grid-cols-5"
+            className="mb-6 grid gap-4 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-4 sm:grid-cols-2 lg:grid-cols-6"
         >
             <div>
                 <label
@@ -91,6 +117,24 @@ function AdminAuditLogFilters({ onFilter }: { onFilter: (f: AdminAuditFilter) =>
             </div>
             <div>
                 <label
+                    htmlFor="audit-status-filter"
+                    className="mb-1 block text-xs font-medium text-(--ink-muted)"
+                >
+                    Status
+                </label>
+                <select
+                    id="audit-status-filter"
+                    value={status}
+                    onChange={(e) => setStatus(e.target.value)}
+                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                >
+                    <option value="">Any status</option>
+                    <option value="success">Success</option>
+                    <option value="failure">Failure</option>
+                </select>
+            </div>
+            <div>
+                <label
                     htmlFor="audit-start-date"
                     className="mb-1 block text-xs font-medium text-(--ink-muted)"
                 >
@@ -119,12 +163,19 @@ function AdminAuditLogFilters({ onFilter }: { onFilter: (f: AdminAuditFilter) =>
                     className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
                 />
             </div>
-            <div className="flex items-end">
+            <div className="flex items-end gap-2">
                 <button
                     type="submit"
                     className="w-full rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90"
                 >
-                    Search
+                    {CTA_LABELS.applyFilters}
+                </button>
+                <button
+                    type="button"
+                    onClick={handleReset}
+                    className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium hover:border-(--ink-muted)"
+                >
+                    {CTA_LABELS.resetFilters}
                 </button>
             </div>
         </form>

--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -4,6 +4,7 @@ import {
     formatMetricValue,
     formatNumber,
     formatPercent,
+    formatDateTimeUTC,
     defaultFormatter,
     integerFormatter,
     compactFormatter,
@@ -113,5 +114,20 @@ describe("formatter caching", () => {
         });
         expect(formatter).not.toBe(compactFormatter);
         expect(customFormatters.size).toBe(1);
+    });
+});
+
+describe("formatDateTimeUTC", () => {
+    it("formats a timestamp deterministically in UTC regardless of runtime timezone", () => {
+        expect(formatDateTimeUTC("2025-01-01T12:34:00Z")).toBe("Jan 1, 2025, 12:34 PM UTC");
+    });
+
+    it("returns an em dash for a null or undefined value", () => {
+        expect(formatDateTimeUTC(null)).toBe("—");
+        expect(formatDateTimeUTC(undefined)).toBe("—");
+    });
+
+    it("returns an em dash for an unparseable value", () => {
+        expect(formatDateTimeUTC("not-a-date")).toBe("—");
     });
 });

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -115,6 +115,8 @@ export const CTA_LABELS = {
     manageConnections: "Manage connections",
     reviewIdentities: "Review identities",
     openSyncStatus: "Open sync status",
+    /** Open the row-level detail surface for an audit-log event (CHAOS-2843). */
+    openDetails: "Open details",
 } as const;
 
 export type CtaKey = keyof typeof CTA_LABELS;

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -117,3 +117,25 @@ export const formatDateUTC = (value: string | null | undefined): string => {
         timeZone: "UTC",
     });
 };
+
+/**
+ * Full date + time formatter locked to UTC (CHAOS-2843): audit-log
+ * timestamps must be unambiguous and deterministic across server/client
+ * rendering, so this never falls back to a bare `toLocaleString()` call.
+ * Appends an explicit `UTC` marker so investigators never misread the
+ * offset.
+ */
+export const formatDateTimeUTC = (value: string | null | undefined): string => {
+    if (!value) return "—";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "—";
+    return date.toLocaleString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        timeZone: "UTC",
+        timeZoneName: "short",
+    });
+};


### PR DESCRIPTION
## Summary

Audit investigation lane of the Org Admin UX redesign (CHAOS-2843): makes `/org/admin/audit-logs` an investigation surface instead of a raw table.

- Filters: explicit **Apply filters** / **Reset filters** (CTA registry) + a **Status** select (already in the `AuditLogFilter` API contract); reset clears and re-queries immediately. Billing filter variant unchanged.
- Row detail drawer (no new route): timestamp (deterministic UTC via new `formatDateTimeUTC`), actor, resource, action, status, description/error, and **Changes** / **Request details** rendered as typed labeled fields — nested values flatten to dotted-path rows, arrays comma-join, deeper structures summarize; never a raw JSON dump.
- Actor/resource labels via `EntityLabel`: names when the API provides them, otherwise an explicit Unresolved treatment with the full ID as secondary, copyable text — never a raw ID as primary label. API has no display-name field today; documented, not faked.
- Accessibility: rows are not synthetic buttons — each row has an explicit **Open details** button (`CTA_LABELS.openDetails`); copy buttons cannot trigger row selection from keyboard (regression-tested).
- Distinct empty states: initial ("No audit events recorded yet") vs filtered ("No audit events match these filters" + Reset CTA).

## Review gates
- Worker gates: lsp clean, focused eslint + `DESIGN_LINT=true` eslint clean, `tsc --noEmit` clean; focused 12 files / 86 tests; **full suite 277 files / 2591 tests passing**.
- Oracle code review: initial REVISE (nested JSON rendering, copy jargon, row a11y) → all fixed → **PASS** on re-review.

## Status
Draft until after-screenshots are attached at the integration QA pass.

## Visual evidence (live stack QA)

List with Apply/Reset + Status filter, Copy + Open details per row, Unresolved actor/resource treatment with copyable IDs, deterministic UTC timestamps:

![chaos-2843-audit-list-after.png](https://github.com/user-attachments/assets/f869f8df-03c6-4c14-94fc-ddb09733e681)

Detail drawer (Changes / Request details sections, copy affordances):

![chaos-2843-audit-detail-drawer-after.png](https://github.com/user-attachments/assets/0338f384-29d3-40e2-874c-0d5d63a620ff)

Filtered empty state (distinct from initial; Reset restores 50 rows and clears inputs — verified live):

![chaos-2843-audit-filtered-empty-after.png](https://github.com/user-attachments/assets/177f5960-1716-46e0-9f04-1b9bbffa19dd)

QA note (non-blocking follow-up): the drawer closes via the Close panel button and backdrop, but not via Escape — candidate for a later polish pass alongside shared-primitive adoption.
