### PR TITLE
feat(admin): BYO-LLM AI Setup view/edit mode (CHAOS-2565)

### DIFF
--- a/src/app/(app)/org/admin/ai/page.tsx
+++ b/src/app/(app)/org/admin/ai/page.tsx
@@ -1,5 +1,10 @@
 import { ByoLlmSettings } from "@/components/admin/llm/ByoLlmSettings";
-import { getLLMSettings, upsertLLMSettings, deleteLLMSettings } from "@/lib/admin/server";
+import {
+    getLLMSettings,
+    getLLMSettingsStatus,
+    upsertLLMSettings,
+    deleteLLMSettings,
+} from "@/lib/admin/server";
 
 // Bring Your Own LLM (BYO-LLM) org-admin settings page. Sits inside
 // (app)/org/admin so it inherits the AdminSidebar + AdminTierProvider and the
@@ -11,6 +16,7 @@ export default function ByoLlmAdminPage() {
     return (
         <ByoLlmSettings
             loadSettingsAction={getLLMSettings}
+            loadStatusAction={getLLMSettingsStatus}
             saveSettingsAction={upsertLLMSettings}
             removeSettingsAction={deleteLLMSettings}
         />

--- a/src/components/admin/llm/ByoLlmSettings.test.tsx
+++ b/src/components/admin/llm/ByoLlmSettings.test.tsx
@@ -10,6 +10,7 @@ vi.mock("next/link", () => ({
 import { ByoLlmSettings, type ByoLlmSettingsProps } from "./ByoLlmSettings";
 
 const mockLoad = vi.fn<ByoLlmSettingsProps["loadSettingsAction"]>();
+const mockLoadStatus = vi.fn<ByoLlmSettingsProps["loadStatusAction"]>();
 const mockSave = vi.fn<ByoLlmSettingsProps["saveSettingsAction"]>();
 const mockRemove = vi.fn<ByoLlmSettingsProps["removeSettingsAction"]>();
 
@@ -17,6 +18,7 @@ function renderForm() {
     return renderWithToaster(
         <ByoLlmSettings
             loadSettingsAction={mockLoad}
+            loadStatusAction={mockLoadStatus}
             saveSettingsAction={mockSave}
             removeSettingsAction={mockRemove}
         />,
@@ -28,6 +30,12 @@ describe("ByoLlmSettings", () => {
         mockLoad.mockReset();
         mockSave.mockReset();
         mockRemove.mockReset();
+        mockLoadStatus.mockReset();
+        // The CHAOS-2560 status endpoint is being built on a sibling branch;
+        // default every test to the "not built yet" failure so the badge falls
+        // back to settings-derived Saved/Not configured wording unless a test
+        // explicitly exercises the happy-path status DTO.
+        mockLoadStatus.mockResolvedValue({ error: "Not implemented", status: 501 });
     });
 
     it("renders the form with a Not configured status for an empty config", async () => {
@@ -40,7 +48,7 @@ describe("ByoLlmSettings", () => {
         expect(screen.getByLabelText("API Key")).toBeInTheDocument();
     });
 
-    it("hydrates fields and shows Saved when settings are persisted", async () => {
+    it("renders a read-only summary with a Saved badge when settings are persisted", async () => {
         mockLoad.mockResolvedValue({
             data: {
                 provider: "anthropic",
@@ -53,11 +61,135 @@ describe("ByoLlmSettings", () => {
 
         await screen.findByRole("heading", { name: "AI Setup" });
         expect(screen.getByText("Saved")).toBeInTheDocument();
-        expect(screen.getByLabelText<HTMLSelectElement>("Provider").value).toBe("anthropic");
-        expect(screen.getByLabelText<HTMLInputElement>("Model").value).toBe("claude-3-5-sonnet");
-        expect(screen.getByLabelText<HTMLInputElement>("Base URL").value).toBe(
-            "https://example.test",
+        expect(screen.getByText("Anthropic")).toBeInTheDocument();
+        expect(screen.getByText("claude-3-5-sonnet")).toBeInTheDocument();
+        expect(screen.getByText("https://example.test")).toBeInTheDocument();
+        expect(screen.getByText("sk-1…last")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+        // Read-only summary: no editable form fields until Edit is clicked.
+        expect(screen.queryByLabelText("Provider")).not.toBeInTheDocument();
+        expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+    });
+
+    it("shows an Active badge when the status endpoint reports an active configuration", async () => {
+        mockLoad.mockResolvedValue({ data: { provider: "openai", model: "gpt-4o" } });
+        mockLoadStatus.mockResolvedValue({
+            data: {
+                configured: true,
+                active: true,
+                degraded: false,
+                reason_code: "active",
+                last_fallback_at: null,
+            },
+        });
+        renderForm();
+
+        expect(await screen.findByText("Active")).toBeInTheDocument();
+    });
+
+    it("shows a degraded badge when the stored config is falling back to the platform default", async () => {
+        mockLoad.mockResolvedValue({
+            data: { provider: "openai", model: "gpt-4o", base_url: "https://bad.test" },
+        });
+        mockLoadStatus.mockResolvedValue({
+            data: {
+                configured: true,
+                active: false,
+                degraded: true,
+                reason_code: "invalid_base_url",
+                last_fallback_at: "2026-01-01T00:00:00Z",
+            },
+        });
+        renderForm();
+
+        expect(await screen.findByText("Invalid — using platform default")).toBeInTheDocument();
+    });
+
+    it("enters edit mode from the summary, edits, and saves", async () => {
+        mockLoad.mockResolvedValue({
+            data: {
+                provider: "openai",
+                model: "gpt-4o",
+                api_key: "sk-1…last",
+                base_url: "https://a.test",
+            },
+        });
+        mockSave.mockResolvedValue({
+            data: {
+                provider: "openai",
+                model: "gpt-4o-mini",
+                api_key: "sk-1…last",
+                base_url: "https://a.test",
+            },
+        });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        expect(screen.getByText("gpt-4o")).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+        const modelInput = screen.getByLabelText<HTMLInputElement>("Model");
+        expect(modelInput.value).toBe("gpt-4o");
+        await userEvent.clear(modelInput);
+        await userEvent.type(modelInput, "gpt-4o-mini");
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(mockSave).toHaveBeenCalledWith(
+            expect.objectContaining({ provider: "openai", model: "gpt-4o-mini" }),
         );
+        await waitFor(() => {
+            expect(screen.getByText("BYO-LLM settings saved.")).toBeInTheDocument();
+        });
+        // Reverts to the read-only summary after a successful save.
+        expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+        expect(screen.getByText("gpt-4o-mini")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    });
+
+    it("reverts to the summary without saving when edit is cancelled", async () => {
+        mockLoad.mockResolvedValue({
+            data: {
+                provider: "openai",
+                model: "gpt-4o",
+                api_key: "sk-1…last",
+                base_url: "https://a.test",
+            },
+        });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+        const modelInput = screen.getByLabelText<HTMLInputElement>("Model");
+        await userEvent.clear(modelInput);
+        await userEvent.type(modelInput, "some-other-model");
+        await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+        expect(mockSave).not.toHaveBeenCalled();
+        expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+        expect(screen.getByText("gpt-4o")).toBeInTheDocument();
+        expect(screen.queryByText("some-other-model")).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    });
+
+    it("omits api_key from the save payload when the key field is left blank", async () => {
+        mockLoad.mockResolvedValue({
+            data: { provider: "openai", model: "gpt-4o", api_key: "sk-1…last" },
+        });
+        mockSave.mockResolvedValue({
+            data: { provider: "openai", model: "gpt-4o", api_key: "sk-1…last" },
+        });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+        expect(screen.getByLabelText<HTMLInputElement>("API Key").value).toBe("");
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() => {
+            expect(mockSave).toHaveBeenCalledTimes(1);
+        });
+        const payload = mockSave.mock.calls[0][0];
+        expect("api_key" in payload).toBe(false);
     });
 
     it("blocks saving until settings load successfully after a retry", async () => {
@@ -76,7 +208,7 @@ describe("ByoLlmSettings", () => {
         await userEvent.click(screen.getByRole("button", { name: "Retry" }));
 
         expect(await screen.findByText("Saved")).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
         expect(mockLoad).toHaveBeenCalledTimes(2);
         expect(mockSave).not.toHaveBeenCalled();
     });
@@ -135,6 +267,7 @@ describe("ByoLlmSettings", () => {
         renderForm();
 
         await screen.findByRole("heading", { name: "AI Setup" });
+        await userEvent.click(screen.getByRole("button", { name: "Edit" }));
         await userEvent.type(screen.getByLabelText("Base URL"), "not-a-url");
         await userEvent.click(screen.getByRole("button", { name: "Save" }));
 

--- a/src/components/admin/llm/ByoLlmSettings.tsx
+++ b/src/components/admin/llm/ByoLlmSettings.tsx
@@ -10,6 +10,7 @@ import {
     type LLMProvider,
     type LLMSettingsActionResult,
     type LLMSettingsResponse,
+    type LLMSettingsStatusResponse,
     type LLMSettingsUpsert,
 } from "@/lib/admin/types";
 
@@ -21,8 +22,25 @@ type LockState = {
     message: string;
 } | null;
 
+/** Read-only summary vs. editable-form view of the saved configuration (CHAOS-2565). */
+type Mode = "view" | "edit";
+
+type BadgeTone = "positive" | "caution" | "muted";
+
+type BadgeInfo = {
+    label: string;
+    tone: BadgeTone;
+};
+
 export type ByoLlmSettingsProps = {
     loadSettingsAction: () => Promise<LLMSettingsActionResult<LLMSettingsResponse>>;
+    /**
+     * BYO-LLM status badge read (CHAOS-2560/2565). The backend endpoint is
+     * built on a sibling branch; a failed/errored result degrades gracefully
+     * to the settings-derived Saved/Not configured wording rather than
+     * blocking the summary or form.
+     */
+    loadStatusAction: () => Promise<LLMSettingsActionResult<LLMSettingsStatusResponse>>;
     saveSettingsAction: (
         data: LLMSettingsUpsert,
     ) => Promise<LLMSettingsActionResult<LLMSettingsResponse>>;
@@ -34,14 +52,58 @@ const inputClass =
 const labelClass = "mb-1 block text-xs font-medium uppercase tracking-wide text-(--ink-muted)";
 const captionClass = "mt-1 text-xs text-(--ink-muted)";
 
+const BADGE_TONE_CLASSES: Record<BadgeTone, string> = {
+    positive: "bg-(--positive)/10 text-(--positive)",
+    caution: "bg-(--caution)/10 text-(--caution)",
+    muted: "bg-(--card-70) text-(--ink-muted)",
+};
+
+const BADGE_DOT_CLASSES: Record<BadgeTone, string> = {
+    positive: "bg-(--positive)",
+    caution: "bg-(--caution)",
+    muted: "bg-(--ink-muted)",
+};
+
+/**
+ * Derives the status badge wording/tone from the CHAOS-2560 status DTO.
+ * When `status` is null (endpoint not yet available or the call failed),
+ * fall back to the settings-derived Saved/Not configured wording so the
+ * summary never blocks on a still-being-built backend endpoint.
+ */
+function deriveStatusBadge(
+    status: LLMSettingsStatusResponse | null,
+    hasSavedSettings: boolean,
+): BadgeInfo {
+    if (!status) {
+        return hasSavedSettings
+            ? { label: "Saved", tone: "positive" }
+            : { label: "Not configured", tone: "muted" };
+    }
+    if (!status.configured) {
+        return { label: "Not configured", tone: "muted" };
+    }
+    if (status.active) {
+        return { label: "Active", tone: "positive" };
+    }
+    if (status.degraded) {
+        return { label: "Invalid — using platform default", tone: "caution" };
+    }
+    return { label: "Saved", tone: "positive" };
+}
+
 export function ByoLlmSettings({
     loadSettingsAction,
+    loadStatusAction,
     saveSettingsAction,
     removeSettingsAction,
 }: ByoLlmSettingsProps) {
     const [loading, setLoading] = useState(true);
     const [locked, setLocked] = useState<LockState>(null);
     const [loadError, setLoadError] = useState<string | null>(null);
+
+    const [mode, setMode] = useState<Mode>("edit");
+    const [savedSettings, setSavedSettings] = useState<LLMSettingsResponse | null>(null);
+    const [status, setStatus] = useState<LLMSettingsStatusResponse | null>(null);
 
     const [provider, setProvider] = useState<string>(DEFAULT_PROVIDER);
     const [model, setModel] = useState("");
@@ -57,15 +119,21 @@ export function ByoLlmSettings({
     const [baseUrlError, setBaseUrlError] = useState<string | null>(null);
     const [formError, setFormError] = useState<string | null>(null);
 
+    const fetchStatus = useCallback(async () => {
+        const result = await loadStatusAction();
+        setStatus(result.data ?? null);
+    }, [loadStatusAction]);
+
     const applySettings = useCallback((data: LLMSettingsResponse) => {
+        setSavedSettings(data);
         setProvider(data.provider ?? DEFAULT_PROVIDER);
         setModel(data.model ?? "");
         setBaseUrl(data.base_url ?? "");
         setMaskedKey(data.api_key ?? null);
         setHasStoredKey(Boolean(data.api_key));
-        // TODO(CHAOS-2560): replace Saved/Not configured with backend validity-driven routing states.
         setHasSavedSettings(Boolean(data.provider));
         setApiKey("");
+        setMode(data.provider ? "view" : "edit");
     }, []);
 
     const fetchSettings = useCallback(async () => {
@@ -88,14 +156,35 @@ export function ByoLlmSettings({
             setLoadError(result.error);
         } else if (result.data) {
             applySettings(result.data);
+            void fetchStatus();
         }
         setLoading(false);
-    }, [loadSettingsAction, applySettings]);
+    }, [loadSettingsAction, applySettings, fetchStatus]);
 
     useEffect(() => {
         // eslint-disable-next-line react-hooks/set-state-in-effect -- fetchSettings coordinates async loading state after mount.
         fetchSettings();
     }, [fetchSettings]);
+
+    const handleEdit = () => {
+        setFormError(null);
+        setBaseUrlError(null);
+        setConfirmingDelete(false);
+        setMode("edit");
+    };
+
+    const handleCancel = () => {
+        if (savedSettings) {
+            setProvider(savedSettings.provider ?? DEFAULT_PROVIDER);
+            setModel(savedSettings.model ?? "");
+            setBaseUrl(savedSettings.base_url ?? "");
+            setApiKey("");
+        }
+        setFormError(null);
+        setBaseUrlError(null);
+        setConfirmingDelete(false);
+        setMode("view");
+    };
 
     const handleSave = async () => {
         if (!provider.trim()) {
@@ -129,6 +218,7 @@ export function ByoLlmSettings({
         }
         if (result.data) {
             applySettings(result.data);
+            void fetchStatus();
         }
         toast.success("BYO-LLM settings saved.");
     };
@@ -155,6 +245,9 @@ export function ByoLlmSettings({
         setMaskedKey(null);
         setHasStoredKey(false);
         setHasSavedSettings(false);
+        setSavedSettings(null);
+        setStatus(null);
+        setMode("edit");
         toast.success("BYO-LLM settings removed.");
     };
 
@@ -230,22 +323,34 @@ export function ByoLlmSettings({
         );
     }
 
+    const providerLabel = LLM_PROVIDER_LABELS[provider as LLMProvider] ?? provider;
+    const badge = deriveStatusBadge(status, hasSavedSettings);
+
     const statusBadge = (
         <span
-            className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${
-                hasSavedSettings
-                    ? "bg-(--positive)/10 text-(--positive)"
-                    : "bg-(--card-70) text-(--ink-muted)"
-            }`}
+            className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${BADGE_TONE_CLASSES[badge.tone]}`}
         >
             <span
                 aria-hidden="true"
-                className={`h-2 w-2 rounded-full ${
-                    hasSavedSettings ? "bg-(--positive)" : "bg-(--ink-muted)"
-                }`}
+                className={`h-2 w-2 rounded-full ${BADGE_DOT_CLASSES[badge.tone]}`}
             />
-            {hasSavedSettings ? "Saved" : "Not configured"}
+            {badge.label}
         </span>
+    );
+
+    const deleteButton = (
+        <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleting || (!hasSavedSettings && !hasStoredKey)}
+            className="rounded-lg bg-(--negative)/10 px-4 py-2 text-sm font-medium text-(--negative) disabled:opacity-50"
+        >
+            {deleting
+                ? "Deleting…"
+                : confirmingDelete
+                  ? CTA_LABELS.confirmDelete
+                  : CTA_LABELS.delete}
+        </button>
     );
 
     return (
@@ -268,109 +373,149 @@ export function ByoLlmSettings({
                 </div>
             )}
 
-            <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
-                <div className="grid gap-5 sm:grid-cols-2">
-                    <div>
-                        <label htmlFor="byo-provider" className={labelClass}>
-                            Provider
-                        </label>
-                        <select
-                            id="byo-provider"
-                            value={provider}
-                            onChange={(e) => setProvider(e.target.value)}
-                            className={inputClass}
+            {mode === "view" && hasSavedSettings ? (
+                <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <dl className="grid gap-5 sm:grid-cols-2">
+                        <div>
+                            <dt className={labelClass}>Provider</dt>
+                            <dd className="text-sm text-foreground">{providerLabel}</dd>
+                        </div>
+                        <div>
+                            <dt className={labelClass}>Model</dt>
+                            <dd className="text-sm text-foreground">{model || "Not set"}</dd>
+                        </div>
+                        <div>
+                            <dt className={labelClass}>API Key</dt>
+                            <dd className="text-sm text-foreground">{maskedKey ?? "••••••••"}</dd>
+                        </div>
+                        <div>
+                            <dt className={labelClass}>Base URL</dt>
+                            <dd className="text-sm text-foreground">{baseUrl || "Not set"}</dd>
+                        </div>
+                    </dl>
+
+                    <div className="mt-6 rounded-xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-xs text-(--ink-muted)">
+                        BYO-LLM requires Team tier or higher. Keys are encrypted with the org
+                        settings store and masked in all responses.
+                    </div>
+
+                    <div className="mt-6 flex flex-wrap gap-2">
+                        <button
+                            type="button"
+                            onClick={handleEdit}
+                            className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-(--accent)/60"
                         >
-                            {LLM_PROVIDERS.map((p) => (
-                                <option key={p} value={p}>
-                                    {LLM_PROVIDER_LABELS[p]}
-                                </option>
-                            ))}
-                        </select>
+                            {CTA_LABELS.edit}
+                        </button>
+                        {deleteButton}
+                    </div>
+                </div>
+            ) : (
+                <div className="rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    <div className="grid gap-5 sm:grid-cols-2">
+                        <div>
+                            <label htmlFor="byo-provider" className={labelClass}>
+                                Provider
+                            </label>
+                            <select
+                                id="byo-provider"
+                                value={provider}
+                                onChange={(e) => setProvider(e.target.value)}
+                                className={inputClass}
+                            >
+                                {LLM_PROVIDERS.map((p) => (
+                                    <option key={p} value={p}>
+                                        {LLM_PROVIDER_LABELS[p]}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+
+                        <div>
+                            <label htmlFor="byo-model" className={labelClass}>
+                                Model
+                            </label>
+                            <input
+                                id="byo-model"
+                                type="text"
+                                value={model}
+                                placeholder="Model name"
+                                onChange={(e) => setModel(e.target.value)}
+                                className={inputClass}
+                            />
+                        </div>
+
+                        <div>
+                            <label htmlFor="byo-api-key" className={labelClass}>
+                                API Key
+                            </label>
+                            <input
+                                id="byo-api-key"
+                                type="password"
+                                autoComplete="off"
+                                value={apiKey}
+                                placeholder={hasStoredKey ? (maskedKey ?? "••••••••") : "sk-..."}
+                                onChange={(e) => setApiKey(e.target.value)}
+                                className={inputClass}
+                            />
+                            <p className={captionClass}>
+                                {hasStoredKey
+                                    ? "Encrypted at rest, never returned. Enter a new key to replace the stored key."
+                                    : "Encrypted at rest, never returned."}
+                            </p>
+                        </div>
+
+                        <div>
+                            <label htmlFor="byo-base-url" className={labelClass}>
+                                Base URL
+                            </label>
+                            <input
+                                id="byo-base-url"
+                                type="text"
+                                value={baseUrl}
+                                placeholder="https://..."
+                                onChange={(e) => setBaseUrl(e.target.value)}
+                                className={`${inputClass} ${baseUrlError ? "border-(--negative)/60" : ""}`}
+                                aria-invalid={baseUrlError ? true : undefined}
+                            />
+                            {baseUrlError ? (
+                                <p className="mt-1 text-xs text-(--negative)">{baseUrlError}</p>
+                            ) : (
+                                <p className={captionClass}>
+                                    Optional. OpenAI-compatible endpoints.
+                                </p>
+                            )}
+                        </div>
                     </div>
 
-                    <div>
-                        <label htmlFor="byo-model" className={labelClass}>
-                            Model
-                        </label>
-                        <input
-                            id="byo-model"
-                            type="text"
-                            value={model}
-                            placeholder="Model name"
-                            onChange={(e) => setModel(e.target.value)}
-                            className={inputClass}
-                        />
+                    <div className="mt-6 rounded-xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-xs text-(--ink-muted)">
+                        BYO-LLM requires Team tier or higher. Keys are encrypted with the org
+                        settings store and masked in all responses.
                     </div>
 
-                    <div>
-                        <label htmlFor="byo-api-key" className={labelClass}>
-                            API Key
-                        </label>
-                        <input
-                            id="byo-api-key"
-                            type="password"
-                            autoComplete="off"
-                            value={apiKey}
-                            placeholder={hasStoredKey ? (maskedKey ?? "••••••••") : "sk-..."}
-                            onChange={(e) => setApiKey(e.target.value)}
-                            className={inputClass}
-                        />
-                        <p className={captionClass}>
-                            {hasStoredKey
-                                ? "Encrypted at rest, never returned. Enter a new key to replace the stored key."
-                                : "Encrypted at rest, never returned."}
-                        </p>
-                    </div>
-
-                    <div>
-                        <label htmlFor="byo-base-url" className={labelClass}>
-                            Base URL
-                        </label>
-                        <input
-                            id="byo-base-url"
-                            type="text"
-                            value={baseUrl}
-                            placeholder="https://..."
-                            onChange={(e) => setBaseUrl(e.target.value)}
-                            className={`${inputClass} ${baseUrlError ? "border-(--negative)/60" : ""}`}
-                            aria-invalid={baseUrlError ? true : undefined}
-                        />
-                        {baseUrlError ? (
-                            <p className="mt-1 text-xs text-(--negative)">{baseUrlError}</p>
-                        ) : (
-                            <p className={captionClass}>Optional. OpenAI-compatible endpoints.</p>
+                    <div className="mt-6 flex flex-wrap gap-2">
+                        <button
+                            type="button"
+                            onClick={handleSave}
+                            disabled={saving}
+                            className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                        >
+                            {saving ? "Saving…" : CTA_LABELS.save}
+                        </button>
+                        {hasSavedSettings && (
+                            <button
+                                type="button"
+                                onClick={handleCancel}
+                                disabled={saving}
+                                className="rounded-lg border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground disabled:opacity-50"
+                            >
+                                {CTA_LABELS.cancel}
+                            </button>
                         )}
+                        {deleteButton}
                     </div>
                 </div>
-
-                <div className="mt-6 rounded-xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-xs text-(--ink-muted)">
-                    BYO-LLM requires Team tier or higher. Keys are encrypted with the org settings
-                    store and masked in all responses.
-                </div>
-
-                <div className="mt-6 flex flex-wrap gap-2">
-                    <button
-                        type="button"
-                        onClick={handleSave}
-                        disabled={saving}
-                        className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-                    >
-                        {saving ? "Saving…" : CTA_LABELS.save}
-                    </button>
-                    <button
-                        type="button"
-                        onClick={handleDelete}
-                        disabled={deleting || (!hasSavedSettings && !hasStoredKey)}
-                        className="rounded-lg bg-(--negative)/10 px-4 py-2 text-sm font-medium text-(--negative) disabled:opacity-50"
-                    >
-                        {deleting
-                            ? "Deleting…"
-                            : confirmingDelete
-                              ? CTA_LABELS.confirmDelete
-                              : CTA_LABELS.delete}
-                    </button>
-                </div>
-            </div>
+            )}
         </div>
     );
 }

--- a/src/lib/admin/api/llm-settings.ts
+++ b/src/lib/admin/api/llm-settings.ts
@@ -1,5 +1,5 @@
 import { request } from "./_request";
-import type { LLMSettingsResponse, LLMSettingsUpsert } from "../types";
+import type { LLMSettingsResponse, LLMSettingsStatusResponse, LLMSettingsUpsert } from "../types";
 
 // Admin BYO-LLM settings endpoints. The backend force-encrypts and masks the
 // api_key, and tier/flag gates GET/PUT (402/403) while always allowing DELETE
@@ -18,4 +18,10 @@ export const llmSettingsApi = {
 
     remove: (token?: string, orgId?: string) =>
         request<{ deleted: boolean }>("/llm-settings", { method: "DELETE" }, token, orgId),
+
+    // Pure status evaluator (CHAOS-2560, plan correction C2) — no AuditLog side
+    // effects. Backend is being built on a sibling branch; callers must treat a
+    // failure as "unknown" and degrade gracefully rather than blocking the UI.
+    status: (token?: string, orgId?: string) =>
+        request<LLMSettingsStatusResponse>("/llm-settings/status", {}, token, orgId),
 };

--- a/src/lib/admin/server/settings.ts
+++ b/src/lib/admin/server/settings.ts
@@ -22,6 +22,7 @@ import type {
     RetentionPolicyListResponse,
     RetentionExecuteResponse,
     LLMSettingsResponse,
+    LLMSettingsStatusResponse,
     LLMSettingsUpsert,
     LLMSettingsActionResult,
 } from "../types";
@@ -243,6 +244,22 @@ export async function getLLMSettings(): Promise<LLMSettingsActionResult<LLMSetti
     return withStatusErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
         return adminApi.llmSettings.get(token, orgId);
+    });
+}
+
+/**
+ * BYO-LLM status badge read (CHAOS-2560/2565). Pure evaluator, no side
+ * effects on the GET. The backend endpoint is being built on a sibling
+ * branch (CHAOS-2560); callers must treat any error here as "unknown" and
+ * fall back to settings-derived wording rather than surfacing it as a hard
+ * failure.
+ */
+export async function getLLMSettingsStatus(): Promise<
+    LLMSettingsActionResult<LLMSettingsStatusResponse>
+> {
+    return withStatusErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.llmSettings.status(token, orgId);
     });
 }
 

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -772,6 +772,31 @@ export interface LLMSettingsActionResult<T> {
     status?: number;
 }
 
+/**
+ * Reason code for the current BYO-LLM status evaluation (CHAOS-2560, plan
+ * correction C2). The backend evaluator is pure (no AuditLog side effects on
+ * a GET) and returns exactly one of these buckets.
+ */
+export type LLMSettingsStatusReasonCode =
+    "not_configured" | "unknown_provider" | "missing_credentials" | "invalid_base_url" | "active";
+
+/**
+ * GET /admin/llm-settings/status response (CHAOS-2560). Drives the BYO-LLM
+ * status badge on the AI Setup summary (CHAOS-2565): `active` renders
+ * "Active", `configured && degraded` renders "Invalid — using platform
+ * default", and `!configured` renders "Not configured". This endpoint is a
+ * pure evaluator over stored settings + recent fallback audit rows — never a
+ * live provider call — so a fetch failure degrades gracefully to the
+ * settings-derived Saved/Not configured wording rather than blocking the UI.
+ */
+export interface LLMSettingsStatusResponse {
+    configured: boolean;
+    active: boolean;
+    degraded: boolean;
+    reason_code: LLMSettingsStatusReasonCode;
+    last_fallback_at: string | null;
+}
+
 // ---- Provider types ----
 
 export type Provider = "github" | "gitlab" | "jira" | "linear" | "launchdarkly";


### PR DESCRIPTION
## CHAOS-2565 — BYO-LLM AI Setup view/edit mode

Part of the BYO-LLM epic (CHAOS-2349). Linear: https://linear.app/fullchaos/issue/CHAOS-2565

### What
Reworks `src/components/admin/llm/ByoLlmSettings.tsx` so a saved config renders a **read-only summary** by default instead of a permanently-editable form:
- Saved config → read-only summary (provider, model, masked key, base_url, + status badge) with an explicit **Edit**.
- Edit mode → existing form with **Save / Cancel**; Cancel reverts from the last-saved snapshot with no save call.
- Unconfigured → unchanged create form.
- Masked-key semantics preserved (correction **C5**): blank api_key on save omits the field and keeps the stored key.
- Delete/confirm available from both summary and edit.
- Status badge wired to `GET /admin/llm-settings/status` (new server action + REST wrapper + type), degrading gracefully to the legacy Saved/Not-configured wording if the call errors.

### Depends on
Backend status endpoint in #1202 (CHAOS-2560). The DTO (`{configured, active, degraded, reason_code, last_fallback_at}`) is coded to that contract; the badge degrades gracefully until #1202 merges.

### Tests
- `src/components/admin/llm/ByoLlmSettings.test.tsx` — **13 passed**: view→edit→save, view→edit→cancel (reverts), blank-key omits `api_key`, Active/degraded badge, retry→summary, locked 402/403, load-error, inline 400 `invalid_base_url`, delete-confirm. `pnpm typecheck` clean; changed files pass `design-lint`.

### Visual evidence
SCREENSHOT-WAIVER: visual evidence pending — surface is behind auth on `/org/admin/ai`, and the local stack currently HMR-serves `main` (not this branch); the summary/degraded-badge states also depend on backend #1202. Screenshots (summary, edit, degraded badge) will be attached to this PR and the Linear issue before merge.
