### PR TITLE
feat(admin): BYO-LLM spend summary panel (CHAOS-2564)

### DIFF
--- a/src/app/(app)/org/admin/ai/page.tsx
+++ b/src/app/(app)/org/admin/ai/page.tsx
@@ -1,5 +1,11 @@
 import { ByoLlmSettings } from "@/components/admin/llm/ByoLlmSettings";
-import { getLLMSettings, upsertLLMSettings, deleteLLMSettings } from "@/lib/admin/server";
+import { ByoLlmSpendSummary } from "@/components/admin/llm/ByoLlmSpendSummary";
+import {
+    getLLMSettings,
+    upsertLLMSettings,
+    deleteLLMSettings,
+    getLLMSpendSummary,
+} from "@/lib/admin/server";
 
 // Bring Your Own LLM (BYO-LLM) org-admin settings page. Sits inside
 // (app)/org/admin so it inherits the AdminSidebar + AdminTierProvider and the
@@ -9,10 +15,13 @@ import { getLLMSettings, upsertLLMSettings, deleteLLMSettings } from "@/lib/admi
 // state by the form itself.
 export default function ByoLlmAdminPage() {
     return (
-        <ByoLlmSettings
-            loadSettingsAction={getLLMSettings}
-            saveSettingsAction={upsertLLMSettings}
-            removeSettingsAction={deleteLLMSettings}
-        />
+        <div className="space-y-8">
+            <ByoLlmSettings
+                loadSettingsAction={getLLMSettings}
+                saveSettingsAction={upsertLLMSettings}
+                removeSettingsAction={deleteLLMSettings}
+            />
+            <ByoLlmSpendSummary loadSpendAction={getLLMSpendSummary} />
+        </div>
     );
 }

