### PR TITLE
fix(web): decode PR detail route id

### DIFF
--- a/src/app/(app)/prs/[pr_id]/page.test.tsx
+++ b/src/app/(app)/prs/[pr_id]/page.test.tsx
@@ -260,4 +260,20 @@ describe("PrDetailPage", () => {
             useDemoFallback: false,
         });
     });
+
+    it("decodes a URL-encoded colon PR route before requesting persisted detail", async () => {
+        const colonId = "11111111-1111-1111-1111-111111111111:42";
+        const encodedColonId = "11111111-1111-1111-1111-111111111111%3A42";
+        getPrDetailViaGraphQLMock.mockResolvedValue({ ...samplePr, id: colonId });
+
+        await renderPage(encodedColonId);
+
+        expect(getPrDetailViaGraphQLMock).toHaveBeenCalledWith({ orgId: "org-1", id: colonId });
+        expect(getAIWorkflowDrilldownViaGraphQLMock).toHaveBeenCalledWith({
+            orgId: "org-1",
+            rootType: "PR",
+            rootId: colonId,
+            useDemoFallback: false,
+        });
+    });
 });

--- a/src/app/(app)/prs/[pr_id]/page.tsx
+++ b/src/app/(app)/prs/[pr_id]/page.tsx
@@ -159,7 +159,8 @@ export default async function PrDetailPage({ params }: PrDetailPageProps) {
         return <ServiceUnavailable />;
     }
 
-    const { pr_id: prId } = await params;
+    const { pr_id: encodedPrId } = await params;
+    const prId = decodeURIComponent(encodedPrId);
     const session = await requireSession();
     const orgId = session.user.org_id ?? "default-org";
     const demoMode = isExplicitDemoMode();


### PR DESCRIPTION
## Summary
- decode the dynamic PR route parameter before querying GraphQL
- preserve the canonical decoded ID for related evidence and flame requests
- add a regression test for the `%3A` colon separator emitted by the route

## Root cause
The page forwarded a percent-encoded dynamic route segment (for example, `%3A789`) to the PR resolver. The resolver correctly rejected that value as an invalid stable PR ID before it queried ClickHouse. The authenticated organization and decoded `repo_id:number` match the persisted record.

## Validation
- `pnpm exec vitest run 'src/app/(app)/prs/[pr_id]/page.test.tsx'` (red then green)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit` (3155 tests: 3148 passed, 7 skipped)
- `pnpm build`
- authenticated browser QA at `/prs/d29d160a-95fe-5b45-d4c1-fd1f5427b772:789`

## Screenshot
![Resolved PR detail](https://github.com/user-attachments/assets/c81ac6fe-492d-4998-b9ef-aa0bdd03673f)
