### PR TITLE
fix(admin/sync): render sync timestamps in local timezone

### DIFF
--- a/src/components/ClientTimestamp.test.tsx
+++ b/src/components/ClientTimestamp.test.tsx
@@ -21,6 +21,18 @@ describe("ClientTimestamp", () => {
         expect(span?.textContent).not.toBe("");
     });
 
+    it("renders timezone-less API timestamps the same as explicit UTC timestamps", () => {
+        render(
+            <>
+                <ClientTimestamp value="2026-07-08T17:06:00.000" fallback="N/A" />
+                <ClientTimestamp value="2026-07-08T17:06:00.000Z" fallback="N/A" />
+            </>,
+        );
+
+        const spans = document.querySelectorAll("span");
+        expect(spans[0]?.textContent).toBe(spans[1]?.textContent);
+    });
+
     it("renders fallback for an invalid date string", () => {
         render(<ClientTimestamp value="not-a-date" fallback="Invalid" />);
         expect(screen.getByText("Invalid")).toBeInTheDocument();

--- a/src/components/ClientTimestamp.tsx
+++ b/src/components/ClientTimestamp.tsx
@@ -1,21 +1,7 @@
 "use client";
 
 import { useSyncExternalStore } from "react";
-
-const formatter = new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-});
-
-function formatLocal(value: string): string {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return "";
-    const parts = formatter.formatToParts(date);
-    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
-    return `${get("month")} ${get("day")}, ${get("hour")}:${get("minute")} ${get("dayPeriod")}`;
-}
+import { formatTimestamp } from "@/lib/formatters";
 
 const subscribe = () => () => {};
 const getSnapshot = () => true;