--- a/src/components/admin/llm/ByoLlmSpendSummary.test.tsx
+++ b/src/components/admin/llm/ByoLlmSpendSummary.test.tsx
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent, waitFor } from "@/test/utils";
+
+vi.mock("next/link", () => ({
+    default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+import { ByoLlmSpendSummary, type ByoLlmSpendSummaryProps } from "./ByoLlmSpendSummary";
+
+const mockLoad = vi.fn<ByoLlmSpendSummaryProps["loadSpendAction"]>();
+
+function renderPanel() {
+    return render(<ByoLlmSpendSummary loadSpendAction={mockLoad} />);
+}
+
+describe("ByoLlmSpendSummary", () => {
+    beforeEach(() => {
+        mockLoad.mockReset();
+    });
+
+    it("renders the panel title and description", async () => {
+        mockLoad.mockResolvedValue({
+            data: { since: "2024-01-01T00:00:00Z", limit: 20, runs: [], legacy: [] },
+        });
+        renderPanel();
+
+        expect(await screen.findByText("AI / LLM Spend Summary (BYO-LLM)")).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                "Per-run LLM call volume, token usage, and model for the latest runs in the last 30 days.",
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it("renders per-run rows with calls, tokens, model, and failures-by-class", async () => {
+        mockLoad.mockResolvedValue({
+            data: {
+                since: "2024-01-01T00:00:00Z",
+                limit: 20,
+                runs: [
+                    {
+                        run_id: "run-1",
+                        calls: 42,
+                        input_tokens: 12345,
+                        output_tokens: 6789,
+                        model: "gpt-4o",
+                        failures_by_class: { llm_error: 2, low_confidence: 1 },
+                    },
+                    {
+                        run_id: "run-2",
+                        calls: 10,
+                        input_tokens: 1000,
+                        output_tokens: 500,
+                        model: null,
+                        failures_by_class: {},
+                    },
+                ],
+                legacy: [],
+            },
+        });
+        renderPanel();
+
+        await screen.findByText("run-1");
+        expect(screen.getByText("gpt-4o")).toBeInTheDocument();
+        expect(screen.getByText("42")).toBeInTheDocument();
+        expect(screen.getByText("12,345")).toBeInTheDocument();
+        expect(screen.getByText("6,789")).toBeInTheDocument();
+        expect(screen.getByText("llm_error ×2")).toBeInTheDocument();
+        expect(screen.getByText("low_confidence ×1")).toBeInTheDocument();
+
+        // Second row: no model, no failures.
+        expect(screen.getByText("run-2")).toBeInTheDocument();
+        expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+        expect(screen.getByText("None")).toBeInTheDocument();
+
+        // Categorization-outcome disclaimer is always shown alongside populated data.
+        expect(
+            screen.getByText(/persisted categorization outcomes/i, { exact: false }),
+        ).toBeInTheDocument();
+    });
+
+    it("renders an empty state when there is no spend and no legacy rows", async () => {
+        mockLoad.mockResolvedValue({
+            data: { since: "2024-01-01T00:00:00Z", limit: 20, runs: [], legacy: [] },
+        });
+        renderPanel();
+
+        expect(await screen.findByText("No BYO-LLM spend recorded yet")).toBeInTheDocument();
+        expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    });
+
+    it("renders a legacy state when spend exists but predates per-run tracking", async () => {
+        mockLoad.mockResolvedValue({
+            data: {
+                since: "2024-01-01T00:00:00Z",
+                limit: 20,
+                runs: [],
+                legacy: [
+                    {
+                        run_id: "",
+                        marker: "legacy_empty_run_id",
+                        provider: "openai",
+                        model: "gpt-4o",
+                        calls: 3,
+                        input_tokens: 500,
+                        output_tokens: 100,
+                        computed_at: "2023-12-01T00:00:00Z",
+                    },
+                ],
+            },
+        });
+        renderPanel();
+
+        expect(
+            await screen.findByText("Legacy spend not attributable to a run"),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId("byo-llm-spend-legacy")).toBeInTheDocument();
+        expect(screen.queryByRole("table")).not.toBeInTheDocument();
+        expect(screen.queryByText("No BYO-LLM spend recorded yet")).not.toBeInTheDocument();
+    });
+
+    it("renders a locked upsell state when the backend returns 402", async () => {
+        mockLoad.mockResolvedValue({
+            error: "This feature requires the Team plan.",
+            status: 402,
+        });
+        renderPanel();
+
+        expect(await screen.findByTestId("byo-llm-spend-locked")).toBeInTheDocument();
+        expect(screen.getByText("This feature requires the Team plan.")).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "Upgrade plan" })).toBeInTheDocument();
+    });
+
+    it("renders a locked state without an upgrade link when the flag is off (403)", async () => {
+        mockLoad.mockResolvedValue({
+            error: "BYO LLM is not enabled for this organization",
+            status: 403,
+        });
+        renderPanel();
+
+        expect(await screen.findByTestId("byo-llm-spend-locked")).toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "Upgrade plan" })).not.toBeInTheDocument();
+    });
+
+    it("shows a retry action on a generic load error", async () => {
+        mockLoad.mockResolvedValueOnce({ error: "temporary backend failure", status: 500 });
+        mockLoad.mockResolvedValueOnce({
+            data: { since: "2024-01-01T00:00:00Z", limit: 20, runs: [], legacy: [] },
+        });
+        renderPanel();
+
+        expect(await screen.findByText("temporary backend failure")).toBeInTheDocument();
+        const retryButton = screen.getByRole("button", { name: "Retry" });
+
+        await waitFor(() => expect(mockLoad).toHaveBeenCalledTimes(1));
+        await userEvent.click(retryButton);
+
+        await waitFor(() => {
+            expect(screen.getByText("No BYO-LLM spend recorded yet")).toBeInTheDocument();
+        });
+        expect(mockLoad).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/components/admin/llm/ByoLlmSpendSummary.tsx
+++ b/src/components/admin/llm/ByoLlmSpendSummary.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import Link from "next/link";
+import { AIPanelCard } from "@/components/ai/AIPanelCard";
+import { AIEmptyState } from "@/components/ai/AIEmptyState";
+import { DataState } from "@/components/ui/DataState";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { LLMSettingsActionResult, LLMSpendSummaryResponse } from "@/lib/admin/types";
+
+type LockState = {
+    reason: "not_licensed" | "not_enabled";
+    message: string;
+} | null;
+
+export type ByoLlmSpendSummaryProps = {
+    loadSpendAction: () => Promise<LLMSettingsActionResult<LLMSpendSummaryResponse>>;
+};
+
+const PANEL_TITLE = "AI / LLM Spend Summary (BYO-LLM)";
+const PANEL_DESCRIPTION =
+    "Per-run LLM call volume, token usage, and model for the latest runs in the last 30 days.";
+
+function formatNumber(value: number): string {
+    return value.toLocaleString();
+}
+
+/**
+ * Failure counts, keyed by persisted categorization-outcome class (e.g.
+ * "llm_error", "low_confidence") — derived from
+ * `work_unit_investments.categorization_status`. This is NOT the exact fatal
+ * provider-exception taxonomy (`LLMAuthError`/`LLMRateLimitError`/etc, which
+ * is only logged, never persisted) — see CHAOS-2349 plan §7 C4.
+ */
+function FailureBadges({ failuresByClass }: { failuresByClass: Record<string, number> }) {
+    const entries = Object.entries(failuresByClass).filter(([, count]) => count > 0);
+    if (entries.length === 0) {
+        return <span className="text-xs text-(--ink-muted)">None</span>;
+    }
+    return (
+        <div className="flex flex-wrap gap-1">
+            {entries.map(([className, count]) => (
+                <span
+                    key={className}
+                    className="inline-flex items-center rounded-full bg-(--card-70) px-2 py-0.5 text-xs text-(--ink-muted)"
+                    title={`${className}: ${count} (categorization-outcome class, not an exact provider-exception count)`}
+                >
+                    {className} ×{count}
+                </span>
+            ))}
+        </div>
+    );
+}
+
+/**
+ * Org-scoped "AI / LLM Spend Summary (BYO-LLM)" admin panel (CHAOS-2564).
+ * Consumes `GET /admin/llm-settings/spend` via the injected server action,
+ * following the same locked-state pattern as {@link ByoLlmSettings} so a
+ * tier/flag gate (402/403) renders as an explicit upsell rather than a
+ * generic load error. Rows with no `run_id` (spend recorded before per-run
+ * tracking began) are never folded into the per-run table — they surface as
+ * a distinct legacy state (`legacy` rows), per plan §6.3 / §7 C4.
+ */
+export function ByoLlmSpendSummary({ loadSpendAction }: ByoLlmSpendSummaryProps) {
+    const [loading, setLoading] = useState(true);
+    const [locked, setLocked] = useState<LockState>(null);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [summary, setSummary] = useState<LLMSpendSummaryResponse | null>(null);
+
+    const fetchSpend = useCallback(async () => {
+        setLoading(true);
+        setLoadError(null);
+        setLocked(null);
+        const result = await loadSpendAction();
+        if (result.status === 402) {
+            setLocked({
+                reason: "not_licensed",
+                message: result.error ?? "BYO-LLM spend summary requires Team tier or higher.",
+            });
+        } else if (result.status === 403) {
+            setLocked({
+                reason: "not_enabled",
+                message: result.error ?? "BYO-LLM is not enabled for this organization.",
+            });
+        } else if (result.error) {
+            setLoadError(result.error);
+        } else if (result.data) {
+            setSummary(result.data);
+        }
+        setLoading(false);
+    }, [loadSpendAction]);
+
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- fetchSpend coordinates async loading state after mount.
+        fetchSpend();
+    }, [fetchSpend]);
+
+    let body: ReactNode;
+
+    if (loading) {
+        body = <DataState variant="loading" title="Loading spend summary…" />;
+    } else if (locked) {
+        body = (
+            <div
+                className="rounded-2xl border border-(--card-stroke) bg-(--card-70) p-6 text-center"
+                data-testid="byo-llm-spend-locked"
+            >
+                <p className="text-xs font-semibold uppercase tracking-wider text-(--accent)">
+                    {locked.reason === "not_licensed" ? "Team Plan Feature" : "Feature Disabled"}
+                </p>
+                <p className="mt-2 text-sm text-(--ink-muted)">{locked.message}</p>
+                {locked.reason === "not_licensed" ? (
+                    <Link
+                        href="/org/admin/settings"
+                        className="mt-4 inline-flex items-center justify-center rounded-full bg-(--accent) px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-(--accent)/90"
+                    >
+                        {CTA_LABELS.upgradePlan}
+                    </Link>
+                ) : null}
+            </div>
+        );
+    } else if (loadError) {
+        body = (
+            <DataState
+                variant="error"
+                message={loadError}
+                action={
+                    <button
+                        type="button"
+                        onClick={fetchSpend}
+                        className="rounded-lg border border-(--negative)/30 bg-(--card-80) px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-(--negative)/50"
+                    >
+                        {CTA_LABELS.retry}
+                    </button>
+                }
+            />
+        );
+    } else if (!summary || (summary.runs.length === 0 && summary.legacy.length === 0)) {
+        body = (
+            <AIEmptyState title="No BYO-LLM spend recorded yet">
+                Spend appears here once a run makes at least one BYO-LLM call.
+            </AIEmptyState>
+        );
+    } else if (summary.runs.length === 0 && summary.legacy.length > 0) {
+        body = (
+            <DataState
+                variant="detector-unavailable"
+                title="Legacy spend not attributable to a run"
+                description="Spend was recorded before per-run tracking began and can't be attributed to a specific run. Only spend with a known run is shown here."
+                data-testid="byo-llm-spend-legacy"
+            />
+        );
+    } else {
+        body = (
+            <div className="space-y-3">
+                <div className="overflow-x-auto">
+                    <table className="w-full text-left text-sm">
+                        <thead>
+                            <tr className="border-b border-(--card-stroke) text-xs uppercase tracking-wide text-(--ink-muted)">
+                                <th className="py-2 pr-4 font-medium">Run</th>
+                                <th className="py-2 pr-4 font-medium">Model</th>
+                                <th className="py-2 pr-4 text-right font-medium">Calls</th>
+                                <th className="py-2 pr-4 text-right font-medium">Input tokens</th>
+                                <th className="py-2 pr-4 text-right font-medium">Output tokens</th>
+                                <th className="py-2 font-medium">Failures by class</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {summary.runs.map((run) => (
+                                <tr
+                                    key={run.run_id}
+                                    className="border-b border-(--card-stroke)/60 last:border-0"
+                                >
+                                    <td className="py-2 pr-4 font-mono text-xs" title={run.run_id}>
+                                        {run.run_id.slice(0, 8)}
+                                    </td>
+                                    <td className="py-2 pr-4">{run.model ?? "—"}</td>
+                                    <td className="py-2 pr-4 text-right">
+                                        {formatNumber(run.calls)}
+                                    </td>
+                                    <td className="py-2 pr-4 text-right">
+                                        {formatNumber(run.input_tokens)}
+                                    </td>
+                                    <td className="py-2 pr-4 text-right">
+                                        {formatNumber(run.output_tokens)}
+                                    </td>
+                                    <td className="py-2">
+                                        <FailureBadges failuresByClass={run.failures_by_class} />
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+                <p className="text-xs text-(--ink-muted)">
+                    Failure classes reflect persisted categorization outcomes (from work-unit
+                    categorization), not exact provider-exception counts.
+                </p>
+                {summary.legacy.length > 0 ? (
+                    <p className="text-xs text-(--ink-muted)">
+                        Additional legacy spend recorded before per-run tracking began exists for
+                        this organization and is not attributable to a specific run above.
+                    </p>
+                ) : null}
+            </div>
+        );
+    }
+
+    return (
+        <AIPanelCard title={PANEL_TITLE} description={PANEL_DESCRIPTION}>
+            {body}
+        </AIPanelCard>
+    );
+}

--- a/src/lib/admin/api/llm-settings.ts
+++ b/src/lib/admin/api/llm-settings.ts
@@ -1,5 +1,5 @@
 import { request } from "./_request";
-import type { LLMSettingsResponse, LLMSettingsUpsert } from "../types";
+import type { LLMSettingsResponse, LLMSettingsUpsert, LLMSpendSummaryResponse } from "../types";
 
 // Admin BYO-LLM settings endpoints. The backend force-encrypts and masks the
 // api_key, and tier/flag gates GET/PUT (402/403) while always allowing DELETE
@@ -18,4 +18,9 @@ export const llmSettingsApi = {
 
     remove: (token?: string, orgId?: string) =>
         request<{ deleted: boolean }>("/llm-settings", { method: "DELETE" }, token, orgId),
+
+    // Org-scoped per-run spend summary (CHAOS-2564). Tier/flag-gated the same
+    // way as the settings CRUD above (402/403); see admin/routers/settings.py.
+    spend: (token?: string, orgId?: string) =>
+        request<LLMSpendSummaryResponse>("/llm-settings/spend", {}, token, orgId),
 };

--- a/src/lib/admin/server/settings.ts
+++ b/src/lib/admin/server/settings.ts
@@ -24,6 +24,7 @@ import type {
     LLMSettingsResponse,
     LLMSettingsUpsert,
     LLMSettingsActionResult,
+    LLMSpendSummaryResponse,
 } from "../types";
 import { getSessionContext, withErrorHandling } from "./_shared";
 
@@ -263,5 +264,17 @@ export async function deleteLLMSettings(): Promise<LLMSettingsActionResult<{ del
         const result = await adminApi.llmSettings.remove(token, orgId);
         revalidatePath("/org/admin/ai");
         return result;
+    });
+}
+
+// Org-scoped per-run spend summary (CHAOS-2564). Uses withStatusErrorHandling
+// (not the generic withErrorHandling) so a tier/flag gate (402/403) surfaces
+// as a distinguishable locked state rather than a generic load error.
+export async function getLLMSpendSummary(): Promise<
+    LLMSettingsActionResult<LLMSpendSummaryResponse>
+> {
+    return withStatusErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.llmSettings.spend(token, orgId);
     });
 }

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -772,6 +772,64 @@ export interface LLMSettingsActionResult<T> {
     status?: number;
 }
 
