### PR TITLE
feat(admin): harden enterprise IP allowlist and retention controls (CHAOS-2842)

### DIFF
--- a/src/app/(app)/org/admin/ip-allowlist/CidrField.tsx
+++ b/src/app/(app)/org/admin/ip-allowlist/CidrField.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+type CidrFieldProps = {
+    id: string;
+    label: string;
+    value: string;
+    error: string | null;
+    disabled?: boolean;
+    onChangeAction: (value: string) => void;
+};
+
+/** Labeled IP/CIDR text input with inline, user-safe validation feedback. */
+export function CidrField({ id, label, value, error, disabled, onChangeAction }: CidrFieldProps) {
+    const errorId = `${id}-error`;
+
+    return (
+        <div>
+            <label htmlFor={id} className="mb-1 block text-xs font-medium text-(--ink-muted)">
+                {label}
+            </label>
+            <input
+                id={id}
+                type="text"
+                placeholder="192.168.1.0/24"
+                value={value}
+                disabled={disabled}
+                onChange={(event) => onChangeAction(event.target.value)}
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? errorId : undefined}
+                className={`w-full rounded-lg border bg-(--card-70) px-3 py-2 text-sm focus:outline-none ${
+                    error
+                        ? "border-(--negative) focus:border-(--negative)"
+                        : "border-(--card-stroke) focus:border-(--accent)"
+                }`}
+            />
+            {error ? (
+                <p id={errorId} className="mt-1 text-xs text-(--negative)">
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/ip-allowlist/IpAllowlistForm.test.tsx
+++ b/src/app/(app)/org/admin/ip-allowlist/IpAllowlistForm.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "@/test/utils";
+import { IpAllowlistForm } from "./IpAllowlistForm";
+import type { IPAllowlist } from "@/lib/admin/types";
+
+function renderForm(overrides: Partial<Parameters<typeof IpAllowlistForm>[0]> = {}) {
+    const onSaveAction = vi.fn();
+    const onCancelAction = vi.fn();
+    const props = {
+        mode: "create" as const,
+        currentIp: "203.0.113.5",
+        isSaving: false,
+        onSaveAction,
+        onCancelAction,
+        ...overrides,
+    };
+    render(<IpAllowlistForm {...props} />);
+    return { onSaveAction, onCancelAction };
+}
+
+describe("IpAllowlistForm", () => {
+    it("rejects a malformed CIDR with a user-safe inline message and does not submit", async () => {
+        const user = userEvent.setup();
+        const { onSaveAction } = renderForm();
+
+        await user.type(screen.getByLabelText("IP Range"), "999.1.1.1/99");
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(screen.getByText(/not a valid IPv4 or IPv6 address/i)).toBeInTheDocument();
+        expect(onSaveAction).not.toHaveBeenCalled();
+    });
+
+    it("saves directly when the CIDR is valid and covers the current IP", async () => {
+        const user = userEvent.setup();
+        const { onSaveAction } = renderForm({ currentIp: "203.0.113.5" });
+
+        await user.type(screen.getByLabelText("IP Range"), "203.0.113.0/24");
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(onSaveAction).toHaveBeenCalledWith(
+            expect.objectContaining({ ip_range: "203.0.113.0/24" }),
+        );
+    });
+
+    it("warns before saving a range that excludes the admin's own current IP, and blocks until acknowledged", async () => {
+        const user = userEvent.setup();
+        const { onSaveAction } = renderForm({ currentIp: "203.0.113.5" });
+
+        await user.type(screen.getByLabelText("IP Range"), "10.0.0.0/24");
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        // Direct save is blocked; a lockout-risk confirmation appears instead.
+        expect(onSaveAction).not.toHaveBeenCalled();
+        expect(
+            screen.getByRole("dialog", { name: "This rule may lock you out" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText(/not covered by this range/i)).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: "Save anyway" }));
+        expect(onSaveAction).toHaveBeenCalledWith(
+            expect.objectContaining({ ip_range: "10.0.0.0/24" }),
+        );
+    });
+
+    it("does not warn about lockout when editing an entry that is already inactive", async () => {
+        const user = userEvent.setup();
+        const inactiveEntry: IPAllowlist = {
+            id: "ip-1",
+            org_id: "org-1",
+            ip_range: "10.0.0.0/24",
+            description: null,
+            is_active: false,
+            created_by_id: null,
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-01-01T00:00:00Z",
+            expires_at: null,
+        };
+        const { onSaveAction } = renderForm({
+            mode: "edit",
+            initialEntry: inactiveEntry,
+            currentIp: "203.0.113.5",
+        });
+
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        expect(onSaveAction).toHaveBeenCalledWith(
+            expect.objectContaining({ ip_range: "10.0.0.0/24" }),
+        );
+    });
+
+    it("fires onCancelAction when Cancel is clicked", async () => {
+        const user = userEvent.setup();
+        const { onCancelAction } = renderForm();
+
+        await user.click(screen.getByRole("button", { name: "Cancel" }));
+        expect(onCancelAction).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/app/(app)/org/admin/ip-allowlist/IpAllowlistForm.test.tsx
+++ b/src/app/(app)/org/admin/ip-allowlist/IpAllowlistForm.test.tsx
@@ -62,6 +62,24 @@ describe("IpAllowlistForm", () => {
         );
     });
 
+    it("warns before saving an IPv6 range when the admin's current IP is IPv4 (cross-version lockout)", async () => {
+        const user = userEvent.setup();
+        const { onSaveAction } = renderForm({ currentIp: "203.0.113.5" });
+
+        await user.type(screen.getByLabelText("IP Range"), "2001:db8::/32");
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(onSaveAction).not.toHaveBeenCalled();
+        expect(
+            screen.getByRole("dialog", { name: "This rule may lock you out" }),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: "Save anyway" }));
+        expect(onSaveAction).toHaveBeenCalledWith(
+            expect.objectContaining({ ip_range: "2001:db8::/32" }),
+        );
+    });
+
     it("does not warn about lockout when editing an entry that is already inactive", async () => {
         const user = userEvent.setup();
         const inactiveEntry: IPAllowlist = {

--- a/src/app/(app)/org/admin/ip-allowlist/IpAllowlistForm.tsx
+++ b/src/app/(app)/org/admin/ip-allowlist/IpAllowlistForm.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { ReviewSummary, type ReviewSummaryRow } from "@/components/shared/ReviewSummary";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { IPAllowlist, IPAllowlistCreate, IPAllowlistUpdate } from "@/lib/admin/types";
+import { CidrField } from "./CidrField";
+import { currentIpCoveredByRule, validateIpOrCidrInput } from "./cidr";
+
+type IpAllowlistFormMode = "create" | "edit";
+
+type IpAllowlistFormProps = {
+    mode: IpAllowlistFormMode;
+    /** Required when `mode === "edit"`; ignored otherwise. */
+    initialEntry?: IPAllowlist;
+    /** The requesting admin's own apparent IP, or `null` if undetermined. */
+    currentIp: string | null;
+    isSaving: boolean;
+    onSaveAction: (data: IPAllowlistCreate | IPAllowlistUpdate) => void;
+    onCancelAction: () => void;
+};
+
+function toDatetimeLocalValue(iso: string | null | undefined): string {
+    if (!iso) return "";
+    return iso.slice(0, 16);
+}
+
+/**
+ * Create/edit form for a single IP allowlist entry (CHAOS-2842). Validates
+ * the CIDR/IP input before it can be saved, and — since a bad range here can
+ * lock an admin out of their own console — requires an explicit acknowledgment
+ * via {@link ConfirmDialog} whenever the range being saved would exclude the
+ * requesting admin's own current IP.
+ */
+export function IpAllowlistForm({
+    mode,
+    initialEntry,
+    currentIp,
+    isSaving,
+    onSaveAction,
+    onCancelAction,
+}: IpAllowlistFormProps) {
+    const [ipRange, setIpRange] = useState(initialEntry?.ip_range ?? "");
+    const [description, setDescription] = useState(initialEntry?.description ?? "");
+    const [expiresAt, setExpiresAt] = useState(toDatetimeLocalValue(initialEntry?.expires_at));
+    const [touched, setTouched] = useState(false);
+    const [pendingLockoutConfirm, setPendingLockoutConfirm] = useState(false);
+
+    const ipRangeError = touched ? validateIpOrCidrInput(ipRange) : null;
+
+    // New entries are always active on the backend; edits keep the entry's
+    // existing active state (toggling is handled separately by the table).
+    const willBeActive = mode === "create" ? true : (initialEntry?.is_active ?? true);
+    const coversCurrentIp = currentIpCoveredByRule(currentIp, ipRange);
+    const showLockoutWarning = willBeActive && coversCurrentIp === false;
+
+    function buildPayload(): IPAllowlistCreate | IPAllowlistUpdate {
+        const trimmedDescription = description.trim();
+        return {
+            ip_range: ipRange.trim(),
+            description: trimmedDescription || null,
+            expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+        };
+    }
+
+    function handleSaveClick() {
+        setTouched(true);
+        if (validateIpOrCidrInput(ipRange)) return;
+
+        if (showLockoutWarning) {
+            setPendingLockoutConfirm(true);
+            return;
+        }
+        onSaveAction(buildPayload());
+    }
+
+    const reviewRows: ReviewSummaryRow[] = [
+        { label: "IP range", value: ipRange.trim() || "--" },
+        { label: "Your current IP", value: currentIp ?? "Unknown" },
+        { label: "Description", value: description.trim() || "--" },
+    ];
+
+    return (
+        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-5">
+            <div className="grid gap-4 sm:grid-cols-3">
+                <CidrField
+                    id="ip-range"
+                    label="IP Range"
+                    value={ipRange}
+                    error={ipRangeError}
+                    disabled={isSaving}
+                    onChangeAction={setIpRange}
+                />
+                <div>
+                    <label
+                        htmlFor="ip-description"
+                        className="mb-1 block text-xs font-medium text-(--ink-muted)"
+                    >
+                        Description
+                    </label>
+                    <input
+                        id="ip-description"
+                        type="text"
+                        placeholder="Optional"
+                        value={description ?? ""}
+                        disabled={isSaving}
+                        onChange={(event) => setDescription(event.target.value)}
+                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                    />
+                </div>
+                <div>
+                    <label
+                        htmlFor="ip-expires"
+                        className="mb-1 block text-xs font-medium text-(--ink-muted)"
+                    >
+                        Expires At
+                    </label>
+                    <input
+                        id="ip-expires"
+                        type="datetime-local"
+                        value={expiresAt}
+                        disabled={isSaving}
+                        onChange={(event) => setExpiresAt(event.target.value)}
+                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                    />
+                </div>
+            </div>
+
+            {showLockoutWarning ? (
+                <div
+                    role="alert"
+                    className="mt-4 rounded-lg border border-(--caution)/30 bg-(--caution)/10 p-3 text-xs text-(--caution)"
+                >
+                    This range does not include your current IP address
+                    {currentIp ? ` (${currentIp})` : ""}. If this is your only active rule, enabling
+                    it may lock you out of the admin console.
+                </div>
+            ) : null}
+
+            <div className="mt-4 flex gap-2">
+                <button
+                    type="button"
+                    onClick={handleSaveClick}
+                    disabled={isSaving}
+                    className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                >
+                    {isSaving ? CTA_LABELS.savingConfiguration : CTA_LABELS.save}
+                </button>
+                <button
+                    type="button"
+                    onClick={onCancelAction}
+                    disabled={isSaving}
+                    className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium disabled:opacity-50"
+                >
+                    {CTA_LABELS.cancel}
+                </button>
+            </div>
+
+            <ConfirmDialog
+                isOpen={pendingLockoutConfirm}
+                title="This rule may lock you out"
+                tone="destructive"
+                description={
+                    <ReviewSummary
+                        rows={reviewRows}
+                        warnings={[
+                            "Your current IP address is not covered by this range. If it is your only active rule, you may lose admin access from your current network.",
+                        ]}
+                    />
+                }
+                confirmLabel={CTA_LABELS.acknowledgeAndSave}
+                isPending={isSaving}
+                onConfirmAction={() => {
+                    setPendingLockoutConfirm(false);
+                    onSaveAction(buildPayload());
+                }}
+                onCancelAction={() => setPendingLockoutConfirm(false)}
+            />
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/ip-allowlist/IpAllowlistTable.test.tsx
+++ b/src/app/(app)/org/admin/ip-allowlist/IpAllowlistTable.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent, within } from "@/test/utils";
+import { IpAllowlistTable } from "./IpAllowlistTable";
+import type { IPAllowlist } from "@/lib/admin/types";
+
+function makeEntry(overrides: Partial<IPAllowlist> = {}): IPAllowlist {
+    return {
+        id: "ip-1",
+        org_id: "org-1",
+        ip_range: "192.168.1.0/24",
+        description: "Office",
+        is_active: true,
+        created_by_id: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        expires_at: null,
+        ...overrides,
+    };
+}
+
+function renderTable(overrides: Partial<Parameters<typeof IpAllowlistTable>[0]> = {}) {
+    const onEditAction = vi.fn();
+    const onToggleAction = vi.fn();
+    const onDeleteAction = vi.fn();
+    const props = {
+        entries: [makeEntry()],
+        currentIp: "203.0.113.5",
+        togglingId: null,
+        onEditAction,
+        onToggleAction,
+        onDeleteAction,
+        formatDate: (d: string | null) => d ?? "--",
+        ...overrides,
+    };
+    render(<IpAllowlistTable {...props} />);
+    return { onEditAction, onToggleAction, onDeleteAction };
+}
+
+describe("IpAllowlistTable", () => {
+    it("renders a customer-safe empty state when there are no entries", () => {
+        renderTable({ entries: [] });
+        expect(screen.getByText("No IP allowlist entries configured.")).toBeInTheDocument();
+    });
+
+    it("fires onEditAction with the row's entry", async () => {
+        const user = userEvent.setup();
+        const entry = makeEntry();
+        const { onEditAction } = renderTable({ entries: [entry] });
+
+        await user.click(screen.getByRole("button", { name: "Edit" }));
+        expect(onEditAction).toHaveBeenCalledWith(entry);
+    });
+
+    it("requires explicit confirmation, with consequence copy, before disabling an active rule", async () => {
+        const user = userEvent.setup();
+        const entry = makeEntry({ is_active: true, ip_range: "192.168.1.0/24" });
+        const { onToggleAction } = renderTable({ entries: [entry] });
+
+        await user.click(screen.getByRole("button", { name: "Disable" }));
+        expect(onToggleAction).not.toHaveBeenCalled();
+        const dialog = screen.getByRole("dialog", { name: "Disable this IP rule?" });
+        expect(dialog).toBeInTheDocument();
+        expect(screen.getByText(/removes this restriction/i)).toBeInTheDocument();
+
+        await user.click(within(dialog).getByRole("button", { name: "Disable" }));
+        expect(onToggleAction).toHaveBeenCalledWith(entry);
+    });
+
+    it("warns about lockout risk when enabling a rule that would exclude the current IP", async () => {
+        const user = userEvent.setup();
+        const entry = makeEntry({ is_active: false, ip_range: "10.0.0.0/24" });
+        renderTable({ entries: [entry], currentIp: "203.0.113.5" });
+
+        await user.click(screen.getByRole("button", { name: "Enable" }));
+        expect(screen.getByText(/does not include your current IP/i)).toBeInTheDocument();
+    });
+
+    it("requires explicit confirmation, with consequence copy, before deleting an entry", async () => {
+        const user = userEvent.setup();
+        const entry = makeEntry();
+        const { onDeleteAction } = renderTable({ entries: [entry] });
+
+        await user.click(screen.getByRole("button", { name: "Delete" }));
+        expect(onDeleteAction).not.toHaveBeenCalled();
+        const dialog = screen.getByRole("dialog", { name: "Delete this IP rule?" });
+        expect(dialog).toBeInTheDocument();
+        expect(screen.getByText(/cannot be undone/i)).toBeInTheDocument();
+
+        await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+        expect(onDeleteAction).toHaveBeenCalledWith(entry);
+    });
+});

--- a/src/app/(app)/org/admin/ip-allowlist/IpAllowlistTable.tsx
+++ b/src/app/(app)/org/admin/ip-allowlist/IpAllowlistTable.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { IPAllowlist } from "@/lib/admin/types";
+import { currentIpCoveredByRule } from "./cidr";
+
+type IpAllowlistTableProps = {
+    entries: IPAllowlist[];
+    /** The requesting admin's own apparent IP, or `null` if undetermined. */
+    currentIp: string | null;
+    togglingId: string | null;
+    onEditAction: (entry: IPAllowlist) => void;
+    onToggleAction: (entry: IPAllowlist) => void;
+    onDeleteAction: (entry: IPAllowlist) => void;
+    formatDate: (d: string | null) => string;
+};
+
+/** Table of IP allowlist entries with edit/enable-disable/delete actions (CHAOS-2842). */
+export function IpAllowlistTable({
+    entries,
+    currentIp,
+    togglingId,
+    onEditAction,
+    onToggleAction,
+    onDeleteAction,
+    formatDate,
+}: IpAllowlistTableProps) {
+    const [confirmToggle, setConfirmToggle] = useState<IPAllowlist | null>(null);
+    const [confirmDelete, setConfirmDelete] = useState<IPAllowlist | null>(null);
+
+    if (entries.length === 0) {
+        return (
+            <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+                <p className="px-4 py-8 text-center text-(--ink-muted)">
+                    No IP allowlist entries configured.
+                </p>
+            </div>
+        );
+    }
+
+    function willExcludeCurrentIpOnEnable(entry: IPAllowlist): boolean {
+        return !entry.is_active && currentIpCoveredByRule(currentIp, entry.ip_range) === false;
+    }
+
+    function toggleDescription(entry: IPAllowlist | null): string {
+        if (!entry) return "";
+        if (entry.is_active) {
+            return `Disabling ${entry.ip_range} removes this restriction — requests from outside it will no longer be blocked by this rule.`;
+        }
+        if (willExcludeCurrentIpOnEnable(entry)) {
+            return `Enabling ${entry.ip_range} will start enforcing this restriction. This range does not include your current IP${currentIp ? ` (${currentIp})` : ""} — if it is your only active rule, you may lose admin access.`;
+        }
+        return `Enabling ${entry.ip_range} will start enforcing this restriction for new requests.`;
+    }
+
+    return (
+        <>
+            <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+                            <th className="px-4 py-3 text-left font-medium">IP Range</th>
+                            <th className="px-4 py-3 text-left font-medium">Description</th>
+                            <th className="px-4 py-3 text-left font-medium">Status</th>
+                            <th className="px-4 py-3 text-left font-medium">Created</th>
+                            <th className="px-4 py-3 text-left font-medium">Expires</th>
+                            <th className="px-4 py-3 text-right font-medium">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {entries.map((entry) => (
+                            <tr
+                                key={entry.id}
+                                className="border-b border-(--card-stroke) last:border-0"
+                            >
+                                <td className="px-4 py-3 font-mono text-xs">{entry.ip_range}</td>
+                                <td className="px-4 py-3 text-(--ink-muted)">
+                                    {entry.description ?? "--"}
+                                </td>
+                                <td className="px-4 py-3">
+                                    <span
+                                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                                            entry.is_active
+                                                ? "bg-green-500/10 text-green-500"
+                                                : "bg-red-500/10 text-red-500"
+                                        }`}
+                                    >
+                                        {entry.is_active ? "Active" : "Inactive"}
+                                    </span>
+                                </td>
+                                <td className="px-4 py-3 text-(--ink-muted)">
+                                    {formatDate(entry.created_at)}
+                                </td>
+                                <td className="px-4 py-3 text-(--ink-muted)">
+                                    {formatDate(entry.expires_at)}
+                                </td>
+                                <td className="px-4 py-3 text-right">
+                                    <div className="flex items-center justify-end gap-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => onEditAction(entry)}
+                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium"
+                                        >
+                                            {CTA_LABELS.edit}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => setConfirmToggle(entry)}
+                                            disabled={togglingId === entry.id}
+                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
+                                        >
+                                            {entry.is_active
+                                                ? CTA_LABELS.disableEntry
+                                                : CTA_LABELS.enableEntry}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => setConfirmDelete(entry)}
+                                            className="rounded-lg bg-red-500/10 px-3 py-1 text-xs font-medium text-red-500"
+                                        >
+                                            {CTA_LABELS.delete}
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            <ConfirmDialog
+                isOpen={confirmToggle !== null}
+                title={confirmToggle?.is_active ? "Disable this IP rule?" : "Enable this IP rule?"}
+                tone={confirmToggle?.is_active ? "destructive" : "default"}
+                description={toggleDescription(confirmToggle)}
+                confirmLabel={
+                    confirmToggle?.is_active ? CTA_LABELS.disableEntry : CTA_LABELS.enableEntry
+                }
+                isPending={togglingId === confirmToggle?.id}
+                onConfirmAction={() => {
+                    if (confirmToggle) onToggleAction(confirmToggle);
+                    setConfirmToggle(null);
+                }}
+                onCancelAction={() => setConfirmToggle(null)}
+            />
+
+            <ConfirmDialog
+                isOpen={confirmDelete !== null}
+                title="Delete this IP rule?"
+                tone="destructive"
+                description={`This permanently removes ${confirmDelete?.ip_range ?? ""} from the allowlist. Requests from this range will no longer be treated as trusted by this rule. This cannot be undone.`}
+                confirmLabel={CTA_LABELS.delete}
+                onConfirmAction={() => {
+                    if (confirmDelete) onDeleteAction(confirmDelete);
+                    setConfirmDelete(null);
+                }}
+                onCancelAction={() => setConfirmDelete(null)}
+            />
+        </>
+    );
+}

--- a/src/app/(app)/org/admin/ip-allowlist/cidr.test.tsx
+++ b/src/app/(app)/org/admin/ip-allowlist/cidr.test.tsx
@@ -10,6 +10,9 @@ describe("validateIpOrCidrInput", () => {
         ["2001:db8::/32", null],
         ["::1", null],
         ["fe80::1/64", null],
+        ["::ffff:192.0.2.1", null],
+        ["::ffff:192.0.2.0/120", null],
+        ["::ffff:192.0.2.1/128", null],
     ])("accepts %s", (value, expected) => {
         expect(validateIpOrCidrInput(value)).toBe(expected);
     });
@@ -25,6 +28,8 @@ describe("validateIpOrCidrInput", () => {
         ["10.0.0"],
         ["gggg::1"],
         ["2001:db8::/129"],
+        ["::ffff:999.0.2.1"],
+        ["::ffff:192.0.2.1/129"],
     ])("rejects %s with a user-safe message", (value) => {
         const error = validateIpOrCidrInput(value);
         expect(error).not.toBeNull();
@@ -68,11 +73,19 @@ describe("currentIpCoveredByRule", () => {
         expect(currentIpCoveredByRule(null, "10.0.0.0/24")).toBeNull();
     });
 
-    it("returns null when the range input is invalid", () => {
-        expect(currentIpCoveredByRule("10.0.0.1", "not-a-cidr")).toBeNull();
+    it("returns false (not null) for a cross-version comparison so the lockout warning still fires", () => {
+        expect(currentIpCoveredByRule("2001:db8::1", "10.0.0.0/24")).toBe(false);
+        expect(currentIpCoveredByRule("10.0.0.1", "2001:db8::/32")).toBe(false);
     });
 
-    it("returns null when IP versions differ", () => {
-        expect(currentIpCoveredByRule("2001:db8::1", "10.0.0.0/24")).toBeNull();
+    it("returns null only for unparseable input, never for a valid cross-version pair", () => {
+        expect(currentIpCoveredByRule("10.0.0.1", "not-a-cidr")).toBeNull();
+        expect(currentIpCoveredByRule("not-an-ip", "10.0.0.0/24")).toBeNull();
+    });
+
+    it("handles IPv4-mapped IPv6 (embedded dotted-quad) containment", () => {
+        expect(currentIpCoveredByRule("::ffff:192.0.2.5", "::ffff:192.0.2.0/120")).toBe(true);
+        expect(currentIpCoveredByRule("::ffff:192.0.3.5", "::ffff:192.0.2.0/120")).toBe(false);
+        expect(currentIpCoveredByRule("::ffff:192.0.2.1", "::ffff:192.0.2.1")).toBe(true);
     });
 });

--- a/src/app/(app)/org/admin/ip-allowlist/cidr.test.tsx
+++ b/src/app/(app)/org/admin/ip-allowlist/cidr.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { currentIpCoveredByRule, parseIpOrCidr, validateIpOrCidrInput } from "./cidr";
+
+describe("validateIpOrCidrInput", () => {
+    it.each([
+        ["192.168.1.0/24", null],
+        ["10.0.0.1", null],
+        ["0.0.0.0/0", null],
+        ["255.255.255.255/32", null],
+        ["2001:db8::/32", null],
+        ["::1", null],
+        ["fe80::1/64", null],
+    ])("accepts %s", (value, expected) => {
+        expect(validateIpOrCidrInput(value)).toBe(expected);
+    });
+
+    it.each([
+        [""],
+        ["   "],
+        ["not-an-ip"],
+        ["999.1.1.1/24"],
+        ["10.0.0.1/33"],
+        ["10.0.0.1/-1"],
+        ["10.0.0.1/24/24"],
+        ["10.0.0"],
+        ["gggg::1"],
+        ["2001:db8::/129"],
+    ])("rejects %s with a user-safe message", (value) => {
+        const error = validateIpOrCidrInput(value);
+        expect(error).not.toBeNull();
+        expect(typeof error).toBe("string");
+    });
+});
+
+describe("parseIpOrCidr", () => {
+    it("defaults to a full-length prefix when none is given", () => {
+        const v4 = parseIpOrCidr("10.0.0.1");
+        expect(v4).toEqual({ valid: true, ip: "10.0.0.1", version: 4, prefixLength: 32 });
+
+        const v6 = parseIpOrCidr("::1");
+        expect(v6).toEqual({ valid: true, ip: "::1", version: 6, prefixLength: 128 });
+    });
+});
+
+describe("currentIpCoveredByRule", () => {
+    it("returns true when the current IP is inside the CIDR range", () => {
+        expect(currentIpCoveredByRule("192.168.1.42", "192.168.1.0/24")).toBe(true);
+    });
+
+    it("returns false when the current IP is outside the CIDR range", () => {
+        expect(currentIpCoveredByRule("10.0.0.1", "192.168.1.0/24")).toBe(false);
+    });
+
+    it("returns true for an exact bare-IP match", () => {
+        expect(currentIpCoveredByRule("10.0.0.1", "10.0.0.1")).toBe(true);
+    });
+
+    it("returns false for a bare-IP mismatch", () => {
+        expect(currentIpCoveredByRule("10.0.0.2", "10.0.0.1")).toBe(false);
+    });
+
+    it("handles IPv6 CIDR containment", () => {
+        expect(currentIpCoveredByRule("2001:db8::abcd", "2001:db8::/32")).toBe(true);
+        expect(currentIpCoveredByRule("2001:db9::abcd", "2001:db8::/32")).toBe(false);
+    });
+
+    it("returns null when currentIp is unknown", () => {
+        expect(currentIpCoveredByRule(null, "10.0.0.0/24")).toBeNull();
+    });
+
+    it("returns null when the range input is invalid", () => {
+        expect(currentIpCoveredByRule("10.0.0.1", "not-a-cidr")).toBeNull();
+    });
+
+    it("returns null when IP versions differ", () => {
+        expect(currentIpCoveredByRule("2001:db8::1", "10.0.0.0/24")).toBeNull();
+    });
+});

--- a/src/app/(app)/org/admin/ip-allowlist/cidr.ts
+++ b/src/app/(app)/org/admin/ip-allowlist/cidr.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure IP/CIDR parsing, validation, and containment logic for the IP
+ * allowlist admin surface (CHAOS-2842). No React, no server dependencies —
+ * safe to unit test in isolation and to share between the client form and
+ * the client-side lockout-prevention warning.
+ */
+
+export type CidrParseResult =
+    | { valid: true; ip: string; version: 4 | 6; prefixLength: number }
+    | { valid: false; error: string };
+
+const IPV4_OCTET = "(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)";
+const IPV4_REGEX = new RegExp(`^${IPV4_OCTET}(\\.${IPV4_OCTET}){3}$`);
+
+// Canonical IPv6 pattern covering full, compressed ("::"), and mixed forms.
+const V6_SEG = "[0-9a-fA-F]{1,4}";
+const IPV6_REGEX = new RegExp(
+    "^(" +
+        `(${V6_SEG}:){7}${V6_SEG}` +
+        `|(${V6_SEG}:){1,7}:` +
+        `|(${V6_SEG}:){1,6}:${V6_SEG}` +
+        `|(${V6_SEG}:){1,5}(:${V6_SEG}){1,2}` +
+        `|(${V6_SEG}:){1,4}(:${V6_SEG}){1,3}` +
+        `|(${V6_SEG}:){1,3}(:${V6_SEG}){1,4}` +
+        `|(${V6_SEG}:){1,2}(:${V6_SEG}){1,5}` +
+        `|${V6_SEG}:((:${V6_SEG}){1,6})` +
+        `|:((:${V6_SEG}){1,7}|:)` +
+        ")$",
+);
+
+function isValidIpv4(address: string): boolean {
+    return IPV4_REGEX.test(address);
+}
+
+function isValidIpv6(address: string): boolean {
+    return IPV6_REGEX.test(address);
+}
+
+/** Parses a bare IP address or a `<ip>/<prefix>` CIDR range. */
+export function parseIpOrCidr(value: string): CidrParseResult {
+    const segments = value.split("/");
+    if (segments.length > 2) {
+        return {
+            valid: false,
+            error: 'Use a single "/" to separate the address and prefix length.',
+        };
+    }
+
+    const [address, prefixPart] = segments;
+    if (!address) {
+        return { valid: false, error: "Enter an IP address or CIDR range." };
+    }
+
+    const version = isValidIpv4(address) ? 4 : isValidIpv6(address) ? 6 : null;
+    if (!version) {
+        return { valid: false, error: `"${address}" is not a valid IPv4 or IPv6 address.` };
+    }
+
+    const maxPrefix = version === 4 ? 32 : 128;
+    if (prefixPart === undefined) {
+        return { valid: true, ip: address, version, prefixLength: maxPrefix };
+    }
+
+    if (!/^\d{1,3}$/.test(prefixPart)) {
+        return {
+            valid: false,
+            error: `Prefix length must be a number between 0 and ${maxPrefix}.`,
+        };
+    }
+
+    const prefixLength = Number(prefixPart);
+    if (prefixLength < 0 || prefixLength > maxPrefix) {
+        return {
+            valid: false,
+            error: `Prefix length must be between 0 and ${maxPrefix} for IPv${version}.`,
+        };
+    }
+
+    return { valid: true, ip: address, version, prefixLength };
+}
+
+/** Returns a user-safe error message, or `null` when the input is a valid IP/CIDR. */
+export function validateIpOrCidrInput(value: string): string | null {
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return "Enter an IP address or CIDR range.";
+    }
+    const result = parseIpOrCidr(trimmed);
+    return result.valid ? null : result.error;
+}
+
+function ipv4ToInt(ip: string): number {
+    return ip.split(".").reduce((acc, octet) => (acc << 8) + Number(octet), 0) >>> 0;
+}
+
+function isIpv4InCidr(ip: string, network: string, prefixLength: number): boolean {
+    if (prefixLength === 0) return true;
+    const mask = prefixLength === 32 ? 0xffffffff : (~0 << (32 - prefixLength)) >>> 0;
+    return (ipv4ToInt(ip) & mask) === (ipv4ToInt(network) & mask);
+}
+
+function expandIpv6Groups(ip: string): string[] {
+    const [head, tail] = ip.includes("::") ? ip.split("::") : [ip, undefined];
+    const headParts = head ? head.split(":") : [];
+    const tailParts = tail ? tail.split(":") : [];
+    const missing = 8 - headParts.length - tailParts.length;
+    const middle: string[] = missing > 0 ? new Array(missing).fill("0") : [];
+    return [...headParts, ...middle, ...tailParts].map((part) => part || "0");
+}
+
+function ipv6ToBigInt(ip: string): bigint {
+    return expandIpv6Groups(ip).reduce(
+        (acc, group) => acc * BigInt(65536) + BigInt(parseInt(group, 16)),
+        BigInt(0),
+    );
+}
+
+function isIpv6InCidr(ip: string, network: string, prefixLength: number): boolean {
+    const fullMask = BigInt(2) ** BigInt(128) - BigInt(1);
+    const mask =
+        prefixLength === 0 ? BigInt(0) : (~BigInt(0) << BigInt(128 - prefixLength)) & fullMask;
+    return (ipv6ToBigInt(ip) & mask) === (ipv6ToBigInt(network) & mask);
+}
+
+/**
+ * Whether `currentIp` falls inside the range described by `ipRangeInput`.
+ * Returns `null` (unknown/not applicable) when either value is missing,
+ * invalid, or the two are different IP versions — callers should treat
+ * `null` as "can't tell", never as "not covered".
+ */
+export function currentIpCoveredByRule(
+    currentIp: string | null,
+    ipRangeInput: string,
+): boolean | null {
+    if (!currentIp) return null;
+
+    const range = parseIpOrCidr(ipRangeInput.trim());
+    const current = parseIpOrCidr(currentIp.trim());
+    if (!range.valid || !current.valid || range.version !== current.version) {
+        return null;
+    }
+
+    return range.version === 4
+        ? isIpv4InCidr(current.ip, range.ip, range.prefixLength)
+        : isIpv6InCidr(current.ip, range.ip, range.prefixLength);
+}

--- a/src/app/(app)/org/admin/ip-allowlist/cidr.ts
+++ b/src/app/(app)/org/admin/ip-allowlist/cidr.ts
@@ -32,8 +32,27 @@ function isValidIpv4(address: string): boolean {
     return IPV4_REGEX.test(address);
 }
 
-function isValidIpv6(address: string): boolean {
-    return IPV6_REGEX.test(address);
+/**
+ * Expands an IPv4-mapped/compatible IPv6 tail (e.g. "::ffff:192.0.2.1" ->
+ * "::ffff:c000:201") into pure hextets so the rest of the parser and the
+ * containment math can treat every IPv6 address as 8 hex groups — matching
+ * what the backend's Python `ipaddress` module accepts. Returns the address
+ * unchanged when it has no dotted-quad tail, or `null` when a "." is
+ * present but the tail isn't a valid IPv4 address.
+ */
+function expandEmbeddedIpv4Tail(address: string): string | null {
+    if (!address.includes(".")) return address;
+
+    const lastColon = address.lastIndexOf(":");
+    if (lastColon === -1) return null;
+
+    const tail = address.slice(lastColon + 1);
+    if (!isValidIpv4(tail)) return null;
+
+    const octets = tail.split(".").map(Number);
+    const hexHigh = ((octets[0] << 8) | octets[1]).toString(16);
+    const hexLow = ((octets[2] << 8) | octets[3]).toString(16);
+    return `${address.slice(0, lastColon)}:${hexHigh}:${hexLow}`;
 }
 
 /** Parses a bare IP address or a `<ip>/<prefix>` CIDR range. */
@@ -51,14 +70,23 @@ export function parseIpOrCidr(value: string): CidrParseResult {
         return { valid: false, error: "Enter an IP address or CIDR range." };
     }
 
-    const version = isValidIpv4(address) ? 4 : isValidIpv6(address) ? 6 : null;
-    if (!version) {
-        return { valid: false, error: `"${address}" is not a valid IPv4 or IPv6 address.` };
+    let normalizedIp: string;
+    let version: 4 | 6;
+    if (isValidIpv4(address)) {
+        normalizedIp = address;
+        version = 4;
+    } else {
+        const expanded = expandEmbeddedIpv4Tail(address);
+        if (expanded === null || !IPV6_REGEX.test(expanded)) {
+            return { valid: false, error: `"${address}" is not a valid IPv4 or IPv6 address.` };
+        }
+        normalizedIp = expanded;
+        version = 6;
     }
 
     const maxPrefix = version === 4 ? 32 : 128;
     if (prefixPart === undefined) {
-        return { valid: true, ip: address, version, prefixLength: maxPrefix };
+        return { valid: true, ip: normalizedIp, version, prefixLength: maxPrefix };
     }
 
     if (!/^\d{1,3}$/.test(prefixPart)) {
@@ -76,7 +104,7 @@ export function parseIpOrCidr(value: string): CidrParseResult {
         };
     }
 
-    return { valid: true, ip: address, version, prefixLength };
+    return { valid: true, ip: normalizedIp, version, prefixLength };
 }
 
 /** Returns a user-safe error message, or `null` when the input is a valid IP/CIDR. */
@@ -124,9 +152,12 @@ function isIpv6InCidr(ip: string, network: string, prefixLength: number): boolea
 
 /**
  * Whether `currentIp` falls inside the range described by `ipRangeInput`.
- * Returns `null` (unknown/not applicable) when either value is missing,
- * invalid, or the two are different IP versions — callers should treat
- * `null` as "can't tell", never as "not covered".
+ * Returns `false` when the range does not cover `currentIp` — including
+ * when the two are different (but individually valid) IP versions, since
+ * an IPv6 current IP is definitively NOT covered by an IPv4-only rule and
+ * vice versa, and callers rely on `false` to trigger the lockout warning.
+ * Returns `null` only when the comparison is genuinely undeterminable:
+ * `currentIp` is unknown, or either value fails to parse as a valid IP/CIDR.
  */
 export function currentIpCoveredByRule(
     currentIp: string | null,
@@ -136,9 +167,8 @@ export function currentIpCoveredByRule(
 
     const range = parseIpOrCidr(ipRangeInput.trim());
     const current = parseIpOrCidr(currentIp.trim());
-    if (!range.valid || !current.valid || range.version !== current.version) {
-        return null;
-    }
+    if (!range.valid || !current.valid) return null;
+    if (range.version !== current.version) return false;
 
     return range.version === 4
         ? isIpv4InCidr(current.ip, range.ip, range.prefixLength)

--- a/src/app/(app)/org/admin/ip-allowlist/page.test.tsx
+++ b/src/app/(app)/org/admin/ip-allowlist/page.test.tsx
@@ -1,0 +1,155 @@
+/** IPAllowlistPage integration tests (CHAOS-2842). */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, userEvent, waitFor, within } from "@/test/utils";
+import type { IPAllowlist } from "@/lib/admin/types";
+
+const mockListIPAllowlistEntries = vi.fn();
+const mockCreateIPAllowlistEntry = vi.fn();
+const mockUpdateIPAllowlistEntry = vi.fn();
+const mockDeleteIPAllowlistEntry = vi.fn();
+const mockGetCurrentClientIp = vi.fn();
+
+vi.mock("@/lib/admin/server", () => ({
+    listIPAllowlistEntries: (...args: unknown[]) => mockListIPAllowlistEntries(...args),
+    createIPAllowlistEntry: (...args: unknown[]) => mockCreateIPAllowlistEntry(...args),
+    updateIPAllowlistEntry: (...args: unknown[]) => mockUpdateIPAllowlistEntry(...args),
+    deleteIPAllowlistEntry: (...args: unknown[]) => mockDeleteIPAllowlistEntry(...args),
+    getCurrentClientIp: (...args: unknown[]) => mockGetCurrentClientIp(...args),
+}));
+
+let mockTier = {
+    tier: "enterprise",
+    features: { ip_allowlist: true },
+    minSyncIntervalHours: 0.25,
+    limits: {},
+};
+vi.mock("@/components/admin/AdminTierContext", () => ({
+    useAdminTier: () => mockTier,
+}));
+
+import IPAllowlistPage from "./page";
+
+function makeEntry(overrides: Partial<IPAllowlist> = {}): IPAllowlist {
+    return {
+        id: "ip-1",
+        org_id: "org-1",
+        ip_range: "192.168.1.0/24",
+        description: "Office",
+        is_active: true,
+        created_by_id: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        expires_at: null,
+        ...overrides,
+    };
+}
+
+function respondWith(items: IPAllowlist[]) {
+    return { data: { items, total: items.length, limit: 50, offset: 0 }, error: undefined };
+}
+
+describe("IPAllowlistPage", () => {
+    beforeEach(() => {
+        mockListIPAllowlistEntries.mockReset();
+        mockCreateIPAllowlistEntry.mockReset();
+        mockUpdateIPAllowlistEntry.mockReset();
+        mockDeleteIPAllowlistEntry.mockReset();
+        mockGetCurrentClientIp.mockReset();
+        mockGetCurrentClientIp.mockResolvedValue({ data: "203.0.113.5" });
+        mockTier = {
+            tier: "enterprise",
+            features: { ip_allowlist: true },
+            minSyncIntervalHours: 0.25,
+            limits: {},
+        };
+    });
+    afterEach(() => cleanup());
+
+    it("renders the locked upsell state when the enterprise feature gate is closed", async () => {
+        mockTier = { ...mockTier, features: { ip_allowlist: false } };
+        mockListIPAllowlistEntries.mockResolvedValue(respondWith([]));
+
+        render(<IPAllowlistPage />);
+
+        expect(await screen.findByText(/unlock ip allowlist/i)).toBeInTheDocument();
+    });
+
+    it("loads and renders entries on mount when the gate is open", async () => {
+        mockListIPAllowlistEntries.mockResolvedValue(respondWith([makeEntry()]));
+
+        render(<IPAllowlistPage />);
+
+        await waitFor(() => expect(screen.getByText("192.168.1.0/24")).toBeInTheDocument());
+    });
+
+    it("creates a new entry directly when it covers the admin's current IP", async () => {
+        mockListIPAllowlistEntries.mockResolvedValueOnce(respondWith([]));
+        mockCreateIPAllowlistEntry.mockResolvedValue({ data: makeEntry(), error: undefined });
+        mockListIPAllowlistEntries.mockResolvedValueOnce(respondWith([makeEntry()]));
+        const user = userEvent.setup();
+
+        render(<IPAllowlistPage />);
+        await waitFor(() => expect(mockGetCurrentClientIp).toHaveBeenCalled());
+
+        await user.click(screen.getByRole("button", { name: "Add IP Rule" }));
+        await user.type(screen.getByLabelText("IP Range"), "203.0.113.0/24");
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() =>
+            expect(mockCreateIPAllowlistEntry).toHaveBeenCalledWith(
+                expect.objectContaining({ ip_range: "203.0.113.0/24" }),
+            ),
+        );
+    });
+
+    it("supports the full edit flow, prefilling the existing entry", async () => {
+        const entry = makeEntry({ ip_range: "203.0.113.0/24" });
+        mockListIPAllowlistEntries.mockResolvedValue(respondWith([entry]));
+        mockUpdateIPAllowlistEntry.mockResolvedValue({ data: { ...entry, description: "HQ" } });
+        const user = userEvent.setup();
+
+        render(<IPAllowlistPage />);
+        await waitFor(() => expect(screen.getByText("203.0.113.0/24")).toBeInTheDocument());
+
+        await user.click(screen.getByRole("button", { name: "Edit" }));
+        expect(screen.getByLabelText("IP Range")).toHaveValue("203.0.113.0/24");
+
+        await user.clear(screen.getByLabelText("Description"));
+        await user.type(screen.getByLabelText("Description"), "HQ");
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() =>
+            expect(mockUpdateIPAllowlistEntry).toHaveBeenCalledWith(
+                "ip-1",
+                expect.objectContaining({ description: "HQ" }),
+            ),
+        );
+    });
+
+    it("deletes an entry only after explicit confirmation", async () => {
+        const entry = makeEntry();
+        mockListIPAllowlistEntries.mockResolvedValue(respondWith([entry]));
+        mockDeleteIPAllowlistEntry.mockResolvedValue({ data: undefined, error: undefined });
+        const user = userEvent.setup();
+
+        render(<IPAllowlistPage />);
+        await waitFor(() => expect(screen.getByText("192.168.1.0/24")).toBeInTheDocument());
+
+        await user.click(screen.getByRole("button", { name: "Delete" }));
+        const dialog = screen.getByRole("dialog", { name: "Delete this IP rule?" });
+        expect(mockDeleteIPAllowlistEntry).not.toHaveBeenCalled();
+
+        await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+        await waitFor(() => expect(mockDeleteIPAllowlistEntry).toHaveBeenCalledWith("ip-1"));
+    });
+
+    it("shows a customer-safe empty state when there are no entries", async () => {
+        mockListIPAllowlistEntries.mockResolvedValue(respondWith([]));
+
+        render(<IPAllowlistPage />);
+
+        await waitFor(() =>
+            expect(screen.getByText("No IP allowlist entries configured.")).toBeInTheDocument(),
+        );
+    });
+});

--- a/src/app/(app)/org/admin/ip-allowlist/page.tsx
+++ b/src/app/(app)/org/admin/ip-allowlist/page.tsx
@@ -1,15 +1,26 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import {
     listIPAllowlistEntries,
     createIPAllowlistEntry,
     updateIPAllowlistEntry,
     deleteIPAllowlistEntry,
+    getCurrentClientIp,
 } from "@/lib/admin/server";
-import type { IPAllowlist, IPAllowlistCreate } from "@/lib/admin/types";
+import type { IPAllowlist, IPAllowlistCreate, IPAllowlistUpdate } from "@/lib/admin/types";
 import { UpgradeGate } from "@/components/billing/UpgradeGate";
+import { CTA_LABELS } from "@/lib/design/cta";
+import { IpAllowlistForm } from "./IpAllowlistForm";
+import { IpAllowlistTable } from "./IpAllowlistTable";
+
+type FormState = { mode: "closed" } | { mode: "create" } | { mode: "edit"; entry: IPAllowlist };
+
+function formatDate(d: string | null): string {
+    if (!d) return "--";
+    return new Date(d).toLocaleDateString();
+}
 
 export default function IPAllowlistPage() {
     const [entries, setEntries] = useState<IPAllowlist[]>([]);
@@ -18,11 +29,10 @@ export default function IPAllowlistPage() {
     const [offset, setOffset] = useState(0);
     const limit = 50;
 
-    const [showAddForm, setShowAddForm] = useState(false);
-    const [formData, setFormData] = useState<IPAllowlistCreate>({ ip_range: "" });
+    const [formState, setFormState] = useState<FormState>({ mode: "closed" });
     const [saving, setSaving] = useState(false);
-    const [deletingId, setDeletingId] = useState<string | null>(null);
     const [togglingId, setTogglingId] = useState<string | null>(null);
+    const [currentIp, setCurrentIp] = useState<string | null>(null);
 
     const fetchEntries = useCallback(async () => {
         setLoading(true);
@@ -46,16 +56,23 @@ export default function IPAllowlistPage() {
         fetchEntries();
     }, [fetchEntries]);
 
-    const handleCreate = async () => {
-        if (!formData.ip_range.trim()) return;
+    useEffect(() => {
+        getCurrentClientIp().then(({ data }) => {
+            if (data) setCurrentIp(data);
+        });
+    }, []);
+
+    const handleSave = async (data: IPAllowlistCreate | IPAllowlistUpdate) => {
         setSaving(true);
-        const { error: apiError } = await createIPAllowlistEntry(formData);
+        const result =
+            formState.mode === "edit"
+                ? await updateIPAllowlistEntry(formState.entry.id, data)
+                : await createIPAllowlistEntry(data as IPAllowlistCreate);
         setSaving(false);
-        if (apiError) {
-            setError(apiError);
+        if (result.error) {
+            setError(result.error);
         } else {
-            setShowAddForm(false);
-            setFormData({ ip_range: "" });
+            setFormState({ mode: "closed" });
             fetchEntries();
         }
     };
@@ -73,23 +90,13 @@ export default function IPAllowlistPage() {
         }
     };
 
-    const handleDelete = async (id: string) => {
-        if (deletingId === id) {
-            const { error: apiError } = await deleteIPAllowlistEntry(id);
-            setDeletingId(null);
-            if (apiError) {
-                setError(apiError);
-            } else {
-                fetchEntries();
-            }
+    const handleDelete = async (entry: IPAllowlist) => {
+        const { error: apiError } = await deleteIPAllowlistEntry(entry.id);
+        if (apiError) {
+            setError(apiError);
         } else {
-            setDeletingId(id);
+            fetchEntries();
         }
-    };
-
-    const formatDate = (d: string | null) => {
-        if (!d) return "--";
-        return new Date(d).toLocaleDateString();
     };
 
     return (
@@ -107,87 +114,22 @@ export default function IPAllowlistPage() {
                 )}
 
                 <div className="mb-6">
-                    {showAddForm ? (
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-5">
-                            <div className="grid gap-4 sm:grid-cols-3">
-                                <div>
-                                    <label className="mb-1 block text-xs font-medium text-(--ink-muted)">
-                                        IP Range
-                                    </label>
-                                    <input
-                                        type="text"
-                                        placeholder="192.168.1.0/24"
-                                        value={formData.ip_range}
-                                        onChange={(e) =>
-                                            setFormData({ ...formData, ip_range: e.target.value })
-                                        }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
-                                    />
-                                </div>
-                                <div>
-                                    <label className="mb-1 block text-xs font-medium text-(--ink-muted)">
-                                        Description
-                                    </label>
-                                    <input
-                                        type="text"
-                                        placeholder="Optional"
-                                        value={formData.description ?? ""}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                description: e.target.value || null,
-                                            })
-                                        }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
-                                    />
-                                </div>
-                                <div>
-                                    <label className="mb-1 block text-xs font-medium text-(--ink-muted)">
-                                        Expires At
-                                    </label>
-                                    <input
-                                        type="datetime-local"
-                                        value={formData.expires_at ?? ""}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                expires_at: e.target.value
-                                                    ? new Date(e.target.value).toISOString()
-                                                    : null,
-                                            })
-                                        }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
-                                    />
-                                </div>
-                            </div>
-                            <div className="mt-4 flex gap-2">
-                                <button
-                                    type="button"
-                                    onClick={handleCreate}
-                                    disabled={saving}
-                                    className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-                                >
-                                    {saving ? "Saving..." : "Save"}
-                                </button>
-                                <button
-                                    type="button"
-                                    onClick={() => {
-                                        setShowAddForm(false);
-                                        setFormData({ ip_range: "" });
-                                    }}
-                                    className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium"
-                                >
-                                    Cancel
-                                </button>
-                            </div>
-                        </div>
+                    {formState.mode !== "closed" ? (
+                        <IpAllowlistForm
+                            mode={formState.mode}
+                            initialEntry={formState.mode === "edit" ? formState.entry : undefined}
+                            currentIp={currentIp}
+                            isSaving={saving}
+                            onSaveAction={handleSave}
+                            onCancelAction={() => setFormState({ mode: "closed" })}
+                        />
                     ) : (
                         <button
                             type="button"
-                            onClick={() => setShowAddForm(true)}
+                            onClick={() => setFormState({ mode: "create" })}
                             className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white"
                         >
-                            Add IP Rule
+                            {CTA_LABELS.addIpAllowlistEntry}
                         </button>
                     )}
                 </div>
@@ -198,90 +140,15 @@ export default function IPAllowlistPage() {
                     </div>
                 ) : (
                     <>
-                        <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
-                            <table className="w-full text-sm">
-                                <thead>
-                                    <tr className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
-                                        <th className="px-4 py-3 text-left font-medium">
-                                            IP Range
-                                        </th>
-                                        <th className="px-4 py-3 text-left font-medium">
-                                            Description
-                                        </th>
-                                        <th className="px-4 py-3 text-left font-medium">Status</th>
-                                        <th className="px-4 py-3 text-left font-medium">Created</th>
-                                        <th className="px-4 py-3 text-left font-medium">Expires</th>
-                                        <th className="px-4 py-3 text-right font-medium">
-                                            Actions
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {entries.length === 0 ? (
-                                        <tr>
-                                            <td
-                                                colSpan={6}
-                                                className="px-4 py-8 text-center text-(--ink-muted)"
-                                            >
-                                                No IP allowlist entries configured.
-                                            </td>
-                                        </tr>
-                                    ) : (
-                                        entries.map((entry) => (
-                                            <tr
-                                                key={entry.id}
-                                                className="border-b border-(--card-stroke) last:border-0"
-                                            >
-                                                <td className="px-4 py-3 font-mono text-xs">
-                                                    {entry.ip_range}
-                                                </td>
-                                                <td className="px-4 py-3 text-(--ink-muted)">
-                                                    {entry.description ?? "--"}
-                                                </td>
-                                                <td className="px-4 py-3">
-                                                    <span
-                                                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                                                            entry.is_active
-                                                                ? "bg-green-500/10 text-green-500"
-                                                                : "bg-red-500/10 text-red-500"
-                                                        }`}
-                                                    >
-                                                        {entry.is_active ? "Active" : "Inactive"}
-                                                    </span>
-                                                </td>
-                                                <td className="px-4 py-3 text-(--ink-muted)">
-                                                    {formatDate(entry.created_at)}
-                                                </td>
-                                                <td className="px-4 py-3 text-(--ink-muted)">
-                                                    {formatDate(entry.expires_at)}
-                                                </td>
-                                                <td className="px-4 py-3 text-right">
-                                                    <div className="flex items-center justify-end gap-2">
-                                                        <button
-                                                            type="button"
-                                                            onClick={() => handleToggle(entry)}
-                                                            disabled={togglingId === entry.id}
-                                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
-                                                        >
-                                                            {entry.is_active ? "Disable" : "Enable"}
-                                                        </button>
-                                                        <button
-                                                            type="button"
-                                                            onClick={() => handleDelete(entry.id)}
-                                                            className="rounded-lg bg-red-500/10 px-3 py-1 text-xs font-medium text-red-500"
-                                                        >
-                                                            {deletingId === entry.id
-                                                                ? "Confirm?"
-                                                                : "Delete"}
-                                                        </button>
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        ))
-                                    )}
-                                </tbody>
-                            </table>
-                        </div>
+                        <IpAllowlistTable
+                            entries={entries}
+                            currentIp={currentIp}
+                            togglingId={togglingId}
+                            onEditAction={(entry) => setFormState({ mode: "edit", entry })}
+                            onToggleAction={handleToggle}
+                            onDeleteAction={handleDelete}
+                            formatDate={formatDate}
+                        />
 
                         <div className="mt-4 flex items-center justify-between">
                             <button
@@ -290,7 +157,7 @@ export default function IPAllowlistPage() {
                                 disabled={offset === 0}
                                 className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
-                                Previous
+                                {CTA_LABELS.previousPage}
                             </button>
                             <span className="text-sm text-(--ink-muted)">
                                 Showing {offset + 1}-{offset + entries.length}
@@ -301,7 +168,7 @@ export default function IPAllowlistPage() {
                                 disabled={entries.length < limit}
                                 className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
-                                Next
+                                {CTA_LABELS.nextPage}
                             </button>
                         </div>
                     </>

--- a/src/app/(app)/org/admin/retention/RetentionPolicyForm.test.tsx
+++ b/src/app/(app)/org/admin/retention/RetentionPolicyForm.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "@/test/utils";
+import { RetentionPolicyForm } from "./RetentionPolicyForm";
+import type { RetentionPolicy } from "@/lib/admin/types";
+
+function makePolicy(overrides: Partial<RetentionPolicy> = {}): RetentionPolicy {
+    return {
+        id: "rp-1",
+        org_id: "org-1",
+        resource_type: "audit_logs",
+        retention_days: 90,
+        description: "Keep audit logs",
+        is_active: true,
+        last_run_at: "2025-06-01T00:00:00Z",
+        last_run_deleted_count: 12,
+        next_run_at: "2025-07-01T00:00:00Z",
+        created_by_id: "u-1",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        ...overrides,
+    };
+}
+
+function renderForm(overrides: Partial<Parameters<typeof RetentionPolicyForm>[0]> = {}) {
+    const onSaveAction = vi.fn();
+    const onCancelAction = vi.fn();
+    const props = {
+        mode: "create" as const,
+        resourceTypes: ["audit_logs", "metrics"],
+        isSaving: false,
+        onSaveAction,
+        onCancelAction,
+        ...overrides,
+    };
+    render(<RetentionPolicyForm {...props} />);
+    return { onSaveAction, onCancelAction };
+}
+
+describe("RetentionPolicyForm", () => {
+    it("disables Save until a resource type is selected on create", () => {
+        renderForm();
+        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    });
+
+    it("explains resource type, retention period, and expected effect while filling out the form", async () => {
+        const user = userEvent.setup();
+        renderForm();
+
+        await user.selectOptions(screen.getByLabelText("Resource Type"), "audit_logs");
+
+        expect(screen.getByText("Expected effect")).toBeInTheDocument();
+        expect(
+            screen.getByText(/audit_logs records older than 90 days will be automatically/i),
+        ).toBeInTheDocument();
+    });
+
+    it("submits the create payload with the selected resource type and retention days", async () => {
+        const user = userEvent.setup();
+        const { onSaveAction } = renderForm();
+
+        await user.selectOptions(screen.getByLabelText("Resource Type"), "metrics");
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(onSaveAction).toHaveBeenCalledWith(
+            expect.objectContaining({ resource_type: "metrics", retention_days: 90 }),
+        );
+    });
+
+    it("shows last run and next run, and locks the resource type, when editing", () => {
+        renderForm({ mode: "edit", initialPolicy: makePolicy() });
+
+        expect(screen.getByLabelText("Resource Type")).toBeDisabled();
+        expect(screen.getByText("Last run")).toBeInTheDocument();
+        expect(screen.getByText("Next run")).toBeInTheDocument();
+        expect(screen.queryByText("Never")).not.toBeInTheDocument();
+    });
+
+    it("submits an update payload without resource_type when editing", async () => {
+        const user = userEvent.setup();
+        const { onSaveAction } = renderForm({ mode: "edit", initialPolicy: makePolicy() });
+
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(onSaveAction).toHaveBeenCalledWith(
+            expect.not.objectContaining({ resource_type: expect.anything() }),
+        );
+        expect(onSaveAction).toHaveBeenCalledWith(expect.objectContaining({ retention_days: 90 }));
+    });
+});

--- a/src/app/(app)/org/admin/retention/RetentionPolicyForm.tsx
+++ b/src/app/(app)/org/admin/retention/RetentionPolicyForm.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState } from "react";
+import { ReviewSummary, type ReviewSummaryRow } from "@/components/shared/ReviewSummary";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type {
+    RetentionPolicy,
+    RetentionPolicyCreate,
+    RetentionPolicyUpdate,
+} from "@/lib/admin/types";
+
+type RetentionPolicyFormMode = "create" | "edit";
+
+type RetentionPolicyFormProps = {
+    mode: RetentionPolicyFormMode;
+    /** Required when `mode === "edit"`; ignored otherwise. */
+    initialPolicy?: RetentionPolicy;
+    resourceTypes: string[];
+    isSaving: boolean;
+    onSaveAction: (data: RetentionPolicyCreate | RetentionPolicyUpdate) => void;
+    onCancelAction: () => void;
+};
+
+function formatRunDate(d: string | null): string {
+    if (!d) return "Never";
+    return new Date(d).toLocaleDateString();
+}
+
+/**
+ * Create/edit form for a single data retention policy (CHAOS-2842). Always
+ * shows a live {@link ReviewSummary} explaining the resource type, retention
+ * period, and expected deletion effect — plus last/next run for edits — so
+ * the admin understands exactly what this policy will permanently delete
+ * before saving.
+ */
+export function RetentionPolicyForm({
+    mode,
+    initialPolicy,
+    resourceTypes,
+    isSaving,
+    onSaveAction,
+    onCancelAction,
+}: RetentionPolicyFormProps) {
+    const [resourceType, setResourceType] = useState(initialPolicy?.resource_type ?? "");
+    const [retentionDays, setRetentionDays] = useState(initialPolicy?.retention_days ?? 90);
+    const [description, setDescription] = useState(initialPolicy?.description ?? "");
+
+    const canSave = mode === "edit" || resourceType !== "";
+    const effectiveResourceType =
+        mode === "edit" ? (initialPolicy?.resource_type ?? "") : resourceType;
+
+    function handleSave() {
+        if (!canSave) return;
+        const trimmedDescription = description.trim();
+        if (mode === "edit") {
+            onSaveAction({
+                retention_days: retentionDays,
+                description: trimmedDescription || null,
+            });
+        } else {
+            onSaveAction({
+                resource_type: resourceType,
+                retention_days: retentionDays,
+                description: trimmedDescription || null,
+            });
+        }
+    }
+
+    const reviewRows: ReviewSummaryRow[] = [
+        { label: "Resource type", value: effectiveResourceType || "Not selected" },
+        {
+            label: "Retention period",
+            value: `${retentionDays} day${retentionDays === 1 ? "" : "s"}`,
+        },
+        {
+            label: "Expected effect",
+            value: effectiveResourceType
+                ? `${effectiveResourceType} records older than ${retentionDays} days will be automatically and permanently deleted on each scheduled run.`
+                : "Select a resource type to see the expected effect.",
+        },
+    ];
+
+    if (mode === "edit" && initialPolicy) {
+        reviewRows.push(
+            { label: "Last run", value: formatRunDate(initialPolicy.last_run_at) },
+            { label: "Next run", value: formatRunDate(initialPolicy.next_run_at) },
+        );
+    }
+
+    return (
+        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-5">
+            <div className="grid gap-4 sm:grid-cols-3">
+                <div>
+                    <label
+                        htmlFor="retention-resource-type"
+                        className="mb-1 block text-xs font-medium text-(--ink-muted)"
+                    >
+                        Resource Type
+                    </label>
+                    {mode === "edit" ? (
+                        <input
+                            id="retention-resource-type"
+                            type="text"
+                            value={effectiveResourceType}
+                            disabled
+                            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-(--ink-muted)"
+                        />
+                    ) : (
+                        <select
+                            id="retention-resource-type"
+                            value={resourceType}
+                            onChange={(event) => setResourceType(event.target.value)}
+                            disabled={isSaving}
+                            className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                        >
+                            <option value="">Select...</option>
+                            {resourceTypes.map((rt) => (
+                                <option key={rt} value={rt}>
+                                    {rt}
+                                </option>
+                            ))}
+                        </select>
+                    )}
+                </div>
+                <div>
+                    <label
+                        htmlFor="retention-days"
+                        className="mb-1 block text-xs font-medium text-(--ink-muted)"
+                    >
+                        Retention Days
+                    </label>
+                    <input
+                        id="retention-days"
+                        type="number"
+                        min={1}
+                        value={retentionDays}
+                        disabled={isSaving}
+                        onChange={(event) =>
+                            setRetentionDays(parseInt(event.target.value, 10) || 90)
+                        }
+                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                    />
+                </div>
+                <div>
+                    <label
+                        htmlFor="retention-description"
+                        className="mb-1 block text-xs font-medium text-(--ink-muted)"
+                    >
+                        Description
+                    </label>
+                    <input
+                        id="retention-description"
+                        type="text"
+                        placeholder="Optional"
+                        value={description ?? ""}
+                        disabled={isSaving}
+                        onChange={(event) => setDescription(event.target.value)}
+                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
+                    />
+                </div>
+            </div>
+
+            <div className="mt-4">
+                <ReviewSummary rows={reviewRows} />
+            </div>
+
+            <div className="mt-4 flex gap-2">
+                <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={isSaving || !canSave}
+                    className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                >
+                    {isSaving ? CTA_LABELS.savingConfiguration : CTA_LABELS.save}
+                </button>
+                <button
+                    type="button"
+                    onClick={onCancelAction}
+                    disabled={isSaving}
+                    className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium disabled:opacity-50"
+                >
+                    {CTA_LABELS.cancel}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/app/(app)/org/admin/retention/RetentionPolicyTable.test.tsx
+++ b/src/app/(app)/org/admin/retention/RetentionPolicyTable.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent, within } from "@/test/utils";
+import { RetentionPolicyTable } from "./RetentionPolicyTable";
+import type { RetentionPolicy } from "@/lib/admin/types";
+
+function makePolicy(overrides: Partial<RetentionPolicy> = {}): RetentionPolicy {
+    return {
+        id: "rp-1",
+        org_id: "org-1",
+        resource_type: "audit_logs",
+        retention_days: 90,
+        description: null,
+        is_active: true,
+        last_run_at: null,
+        last_run_deleted_count: null,
+        next_run_at: null,
+        created_by_id: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        ...overrides,
+    };
+}
+
+function renderTable(overrides: Partial<Parameters<typeof RetentionPolicyTable>[0]> = {}) {
+    const onEditAction = vi.fn();
+    const onToggleAction = vi.fn();
+    const onDeleteAction = vi.fn();
+    const onRequestRunAction = vi.fn();
+    const props = {
+        policies: [makePolicy()],
+        togglingId: null,
+        onEditAction,
+        onToggleAction,
+        onDeleteAction,
+        onRequestRunAction,
+        formatDate: (d: string | null) => d ?? "--",
+        ...overrides,
+    };
+    render(<RetentionPolicyTable {...props} />);
+    return { onEditAction, onToggleAction, onDeleteAction, onRequestRunAction };
+}
+
+describe("RetentionPolicyTable", () => {
+    it("renders a customer-safe empty state when there are no policies", () => {
+        renderTable({ policies: [] });
+        expect(screen.getByText("No retention policies configured.")).toBeInTheDocument();
+    });
+
+    it("fires onRequestRunAction with the row's policy", async () => {
+        const user = userEvent.setup();
+        const policy = makePolicy();
+        const { onRequestRunAction } = renderTable({ policies: [policy] });
+
+        await user.click(screen.getByRole("button", { name: "Run Now" }));
+        expect(onRequestRunAction).toHaveBeenCalledWith(policy);
+    });
+
+    it("requires explicit confirmation, with consequence copy, before disabling an active policy", async () => {
+        const user = userEvent.setup();
+        const policy = makePolicy({ is_active: true });
+        const { onToggleAction } = renderTable({ policies: [policy] });
+
+        await user.click(screen.getByRole("button", { name: "Disable" }));
+        expect(onToggleAction).not.toHaveBeenCalled();
+        const dialog = screen.getByRole("dialog", { name: "Disable this retention policy?" });
+        expect(screen.getByText(/stops future automatic deletion/i)).toBeInTheDocument();
+
+        await user.click(within(dialog).getByRole("button", { name: "Disable" }));
+        expect(onToggleAction).toHaveBeenCalledWith(policy);
+    });
+
+    it("requires explicit confirmation, with consequence copy, before deleting a policy", async () => {
+        const user = userEvent.setup();
+        const policy = makePolicy();
+        const { onDeleteAction } = renderTable({ policies: [policy] });
+
+        await user.click(screen.getByRole("button", { name: "Delete" }));
+        expect(onDeleteAction).not.toHaveBeenCalled();
+        const dialog = screen.getByRole("dialog", { name: "Delete this retention policy?" });
+        expect(screen.getByText(/does not restore any records/i)).toBeInTheDocument();
+
+        await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+        expect(onDeleteAction).toHaveBeenCalledWith(policy);
+    });
+});

--- a/src/app/(app)/org/admin/retention/RetentionPolicyTable.tsx
+++ b/src/app/(app)/org/admin/retention/RetentionPolicyTable.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState } from "react";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { RetentionPolicy } from "@/lib/admin/types";
+
+type RetentionPolicyTableProps = {
+    policies: RetentionPolicy[];
+    togglingId: string | null;
+    onEditAction: (policy: RetentionPolicy) => void;
+    onToggleAction: (policy: RetentionPolicy) => void;
+    onDeleteAction: (policy: RetentionPolicy) => void;
+    onRequestRunAction: (policy: RetentionPolicy) => void;
+    formatDate: (d: string | null) => string;
+};
+
+/** Table of retention policies with edit/enable-disable/run-now/delete actions (CHAOS-2842). */
+export function RetentionPolicyTable({
+    policies,
+    togglingId,
+    onEditAction,
+    onToggleAction,
+    onDeleteAction,
+    onRequestRunAction,
+    formatDate,
+}: RetentionPolicyTableProps) {
+    const [confirmToggle, setConfirmToggle] = useState<RetentionPolicy | null>(null);
+    const [confirmDelete, setConfirmDelete] = useState<RetentionPolicy | null>(null);
+
+    if (policies.length === 0) {
+        return (
+            <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+                <p className="px-4 py-8 text-center text-(--ink-muted)">
+                    No retention policies configured.
+                </p>
+            </div>
+        );
+    }
+
+    function toggleDescription(policy: RetentionPolicy | null): string {
+        if (!policy) return "";
+        return policy.is_active
+            ? `Disabling this policy stops future automatic deletion of ${policy.resource_type} records older than ${policy.retention_days} days. Records already deleted by previous runs are not restored.`
+            : `Enabling this policy resumes automatic deletion of ${policy.resource_type} records older than ${policy.retention_days} days on its next scheduled run.`;
+    }
+
+    return (
+        <>
+            <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
+                            <th className="px-4 py-3 text-left font-medium">Resource Type</th>
+                            <th className="px-4 py-3 text-left font-medium">Retention</th>
+                            <th className="px-4 py-3 text-left font-medium">Status</th>
+                            <th className="px-4 py-3 text-left font-medium">Last Run</th>
+                            <th className="px-4 py-3 text-left font-medium">Deleted</th>
+                            <th className="px-4 py-3 text-left font-medium">Next Run</th>
+                            <th className="px-4 py-3 text-right font-medium">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {policies.map((policy) => (
+                            <tr
+                                key={policy.id}
+                                className="border-b border-(--card-stroke) last:border-0"
+                            >
+                                <td className="px-4 py-3 font-mono text-xs">
+                                    {policy.resource_type}
+                                </td>
+                                <td className="px-4 py-3">{policy.retention_days} days</td>
+                                <td className="px-4 py-3">
+                                    <span
+                                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                                            policy.is_active
+                                                ? "bg-green-500/10 text-green-500"
+                                                : "bg-red-500/10 text-red-500"
+                                        }`}
+                                    >
+                                        {policy.is_active ? "Active" : "Inactive"}
+                                    </span>
+                                </td>
+                                <td className="px-4 py-3 text-(--ink-muted)">
+                                    {policy.last_run_at ? formatDate(policy.last_run_at) : "Never"}
+                                </td>
+                                <td className="px-4 py-3 text-(--ink-muted)">
+                                    {policy.last_run_deleted_count ?? "--"}
+                                </td>
+                                <td className="px-4 py-3 text-(--ink-muted)">
+                                    {formatDate(policy.next_run_at)}
+                                </td>
+                                <td className="px-4 py-3 text-right">
+                                    <div className="flex flex-wrap items-center justify-end gap-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => onEditAction(policy)}
+                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium"
+                                        >
+                                            {CTA_LABELS.edit}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => setConfirmToggle(policy)}
+                                            disabled={togglingId === policy.id}
+                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
+                                        >
+                                            {policy.is_active
+                                                ? CTA_LABELS.disableEntry
+                                                : CTA_LABELS.enableEntry}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => onRequestRunAction(policy)}
+                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium"
+                                        >
+                                            {CTA_LABELS.runPolicyNow}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => setConfirmDelete(policy)}
+                                            className="rounded-lg bg-red-500/10 px-3 py-1 text-xs font-medium text-red-500"
+                                        >
+                                            {CTA_LABELS.delete}
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            <ConfirmDialog
+                isOpen={confirmToggle !== null}
+                title={
+                    confirmToggle?.is_active
+                        ? "Disable this retention policy?"
+                        : "Enable this retention policy?"
+                }
+                tone={confirmToggle?.is_active ? "destructive" : "default"}
+                description={toggleDescription(confirmToggle)}
+                confirmLabel={
+                    confirmToggle?.is_active ? CTA_LABELS.disableEntry : CTA_LABELS.enableEntry
+                }
+                isPending={togglingId === confirmToggle?.id}
+                onConfirmAction={() => {
+                    if (confirmToggle) onToggleAction(confirmToggle);
+                    setConfirmToggle(null);
+                }}
+                onCancelAction={() => setConfirmToggle(null)}
+            />
+
+            <ConfirmDialog
+                isOpen={confirmDelete !== null}
+                title="Delete this retention policy?"
+                tone="destructive"
+                description={`This stops enforcing retention for ${confirmDelete?.resource_type ?? ""}. It does not restore any records already deleted by previous runs. This cannot be undone.`}
+                confirmLabel={CTA_LABELS.delete}
+                onConfirmAction={() => {
+                    if (confirmDelete) onDeleteAction(confirmDelete);
+                    setConfirmDelete(null);
+                }}
+                onCancelAction={() => setConfirmDelete(null)}
+            />
+        </>
+    );
+}

--- a/src/app/(app)/org/admin/retention/RetentionRunConfirm.test.tsx
+++ b/src/app/(app)/org/admin/retention/RetentionRunConfirm.test.tsx
@@ -98,6 +98,35 @@ describe("RetentionRunConfirm", () => {
         expect(screen.getByRole("button", { name: "Run Now" })).toBeDisabled();
     });
 
+    it("keeps confirm disabled and shows the error when the dry run reports a 200-OK embedded failure", async () => {
+        // The backend can return a dry-run failure (inactive policy, unimplemented
+        // resource type) as HTTP 200 with { deleted_count, error } — result.error
+        // is unset, but result.data.error is populated. This must block confirm
+        // just like a transport-level failure, and onExecuteAction must never fire.
+        const onDryRunAction = vi
+            .fn()
+            .mockResolvedValue({ data: { deleted_count: 0, error: "Policy is inactive" } });
+        const onExecuteAction = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <RetentionRunConfirm
+                policy={makePolicy()}
+                onDryRunAction={onDryRunAction}
+                onExecuteAction={onExecuteAction}
+                onCloseAction={vi.fn()}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByText("Policy is inactive")).toBeInTheDocument());
+        const confirmButton = screen.getByRole("button", { name: "Run Now" });
+        expect(confirmButton).toBeDisabled();
+        expect(screen.queryByText("0")).not.toBeInTheDocument();
+
+        await user.click(confirmButton);
+        expect(onExecuteAction).not.toHaveBeenCalled();
+    });
+
     it("dismisses via Cancel without executing", async () => {
         const onDryRunAction = vi
             .fn()

--- a/src/app/(app)/org/admin/retention/RetentionRunConfirm.test.tsx
+++ b/src/app/(app)/org/admin/retention/RetentionRunConfirm.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent, waitFor } from "@/test/utils";
+import { RetentionRunConfirm } from "./RetentionRunConfirm";
+import type { RetentionPolicy } from "@/lib/admin/types";
+
+function makePolicy(overrides: Partial<RetentionPolicy> = {}): RetentionPolicy {
+    return {
+        id: "rp-1",
+        org_id: "org-1",
+        resource_type: "audit_logs",
+        retention_days: 90,
+        description: null,
+        is_active: true,
+        last_run_at: null,
+        last_run_deleted_count: null,
+        next_run_at: null,
+        created_by_id: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        ...overrides,
+    };
+}
+
+describe("RetentionRunConfirm", () => {
+    it("renders nothing when no policy is targeted", () => {
+        render(
+            <RetentionRunConfirm
+                policy={null}
+                onDryRunAction={vi.fn()}
+                onExecuteAction={vi.fn()}
+                onCloseAction={vi.fn()}
+            />,
+        );
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("fetches a real dry-run count and blocks confirm until it resolves", async () => {
+        const onDryRunAction = vi
+            .fn()
+            .mockResolvedValue({ data: { deleted_count: 42, error: null } });
+        render(
+            <RetentionRunConfirm
+                policy={makePolicy()}
+                onDryRunAction={onDryRunAction}
+                onExecuteAction={vi.fn()}
+                onCloseAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByRole("button", { name: "Run Now" })).toBeDisabled();
+        expect(onDryRunAction).toHaveBeenCalledWith("rp-1");
+
+        await waitFor(() => expect(screen.getByText("42")).toBeInTheDocument());
+        expect(screen.getByText(/42 audit_logs record\(s\)/i)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Run Now" })).toBeEnabled();
+    });
+
+    it("only calls onExecuteAction after the admin confirms, and closes afterward", async () => {
+        const onDryRunAction = vi
+            .fn()
+            .mockResolvedValue({ data: { deleted_count: 5, error: null } });
+        const onExecuteAction = vi
+            .fn()
+            .mockResolvedValue({ data: { deleted_count: 5, error: null } });
+        const onCloseAction = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <RetentionRunConfirm
+                policy={makePolicy()}
+                onDryRunAction={onDryRunAction}
+                onExecuteAction={onExecuteAction}
+                onCloseAction={onCloseAction}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByRole("button", { name: "Run Now" })).toBeEnabled());
+        expect(onExecuteAction).not.toHaveBeenCalled();
+
+        await user.click(screen.getByRole("button", { name: "Run Now" }));
+
+        await waitFor(() => expect(onExecuteAction).toHaveBeenCalledWith("rp-1"));
+        await waitFor(() => expect(onCloseAction).toHaveBeenCalledTimes(1));
+    });
+
+    it("keeps confirm disabled and shows the error when the dry run fails", async () => {
+        const onDryRunAction = vi.fn().mockResolvedValue({ error: "Backend unavailable" });
+        render(
+            <RetentionRunConfirm
+                policy={makePolicy()}
+                onDryRunAction={onDryRunAction}
+                onExecuteAction={vi.fn()}
+                onCloseAction={vi.fn()}
+            />,
+        );
+
+        await waitFor(() => expect(screen.getByText("Backend unavailable")).toBeInTheDocument());
+        expect(screen.getByRole("button", { name: "Run Now" })).toBeDisabled();
+    });
+
+    it("dismisses via Cancel without executing", async () => {
+        const onDryRunAction = vi
+            .fn()
+            .mockResolvedValue({ data: { deleted_count: 1, error: null } });
+        const onExecuteAction = vi.fn();
+        const onCloseAction = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <RetentionRunConfirm
+                policy={makePolicy()}
+                onDryRunAction={onDryRunAction}
+                onExecuteAction={onExecuteAction}
+                onCloseAction={onCloseAction}
+            />,
+        );
+
+        const cancelButtons = screen.getAllByRole("button", { name: "Cancel" });
+        const cancelButton = cancelButtons.find((button) => button.textContent === "Cancel");
+        if (!cancelButton) throw new Error("Expected a labeled Cancel button.");
+        await user.click(cancelButton);
+        expect(onExecuteAction).not.toHaveBeenCalled();
+        expect(onCloseAction).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/app/(app)/org/admin/retention/RetentionRunConfirm.tsx
+++ b/src/app/(app)/org/admin/retention/RetentionRunConfirm.tsx
@@ -55,11 +55,20 @@ export function RetentionRunConfirm({
             const result = await onDryRunAction(targetPolicyId);
             if (!active) return;
             setIsPending(false);
+
             if (result.error) {
                 setDryRunError(result.error);
-            } else if (result.data) {
-                setDryRunResult(result.data);
+                return;
             }
+            if (!result.data) {
+                setDryRunError("Dry run failed: the backend returned no response data.");
+                return;
+            }
+            if (result.data.error) {
+                setDryRunError(result.data.error);
+                return;
+            }
+            setDryRunResult(result.data);
         }
         runDryRun();
 
@@ -100,7 +109,7 @@ export function RetentionRunConfirm({
                 )
             }
             confirmLabel={CTA_LABELS.runPolicyNow}
-            isPending={isPending || dryRunError !== null}
+            isPending={isPending || dryRunResult === null}
             onConfirmAction={() => {
                 setIsPending(true);
                 onExecuteAction(policy.id).finally(() => {

--- a/src/app/(app)/org/admin/retention/RetentionRunConfirm.tsx
+++ b/src/app/(app)/org/admin/retention/RetentionRunConfirm.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { ReviewSummary, type ReviewSummaryRow } from "@/components/shared/ReviewSummary";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { ActionResult } from "@/lib/result";
+import type { RetentionExecuteResponse, RetentionPolicy } from "@/lib/admin/types";
+
+type RetentionRunConfirmProps = {
+    /** The policy pending a manual run, or `null` to keep this dialog closed. */
+    policy: RetentionPolicy | null;
+    onDryRunAction: (id: string) => Promise<ActionResult<RetentionExecuteResponse>>;
+    onExecuteAction: (id: string) => Promise<ActionResult<RetentionExecuteResponse>>;
+    onCloseAction: () => void;
+};
+
+/**
+ * Manual-run flow for a single retention policy (CHAOS-2842): fetches a real
+ * backend dry-run count first (`executeRetentionPolicy(id, true)` — a genuine
+ * server-side preview, not a client estimate) and renders it as a
+ * {@link ReviewSummary}, then requires an explicit {@link ConfirmDialog}
+ * confirmation before the destructive, non-dry-run execution actually
+ * deletes records.
+ */
+export function RetentionRunConfirm({
+    policy,
+    onDryRunAction,
+    onExecuteAction,
+    onCloseAction,
+}: RetentionRunConfirmProps) {
+    const [dryRunResult, setDryRunResult] = useState<RetentionExecuteResponse | null>(null);
+    const [dryRunError, setDryRunError] = useState<string | null>(null);
+    const [isPending, setIsPending] = useState(policy !== null);
+    const [trackedPolicyId, setTrackedPolicyId] = useState<string | null>(policy?.id ?? null);
+
+    const targetId = policy?.id ?? null;
+    if (targetId !== trackedPolicyId) {
+        // Reset the stale dry-run result when the targeted policy changes —
+        // adjusting state during render (React's documented pattern) since
+        // this derives state from a prop change, not from synchronizing
+        // with an external system.
+        setTrackedPolicyId(targetId);
+        setDryRunResult(null);
+        setDryRunError(null);
+        setIsPending(targetId !== null);
+    }
+
+    useEffect(() => {
+        if (!policy) return;
+        const targetPolicyId = policy.id;
+        let active = true;
+
+        async function runDryRun() {
+            const result = await onDryRunAction(targetPolicyId);
+            if (!active) return;
+            setIsPending(false);
+            if (result.error) {
+                setDryRunError(result.error);
+            } else if (result.data) {
+                setDryRunResult(result.data);
+            }
+        }
+        runDryRun();
+
+        return () => {
+            active = false;
+        };
+        // Re-run only when the target policy's identity changes.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [policy?.id]);
+
+    if (!policy) return null;
+
+    const rows: ReviewSummaryRow[] = [
+        { label: "Resource type", value: policy.resource_type },
+        { label: "Retention period", value: `${policy.retention_days} days` },
+        {
+            label: "Records matched by this run",
+            value: dryRunResult ? dryRunResult.deleted_count.toLocaleString() : "Checking...",
+        },
+    ];
+
+    const warnings = dryRunResult
+        ? [
+              `${dryRunResult.deleted_count.toLocaleString()} ${policy.resource_type} record(s) older than ${policy.retention_days} days will be permanently deleted. This cannot be undone.`,
+          ]
+        : [];
+
+    return (
+        <ConfirmDialog
+            isOpen
+            title="Run retention policy now?"
+            tone="destructive"
+            description={
+                dryRunError ? (
+                    <p className="text-(--negative)">{dryRunError}</p>
+                ) : (
+                    <ReviewSummary rows={rows} warnings={warnings} />
+                )
+            }
+            confirmLabel={CTA_LABELS.runPolicyNow}
+            isPending={isPending || dryRunError !== null}
+            onConfirmAction={() => {
+                setIsPending(true);
+                onExecuteAction(policy.id).finally(() => {
+                    setIsPending(false);
+                    onCloseAction();
+                });
+            }}
+            onCancelAction={onCloseAction}
+        />
+    );
+}

--- a/src/app/(app)/org/admin/retention/page.test.tsx
+++ b/src/app/(app)/org/admin/retention/page.test.tsx
@@ -160,4 +160,32 @@ describe("RetentionPolicyPage", () => {
 
         await waitFor(() => expect(mockExecuteRetentionPolicy).toHaveBeenCalledWith("rp-1", false));
     });
+
+    it("surfaces a 200-OK embedded execute failure instead of silently refreshing", async () => {
+        const policy = makePolicy();
+        mockListRetentionPolicies.mockResolvedValue(respondWith([policy]));
+        mockExecuteRetentionPolicy.mockImplementation((_id: string, dryRun: boolean) =>
+            Promise.resolve(
+                dryRun
+                    ? { data: { deleted_count: 7, error: null } }
+                    : { data: { deleted_count: 0, error: "Policy is inactive" } },
+            ),
+        );
+        const user = userEvent.setup();
+
+        render(<RetentionPolicyPage />);
+        await waitFor(() => expect(screen.getByText("audit_logs")).toBeInTheDocument());
+
+        await user.click(screen.getByRole("button", { name: "Run Now" }));
+        await waitFor(() => expect(screen.getByText("7")).toBeInTheDocument());
+
+        const dialog = screen.getByRole("dialog", { name: "Run retention policy now?" });
+        await user.click(within(dialog).getByRole("button", { name: "Run Now" }));
+
+        await waitFor(() => expect(mockExecuteRetentionPolicy).toHaveBeenCalledWith("rp-1", false));
+        await waitFor(() => expect(screen.getByText("Policy is inactive")).toBeInTheDocument());
+        // Only the initial mount call + the dry-run should have listed policies —
+        // a failed execute must not silently trigger a refetch as if it succeeded.
+        expect(mockListRetentionPolicies).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/app/(app)/org/admin/retention/page.test.tsx
+++ b/src/app/(app)/org/admin/retention/page.test.tsx
@@ -1,0 +1,163 @@
+/** RetentionPolicyPage integration tests (CHAOS-2842). */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup, userEvent, waitFor, within } from "@/test/utils";
+import type { RetentionPolicy } from "@/lib/admin/types";
+
+const mockListRetentionPolicies = vi.fn();
+const mockCreateRetentionPolicy = vi.fn();
+const mockUpdateRetentionPolicy = vi.fn();
+const mockDeleteRetentionPolicy = vi.fn();
+const mockExecuteRetentionPolicy = vi.fn();
+const mockListRetentionResourceTypes = vi.fn();
+
+vi.mock("@/lib/admin/server", () => ({
+    listRetentionPolicies: (...args: unknown[]) => mockListRetentionPolicies(...args),
+    createRetentionPolicy: (...args: unknown[]) => mockCreateRetentionPolicy(...args),
+    updateRetentionPolicy: (...args: unknown[]) => mockUpdateRetentionPolicy(...args),
+    deleteRetentionPolicy: (...args: unknown[]) => mockDeleteRetentionPolicy(...args),
+    executeRetentionPolicy: (...args: unknown[]) => mockExecuteRetentionPolicy(...args),
+    listRetentionResourceTypes: (...args: unknown[]) => mockListRetentionResourceTypes(...args),
+}));
+
+let mockTier = {
+    tier: "enterprise",
+    features: { custom_retention: true },
+    minSyncIntervalHours: 0.25,
+    limits: {},
+};
+vi.mock("@/components/admin/AdminTierContext", () => ({
+    useAdminTier: () => mockTier,
+}));
+
+import RetentionPolicyPage from "./page";
+
+function makePolicy(overrides: Partial<RetentionPolicy> = {}): RetentionPolicy {
+    return {
+        id: "rp-1",
+        org_id: "org-1",
+        resource_type: "audit_logs",
+        retention_days: 90,
+        description: null,
+        is_active: true,
+        last_run_at: null,
+        last_run_deleted_count: null,
+        next_run_at: null,
+        created_by_id: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        ...overrides,
+    };
+}
+
+function respondWith(items: RetentionPolicy[]) {
+    return { data: { items, total: items.length, limit: 50, offset: 0 }, error: undefined };
+}
+
+describe("RetentionPolicyPage", () => {
+    beforeEach(() => {
+        mockListRetentionPolicies.mockReset();
+        mockCreateRetentionPolicy.mockReset();
+        mockUpdateRetentionPolicy.mockReset();
+        mockDeleteRetentionPolicy.mockReset();
+        mockExecuteRetentionPolicy.mockReset();
+        mockListRetentionResourceTypes.mockReset();
+        mockListRetentionResourceTypes.mockResolvedValue({ data: ["audit_logs", "metrics"] });
+        mockTier = {
+            tier: "enterprise",
+            features: { custom_retention: true },
+            minSyncIntervalHours: 0.25,
+            limits: {},
+        };
+    });
+    afterEach(() => cleanup());
+
+    it("renders the locked upsell state when the enterprise feature gate is closed", async () => {
+        mockTier = { ...mockTier, features: { custom_retention: false } };
+        mockListRetentionPolicies.mockResolvedValue(respondWith([]));
+
+        render(<RetentionPolicyPage />);
+
+        expect(await screen.findByText(/unlock custom retention/i)).toBeInTheDocument();
+    });
+
+    it("loads and renders policies on mount when the gate is open", async () => {
+        mockListRetentionPolicies.mockResolvedValue(respondWith([makePolicy()]));
+
+        render(<RetentionPolicyPage />);
+
+        await waitFor(() => expect(screen.getByText("audit_logs")).toBeInTheDocument());
+    });
+
+    it("shows a customer-safe empty state when there are no policies", async () => {
+        mockListRetentionPolicies.mockResolvedValue(respondWith([]));
+
+        render(<RetentionPolicyPage />);
+
+        await waitFor(() =>
+            expect(screen.getByText("No retention policies configured.")).toBeInTheDocument(),
+        );
+    });
+
+    it("creates a new policy through the form", async () => {
+        mockListRetentionPolicies.mockResolvedValueOnce(respondWith([]));
+        mockCreateRetentionPolicy.mockResolvedValue({ data: makePolicy(), error: undefined });
+        mockListRetentionPolicies.mockResolvedValueOnce(respondWith([makePolicy()]));
+        const user = userEvent.setup();
+
+        render(<RetentionPolicyPage />);
+        await waitFor(() => expect(mockListRetentionResourceTypes).toHaveBeenCalled());
+
+        await user.click(screen.getByRole("button", { name: "Add Policy" }));
+        await user.selectOptions(screen.getByLabelText("Resource Type"), "audit_logs");
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() =>
+            expect(mockCreateRetentionPolicy).toHaveBeenCalledWith(
+                expect.objectContaining({ resource_type: "audit_logs", retention_days: 90 }),
+            ),
+        );
+    });
+
+    it("deletes a policy only after explicit confirmation", async () => {
+        const policy = makePolicy();
+        mockListRetentionPolicies.mockResolvedValue(respondWith([policy]));
+        mockDeleteRetentionPolicy.mockResolvedValue({ data: undefined, error: undefined });
+        const user = userEvent.setup();
+
+        render(<RetentionPolicyPage />);
+        await waitFor(() => expect(screen.getByText("audit_logs")).toBeInTheDocument());
+
+        await user.click(screen.getByRole("button", { name: "Delete" }));
+        const dialog = screen.getByRole("dialog", { name: "Delete this retention policy?" });
+        expect(mockDeleteRetentionPolicy).not.toHaveBeenCalled();
+
+        await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+        await waitFor(() => expect(mockDeleteRetentionPolicy).toHaveBeenCalledWith("rp-1"));
+    });
+
+    it("runs the dry-run-then-confirm manual run flow end to end", async () => {
+        const policy = makePolicy();
+        mockListRetentionPolicies.mockResolvedValue(respondWith([policy]));
+        mockExecuteRetentionPolicy.mockImplementation((_id: string, dryRun: boolean) =>
+            Promise.resolve(
+                dryRun
+                    ? { data: { deleted_count: 7, error: null } }
+                    : { data: { deleted_count: 7, error: null } },
+            ),
+        );
+        const user = userEvent.setup();
+
+        render(<RetentionPolicyPage />);
+        await waitFor(() => expect(screen.getByText("audit_logs")).toBeInTheDocument());
+
+        await user.click(screen.getByRole("button", { name: "Run Now" }));
+
+        expect(mockExecuteRetentionPolicy).toHaveBeenCalledWith("rp-1", true);
+        await waitFor(() => expect(screen.getByText("7")).toBeInTheDocument());
+
+        const dialog = screen.getByRole("dialog", { name: "Run retention policy now?" });
+        await user.click(within(dialog).getByRole("button", { name: "Run Now" }));
+
+        await waitFor(() => expect(mockExecuteRetentionPolicy).toHaveBeenCalledWith("rp-1", false));
+    });
+});

--- a/src/app/(app)/org/admin/retention/page.tsx
+++ b/src/app/(app)/org/admin/retention/page.tsx
@@ -111,6 +111,12 @@ export default function RetentionPolicyPage() {
         const result = await executeRetentionPolicy(id, false);
         if (result.error) {
             setError(result.error);
+        } else if (result.data?.error) {
+            // The backend can report a failed run as an HTTP 200 with an
+            // embedded error (e.g. the policy went inactive, or the resource
+            // type isn't implemented) — surface it instead of silently
+            // refetching as if the run succeeded.
+            setError(result.data.error);
         } else {
             fetchPolicies();
         }

--- a/src/app/(app)/org/admin/retention/page.tsx
+++ b/src/app/(app)/org/admin/retention/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import {
     listRetentionPolicies,
@@ -10,8 +10,24 @@ import {
     executeRetentionPolicy,
     listRetentionResourceTypes,
 } from "@/lib/admin/server";
-import type { RetentionPolicy, RetentionPolicyCreate } from "@/lib/admin/types";
+import type {
+    RetentionPolicy,
+    RetentionPolicyCreate,
+    RetentionPolicyUpdate,
+} from "@/lib/admin/types";
 import { UpgradeGate } from "@/components/billing/UpgradeGate";
+import { CTA_LABELS } from "@/lib/design/cta";
+import { RetentionPolicyForm } from "./RetentionPolicyForm";
+import { RetentionPolicyTable } from "./RetentionPolicyTable";
+import { RetentionRunConfirm } from "./RetentionRunConfirm";
+
+type FormState =
+    { mode: "closed" } | { mode: "create" } | { mode: "edit"; policy: RetentionPolicy };
+
+function formatDate(d: string | null): string {
+    if (!d) return "--";
+    return new Date(d).toLocaleDateString();
+}
 
 export default function RetentionPolicyPage() {
     const [policies, setPolicies] = useState<RetentionPolicy[]>([]);
@@ -21,20 +37,10 @@ export default function RetentionPolicyPage() {
     const [offset, setOffset] = useState(0);
     const limit = 50;
 
-    const [showAddForm, setShowAddForm] = useState(false);
-    const [formData, setFormData] = useState<RetentionPolicyCreate>({
-        resource_type: "",
-        retention_days: 90,
-    });
+    const [formState, setFormState] = useState<FormState>({ mode: "closed" });
     const [saving, setSaving] = useState(false);
-    const [deletingId, setDeletingId] = useState<string | null>(null);
     const [togglingId, setTogglingId] = useState<string | null>(null);
-    const [executingId, setExecutingId] = useState<string | null>(null);
-    const [executeResult, setExecuteResult] = useState<{
-        id: string;
-        count: number;
-        confirming: boolean;
-    } | null>(null);
+    const [runTarget, setRunTarget] = useState<RetentionPolicy | null>(null);
 
     const fetchPolicies = useCallback(async () => {
         setLoading(true);
@@ -64,16 +70,17 @@ export default function RetentionPolicyPage() {
         });
     }, []);
 
-    const handleCreate = async () => {
-        if (!formData.resource_type) return;
+    const handleSave = async (data: RetentionPolicyCreate | RetentionPolicyUpdate) => {
         setSaving(true);
-        const { error: apiError } = await createRetentionPolicy(formData);
+        const result =
+            formState.mode === "edit"
+                ? await updateRetentionPolicy(formState.policy.id, data)
+                : await createRetentionPolicy(data as RetentionPolicyCreate);
         setSaving(false);
-        if (apiError) {
-            setError(apiError);
+        if (result.error) {
+            setError(result.error);
         } else {
-            setShowAddForm(false);
-            setFormData({ resource_type: "", retention_days: 90 });
+            setFormState({ mode: "closed" });
             fetchPolicies();
         }
     };
@@ -91,50 +98,23 @@ export default function RetentionPolicyPage() {
         }
     };
 
-    const handleDryRun = async (id: string) => {
-        setExecutingId(id);
-        const { data, error: apiError } = await executeRetentionPolicy(id, true);
-        setExecutingId(null);
+    const handleDelete = async (policy: RetentionPolicy) => {
+        const { error: apiError } = await deleteRetentionPolicy(policy.id);
         if (apiError) {
             setError(apiError);
-        } else if (data) {
-            setExecuteResult({ id, count: data.deleted_count, confirming: false });
+        } else {
+            fetchPolicies();
         }
     };
 
     const handleExecute = async (id: string) => {
-        if (executeResult?.id === id && executeResult.confirming) {
-            setExecutingId(id);
-            const { data, error: apiError } = await executeRetentionPolicy(id, false);
-            setExecutingId(null);
-            setExecuteResult(null);
-            if (apiError) {
-                setError(apiError);
-            } else if (data) {
-                fetchPolicies();
-            }
-        } else if (executeResult?.id === id) {
-            setExecuteResult({ ...executeResult, confirming: true });
-        }
-    };
-
-    const handleDelete = async (id: string) => {
-        if (deletingId === id) {
-            const { error: apiError } = await deleteRetentionPolicy(id);
-            setDeletingId(null);
-            if (apiError) {
-                setError(apiError);
-            } else {
-                fetchPolicies();
-            }
+        const result = await executeRetentionPolicy(id, false);
+        if (result.error) {
+            setError(result.error);
         } else {
-            setDeletingId(id);
+            fetchPolicies();
         }
-    };
-
-    const formatDate = (d: string | null) => {
-        if (!d) return "--";
-        return new Date(d).toLocaleDateString();
+        return result;
     };
 
     return (
@@ -152,94 +132,22 @@ export default function RetentionPolicyPage() {
                 )}
 
                 <div className="mb-6">
-                    {showAddForm ? (
-                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-5">
-                            <div className="grid gap-4 sm:grid-cols-3">
-                                <div>
-                                    <label className="mb-1 block text-xs font-medium text-(--ink-muted)">
-                                        Resource Type
-                                    </label>
-                                    <select
-                                        value={formData.resource_type}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                resource_type: e.target.value,
-                                            })
-                                        }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
-                                    >
-                                        <option value="">Select...</option>
-                                        {resourceTypes.map((rt) => (
-                                            <option key={rt} value={rt}>
-                                                {rt}
-                                            </option>
-                                        ))}
-                                    </select>
-                                </div>
-                                <div>
-                                    <label className="mb-1 block text-xs font-medium text-(--ink-muted)">
-                                        Retention Days
-                                    </label>
-                                    <input
-                                        type="number"
-                                        min={1}
-                                        value={formData.retention_days ?? 90}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                retention_days: parseInt(e.target.value) || 90,
-                                            })
-                                        }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
-                                    />
-                                </div>
-                                <div>
-                                    <label className="mb-1 block text-xs font-medium text-(--ink-muted)">
-                                        Description
-                                    </label>
-                                    <input
-                                        type="text"
-                                        placeholder="Optional"
-                                        value={formData.description ?? ""}
-                                        onChange={(e) =>
-                                            setFormData({
-                                                ...formData,
-                                                description: e.target.value || null,
-                                            })
-                                        }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm focus:border-(--accent) focus:outline-none"
-                                    />
-                                </div>
-                            </div>
-                            <div className="mt-4 flex gap-2">
-                                <button
-                                    type="button"
-                                    onClick={handleCreate}
-                                    disabled={saving}
-                                    className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-                                >
-                                    {saving ? "Saving..." : "Save"}
-                                </button>
-                                <button
-                                    type="button"
-                                    onClick={() => {
-                                        setShowAddForm(false);
-                                        setFormData({ resource_type: "", retention_days: 90 });
-                                    }}
-                                    className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium"
-                                >
-                                    Cancel
-                                </button>
-                            </div>
-                        </div>
+                    {formState.mode !== "closed" ? (
+                        <RetentionPolicyForm
+                            mode={formState.mode}
+                            initialPolicy={formState.mode === "edit" ? formState.policy : undefined}
+                            resourceTypes={resourceTypes}
+                            isSaving={saving}
+                            onSaveAction={handleSave}
+                            onCancelAction={() => setFormState({ mode: "closed" })}
+                        />
                     ) : (
                         <button
                             type="button"
-                            onClick={() => setShowAddForm(true)}
+                            onClick={() => setFormState({ mode: "create" })}
                             className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white"
                         >
-                            Add Policy
+                            {CTA_LABELS.addRetentionPolicy}
                         </button>
                     )}
                 </div>
@@ -250,123 +158,15 @@ export default function RetentionPolicyPage() {
                     </div>
                 ) : (
                     <>
-                        <div className="overflow-x-auto rounded-2xl border border-(--card-stroke) bg-(--card-80)">
-                            <table className="w-full text-sm">
-                                <thead>
-                                    <tr className="border-b border-(--card-stroke) bg-(--card-70) text-(--ink-muted)">
-                                        <th className="px-4 py-3 text-left font-medium">
-                                            Resource Type
-                                        </th>
-                                        <th className="px-4 py-3 text-left font-medium">
-                                            Retention
-                                        </th>
-                                        <th className="px-4 py-3 text-left font-medium">Status</th>
-                                        <th className="px-4 py-3 text-left font-medium">
-                                            Last Run
-                                        </th>
-                                        <th className="px-4 py-3 text-left font-medium">Deleted</th>
-                                        <th className="px-4 py-3 text-left font-medium">
-                                            Next Run
-                                        </th>
-                                        <th className="px-4 py-3 text-right font-medium">
-                                            Actions
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {policies.length === 0 ? (
-                                        <tr>
-                                            <td
-                                                colSpan={7}
-                                                className="px-4 py-8 text-center text-(--ink-muted)"
-                                            >
-                                                No retention policies configured.
-                                            </td>
-                                        </tr>
-                                    ) : (
-                                        policies.map((policy) => (
-                                            <tr
-                                                key={policy.id}
-                                                className="border-b border-(--card-stroke) last:border-0"
-                                            >
-                                                <td className="px-4 py-3 font-mono text-xs">
-                                                    {policy.resource_type}
-                                                </td>
-                                                <td className="px-4 py-3">
-                                                    {policy.retention_days} days
-                                                </td>
-                                                <td className="px-4 py-3">
-                                                    <span
-                                                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                                                            policy.is_active
-                                                                ? "bg-green-500/10 text-green-500"
-                                                                : "bg-red-500/10 text-red-500"
-                                                        }`}
-                                                    >
-                                                        {policy.is_active ? "Active" : "Inactive"}
-                                                    </span>
-                                                </td>
-                                                <td className="px-4 py-3 text-(--ink-muted)">
-                                                    {policy.last_run_at
-                                                        ? formatDate(policy.last_run_at)
-                                                        : "Never"}
-                                                </td>
-                                                <td className="px-4 py-3 text-(--ink-muted)">
-                                                    {policy.last_run_deleted_count ?? "--"}
-                                                </td>
-                                                <td className="px-4 py-3 text-(--ink-muted)">
-                                                    {formatDate(policy.next_run_at)}
-                                                </td>
-                                                <td className="px-4 py-3 text-right">
-                                                    <div className="flex flex-wrap items-center justify-end gap-2">
-                                                        <button
-                                                            type="button"
-                                                            onClick={() => handleToggle(policy)}
-                                                            disabled={togglingId === policy.id}
-                                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
-                                                        >
-                                                            {policy.is_active
-                                                                ? "Disable"
-                                                                : "Enable"}
-                                                        </button>
-                                                        <button
-                                                            type="button"
-                                                            onClick={() => handleDryRun(policy.id)}
-                                                            disabled={executingId === policy.id}
-                                                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-1 text-xs font-medium disabled:opacity-50"
-                                                        >
-                                                            Dry Run
-                                                        </button>
-                                                        {executeResult?.id === policy.id && (
-                                                            <button
-                                                                type="button"
-                                                                onClick={() =>
-                                                                    handleExecute(policy.id)
-                                                                }
-                                                                className="rounded-lg bg-red-500 px-3 py-1 text-xs font-medium text-white"
-                                                            >
-                                                                {executeResult.confirming
-                                                                    ? `Confirm delete ${executeResult.count} records?`
-                                                                    : `${executeResult.count} would be deleted`}
-                                                            </button>
-                                                        )}
-                                                        <button
-                                                            type="button"
-                                                            onClick={() => handleDelete(policy.id)}
-                                                            className="rounded-lg bg-red-500/10 px-3 py-1 text-xs font-medium text-red-500"
-                                                        >
-                                                            {deletingId === policy.id
-                                                                ? "Confirm?"
-                                                                : "Delete"}
-                                                        </button>
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        ))
-                                    )}
-                                </tbody>
-                            </table>
-                        </div>
+                        <RetentionPolicyTable
+                            policies={policies}
+                            togglingId={togglingId}
+                            onEditAction={(policy) => setFormState({ mode: "edit", policy })}
+                            onToggleAction={handleToggle}
+                            onDeleteAction={handleDelete}
+                            onRequestRunAction={setRunTarget}
+                            formatDate={formatDate}
+                        />
 
                         <div className="mt-4 flex items-center justify-between">
                             <button
@@ -375,7 +175,7 @@ export default function RetentionPolicyPage() {
                                 disabled={offset === 0}
                                 className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
-                                Previous
+                                {CTA_LABELS.previousPage}
                             </button>
                             <span className="text-sm text-(--ink-muted)">
                                 Showing {offset + 1}-{offset + policies.length}
@@ -386,11 +186,18 @@ export default function RetentionPolicyPage() {
                                 disabled={policies.length < limit}
                                 className="rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium disabled:opacity-50"
                             >
-                                Next
+                                {CTA_LABELS.nextPage}
                             </button>
                         </div>
                     </>
                 )}
+
+                <RetentionRunConfirm
+                    policy={runTarget}
+                    onDryRunAction={(id) => executeRetentionPolicy(id, true)}
+                    onExecuteAction={handleExecute}
+                    onCloseAction={() => setRunTarget(null)}
+                />
             </div>
         </UpgradeGate>
     );

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mock dependencies BEFORE importing the module under test
 vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/headers", () => ({ headers: vi.fn() }));
 
 import { revalidatePath } from "next/cache";
 import { mockAuth } from "@/test/mocks/auth";
@@ -20,6 +21,7 @@ import {
     updateIPAllowlistEntry,
     deleteIPAllowlistEntry,
     checkIPAllowed,
+    getCurrentClientIp,
     listRetentionPolicies,
     createRetentionPolicy,
     updateRetentionPolicy,
@@ -851,6 +853,35 @@ describe("admin/server IP allowlist actions", () => {
             expect(result.data).toBeDefined();
             expect(result.data?.allowed).toBe(true);
             fetchSpy.mockRestore();
+        });
+    });
+
+    describe("getCurrentClientIp", () => {
+        it("derives the client IP from request headers via getClientIp", async () => {
+            mockSession();
+            vi.stubEnv("TRUST_PROXY", "true");
+            const { headers } = await import("next/headers");
+            vi.mocked(headers).mockResolvedValue(
+                new Headers({ "x-forwarded-for": "198.51.100.10, 10.0.0.1" }),
+            );
+
+            const result = await getCurrentClientIp();
+            expect(result.data).toBe("198.51.100.10");
+        });
+
+        it("falls back to an anonymous fingerprint when no forwarded header is trusted", async () => {
+            mockSession();
+            vi.stubEnv("TRUST_PROXY", "false");
+            const { headers } = await import("next/headers");
+            vi.mocked(headers).mockResolvedValue(
+                new Headers({
+                    "x-forwarded-for": "198.51.100.10",
+                    "user-agent": "vitest",
+                }),
+            );
+
+            const result = await getCurrentClientIp();
+            expect(result.data).toMatch(/^anon:/);
         });
     });
 });

--- a/src/lib/admin/server/settings.ts
+++ b/src/lib/admin/server/settings.ts
@@ -3,6 +3,9 @@
 import { adminApi } from "../api";
 import { AdminApiError } from "../api";
 import { revalidatePath } from "next/cache";
+import { headers } from "next/headers";
+import { getClientIp, isTrustProxyEnabled } from "@/lib/client-ip";
+import { getServerEnv } from "@/lib/config";
 import type { ActionResult } from "@/lib/result";
 import type {
     Setting,
@@ -132,6 +135,24 @@ export async function checkIPAllowed(ipAddress: string): Promise<ActionResult<IP
     return withErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
         return adminApi.ipAllowlist.check(ipAddress, token, orgId);
+    });
+}
+
+/**
+ * Best-effort detection of the requesting admin's own client IP (CHAOS-2842),
+ * derived the same way as rate limiting (`getClientIp` + `TRUST_PROXY`) so it
+ * reflects what the backend itself would see. Used only to warn admins before
+ * they save an IP allowlist rule that would exclude their own current IP —
+ * never treated as an authoritative allow/deny decision.
+ */
+export async function getCurrentClientIp(): Promise<ActionResult<string>> {
+    return withErrorHandling(async () => {
+        await getSessionContext();
+        const requestHeaders = await headers();
+        return getClientIp(
+            { headers: requestHeaders },
+            { trustProxy: isTrustProxyEnabled(getServerEnv().TRUST_PROXY) },
+        );
     });
 }
 

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -133,6 +133,18 @@ export const CTA_LABELS = {
     savingConfiguration: "Saving...",
     /** Link to plan settings from a tier-gated/locked option's upgrade copy (CHAOS-2838). */
     upgradePlan: "Upgrade plan",
+    /** Open the create-entry form on the IP allowlist admin page (CHAOS-2842). */
+    addIpAllowlistEntry: "Add IP Rule",
+    /** Open the create-policy form on the data retention admin page (CHAOS-2842). */
+    addRetentionPolicy: "Add Policy",
+    /** Turn on a currently-inactive IP rule or retention policy (CHAOS-2842). */
+    enableEntry: "Enable",
+    /** Turn off a currently-active IP rule or retention policy (CHAOS-2842). */
+    disableEntry: "Disable",
+    /** Trigger the dry-run-then-confirm manual retention run flow (CHAOS-2842). */
+    runPolicyNow: "Run Now",
+    /** Proceed with a safety-critical change despite an explicit lockout-risk warning (CHAOS-2842). */
+    acknowledgeAndSave: "Save anyway",
 } as const;
 
 export type CtaKey = keyof typeof CTA_LABELS;