@@ -38,7 +24,7 @@ export function ClientTimestamp({
 }: ClientTimestampProps) {
     const isClient = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
-    const formatted = isClient ? (value ? formatLocal(value) || fallback : fallback) : "";
+    const formatted = isClient ? formatTimestamp(value, fallback) : "";
 
     return (
         <span className={className}>

--- a/src/components/admin/sync/SyncJobHistory.helpers.ts
+++ b/src/components/admin/sync/SyncJobHistory.helpers.ts
@@ -1,0 +1,121 @@
+import type { SyncJob } from "@/lib/admin/types";
+import { formatDateUTC, formatNumber, parseTimestampDate } from "@/lib/formatters";
+import type { JobCoverageResult } from "./CoverageBadge";
+
+export const PAGE_SIZE = 10;
+
+export const HEADINGS = [
+    "Trigger",
+    "Mode",
+    "Requested range",
+    "Covered range",
+    "Status",
+    "Scope",
+    "Units",
+    "Started",
+    "Duration",
+    "Actions",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function formatRange(range: { since: string; before: string } | null | undefined): string {
+    if (!range) return "—";
+    return `${formatDateUTC(range.since)} → ${formatDateUTC(range.before)}`;
+}
+
+export function getDuration(job: SyncJob): string {
+    if (job.duration_seconds != null) return `${Math.round(job.duration_seconds)}s`;
+    if (job.completed_at && job.started_at) {
+        const completedAt = parseTimestampDate(job.completed_at);
+        const startedAt = parseTimestampDate(job.started_at);
+        if (completedAt && startedAt) {
+            return `${Math.round((completedAt.getTime() - startedAt.getTime()) / 1000)}s`;
+        }
+    }
+    return "—";
+}
+
+export function getBadgeStatus(status: SyncJob["status"]) {
+    switch (status) {
+        case "success":
+            return "success" as const;
+        case "failed":
+        case "cancelled":
+            return "failed" as const;
+        case "running":
+            return "running" as const;
+        case "pending":
+            return "idle" as const;
+        default:
+            return "never" as const;
+    }
+}
+
+export function getBadgeLabel(status: SyncJob["status"]) {
+    switch (status) {
+        case "pending":
+            return "Queued";
+        case "cancelled":
+            return "Cancelled";
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Derive the coverage-result label for a planner-backed job (CHAOS-2792),
+ * using ONLY persisted job status + sync_run unit counts. Never re-derives
+ * from range/interval comparisons (platform ban on client-side coverage math).
+ * Returns null for non-terminal jobs or legacy rows (no sync_run block) —
+ * those render the plain job status badge instead.
+ *
+ * Precedence is deliberate and pinned by tests: failed > partial > gap >
+ * complete. A terminal failed/cancelled run is a STRONGER signal than an
+ * unsettled-units gap — so a failed/cancelled run with unsettled units
+ * (settled < total_units) still reports "failed"/"partial", never "gap".
+ * Only a terminal SUCCESS run with unsettled units reports "gap".
+ */
+export function deriveJobCoverageResult(job: SyncJob): JobCoverageResult | null {
+    const sr = job.sync_run;
+    if (!sr) return null;
+    if (job.status === "pending" || job.status === "running") return null;
+
+    const settled = sr.completed_units + sr.failed_units;
+
+    if (job.status === "failed" || job.status === "cancelled") {
+        return sr.completed_units === 0 ? "failed" : "partial";
+    }
+    if (sr.total_units === 0) return "complete";
+    if (sr.failed_units > 0 && sr.completed_units > 0) return "partial";
+    if (sr.failed_units > 0 && sr.completed_units === 0) return "failed";
+    if (settled < sr.total_units) return "gap";
+    return "complete";
+}
+
+export function getRunId(job: SyncJob): string | null {
+    if (job.sync_run?.sync_run_id) return job.sync_run.sync_run_id;
+    if (isRecord(job.result) && typeof job.result.sync_run_id === "string") {
+        return job.result.sync_run_id;
+    }
+    return null;
+}
+
+export function getScopeLabel(job: SyncJob): string {
+    const sr = job.sync_run;
+    if (!sr) {
+        const datasetKey =
+            isRecord(job.result) && typeof job.result.dataset_key === "string"
+                ? job.result.dataset_key
+                : null;
+        return datasetKey ?? "—";
+    }
+    const sourceIds = new Set<string>([
+        ...(sr.requested_range?.source_ids ?? []),
+        ...(sr.covered_range?.source_ids ?? []),
+    ]);
+    if (sourceIds.size === 0) return "—";
+    return `${formatNumber(sourceIds.size)} source${sourceIds.size === 1 ? "" : "s"}`;
+}

--- a/src/components/admin/sync/SyncJobHistory.test.tsx
+++ b/src/components/admin/sync/SyncJobHistory.test.tsx
@@ -69,7 +69,9 @@ describe("SyncJobHistory", () => {
     it("renders requested/covered ranges and links planner-backed rows to run detail", () => {
         render(<SyncJobHistory jobs={[SYNC_JOB_WITH_RUN]} configId="cfg-1" testMode />);
 
-        const link = screen.getByRole("link", { name: "View run" });
+        const link = screen.getByRole("link", {
+            name: /View run details for sync run started/,
+        });
         expect(link).toHaveAttribute("href", "/org/admin/sync/cfg-1/runs/run-coverage");
         expect(screen.getByText("Jan 1, 2026 → Jan 3, 2026")).toBeInTheDocument();
     });

--- a/src/components/admin/sync/SyncJobHistory.test.tsx
+++ b/src/components/admin/sync/SyncJobHistory.test.tsx
@@ -69,7 +69,7 @@ describe("SyncJobHistory", () => {
     it("renders requested/covered ranges and links planner-backed rows to run detail", () => {
         render(<SyncJobHistory jobs={[SYNC_JOB_WITH_RUN]} configId="cfg-1" testMode />);
 
-        const link = screen.getByRole("link", { name: /View run details/ });
+        const link = screen.getByRole("link", { name: "View run" });
         expect(link).toHaveAttribute("href", "/org/admin/sync/cfg-1/runs/run-coverage");
         expect(screen.getByText("Jan 1, 2026 → Jan 3, 2026")).toBeInTheDocument();
     });

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -3,19 +3,24 @@
 import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { ClientTimestamp } from "@/components/ClientTimestamp";
 import { getSyncJobs } from "@/lib/admin/server";
 import type { SyncJob } from "@/lib/admin/types";
 import { CTA_LABELS } from "@/lib/design/cta";
-import { formatDateUTC, formatNumber } from "@/lib/formatters";
+import { formatNumber } from "@/lib/formatters";
 import { SyncStatusBadge } from "./SyncStatusBadge";
+import { CoverageBadge, jobCoverageLabel, jobCoverageTone } from "./CoverageBadge";
 import {
-    CoverageBadge,
-    jobCoverageLabel,
-    jobCoverageTone,
-    type JobCoverageResult,
-} from "./CoverageBadge";
-
-const PAGE_SIZE = 10;
+    deriveJobCoverageResult,
+    formatRange,
+    getBadgeLabel,
+    getBadgeStatus,
+    getDuration,
+    getRunId,
+    getScopeLabel,
+    HEADINGS,
+    PAGE_SIZE,
+} from "./SyncJobHistory.helpers";
 
 interface SyncJobHistoryProps {
     jobs: SyncJob[];
@@ -27,139 +32,6 @@ interface SyncJobHistoryProps {
      */
     testMode?: boolean;
 }
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-// Locked UTC-anchored formatter: bare toLocaleString() drifts between Node
-// and browser locales/timezones (hydration + CI mismatches). Module-level
-// so we don't allocate a new Intl.DateTimeFormat per render.
-const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
-    dateStyle: "medium",
-    timeStyle: "short",
-    timeZone: "UTC",
-});
-
-function formatTimestamp(value: string | null | undefined): string {
-    if (!value) return "—";
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return "—";
-    return TIMESTAMP_FORMATTER.format(date);
-}
-
-function formatRange(range: { since: string; before: string } | null | undefined): string {
-    if (!range) return "—";
-    return `${formatDateUTC(range.since)} → ${formatDateUTC(range.before)}`;
-}
-
-function getDuration(job: SyncJob): string {
-    if (job.duration_seconds != null) return `${Math.round(job.duration_seconds)}s`;
-    if (job.completed_at && job.started_at) {
-        return `${Math.round(
-            (new Date(job.completed_at).getTime() - new Date(job.started_at).getTime()) / 1000,
-        )}s`;
-    }
-    return "—";
-}
-
-function getBadgeStatus(status: SyncJob["status"]) {
-    switch (status) {
-        case "success":
-            return "success" as const;
-        case "failed":
-        case "cancelled":
-            return "failed" as const;
-        case "running":
-            return "running" as const;
-        case "pending":
-            return "idle" as const;
-        default:
-            return "never" as const;
-    }
-}
-
-function getBadgeLabel(status: SyncJob["status"]) {
-    switch (status) {
-        case "pending":
-            return "Queued";
-        case "cancelled":
-            return "Cancelled";
-        default:
-            return undefined;
-    }
-}
-
-/**
- * Derive the coverage-result label for a planner-backed job (CHAOS-2792),
- * using ONLY persisted job status + sync_run unit counts. Never re-derives
- * from range/interval comparisons (platform ban on client-side coverage math).
- * Returns null for non-terminal jobs or legacy rows (no sync_run block) —
- * those render the plain job status badge instead.
- *
- * Precedence is deliberate and pinned by tests: failed > partial > gap >
- * complete. A terminal failed/cancelled run is a STRONGER signal than an
- * unsettled-units gap — so a failed/cancelled run with unsettled units
- * (settled < total_units) still reports "failed"/"partial", never "gap".
- * Only a terminal SUCCESS run with unsettled units reports "gap".
- */
-function deriveJobCoverageResult(job: SyncJob): JobCoverageResult | null {
-    const sr = job.sync_run;
-    if (!sr) return null;
-    if (job.status === "pending" || job.status === "running") return null;
-
-    const settled = sr.completed_units + sr.failed_units;
-
-    // failed/cancelled precedence: a stronger signal than "gap" (see doc
-    // comment above) — reported regardless of how many units settled.
-    if (job.status === "failed" || job.status === "cancelled") {
-        return sr.completed_units === 0 ? "failed" : "partial";
-    }
-    // job.status === "success"
-    if (sr.total_units === 0) return "complete";
-    if (sr.failed_units > 0 && sr.completed_units > 0) return "partial";
-    if (sr.failed_units > 0 && sr.completed_units === 0) return "failed";
-    if (settled < sr.total_units) return "gap";
-    return "complete";
-}
-
-function getRunId(job: SyncJob): string | null {
-    if (job.sync_run?.sync_run_id) return job.sync_run.sync_run_id;
-    if (isRecord(job.result) && typeof job.result.sync_run_id === "string") {
-        return job.result.sync_run_id;
-    }
-    return null;
-}
-
-function getScopeLabel(job: SyncJob): string {
-    const sr = job.sync_run;
-    if (!sr) {
-        const datasetKey =
-            isRecord(job.result) && typeof job.result.dataset_key === "string"
-                ? job.result.dataset_key
-                : null;
-        return datasetKey ?? "—";
-    }
-    const sourceIds = new Set<string>([
-        ...(sr.requested_range?.source_ids ?? []),
-        ...(sr.covered_range?.source_ids ?? []),
-    ]);
-    if (sourceIds.size === 0) return "—";
-    return `${formatNumber(sourceIds.size)} source${sourceIds.size === 1 ? "" : "s"}`;
-}
-
-const HEADINGS = [
-    "Trigger",
-    "Mode",
-    "Requested range",
-    "Covered range",
-    "Status",
-    "Scope",
-    "Units",
-    "Started",
-    "Duration",
-    "Actions",
-];
 
 export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHistoryProps) {
     const router = useRouter();
@@ -293,7 +165,7 @@ export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHist
                                         : (job.items_synced ?? "—")}
                                 </td>
                                 <td className="px-4 py-3 whitespace-nowrap text-sm text-foreground">
-                                    {formatTimestamp(job.started_at)}
+                                    <ClientTimestamp value={job.started_at} fallback="—" />
                                 </td>
                                 <td className="px-4 py-3 whitespace-nowrap text-sm text-(--ink-muted)">
                                     {getDuration(job)}
@@ -302,9 +174,7 @@ export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHist
                                     {href ? (
                                         <Link
                                             href={href}
-                                            aria-label={`View run details for sync run started ${formatTimestamp(
-                                                job.started_at,
-                                            )}`}
+                                            aria-label={CTA_LABELS.viewRun}
                                             className="text-(--accent) hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--accent)"
                                         >
                                             {CTA_LABELS.viewRun}

--- a/src/components/admin/sync/SyncJobHistory.tsx
+++ b/src/components/admin/sync/SyncJobHistory.tsx
@@ -7,7 +7,7 @@ import { ClientTimestamp } from "@/components/ClientTimestamp";
 import { getSyncJobs } from "@/lib/admin/server";
 import type { SyncJob } from "@/lib/admin/types";
 import { CTA_LABELS } from "@/lib/design/cta";
-import { formatNumber } from "@/lib/formatters";
+import { formatDateTimeUTC, formatNumber } from "@/lib/formatters";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 import { CoverageBadge, jobCoverageLabel, jobCoverageTone } from "./CoverageBadge";
 import {
@@ -118,6 +118,9 @@ export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHist
                     {visibleJobs.map((job) => {
                         const runId = getRunId(job);
                         const href = runId ? `/org/admin/sync/${configId}/runs/${runId}` : null;
+                        const formattedRunStarted = formatDateTimeUTC(job.started_at);
+                        const runStartedLabel =
+                            formattedRunStarted === "—" ? "unknown time" : formattedRunStarted;
                         const coverageResult = deriveJobCoverageResult(job);
                         const sr = job.sync_run;
 
@@ -174,7 +177,7 @@ export function SyncJobHistory({ jobs, configId, testMode = false }: SyncJobHist
                                     {href ? (
                                         <Link
                                             href={href}
-                                            aria-label={CTA_LABELS.viewRun}
+                                            aria-label={`View run details for sync run started ${runStartedLabel}`}
                                             className="text-(--accent) hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--accent)"
                                         >
                                             {CTA_LABELS.viewRun}

--- a/src/lib/__tests__/formatters.test.ts
+++ b/src/lib/__tests__/formatters.test.ts
@@ -4,7 +4,9 @@ import {
     formatMetricValue,
     formatNumber,
     formatPercent,
+    formatTimestamp,
     formatDateTimeUTC,
+    parseTimestampDate,
     defaultFormatter,
     integerFormatter,
     compactFormatter,
@@ -61,6 +63,25 @@ describe("formatters", () => {
             expect(formatMetricValue(42, "%")).toBe("42%");
             expect(formatMetricValue(3, "days")).toBe("3d");
         });
+    });
+});
+
+describe("timestamp formatting", () => {
+    it("parses API timestamps without an explicit timezone as UTC", () => {
+        expect(parseTimestampDate("2026-07-08T17:06:00.000")?.toISOString()).toBe(
+            "2026-07-08T17:06:00.000Z",
+        );
+    });
+
+    it("formats timezone-less and explicit UTC timestamps identically", () => {
+        expect(formatTimestamp("2026-07-08T17:06:00.000")).toBe(
+            formatTimestamp("2026-07-08T17:06:00.000Z"),
+        );
+    });
+
+    it("uses the provided fallback for missing or invalid values", () => {
+        expect(formatTimestamp(null, "—")).toBe("—");
+        expect(formatTimestamp("not-a-date", "—")).toBe("—");
     });
 });
 

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -19,6 +19,15 @@ const _tsParts = new Intl.DateTimeFormat("en-US", {
     minute: "2-digit",
 });
 
+const ISO_DATETIME_WITHOUT_TIMEZONE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?$/;
+
+export const parseTimestampDate = (value: string | null | undefined): Date | null => {
+    if (!value) return null;
+    const normalizedValue = ISO_DATETIME_WITHOUT_TIMEZONE.test(value) ? `${value}Z` : value;
+    const date = new Date(normalizedValue);
+    return Number.isNaN(date.getTime()) ? null : date;
+};
+
 // Fallback cache for custom formatter options - exported for testing
 export const customFormatters = new Map<string, Intl.NumberFormat>();
 
@@ -87,14 +96,9 @@ export const formatMetricValue = (value: number, unit: string) => {
     return `${formatNumber(value)} ${unit}`.trim();
 };
 
-export const formatTimestamp = (value?: string | null) => {
-    if (!value) {
-        return "Unavailable";
-    }
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return "Unavailable";
-    }
+export const formatTimestamp = (value?: string | null, fallback = "Unavailable") => {
+    const date = parseTimestampDate(value);
+    if (!date) return fallback;
     const parts = _tsParts.formatToParts(date);
     const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
     return `${get("month")} ${get("day")}, ${get("hour")}:${get("minute")} ${get("dayPeriod")}`;
@@ -107,9 +111,8 @@ export const formatTimestamp = (value?: string | null) => {
  * two coverage surfaces never drift apart on date-only formatting.
  */
 export const formatDateUTC = (value: string | null | undefined): string => {
-    if (!value) return "—";
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return "—";
+    const date = parseTimestampDate(value);
+    if (!date) return "—";
     return date.toLocaleDateString("en-US", {
         year: "numeric",
         month: "short",
@@ -126,9 +129,8 @@ export const formatDateUTC = (value: string | null | undefined): string => {
  * offset.
  */
 export const formatDateTimeUTC = (value: string | null | undefined): string => {
-    if (!value) return "—";
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return "—";
+    const date = parseTimestampDate(value);
+    if (!date) return "—";
     return date.toLocaleString("en-US", {
         year: "numeric",
         month: "short",


### PR DESCRIPTION
Linear: CHAOS-2897

## Summary
- Treat timezone-less ISO API timestamps as UTC before formatting.
- Reuse shared timestamp formatting in ClientTimestamp and SyncJobHistory.
- Render SyncJobHistory started timestamps client-side to avoid server/client timezone drift.
- Extract SyncJobHistory helper logic to keep the component under the 250 pure-LOC ceiling.

## Verification
- LSP diagnostics clean on changed TS/TSX files.
- `pnpm exec vitest run "src/lib/__tests__/formatters.test.ts" "src/components/ClientTimestamp.test.tsx" "src/components/admin/sync/SyncJobHistory.test.tsx"` (45 passed).
- `pnpm typecheck`.
- Targeted ESLint/design-lint on touched files.
- `pnpm build`.
- Isolated Chromium QA in `America/Los_Angeles`: timezone-less `2026-07-08T17:06:00.000` and explicit UTC `2026-07-08T17:06:00.000Z` both rendered `Jul 8, 10:06 AM`.
- Oracle review: no blocking findings.

## Known issues
- Full `pnpm design-lint` still fails on pre-existing repo-wide CTA/token violations outside this change.
- SCREENSHOT-WAIVER: Local authenticated sync route visual QA was blocked by dev/auth and Playwright MCP session issues; timestamp rendering was verified through isolated Chromium and component tests instead.
