### PR TITLE
docs(architecture): document ACR entitlement contract (CHAOS-2921)

### DIFF
--- a/docs/agent-context-runtime-entitlement.md
+++ b/docs/agent-context-runtime-entitlement.md
@@ -1,0 +1,19 @@
+# Agent Context Runtime Entitlement Contract
+
+`agent_context_runtime` is an organization-scoped, purchased hosted product
+entitlement. It is never enabled merely because an organization is on a paid
+Dev Health tier, trial, or self-hosted installation.
+
+The web entitlement management surface consumes the existing authenticated
+`GET /api/v1/licensing/entitlements/{org_id}` response through
+`OrgEntitlements.features`. It can display the boolean and create the existing
+organization-scoped feature overrides for superadmins. It must not infer ACR
+access from `tier`, cache a positive result as durable authorization, pass an
+organization chosen by the browser as trusted identity, or attach Dev Health
+license material to an ACR request.
+
+The hosted ACR service independently validates its own credential, organization,
+and repository scope before it reads this entitlement. A value of `false`, a
+missing feature row, or an unavailable entitlement record is denied. The web is
+an inspection and administration surface only; it does not implement ACR
+assembly or authorization.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,6 +115,10 @@ All routes below require an active session. The `(app)` layout wraps them in `Se
 | `/superadmin/licensing` | `superadmin/licensing/page.tsx` | Licence management per org                                     |
 | `/superadmin/billing/*` | `superadmin/billing/*/page.tsx` | Billing views — subscriptions, invoices, plans, refunds, audit |
 
+The licensing surface consumes organization-scoped feature booleans; see the
+[Agent Context Runtime entitlement contract](agent-context-runtime-entitlement.md)
+for the hosted ACR-specific boundary.
+
 ### `(auth)` — Public Auth Flows
 
 | Route           | Page                    | Description                  |


### PR DESCRIPTION
## Summary
- document the web-facing `agent_context_runtime` entitlement contract
- prohibit tier inference, browser-trusted organization scope, and license artifacts as API credentials
- link the contract from web architecture docs

## Verification
- `pnpm test:unit` (2,938 passed)
- `pnpm lint` (0 errors; one pre-existing warning)
- `pnpm typecheck`
- `pnpm build`
- full `pnpm design-lint` remains blocked by 275 pre-existing violations outside this docs-only diff
- independent changeset review: APPROVE, no blocking findings

SCREENSHOT-WAIVER: documentation-only change; no rendered UI.

Linear: CHAOS-2921