### PR TITLE
fix(admin): credential timestamp hydration + audit drawer Escape-to-close

### DIFF
--- a/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.test.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.test.tsx
@@ -109,4 +109,36 @@ describe("AuditLogDetailDrawer", () => {
 
         expect(onCloseAction).toHaveBeenCalled();
     });
+
+    it("calls onCloseAction when Escape is pressed while open", async () => {
+        const onCloseAction = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <AuditLogDetailDrawer
+                entry={makeEntry()}
+                isOpen={true}
+                onCloseAction={onCloseAction}
+            />,
+        );
+
+        await user.keyboard("{Escape}");
+
+        expect(onCloseAction).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not close on Escape when the drawer is closed", async () => {
+        const onCloseAction = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <AuditLogDetailDrawer
+                entry={makeEntry()}
+                isOpen={false}
+                onCloseAction={onCloseAction}
+            />,
+        );
+
+        await user.keyboard("{Escape}");
+
+        expect(onCloseAction).not.toHaveBeenCalled();
+    });
 });

--- a/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.tsx
+++ b/src/app/(app)/org/admin/audit-logs/AuditLogDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import type { AuditLog } from "@/lib/admin/types";
 import { formatDateTimeUTC } from "@/lib/formatters";
 import { CTA_LABELS } from "@/lib/design/cta";
