### PR TITLE
feat(admin): improve team ownership and identity mapping forms (CHAOS-2841)

### DIFF
--- a/src/app/(app)/org/admin/identities/[id]/edit/EditIdentityFormWrapper.tsx
+++ b/src/app/(app)/org/admin/identities/[id]/edit/EditIdentityFormWrapper.tsx
@@ -29,7 +29,12 @@ export function EditIdentityFormWrapper({ identity, teams }: EditIdentityFormWra
     const handleSubmit = async (data: Identity) => {
         setIsLoading(true);
 
-        const result = await updateIdentity(identity.id, {
+        // POST /identities is an upsert keyed on canonical_id — there is no
+        // PATCH /identities/{id} route, so the full desired state (including
+        // canonical_id and complete team_ids/provider_identities arrays) must
+        // be sent, not a partial diff.
+        const result = await updateIdentity({
+            canonical_id: data.canonical_id,
             display_name: data.display_name || undefined,
             email: data.email || undefined,
             provider_identities: data.provider_identities,

--- a/src/app/(app)/org/admin/teams/[id]/edit/EditTeamFormWrapper.tsx
+++ b/src/app/(app)/org/admin/teams/[id]/edit/EditTeamFormWrapper.tsx
@@ -10,9 +10,10 @@ import type { TeamMapping } from "@/lib/admin/types";
 
 type EditTeamFormWrapperProps = {
     team: TeamMapping;
+    linkedIdentityCount?: number;
 };
 
-export function EditTeamFormWrapper({ team }: EditTeamFormWrapperProps) {
+export function EditTeamFormWrapper({ team, linkedIdentityCount }: EditTeamFormWrapperProps) {
     const router = useRouter();
     const [isLoading, setIsLoading] = useState(false);
 
@@ -50,6 +51,7 @@ export function EditTeamFormWrapper({ team }: EditTeamFormWrapperProps) {
             onSubmit={handleSubmit}
             isEditing
             isLoading={isLoading}
+            linkedIdentityCount={linkedIdentityCount}
         />
     );
 }

--- a/src/app/(app)/org/admin/teams/[id]/edit/page.test.tsx
+++ b/src/app/(app)/org/admin/teams/[id]/edit/page.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * EditTeamPage — asserts the "Linked identities" preview count is never
+ * fabricated. When listIdentities() fails/returns no data, the page must
+ * pass linkedIdentityCount=undefined (so the preview row is omitted); it
+ * must only pass a real number when listIdentities() genuinely succeeded.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test/utils";
+import type { IdentityMapping, TeamMapping } from "@/lib/admin/types";
+import EditTeamPage from "./page";
+
+const mockGetTeam = vi.fn();
+const mockListIdentities = vi.fn();
+
+vi.mock("@/lib/admin/server", () => ({
+    getTeam: (...args: unknown[]) => mockGetTeam(...args),
+    listIdentities: (...args: unknown[]) => mockListIdentities(...args),
+}));
+
+vi.mock("./EditTeamFormWrapper", () => ({
+    EditTeamFormWrapper: ({ linkedIdentityCount }: { linkedIdentityCount?: number }) => (
+        <div data-testid="linked-identity-count">
+            {linkedIdentityCount === undefined ? "undefined" : linkedIdentityCount}
+        </div>
+    ),
+}));
+
+function makeTeam(overrides: Partial<TeamMapping> = {}): TeamMapping {
+    return {
+        id: "team-row-1",
+        team_id: "eng",
+        name: "Engineering",
+        description: null,
+        repo_patterns: [],
+        project_keys: [],
+        extra_data: {},
+        managed_fields: [],
+        sync_policy: 0,
+        flagged_changes: null,
+        last_drift_sync_at: null,
+        is_active: true,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        ...overrides,
+    };
+}
+
+function makeIdentity(overrides: Partial<IdentityMapping> = {}): IdentityMapping {
+    return {
+        id: "identity-1",
+        canonical_id: "alice",
+        display_name: null,
+        email: null,
+        provider_identities: {},
+        team_ids: [],
+        is_active: true,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        ...overrides,
+    };
+}
+
+describe("EditTeamPage — linked identity count", () => {
+    beforeEach(() => {
+        mockGetTeam.mockReset();
+        mockListIdentities.mockReset();
+    });
+
+    it("omits the preview row (linkedIdentityCount=undefined) when listIdentities fails", async () => {
+        mockGetTeam.mockResolvedValue({ data: makeTeam(), error: undefined });
+        mockListIdentities.mockResolvedValue({ data: undefined, error: "backend unavailable" });
+
+        const ui = await EditTeamPage({ params: Promise.resolve({ id: "eng" }) });
+        render(ui);
+
+        expect(screen.getByTestId("linked-identity-count")).toHaveTextContent("undefined");
+    });
+
+    it("passes a real count when listIdentities genuinely succeeds", async () => {
+        mockGetTeam.mockResolvedValue({ data: makeTeam(), error: undefined });
+        mockListIdentities.mockResolvedValue({
+            data: [
+                makeIdentity({ canonical_id: "alice", team_ids: ["eng"] }),
+                makeIdentity({ canonical_id: "bob", team_ids: ["design"] }),
+                makeIdentity({ canonical_id: "carol", team_ids: ["eng", "design"] }),
+            ],
+            error: undefined,
+        });
+
+        const ui = await EditTeamPage({ params: Promise.resolve({ id: "eng" }) });
+        render(ui);
+
+        expect(screen.getByTestId("linked-identity-count")).toHaveTextContent("2");
+    });
+});

--- a/src/app/(app)/org/admin/teams/[id]/edit/page.tsx
+++ b/src/app/(app)/org/admin/teams/[id]/edit/page.tsx
@@ -12,9 +12,10 @@ export default async function EditTeamPage({ params }: { params: Promise<{ id: s
     }
 
     const team = result.data;
-    const linkedIdentityCount = (identitiesResult.data ?? []).filter((identity) =>
-        identity.team_ids.includes(team.team_id),
-    ).length;
+    const linkedIdentityCount = identitiesResult.data
+        ? identitiesResult.data.filter((identity) => identity.team_ids.includes(team.team_id))
+              .length
+        : undefined;
 
     return (
         <div>

--- a/src/app/(app)/org/admin/teams/[id]/edit/page.tsx
+++ b/src/app/(app)/org/admin/teams/[id]/edit/page.tsx
@@ -1,22 +1,25 @@
 import { notFound } from "next/navigation";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { EditTeamFormWrapper } from "./EditTeamFormWrapper";
-import { getTeam } from "@/lib/admin/server";
+import { getTeam, listIdentities } from "@/lib/admin/server";
 
 export default async function EditTeamPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
-    const result = await getTeam(id);
+    const [result, identitiesResult] = await Promise.all([getTeam(id), listIdentities()]);
 
     if (result.error || !result.data) {
         notFound();
     }
 
     const team = result.data;
+    const linkedIdentityCount = (identitiesResult.data ?? []).filter((identity) =>
+        identity.team_ids.includes(team.team_id),
+    ).length;
 
     return (
         <div>
             <AdminHeader title="Edit Team" description={`Edit configuration for ${team.name}`} />
-            <EditTeamFormWrapper team={team} />
+            <EditTeamFormWrapper team={team} linkedIdentityCount={linkedIdentityCount} />
         </div>
     );
 }

--- a/src/components/admin/identities/IdentityForm.test.tsx
+++ b/src/components/admin/identities/IdentityForm.test.tsx
@@ -39,17 +39,32 @@ describe("IdentityForm", () => {
         expect(screen.getByLabelText("Canonical ID")).toBeInTheDocument();
         expect(screen.getByLabelText("Display Name")).toBeInTheDocument();
         expect(screen.getByLabelText("Email")).toBeInTheDocument();
-        expect(screen.getByLabelText("Team")).toBeInTheDocument();
+        expect(screen.getByRole("group", { name: "Teams" })).toBeInTheDocument();
         expect(screen.getByText("Provider Identities")).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "Create Identity" })).toBeInTheDocument();
         expect(screen.getByRole("link", { name: "Cancel" })).toBeInTheDocument();
     });
 
-    it("renders team options in select", () => {
+    it("renders one checkbox per team and supports selecting multiple teams", async () => {
+        const user = userEvent.setup();
         render(<IdentityForm teams={mockTeams} onSubmit={mockOnSubmit} />);
 
-        expect(screen.getByRole("option", { name: "Engineering" })).toBeInTheDocument();
-        expect(screen.getByRole("option", { name: "Design" })).toBeInTheDocument();
+        const engineering = screen.getByRole("checkbox", { name: "Engineering" });
+        const design = screen.getByRole("checkbox", { name: "Design" });
+        expect(engineering).not.toBeChecked();
+        expect(design).not.toBeChecked();
+
+        await user.click(engineering);
+        await user.click(design);
+
+        expect(engineering).toBeChecked();
+        expect(design).toBeChecked();
+    });
+
+    it("shows a hint when no teams are available yet", () => {
+        render(<IdentityForm teams={[]} onSubmit={mockOnSubmit} />);
+
+        expect(screen.getByText("No teams available yet.")).toBeInTheDocument();
     });
 
     it('adds provider identity row when clicking "+ Add Identity"', async () => {
@@ -59,27 +74,28 @@ describe("IdentityForm", () => {
         await user.click(screen.getByRole("button", { name: "+ Add Identity" }));
 
         expect(screen.getByPlaceholderText("Username / ID")).toBeInTheDocument();
-        expect(screen.getAllByRole("combobox")).toHaveLength(2);
+        expect(screen.getAllByRole("combobox")).toHaveLength(1);
     });
 
-    it("removes provider identity row", async () => {
+    it("removes provider identity row via its clearly labeled remove action", async () => {
         const user = userEvent.setup();
         render(<IdentityForm teams={mockTeams} onSubmit={mockOnSubmit} />);
 
         await user.click(screen.getByRole("button", { name: "+ Add Identity" }));
         expect(screen.getByPlaceholderText("Username / ID")).toBeInTheDocument();
 
-        await user.click(screen.getByRole("button", { name: "Remove identity" }));
+        await user.click(screen.getByRole("button", { name: "Remove github identity" }));
 
         expect(screen.queryByPlaceholderText("Username / ID")).not.toBeInTheDocument();
     });
 
-    it("submits form with provider identities", async () => {
+    it("submits form with provider identities and selected teams", async () => {
         const user = userEvent.setup();
         render(<IdentityForm teams={mockTeams} onSubmit={mockOnSubmit} />);
 
         await user.type(screen.getByLabelText("Canonical ID"), "alice-smith");
         await user.type(screen.getByLabelText("Display Name"), "Alice Smith");
+        await user.click(screen.getByRole("checkbox", { name: "Engineering" }));
         await user.click(screen.getByRole("button", { name: "+ Add Identity" }));
         await user.type(screen.getByPlaceholderText("Username / ID"), "octocat");
 
@@ -89,9 +105,39 @@ describe("IdentityForm", () => {
             canonical_id: "alice-smith",
             display_name: "Alice Smith",
             email: "",
-            team_ids: [],
+            team_ids: ["eng"],
             provider_identities: { github: ["octocat"] },
         });
+    });
+
+    it("blocks submit and shows an error when a provider identity has an empty username", async () => {
+        const user = userEvent.setup();
+        render(<IdentityForm teams={mockTeams} onSubmit={mockOnSubmit} />);
+
+        await user.type(screen.getByLabelText("Canonical ID"), "alice-smith");
+        await user.click(screen.getByRole("button", { name: "+ Add Identity" }));
+
+        await user.click(screen.getByRole("button", { name: "Create Identity" }));
+
+        expect(screen.getByRole("alert")).toHaveTextContent(/username/iu);
+        expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it("blocks submit and shows an error for a duplicate provider identity", async () => {
+        const user = userEvent.setup();
+        render(<IdentityForm teams={mockTeams} onSubmit={mockOnSubmit} />);
+
+        await user.type(screen.getByLabelText("Canonical ID"), "alice-smith");
+        await user.click(screen.getByRole("button", { name: "+ Add Identity" }));
+        await user.click(screen.getByRole("button", { name: "+ Add Identity" }));
+        const usernameInputs = screen.getAllByPlaceholderText("Username / ID");
+        await user.type(usernameInputs[0], "octocat");
+        await user.type(usernameInputs[1], "octocat");
+
+        await user.click(screen.getByRole("button", { name: "Create Identity" }));
+
+        expect(screen.getByRole("alert")).toHaveTextContent(/duplicate/iu);
+        expect(mockOnSubmit).not.toHaveBeenCalled();
     });
 
     it("canonical_id is disabled in edit mode", () => {

--- a/src/components/admin/identities/IdentityForm.tsx
+++ b/src/components/admin/identities/IdentityForm.tsx
@@ -1,10 +1,16 @@
-import { useState, type ChangeEvent, type SyntheticEvent } from "react";
+import { useState, type SyntheticEvent } from "react";
 import Link from "next/link";
 import { Identity } from "./IdentityTable";
 import { Team } from "../teams/TeamTable";
 import { BaseForm, inputClass, useBaseFormState } from "@/components/shared/BaseForm";
-
-type ProviderEntry = { id: string; provider: string; username: string };
+import { ProviderIdentitySection } from "./ProviderIdentitySection";
+import {
+    arrayToRecord,
+    recordToArray,
+    validateProviderEntries,
+    type ProviderEntry,
+} from "./providerIdentityUtils";
+import { CTA_LABELS } from "@/lib/design/cta";
 
 type IdentityFormProps = {
     initialData?: Identity;
@@ -13,27 +19,6 @@ type IdentityFormProps = {
     isEditing?: boolean;
     isLoading?: boolean;
 };
-
-const PROVIDERS = ["github", "gitlab", "jira", "email"];
-
-function recordToArray(record: Record<string, string[]>): ProviderEntry[] {
-    return Object.entries(record).flatMap(([provider, usernames]) =>
-        usernames.map((username, index) => ({
-            id: `${provider}-${username}-${index}`,
-            provider,
-            username,
-        })),
-    );
-}
-
-function arrayToRecord(arr: ProviderEntry[]): Record<string, string[]> {
-    const result: Record<string, string[]> = {};
-    arr.forEach(({ provider, username }) => {
-        if (!result[provider]) result[provider] = [];
-        if (username) result[provider].push(username);
-    });
-    return result;
-}
 
 export function IdentityForm({
     initialData,
@@ -52,22 +37,24 @@ export function IdentityForm({
     const [providerEntries, setProviderEntries] = useState<ProviderEntry[]>(
         initialData ? recordToArray(initialData.provider_identities) : [],
     );
+    const [providerError, setProviderError] = useState<string | null>(null);
 
-    const handleFormChange = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-        if (event.target.name === "team_ids") {
-            setFormData((prev) => ({
-                ...prev,
-                team_ids: event.target.value ? [event.target.value] : [],
-            }));
-            return;
-        }
-        handleChange(event);
+    const handleTeamToggle = (teamId: string, checked: boolean) => {
+        setFormData((prev) => ({
+            ...prev,
+            team_ids: checked
+                ? [...prev.team_ids, teamId]
+                : prev.team_ids.filter((id) => id !== teamId),
+        }));
     };
 
     const handleProviderChange = (index: number, field: "provider" | "username", value: string) => {
-        const nextProviders = [...providerEntries];
-        nextProviders[index] = { ...nextProviders[index], [field]: value };
-        setProviderEntries(nextProviders);
+        setProviderEntries((prev) => {
+            const next = [...prev];
+            next[index] = { ...next[index], [field]: value };
+            return next;
+        });
+        setProviderError(null);
     };
 
     const addProvider = () => {
@@ -83,10 +70,19 @@ export function IdentityForm({
 
     const removeProvider = (index: number) => {
         setProviderEntries((prev) => prev.filter((_, idx) => idx !== index));
+        setProviderError(null);
     };
 
     const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
         event.preventDefault();
+
+        const validation = validateProviderEntries(providerEntries);
+        if (!validation.ok) {
+            setProviderError(validation.message);
+            return;
+        }
+        setProviderError(null);
+
         onSubmit({
             ...formData,
             provider_identities: arrayToRecord(providerEntries),
@@ -108,7 +104,7 @@ export function IdentityForm({
                     href="/org/admin/identities"
                     className="rounded-lg px-4 py-2 text-sm font-medium text-(--ink-muted) hover:text-foreground"
                 >
-                    Cancel
+                    {CTA_LABELS.cancel}
                 </Link>
             }
         >
@@ -121,7 +117,7 @@ export function IdentityForm({
                     id="canonical_id"
                     name="canonical_id"
                     value={formData.canonical_id}
-                    onChange={handleFormChange}
+                    onChange={handleChange}
                     disabled={isEditing}
                     required
                     className={`${inputClass} text-sm disabled:opacity-50`}
@@ -141,7 +137,7 @@ export function IdentityForm({
                     id="display_name"
                     name="display_name"
                     value={formData.display_name ?? ""}
-                    onChange={handleFormChange}
+                    onChange={handleChange}
                     className={`${inputClass} text-sm`}
                     placeholder="e.g., Alice Smith"
                 />
@@ -156,85 +152,51 @@ export function IdentityForm({
                     id="email"
                     name="email"
                     value={formData.email ?? ""}
-                    onChange={handleFormChange}
+                    onChange={handleChange}
                     className={`${inputClass} text-sm`}
                     placeholder="e.g., alice@example.com"
                 />
             </div>
 
-            <div>
-                <label htmlFor="team_ids" className="mb-1.5 block text-sm font-medium">
-                    Team
-                </label>
-                <select
-                    id="team_ids"
-                    name="team_ids"
-                    value={formData.team_ids[0] ?? ""}
-                    onChange={handleFormChange}
-                    className={`${inputClass} text-sm`}
-                >
-                    <option value="">Select a team...</option>
-                    {teams.map((team) => (
-                        <option key={team.team_id} value={team.team_id}>
-                            {team.name}
-                        </option>
-                    ))}
-                </select>
-            </div>
+            <fieldset>
+                <legend className="mb-1.5 block text-sm font-medium">Teams</legend>
+                {teams.length === 0 ? (
+                    <p className="text-sm italic text-(--ink-muted)">No teams available yet.</p>
+                ) : (
+                    <div className="space-y-2">
+                        {teams.map((team) => {
+                            const checked = formData.team_ids.includes(team.team_id);
+                            return (
+                                <label
+                                    key={team.team_id}
+                                    className="flex cursor-pointer items-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-70) p-2.5 hover:bg-(--card-60)"
+                                >
+                                    <input
+                                        type="checkbox"
+                                        checked={checked}
+                                        onChange={(event) =>
+                                            handleTeamToggle(team.team_id, event.target.checked)
+                                        }
+                                        className="h-4 w-4 rounded border-(--card-stroke) bg-(--card-80) text-(--accent) focus:ring-(--accent)"
+                                    />
+                                    <span className="text-sm">{team.name}</span>
+                                </label>
+                            );
+                        })}
+                    </div>
+                )}
+                <p className="mt-1 text-xs text-(--ink-muted)">
+                    Select every team this identity belongs to.
+                </p>
+            </fieldset>
 
-            <div>
-                <div className="mb-2 flex items-center justify-between">
-                    <span className="block text-sm font-medium">Provider Identities</span>
-                    <button
-                        type="button"
-                        onClick={addProvider}
-                        className="text-xs font-medium text-(--accent) hover:underline"
-                    >
-                        + Add Identity
-                    </button>
-                </div>
-                <div className="space-y-3">
-                    {providerEntries.map((entry, index) => (
-                        <div key={entry.id} className="flex gap-3">
-                            <select
-                                value={entry.provider}
-                                onChange={(event) =>
-                                    handleProviderChange(index, "provider", event.target.value)
-                                }
-                                className="w-1/3 rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
-                            >
-                                {PROVIDERS.map((provider) => (
-                                    <option key={provider} value={provider}>
-                                        {provider.charAt(0).toUpperCase() + provider.slice(1)}
-                                    </option>
-                                ))}
-                            </select>
-                            <input
-                                type="text"
-                                value={entry.username}
-                                onChange={(event) =>
-                                    handleProviderChange(index, "username", event.target.value)
-                                }
-                                placeholder="Username / ID"
-                                className={`${inputClass} flex-1 text-sm`}
-                            />
-                            <button
-                                type="button"
-                                onClick={() => removeProvider(index)}
-                                className="text-red-500 hover:text-red-600"
-                                aria-label="Remove identity"
-                            >
-                                x
-                            </button>
-                        </div>
-                    ))}
-                    {providerEntries.length === 0 && (
-                        <p className="text-sm italic text-(--ink-muted)">
-                            No provider identities linked.
-                        </p>
-                    )}
-                </div>
-            </div>
+            <ProviderIdentitySection
+                entries={providerEntries}
+                error={providerError}
+                onEntryChangeAction={handleProviderChange}
+                onAddAction={addProvider}
+                onRemoveAction={removeProvider}
+            />
         </BaseForm>
     );
 }

--- a/src/components/admin/identities/ProviderIdentitySection.test.tsx
+++ b/src/components/admin/identities/ProviderIdentitySection.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "@/test/utils";
+
+import { ProviderIdentitySection } from "./ProviderIdentitySection";
+import type { ProviderEntry } from "./providerIdentityUtils";
+
+describe("ProviderIdentitySection", () => {
+    it("renders an empty state when there are no rows", () => {
+        render(
+            <ProviderIdentitySection
+                entries={[]}
+                error={null}
+                onEntryChangeAction={vi.fn()}
+                onAddAction={vi.fn()}
+                onRemoveAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText("No provider identities linked.")).toBeInTheDocument();
+    });
+
+    it("renders a clearly labeled, discoverable remove action per row (not a bare x)", () => {
+        const entries: ProviderEntry[] = [{ id: "a", provider: "github", username: "octocat" }];
+
+        render(
+            <ProviderIdentitySection
+                entries={entries}
+                error={null}
+                onEntryChangeAction={vi.fn()}
+                onAddAction={vi.fn()}
+                onRemoveAction={vi.fn()}
+            />,
+        );
+
+        const removeButton = screen.getByRole("button", {
+            name: "Remove github identity octocat",
+        });
+        expect(removeButton).toHaveTextContent("Remove");
+    });
+
+    it("calls onRemoveAction with the row index when the remove button is clicked", async () => {
+        const onRemoveAction = vi.fn();
+        const entries: ProviderEntry[] = [
+            { id: "a", provider: "github", username: "octocat" },
+            { id: "b", provider: "gitlab", username: "glcat" },
+        ];
+        const user = userEvent.setup();
+
+        render(
+            <ProviderIdentitySection
+                entries={entries}
+                error={null}
+                onEntryChangeAction={vi.fn()}
+                onAddAction={vi.fn()}
+                onRemoveAction={onRemoveAction}
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Remove gitlab identity glcat" }));
+
+        expect(onRemoveAction).toHaveBeenCalledWith(1);
+    });
+
+    it("surfaces a validation error passed from the parent form as an alert", () => {
+        render(
+            <ProviderIdentitySection
+                entries={[]}
+                error="Every provider identity needs a username."
+                onEntryChangeAction={vi.fn()}
+                onAddAction={vi.fn()}
+                onRemoveAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByRole("alert")).toHaveTextContent(
+            "Every provider identity needs a username.",
+        );
+    });
+
+    it("renders no alert when there is no error", () => {
+        render(
+            <ProviderIdentitySection
+                entries={[]}
+                error={null}
+                onEntryChangeAction={vi.fn()}
+                onAddAction={vi.fn()}
+                onRemoveAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+});

--- a/src/components/admin/identities/ProviderIdentitySection.tsx
+++ b/src/components/admin/identities/ProviderIdentitySection.tsx
@@ -1,0 +1,93 @@
+import { inputClass } from "@/components/shared/BaseForm";
+import { CTA_LABELS } from "@/lib/design/cta";
+import { PROVIDERS, type ProviderEntry } from "./providerIdentityUtils";
+
+type ProviderIdentitySectionProps = {
+    entries: ProviderEntry[];
+    error: string | null;
+    onEntryChangeAction: (index: number, field: "provider" | "username", value: string) => void;
+    onAddAction: () => void;
+    onRemoveAction: (index: number) => void;
+};
+
+/**
+ * Provider-identity row editor for IdentityForm (CHAOS-2841 mapping-forms
+ * lane): one provider+username row per linked account, a discoverable
+ * labeled remove action per row (not a bare "x"), and a blocking validation
+ * banner surfaced by the parent form before submit.
+ */
+export function ProviderIdentitySection({
+    entries,
+    error,
+    onEntryChangeAction,
+    onAddAction,
+    onRemoveAction,
+}: ProviderIdentitySectionProps) {
+    return (
+        <div>
+            <div className="mb-2 flex items-center justify-between">
+                <span className="block text-sm font-medium">Provider Identities</span>
+                <button
+                    type="button"
+                    onClick={onAddAction}
+                    className="text-xs font-medium text-(--accent) hover:underline"
+                >
+                    {CTA_LABELS.addProviderIdentity}
+                </button>
+            </div>
+
+            {error ? (
+                <p role="alert" className="mb-2 text-xs text-(--negative)">
+                    {error}
+                </p>
+            ) : null}
+
+            <div className="space-y-3">
+                {entries.map((entry, index) => (
+                    <div key={entry.id} className="flex gap-3">
+                        <select
+                            value={entry.provider}
+                            onChange={(event) =>
+                                onEntryChangeAction(index, "provider", event.target.value)
+                            }
+                            aria-label="Provider"
+                            className="w-1/3 rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                        >
+                            {PROVIDERS.map((provider) => (
+                                <option key={provider} value={provider}>
+                                    {provider.charAt(0).toUpperCase() + provider.slice(1)}
+                                </option>
+                            ))}
+                        </select>
+                        <input
+                            type="text"
+                            value={entry.username}
+                            onChange={(event) =>
+                                onEntryChangeAction(index, "username", event.target.value)
+                            }
+                            placeholder="Username / ID"
+                            className={`${inputClass} flex-1 text-sm`}
+                        />
+                        <button
+                            type="button"
+                            onClick={() => onRemoveAction(index)}
+                            aria-label={
+                                entry.username
+                                    ? `Remove ${entry.provider} identity ${entry.username}`
+                                    : `Remove ${entry.provider} identity`
+                            }
+                            className="shrink-0 rounded-lg border border-(--card-stroke) px-3 py-2 text-xs font-medium text-red-500 hover:bg-red-500/10"
+                        >
+                            {CTA_LABELS.remove}
+                        </button>
+                    </div>
+                ))}
+                {entries.length === 0 && (
+                    <p className="text-sm italic text-(--ink-muted)">
+                        No provider identities linked.
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/identities/providerIdentityUtils.test.ts
+++ b/src/components/admin/identities/providerIdentityUtils.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    arrayToRecord,
+    recordToArray,
+    validateProviderEntries,
+    type ProviderEntry,
+} from "./providerIdentityUtils";
+
+describe("recordToArray / arrayToRecord", () => {
+    it("round-trips a provider_identities record through the editable row list", () => {
+        const record = { github: ["octocat"], gitlab: ["glcat"] };
+
+        const entries = recordToArray(record);
+        expect(entries).toHaveLength(2);
+        expect(entries.map(({ provider, username }) => ({ provider, username }))).toEqual([
+            { provider: "github", username: "octocat" },
+            { provider: "gitlab", username: "glcat" },
+        ]);
+
+        expect(arrayToRecord(entries)).toEqual(record);
+    });
+
+    it("drops empty/whitespace-only usernames when building the record", () => {
+        const entries: ProviderEntry[] = [
+            { id: "a", provider: "github", username: "  octocat  " },
+            { id: "b", provider: "github", username: "   " },
+        ];
+
+        expect(arrayToRecord(entries)).toEqual({ github: ["octocat"] });
+    });
+});
+
+describe("validateProviderEntries", () => {
+    it("passes for distinct, non-empty provider+username rows", () => {
+        const entries: ProviderEntry[] = [
+            { id: "a", provider: "github", username: "octocat" },
+            { id: "b", provider: "gitlab", username: "octocat" },
+        ];
+
+        expect(validateProviderEntries(entries)).toEqual({ ok: true });
+    });
+
+    it("blocks on an empty username with a user-safe message", () => {
+        const entries: ProviderEntry[] = [{ id: "a", provider: "github", username: "  " }];
+
+        const result = validateProviderEntries(entries);
+        if (result.ok) throw new Error("expected validation to fail");
+        expect(result.message).toMatch(/username/iu);
+    });
+
+    it("blocks on a case-insensitive duplicate provider+username pair", () => {
+        const entries: ProviderEntry[] = [
+            { id: "a", provider: "github", username: "octocat" },
+            { id: "b", provider: "github", username: "OctoCat" },
+        ];
+
+        const result = validateProviderEntries(entries);
+        if (result.ok) throw new Error("expected validation to fail");
+        expect(result.message).toMatch(/duplicate/iu);
+    });
+
+    it("allows the same username across different providers", () => {
+        const entries: ProviderEntry[] = [
+            { id: "a", provider: "github", username: "shared-name" },
+            { id: "b", provider: "jira", username: "shared-name" },
+        ];
+
+        expect(validateProviderEntries(entries)).toEqual({ ok: true });
+    });
+});

--- a/src/components/admin/identities/providerIdentityUtils.ts
+++ b/src/components/admin/identities/providerIdentityUtils.ts
@@ -1,0 +1,65 @@
+/**
+ * Provider-identity row helpers for IdentityForm (CHAOS-2841 mapping-forms
+ * lane): converting the `provider_identities` record to/from an editable row
+ * list, and validating those rows before submit so an empty username or a
+ * duplicate provider+username pair is caught with a user-safe message
+ * instead of being silently dropped or double-submitted.
+ */
+
+export type ProviderEntry = { id: string; provider: string; username: string };
+
+export const PROVIDERS = ["github", "gitlab", "jira", "email"];
+
+export function recordToArray(record: Record<string, string[]>): ProviderEntry[] {
+    return Object.entries(record).flatMap(([provider, usernames]) =>
+        usernames.map((username, index) => ({
+            id: `${provider}-${username}-${index}`,
+            provider,
+            username,
+        })),
+    );
+}
+
+export function arrayToRecord(entries: ProviderEntry[]): Record<string, string[]> {
+    const result: Record<string, string[]> = {};
+    entries.forEach(({ provider, username }) => {
+        const trimmed = username.trim();
+        if (!trimmed) return;
+        if (!result[provider]) result[provider] = [];
+        result[provider].push(trimmed);
+    });
+    return result;
+}
+
+export type ProviderEntriesValidation = { ok: true } | { ok: false; message: string };
+
+/**
+ * Blocks submit on an empty username (rather than silently dropping the row)
+ * or a case-insensitive duplicate provider+username pair, so a mistyped or
+ * repeated mapping is caught before it reaches the backend.
+ */
+export function validateProviderEntries(entries: ProviderEntry[]): ProviderEntriesValidation {
+    const seen = new Set<string>();
+
+    for (const entry of entries) {
+        const username = entry.username.trim();
+        if (!username) {
+            return {
+                ok: false,
+                message:
+                    "Every provider identity needs a username — remove empty rows or fill them in.",
+            };
+        }
+
+        const key = `${entry.provider.toLowerCase()}:${username.toLowerCase()}`;
+        if (seen.has(key)) {
+            return {
+                ok: false,
+                message: `Duplicate provider identity: "${username}" is already added for ${entry.provider}.`,
+            };
+        }
+        seen.add(key);
+    }
+
+    return { ok: true };
+}

--- a/src/components/admin/teams/TeamForm.test.tsx
+++ b/src/components/admin/teams/TeamForm.test.tsx
@@ -40,7 +40,7 @@ describe("TeamForm", () => {
         expect(screen.getByRole("link", { name: "Cancel" })).toBeInTheDocument();
     });
 
-    it("pre-fills form when initialData provided", () => {
+    it("pre-fills form and renders existing patterns/keys as tokens", () => {
         const initialData: Team = {
             team_id: "eng",
             name: "Engineering",
@@ -54,8 +54,10 @@ describe("TeamForm", () => {
         expect(screen.getByLabelText("Team ID")).toHaveValue("eng");
         expect(screen.getByLabelText("Display Name")).toHaveValue("Engineering");
         expect(screen.getByLabelText("Description")).toHaveValue("Core product team");
-        expect(screen.getByLabelText("Repository Patterns")).toHaveValue("org/repo-a, org/repo-b");
-        expect(screen.getByLabelText("Project Keys")).toHaveValue("PROJ, ENG");
+        expect(screen.getByText("org/repo-a")).toBeInTheDocument();
+        expect(screen.getByText("org/repo-b")).toBeInTheDocument();
+        expect(screen.getByText("PROJ")).toBeInTheDocument();
+        expect(screen.getByText("ENG")).toBeInTheDocument();
     });
 
     it("team_id is disabled in edit mode", () => {
@@ -64,14 +66,14 @@ describe("TeamForm", () => {
         expect(screen.getByLabelText("Team ID")).toBeDisabled();
     });
 
-    it("submits form with parsed comma-separated values", async () => {
+    it("submits form with tokens entered via the repository patterns and project keys inputs", async () => {
         const user = userEvent.setup();
         render(<TeamForm onSubmit={mockOnSubmit} />);
 
         await user.type(screen.getByLabelText("Team ID"), "eng");
         await user.type(screen.getByLabelText("Display Name"), "Engineering");
-        await user.type(screen.getByLabelText("Repository Patterns"), "org/repo-a, org/repo-b");
-        await user.type(screen.getByLabelText("Project Keys"), "PROJ, ENG");
+        await user.type(screen.getByLabelText("Repository Patterns"), "org/repo-a,org/repo-b,");
+        await user.type(screen.getByLabelText("Project Keys"), "PROJ,ENG,");
 
         await user.click(screen.getByRole("button", { name: "Create Team" }));
 
@@ -82,6 +84,17 @@ describe("TeamForm", () => {
             repo_patterns: ["org/repo-a", "org/repo-b"],
             project_keys: ["PROJ", "ENG"],
         });
+    });
+
+    it("rejects a duplicate repository pattern with visible feedback and does not resubmit it", async () => {
+        const user = userEvent.setup();
+        render(<TeamForm onSubmit={mockOnSubmit} />);
+
+        await user.type(screen.getByLabelText("Repository Patterns"), "org/repo-a,");
+        await user.type(screen.getByLabelText("Repository Patterns"), "org/repo-a,");
+
+        expect(screen.getByRole("status")).toHaveTextContent("Already added");
+        expect(screen.getAllByRole("button", { name: "Remove org/repo-a" })).toHaveLength(1);
     });
 
     it("shows loading state", () => {
@@ -97,5 +110,32 @@ describe("TeamForm", () => {
             "href",
             "/org/admin/teams",
         );
+    });
+
+    it("renders a live review-before-saving preview reflecting entered tokens", async () => {
+        const user = userEvent.setup();
+        render(<TeamForm onSubmit={mockOnSubmit} />);
+
+        expect(screen.getByText("Review before saving")).toBeInTheDocument();
+        expect(screen.getAllByText("None added")).toHaveLength(2);
+
+        await user.type(screen.getByLabelText("Project Keys"), "PROJ,");
+
+        const projectKeysRow = screen.getByText("Project keys").closest("div");
+        expect(projectKeysRow).toHaveTextContent("PROJ");
+        expect(screen.getAllByText("None added")).toHaveLength(1);
+    });
+
+    it("shows a linked-identities row in the review preview when the count is provided", () => {
+        render(<TeamForm onSubmit={mockOnSubmit} linkedIdentityCount={3} />);
+
+        expect(screen.getByText("Linked identities")).toBeInTheDocument();
+        expect(screen.getByText("3 identities currently mapped")).toBeInTheDocument();
+    });
+
+    it("gracefully degrades the review preview when no linked-identity data is available", () => {
+        render(<TeamForm onSubmit={mockOnSubmit} />);
+
+        expect(screen.queryByText("Linked identities")).not.toBeInTheDocument();
     });
 });

--- a/src/components/admin/teams/TeamForm.tsx
+++ b/src/components/admin/teams/TeamForm.tsx
@@ -1,13 +1,22 @@
-import { useState, type SyntheticEvent } from "react";
+import { type SyntheticEvent } from "react";
 import Link from "next/link";
 import { Team } from "./TeamTable";
 import { BaseForm, inputClass, useBaseFormState } from "@/components/shared/BaseForm";
+import { TokenInput } from "@/components/shared/TokenInput";
+import { ReviewSummary, type ReviewSummaryRow } from "@/components/shared/ReviewSummary";
+import { CTA_LABELS } from "@/lib/design/cta";
 
 type TeamFormProps = {
     initialData?: Team;
     onSubmit: (data: Team) => void;
     isEditing?: boolean;
     isLoading?: boolean;
+    /**
+     * Count of identities currently mapped to this team (real backend data,
+     * sourced from the identities list) — omitted on the create form, where
+     * no such data exists yet, so the review preview degrades gracefully.
+     */
+    linkedIdentityCount?: number;
 };
 
 export function TeamForm({
@@ -15,8 +24,9 @@ export function TeamForm({
     onSubmit,
     isEditing = false,
     isLoading = false,
+    linkedIdentityCount,
 }: TeamFormProps) {
-    const { formData, handleChange } = useBaseFormState<Team>(
+    const { formData, setFormData, handleChange } = useBaseFormState<Team>(
         initialData || {
             team_id: "",
             name: "",
@@ -26,30 +36,40 @@ export function TeamForm({
         },
     );
 
-    const [repoPatternsInput, setRepoPatternsInput] = useState(
-        initialData?.repo_patterns.join(", ") || "",
-    );
-    const [projectKeysInput, setProjectKeysInput] = useState(
-        initialData?.project_keys.join(", ") || "",
-    );
+    const handleRepoPatternsChange = (next: string[]) => {
+        setFormData((prev) => ({ ...prev, repo_patterns: next }));
+    };
+
+    const handleProjectKeysChange = (next: string[]) => {
+        setFormData((prev) => ({ ...prev, project_keys: next }));
+    };
 
     const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
         event.preventDefault();
-        const repo_patterns = repoPatternsInput
-            .split(",")
-            .map((value) => value.trim())
-            .filter(Boolean);
-        const project_keys = projectKeysInput
-            .split(",")
-            .map((value) => value.trim())
-            .filter(Boolean);
-
-        onSubmit({
-            ...formData,
-            repo_patterns,
-            project_keys,
-        });
+        onSubmit({ ...formData });
     };
+
+    const reviewRows: ReviewSummaryRow[] = [
+        { label: "Team ID", value: formData.team_id || "—" },
+        {
+            label: "Repository patterns",
+            value:
+                formData.repo_patterns.length > 0
+                    ? formData.repo_patterns.join(", ")
+                    : "None added",
+        },
+        {
+            label: "Project keys",
+            value:
+                formData.project_keys.length > 0 ? formData.project_keys.join(", ") : "None added",
+        },
+    ];
+    if (linkedIdentityCount !== undefined) {
+        reviewRows.push({
+            label: "Linked identities",
+            value: `${linkedIdentityCount} ${linkedIdentityCount === 1 ? "identity" : "identities"} currently mapped`,
+        });
+    }
 
     return (
         <BaseForm
@@ -64,7 +84,7 @@ export function TeamForm({
                     href="/org/admin/teams"
                     className="rounded-lg px-4 py-2 text-sm font-medium text-(--ink-muted) hover:text-foreground"
                 >
-                    Cancel
+                    {CTA_LABELS.cancel}
                 </Link>
             }
         >
@@ -120,37 +140,36 @@ export function TeamForm({
             </div>
 
             <div>
-                <label htmlFor="repo_patterns" className="mb-1.5 block text-sm font-medium">
-                    Repository Patterns
-                </label>
-                <input
-                    type="text"
-                    id="repo_patterns"
-                    value={repoPatternsInput}
-                    onChange={(event) => setRepoPatternsInput(event.target.value)}
-                    className={`${inputClass} text-sm`}
-                    placeholder="e.g., github/org/repo-*, gitlab/group/*"
+                <span className="mb-1.5 block text-sm font-medium">Repository Patterns</span>
+                <TokenInput
+                    value={formData.repo_patterns}
+                    onChangeAction={handleRepoPatternsChange}
+                    ariaLabel="Repository Patterns"
+                    placeholder="e.g., github/org/repo-*"
                 />
                 <p className="mt-1 text-xs text-(--ink-muted)">
-                    Comma-separated list of glob patterns to match repositories owned by this team.
+                    Glob patterns matching repositories owned by this team. Press Enter or comma to
+                    add each pattern.
                 </p>
             </div>
 
             <div>
-                <label htmlFor="project_keys" className="mb-1.5 block text-sm font-medium">
-                    Project Keys
-                </label>
-                <input
-                    type="text"
-                    id="project_keys"
-                    value={projectKeysInput}
-                    onChange={(event) => setProjectKeysInput(event.target.value)}
-                    className={`${inputClass} text-sm`}
-                    placeholder="e.g., PROJ, PLAT"
+                <span className="mb-1.5 block text-sm font-medium">Project Keys</span>
+                <TokenInput
+                    value={formData.project_keys}
+                    onChangeAction={handleProjectKeysChange}
+                    ariaLabel="Project Keys"
+                    placeholder="e.g., PROJ"
                 />
                 <p className="mt-1 text-xs text-(--ink-muted)">
-                    Comma-separated list of project keys (e.g. Jira) owned by this team.
+                    Project keys (e.g. Jira) owned by this team. Press Enter or comma to add each
+                    key.
                 </p>
+            </div>
+
+            <div>
+                <span className="mb-1.5 block text-sm font-medium">Review before saving</span>
+                <ReviewSummary rows={reviewRows} />
             </div>
         </BaseForm>
     );

--- a/src/lib/admin/api/__tests__/identities-api.test.ts
+++ b/src/lib/admin/api/__tests__/identities-api.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Contract test: identitiesApi.update must issue POST /identities (the
+ * supported create_or_update upsert) with the FULL desired state \u2014
+ * canonical_id + complete team_ids/provider_identities \u2014 rather than
+ * PATCH /identities/{id}, which does not exist on the backend
+ * (dev_health_ops/api/admin/routers/identities.py only registers
+ * GET/POST /identities).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../_request", () => ({
+    request: vi.fn().mockResolvedValue({}),
+}));
+
+import { request } from "../_request";
+import { identitiesApi } from "../identities";
+import type { IdentityMappingCreate } from "../../types";
+
+const mockRequest = vi.mocked(request);
+
+beforeEach(() => {
+    mockRequest.mockClear();
+});
+
+describe("identitiesApi.update path contract", () => {
+    it("issues POST /identities (not PATCH /identities/:id)", async () => {
+        const payload: IdentityMappingCreate = {
+            canonical_id: "alice-smith",
+            display_name: "Alice Smith",
+            email: null,
+            provider_identities: { github: ["octocat"] },
+            team_ids: ["eng", "design"],
+        };
+
+        await identitiesApi.update(payload);
+
+        expect(mockRequest).toHaveBeenCalledOnce();
+        const [path, options] = mockRequest.mock.calls[0];
+        expect(path).toBe("/identities");
+        expect((options as RequestInit).method).toBe("POST");
+    });
+
+    it("sends the full canonical_id + team_ids in the request body (no partial diff)", async () => {
+        const payload: IdentityMappingCreate = {
+            canonical_id: "alice-smith",
+            team_ids: ["eng", "design"],
+            provider_identities: { github: ["octocat"] },
+        };
+
+        await identitiesApi.update(payload);
+
+        const [, options] = mockRequest.mock.calls[0];
+        const sentBody = JSON.parse((options as RequestInit).body as string);
+        expect(sentBody.canonical_id).toBe("alice-smith");
+        expect(sentBody.team_ids).toEqual(["eng", "design"]);
+    });
+
+    it("uses the same POST /identities path as create (both hit the upsert route)", async () => {
+        await identitiesApi.create({ canonical_id: "bob" });
+        await identitiesApi.update({ canonical_id: "bob", team_ids: [] });
+
+        expect(mockRequest.mock.calls[0][0]).toBe("/identities");
+        expect(mockRequest.mock.calls[1][0]).toBe("/identities");
+        expect((mockRequest.mock.calls[0][1] as RequestInit).method).toBe("POST");
+        expect((mockRequest.mock.calls[1][1] as RequestInit).method).toBe("POST");
+    });
+});

--- a/src/lib/admin/api/identities.ts
+++ b/src/lib/admin/api/identities.ts
@@ -1,5 +1,5 @@
 import { request } from "./_request";
-import type { IdentityMapping, IdentityMappingCreate, IdentityMappingUpdate } from "../types";
+import type { IdentityMapping, IdentityMappingCreate } from "../types";
 
 export const identitiesApi = {
     list: (token?: string, orgId?: string) =>
@@ -16,10 +16,13 @@ export const identitiesApi = {
             orgId,
         ),
 
-    update: (id: string, data: IdentityMappingUpdate, token?: string, orgId?: string) =>
+    // No PATCH /identities/{id} route exists on the backend — identity
+    // updates go through the same POST /identities upsert as create, keyed
+    // on `canonical_id` in the body (see create_or_update_identity).
+    update: (data: IdentityMappingCreate, token?: string, orgId?: string) =>
         request<IdentityMapping>(
-            `/identities/${id}`,
-            { method: "PATCH", body: JSON.stringify(data) },
+            "/identities",
+            { method: "POST", body: JSON.stringify(data) },
             token,
             orgId,
         ),

--- a/src/lib/admin/server/identities.ts
+++ b/src/lib/admin/server/identities.ts
@@ -2,7 +2,7 @@
 
 import { adminApi } from "../api";
 import type { ActionResult } from "@/lib/result";
-import type { IdentityMapping, IdentityMappingCreate, IdentityMappingUpdate } from "../types";
+import type { IdentityMapping, IdentityMappingCreate } from "../types";
 import { getSessionContext, withErrorHandling } from "./_shared";
 
 export async function listIdentities(): Promise<ActionResult<IdentityMapping[]>> {
@@ -29,12 +29,11 @@ export async function getIdentity(id: string): Promise<ActionResult<IdentityMapp
 }
 
 export async function updateIdentity(
-    id: string,
-    data: IdentityMappingUpdate,
+    data: IdentityMappingCreate,
 ): Promise<ActionResult<IdentityMapping>> {
     return withErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
-        return adminApi.identities.update(id, data, token, orgId);
+        return adminApi.identities.update(data, token, orgId);
     });
 }
 

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -406,19 +406,21 @@ export interface IdentityMapping {
     updated_at: string;
 }
 
+/**
+ * Payload for POST /identities. The backend endpoint
+ * (create_or_update_identity) is an UPSERT keyed on `canonical_id` with
+ * replacement semantics for `provider_identities` / `team_ids`: a field
+ * that IS present in the request body replaces the stored value wholesale,
+ * even if the array/object is empty. There is no PATCH /identities/{id}
+ * route — both create and update flows must POST the FULL desired state
+ * (not a partial diff) through this same shape.
+ */
 export interface IdentityMappingCreate {
     canonical_id: string;
     display_name?: string | null;
     email?: string | null;
     provider_identities?: Record<string, string[]>;
     team_ids?: string[];
-}
-
-export interface IdentityMappingUpdate {
-    display_name?: string | null;
-    email?: string | null;
-    provider_identities?: Record<string, string[]> | null;
-    team_ids?: string[] | null;
 }
 
 // ---- Team Mappings ----

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -133,6 +133,10 @@ export const CTA_LABELS = {
     savingConfiguration: "Saving...",
     /** Link to plan settings from a tier-gated/locked option's upgrade copy (CHAOS-2838). */
     upgradePlan: "Upgrade plan",
+    /** Discoverable row-level remove action for a mapping entry (provider identity row, CHAOS-2841). */
+    remove: "Remove",
+    /** Add another provider identity row to the identity mapping form (CHAOS-2841). */
+    addProviderIdentity: "+ Add Identity",
 } as const;
 
 export type CtaKey = keyof typeof CTA_LABELS;

--- a/tests/admin-teams.spec.ts
+++ b/tests/admin-teams.spec.ts
@@ -17,8 +17,8 @@ test("new team form renders all fields", async ({ page }) => {
     await expect(page.locator("#team_id")).toBeVisible();
     await expect(page.locator("#name")).toBeVisible();
     await expect(page.locator("#description")).toBeVisible();
-    await expect(page.locator("#repo_patterns")).toBeVisible();
-    await expect(page.locator("#project_keys")).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Repository Patterns" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Project Keys" })).toBeVisible();
 });
 
 test("creating team redirects to team list", async ({ page }) => {


### PR DESCRIPTION
## CHAOS-2841 — Improve team ownership and identity mapping forms

Makes team-ownership and identity mappings hard to mistype and easy to review before saving. Replaces comma-separated text fields and single-select provider rows with token/chip inputs, pre-submit validation, and a live review preview.

### Acceptance criteria
- [x] Repository patterns and project keys are entered as tokens/chips (`TokenInput`, replacing comma-separated text).
- [x] Empty and duplicate mapping entries are caught before submit with user-safe messages.
- [x] Team ownership form shows a preview of matched resources when backend data is available — and gracefully omits it otherwise (no fabricated counts).
- [x] Provider identity rows use clear labels and a discoverable **Remove** button (per-row `aria-label`), not a bare "×".
- [x] Team assignment is explicit: **multi-team is supported** (see below).
- [x] TeamTable/IdentityTable keep consistent empty states, search, and row actions.

### Multi-team assignment
`IdentityMapping.team_ids` is a `string[]` end-to-end and the backend `POST /identities` (`create_or_update_identity`) accepts the full array — only the form UI had forced single-select. Replaced the `<select>` with a checkbox `<fieldset>` so admins can assign multiple teams. The identity **update** path was also corrected: it previously issued `PATCH /identities/{id}` (a route the backend does not expose) and now uses the supported `POST /identities` upsert, sending `canonical_id` + the full `team_ids` **and** `provider_identities` arrays (the upsert does full replacement, so partial bodies would wipe data).

### Implementation
- `TokenInput` for repo patterns / project keys (chip entry, Enter/comma commit, empty+duplicate rejection).
- `providerIdentityUtils.ts` — pre-submit validation (empty username + case-insensitive duplicate provider+username), surfaced via `role="alert"`.
- `ReviewSummary` live preview; edit page passes a real `listIdentities()`-derived `linkedIdentityCount` only when the query succeeds (`undefined` on failure → row omitted).
- `ProviderIdentitySection.tsx` — labeled rows + discoverable Remove button.

### Tests / gates
- `vitest` teams+identities+admin scope: **103 passing** (incl. new `page.test.tsx`, `identities-api.test.ts` asserting POST-upsert with full arrays, provider-validation, multi-team selection).
- `tsc` clean · `eslint` 0 · `design-lint` 0 in touched src · `prettier` clean.
- Reviewed via Oracle gate (2 rounds): REVISE (fabricated preview count; dead PATCH update route) → fixed → PASS.
- Updated `tests/admin-teams.spec.ts` e2e locators from `#id` to accessible-name selectors (TokenInput has no id).

### Visual evidence
**Team form — token/chip repo patterns + project keys, with live "Review before saving" preview**
![team form](https://github.com/user-attachments/assets/89ae8e6b-fbc7-48ad-be25-23b042d6f10f)

**Identity form — multi-team checkbox group + labeled provider "Remove" action**
![identity form](https://github.com/user-attachments/assets/5f76ce03-cb84-4ad7-b367-3faca8539882)

Closes CHAOS-2841.
