### PR TITLE
fix(acr): request evidence capability for explorer

### DIFF
--- a/src/lib/acr/__tests__/service.test.ts
+++ b/src/lib/acr/__tests__/service.test.ts
@@ -152,10 +152,15 @@ function installAcrHappyResponses(): void {
                 body_sha256: createHash("sha256").update("").digest("base64url"),
                 method: "GET",
                 path: "/api/v1/agent-context/capabilities",
-                permissions: ["context:read"],
+                permissions: ["context:read", "evidence:read"],
                 repository_scopes: ["full-chaos/dev-health-acr"],
             });
-            return HttpResponse.json(capabilities);
+            const evidenceRead = payload.permissions.includes("evidence:read");
+            return HttpResponse.json({
+                ...capabilities,
+                enabled_tools: evidenceRead ? capabilities.enabled_tools : ["context_for_task"],
+                permissions: { ...capabilities.permissions, evidence_read: evidenceRead },
+            });
         }),
         http.post(
             "https://acr.example.test/api/v1/agent-context/context-packets",

--- a/src/lib/acr/client.ts
+++ b/src/lib/acr/client.ts
@@ -42,7 +42,7 @@ type AcrRequest = {
     readonly body?: string;
     readonly method: "GET" | "POST";
     readonly path: string;
-    readonly permission: "context:read" | "evidence:read";
+    readonly permissions: readonly ("context:read" | "evidence:read")[];
     readonly signal: AbortSignal;
 };
 
@@ -131,13 +131,13 @@ export class AcrRuntimeClient {
     constructor(private readonly config: AcrRuntimeConfig) {}
 
     async capabilities(
-        input: Omit<AcrRequest, "body" | "method" | "path" | "permission">,
+        input: Omit<AcrRequest, "body" | "method" | "path" | "permissions">,
     ): Promise<AcrCapabilities> {
         const value = await this.request({
             ...input,
             method: "GET",
             path: "/api/v1/agent-context/capabilities",
-            permission: "context:read",
+            permissions: ["context:read", "evidence:read"],
         });
         if (!validateAcrContract("capabilities.v1.schema.json", value).valid) {
             throw new AcrRuntimeError(
@@ -161,7 +161,7 @@ export class AcrRuntimeClient {
             ...input,
             method: "POST",
             path: "/api/v1/agent-context/context-packets",
-            permission: "context:read",
+            permissions: ["context:read"],
         });
         if (!validateAcrContract("context_packet.v1.schema.json", value).valid) {
             throw new AcrRuntimeError(
@@ -177,7 +177,7 @@ export class AcrRuntimeClient {
             ...input,
             method: "GET",
             path: `/api/v1/agent-context/evidence/${encodeURIComponent(input.evidenceRefId)}`,
-            permission: "evidence:read",
+            permissions: ["evidence:read"],
         });
         if (!validateAcrContract("expanded_evidence.v1.schema.json", value).valid) {
             throw new AcrRuntimeError(
@@ -202,7 +202,7 @@ export class AcrRuntimeClient {
                     method: input.method,
                     orgId: input.authorization.orgId,
                     path: input.path,
-                    permissions: [input.permission],
+                    permissions: input.permissions,
                     privateKey: this.config.privateKey,
                     repositoryScopes: input.authorization.repositoryScopes,
                     subject: input.authorization.subject,


### PR DESCRIPTION
## Summary
- request both context and evidence permissions on the capabilities assertion
- keep packet and evidence operations individually least-privileged
- make the service mock scope returned capabilities to asserted permissions

## Why
The production Context Fabric BFF validated evidence support after sending a context-only capabilities assertion. ACR correctly scoped the response, so the BFF rejected the otherwise compatible service with HTTP 426.

## Verification
- `pnpm exec vitest run src/lib/acr/__tests__/service.test.ts` — 21 passed
- `pnpm typecheck`
- clean TypeScript LSP diagnostics
- canonical production web container completed the CHAOS-2914 API/MCP/browser parity journey

SCREENSHOT-WAIVER: Backend-only assertion permission fix; no rendered UI changed.

Related: CHAOS-2914