@@ -34,6 +34,17 @@ function DetailRow({ label, children }: { label: string; children: ReactNode }) 
  * instead of a raw JSON dump.
  */
 export function AuditLogDetailDrawer({ entry, isOpen, onCloseAction }: AuditLogDetailDrawerProps) {
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                onCloseAction();
+            }
+        };
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [isOpen, onCloseAction]);
+
     if (!isOpen || !entry) return null;
 
     return (

--- a/src/components/admin/integrations/CredentialCard.test.tsx
+++ b/src/components/admin/integrations/CredentialCard.test.tsx
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup } from "@/test/utils";
+import { CredentialCard } from "./CredentialCard";
+import type { IntegrationCredential } from "@/lib/admin/types";
+
+vi.mock("@/lib/admin/server", () => ({
+    testConnection: vi.fn(),
+    deleteCredential: vi.fn(),
+}));
+
+function makeCredential(overrides: Partial<IntegrationCredential> = {}): IntegrationCredential {
+    return {
+        id: "cred-1",
+        provider: "github",
+        name: "Primary GitHub",
+        is_active: true,
+        config: {},
+        last_test_at: "2025-01-01T12:00:00Z",
+        last_test_success: true,
+        last_test_error: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        ...overrides,
+    };
+}
+
+describe("CredentialCard", () => {
+    afterEach(() => cleanup());
+
+    it("renders the last-tested timestamp with deterministic UTC formatting (no locale drift)", () => {
+        render(
+            <CredentialCard
+                credential={makeCredential()}
+                providerName="GitHub"
+                isUsedBySyncConfigs={false}
+                onEdit={vi.fn()}
+            />,
+        );
+
+        // Server and client must agree on this string to avoid hydration mismatch.
+        expect(screen.getByText("Last tested: Jan 1, 2025, 12:00 PM UTC")).toBeInTheDocument();
+    });
+
+    it("shows 'Never tested' when there is no last_test_at", () => {
+        render(
+            <CredentialCard
+                credential={makeCredential({ last_test_at: null })}
+                providerName="GitHub"
+                isUsedBySyncConfigs={false}
+                onEdit={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText("Never tested")).toBeInTheDocument();
+    });
+});

--- a/src/components/admin/integrations/CredentialCard.tsx
+++ b/src/components/admin/integrations/CredentialCard.tsx
@@ -5,6 +5,8 @@ import { toast } from "sonner";
 import { ConnectionStatus } from "./ConnectionStatus";
 import { deriveCredentialStatus } from "./credentialStatus";
 import { testConnection, deleteCredential } from "@/lib/admin/server";
+import { formatDateTimeUTC } from "@/lib/formatters";
+import { CTA_LABELS } from "@/lib/design/cta";
 import type { IntegrationCredential } from "@/lib/admin/types";
 
 type CredentialCardProps = {
@@ -58,7 +60,7 @@ export function CredentialCard({
                 </div>
                 <div className="mb-6 text-sm text-(--ink-muted)">
                     {credential.last_test_at ? (
-                        <p>Last tested: {new Date(credential.last_test_at).toLocaleString()}</p>
+                        <p>Last tested: {formatDateTimeUTC(credential.last_test_at)}</p>
                     ) : (
                         <p>Never tested</p>
                     )}
@@ -79,7 +81,7 @@ export function CredentialCard({
                     disabled={isTesting || isDeleting}
                     className="inline-flex items-center justify-center rounded-md border border-(--border-subtle) bg-(--surface-base) px-3 py-1.5 text-sm font-medium text-(--ink-base) hover:bg-(--surface-muted) disabled:opacity-50"
                 >
-                    Edit
+                    {CTA_LABELS.edit}
                 </button>
                 <button
                     type="button"
@@ -87,7 +89,7 @@ export function CredentialCard({
                     disabled={isTesting || isDeleting}
                     className="inline-flex items-center justify-center rounded-md border border-red-500/20 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-500/20 disabled:opacity-50"
                 >
-                    Delete
+                    {CTA_LABELS.delete}
                 </button>
             </div>
 
@@ -114,7 +116,7 @@ export function CredentialCard({
                                 disabled={isDeleting}
                                 className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm hover:bg-(--card-80) disabled:opacity-50"
                             >
-                                Cancel
+                                {CTA_LABELS.cancel}
                             </button>
                             <button
                                 type="button"


### PR DESCRIPTION
## Org-admin polish: credential timestamp hydration + audit drawer Escape-to-close

Two small, independent follow-ups flagged during the Org Admin UX redesign epic.

### 1. `fix(admin)` — deterministic UTC credential timestamp (hydration mismatch)
`CredentialCard` rendered `new Date(credential.last_test_at).toLocaleString()`, which formats in the runtime locale/timezone. Server (UTC) and client (local) disagreed, producing a hydration mismatch on the GitHub provider page (noted in the epic handoff: `6/23/2026, 7:05:40 AM` vs `2:05:40 PM`).

- Render via `formatDateTimeUTC` — the same UTC, fixed `en-US` formatter already used by `UserTable` and `AuditLogDetailDrawer`, so SSR and client agree.
- Also routed the `Edit` / `Delete` / `Cancel` button copy through `CTA_LABELS` (the card was flagged by `design-lint/cta-from-registry`).
- New `CredentialCard.test.tsx` asserts the exact rendered string (`Last tested: Jan 1, 2025, 12:00 PM UTC`) and the never-tested state.

### 2. `feat(admin)` — audit log detail drawer closes on Escape
The investigation drawer (`AuditLogDetailDrawer`, CHAOS-2843 / #755 follow-up) could only be dismissed via the close button or backdrop click. Added a keydown listener (active only while open, cleaned up on unmount/close) that calls the close handler on `Escape`, matching standard slide-over affordances. Two regression tests: Escape closes when open; inert when closed.

### Verification
- `pnpm exec tsc --noEmit`: clean (0 errors)
- `eslint` on changed files: 0 errors
- `DESIGN_LINT=true eslint` on touched src: 0 errors
- `prettier --check`: clean
- `vitest` CredentialCard + AuditLogDetailDrawer: **12/12 passed** (2 credential + 10 drawer, incl. 2 new Escape tests)

SCREENSHOT-WAIVER: no visual/layout change. The audit-drawer change is keyboard-behavior only (zero visual delta). The credential timestamp is a date-format normalization to the repo-standard `formatDateTimeUTC` (same rendering approach already shipped in `UserTable`/`AuditLogDetailDrawer`), unit-locked by an assertion on the exact rendered string — it cannot introduce a layout regression.
