### PR TITLE
fix(cockpit): show latest successful provider sync

### DIFF
--- a/src/app/(app)/dashboard/page.test.tsx
+++ b/src/app/(app)/dashboard/page.test.tsx
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/test/utils";
+
+import { getHomeData } from "@/lib/api/home";
+import { checkApiHealth, getApiMeta } from "@/lib/api/system";
+import { getSetupStatus } from "@/lib/admin/server";
+import type { HomeResponse } from "@/lib/types";
+import Home from "./page";
+
+vi.mock("@/lib/api/home", () => ({ getHomeData: vi.fn() }));
+vi.mock("@/lib/api/system", () => ({ checkApiHealth: vi.fn(), getApiMeta: vi.fn() }));
+vi.mock("@/lib/admin/server", () => ({ getSetupStatus: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+    auth: vi.fn(async () => ({ user: { org_id: "org-1" } })),
+}));
+
+vi.mock("@/components/ClientTimestamp", () => ({
+    ClientTimestamp: ({ value, prefix }: { value?: string | null; prefix?: string }) => (
+        <span>
+            {prefix}
+            {value}
+        </span>
+    ),
+}));
+vi.mock("@/components/ServiceUnavailable", () => ({ ServiceUnavailable: () => null }));
+vi.mock("@/components/filters/FilterBar", () => ({ FilterBar: () => null }));
+vi.mock("@/components/home/AiWorkflowCallout", () => ({ AiWorkflowCallout: () => null }));
+vi.mock("@/components/home/BackendBanner", () => ({ BackendBanner: () => null }));
+vi.mock("@/components/home/CockpitClient", () => ({ CockpitClient: () => null }));
+vi.mock("@/components/home/CockpitSummary", () => ({ CockpitSummary: () => null }));
+vi.mock("@/components/home/DataConfidenceIndicator", () => ({
+    DataConfidenceIndicator: () => null,
+}));
+vi.mock("@/components/home/InvestmentPreview", () => ({ InvestmentPreview: () => null }));
+vi.mock("@/components/home/RankedSignals", () => ({ RankedSignals: () => null }));
+vi.mock("@/components/navigation/GlobalContextBar", () => ({ GlobalContextBar: () => null }));
+vi.mock("@/components/navigation/PrimaryNav", () => ({ PrimaryNav: () => null }));
+vi.mock("@/components/onboarding/SetupBanner", () => ({ SetupBanner: () => null }));
+
+const HOME_DATA: HomeResponse = {
+    freshness: {
+        last_ingested_at: "2026-07-12T00:07:00Z",
+        latest_successful_sync_at: "2026-07-13T15:05:00Z",
+        sources: {},
+        coverage: {
+            repos_covered_pct: 100,
+            prs_linked_to_issues_pct: 100,
+            issues_with_cycle_states_pct: 100,
+        },
+    },
+    deltas: [],
+    summary: [],
+    tiles: {},
+    constraint: { title: "", claim: "", evidence: [], experiments: [] },
+    events: [],
+};
+
+describe("dashboard freshness", () => {
+    beforeEach(() => {
+        vi.mocked(checkApiHealth).mockResolvedValue({ ok: true, data: null });
+        vi.mocked(getApiMeta).mockResolvedValue({
+            backend: "clickhouse",
+            version: "test",
+            last_ingest_at: null,
+            coverage: {},
+            limits: {},
+            supported_endpoints: [],
+        });
+        vi.mocked(getSetupStatus).mockResolvedValue({ error: "not needed for this test" });
+        vi.mocked(getHomeData).mockResolvedValue(HOME_DATA);
+    });
+
+    it("renders the org-readable successful sync time instead of older metric computation time", async () => {
+        render(await Home({ searchParams: Promise.resolve({}) }));
+
+        expect(screen.getByText("Last updated: 2026-07-13T15:05:00Z")).toBeInTheDocument();
+    });
+
+    it.each([null, undefined])(
+        "falls back to metric computation time when successful sync time is %s",
+        async (latestSuccessfulSyncAt) => {
+            vi.mocked(getHomeData).mockResolvedValue({
+                ...HOME_DATA,
+                freshness: {
+                    ...HOME_DATA.freshness,
+                    last_ingested_at: "2026-07-12T00:07:00Z",
+                    latest_successful_sync_at: latestSuccessfulSyncAt,
+                },
+            });
+
+            render(await Home({ searchParams: Promise.resolve({}) }));
+
+            expect(screen.getByText("Last updated: 2026-07-12T00:07:00Z")).toBeInTheDocument();
+        },
+    );
+});

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -96,7 +96,8 @@ export default async function Home({ searchParams }: HomePageProps) {
     if (!health.ok) {
         return <ServiceUnavailable />;
     }
-    const lastIngestedAt = home?.freshness.last_ingested_at ?? null;
+    const lastUpdatedAt =
+        home?.freshness.latest_successful_sync_at ?? home?.freshness.last_ingested_at ?? null;
     // Reorder Monitoring Views based on active lens (cockpit surface priority).
     const viewPriority: Record<string, string[]> = {
         ic: ["flow", "throughput", "dora"],
@@ -141,9 +142,9 @@ export default async function Home({ searchParams }: HomePageProps) {
 
                             <div className="flex items-center justify-between">
                                 <BackendBanner meta={meta} />
-                                <p className="text-sm text-(--ink-muted)">
+                                <p className="text-body font-medium text-(--text-secondary)">
                                     <ClientTimestamp
-                                        value={lastIngestedAt}
+                                        value={lastUpdatedAt}
                                         prefix="Last updated: "
                                     />
                                 </p>

--- a/src/app/(app)/org/admin/sync/page.tsx
+++ b/src/app/(app)/org/admin/sync/page.tsx
@@ -72,7 +72,7 @@ export default async function SyncStatusPage() {
 
             {/* Standalone configs (no parent, no children) */}
             {standalones.length > 0 && (
-                <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                <div className="grid gap-6 xl:grid-cols-2">
                     {standalones.map((config) => (
                         <SyncConfigCard key={config.id} config={config} />
                     ))}

--- a/src/components/admin/sync/SyncConfigCard.tsx
+++ b/src/components/admin/sync/SyncConfigCard.tsx
@@ -85,8 +85,8 @@ export function SyncConfigCard({ config }: SyncConfigCardProps) {
                 <SyncStatusBadge status={getStatus()} />
             </div>
 
-            <div className="mt-6 flex items-center justify-between border-t border-(--card-stroke) pt-4">
-                <div className="text-xs text-(--ink-muted)">
+            <div className="mt-6 flex flex-col gap-4 border-t border-(--card-stroke) pt-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="shrink-0 text-xs text-(--ink-muted)">
                     <ClientTimestamp
                         value={config.last_sync_at}
                         prefix="Last sync: "
@@ -94,7 +94,10 @@ export function SyncConfigCard({ config }: SyncConfigCardProps) {
                     />
                 </div>
 
-                <div className="flex items-center gap-2" onClick={(e) => e.preventDefault()}>
+                <div
+                    className="flex flex-wrap items-center gap-2"
+                    onClick={(e) => e.preventDefault()}
+                >
                     {showDeleteConfirm ? (
                         <div className="flex items-center gap-2">
                             <span className="text-xs text-red-500">Are you sure?</span>

--- a/src/components/admin/sync/SyncConfigGroup.test.tsx
+++ b/src/components/admin/sync/SyncConfigGroup.test.tsx
@@ -144,6 +144,22 @@ describe("SyncConfigGroup", () => {
         expect(expandToggle).toHaveAttribute("aria-expanded", "true");
     });
 
+    it("keeps child cards and their footers readable through tablet widths", async () => {
+        renderWithToaster(<SyncConfigGroup parent={parent} childConfigs={childConfigs} />);
+
+        await userEvent.click(screen.getByRole("button", { expanded: false }));
+
+        const childCard = screen.getByRole("link", { name: /chaos\/repo-a/ });
+        const childGrid = childCard.parentElement;
+        const timestamp = screen.getAllByText("Last sync: Never")[0];
+        const footer = timestamp.parentElement?.parentElement;
+
+        expect(childGrid).toHaveClass("xl:grid-cols-2");
+        expect(childGrid).not.toHaveClass("md:grid-cols-2");
+        expect(timestamp.parentElement).toHaveClass("shrink-0");
+        expect(footer).toHaveClass("flex-col", "sm:flex-row");
+    });
+
     it("uses singular copy for a single repo config", async () => {
         renderWithToaster(<SyncConfigGroup parent={parent} childConfigs={[childConfigs[0]]} />);
 

--- a/src/components/admin/sync/SyncConfigGroup.tsx
+++ b/src/components/admin/sync/SyncConfigGroup.tsx
@@ -144,7 +144,7 @@ export function SyncConfigGroup({ parent, childConfigs }: SyncConfigGroupProps) 
 
             {/* Children */}
             {expanded && (
-                <div className="border-t border-(--card-stroke) p-4 grid gap-4 md:grid-cols-2">
+                <div className="grid gap-4 border-t border-(--card-stroke) p-4 xl:grid-cols-2">
                     {childConfigs.map((child) => (
                         <SyncConfigCard key={child.id} config={child} />
                     ))}

--- a/src/lib/__tests__/apiClient.test.ts
+++ b/src/lib/__tests__/apiClient.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { auth } from "@/lib/auth";
 import { apiClient } from "@/lib/apiClient";
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(auth).mockReset();
+});
 
 describe("apiClient.buildUrl", () => {
     it("skips empty values while keeping falsy primitives", () => {
@@ -20,5 +28,43 @@ describe("apiClient.buildUrl", () => {
         expect(url.searchParams.has("c")).toBe(false);
         expect(url.searchParams.get("d")).toBe("0");
         expect(url.searchParams.get("e")).toBe("false");
+    });
+});
+
+describe("apiClient.request", () => {
+    it("does not share in-flight responses across authenticated sessions", async () => {
+        vi.mocked(auth).mockResolvedValueOnce({
+            access_token: "token-a",
+            expires: "2099-01-01T00:00:00Z",
+            user: { id: "user-a" },
+        });
+
+        let releaseFetches: (() => void) | undefined;
+        const fetchesMayComplete = new Promise<void>((resolve) => {
+            releaseFetches = resolve;
+        });
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+            await fetchesMayComplete;
+            const authorization = new Headers(init?.headers).get("Authorization");
+            return Response.json({ authorization });
+        });
+
+        const first = apiClient.getJson<{ authorization: string }>("/api/v1/home");
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+        vi.mocked(auth).mockResolvedValueOnce({
+            access_token: "token-b",
+            expires: "2099-01-01T00:00:00Z",
+            user: { id: "user-b" },
+        });
+        const second = apiClient.getJson<{ authorization: string }>("/api/v1/home");
+
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+        releaseFetches?.();
+
+        await expect(Promise.all([first, second])).resolves.toEqual([
+            { authorization: "Bearer token-a" },
+            { authorization: "Bearer token-b" },
+        ]);
     });
 });

--- a/src/lib/__tests__/homeApi.test.ts
+++ b/src/lib/__tests__/homeApi.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { postJson } from "@/lib/api/_shared";
+import { getHomeData } from "@/lib/api/home";
+import type { MetricFilter } from "@/lib/filters/types";
+
+vi.mock("@/lib/api/_shared", () => ({
+    normalizeFilters: vi.fn((filters: MetricFilter) => filters),
+    postJson: vi.fn(),
+}));
+
+const FILTERS: MetricFilter = {
+    time: { range_days: 14, compare_days: 14 },
+    scope: { level: "org", ids: [] },
+    who: {},
+    what: {},
+    why: {},
+    how: {},
+};
+
+describe("getHomeData", () => {
+    beforeEach(() => {
+        vi.mocked(postJson).mockReset();
+    });
+
+    it("disables web-layer revalidation so sync freshness stays current", async () => {
+        vi.mocked(postJson).mockResolvedValue({});
+
+        await getHomeData(FILTERS);
+
+        expect(postJson).toHaveBeenCalledWith(
+            "/api/v1/home",
+            { filters: FILTERS },
+            0,
+            expect.any(Object),
+        );
+    });
+});

--- a/src/lib/api/home.ts
+++ b/src/lib/api/home.ts
@@ -11,7 +11,7 @@ import { normalizeFilters, postJson } from "./_shared";
  */
 export const getHomeData = cache(async function getHomeData(filters: MetricFilter) {
     const normalized = normalizeFilters(filters);
-    return postJson<HomeResponse>("/api/v1/home", { filters: normalized }, 60, {
+    return postJson<HomeResponse>("/api/v1/home", { filters: normalized }, 0, {
         f: encodeFilterParam(normalized),
     });
 });

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -45,7 +45,10 @@ async function getServerAuthHeaders(): Promise<Record<string, string>> {
         if (session?.access_token) {
             return { Authorization: `Bearer ${session.access_token}` };
         }
-    } catch {}
+    } catch {
+        // The backend remains the authentication boundary and will return 401.
+        return {};
+    }
     return {};
 }
 
@@ -57,13 +60,6 @@ const request = async (
     params?: ApiQueryParams,
 ): Promise<Response> => {
     const url = buildUrl(path, params);
-    const cacheKey = `${init?.method ?? "GET"}:${url}`;
-
-    const existing = inflightRequests.get(cacheKey);
-    if (existing) {
-        return existing.then((r) => r.clone());
-    }
-
     const authHeaders = await getServerAuthHeaders();
 
     // Attach X-Request-ID for distributed tracing across the web → backend boundary.
@@ -80,8 +76,22 @@ const request = async (
             "X-Request-ID": requestId,
         },
     };
+    const method = (mergedInit.method ?? "GET").toUpperCase();
+    const hasAuthorization = new Headers(mergedInit.headers).has("Authorization");
+    const canDedupe = !hasAuthorization && (method === "GET" || method === "HEAD");
+    const cacheKey = `${method}:${url}`;
+
+    if (canDedupe) {
+        const existing = inflightRequests.get(cacheKey);
+        if (existing) {
+            return existing.then((response) => response.clone());
+        }
+    }
 
     const promise = fetch(url, mergedInit);
+    if (!canDedupe) {
+        return promise;
+    }
     inflightRequests.set(cacheKey, promise);
 
     try {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,7 @@ export type MetaResponse = {
 
 export type Freshness = {
     last_ingested_at: string | null;
+    latest_successful_sync_at?: string | null;
     sources: Record<string, "ok" | "degraded" | "down">;
     coverage: Coverage;
 };


### PR DESCRIPTION
## Summary

- render Cockpit's `Last updated` value from the newest successful provider sync, with the existing ingestion timestamp as a compatibility fallback
- disable stale home revalidation and prevent authenticated requests from sharing in-flight responses across sessions
- strengthen timestamp typography and keep Sync Status cards readable without overflow at mobile, tablet, and desktop widths
- add regressions for timestamp selection, home fetch freshness, authenticated request isolation, and responsive card structure

## Backend dependency

- full-chaos/dev-health-ops#1226
- The optional frontend field preserves compatibility while the backend PR lands.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (one unrelated existing warning)
- `pnpm test:unit` (2,944 tests)
- production-browser QA at 375px, 768px, and 1440px with no console errors, failed HTTP responses, clipping, or horizontal overflow
- two independent final visual reviews: PASS with zero findings
- all changed files report clean LSP diagnostics

## Known repository baseline

`pnpm design-lint` continues to report the existing repository baseline (275 errors and one warning). This PR does not introduce new design-lint violations; reported violations in touched Sync Status files are unchanged CTA strings outside the modified lines.

## Visual result

- Cockpit: `Last updated: Jul 13, 9:11 AM`
- GitHub: `Last sync: Jul 13, 9:11 AM`
- Linear: `Last sync: Jul 13, 9:05 AM`

### Cockpit

![Cockpit at 375px](https://github.com/user-attachments/assets/496ddbb5-9c25-4bb6-a591-403eedd43ed1)
![Cockpit at 768px](https://github.com/user-attachments/assets/7165f2c5-d123-41dd-8baa-95456d197d41)
![Cockpit at 1440px](https://github.com/user-attachments/assets/c22d6f88-54cc-48b7-815f-dc48bacb9650)

### Sync Status

![Sync Status at 375px](https://github.com/user-attachments/assets/d65c314a-6960-4da8-a948-e82f26f0e526)
![Sync Status at 768px](https://github.com/user-attachments/assets/866c6203-cb60-4d81-b682-98c1e4294862)
![Sync Status at 1440px](https://github.com/user-attachments/assets/96136d4a-370b-47d9-8131-3171fa103e23)
