### PR TITLE
fix(admin/sync): stale-filter progressed backfill jobs

### DIFF
--- a/src/components/admin/sync/BackfillStatus.test.tsx
+++ b/src/components/admin/sync/BackfillStatus.test.tsx
@@ -22,6 +22,7 @@ const RUNNING_JOB: BackfillJob = {
     started_at: "2026-07-02T15:05:00.000Z",
     completed_at: null,
     created_at: "2026-07-02T15:00:00.000Z",
+    updated_at: "2026-07-02T15:05:00.000Z",
 };
 
 describe("BackfillStatus", () => {

--- a/src/data/syncCoverageSample.ts
+++ b/src/data/syncCoverageSample.ts
@@ -709,6 +709,7 @@ export const SAMPLE_ACTIVE_BACKFILL_JOB: BackfillJob = {
     started_at: "2026-07-02T15:05:00.000Z",
     completed_at: null,
     created_at: "2026-07-02T15:00:00.000Z",
+    updated_at: "2026-07-02T15:05:00.000Z",
 };
 
 /** Named scenarios selectable via the `?backfill_scenario=` test-mode query param. */

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -293,6 +293,7 @@ describe("admin/server sync config actions", () => {
                     started_at: null,
                     completed_at: null,
                     created_at: "2026-06-01T00:00:00Z",
+                    updated_at: "2026-06-01T00:00:00Z",
                 },
                 {
                     id: "job-completed",
@@ -308,6 +309,7 @@ describe("admin/server sync config actions", () => {
                     started_at: "2026-05-01T00:00:00Z",
                     completed_at: "2026-05-01T01:00:00Z",
                     created_at: "2026-05-01T00:00:00Z",
+                    updated_at: "2026-05-01T01:00:00Z",
                 },
                 {
                     id: "job-active",
@@ -323,6 +325,7 @@ describe("admin/server sync config actions", () => {
                     started_at: hoursAgoIso(1),
                     completed_at: null,
                     created_at: hoursAgoIso(1),
+                    updated_at: hoursAgoIso(1),
                 },
             ];
             const fetchSpy = vi
@@ -373,6 +376,7 @@ describe("admin/server sync config actions", () => {
                     started_at: null,
                     completed_at: null,
                     created_at: hoursAgoIso(1),
+                    updated_at: hoursAgoIso(1),
                 },
             ];
             const fetchSpy = vi
@@ -407,6 +411,7 @@ describe("admin/server sync config actions", () => {
                     started_at: null,
                     completed_at: null,
                     created_at: hoursAgoIso(48),
+                    updated_at: hoursAgoIso(48),
                 },
             ];
             const fetchSpy = vi
@@ -441,6 +446,7 @@ describe("admin/server sync config actions", () => {
                     started_at: hoursAgoIso(1),
                     completed_at: null,
                     created_at: hoursAgoIso(48),
+                    updated_at: hoursAgoIso(1),
                 },
             ];
             const fetchSpy = vi
@@ -458,7 +464,7 @@ describe("admin/server sync config actions", () => {
             fetchSpy.mockRestore();
         });
 
-        it("keeps a job with real progress visible past the staleness cutoff (CHAOS-2868 review: age alone must not hide progressed jobs)", async () => {
+        it("keeps a progressed job visible when its freshness timestamp is recent", async () => {
             mockSession();
             const jobs = [
                 {
@@ -475,6 +481,7 @@ describe("admin/server sync config actions", () => {
                     started_at: hoursAgoIso(48),
                     completed_at: null,
                     created_at: hoursAgoIso(48),
+                    updated_at: hoursAgoIso(1),
                 },
             ];
             const fetchSpy = vi
@@ -489,6 +496,41 @@ describe("admin/server sync config actions", () => {
             const result = await getActiveBackfillJob("cfg-coverage");
 
             expect(result.data?.id).toBe("job-long-running");
+            fetchSpy.mockRestore();
+        });
+
+        it("excludes a progressed non-terminal job when its freshness timestamp is stale (CHAOS-2872)", async () => {
+            mockSession();
+            const jobs = [
+                {
+                    id: "job-progress-zombie",
+                    sync_config_id: "cfg-coverage",
+                    status: "running",
+                    since_date: "2026-06-01",
+                    before_date: "2026-06-05",
+                    total_chunks: 5,
+                    completed_chunks: 2,
+                    failed_chunks: 0,
+                    progress_pct: 40,
+                    error_message: null,
+                    started_at: hoursAgoIso(48),
+                    completed_at: null,
+                    created_at: hoursAgoIso(48),
+                    updated_at: hoursAgoIso(48),
+                },
+            ];
+            const fetchSpy = vi
+                .spyOn(global, "fetch")
+                .mockResolvedValue(
+                    new Response(
+                        JSON.stringify({ items: jobs, total: jobs.length, limit: 50, offset: 0 }),
+                        { status: 200 },
+                    ),
+                );
+
+            const result = await getActiveBackfillJob("cfg-coverage");
+
+            expect(result.data).toBeNull();
             fetchSpy.mockRestore();
         });
 
@@ -509,6 +551,7 @@ describe("admin/server sync config actions", () => {
                     started_at: null,
                     completed_at: null,
                     created_at: null,
+                    updated_at: null,
                 },
             ];
             const fetchSpy = vi

--- a/src/lib/admin/server/sync.ts
+++ b/src/lib/admin/server/sync.ts
@@ -132,34 +132,25 @@ export async function triggerBackfill(
 const ACTIVE_BACKFILL_STATUSES = new Set(["pending", "planned", "dispatching", "running"]);
 
 /**
- * Non-terminal jobs with ZERO recorded progress whose most recent activity
- * timestamp is older than this are treated as stranded zombies and excluded
- * from discovery (CHAOS-2868): the backend merges a linked SyncRun's status
- * over the stored BackfillJob row, so a job whose run got stuck/lost reports
- * pending|dispatching forever with 0% progress. Re-surfacing a week-old
- * zombie on every page load would otherwise pin the "Backfill in progress"
- * banner on indefinitely. Jobs with real progress are NEVER excluded by age
- * alone — a legitimate long-running backfill must stay visible.
+ * Non-terminal jobs whose most recent BackfillJob update is older than this are
+ * treated as stranded zombies and excluded from discovery (CHAOS-2868/2872):
+ * the backend merges a linked SyncRun's status over the stored BackfillJob row,
+ * so a lost run can report pending|dispatching|running forever, even after
+ * recording partial progress. Re-surfacing a week-old zombie on every page load
+ * would otherwise pin the "Backfill in progress" banner indefinitely. Freshly
+ * updated long-running backfills remain visible regardless of progress percent.
  */
 const ACTIVE_BACKFILL_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
-/** True when a job has recorded any forward progress (chunks or percent). */
-function hasBackfillProgress(job: BackfillJob): boolean {
-    return job.progress_pct > 0 || job.completed_chunks > 0 || job.failed_chunks > 0;
-}
-
 /**
- * True when a non-terminal, zero-progress job's activity is older than
- * ACTIVE_BACKFILL_MAX_AGE_MS. A job with any recorded progress is never
- * stale regardless of age (see ACTIVE_BACKFILL_MAX_AGE_MS doc).
+ * True when a non-terminal job's freshness timestamp is older than
+ * ACTIVE_BACKFILL_MAX_AGE_MS.
  */
 function isStaleBackfillJob(job: BackfillJob, now: number): boolean {
-    if (hasBackfillProgress(job)) return false;
-
     // Falsy/missing timestamps (defensive against a malformed row despite
     // the response type) are treated as NOT stale — age can't be judged, so
     // err on the side of keeping the job visible rather than hiding it.
-    const timestamp = job.started_at || job.created_at;
+    const timestamp = job.updated_at || job.started_at || job.created_at;
     if (!timestamp) return false;
 
     // Backend datetimes are stored `DateTime(timezone=True)` and always

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -373,6 +373,7 @@ export interface BackfillJob {
     started_at: string | null;
     completed_at: string | null;
     created_at: string;
+    updated_at: string;
 }
 
 export interface BackfillJobListResponse {


### PR DESCRIPTION
## Summary
- Add `updated_at` to the admin `BackfillJob` response type consumed by web.
- Use `updated_at` as the freshness timestamp for active backfill discovery.
- Filter non-terminal progressed jobs whose freshness is older than the 24h zombie cutoff.

Linear: CHAOS-2872
Companion OPS PR: https://github.com/full-chaos/dev-health-ops/pull/1200

## Verification
- `pnpm test:unit -- src/lib/admin/__tests__/server.test.ts src/components/admin/sync/BackfillStatus.test.tsx`
- `pnpm typecheck`
- `pnpm build`
- LSP diagnostics clean on changed files

## Visual evidence
Stale-progress filtered state: no `Backfill in progress` banner renders after stale active job discovery returns null.

![chaos-2872-stale-progress-filtered-after.png](https://github.com/user-attachments/assets/5186baf6-f5b4-4d16-a6f5-4d300568db07)