+// ---- BYO LLM Spend Summary (CHAOS-2564) ----
+
+/**
+ * A single run's LLM spend aggregate row, returned inside
+ * `GET /admin/llm-settings/spend`. Sourced from ClickHouse `llm_token_usage`
+ * (per-run calls/tokens/model) joined with `failures_by_class` derived from
+ * `work_unit_investments.categorization_status` / `categorization_errors_json`
+ * for that run (see CHAOS-2349 plan §3 Task B).
+ *
+ * `failures_by_class` keys are persisted **categorization-outcome** classes
+ * (e.g. "llm_error", "low_confidence") — NOT the exact fatal provider-exception
+ * taxonomy (`LLMAuthError`/`LLMRateLimitError`/etc, which is only logged, never
+ * persisted). The UI must label this distinction explicitly (plan §7 C4).
+ */
+export interface LLMSpendRunSummary {
+    run_id: string;
+    provider?: string | null;
+    model: string | null;
+    calls: number;
+    input_tokens: number;
+    output_tokens: number;
+    computed_at?: string | null;
+    failures_by_class: Record<string, number>;
+}
+
+/**
+ * A pre-run_id `llm_token_usage` row — spend recorded before `run_id` was
+ * threaded through the sink (plan §7 C1). `run_id` is always the empty
+ * string here (`marker: "legacy_empty_run_id"` flags it); the UI must never
+ * present these as per-run data (plan §6.3, §7 C4).
+ */
+export interface LLMSpendLegacyRow {
+    run_id: "";
+    marker: "legacy_empty_run_id";
+    provider: string | null;
+    model: string | null;
+    calls: number;
+    input_tokens: number;
+    output_tokens: number;
+    computed_at: string | null;
+}
+
+/**
+ * `GET /admin/llm-settings/spend` response. Org-scoped; `runs` defaults to
+ * the latest ~20 non-empty `run_id`s within the last 30 days (`since`),
+ * capped at `limit`, ordered by `max(computed_at) DESC` (CHAOS-2349 plan
+ * §6.3). `legacy` holds pre-run_id rows excluded from `runs` — spend
+ * happened but can't be attributed to a specific run; the UI must render an
+ * explicit legacy state for them and never fold them into per-run data
+ * (plan §6.3, §7 C4).
+ */
+export interface LLMSpendSummaryResponse {
+    since: string;
+    limit: number;
+    runs: LLMSpendRunSummary[];
+    legacy: LLMSpendLegacyRow[];
+}
+
 // ---- Provider types ----
 
 export type Provider = "github" | "gitlab" | "jira" | "linear" | "launchdarkly";


