### PR TITLE
fix(admin/sync): hide first-sync banner after setup completes (CHAOS-2877)

### DIFF
--- a/src/app/(app)/org/admin/integrations/github/sync/page.tsx
+++ b/src/app/(app)/org/admin/integrations/github/sync/page.tsx
@@ -17,6 +17,7 @@ const DISCONNECTED_STATUS: SetupStatus = {
     has_sync_config: false,
     sync_config_id: null,
     first_sync_started: false,
+    first_sync_completed: false,
     sync_status: "none",
     selected_repositories_count: 0,
     last_sync_error: null,

--- a/src/components/onboarding/FirstRunSync.test.tsx
+++ b/src/components/onboarding/FirstRunSync.test.tsx
@@ -25,6 +25,7 @@ const baseStatus: SetupStatus = {
     has_sync_config: true,
     sync_config_id: "sync-1",
     first_sync_started: false,
+    first_sync_completed: false,
     sync_status: "pending",
     selected_repositories_count: 3,
     last_sync_error: null,
@@ -173,7 +174,11 @@ describe("FirstRunSync (CHAOS-2681 / CHAOS-2683)", () => {
     it("complete → emits onboarding_completed once and offers a return to the cockpit", () => {
         render(
             <FirstRunSync
-                status={status({ sync_status: "complete", next_action: "complete" })}
+                status={status({
+                    first_sync_completed: true,
+                    sync_status: "complete",
+                    next_action: "complete",
+                })}
                 orgId="org-1"
             />,
         );
@@ -187,6 +192,22 @@ describe("FirstRunSync (CHAOS-2681 / CHAOS-2683)", () => {
             "href",
             "/dashboard",
         );
+    });
+
+    it("later running sync stays complete after the first sync completed", () => {
+        render(
+            <FirstRunSync
+                status={status({
+                    first_sync_started: true,
+                    first_sync_completed: true,
+                    sync_status: "running",
+                    next_action: "complete",
+                })}
+                orgId="org-1"
+            />,
+        );
+
+        expect(screen.getByTestId("first-run-sync")).toHaveAttribute("data-phase", "complete");
     });
 
     it("arrival error → recoverable connect prompt without restarting onboarding", () => {

--- a/src/components/onboarding/FirstRunSync.tsx
+++ b/src/components/onboarding/FirstRunSync.tsx
@@ -25,6 +25,7 @@ type FirstRunSyncProps = {
 type SyncPhase = "connect" | "select-repos" | "ready-to-sync" | "syncing" | "failed" | "complete";
 
 function derivePhase(status: SetupStatus, locallyStarted: boolean): SyncPhase {
+    if (status.first_sync_completed) return "complete";
     if (status.sync_status === "failed") return "failed";
     if (status.sync_status === "complete") return "complete";
     if (!status.has_integration) return "connect";

--- a/src/components/onboarding/SetupBanner.strictmode.test.tsx
+++ b/src/components/onboarding/SetupBanner.strictmode.test.tsx
@@ -21,6 +21,7 @@ const noIntegration: SetupStatus = {
     has_sync_config: false,
     sync_config_id: null,
     first_sync_started: false,
+    first_sync_completed: false,
     sync_status: "none",
     selected_repositories_count: 0,
     last_sync_error: null,

--- a/src/components/onboarding/SetupBanner.test.tsx
+++ b/src/components/onboarding/SetupBanner.test.tsx
@@ -20,6 +20,7 @@ const baseStatus: SetupStatus = {
     has_sync_config: false,
     sync_config_id: null,
     first_sync_started: false,
+    first_sync_completed: false,
     sync_status: "none",
     selected_repositories_count: 0,
     last_sync_error: null,
@@ -71,6 +72,26 @@ describe("SetupBanner (CHAOS-2678, four C2 states)", () => {
         expect(cta).toHaveAttribute("href", connectGitHubHref());
 
         expect(emitOnboardingEventOnce).not.toHaveBeenCalled();
+    });
+
+    it("later running sync after first sync completed → renders nothing", () => {
+        const { container } = render(
+            <SetupBanner
+                status={status({
+                    has_integration: true,
+                    providers: ["github"],
+                    has_sync_config: true,
+                    first_sync_started: true,
+                    first_sync_completed: true,
+                    sync_status: "running",
+                    next_action: "complete",
+                })}
+            />,
+        );
+
+        expect(screen.queryByText(/first sync/i)).not.toBeInTheDocument();
+        expect(screen.queryByTestId("setup-banner")).not.toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
     });
 
     it("connected but unsynced → distinct sync-pending banner with continue CTA to the sync surface", () => {
@@ -137,6 +158,7 @@ describe("SetupBanner (CHAOS-2678, four C2 states)", () => {
             <SetupBanner
                 status={status({
                     has_integration: true,
+                    first_sync_completed: true,
                     sync_status: "complete",
                     next_action: "complete",
                 })}

--- a/src/lib/onboarding/__tests__/setupSurface.test.ts
+++ b/src/lib/onboarding/__tests__/setupSurface.test.ts
@@ -19,6 +19,7 @@ const baseStatus: SetupStatus = {
     has_sync_config: false,
     sync_config_id: null,
     first_sync_started: false,
+    first_sync_completed: false,
     sync_status: "none",
     selected_repositories_count: 0,
     last_sync_error: null,
@@ -59,13 +60,42 @@ describe("deriveSetupSurface (CHAOS-2678, C2)", () => {
     });
 
     it.each(["none", "pending", "running", "partial"] as const)(
-        "treats connected + %s sync as sync-pending",
+        "treats connected + %s first sync as sync-pending",
         (sync_status) => {
             expect(deriveSetupSurface(status({ has_integration: true, sync_status }))).toBe(
                 "sync-pending",
             );
         },
     );
+
+    it("maps a later running sync to ready after the first sync completed", () => {
+        expect(
+            deriveSetupSurface(
+                status({
+                    has_integration: true,
+                    first_sync_started: true,
+                    first_sync_completed: true,
+                    sync_status: "running",
+                    next_action: "complete",
+                }),
+            ),
+        ).toBe("ready");
+    });
+
+    it("does not reopen setup blockers for a later failed sync", () => {
+        expect(
+            deriveSetupSurface(
+                status({
+                    has_integration: true,
+                    first_sync_started: true,
+                    first_sync_completed: true,
+                    sync_status: "failed",
+                    blocker: "Later sync failed",
+                    next_action: "start_sync",
+                }),
+            ),
+        ).toBe("ready");
+    });
 
     it("maps a failed sync to sync-failed regardless of integration", () => {
         expect(
@@ -78,7 +108,12 @@ describe("deriveSetupSurface (CHAOS-2678, C2)", () => {
     it("maps a completed sync to ready", () => {
         expect(
             deriveSetupSurface(
-                status({ has_integration: true, sync_status: "complete", next_action: "complete" }),
+                status({
+                    has_integration: true,
+                    first_sync_completed: true,
+                    sync_status: "complete",
+                    next_action: "complete",
+                }),
             ),
         ).toBe("ready");
     });
@@ -146,7 +181,13 @@ describe("setupSurfaceCta (CTA hrefs)", () => {
 
     it("ready → no CTA", () => {
         expect(
-            setupSurfaceCta(status({ has_integration: true, sync_status: "complete" })),
+            setupSurfaceCta(
+                status({
+                    has_integration: true,
+                    first_sync_completed: true,
+                    sync_status: "complete",
+                }),
+            ),
         ).toBeNull();
     });
 });

--- a/src/lib/onboarding/setupSurface.ts
+++ b/src/lib/onboarding/setupSurface.ts
@@ -44,17 +44,18 @@ export function repoSelectionHref(syncConfigId: string | null): string {
  * Precedence is deterministic: a failed sync always surfaces the blocker first;
  * otherwise a missing integration is either an active prompt or a non-blocking
  * "skipped" banner (distinguished by `next_action`); a present integration is
- * either pending sync or fully ready.
+ * pending only until the first sync has completed. Later in-flight syncs must
+ * not reopen first-run setup copy.
  */
 export function deriveSetupSurface(status: SetupStatus): SetupSurfaceVariant {
-    if (status.sync_status === "failed") {
-        return "sync-failed";
-    }
     if (!status.has_integration) {
         return status.next_action === "complete" ? "skipped" : "no-integration";
     }
-    if (status.sync_status === "complete") {
+    if (status.first_sync_completed || status.sync_status === "complete") {
         return "ready";
+    }
+    if (status.sync_status === "failed") {
+        return "sync-failed";
     }
     return "sync-pending";
 }

--- a/src/lib/onboarding/types.ts
+++ b/src/lib/onboarding/types.ts
@@ -43,6 +43,7 @@ export interface SetupStatus {
     has_sync_config: boolean;
     sync_config_id: string | null;
     first_sync_started: boolean;
+    first_sync_completed: boolean;
     sync_status: SetupSyncStatus;
     selected_repositories_count: number;
     last_sync_error: string | null;

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -1604,6 +1604,7 @@ function buildSetupStatus() {
         has_sync_config: false,
         sync_config_id: null,
         first_sync_started: false,
+        first_sync_completed: false,
         sync_status: "none",
         selected_repositories_count: 0,
         last_sync_error: null,


### PR DESCRIPTION
## Summary
- Adds `first_sync_completed` to the setup-status contract consumed by onboarding UI.
- Treats setup as ready once the first sync has completed, even if a later sync is running or failed.
- Updates SetupBanner and FirstRunSync regressions so first-run copy does not reopen after setup completion.

Linear: CHAOS-2877

## Test plan
- `pnpm exec vitest run src/lib/onboarding/__tests__/setupSurface.test.ts src/components/onboarding/SetupBanner.test.tsx src/components/onboarding/FirstRunSync.test.tsx src/components/onboarding/SetupBanner.strictmode.test.tsx`
- `pnpm typecheck`
- `pnpm build`
- LSP diagnostics clean on changed files.
- Browser QA: authenticated dashboard rendered with `setupBannerCount=0`; no first-sync pending copy rendered.

## Visual evidence
![chaos-2877-first-sync-banner-after.png](https://github.com/user-attachments/assets/a0b416bb-61ec-4532-be74-068392f7ff58)

## Known pre-existing issue
- `pnpm design-lint` / pre-push design-lint still reports repo-wide pre-existing design-token and CTA registry violations outside this change.
- Targeted ESLint warning remains pre-existing in `tests/mocks/handlers.ts:2641` for silent `.catch(() => null)`.