### PR DESCRIPTION
## CHAOS-2842 — Harden enterprise safety-critical IP allowlist and retention controls

Treats IP allowlist and data-retention as high-risk flows: strong CIDR validation, lockout-prevention warnings, review summaries, and explicit confirmation before any change that affects access or data lifecycle.

### Acceptance criteria
- [x] IP allowlist creation validates CIDR/IP with user-safe messages (IPv4, IPv6, and embedded-IPv4 IPv6 like `::ffff:192.0.2.0/120`).
- [x] Warns the admin when a rule would be active but excludes their current IP (lockout prevention) — including cross IP-version rules.
- [x] IP allowlist entries are editable (backend `PATCH /ip-allowlist/{id}` — verified real).
- [x] Retention create/edit explains resource type, retention period, last run, next run, expected effect.
- [x] Retention manual run performs a real server dry-run → `ReviewSummary` → explicit `ConfirmDialog`; a failed dry-run keeps Confirm disabled and surfaces the error (no destructive run on a failed/absent preview).
- [x] Toggle/delete explain consequences (incl. that already-deleted records are not restored).
- [x] Tests cover validation, empty states, confirmation flows, and the enterprise gate.

### Safety-critical details
- **CIDR validation** (`cidr.ts`): IPv4/IPv6 + prefix parsing with BigInt containment math; `expandEmbeddedIpv4Tail` normalizes dotted-quad IPv6 tails to match the backend's Python `ipaddress` acceptance.
- **Lockout warning**: `currentIpCoveredByRule` returns `false` (warn) for valid-but-different IP versions, `null` only for unparseable input — so an IPv4 admin enabling an IPv6-only rule is warned. Copy is hedged ("if this is your only active rule") since multi-rule AND/OR semantics aren't exposed by the schema.
- **`getCurrentClientIp`**: session-gated server action reusing the existing `getClientIp`/`TRUST_PROXY` utility; advisory-only, never authoritative.
- **Dry-run gating**: the backend returns dry-run failures as HTTP 200 `{deleted_count, error}`; the UI now treats `error || data.error || !data` as blocking, so a failed dry-run cannot enable the destructive Confirm.