### PR DESCRIPTION
## CHAOS-2564 (frontend) — BYO-LLM Spend Summary panel

Part of the BYO-LLM epic (CHAOS-2349). Linear: https://linear.app/fullchaos/issue/CHAOS-2564

### What
- New component `src/components/admin/llm/ByoLlmSpendSummary.tsx` rendering the "AI / LLM Spend Summary (BYO-LLM)" board: per-run LLM calls, input/output tokens, model, and failures-by-class (labelled as categorization-outcome classes, not provider-exception counts).
- States: loading · populated · empty · legacy (empty-`run_id` rows) · locked (402/403) · error/retry.
- Consumes `GET /admin/llm-settings/spend` via a new server action + REST wrapper + type. DTO aligned to the backend contract `{ since, limit, runs[], legacy[] }`.
- Additive mount on `src/app/(app)/org/admin/ai/page.tsx`. Reuses `AIPanelCard`.

### Depends on
Backend spend endpoint in #1203 (CHAOS-2564 backend). Coded to that DTO; degrades to the error/empty state until #1203 merges.

### Tests
- `src/components/admin/llm/ByoLlmSpendSummary.test.tsx` — **7 passed**: populated (calls/tokens/model/failures + outcome disclaimer), empty, legacy, locked 402 (upgrade link), locked 403 (no link), retry-after-error. `pnpm typecheck` clean; changed files pass `design-lint`.

### Visual evidence
SCREENSHOT-WAIVER: visual evidence pending — surface is behind auth on `/org/admin/ai`; populated state requires backend #1203 and the local stack currently HMR-serves `main` (not this branch). Screenshots (populated + empty) will be attached to this PR and the Linear issue once #1203 merges.
