### PR TITLE
fix: remove demoted styling from Feature Flags menu item

### DIFF
--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -540,8 +540,6 @@ export const navAreas: readonly NavArea[] = [
                 label: "Feature Flags",
                 path: "/feature-flags",
                 navVisible: true,
-                // R4 low-value surface — rendered visually secondary in the list.
-                demoted: true,
             },
             {
                 id: "risk-compounding",


### PR DESCRIPTION
Fixes CHAOS-2949

## Problem
The Feature Flags menu item was using demoted styling making it appear grayed out compared to other nav items like TestOps, Quality, Security, etc.

## Solution
Removed the `demoted: true` flag from the Feature Flags nav item configuration in `src/lib/navigation/areas.ts` to match the standard styling used by other menu items.

## Changes
- Removed `demoted: true` from Feature Flags nav item
- Removed associated comment explaining the demoted styling

Feature Flags will now render with the same visual weight as other menu items in the Govern section.

SCREENSHOT-WAIVER: Config-only change, styling is deterministic (removes opacity modifier)