### PR TITLE
feat(admin): BYO-LLM explain error-states panel (CHAOS-2563)

### DIFF
--- a/src/app/(app)/org/admin/ai/page.tsx
+++ b/src/app/(app)/org/admin/ai/page.tsx
@@ -1,4 +1,5 @@
 import { ByoLlmSettings } from "@/components/admin/llm/ByoLlmSettings";
+import { ByoLlmErrorStates } from "@/components/admin/llm/ByoLlmErrorStates";
 import { getLLMSettings, upsertLLMSettings, deleteLLMSettings } from "@/lib/admin/server";
 
 // Bring Your Own LLM (BYO-LLM) org-admin settings page. Sits inside
@@ -9,10 +10,13 @@ import { getLLMSettings, upsertLLMSettings, deleteLLMSettings } from "@/lib/admi
 // state by the form itself.
 export default function ByoLlmAdminPage() {
     return (
-        <ByoLlmSettings
-            loadSettingsAction={getLLMSettings}
-            saveSettingsAction={upsertLLMSettings}
-            removeSettingsAction={deleteLLMSettings}
-        />
+        <div className="flex flex-col gap-8">
+            <ByoLlmSettings
+                loadSettingsAction={getLLMSettings}
+                saveSettingsAction={upsertLLMSettings}
+                removeSettingsAction={deleteLLMSettings}
+            />
+            <ByoLlmErrorStates />
+        </div>
     );
 }

