### PR TITLE
revert(web): restore bug report button to pre-#786 position

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -43,9 +43,7 @@ export default async function AppLayout({
                                 </nav>
                             </header>
                             {children}
-                            <div className="flex justify-end px-4 pb-6 sm:px-6">
-                                <BugReportButton />
-                            </div>
+                            <BugReportButton />
                             <Toaster richColors position="top-right" theme="dark" />
                         </div>
                     </TelemetryProvider>


### PR DESCRIPTION
## Summary
- Restore the bare `<BugReportButton />` immediately after `{children}` in the global app shell.
- Remove only the unapproved #786 flex wrapper; retain the approved account-menu header and leave `BugReportButton.tsx` unchanged.

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (one pre-existing unused-variable warning; no errors)
- Playwright on isolated ports 3017/8017: authenticated `/demo`, confirmed the restored trigger after page content, clicked it, and confirmed the `Report an Issue` drawer. Screenshots captured for both states.

`pnpm design-lint` remains baseline-red with unrelated existing violations outside this change.