### Tests / gates
- `vitest` ip-allowlist + retention + admin server: **113 passing** (CIDR valid/invalid matrix incl. embedded-IPv4 + cross-version, lockout warning, dry-run-failure-blocks-confirm, execute-error surfaced, gate locked/unlocked).
- `tsc` clean · `eslint` 0 · `design-lint` 0 in touched src · `prettier` clean.
- Reviewed via Oracle gate (2 rounds): REVISE (cross-version lockout gap; embedded-IPv4 false-reject; failed-dry-run allowed execute) → fixed → PASS.

### Visual evidence
**IP allowlist — CIDR validation with user-safe message**
![cidr validation](https://github.com/user-attachments/assets/c034fd6c-8cb2-4903-aad9-bc62ee3284ba)

**IP allowlist — destructive delete gated by a confirmation dialog with honest consequence copy**
![delete confirm](https://github.com/user-attachments/assets/fa9a6c76-7b81-4c98-ac1e-047624c38d8c)

**Retention — create form with resource-type / retention-period / expected-effect explanations (`ReviewSummary`)**
![retention effect](https://github.com/user-attachments/assets/ccd8ff60-b7f7-411f-9c82-6756c991ed9c)

> The current-IP lockout `ConfirmDialog` and the retention dry-run confirmation flow could not be triggered in the local dev environment (the dev client IP is not detected as excluded, and no retention resource types are configured in the seed backend). Both are covered by unit/integration tests (cross-version lockout warning; 200-OK embedded-error dry-run keeps Confirm disabled).

Closes CHAOS-2842.