--- a/src/components/admin/llm/ByoLlmErrorStates.test.tsx
+++ b/src/components/admin/llm/ByoLlmErrorStates.test.tsx
@@ -1,0 +1,47 @@
+/** ByoLlmErrorStates component tests — CHAOS-2563. */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test/utils";
+import { ByoLlmErrorStates } from "./ByoLlmErrorStates";
+
+describe("ByoLlmErrorStates", () => {
+    it("renders the panel title and description", () => {
+        render(<ByoLlmErrorStates />);
+        expect(screen.getByText("Explain Error States")).toBeInTheDocument();
+    });
+
+    it("renders all five classified states with their HTTP status codes", () => {
+        render(<ByoLlmErrorStates />);
+        for (const status of ["200", "422", "429", "503", "402"]) {
+            expect(screen.getByTestId(`byo-llm-error-state-${status}`)).toBeInTheDocument();
+        }
+    });
+
+    it("maps each error status to the real backend taxonomy name", () => {
+        render(<ByoLlmErrorStates />);
+        expect(screen.getByTestId("byo-llm-error-state-422")).toHaveTextContent("LLMAuthError");
+        expect(screen.getByTestId("byo-llm-error-state-429")).toHaveTextContent(
+            "LLMRateLimitError",
+        );
+        expect(screen.getByTestId("byo-llm-error-state-429")).toHaveTextContent("Retry-After");
+        expect(screen.getByTestId("byo-llm-error-state-503")).toHaveTextContent("LLMServerError");
+    });
+
+    it("labels the streamed success state without a taxonomy exception", () => {
+        render(<ByoLlmErrorStates />);
+        const successState = screen.getByTestId("byo-llm-error-state-200");
+        expect(successState).toHaveTextContent("Streamed response");
+    });
+
+    it("labels the licensing state as a tier gate, not a provider error", () => {
+        render(<ByoLlmErrorStates />);
+        const lockedState = screen.getByTestId("byo-llm-error-state-402");
+        expect(lockedState).toHaveTextContent("Not licensed");
+        expect(lockedState).toHaveTextContent("Tier gate");
+    });
+
+    it("renders nothing interactive — purely presentational output", () => {
+        render(<ByoLlmErrorStates />);
+        expect(screen.queryByRole("button")).not.toBeInTheDocument();
+        expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+});

--- a/src/components/admin/llm/ByoLlmErrorStates.tsx
+++ b/src/components/admin/llm/ByoLlmErrorStates.tsx
@@ -1,0 +1,105 @@
+import { AIPanelCard } from "@/components/ai/AIPanelCard";
+
+/**
+ * Display-only reference for how BYO-LLM provider failures surface to org
+ * admins (CHAOS-2563). Purely presentational — no data fetch, no recompute,
+ * no mutation. Wording mirrors the real exception hierarchy in
+ * `ops/.../llm/errors.py` (`LLMAuthError`, `LLMRateLimitError`,
+ * `LLMServerError`) plus the two non-provider states an admin can hit before
+ * a provider call is even attempted (the tier gate) or when a call succeeds
+ * (the streamed success path).
+ */
+
+type ErrorStateTone = "success" | "warning" | "danger" | "locked";
+
+type ErrorStateEntry = {
+    status: string;
+    title: string;
+    /** Exception class from `ops/.../llm/errors.py`, when one applies. */
+    taxonomy?: string;
+    description: string;
+    tone: ErrorStateTone;
+};
+
+const TONE_CLASSES: Record<ErrorStateTone, string> = {
+    success: "border-(--positive)/30 bg-(--positive)/10 text-(--positive)",
+    warning: "border-(--accent-3)/40 bg-(--accent-3)/10 text-(--accent-3)",
+    danger: "border-(--negative)/30 bg-(--negative)/10 text-(--negative)",
+    locked: "border-(--card-stroke) bg-(--card-70) text-(--ink-muted)",
+};
+
+const ERROR_STATES: ErrorStateEntry[] = [
+    {
+        status: "200",
+        title: "Streamed response",
+        description:
+            "The provider call succeeds and the response streams back to the caller normally.",
+        tone: "success",
+    },
+    {
+        status: "422",
+        title: "Invalid key",
+        taxonomy: "LLMAuthError",
+        description:
+            "The provider rejects the stored credentials (bad or missing API key). Resolve by updating the API key in AI Setup.",
+        tone: "danger",
+    },
+    {
+        status: "429",
+        title: "Rate limited",
+        taxonomy: "LLMRateLimitError",
+        description:
+            "The provider's rate limit or quota is exceeded. The provider's Retry-After header is honored (capped) before an automatic retry.",
+        tone: "warning",
+    },
+    {
+        status: "503",
+        title: "Provider error",
+        taxonomy: "LLMServerError",
+        description:
+            "A transient 5xx from the provider. Retried with exponential backoff before surfacing as a failure.",
+        tone: "warning",
+    },
+    {
+        status: "402",
+        title: "Not licensed",
+        taxonomy: "Tier gate",
+        description:
+            "The organization's plan does not include BYO-LLM. Enforced before any provider call is attempted — no request ever leaves the platform.",
+        tone: "locked",
+    },
+];
+
+export function ByoLlmErrorStates() {
+    return (
+        <AIPanelCard
+            title="Explain Error States"
+            description="How BYO-LLM provider failures surface to org admins. Reference only — nothing here is live."
+        >
+            <dl className="grid gap-3 sm:grid-cols-2">
+                {ERROR_STATES.map((entry) => (
+                    <div
+                        key={entry.status}
+                        data-testid={`byo-llm-error-state-${entry.status}`}
+                        className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-4"
+                    >
+                        <div className="flex flex-wrap items-center gap-2">
+                            <span
+                                className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${TONE_CLASSES[entry.tone]}`}
+                            >
+                                {entry.status}
+                            </span>
+                            <dt className="text-sm font-semibold text-foreground">{entry.title}</dt>
+                            {entry.taxonomy && (
+                                <code className="rounded bg-(--card-80) px-1.5 py-0.5 text-xs text-(--ink-muted)">
+                                    {entry.taxonomy}
+                                </code>
+                            )}
+                        </div>
+                        <dd className="mt-2 text-xs text-(--ink-muted)">{entry.description}</dd>
+                    </div>
+                ))}
+            </dl>
+        </AIPanelCard>
+    );
+}


### PR DESCRIPTION
## CHAOS-2563 — BYO-LLM Explain Error-States panel (display-only)

Part of the BYO-LLM epic (CHAOS-2349). Linear: https://linear.app/fullchaos/issue/CHAOS-2563

### What
- New display-only component `src/components/admin/llm/ByoLlmErrorStates.tsx` rendering the failure-classification reference from the Penpot "AI / Explain Error States (BYO-LLM)" board: `200` streamed · `422` invalid key / `LLMAuthError` · `429` rate limited / Retry-After / `LLMRateLimitError` · `503` provider error / `LLMServerError` · `402` not licensed / tier gate.
- Purely presentational — no fetch, no GraphQL, no recompute. Wording maps to the real backend taxonomy in ops `llm/errors.py`.
- Additive mount on `src/app/(app)/org/admin/ai/page.tsx` (existing composition untouched). Reuses `AIPanelCard`.

### Tests
- `src/components/admin/llm/ByoLlmErrorStates.test.tsx` — **6 passed** (all five states render with correct status codes + taxonomy names; no interactive elements). `pnpm typecheck` clean; new file passes `design-lint`.

### Visual evidence
SCREENSHOT-WAIVER: visual evidence pending — this panel lives behind auth on `/org/admin/ai`, and the local stack currently HMR-serves `main` (not this branch). Screenshots will be attached to this PR and the Linear issue before merge (static panel; component test asserts all five rendered states in the interim).
