### PR TITLE
fix(admin/sync): use unit rollups for progress

### DIFF
--- a/src/components/admin/sync/SyncProgressBar.test.tsx
+++ b/src/components/admin/sync/SyncProgressBar.test.tsx
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen } from "@/test/utils";
 import { SyncProgressBar } from "./SyncProgressBar";
-import { getSyncJobs, getSyncRunStatus } from "@/lib/admin/server";
-import type { SyncJob, SyncRun, SyncRunJobEnrichment } from "@/lib/admin/types";
+import { getSyncJobs, getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
+import type {
+    SyncJob,
+    SyncRun,
+    SyncRunJobEnrichment,
+    SyncRunUnit,
+    SyncRunUnitSummary,
+} from "@/lib/admin/types";
 
 // The component polls the admin server actions directly (CHAOS-2799 —
 // config-scoped polling replaces the org+provider GraphQL subscription), so
@@ -10,6 +16,7 @@ import type { SyncJob, SyncRun, SyncRunJobEnrichment } from "@/lib/admin/types";
 vi.mock("@/lib/admin/server", () => ({
     getSyncJobs: vi.fn(),
     getSyncRunStatus: vi.fn(),
+    getSyncRunUnits: vi.fn(),
 }));
 
 function buildEnrichment(overrides: Partial<SyncRunJobEnrichment> = {}): SyncRunJobEnrichment {
@@ -59,6 +66,53 @@ function buildRun(overrides: Partial<SyncRun> = {}): SyncRun {
     };
 }
 
+function buildUnit(overrides: Partial<SyncRunUnit> = {}): SyncRunUnit {
+    return {
+        id: "unit-1",
+        org_id: "org-1",
+        sync_run_id: "run-1",
+        integration_id: "integration-1",
+        source_id: "source-1",
+        source_name: "source",
+        source_full_name: "org/source",
+        provider: "github",
+        dataset_key: "git",
+        cost_class: "rest",
+        mode: "incremental",
+        since_at: null,
+        before_at: null,
+        status: "running",
+        attempts: 1,
+        available_at: null,
+        rate_limit_deferrals: 0,
+        duration_seconds: null,
+        error: null,
+        error_category: null,
+        last_heartbeat_at: null,
+        result: null,
+        created_at: "2024-01-01T00:00:00.000Z",
+        updated_at: "2024-01-01T00:00:00.000Z",
+        ...overrides,
+    };
+}
+
+function buildSummary(overrides: Partial<SyncRunUnitSummary> = {}): SyncRunUnitSummary {
+    return {
+        by_status: { running: 10 },
+        by_source: {},
+        by_dataset: {},
+        by_cost_class: {},
+        slowest_unit_ids: [],
+        failed_unit_ids: [],
+        failed_unit_count: 0,
+        unit_count: 10,
+        partial_failure_summary: null,
+        next_retry_at: null,
+        units: [],
+        ...overrides,
+    };
+}
+
 async function flush() {
     await act(async () => {
         await vi.advanceTimersByTimeAsync(0);
@@ -70,6 +124,7 @@ describe("SyncProgressBar", () => {
         vi.useFakeTimers();
         vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
         vi.clearAllMocks();
+        vi.mocked(getSyncRunUnits).mockResolvedValue({ error: "Unit rollups unavailable" });
     });
 
     afterEach(() => {
@@ -99,8 +154,147 @@ describe("SyncProgressBar", () => {
 
         expect(getSyncJobs).toHaveBeenCalledWith("cfg-1", 25);
         expect(getSyncRunStatus).toHaveBeenCalledWith("run-1");
+        expect(getSyncRunUnits).toHaveBeenCalledWith("run-1");
         expect(screen.getByText("Syncing...")).toBeInTheDocument();
         expect(screen.getByText(/4 \/ 10/)).toBeInTheDocument();
+    });
+
+    it("uses unit rollups for active-run progress when run counters are stale", async () => {
+        vi.mocked(getSyncJobs).mockResolvedValue({ data: [buildJob({ status: "running" })] });
+        vi.mocked(getSyncRunStatus).mockResolvedValue({
+            data: buildRun({ completed_units: 0, failed_units: 0, total_units: 4 }),
+        });
+        vi.mocked(getSyncRunUnits).mockResolvedValue({
+            data: buildSummary({
+                by_status: { success: 2, failed: 1, running: 1 },
+                unit_count: 4,
+                failed_unit_count: 1,
+                units: [
+                    buildUnit({ id: "unit-success-1", status: "success" }),
+                    buildUnit({ id: "unit-success-2", status: "success" }),
+                    buildUnit({ id: "unit-failed", status: "failed" }),
+                    buildUnit({ id: "unit-running", status: "running" }),
+                ],
+            }),
+        });
+
+        render(<SyncProgressBar configId="cfg-1" />);
+        await flush();
+
+        expect(screen.getByText("Syncing...")).toBeInTheDocument();
+        expect(screen.getByText(/3 \/ 4/)).toBeInTheDocument();
+        expect(screen.getByText(/75% complete/)).toBeInTheDocument();
+        expect(screen.getByRole("progressbar", { name: "Sync progress" })).toHaveAttribute(
+            "aria-valuenow",
+            "75",
+        );
+    });
+
+    it("keeps the last good unit rollup when a later units poll errors", async () => {
+        vi.mocked(getSyncJobs).mockResolvedValue({ data: [buildJob({ status: "running" })] });
+        vi.mocked(getSyncRunStatus).mockResolvedValue({
+            data: buildRun({ completed_units: 0, failed_units: 0, total_units: 4 }),
+        });
+        vi.mocked(getSyncRunUnits)
+            .mockResolvedValueOnce({
+                data: buildSummary({
+                    by_status: { success: 2, running: 2 },
+                    unit_count: 4,
+                    units: [
+                        buildUnit({ id: "unit-success-1", status: "success" }),
+                        buildUnit({ id: "unit-success-2", status: "success" }),
+                        buildUnit({ id: "unit-running-1", status: "running" }),
+                        buildUnit({ id: "unit-running-2", status: "running" }),
+                    ],
+                }),
+            })
+            .mockResolvedValueOnce({ error: "Unit rollups unavailable" });
+
+        render(<SyncProgressBar configId="cfg-1" />);
+        await flush();
+
+        expect(screen.getByText(/2 \/ 4/)).toBeInTheDocument();
+        expect(screen.getByText(/50% complete/)).toBeInTheDocument();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3500);
+        });
+
+        expect(screen.getByText(/2 \/ 4/)).toBeInTheDocument();
+        expect(screen.getByText(/50% complete/)).toBeInTheDocument();
+    });
+
+    it("does not rediscover a stale running job whose unit rollup is already terminal", async () => {
+        vi.mocked(getSyncJobs).mockResolvedValue({
+            data: [
+                buildJob({
+                    status: "running",
+                    sync_run: buildEnrichment({
+                        total_units: 4,
+                        completed_units: 4,
+                        failed_units: 0,
+                    }),
+                }),
+            ],
+        });
+
+        render(<SyncProgressBar configId="cfg-1" />);
+        await flush();
+
+        expect(getSyncJobs).toHaveBeenCalledWith("cfg-1", 25);
+        expect(getSyncRunStatus).not.toHaveBeenCalled();
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("keeps active-run progress non-terminal when unit rows are incomplete", async () => {
+        vi.mocked(getSyncJobs).mockResolvedValue({ data: [buildJob({ status: "running" })] });
+        vi.mocked(getSyncRunStatus).mockResolvedValue({
+            data: buildRun({ completed_units: 0, failed_units: 0, total_units: 4 }),
+        });
+        vi.mocked(getSyncRunUnits).mockResolvedValue({
+            data: buildSummary({
+                by_status: { success: 1 },
+                unit_count: 1,
+                units: [buildUnit({ status: "success" })],
+            }),
+        });
+
+        render(<SyncProgressBar configId="cfg-1" />);
+        await flush();
+
+        expect(screen.getByText("Syncing...")).toBeInTheDocument();
+        expect(screen.getByText(/1 \/ 4/)).toBeInTheDocument();
+        expect(screen.getByText(/25% complete/)).toBeInTheDocument();
+    });
+
+    it("uses unit rows over a stale terminal run status", async () => {
+        vi.mocked(getSyncJobs).mockResolvedValue({ data: [buildJob({ status: "running" })] });
+        vi.mocked(getSyncRunStatus).mockResolvedValue({
+            data: buildRun({
+                status: "success",
+                completed_units: 4,
+                failed_units: 0,
+                total_units: 4,
+            }),
+        });
+        vi.mocked(getSyncRunUnits).mockResolvedValue({
+            data: buildSummary({
+                by_status: { success: 1, running: 3 },
+                unit_count: 4,
+                units: [
+                    buildUnit({ id: "unit-success", status: "success" }),
+                    buildUnit({ id: "unit-running-1", status: "running" }),
+                    buildUnit({ id: "unit-running-2", status: "running" }),
+                    buildUnit({ id: "unit-running-3", status: "running" }),
+                ],
+            }),
+        });
+
+        render(<SyncProgressBar configId="cfg-1" />);
+        await flush();
+
+        expect(screen.getByText("Syncing...")).toBeInTheDocument();
+        expect(screen.getByText(/1 \/ 4/)).toBeInTheDocument();
     });
 
     it("discovers a scheduled (not-yet-started) run via a pending job", async () => {

--- a/src/components/admin/sync/SyncProgressBar.tsx
+++ b/src/components/admin/sync/SyncProgressBar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { getSyncJobs, getSyncRunStatus } from "@/lib/admin/server";
+import type { SyncRun, SyncRunUnitSummary } from "@/lib/admin/types";
+import { getSyncJobs, getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
 import { isTerminalSyncStatus, mapPlannerRunStatus } from "@/lib/sync-types";
-import type { SyncRun } from "@/lib/admin/types";
+import type { SyncJob } from "@/lib/admin/types";
 
 /**
  * Config-scoped live sync progress (CHAOS-2799).
@@ -42,7 +43,6 @@ const MAX_TRACK_DURATION_MS = 10 * 60 * 1000;
  * cheap request — a paging loop would be overkill for a 3.5s poll cadence.
  */
 const DISCOVERY_JOB_LIMIT = 25;
-
 interface SyncProgressBarProps {
     configId: string;
     /** When true, never poll a live API (Playwright/test-mode sample rendering). */
@@ -55,8 +55,53 @@ function formatElapsed(seconds: number): string {
     return `${String(minutes).padStart(2, "0")}:${String(remainder).padStart(2, "0")}`;
 }
 
+function statusCount(summary: SyncRunUnitSummary | null, status: string): number | null {
+    if (!summary) return null;
+    return summary.by_status[status] ?? 0;
+}
+
+function totalUnitCount(run: SyncRun, summary: SyncRunUnitSummary | null): number {
+    return summary ? Math.max(summary.unit_count, run.total_units) : run.total_units;
+}
+
+function effectiveRunStatus(run: SyncRun, summary: SyncRunUnitSummary | null): string {
+    if (!summary) return run.status;
+
+    const successCount = statusCount(summary, "success") ?? 0;
+    const failedCount = statusCount(summary, "failed") ?? 0;
+    const settledCount = successCount + failedCount;
+    const totalUnits = totalUnitCount(run, summary);
+    if (totalUnits > 0 && settledCount >= totalUnits) {
+        if (failedCount === 0) return "success";
+        if (successCount === 0) return "failed";
+        return "partial_failed";
+    }
+    if (
+        settledCount > 0 ||
+        (statusCount(summary, "running") ?? 0) > 0 ||
+        (statusCount(summary, "retrying") ?? 0) > 0
+    ) {
+        return "running";
+    }
+    if ((statusCount(summary, "dispatching") ?? 0) > 0) return "dispatching";
+    if ((statusCount(summary, "planned") ?? 0) > 0) return "planned";
+    return run.status;
+}
+
+function hasActiveSyncRun(job: SyncJob): boolean {
+    if (!job.sync_run?.sync_run_id) return false;
+    if (job.status !== "running" && job.status !== "pending") return false;
+    const totalUnits = job.sync_run.total_units;
+    const settledUnits = job.sync_run.completed_units + job.sync_run.failed_units;
+    return totalUnits === 0 || settledUnits < totalUnits;
+}
+
 export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarProps) {
-    const [tracked, setTracked] = useState<{ configId: string; run: SyncRun } | null>(null);
+    const [tracked, setTracked] = useState<{
+        configId: string;
+        run: SyncRun;
+        summary: SyncRunUnitSummary | null;
+    } | null>(null);
     const [now, setNow] = useState(() => Date.now());
     const [terminalUntil, setTerminalUntil] = useState<number | null>(null);
 
@@ -66,6 +111,7 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
     const runIdRef = useRef<string | null>(null);
     const trackStartedAtRef = useRef<number | null>(null);
     const inFlightRef = useRef(false);
+    const lastSummaryByRunRef = useRef<Record<string, SyncRunUnitSummary>>({});
     // Invalidates any in-flight response once the effect tears down (configId
     // change or unmount) so a slow discovery/tracking call can never mutate
     // state for a config this instance has moved away from.
@@ -90,11 +136,7 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
                     const jobsRes = await getSyncJobs(configId, DISCOVERY_JOB_LIMIT);
                     if (effectSeq !== seqRef.current) return;
                     if (jobsRes.error || !jobsRes.data) return;
-                    const activeJob = jobsRes.data.find(
-                        (job) =>
-                            job.sync_run?.sync_run_id &&
-                            (job.status === "running" || job.status === "pending"),
-                    );
+                    const activeJob = jobsRes.data.find(hasActiveSyncRun);
                     if (!activeJob?.sync_run) return;
                     runIdRef.current = activeJob.sync_run.sync_run_id;
                     trackStartedAtRef.current = Date.now();
@@ -103,20 +145,27 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
                 const runId = runIdRef.current;
                 if (!runId) return;
 
-                const runRes = await getSyncRunStatus(runId);
+                const [runRes, unitsRes] = await Promise.all([
+                    getSyncRunStatus(runId),
+                    getSyncRunUnits(runId),
+                ]);
                 // Ignore stale responses: a newer effect run (configId
                 // changed) or a since-cleared tracked run must never apply.
                 if (effectSeq !== seqRef.current || runIdRef.current !== runId) return;
                 if (runRes.error || !runRes.data) return;
+                const summary = unitsRes.error
+                    ? (lastSummaryByRunRef.current[runId] ?? null)
+                    : (unitsRes.data ?? null);
+                if (summary) lastSummaryByRunRef.current[runId] = summary;
 
                 // Pair the run with the configId this tick was discovered
                 // for (not just the current prop) so a later configId change
                 // can never keep rendering a stale config's run — render
                 // gates on `tracked.configId === configId` below.
-                setTracked({ configId, run: runRes.data });
+                setTracked({ configId, run: runRes.data, summary });
                 setTerminalUntil(null);
 
-                const liveStatus = mapPlannerRunStatus(runRes.data.status);
+                const liveStatus = mapPlannerRunStatus(effectiveRunStatus(runRes.data, summary));
                 const trackedTooLong =
                     trackStartedAtRef.current !== null &&
                     Date.now() - trackStartedAtRef.current > MAX_TRACK_DURATION_MS;
@@ -151,7 +200,9 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
     // before this instance's tracking state is cleared/overwritten, the OLD
     // config's run immediately stops rendering rather than persisting until
     // the next terminal/cleanup tick (CHAOS-2799).
-    const visibleRun = tracked && tracked.configId === configId ? tracked.run : null;
+    const visibleTracked = tracked && tracked.configId === configId ? tracked : null;
+    const visibleRun = visibleTracked?.run ?? null;
+    const visibleSummary = visibleTracked?.summary ?? null;
     const runStatus = visibleRun?.status ?? null;
     const runStartedAt = visibleRun?.started_at ?? null;
 
@@ -184,17 +235,19 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
 
     const run = visibleRun;
 
-    const liveStatus = mapPlannerRunStatus(run.status);
-    const settled = Math.min(run.total_units, run.completed_units + run.failed_units);
-    const percentage =
-        run.total_units > 0 ? Math.min(100, Math.round((settled / run.total_units) * 100)) : 0;
+    const liveStatus = mapPlannerRunStatus(effectiveRunStatus(run, visibleSummary));
+    const totalUnits = totalUnitCount(run, visibleSummary);
+    const completed = statusCount(visibleSummary, "success") ?? run.completed_units;
+    const failed = statusCount(visibleSummary, "failed") ?? run.failed_units;
+    const settled = Math.min(totalUnits, completed + failed);
+    const percentage = totalUnits > 0 ? Math.min(100, Math.round((settled / totalUnits) * 100)) : 0;
     const elapsedSeconds = run.started_at
         ? Math.max(0, Math.floor((now - new Date(run.started_at).getTime()) / 1000))
         : 0;
 
-    const hasEtaData = settled >= 2 && elapsedSeconds > 0 && run.total_units > settled;
+    const hasEtaData = settled >= 2 && elapsedSeconds > 0 && totalUnits > settled;
     const estimatedSecondsRemaining = hasEtaData
-        ? Math.max(0, Math.round((run.total_units - settled) * (elapsedSeconds / settled)))
+        ? Math.max(0, Math.round((totalUnits - settled) * (elapsedSeconds / settled)))
         : null;
     const etaText =
         estimatedSecondsRemaining === null
@@ -217,11 +270,19 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
             <div className="mb-2 flex items-center justify-between text-sm">
                 <span className="font-medium text-foreground">{statusLabel}</span>
                 <span className="text-(--ink-muted)">
-                    {settled} / {run.total_units} ({percentage}%)
+                    {settled} / {totalUnits} ({percentage}%)
                 </span>
             </div>
 
-            <div className="h-2 w-full overflow-hidden rounded-full bg-(--card-70)">
+            <div
+                className="h-2 w-full overflow-hidden rounded-full bg-(--card-70)"
+                role="progressbar"
+                aria-label="Sync progress"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={percentage}
+                aria-valuetext={`${settled} of ${totalUnits} units settled`}
+            >
                 <div
                     className="h-full bg-(--accent) transition-all duration-500 ease-out"
                     style={{ width: `${percentage}%` }}

--- a/src/components/admin/sync/SyncRunDetail.test.tsx
+++ b/src/components/admin/sync/SyncRunDetail.test.tsx
@@ -29,6 +29,10 @@ describe("SyncRunDetailLive", () => {
         // completed (2) + failed (1) = 3 of 4 settled → 75%
         expect(screen.getByText(/3 \/ 4/)).toBeInTheDocument();
         expect(screen.getByText(/75%/)).toBeInTheDocument();
+        expect(screen.getByRole("progressbar", { name: "Overall sync progress" })).toHaveAttribute(
+            "aria-valuenow",
+            "75",
+        );
 
         // Status rollup labels from by_status.
         expect(screen.getByText("Unit status")).toBeInTheDocument();
@@ -37,6 +41,62 @@ describe("SyncRunDetailLive", () => {
 
         // Unit count header reflects the summary.
         expect(screen.getByText(/Units \(4\)/)).toBeInTheDocument();
+    });
+
+    it("uses unit rollups for progress when run counters are stale", () => {
+        render(
+            <SyncRunDetailLive
+                initialRun={{
+                    ...SAMPLE_SYNC_RUN,
+                    status: "dispatching",
+                    total_units: 4,
+                    completed_units: 0,
+                    failed_units: 0,
+                }}
+                initialSummary={SAMPLE_SYNC_RUN_UNIT_SUMMARY}
+                testMode
+            />,
+        );
+
+        expect(screen.getByText(/3 \/ 4/)).toBeInTheDocument();
+        expect(screen.getByText(/75%/)).toBeInTheDocument();
+        expect(screen.getByText("running")).toBeInTheDocument();
+        const progressCard = screen.getByText("Overall progress").closest(".rounded-xl");
+        expect(progressCard).toBeInstanceOf(HTMLElement);
+        if (!(progressCard instanceof HTMLElement)) return;
+        expect(within(progressCard).getByText("2")).toBeInTheDocument();
+        expect(within(progressCard).getByText("1")).toBeInTheDocument();
+    });
+
+    it("uses unit rows over a stale terminal run status", () => {
+        render(
+            <SyncRunDetailLive
+                initialRun={{
+                    ...SAMPLE_SYNC_RUN,
+                    status: "success",
+                    total_units: 4,
+                    completed_units: 4,
+                    failed_units: 0,
+                }}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { success: 1, running: 3 },
+                    unit_count: 4,
+                    units: SAMPLE_SYNC_RUN_UNIT_SUMMARY.units.map((unit, index) => ({
+                        ...unit,
+                        status: index === 0 ? "success" : "running",
+                    })),
+                }}
+                testMode
+            />,
+        );
+
+        expect(screen.getByText(/1 \/ 4/)).toBeInTheDocument();
+        expect(screen.getByText(/25%/)).toBeInTheDocument();
+        const headerCard = screen.getAllByText("Status")[0]?.closest(".rounded-xl");
+        expect(headerCard).toBeInstanceOf(HTMLElement);
+        if (!(headerCard instanceof HTMLElement)) return;
+        expect(within(headerCard).getByText("running")).toBeInTheDocument();
     });
 
     it("renders resolved source NAMES and never the raw source id", () => {
@@ -273,6 +333,67 @@ describe("SyncRunDetailLive — live poll error handling", () => {
 
         // Last good snapshot is retained — units were NOT fabricated/emptied.
         expect(screen.getByText(/Units \(4\)/)).toBeInTheDocument();
+    });
+
+    it("does not poll when initial unit rollups make a stale running run terminal", async () => {
+        render(
+            <SyncRunDetailLive
+                initialRun={{
+                    ...RUNNING_RUN,
+                    total_units: 4,
+                    completed_units: 0,
+                    failed_units: 0,
+                }}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { success: 4 },
+                    unit_count: 4,
+                    units: SAMPLE_SYNC_RUN_UNIT_SUMMARY.units.map((unit) => ({
+                        ...unit,
+                        status: "success",
+                    })),
+                }}
+            />,
+        );
+
+        expect(screen.getByText(/Run complete/)).toBeInTheDocument();
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3500 * 2);
+        });
+        expect(getSyncRunStatus).not.toHaveBeenCalled();
+    });
+
+    it("keeps polling when unit rows are incomplete relative to run total", async () => {
+        const partialSummary = {
+            ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+            by_status: { success: 1 },
+            unit_count: 1,
+            units: [
+                {
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY.units[0],
+                    status: "success",
+                },
+            ],
+        };
+        const staleRun = {
+            ...RUNNING_RUN,
+            total_units: 4,
+            completed_units: 0,
+            failed_units: 0,
+        };
+        vi.mocked(getSyncRunStatus).mockResolvedValue({ data: staleRun });
+        vi.mocked(getSyncRunUnits).mockResolvedValue({ data: partialSummary });
+
+        render(<SyncRunDetailLive initialRun={staleRun} initialSummary={partialSummary} />);
+
+        expect(screen.getByText(/1 \/ 4/)).toBeInTheDocument();
+        expect(screen.getByText(/25%/)).toBeInTheDocument();
+        expect(screen.getByText("running")).toBeInTheDocument();
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3500 * 2);
+        });
+        expect(getSyncRunStatus).toHaveBeenCalledTimes(2);
+        expect(getSyncRunUnits).toHaveBeenCalledTimes(2);
     });
 
     it("renders the server-side initialUnitsError without polling for a terminal run", () => {

--- a/src/components/admin/sync/SyncRunDetailLive.tsx
+++ b/src/components/admin/sync/SyncRunDetailLive.tsx
@@ -58,6 +58,39 @@ function unitBadgeStatus(status: string): SyncStatus {
     }
 }
 
+function statusCount(summary: SyncRunUnitSummary | null, status: string): number | null {
+    if (!summary) return null;
+    return summary.by_status[status] ?? 0;
+}
+
+function totalUnitCount(run: SyncRun, summary: SyncRunUnitSummary | null): number {
+    return summary ? Math.max(summary.unit_count, run.total_units) : run.total_units;
+}
+
+function effectiveRunStatus(run: SyncRun, summary: SyncRunUnitSummary | null): string {
+    if (!summary) return run.status;
+
+    const successCount = statusCount(summary, "success") ?? 0;
+    const failedCount = statusCount(summary, "failed") ?? 0;
+    const settledCount = successCount + failedCount;
+    const totalUnits = totalUnitCount(run, summary);
+    if (totalUnits > 0 && settledCount >= totalUnits) {
+        if (failedCount === 0) return "success";
+        if (successCount === 0) return "failed";
+        return "partial_failed";
+    }
+    if (
+        settledCount > 0 ||
+        (statusCount(summary, "running") ?? 0) > 0 ||
+        (statusCount(summary, "retrying") ?? 0) > 0
+    ) {
+        return "running";
+    }
+    if ((statusCount(summary, "dispatching") ?? 0) > 0) return "dispatching";
+    if ((statusCount(summary, "planned") ?? 0) > 0) return "planned";
+    return run.status;
+}
+
 function formatDuration(seconds: number | null): string {
     if (seconds == null) return "—";
     if (seconds < 60) return `${formatNumber(seconds)}s`;
@@ -194,13 +227,17 @@ export function SyncRunDetailLive({
         }
     }, []);
 
+    const currentRunStatus = effectiveRunStatus(run, summary);
+    const liveStatus = mapPlannerRunStatus(currentRunStatus);
+    const isTerminal = isTerminalSyncStatus(liveStatus);
+
     // Poll run + unit state while the run is non-terminal, mirroring the
     // cleanup/timeout discipline in useSyncTrigger.ts. State is only mutated
     // inside the async interval callback (never synchronously in the effect
     // body), so react-hooks/set-state-in-effect stays satisfied.
     useEffect(() => {
         if (testMode) return undefined;
-        if (isTerminalSyncStatus(mapPlannerRunStatus(initialRun.status))) return undefined;
+        if (isTerminal) return undefined;
 
         let cancelled = false;
 
@@ -233,7 +270,10 @@ export function SyncRunDetailLive({
                 setUnitsError(null);
                 const nextRun = runRes.data;
                 setRun(nextRun);
-                if (isTerminalSyncStatus(mapPlannerRunStatus(nextRun.status))) {
+                const nextLiveStatus = mapPlannerRunStatus(
+                    effectiveRunStatus(nextRun, unitsRes.data),
+                );
+                if (isTerminalSyncStatus(nextLiveStatus)) {
                     stopPolling();
                 }
             } finally {
@@ -248,10 +288,7 @@ export function SyncRunDetailLive({
             cancelled = true;
             stopPolling();
         };
-    }, [testMode, runId, initialRun.status, stopPolling]);
-
-    const liveStatus = mapPlannerRunStatus(run.status);
-    const isTerminal = isTerminalSyncStatus(liveStatus);
+    }, [testMode, runId, isTerminal, stopPolling]);
 
     // Resolve source ids → display names from the units themselves. We NEVER
     // surface a raw source id when a resolved name exists (web DoD / A7).
@@ -269,9 +306,9 @@ export function SyncRunDetailLive({
         [sourceNameById],
     );
 
-    const total = run.total_units;
-    const completed = run.completed_units;
-    const failed = run.failed_units;
+    const total = totalUnitCount(run, summary);
+    const completed = statusCount(summary, "success") ?? run.completed_units;
+    const failed = statusCount(summary, "failed") ?? run.failed_units;
     const settled = Math.min(total, completed + failed);
     const percent = total > 0 ? Math.min(100, Math.round((settled / total) * 100)) : 0;
 
@@ -391,7 +428,7 @@ export function SyncRunDetailLive({
                                 <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
                                     Status
                                 </dt>
-                                <dd className="text-foreground">{run.status}</dd>
+                                <dd className="text-foreground">{currentRunStatus}</dd>
                             </div>
                             <div>
                                 <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
@@ -484,7 +521,15 @@ export function SyncRunDetailLive({
                         {formatNumber(settled)} / {formatNumber(total)} ({formatPercent(percent)})
                     </span>
                 </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-(--card-70)">
+                <div
+                    className="h-2 w-full overflow-hidden rounded-full bg-(--card-70)"
+                    role="progressbar"
+                    aria-label="Overall sync progress"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={percent}
+                    aria-valuetext={`${formatNumber(settled)} of ${formatNumber(total)} units settled`}
+                >
                     <div
                         className="h-full bg-(--accent) transition-all duration-500 ease-out"
                         style={{ width: `${percent}%` }}


### PR DESCRIPTION
## Summary
- Drive config-level sync progress from live `SyncRunUnit` rollups and preserve the last good rollup on transient unit-summary errors.
- Drive sync run detail status/progress from unit rows so stale terminal `SyncRun.status` and counters cannot hide active work.
- Add semantic progressbar ARIA labels and regression coverage for stale counters, stale terminal run status, and rediscovery avoidance.

Companion backend PR: https://github.com/full-chaos/dev-health-ops/pull/1212

## Validation
- `pnpm exec vitest run src/components/admin/sync/SyncProgressBar.test.tsx src/components/admin/sync/SyncRunDetail.test.tsx` → 36 passed
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/components/admin/sync/SyncProgressBar.tsx src/components/admin/sync/SyncProgressBar.test.tsx src/components/admin/sync/SyncRunDetailLive.tsx src/components/admin/sync/SyncRunDetail.test.tsx`
- `pnpm exec prettier --check src/components/admin/sync/SyncProgressBar.tsx src/components/admin/sync/SyncProgressBar.test.tsx src/components/admin/sync/SyncRunDetailLive.tsx src/components/admin/sync/SyncRunDetail.test.tsx`
- `DESIGN_LINT=true pnpm exec eslint src/components/admin/sync/SyncProgressBar.tsx src/components/admin/sync/SyncProgressBar.test.tsx src/components/admin/sync/SyncRunDetailLive.tsx src/components/admin/sync/SyncRunDetail.test.tsx`
- `pnpm build`
- Browser QA: config page and run-detail page both rendered completed unit rollups with correct progressbar ARIA values.

Known pre-existing: repo-wide `pnpm design-lint` still reports unrelated legacy findings outside this diff; changed-file design lint passed.

## Visual evidence
![sync-config-progress-rollup-final.png](https://github.com/user-attachments/assets/9291d424-5c98-41c9-a625-70ee9ff10d6e)

![sync-run-detail-rollup-final.png](https://github.com/user-attachments/assets/e8d9f494-b00e-40e7-92e6-89dc15dba749)
