### PR TITLE
fix(admin/integrations): unify credential status semantics across surfaces

### DIFF
--- a/src/app/(app)/org/admin/integrations/page.tsx
+++ b/src/app/(app)/org/admin/integrations/page.tsx
@@ -4,6 +4,10 @@ import {
     IntegrationProvider,
 } from "@/components/admin/integrations/IntegrationCard";
 import { listCredentials } from "@/lib/admin/server";
+import {
+    CREDENTIAL_STATUS_PRIORITY,
+    deriveCredentialStatus,
+} from "@/components/admin/integrations/credentialStatus";
 import type { ConnectionStatusType } from "@/components/admin/integrations/ConnectionStatus";
 
 const GitHubIcon = () => (
@@ -73,9 +77,8 @@ export default async function IntegrationsPage() {
     const getStatus = (providerId: string): ConnectionStatusType => {
         const creds = credentials.filter((c) => c.provider === providerId);
         if (creds.length === 0) return "not_configured";
-        if (creds.some((c) => c.last_test_success === false)) return "error";
-        if (creds.some((c) => c.last_test_success === true)) return "connected";
-        return "connected";
+        const statuses = new Set(creds.map(deriveCredentialStatus));
+        return CREDENTIAL_STATUS_PRIORITY.find((status) => statuses.has(status)) ?? "inactive";
     };
 
     const getCount = (providerId: string): number => {

--- a/src/components/admin/integrations/ConnectionStatus.test.tsx
+++ b/src/components/admin/integrations/ConnectionStatus.test.tsx
@@ -32,6 +32,28 @@ describe("ConnectionStatus", () => {
         expect(container.querySelector("span.bg-blue-500.animate-pulse")).toBeInTheDocument();
     });
 
+    it('renders "Connection failing" status with red styling', () => {
+        const { container } = render(<ConnectionStatus status="failing" />);
+
+        expect(screen.getByText("Connection failing")).toBeInTheDocument();
+        expect(container.querySelector("span.bg-red-500")).toBeInTheDocument();
+    });
+
+    it('renders "Needs verification" status with amber styling, never "Connected"', () => {
+        const { container } = render(<ConnectionStatus status="untested" />);
+
+        expect(screen.getByText("Needs verification")).toBeInTheDocument();
+        expect(container.querySelector("span.bg-amber-500")).toBeInTheDocument();
+        expect(screen.queryByText("Connected")).not.toBeInTheDocument();
+    });
+
+    it('renders "Inactive" status with gray styling', () => {
+        const { container } = render(<ConnectionStatus status="inactive" />);
+
+        expect(screen.getByText("Inactive")).toBeInTheDocument();
+        expect(container.querySelector("span.bg-gray-400")).toBeInTheDocument();
+    });
+
     it("applies custom className", () => {
         render(<ConnectionStatus status="connected" className="my-custom-class" />);
 

--- a/src/components/admin/integrations/ConnectionStatus.tsx
+++ b/src/components/admin/integrations/ConnectionStatus.tsx
@@ -2,13 +2,7 @@ import React from "react";
 import { CREDENTIAL_STATUS_META } from "./credentialStatus";
 
 export type ConnectionStatusType =
-    | "connected"
-    | "error"
-    | "not_configured"
-    | "connecting"
-    | "failing"
-    | "untested"
-    | "inactive";
+    "connected" | "error" | "not_configured" | "connecting" | "failing" | "untested" | "inactive";
 
 type ConnectionStatusProps = {
     status: ConnectionStatusType;

--- a/src/components/admin/integrations/ConnectionStatus.tsx
+++ b/src/components/admin/integrations/ConnectionStatus.tsx
@@ -1,42 +1,60 @@
 import React from "react";
+import { CREDENTIAL_STATUS_META } from "./credentialStatus";
 
-export type ConnectionStatusType = "connected" | "error" | "not_configured" | "connecting";
+export type ConnectionStatusType =
+    | "connected"
+    | "error"
+    | "not_configured"
+    | "connecting"
+    | "failing"
+    | "untested"
+    | "inactive";
 
 type ConnectionStatusProps = {
     status: ConnectionStatusType;
     className?: string;
 };
 
+const BADGE_CLASSES: Record<ConnectionStatusType, string> = {
+    connected: "bg-green-100 text-green-700 border-green-200",
+    error: "bg-red-100 text-red-700 border-red-200",
+    not_configured: "bg-gray-100 text-gray-600 border-gray-200",
+    connecting: "bg-blue-100 text-blue-700 border-blue-200",
+    failing: "bg-red-100 text-red-700 border-red-200",
+    untested: "bg-amber-100 text-amber-700 border-amber-200",
+    inactive: "bg-gray-100 text-gray-600 border-gray-200",
+};
+
+const DOT_CLASSES: Record<ConnectionStatusType, string> = {
+    connected: "bg-green-500",
+    error: "bg-red-500",
+    not_configured: "bg-gray-400",
+    connecting: "bg-blue-500 animate-pulse",
+    failing: "bg-red-500",
+    untested: "bg-amber-500",
+    inactive: "bg-gray-400",
+};
+
+// Labels for the credential-derived statuses come from the shared
+// credentialStatus registry so a badge never drifts from CredentialCard /
+// ProviderCredentialsList / the integrations list page's own copy.
+const LABELS: Record<ConnectionStatusType, string> = {
+    connected: CREDENTIAL_STATUS_META.connected.label,
+    error: "Connection Error",
+    not_configured: "Not Configured",
+    connecting: "Connecting...",
+    failing: CREDENTIAL_STATUS_META.failing.label,
+    untested: CREDENTIAL_STATUS_META.untested.label,
+    inactive: CREDENTIAL_STATUS_META.inactive.label,
+};
+
 export function ConnectionStatus({ status, className = "" }: ConnectionStatusProps) {
-    const styles = {
-        connected: "bg-green-100 text-green-700 border-green-200",
-        error: "bg-red-100 text-red-700 border-red-200",
-        not_configured: "bg-gray-100 text-gray-600 border-gray-200",
-        connecting: "bg-blue-100 text-blue-700 border-blue-200",
-    };
-
-    const labels = {
-        connected: "Connected",
-        error: "Connection Error",
-        not_configured: "Not Configured",
-        connecting: "Connecting...",
-    };
-
     return (
         <span
-            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${styles[status]} ${className}`}
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${BADGE_CLASSES[status]} ${className}`}
         >
-            {status === "connected" && (
-                <span className="mr-1.5 h-1.5 w-1.5 rounded-full bg-green-500" />
-            )}
-            {status === "error" && <span className="mr-1.5 h-1.5 w-1.5 rounded-full bg-red-500" />}
-            {status === "not_configured" && (
-                <span className="mr-1.5 h-1.5 w-1.5 rounded-full bg-gray-400" />
-            )}
-            {status === "connecting" && (
-                <span className="mr-1.5 h-1.5 w-1.5 rounded-full bg-blue-500 animate-pulse" />
-            )}
-            {labels[status]}
+            <span className={`mr-1.5 h-1.5 w-1.5 rounded-full ${DOT_CLASSES[status]}`} />
+            {LABELS[status]}
         </span>
     );
 }

--- a/src/components/admin/integrations/CredentialCard.tsx
+++ b/src/components/admin/integrations/CredentialCard.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { ConnectionStatus } from "./ConnectionStatus";
+import { deriveCredentialStatus } from "./credentialStatus";
 import { testConnection, deleteCredential } from "@/lib/admin/server";
 import type { IntegrationCredential } from "@/lib/admin/types";
 
@@ -23,12 +24,7 @@ export function CredentialCard({
     const [isDeleting, startDeleting] = useTransition();
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-    const status =
-        credential.last_test_success === true
-            ? "connected"
-            : credential.last_test_success === false
-              ? "error"
-              : "not_configured";
+    const status = deriveCredentialStatus(credential);
 
     const handleTest = () => {
         startTesting(async () => {

--- a/src/components/admin/integrations/IntegrationCard.test.tsx
+++ b/src/components/admin/integrations/IntegrationCard.test.tsx
@@ -17,7 +17,9 @@ function makeProvider(overrides: Partial<IntegrationProvider> = {}): Integration
 
 describe("IntegrationCard", () => {
     it('renders "Needs verification" and neutral count copy, never "1 connected"', () => {
-        render(<IntegrationCard provider={makeProvider({ status: "untested", credentialCount: 1 })} />);
+        render(
+            <IntegrationCard provider={makeProvider({ status: "untested", credentialCount: 1 })} />,
+        );
 
         expect(screen.getByText("Needs verification")).toBeInTheDocument();
         expect(screen.getByText("1 credential")).toBeInTheDocument();
@@ -26,14 +28,22 @@ describe("IntegrationCard", () => {
     });
 
     it("pluralizes credential count copy for more than one credential", () => {
-        render(<IntegrationCard provider={makeProvider({ status: "connected", credentialCount: 3 })} />);
+        render(
+            <IntegrationCard
+                provider={makeProvider({ status: "connected", credentialCount: 3 })}
+            />,
+        );
 
         expect(screen.getByText("3 credentials")).toBeInTheDocument();
         expect(screen.queryByText("3 connected")).not.toBeInTheDocument();
     });
 
     it("hides the count badge when there are no credentials", () => {
-        render(<IntegrationCard provider={makeProvider({ status: "not_configured", credentialCount: 0 })} />);
+        render(
+            <IntegrationCard
+                provider={makeProvider({ status: "not_configured", credentialCount: 0 })}
+            />,
+        );
 
         expect(screen.queryByText(/credential/)).not.toBeInTheDocument();
     });

--- a/src/components/admin/integrations/IntegrationCard.test.tsx
+++ b/src/components/admin/integrations/IntegrationCard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/utils";
+
+import { IntegrationCard, IntegrationProvider } from "./IntegrationCard";
+
+function makeProvider(overrides: Partial<IntegrationProvider> = {}): IntegrationProvider {
+    return {
+        id: "github",
+        name: "GitHub",
+        description: "Sync pull requests and issues.",
+        icon: <span data-testid="icon" />,
+        status: "connected",
+        credentialCount: 0,
+        ...overrides,
+    };
+}
+
+describe("IntegrationCard", () => {
+    it('renders "Needs verification" and neutral count copy, never "1 connected"', () => {
+        render(<IntegrationCard provider={makeProvider({ status: "untested", credentialCount: 1 })} />);
+
+        expect(screen.getByText("Needs verification")).toBeInTheDocument();
+        expect(screen.getByText("1 credential")).toBeInTheDocument();
+        expect(screen.queryByText("1 connected")).not.toBeInTheDocument();
+        expect(screen.queryByText("Connected")).not.toBeInTheDocument();
+    });
+
+    it("pluralizes credential count copy for more than one credential", () => {
+        render(<IntegrationCard provider={makeProvider({ status: "connected", credentialCount: 3 })} />);
+
+        expect(screen.getByText("3 credentials")).toBeInTheDocument();
+        expect(screen.queryByText("3 connected")).not.toBeInTheDocument();
+    });
+
+    it("hides the count badge when there are no credentials", () => {
+        render(<IntegrationCard provider={makeProvider({ status: "not_configured", credentialCount: 0 })} />);
+
+        expect(screen.queryByText(/credential/)).not.toBeInTheDocument();
+    });
+});

--- a/src/components/admin/integrations/IntegrationCard.tsx
+++ b/src/components/admin/integrations/IntegrationCard.tsx
@@ -26,7 +26,7 @@ export function IntegrationCard({ provider }: IntegrationCardProps) {
                     <div className="flex items-center gap-2">
                         {provider.credentialCount > 0 && (
                             <span className="inline-flex items-center rounded-full bg-(--surface-muted) px-2.5 py-0.5 text-xs font-medium text-(--ink-base)">
-                                {provider.credentialCount} connected
+                                {provider.credentialCount} credential{provider.credentialCount === 1 ? "" : "s"}
                             </span>
                         )}
                         <ConnectionStatus status={provider.status} />

--- a/src/components/admin/integrations/IntegrationCard.tsx
+++ b/src/components/admin/integrations/IntegrationCard.tsx
@@ -26,7 +26,8 @@ export function IntegrationCard({ provider }: IntegrationCardProps) {
                     <div className="flex items-center gap-2">
                         {provider.credentialCount > 0 && (
                             <span className="inline-flex items-center rounded-full bg-(--surface-muted) px-2.5 py-0.5 text-xs font-medium text-(--ink-base)">
-                                {provider.credentialCount} credential{provider.credentialCount === 1 ? "" : "s"}
+                                {provider.credentialCount} credential
+                                {provider.credentialCount === 1 ? "" : "s"}
                             </span>
                         )}
                         <ConnectionStatus status={provider.status} />

--- a/src/components/admin/integrations/ProviderCredentialsList.tsx
+++ b/src/components/admin/integrations/ProviderCredentialsList.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { CredentialCard } from "./CredentialCard";
+import { deriveCredentialStatus } from "./credentialStatus";
 import { IntegrationFormWrapper } from "@/app/(app)/org/admin/integrations/[provider]/IntegrationFormWrapper";
 import type { IntegrationCredential, Provider } from "@/lib/admin/types";
 import type { ConnectionStatusType } from "@/components/admin/integrations/ConnectionStatus";
@@ -13,11 +14,9 @@ type ProviderCredentialsListProps = {
     syncConfigs: { credential_id: string | null }[];
 };
 
-function getStatus(credential: IntegrationCredential | undefined): ConnectionStatusType {
+function getInitialStatus(credential: IntegrationCredential | undefined): ConnectionStatusType {
     if (!credential) return "not_configured";
-    if (credential.last_test_success === true) return "connected";
-    if (credential.last_test_success === false) return "error";
-    return "connected";
+    return deriveCredentialStatus(credential);
 }
 
 export function ProviderCredentialsList({
@@ -58,7 +57,7 @@ export function ProviderCredentialsList({
             <IntegrationFormWrapper
                 provider={provider}
                 providerName={providerName}
-                initialStatus={getStatus(editingCredential)}
+                initialStatus={getInitialStatus(editingCredential)}
                 existingCredential={editingCredential}
                 onCancel={handleCancel}
                 onSuccess={handleSuccess}

--- a/src/components/admin/integrations/credentialStatus.test.ts
+++ b/src/components/admin/integrations/credentialStatus.test.ts
@@ -53,9 +53,9 @@ describe("deriveCredentialStatus", () => {
     });
 
     it('returns "inactive" when is_active is false, regardless of last test result', () => {
-        expect(deriveCredentialStatus(makeCredential({ is_active: false, last_test_success: true }))).toBe(
-            "inactive",
-        );
+        expect(
+            deriveCredentialStatus(makeCredential({ is_active: false, last_test_success: true })),
+        ).toBe("inactive");
         expect(
             deriveCredentialStatus(makeCredential({ is_active: false, last_test_success: false })),
         ).toBe("inactive");
@@ -75,14 +75,19 @@ describe("CREDENTIAL_STATUS_META", () => {
         });
     });
 
-    it("never uses the word \"connected\" in the untested label", () => {
+    it('never uses the word "connected" in the untested label', () => {
         expect(CREDENTIAL_STATUS_META.untested.label.toLowerCase()).not.toContain("connected");
     });
 });
 
 describe("CREDENTIAL_STATUS_PRIORITY", () => {
     it("ranks failing above untested above connected above inactive", () => {
-        expect(CREDENTIAL_STATUS_PRIORITY).toEqual(["failing", "untested", "connected", "inactive"]);
+        expect(CREDENTIAL_STATUS_PRIORITY).toEqual([
+            "failing",
+            "untested",
+            "connected",
+            "inactive",
+        ]);
     });
 
     it("contains exactly the four credential statuses", () => {

--- a/src/components/admin/integrations/credentialStatus.test.ts
+++ b/src/components/admin/integrations/credentialStatus.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    CREDENTIAL_STATUS_META,
+    CREDENTIAL_STATUS_PRIORITY,
+    deriveCredentialStatus,
+} from "./credentialStatus";
+import type { IntegrationCredential } from "@/lib/admin/types";
+
+function makeCredential(overrides: Partial<IntegrationCredential> = {}): IntegrationCredential {
+    return {
+        id: "cred-1",
+        provider: "github",
+        name: "default",
+        is_active: true,
+        config: {},
+        last_test_at: null,
+        last_test_success: null,
+        last_test_error: null,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        ...overrides,
+    };
+}
+
+describe("deriveCredentialStatus", () => {
+    it('returns "connected" when active and the last test succeeded', () => {
+        const credential = makeCredential({ is_active: true, last_test_success: true });
+
+        expect(deriveCredentialStatus(credential)).toBe("connected");
+    });
+
+    it('returns "failing" when active and the last test failed', () => {
+        const credential = makeCredential({ is_active: true, last_test_success: false });
+
+        expect(deriveCredentialStatus(credential)).toBe("failing");
+    });
+
+    it('returns "untested" when active and last_test_success is null (never tested)', () => {
+        const credential = makeCredential({ is_active: true, last_test_success: null });
+
+        expect(deriveCredentialStatus(credential)).toBe("untested");
+    });
+
+    it('returns "untested" when active and last_test_success is undefined, never "connected"', () => {
+        const credential = makeCredential({
+            is_active: true,
+            last_test_success: undefined as unknown as null,
+        });
+
+        expect(deriveCredentialStatus(credential)).toBe("untested");
+        expect(deriveCredentialStatus(credential)).not.toBe("connected");
+    });
+
+    it('returns "inactive" when is_active is false, regardless of last test result', () => {
+        expect(deriveCredentialStatus(makeCredential({ is_active: false, last_test_success: true }))).toBe(
+            "inactive",
+        );
+        expect(
+            deriveCredentialStatus(makeCredential({ is_active: false, last_test_success: false })),
+        ).toBe("inactive");
+        expect(
+            deriveCredentialStatus(makeCredential({ is_active: false, last_test_success: null })),
+        ).toBe("inactive");
+    });
+});
+
+describe("CREDENTIAL_STATUS_META", () => {
+    it("provides a customer-safe label and tone for every status", () => {
+        expect(CREDENTIAL_STATUS_META).toEqual({
+            connected: { label: "Connected", tone: "positive" },
+            failing: { label: "Connection failing", tone: "negative" },
+            untested: { label: "Needs verification", tone: "caution" },
+            inactive: { label: "Inactive", tone: "neutral" },
+        });
+    });
+
+    it("never uses the word \"connected\" in the untested label", () => {
+        expect(CREDENTIAL_STATUS_META.untested.label.toLowerCase()).not.toContain("connected");
+    });
+});
+
+describe("CREDENTIAL_STATUS_PRIORITY", () => {
+    it("ranks failing above untested above connected above inactive", () => {
+        expect(CREDENTIAL_STATUS_PRIORITY).toEqual(["failing", "untested", "connected", "inactive"]);
+    });
+
+    it("contains exactly the four credential statuses", () => {
+        expect(new Set(CREDENTIAL_STATUS_PRIORITY)).toEqual(
+            new Set(Object.keys(CREDENTIAL_STATUS_META)),
+        );
+    });
+});

--- a/src/components/admin/integrations/credentialStatus.ts
+++ b/src/components/admin/integrations/credentialStatus.ts
@@ -1,0 +1,79 @@
+/**
+ * Single source of truth for integration credential status.
+ *
+ * CHAOS-2837 groundwork: CredentialCard, ProviderCredentialsList, and the
+ * integrations list page each computed this status independently and
+ * disagreed — most notably, an untested credential (never tested, or last
+ * test result unknown) silently rendered as "connected" in some surfaces.
+ * Every surface must derive status through `deriveCredentialStatus` so an
+ * untested credential always reads as "untested", never "connected".
+ */
+import type { IntegrationCredential } from "@/lib/admin/types";
+
+/** Credential status, derived purely from persisted fields. */
+export type CredentialStatus = "connected" | "failing" | "untested" | "inactive";
+
+/**
+ * Rollup priority (most to least urgent) for aggregating multiple
+ * credentials of the same provider into a single visual status: a failing
+ * credential outranks an untested one, which outranks a merely-inactive one.
+ */
+export const CREDENTIAL_STATUS_PRIORITY: readonly CredentialStatus[] = [
+    "failing",
+    "untested",
+    "connected",
+    "inactive",
+];
+
+type CredentialStatusTone = "positive" | "caution" | "negative" | "neutral";
+
+type CredentialStatusMeta = {
+    /** Customer-safe copy (docs/design-system.md A8 — no internal jargon). */
+    label: string;
+    tone: CredentialStatusTone;
+};
+
+function assertNever(value: never): never {
+    throw new Error(`Unhandled credential status: ${JSON.stringify(value)}`);
+}
+
+function credentialStatusMeta(status: CredentialStatus): CredentialStatusMeta {
+    switch (status) {
+        case "connected":
+            return { label: "Connected", tone: "positive" };
+        case "failing":
+            return { label: "Connection failing", tone: "negative" };
+        case "untested":
+            return { label: "Needs verification", tone: "caution" };
+        case "inactive":
+            return { label: "Inactive", tone: "neutral" };
+        default:
+            return assertNever(status);
+    }
+}
+
+/** Status → {label, tone} lookup, derived from the exhaustive switch above. */
+export const CREDENTIAL_STATUS_META: Record<CredentialStatus, CredentialStatusMeta> = {
+    connected: credentialStatusMeta("connected"),
+    failing: credentialStatusMeta("failing"),
+    untested: credentialStatusMeta("untested"),
+    inactive: credentialStatusMeta("inactive"),
+};
+
+/**
+ * Derive a credential's status from its persisted fields only.
+ *
+ * Rules:
+ * - `is_active === false` → "inactive" (deactivated; test result is moot).
+ * - `is_active` and `last_test_success === true` → "connected".
+ * - `is_active` and `last_test_success === false` → "failing".
+ * - `is_active` and `last_test_success` is `null`/`undefined` → "untested"
+ *   (never tested, or the test result is unknown) — this is the case that
+ *   must NEVER silently resolve to "connected".
+ */
+export function deriveCredentialStatus(credential: IntegrationCredential): CredentialStatus {
+    if (!credential.is_active) return "inactive";
+    if (credential.last_test_success === true) return "connected";
+    if (credential.last_test_success === false) return "failing";
+    return "untested";
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
                         "src/lib/**/__tests__/**/*.test.ts",
                         "src/utils/**/__tests__/**/*.test.ts",
                         "src/data/**/__tests__/**/*.test.ts",
+                        "src/components/**/*.test.ts",
                         "scripts/**/__tests__/**/*.test.mjs",
                     ],
                 },


### PR DESCRIPTION
## Summary

Credential-status groundwork for the Integrations lane of the Org Admin UX redesign (CHAOS-2837): one shared status derivation so every surface agrees.

- New `credentialStatus.ts`: `CredentialStatus = connected | failing | untested | inactive` with `deriveCredentialStatus` — `is_active=false → inactive`; `last_test_success` `true → connected`, `false → failing`, `null/undefined → untested` (an untested credential is NEVER silently "connected"). Exhaustive switch + `assertNever`; `CREDENTIAL_STATUS_PRIORITY` (`failing > untested > connected > inactive`) for per-provider rollups.
- Consumers unified: `CredentialCard`, `ProviderCredentialsList`, the integrations index page rollup, and `ConnectionStatus` extended with the new tones (labels from one meta source).
- `IntegrationCard` count badge now uses neutral copy ("1 credential" / "N credentials") so it cannot contradict a "Needs verification"/"Connection failing" status.
- `vitest.config.ts`: `src/components/**/*.test.ts` added to the node-env unit project (plain `.test.ts` under components previously matched no include pattern and would silently never run).
- Note: the task brief named the provider detail page as the third inconsistent surface; source inspection showed it has no status logic — the actual third surface was the integrations index page, fixed here.

## Review gates
- Worker gates: lsp clean, focused eslint + `DESIGN_LINT=true` eslint clean, `tsc --noEmit` clean; integrations suite 7 files / 38 tests (incl. 9 derivation boundary tests + 3 new IntegrationCard tests); **full suite 272 files / 2564 tests passing** pre-fix commit.
- Oracle code review: initial REVISE (count-badge copy contradiction) → fixed → **PASS** on re-review.

## Status
Draft until after-screenshots are attached at the integration QA pass.

## Visual evidence (live stack QA)

Integrations index — untested credentials read "Needs verification" (never silently "connected"), neutral "N credentials" counts, Linear correctly "Connected":

![chaos-2837-integrations-status-after.png](https://github.com/user-attachments/assets/c093ed11-a650-4bf8-b3b7-881e758bff94)

GitHub provider page — per-credential statuses from the shared derivation:

![chaos-2837-github-provider-status-after.png](https://github.com/user-attachments/assets/467091c6-664b-4023-8272-4f9a1d245208)
