### PR TITLE
feat(web): gate PagerDuty creation with canonical incident entitlement

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,8 +6,11 @@ const htmlOutputFolder =
     process.env.PLAYWRIGHT_HTML_REPORT ?? "test-results/playwright-html/default";
 const junitOutputFile = process.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME ?? `${resultsDirectory}/junit.xml`;
 
-const AUTH_FILE = "test-results/.auth/state.json";
-const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3001";
+const authFile = "test-results/.auth/state.json";
+const mockServerPort = Number(process.env.PLAYWRIGHT_MOCK_PORT ?? "8001");
+const webServerPort = Number(process.env.PLAYWRIGHT_WEB_PORT ?? "3001");
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${webServerPort}`;
+const mockServerUrl = `http://127.0.0.1:${mockServerPort}`;
 
 // The guided first-run onboarding journey (auth-onboard.spec.ts) runs with
 // NEXT_PUBLIC_GUIDED_ONBOARDING enabled and therefore lives in its own config
@@ -45,11 +48,11 @@ export default defineConfig({
             // control endpoint. One worker prevents one file from replacing
             // another file's scenario while preserving normal-suite parallelism.
             name: "pagerduty-final-qa",
-            testMatch: /pagerduty-final-qa-p[012]\.spec\.ts/,
+            testMatch: /pagerduty-final-qa-p[0-3]\.spec\.ts/,
             dependencies: ["auth-setup"],
             workers: 1,
             use: {
-                storageState: AUTH_FILE,
+                storageState: authFile,
             },
         },
         {
@@ -66,11 +69,11 @@ export default defineConfig({
                 /account-creation-journey\.spec\.ts/,
                 /auth-onboard-legacy\.spec\.ts/,
                 /acr-context-fabric\.production\.spec\.ts/,
-                /pagerduty-final-qa-p[012]\.spec\.ts/,
+                /pagerduty-final-qa-p[0-3]\.spec\.ts/,
             ],
             dependencies: ["auth-setup"],
             use: {
-                storageState: AUTH_FILE,
+                storageState: authFile,
             },
         },
         {
@@ -94,16 +97,16 @@ export default defineConfig({
     webServer: [
         {
             command: "npx tsx ./tests/mocks/http-server.ts",
-            url: "http://127.0.0.1:8001/health",
+            url: `${mockServerUrl}/health`,
             reuseExistingServer: false,
             timeout: 30_000,
             env: {
-                MOCK_SERVER_PORT: "8001",
+                MOCK_SERVER_PORT: String(mockServerPort),
             },
         },
         {
-            command: "npm run dev -- --hostname 127.0.0.1 --port 3001",
-            url: "http://127.0.0.1:3001",
+            command: `npm run dev -- --hostname 127.0.0.1 --port ${webServerPort}`,
+            url: baseURL,
             reuseExistingServer: false,
             timeout: 120_000,
             env: {
@@ -111,7 +114,7 @@ export default defineConfig({
                 DEV_HEALTH_TEST_MODE: "true",
                 NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: "true",
                 NEXT_PUBLIC_GUIDED_ONBOARDING: "false",
-                BACKEND_URL: "http://127.0.0.1:8001",
+                BACKEND_URL: mockServerUrl,
             },
         },
     ],

--- a/scripts/__tests__/playwright-config.test.mjs
+++ b/scripts/__tests__/playwright-config.test.mjs
@@ -44,9 +44,9 @@ describe("default Playwright web servers", () => {
             name: "pagerduty-final-qa",
             workers: 1,
         });
-        expect(pagerDutyProject?.testMatch).toEqual(/pagerduty-final-qa-p[012]\.spec\.ts/);
+        expect(pagerDutyProject?.testMatch).toEqual(/pagerduty-final-qa-p[0-3]\.spec\.ts/);
         expect(authenticatedProject?.testIgnore).toContainEqual(
-            /pagerduty-final-qa-p[012]\.spec\.ts/,
+            /pagerduty-final-qa-p[0-3]\.spec\.ts/,
         );
     });
 

--- a/src/app/(app)/org/admin/integrations/[provider]/page.test.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/page.test.tsx
@@ -9,7 +9,10 @@ import {
 } from "@/lib/admin/server";
 import type { CustomerPushSource, IntegrationCredential } from "@/lib/admin/types";
 
+const mockGetCanonicalIncidentIngestionEntitlement = vi.hoisted(() => vi.fn());
+
 vi.mock("@/lib/admin/server", () => ({
+    getCanonicalIncidentIngestionEntitlement: mockGetCanonicalIncidentIngestionEntitlement,
     getCustomerPushIngestEntitlement: vi.fn(),
     listCredentials: vi.fn(),
     listCustomerPushSources: vi.fn(),
@@ -21,8 +24,14 @@ vi.mock("@/components/admin/integrations/ProviderCredentialsList", () => ({
 }));
 
 vi.mock("@/components/admin/integrations/PagerDutySetup", () => ({
-    PagerDutySetup: ({ credentials }: { credentials: readonly IntegrationCredential[] }) => (
-        <div data-testid="pagerduty-setup">
+    PagerDutySetup: ({
+        canCreatePagerDuty,
+        credentials,
+    }: {
+        canCreatePagerDuty: boolean;
+        credentials: readonly IntegrationCredential[];
+    }) => (
+        <div data-can-create={String(canCreatePagerDuty)} data-testid="pagerduty-setup">
             {credentials.map((credential) => credential.name).join(", ")}
         </div>
     ),
@@ -79,6 +88,10 @@ function makeCustomerPushSource(): CustomerPushSource {
 
 describe("IntegrationPage ([provider]) — CHAOS-2837 blocker 3", () => {
     beforeEach(() => {
+        mockGetCanonicalIncidentIngestionEntitlement.mockReset();
+        mockGetCanonicalIncidentIngestionEntitlement.mockResolvedValue({
+            data: { enabled: false },
+        });
         vi.mocked(getCustomerPushIngestEntitlement).mockResolvedValue({
             data: {
                 tier: "team",
@@ -179,6 +192,59 @@ describe("IntegrationPage ([provider]) — CHAOS-2837 blocker 3", () => {
         expect(screen.getByTestId("pagerduty-setup")).toBeInTheDocument();
         expect(screen.getByTestId("pagerduty-setup")).toHaveTextContent("production");
         expect(screen.queryByTestId("provider-credentials-list")).not.toBeInTheDocument();
+    });
+
+    it("fails closed for a direct PagerDuty route when an older Ops response has no entitlement", async () => {
+        mockGetCanonicalIncidentIngestionEntitlement.mockResolvedValue({
+            error: "Feature metadata unavailable",
+        });
+        vi.mocked(listCredentials).mockResolvedValue({ data: [makePagerDutyCredential()] });
+        vi.mocked(listSyncConfigs).mockResolvedValue({ data: [] });
+
+        render(
+            await IntegrationPage({
+                params: Promise.resolve({ provider: "pagerduty" }),
+                searchParams: Promise.resolve({}),
+            }),
+        );
+
+        expect(mockGetCanonicalIncidentIngestionEntitlement).toHaveBeenCalledOnce();
+        expect(screen.getByTestId("pagerduty-setup")).toHaveAttribute("data-can-create", "false");
+        expect(screen.getByTestId("pagerduty-setup")).toHaveTextContent("production");
+    });
+
+    it("keeps a direct PagerDuty route manage-only when the entitlement is false", async () => {
+        mockGetCanonicalIncidentIngestionEntitlement.mockResolvedValue({
+            data: { enabled: false },
+        });
+        vi.mocked(listCredentials).mockResolvedValue({ data: [makePagerDutyCredential()] });
+        vi.mocked(listSyncConfigs).mockResolvedValue({ data: [] });
+
+        render(
+            await IntegrationPage({
+                params: Promise.resolve({ provider: "pagerduty" }),
+                searchParams: Promise.resolve({}),
+            }),
+        );
+
+        expect(screen.getByTestId("pagerduty-setup")).toHaveAttribute("data-can-create", "false");
+    });
+
+    it("allows direct PagerDuty setup only for an explicit true entitlement", async () => {
+        mockGetCanonicalIncidentIngestionEntitlement.mockResolvedValue({
+            data: { enabled: true },
+        });
+        vi.mocked(listCredentials).mockResolvedValue({ data: [] });
+        vi.mocked(listSyncConfigs).mockResolvedValue({ data: [] });
+
+        render(
+            await IntegrationPage({
+                params: Promise.resolve({ provider: "pagerduty" }),
+                searchParams: Promise.resolve({}),
+            }),
+        );
+
+        expect(screen.getByTestId("pagerduty-setup")).toHaveAttribute("data-can-create", "true");
     });
 
     it("locks customer-push mode and skips source loading when customer_push_ingest is disabled", async () => {

--- a/src/app/(app)/org/admin/integrations/[provider]/page.tsx
+++ b/src/app/(app)/org/admin/integrations/[provider]/page.tsx
@@ -11,6 +11,7 @@ import { ModeCards } from "@/components/admin/integrations/customer-push/ModeCar
 import { CustomerPushLockedPreview } from "@/components/admin/integrations/customer-push/CustomerPushLockedPreview";
 import { CustomerPushSourceList } from "@/components/admin/integrations/customer-push/CustomerPushSourceList";
 import {
+    getCanonicalIncidentIngestionEntitlement,
     getCustomerPushIngestEntitlement,
     listCredentials,
     listCustomerPushSources,
@@ -61,15 +62,22 @@ export default async function IntegrationPage({
     const isCustomProvider = provider === "custom";
     const supportsCustomerPush = CUSTOMER_PUSH_ENABLED_PROVIDERS.has(provider);
 
-    const [credentialsResult, syncConfigsResult, customerPushEntitlementResult] = await Promise.all(
-        [
-            listCredentials(),
-            listSyncConfigs(),
-            supportsCustomerPush ? getCustomerPushIngestEntitlement() : Promise.resolve(undefined),
-        ],
-    );
+    const [
+        credentialsResult,
+        syncConfigsResult,
+        customerPushEntitlementResult,
+        canonicalIncidentIngestionEntitlementResult,
+    ] = await Promise.all([
+        listCredentials(),
+        listSyncConfigs(),
+        supportsCustomerPush ? getCustomerPushIngestEntitlement() : Promise.resolve(undefined),
+        provider === "pagerduty"
+            ? getCanonicalIncidentIngestionEntitlement()
+            : Promise.resolve(undefined),
+    ]);
     const customerPushEnabled =
         supportsCustomerPush && customerPushEntitlementResult?.data?.enabled === true;
+    const canCreatePagerDuty = canonicalIncidentIngestionEntitlementResult?.data?.enabled === true;
     const customerPushSourcesResult = customerPushEnabled
         ? await listCustomerPushSources(provider)
         : undefined;
@@ -132,7 +140,7 @@ export default async function IntegrationPage({
             )}
 
             {provider === "pagerduty" ? (
-                <PagerDutySetup credentials={credentials} />
+                <PagerDutySetup canCreatePagerDuty={canCreatePagerDuty} credentials={credentials} />
             ) : !isCustomProvider ? (
                 <div id="managed-sync-credentials" className="space-y-8">
                     <ProviderCredentialsList

--- a/src/app/(app)/org/admin/integrations/page.tsx
+++ b/src/app/(app)/org/admin/integrations/page.tsx
@@ -1,7 +1,11 @@
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { ProvidersPage } from "@/components/admin/integrations/ProvidersPage";
 import type { ProviderRow } from "@/components/admin/integrations/ProviderTable";
-import { listCredentials, listSyncConfigs } from "@/lib/admin/server";
+import {
+    getCanonicalIncidentIngestionEntitlement,
+    listCredentials,
+    listSyncConfigs,
+} from "@/lib/admin/server";
 import {
     CREDENTIAL_STATUS_PRIORITY,
     deriveCredentialStatus,
@@ -83,12 +87,14 @@ const PROVIDER_META: Record<string, { name: string; description: string; icon: R
     };
 
 export default async function IntegrationsPage() {
-    const [credentialsResult, syncConfigsResult] = await Promise.all([
+    const [credentialsResult, syncConfigsResult, incidentEntitlementResult] = await Promise.all([
         listCredentials(),
         listSyncConfigs(),
+        getCanonicalIncidentIngestionEntitlement(),
     ]);
     const credentials = credentialsResult.data ?? [];
     const syncConfigs = syncConfigsResult.data ?? [];
+    const canCreatePagerDuty = incidentEntitlementResult.data?.enabled === true;
 
     const getStatus = (providerId: string): ConnectionStatusType => {
         const creds = credentials.filter((c) => c.provider === providerId);
@@ -97,37 +103,45 @@ export default async function IntegrationsPage() {
         return CREDENTIAL_STATUS_PRIORITY.find((status) => statuses.has(status)) ?? "inactive";
     };
 
-    const providers: ProviderRow[] = Object.entries(PROVIDER_META).map(([id, meta]) => {
-        const providerCredentials = credentials.filter((c) => c.provider === id);
-        const lastTestedAt =
-            providerCredentials
-                .map((c) => c.last_test_at)
-                .filter((v): v is string => v !== null)
-                .sort()
-                .at(-1) ?? null;
-        const syncConfigCount = syncConfigs.filter(
-            (sc) =>
-                sc.credential_id !== null &&
-                providerCredentials.some((c) => c.id === sc.credential_id),
-        ).length;
-        const authMethods = new Set(
-            providerCredentials.map((c) => getAuthMethodLabel(id as Provider, c)),
-        );
+    const providers: ProviderRow[] = Object.entries(PROVIDER_META)
+        .filter(
+            ([id]) =>
+                id !== "pagerduty" ||
+                canCreatePagerDuty ||
+                credentials.some((credential) => credential.provider === id) ||
+                syncConfigs.some((config) => config.provider === id),
+        )
+        .map(([id, meta]) => {
+            const providerCredentials = credentials.filter((c) => c.provider === id);
+            const lastTestedAt =
+                providerCredentials
+                    .map((c) => c.last_test_at)
+                    .filter((v): v is string => v !== null)
+                    .sort()
+                    .at(-1) ?? null;
+            const syncConfigCount = syncConfigs.filter(
+                (sc) =>
+                    sc.credential_id !== null &&
+                    providerCredentials.some((c) => c.id === sc.credential_id),
+            ).length;
+            const authMethods = new Set(
+                providerCredentials.map((c) => getAuthMethodLabel(id as Provider, c)),
+            );
 
-        return {
-            id: id as Provider,
-            name: meta.name,
-            description: meta.description,
-            icon: meta.icon,
-            status: getStatus(id),
-            credentialCount: providerCredentials.length,
-            singleCredentialName:
-                providerCredentials.length === 1 ? providerCredentials[0].name : null,
-            authMethodLabel: authMethods.size === 1 ? [...authMethods][0] : null,
-            lastTestedAt,
-            syncConfigCount,
-        };
-    });
+            return {
+                id: id as Provider,
+                name: meta.name,
+                description: meta.description,
+                icon: meta.icon,
+                status: getStatus(id),
+                credentialCount: providerCredentials.length,
+                singleCredentialName:
+                    providerCredentials.length === 1 ? providerCredentials[0].name : null,
+                authMethodLabel: authMethods.size === 1 ? [...authMethods][0] : null,
+                lastTestedAt,
+                syncConfigCount,
+            };
+        });
 
     return (
         <div className="space-y-6">
@@ -142,7 +156,11 @@ export default async function IntegrationsPage() {
                 </div>
             )}
 
-            <ProvidersPage providers={providers} credentials={credentials} />
+            <ProvidersPage
+                canCreatePagerDuty={canCreatePagerDuty}
+                providers={providers}
+                credentials={credentials}
+            />
         </div>
     );
 }

--- a/src/app/(app)/org/admin/sync/new/page.tsx
+++ b/src/app/(app)/org/admin/sync/new/page.tsx
@@ -1,9 +1,12 @@
 import { AdminHeader } from "@/components/admin/AdminHeader";
 import { SyncConfigForm } from "@/components/admin/sync/SyncConfigForm";
-import { listCredentials } from "@/lib/admin/server";
+import { getCanonicalIncidentIngestionEntitlement, listCredentials } from "@/lib/admin/server";
 
 export default async function NewSyncConfigPage() {
-    const credentialsResult = await listCredentials();
+    const [credentialsResult, incidentEntitlementResult] = await Promise.all([
+        listCredentials(),
+        getCanonicalIncidentIngestionEntitlement(),
+    ]);
     const credentials = credentialsResult.data || [];
 
     return (
@@ -13,7 +16,10 @@ export default async function NewSyncConfigPage() {
                 description="Configure a new data synchronization source."
             />
 
-            <SyncConfigForm credentials={credentials} />
+            <SyncConfigForm
+                canCreatePagerDuty={incidentEntitlementResult.data?.enabled === true}
+                credentials={credentials}
+            />
         </div>
     );
 }

--- a/src/components/admin/integrations/PagerDutySetup.test.tsx
+++ b/src/components/admin/integrations/PagerDutySetup.test.tsx
@@ -78,6 +78,7 @@ describe("PagerDutySetup", () => {
         const user = userEvent.setup();
         render(
             <PagerDutySetup
+                canCreatePagerDuty
                 credentials={[
                     makePagerDutyCredential("production"),
                     makePagerDutyCredential("staging"),
@@ -111,7 +112,7 @@ describe("PagerDutySetup", () => {
 
     it("checks the named connection status", async () => {
         const user = userEvent.setup();
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.click(screen.getByRole("button", { name: "Check connection status" }));
 
@@ -119,10 +120,43 @@ describe("PagerDutySetup", () => {
         expect(screen.getByRole("status")).toHaveTextContent("Not connected");
     });
 
+    it("keeps an existing connection manageable while blocking new PagerDuty setup", async () => {
+        const user = userEvent.setup();
+        actions.getPagerDutyStatus.mockResolvedValue({ data: connectedStatus });
+        render(
+            <PagerDutySetup
+                canCreatePagerDuty={false}
+                credentials={[makePagerDutyCredential("production")]}
+            />,
+        );
+
+        expect(screen.getByText("PagerDuty setup is unavailable")).toBeVisible();
+        expect(screen.queryByRole("button", { name: "Connect PagerDuty" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Create credential" })).not.toBeInTheDocument();
+
+        await user.selectOptions(screen.getByLabelText("Saved credentials"), "production");
+        await user.click(screen.getByRole("button", { name: "Check connection status" }));
+
+        expect(await screen.findByRole("button", { name: "Disconnect" })).toBeVisible();
+        expect(
+            screen.queryByRole("link", { name: "Create sync configuration" }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("shows only the unavailable state when no PagerDuty credential exists", () => {
+        render(<PagerDutySetup canCreatePagerDuty={false} />);
+
+        expect(screen.getByText("PagerDuty setup is unavailable")).toBeVisible();
+        expect(screen.queryByLabelText("Saved credentials")).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Check connection status" }),
+        ).not.toBeInTheDocument();
+    });
+
     it("keeps a failed OAuth start visible with a retry action", async () => {
         const user = userEvent.setup();
         actions.startPagerDutyOAuth.mockResolvedValue({ error: "PagerDuty authorization failed." });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.type(screen.getByLabelText("Account subdomain"), "acme");
         await user.click(screen.getByRole("button", { name: "Connect PagerDuty" }));
@@ -139,7 +173,7 @@ describe("PagerDutySetup", () => {
     it("keeps a failed manual credential save visible with a retry action", async () => {
         const user = userEvent.setup();
         actions.connectPagerDutyApiToken.mockResolvedValue({ error: "Credential save failed." });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.click(screen.getByRole("button", { name: "Use API token instead" }));
         await user.type(screen.getByLabelText("Account subdomain"), "acme");
@@ -155,7 +189,7 @@ describe("PagerDutySetup", () => {
 
     it("marks the selected authentication method with visible text as well as aria-pressed", async () => {
         const user = userEvent.setup();
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         const oauth = screen.getByRole("button", { name: "OAuth (recommended)" });
         expect(oauth).toHaveAttribute("aria-pressed", "true");
@@ -182,7 +216,7 @@ describe("PagerDutySetup", () => {
                 has_refresh_token: true,
             },
         });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.click(screen.getByRole("button", { name: "Check connection status" }));
 
@@ -211,7 +245,7 @@ describe("PagerDutySetup", () => {
         actions.getPagerDutyStatus.mockResolvedValue({
             data: { ...connectedStatus, expires_at: "2020-01-01T00:00:00Z" },
         });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.click(screen.getByRole("button", { name: "Check connection status" }));
 
@@ -222,7 +256,12 @@ describe("PagerDutySetup", () => {
     it("clears connected controls when returning to a custom credential name", async () => {
         const user = userEvent.setup();
         actions.getPagerDutyStatus.mockResolvedValue({ data: connectedStatus });
-        render(<PagerDutySetup credentials={[makePagerDutyCredential("production")]} />);
+        render(
+            <PagerDutySetup
+                canCreatePagerDuty
+                credentials={[makePagerDutyCredential("production")]}
+            />,
+        );
 
         const savedCredentials = screen.getByLabelText("Saved credentials");
         await user.selectOptions(savedCredentials, "production");
@@ -242,7 +281,7 @@ describe("PagerDutySetup", () => {
     it("refreshes canonical status after saving client credentials", async () => {
         const user = userEvent.setup();
         actions.getPagerDutyStatus.mockResolvedValue({ data: connectedStatus });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.click(screen.getByRole("button", { name: "Client credentials" }));
         await user.clear(screen.getByLabelText("Credential name"));
@@ -275,7 +314,7 @@ describe("PagerDutySetup", () => {
         actions.getPagerDutyStatus.mockResolvedValue({
             data: { ...connectedStatus, auth_mode: "api_token" as const },
         });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.click(screen.getByRole("button", { name: "Use API token instead" }));
         await user.clear(screen.getByLabelText("Credential name"));
@@ -303,7 +342,7 @@ describe("PagerDutySetup", () => {
     it("does not claim a manual credential is connected when the status refresh fails", async () => {
         const user = userEvent.setup();
         actions.getPagerDutyStatus.mockResolvedValue({ error: "PagerDuty status is unavailable." });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.click(screen.getByRole("button", { name: "Use API token instead" }));
         await user.clear(screen.getByLabelText("Credential name"));
@@ -324,7 +363,7 @@ describe("PagerDutySetup", () => {
         const user = userEvent.setup();
         actions.getPagerDutyStatus.mockResolvedValue({ data: connectedStatus });
         actions.disconnectPagerDuty.mockResolvedValue({ error: "Disconnect failed" });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.click(screen.getByRole("button", { name: "Check connection status" }));
         await waitFor(() =>
@@ -347,6 +386,7 @@ describe("PagerDutySetup", () => {
         actions.getPagerDutyStatus.mockResolvedValue({ data: connectedStatus });
         render(
             <PagerDutySetup
+                canCreatePagerDuty
                 credentials={[
                     makePagerDutyCredential("production"),
                     makePagerDutyCredential("staging"),
@@ -387,7 +427,12 @@ describe("PagerDutySetup", () => {
         });
         actions.connectPagerDutyApiToken.mockReturnValueOnce(pendingSave);
         actions.getPagerDutyStatus.mockResolvedValue({ data: connectedStatus });
-        render(<PagerDutySetup credentials={[makePagerDutyCredential("production")]} />);
+        render(
+            <PagerDutySetup
+                canCreatePagerDuty
+                credentials={[makePagerDutyCredential("production")]}
+            />,
+        );
 
         await user.click(screen.getByRole("button", { name: "Use API token instead" }));
         await user.clear(screen.getByLabelText("Credential name"));
@@ -428,7 +473,7 @@ describe("PagerDutySetup", () => {
                     account_display: "Staging PagerDuty",
                 },
             });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.clear(screen.getByLabelText("Credential name"));
         await user.type(screen.getByLabelText("Credential name"), "production");
@@ -461,7 +506,7 @@ describe("PagerDutySetup", () => {
         });
         actions.preflightPagerDuty.mockResolvedValue({ data: { datasets: [] } });
         actions.disconnectPagerDuty.mockResolvedValue({ data: undefined });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await user.clear(screen.getByLabelText("Credential name"));
         await user.type(screen.getByLabelText("Credential name"), "production");

--- a/src/components/admin/integrations/PagerDutySetupController.tsx
+++ b/src/components/admin/integrations/PagerDutySetupController.tsx
@@ -24,12 +24,15 @@ import {
     type PagerDutyDiagnosticError,
 } from "./PagerDutySetupDiagnostics";
 import { PagerDutySetupFields } from "./PagerDutySetupFields";
+import { DataState } from "@/components/ui/DataState";
 
 type PagerDutySetupProps = {
+    readonly canCreatePagerDuty: boolean;
     readonly credentials?: readonly IntegrationCredential[];
 };
 
-export function PagerDutySetup({ credentials = [] }: PagerDutySetupProps) {
+export function PagerDutySetup({ canCreatePagerDuty, credentials = [] }: PagerDutySetupProps) {
+    const canManagePagerDuty = canCreatePagerDuty || credentials.length > 0;
     const [credentialName, setCredentialName] = useState("default");
     const [authMode, setAuthMode] = useState<PagerDutyAuthMode>("oauth");
     const [clientId, setClientId] = useState("");
@@ -249,43 +252,66 @@ export function PagerDutySetup({ credentials = [] }: PagerDutySetupProps) {
     return (
         <section className="space-y-6 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
             <div>
-                <h2 className="text-h2 text-foreground">Connect PagerDuty</h2>
+                <h2 className="text-h2 text-foreground">
+                    {canCreatePagerDuty ? "Connect PagerDuty" : "Manage PagerDuty"}
+                </h2>
                 <p className="mt-1 text-body text-(--ink-muted)">
-                    Connect with read-only OAuth. Dev Health never asks you to paste a hosted OAuth
-                    token.
+                    {canCreatePagerDuty
+                        ? "Connect with read-only OAuth. Dev Health never asks you to paste a hosted OAuth token."
+                        : "Review connection status or remove an existing PagerDuty credential."}
                 </p>
             </div>
-            <PagerDutySetupFields
-                credentials={credentials}
-                credentialName={credentialName}
-                authMode={authMode}
-                clientId={clientId}
-                clientSecret={clientSecret}
-                apiToken={apiToken}
-                subdomain={subdomain}
-                region={region}
-                datasets={datasets}
-                onCredentialNameChangeAction={changeCredentialName}
-                onAuthModeChangeAction={changeAuthMode}
-                onClientIdChangeAction={setClientId}
-                onClientSecretChangeAction={setClientSecret}
-                onApiTokenChangeAction={setApiToken}
-                onSubdomainChangeAction={setSubdomain}
-                onRegionChangeAction={changeRegion}
-                onDatasetChangeAction={toggleDataset}
-            />
-            <PagerDutySetupDiagnostics
-                authMode={authMode}
-                status={status}
-                preflight={preflight}
-                error={diagnosticError}
-                isPending={isPending}
-                onConnectAction={connect}
-                onSaveManualCredentialAction={saveManualCredential}
-                onRefreshStatusAction={refreshStatus}
-                onRunPreflightAction={runPreflight}
-                onDisconnectAction={disconnect}
-            />
+            {!canCreatePagerDuty && credentials.length === 0 ? (
+                <DataState
+                    variant="no-data-connected"
+                    title="PagerDuty setup is unavailable"
+                    description="New PagerDuty connections are unavailable for this organization."
+                />
+            ) : null}
+            {!canCreatePagerDuty && credentials.length > 0 ? (
+                <DataState
+                    variant="detector-unavailable"
+                    title="PagerDuty setup is unavailable"
+                    description="New PagerDuty connections are unavailable. Existing credentials remain available for status checks and removal."
+                />
+            ) : null}
+            {canManagePagerDuty ? (
+                <>
+                    <PagerDutySetupFields
+                        canCreatePagerDuty={canCreatePagerDuty}
+                        credentials={credentials}
+                        credentialName={credentialName}
+                        authMode={authMode}
+                        clientId={clientId}
+                        clientSecret={clientSecret}
+                        apiToken={apiToken}
+                        subdomain={subdomain}
+                        region={region}
+                        datasets={datasets}
+                        onCredentialNameChangeAction={changeCredentialName}
+                        onAuthModeChangeAction={changeAuthMode}
+                        onClientIdChangeAction={setClientId}
+                        onClientSecretChangeAction={setClientSecret}
+                        onApiTokenChangeAction={setApiToken}
+                        onSubdomainChangeAction={setSubdomain}
+                        onRegionChangeAction={changeRegion}
+                        onDatasetChangeAction={toggleDataset}
+                    />
+                    <PagerDutySetupDiagnostics
+                        authMode={authMode}
+                        canCreatePagerDuty={canCreatePagerDuty}
+                        status={status}
+                        preflight={preflight}
+                        error={diagnosticError}
+                        isPending={isPending}
+                        onConnectAction={connect}
+                        onSaveManualCredentialAction={saveManualCredential}
+                        onRefreshStatusAction={refreshStatus}
+                        onRunPreflightAction={runPreflight}
+                        onDisconnectAction={disconnect}
+                    />
+                </>
+            ) : null}
         </section>
     );
 }

--- a/src/components/admin/integrations/PagerDutySetupDiagnostics.test.tsx
+++ b/src/components/admin/integrations/PagerDutySetupDiagnostics.test.tsx
@@ -77,7 +77,7 @@ describe("PagerDutySetup diagnostics", () => {
                 has_refresh_token: true,
             },
         });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await loadConnectedStatus(user);
 
@@ -94,7 +94,7 @@ describe("PagerDutySetup diagnostics", () => {
                 has_refresh_token: false,
             },
         });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await loadConnectedStatus(user);
 
@@ -104,7 +104,7 @@ describe("PagerDutySetup diagnostics", () => {
 
     it("renders ready preflight datasets persistently", async () => {
         const user = userEvent.setup();
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await loadConnectedStatus(user);
         await renderPreflight(user);
@@ -129,7 +129,7 @@ describe("PagerDutySetup diagnostics", () => {
                 ],
             },
         });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await loadConnectedStatus(user);
         await renderPreflight(user);
@@ -144,7 +144,7 @@ describe("PagerDutySetup diagnostics", () => {
         actions.preflightPagerDuty
             .mockResolvedValueOnce({ error: "PagerDuty preflight failed." })
             .mockResolvedValueOnce({ data: readyPreflight });
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await loadConnectedStatus(user);
         await user.click(screen.getByRole("button", { name: "Run preflight" }));
@@ -162,7 +162,7 @@ describe("PagerDutySetup diagnostics", () => {
 
     it("clears preflight diagnostics when credential, mode, or datasets change", async () => {
         const user = userEvent.setup();
-        render(<PagerDutySetup />);
+        render(<PagerDutySetup canCreatePagerDuty />);
 
         await loadConnectedStatus(user);
         await renderPreflight(user);

--- a/src/components/admin/integrations/PagerDutySetupDiagnostics.tsx
+++ b/src/components/admin/integrations/PagerDutySetupDiagnostics.tsx
@@ -26,6 +26,7 @@ const ERROR_COPY = {
 
 type PagerDutySetupDiagnosticsProps = {
     readonly authMode: PagerDutyAuthMode;
+    readonly canCreatePagerDuty: boolean;
     readonly status: PagerDutyStatusResponse | null;
     readonly preflight: PagerDutyPreflightResponse | null;
     readonly error: PagerDutyDiagnosticError | null;
@@ -80,6 +81,7 @@ function expiryMessage(expiresAt: string | null): string {
 
 export function PagerDutySetupDiagnostics({
     authMode,
+    canCreatePagerDuty,
     status,
     preflight,
     error,
@@ -105,16 +107,20 @@ export function PagerDutySetupDiagnostics({
     return (
         <>
             <div className="flex flex-wrap gap-3">
-                <button
-                    type="button"
-                    disabled={isPending}
-                    onClick={authMode === "oauth" ? onConnectAction : onSaveManualCredentialAction}
-                    className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-(--accent-foreground) disabled:opacity-50"
-                >
-                    {authMode === "oauth"
-                        ? CTA_LABELS.connectPagerDuty
-                        : CTA_LABELS.createCredential}
-                </button>
+                {canCreatePagerDuty ? (
+                    <button
+                        type="button"
+                        disabled={isPending}
+                        onClick={
+                            authMode === "oauth" ? onConnectAction : onSaveManualCredentialAction
+                        }
+                        className="rounded-lg bg-(--accent) px-4 py-2 text-sm font-medium text-(--accent-foreground) disabled:opacity-50"
+                    >
+                        {authMode === "oauth"
+                            ? CTA_LABELS.connectPagerDuty
+                            : CTA_LABELS.createCredential}
+                    </button>
+                ) : null}
                 <button
                     type="button"
                     disabled={isPending}
@@ -133,12 +139,14 @@ export function PagerDutySetupDiagnostics({
                         >
                             {CTA_LABELS.runPreflight}
                         </button>
-                        <Link
-                            href={SYNC_CONFIG_NEW_PATH}
-                            className="rounded-lg border border-(--card-stroke) px-4 py-2 text-sm font-medium text-foreground"
-                        >
-                            {CTA_LABELS.createSyncConfig}
-                        </Link>
+                        {canCreatePagerDuty ? (
+                            <Link
+                                href={SYNC_CONFIG_NEW_PATH}
+                                className="rounded-lg border border-(--card-stroke) px-4 py-2 text-sm font-medium text-foreground"
+                            >
+                                {CTA_LABELS.createSyncConfig}
+                            </Link>
+                        ) : null}
                         <button
                             type="button"
                             disabled={isPending}

--- a/src/components/admin/integrations/PagerDutySetupFields.tsx
+++ b/src/components/admin/integrations/PagerDutySetupFields.tsx
@@ -24,6 +24,7 @@ const DATASET_LABELS: Record<PagerDutyPlannerDataset, string> = {
 const CUSTOM_CREDENTIAL_VALUE = "__custom__";
 
 type PagerDutySetupFieldsProps = {
+    readonly canCreatePagerDuty: boolean;
     readonly credentials: readonly IntegrationCredential[];
     readonly credentialName: string;
     readonly authMode: PagerDutyAuthMode;
@@ -44,6 +45,7 @@ type PagerDutySetupFieldsProps = {
 };
 
 export function PagerDutySetupFields({
+    canCreatePagerDuty,
     credentials,
     credentialName,
     authMode,
@@ -92,122 +94,134 @@ export function PagerDutySetupFields({
                         ))}
                     </select>
                 </label>
-                <label className="text-sm font-medium text-foreground">
-                    Credential name
-                    <input
-                        className="mt-1 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2"
-                        value={credentialName}
-                        onChange={(event) => onCredentialNameChangeAction(event.target.value)}
-                    />
-                </label>
-                <label className="text-sm font-medium text-foreground">
-                    Account subdomain
-                    <input
-                        className="mt-1 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2"
-                        value={subdomain}
-                        onChange={(event) => onSubdomainChangeAction(event.target.value)}
-                    />
-                </label>
-                <label className="text-sm font-medium text-foreground">
-                    Region
-                    <select
-                        className="mt-1 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2"
-                        value={region}
-                        onChange={(event) => onRegionChangeAction(event.target.value)}
-                    >
-                        {PAGERDUTY_REGIONS.map((option) => (
-                            <option key={option} value={option}>
-                                {option.toUpperCase()}
-                            </option>
-                        ))}
-                    </select>
-                </label>
-            </div>
-            <fieldset className="space-y-3">
-                <legend className="text-sm font-medium text-foreground">
-                    Authentication method
-                </legend>
-                <div className="flex flex-wrap gap-2">
-                    {(["oauth", "client_credentials", "api_token"] as const).map((mode) => (
-                        <button
-                            key={mode}
-                            type="button"
-                            aria-pressed={authMode === mode}
-                            onClick={() => onAuthModeChangeAction(mode)}
-                            className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--accent) ${authMode === mode ? "border-(--accent) bg-(--accent)/10 text-(--accent)" : "border-(--card-stroke) text-foreground"}`}
-                        >
-                            <span>
-                                {mode === "oauth"
-                                    ? "OAuth (recommended)"
-                                    : mode === "client_credentials"
-                                      ? "Client credentials"
-                                      : "Use API token instead"}
-                            </span>
-                            {authMode === mode ? (
-                                <span
-                                    aria-hidden="true"
-                                    className="text-label-caps font-semibold uppercase"
-                                >
-                                    Selected
-                                </span>
-                            ) : null}
-                        </button>
-                    ))}
-                </div>
-                {authMode === "client_credentials" ? (
-                    <div className="grid gap-4 sm:grid-cols-2">
+                {canCreatePagerDuty ? (
+                    <>
                         <label className="text-sm font-medium text-foreground">
-                            Client ID
+                            Credential name
                             <input
-                                type="text"
                                 className="mt-1 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2"
-                                value={clientId}
-                                onChange={(event) => onClientIdChangeAction(event.target.value)}
+                                value={credentialName}
+                                onChange={(event) =>
+                                    onCredentialNameChangeAction(event.target.value)
+                                }
                             />
                         </label>
                         <label className="text-sm font-medium text-foreground">
-                            Client secret
+                            Account subdomain
+                            <input
+                                className="mt-1 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                value={subdomain}
+                                onChange={(event) => onSubdomainChangeAction(event.target.value)}
+                            />
+                        </label>
+                        <label className="text-sm font-medium text-foreground">
+                            Region
+                            <select
+                                className="mt-1 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                value={region}
+                                onChange={(event) => onRegionChangeAction(event.target.value)}
+                            >
+                                {PAGERDUTY_REGIONS.map((option) => (
+                                    <option key={option} value={option}>
+                                        {option.toUpperCase()}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                    </>
+                ) : null}
+            </div>
+            {canCreatePagerDuty ? (
+                <fieldset className="space-y-3">
+                    <legend className="text-sm font-medium text-foreground">
+                        Authentication method
+                    </legend>
+                    <div className="flex flex-wrap gap-2">
+                        {(["oauth", "client_credentials", "api_token"] as const).map((mode) => (
+                            <button
+                                key={mode}
+                                type="button"
+                                aria-pressed={authMode === mode}
+                                onClick={() => onAuthModeChangeAction(mode)}
+                                className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--accent) ${authMode === mode ? "border-(--accent) bg-(--accent)/10 text-(--accent)" : "border-(--card-stroke) text-foreground"}`}
+                            >
+                                <span>
+                                    {mode === "oauth"
+                                        ? "OAuth (recommended)"
+                                        : mode === "client_credentials"
+                                          ? "Client credentials"
+                                          : "Use API token instead"}
+                                </span>
+                                {authMode === mode ? (
+                                    <span
+                                        aria-hidden="true"
+                                        className="text-label-caps font-semibold uppercase"
+                                    >
+                                        Selected
+                                    </span>
+                                ) : null}
+                            </button>
+                        ))}
+                    </div>
+                    {authMode === "client_credentials" ? (
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <label className="text-sm font-medium text-foreground">
+                                Client ID
+                                <input
+                                    type="text"
+                                    className="mt-1 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                    value={clientId}
+                                    onChange={(event) => onClientIdChangeAction(event.target.value)}
+                                />
+                            </label>
+                            <label className="text-sm font-medium text-foreground">
+                                Client secret
+                                <input
+                                    type="password"
+                                    className="mt-1 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2"
+                                    value={clientSecret}
+                                    onChange={(event) =>
+                                        onClientSecretChangeAction(event.target.value)
+                                    }
+                                />
+                            </label>
+                        </div>
+                    ) : null}
+                    {authMode === "api_token" ? (
+                        <label className="block text-sm font-medium text-foreground">
+                            API token
                             <input
                                 type="password"
                                 className="mt-1 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2"
-                                value={clientSecret}
-                                onChange={(event) => onClientSecretChangeAction(event.target.value)}
+                                value={apiToken}
+                                onChange={(event) => onApiTokenChangeAction(event.target.value)}
                             />
                         </label>
+                    ) : null}
+                </fieldset>
+            ) : null}
+            {canCreatePagerDuty ? (
+                <fieldset>
+                    <legend className="text-sm font-medium text-foreground">Datasets</legend>
+                    <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                        {PAGERDUTY_PLANNER_DATASETS.map((dataset) => (
+                            <label
+                                key={dataset}
+                                className="flex items-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 text-sm text-foreground"
+                            >
+                                <input
+                                    type="checkbox"
+                                    checked={datasets.includes(dataset)}
+                                    onChange={(event) =>
+                                        onDatasetChangeAction(dataset, event.target.checked)
+                                    }
+                                />
+                                {DATASET_LABELS[dataset]}
+                            </label>
+                        ))}
                     </div>
-                ) : null}
-                {authMode === "api_token" ? (
-                    <label className="block text-sm font-medium text-foreground">
-                        API token
-                        <input
-                            type="password"
-                            className="mt-1 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2"
-                            value={apiToken}
-                            onChange={(event) => onApiTokenChangeAction(event.target.value)}
-                        />
-                    </label>
-                ) : null}
-            </fieldset>
-            <fieldset>
-                <legend className="text-sm font-medium text-foreground">Datasets</legend>
-                <div className="mt-2 grid gap-2 sm:grid-cols-2">
-                    {PAGERDUTY_PLANNER_DATASETS.map((dataset) => (
-                        <label
-                            key={dataset}
-                            className="flex items-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 text-sm text-foreground"
-                        >
-                            <input
-                                type="checkbox"
-                                checked={datasets.includes(dataset)}
-                                onChange={(event) =>
-                                    onDatasetChangeAction(dataset, event.target.checked)
-                                }
-                            />
-                            {DATASET_LABELS[dataset]}
-                        </label>
-                    ))}
-                </div>
-            </fieldset>
+                </fieldset>
+            ) : null}
         </>
     );
 }

--- a/src/components/admin/integrations/ProviderCredentialsList.tsx
+++ b/src/components/admin/integrations/ProviderCredentialsList.tsx
@@ -33,7 +33,7 @@ export function ProviderCredentialsList({
     const [isWizardOpen, setIsWizardOpen] = useState(credentials.length === 0);
 
     if (provider === "pagerduty") {
-        return <PagerDutySetup />;
+        return <PagerDutySetup canCreatePagerDuty={false} credentials={credentials} />;
     }
 
     const handleCreated = () => {

--- a/src/components/admin/integrations/ProvidersPage.test.tsx
+++ b/src/components/admin/integrations/ProvidersPage.test.tsx
@@ -31,14 +31,67 @@ function makeRow(overrides: Partial<ProviderRow> = {}): ProviderRow {
 
 describe("ProvidersPage", () => {
     it("renders the provider table with an Add Provider action, not a card grid", () => {
-        render(<ProvidersPage providers={[makeRow()]} credentials={[]} />);
+        render(
+            <ProvidersPage canCreatePagerDuty={false} providers={[makeRow()]} credentials={[]} />,
+        );
 
         expect(screen.getByRole("table")).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "Add Provider" })).toBeInTheDocument();
     });
 
+    it("keeps PagerDuty in the provider catalog with a direct manage route", () => {
+        render(
+            <ProvidersPage
+                canCreatePagerDuty
+                providers={[makeRow({ id: "pagerduty", name: "PagerDuty" })]}
+                credentials={[]}
+            />,
+        );
+
+        for (const link of screen.getAllByRole("link", { name: "Manage" })) {
+            expect(link).toHaveAttribute("href", "/org/admin/integrations/pagerduty");
+        }
+    });
+
+    it("hides an unconfigured PagerDuty catalog row when creation is unavailable", () => {
+        render(
+            <ProvidersPage
+                canCreatePagerDuty={false}
+                providers={[makeRow({ id: "pagerduty", name: "PagerDuty" })]}
+                credentials={[]}
+            />,
+        );
+
+        expect(screen.queryByText("PagerDuty")).not.toBeInTheDocument();
+    });
+
+    it("keeps an existing PagerDuty catalog row reachable for management when creation is unavailable", () => {
+        render(
+            <ProvidersPage
+                canCreatePagerDuty={false}
+                providers={[
+                    makeRow({
+                        id: "pagerduty",
+                        name: "PagerDuty",
+                        credentialCount: 1,
+                        singleCredentialName: "production",
+                    }),
+                ]}
+                credentials={[]}
+            />,
+        );
+
+        expect(screen.getAllByText("PagerDuty")).toHaveLength(2);
+        expect(screen.getAllByRole("link", { name: "Manage" })[0]).toHaveAttribute(
+            "href",
+            "/org/admin/integrations/pagerduty",
+        );
+    });
+
     it("opens the Add Provider wizard, starting on the provider-select step", async () => {
-        render(<ProvidersPage providers={[makeRow()]} credentials={[]} />);
+        render(
+            <ProvidersPage canCreatePagerDuty={false} providers={[makeRow()]} credentials={[]} />,
+        );
 
         await userEvent.click(screen.getByRole("button", { name: "Add Provider" }));
 

--- a/src/components/admin/integrations/ProvidersPage.tsx
+++ b/src/components/admin/integrations/ProvidersPage.tsx
@@ -8,6 +8,7 @@ import { CTA_LABELS } from "@/lib/design/cta";
 import type { IntegrationCredential } from "@/lib/admin/types";
 
 type ProvidersPageProps = {
+    canCreatePagerDuty: boolean;
     providers: ProviderRow[];
     credentials: IntegrationCredential[];
 };
@@ -18,13 +19,14 @@ type ProvidersPageProps = {
  * card grid. The provider isn't locked here — the wizard's first step lets
  * the user choose which provider to connect.
  */
-export function ProvidersPage({ providers, credentials }: ProvidersPageProps) {
+export function ProvidersPage({ canCreatePagerDuty, providers, credentials }: ProvidersPageProps) {
     const router = useRouter();
     const [isWizardOpen, setIsWizardOpen] = useState(false);
 
     if (isWizardOpen) {
         return (
             <AddProviderWizard
+                canCreatePagerDuty={canCreatePagerDuty}
                 credentials={credentials}
                 onCloseAction={() => setIsWizardOpen(false)}
                 onCreatedAction={() => router.refresh()}
@@ -43,7 +45,18 @@ export function ProvidersPage({ providers, credentials }: ProvidersPageProps) {
                     {CTA_LABELS.addProvider}
                 </button>
             </div>
-            <ProviderTable providers={providers} />
+            <ProviderTable
+                providers={
+                    canCreatePagerDuty
+                        ? providers
+                        : providers.filter(
+                              (provider) =>
+                                  provider.id !== "pagerduty" ||
+                                  provider.credentialCount > 0 ||
+                                  provider.syncConfigCount > 0,
+                          )
+                }
+            />
         </div>
     );
 }

--- a/src/components/admin/integrations/wizard/AddProviderWizard.test.tsx
+++ b/src/components/admin/integrations/wizard/AddProviderWizard.test.tsx
@@ -66,6 +66,7 @@ describe("AddProviderWizard", () => {
     it("routes PagerDuty from the global picker to its dedicated setup page", () => {
         renderWithToaster(
             <AddProviderWizard
+                canCreatePagerDuty
                 credentials={[]}
                 onCloseAction={vi.fn()}
                 onCreatedAction={vi.fn()}
@@ -78,6 +79,19 @@ describe("AddProviderWizard", () => {
         );
         expect(screen.queryByRole("radio", { name: "PagerDuty" })).not.toBeInTheDocument();
         expect(screen.queryByLabelText("API token")).not.toBeInTheDocument();
+    });
+
+    it("removes PagerDuty from the global picker when canonical incident ingestion is unavailable", () => {
+        renderWithToaster(
+            <AddProviderWizard
+                canCreatePagerDuty={false}
+                credentials={[]}
+                onCloseAction={vi.fn()}
+                onCreatedAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.queryByRole("link", { name: "PagerDuty" })).not.toBeInTheDocument();
     });
 
     it("runs the full manual create flow: fill token \u2192 verify \u2192 finish \u2192 persists credential", async () => {

--- a/src/components/admin/integrations/wizard/AddProviderWizard.tsx
+++ b/src/components/admin/integrations/wizard/AddProviderWizard.tsx
@@ -24,6 +24,7 @@ import { VerifyConnectionStep } from "./VerifyConnectionStep";
 import { FinishStep } from "./FinishStep";
 
 type AddProviderWizardProps = {
+    canCreatePagerDuty?: boolean;
     /** Set when launched from a specific provider's detail page — skips the provider-select step. */
     lockedProvider?: Provider;
     /** All credentials, used only to detect an existing GitHub App connection. */
@@ -67,6 +68,7 @@ function initialMethod(provider: Provider | "", hasGitHubApp: boolean): AddProvi
  * so it can never re-enable Finish for inputs it didn't test.
  */
 export function AddProviderWizard({
+    canCreatePagerDuty = false,
     lockedProvider,
     credentials,
     onCloseAction,
@@ -212,7 +214,11 @@ export function AddProviderWizard({
 
             <div className="space-y-6 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
                 {currentStep.id === "provider" && (
-                    <ProviderSelectStep provider={provider} onChangeAction={handleProviderChange} />
+                    <ProviderSelectStep
+                        canCreatePagerDuty={canCreatePagerDuty}
+                        provider={provider}
+                        onChangeAction={handleProviderChange}
+                    />
                 )}
                 {currentStep.id === "method" && (
                     <AuthMethodStep method={method} onChooseAction={handleMethodChange} />

--- a/src/components/admin/integrations/wizard/ProviderSelectStep.tsx
+++ b/src/components/admin/integrations/wizard/ProviderSelectStep.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { PROVIDERS, PROVIDER_LABELS, type Provider } from "@/lib/admin/types";
 
 type ProviderSelectStepProps = {
+    canCreatePagerDuty: boolean;
     provider: Provider | "";
     onChangeAction: (provider: Provider) => void;
 };
@@ -11,7 +12,11 @@ type ProviderSelectStepProps = {
  * to connect. Skipped entirely when the wizard is launched from a specific
  * provider's detail page (see `getVisibleAddProviderSteps`'s `lockProvider`).
  */
-export function ProviderSelectStep({ provider, onChangeAction }: ProviderSelectStepProps) {
+export function ProviderSelectStep({
+    canCreatePagerDuty,
+    provider,
+    onChangeAction,
+}: ProviderSelectStepProps) {
     return (
         <div className="space-y-3">
             <div>
@@ -21,7 +26,9 @@ export function ProviderSelectStep({ provider, onChangeAction }: ProviderSelectS
                 </p>
             </div>
             <div className="grid gap-2 sm:grid-cols-2">
-                {PROVIDERS.map((p) => {
+                {PROVIDERS.filter(
+                    (candidate) => candidate !== "pagerduty" || canCreatePagerDuty,
+                ).map((p) => {
                     if (p === "pagerduty") {
                         return (
                             <Link

--- a/src/components/admin/sync/SyncConfigForm.test.tsx
+++ b/src/components/admin/sync/SyncConfigForm.test.tsx
@@ -206,6 +206,30 @@ describe("SyncConfigForm", () => {
             ).not.toBeInTheDocument();
         });
 
+        it("hides PagerDuty from a new sync configuration when canonical incident ingestion is unavailable", () => {
+            const pagerDutyCredential: IntegrationCredential = {
+                id: "cred-pagerduty",
+                provider: "pagerduty",
+                name: "PagerDuty token",
+                is_active: true,
+                config: {},
+                last_test_at: null,
+                last_test_success: null,
+                last_test_error: null,
+                created_at: "2024-01-01",
+                updated_at: "2024-01-01",
+            };
+
+            render(
+                <SyncConfigForm
+                    canCreatePagerDuty={false}
+                    credentials={[...mockCredentials, pagerDutyCredential]}
+                />,
+            );
+
+            expect(screen.queryByRole("option", { name: "PagerDuty" })).not.toBeInTheDocument();
+        });
+
         it("credential step blocks Continue until a credential is chosen, and offers Create Credential when none exist for the provider", async () => {
             render(<SyncConfigForm credentials={mockCredentials} />);
 
@@ -836,7 +860,12 @@ describe("SyncConfigForm", () => {
                 created_at: "2024-01-01",
                 updated_at: "2024-01-01",
             };
-            render(<SyncConfigForm credentials={[...mockCredentials, pagerDutyCredential]} />);
+            render(
+                <SyncConfigForm
+                    canCreatePagerDuty
+                    credentials={[...mockCredentials, pagerDutyCredential]}
+                />,
+            );
 
             // When: the services dataset is selected and its mapping is completed in the wizard.
             await userEvent.type(screen.getByLabelText("Configuration Name"), "PagerDuty Services");
@@ -882,7 +911,10 @@ describe("SyncConfigForm", () => {
                 updated_at: "2024-01-01",
             };
             renderWithToaster(
-                <SyncConfigForm credentials={[...mockCredentials, pagerDutyCredential]} />,
+                <SyncConfigForm
+                    canCreatePagerDuty
+                    credentials={[...mockCredentials, pagerDutyCredential]}
+                />,
             );
             await userEvent.type(
                 screen.getByLabelText("Configuration Name"),

--- a/src/components/admin/sync/SyncConfigForm.tsx
+++ b/src/components/admin/sync/SyncConfigForm.tsx
@@ -49,6 +49,7 @@ import {
 import type { ServiceRepositoryMappings } from "@/lib/admin/pagerduty";
 
 type SyncConfigFormProps = {
+    canCreatePagerDuty?: boolean;
     initialData?: SyncConfig;
     initialRepositorySelection?: SyncConfigRepositorySelection;
     credentials: IntegrationCredential[];
@@ -104,6 +105,7 @@ function toSnapshot(
 }
 
 export function SyncConfigForm({
+    canCreatePagerDuty = false,
     initialData,
     initialRepositorySelection,
     credentials,
@@ -507,6 +509,7 @@ export function SyncConfigForm({
                 />
             ) : (
                 <CreateSyncConfigWizard
+                    canCreatePagerDuty={canCreatePagerDuty}
                     formData={formData}
                     credentialName={credentialName}
                     filteredCredentials={filteredCredentials}

--- a/src/components/admin/sync/config-form/CreateSyncConfigWizard.tsx
+++ b/src/components/admin/sync/config-form/CreateSyncConfigWizard.tsx
@@ -44,6 +44,7 @@ type CreateSyncConfigWizardFormData = {
 };
 
 type CreateSyncConfigWizardProps = {
+    canCreatePagerDuty: boolean;
     formData: CreateSyncConfigWizardFormData;
     credentialName: string | null;
     filteredCredentials: IntegrationCredential[];
@@ -77,6 +78,7 @@ type CreateSyncConfigWizardProps = {
  * steps rather than reimplementing their field logic.
  */
 export function CreateSyncConfigWizard({
+    canCreatePagerDuty,
     formData,
     credentialName,
     filteredCredentials,
@@ -169,6 +171,7 @@ export function CreateSyncConfigWizard({
             <div className="space-y-6 rounded-2xl border border-(--card-stroke) bg-(--card-80) p-6">
                 {currentStep.id === "provider" && (
                     <IdentitySection
+                        canCreatePagerDuty={canCreatePagerDuty}
                         isEdit={false}
                         name={formData.name}
                         provider={formData.provider}

--- a/src/components/admin/sync/config-form/EditSyncConfigForm.tsx
+++ b/src/components/admin/sync/config-form/EditSyncConfigForm.tsx
@@ -117,6 +117,7 @@ export function EditSyncConfigForm({
             }
         >
             <IdentitySection
+                canCreatePagerDuty={false}
                 isEdit
                 name={formData.name}
                 provider={formData.provider}

--- a/src/components/admin/sync/config-form/IdentitySection.tsx
+++ b/src/components/admin/sync/config-form/IdentitySection.tsx
@@ -5,6 +5,7 @@ import { FormSection } from "./FormSection";
 import { ImmutableField } from "./ImmutableField";
 
 type IdentitySectionProps = {
+    canCreatePagerDuty: boolean;
     isEdit: boolean;
     name: string;
     provider: string;
@@ -13,7 +14,13 @@ type IdentitySectionProps = {
 
 /** Configuration name + provider. Both are immutable once created (the
  * update API never accepts `name`/`provider` — see SyncConfigUpdate). */
-export function IdentitySection({ isEdit, name, provider, onChange }: IdentitySectionProps) {
+export function IdentitySection({
+    canCreatePagerDuty,
+    isEdit,
+    name,
+    provider,
+    onChange,
+}: IdentitySectionProps) {
     return (
         <FormSection title="Identity" description="Name and provider that identify this sync.">
             {isEdit ? (
@@ -58,7 +65,9 @@ export function IdentitySection({ isEdit, name, provider, onChange }: IdentitySe
                         onChange={onChange}
                         className={`${inputClass} text-sm`}
                     >
-                        {PROVIDERS.map((p) => (
+                        {PROVIDERS.filter(
+                            (candidate) => candidate !== "pagerduty" || canCreatePagerDuty,
+                        ).map((p) => (
                             <option key={p} value={p}>
                                 {PROVIDER_LABELS[p]}
                             </option>

--- a/src/components/onboarding/OnboardIntegrationStep.tsx
+++ b/src/components/onboarding/OnboardIntegrationStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 
 import {
@@ -58,10 +58,15 @@ export function OnboardIntegrationStep({
     const { data: session } = useSession();
     const [skipping, setSkipping] = useState(false);
     const [skipError, setSkipError] = useState<string | null>(null);
+    const stepRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         trackOnboardingEventOnce("integration_step_viewed", { orgId });
     }, [orgId]);
+
+    useEffect(() => {
+        stepRef.current?.setAttribute("data-onboarding-interactive", "true");
+    }, []);
 
     const completeHref = trialIntent
         ? "/auth/onboard/complete?plan=team&trial=true"
@@ -100,7 +105,7 @@ export function OnboardIntegrationStep({
 
     if (isConnected) {
         return (
-            <div className="space-y-6">
+            <div ref={stepRef} className="space-y-6">
                 <div
                     role="status"
                     className="rounded-lg border border-green-500/20 bg-green-500/10 p-4 text-sm text-green-700"
@@ -116,7 +121,7 @@ export function OnboardIntegrationStep({
     }
 
     return (
-        <div className="space-y-6">
+        <div ref={stepRef} className="space-y-6">
             <p className="text-sm text-[var(--ink-muted)]">
                 Connect at least one source so Dev Health can measure pull-request flow, review
                 load, delivery, and engineering-health signals. Until a tool is connected these

--- a/src/lib/admin/__tests__/canonicalIncidentIngestion.test.ts
+++ b/src/lib/admin/__tests__/canonicalIncidentIngestion.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+    CANONICAL_INCIDENT_INGESTION_FEATURE,
+    isCanonicalIncidentIngestionEnabled,
+} from "../canonicalIncidentIngestion";
+
+describe("canonical incident ingestion entitlement", () => {
+    it("fails closed when an older Ops response omits the feature", () => {
+        expect(isCanonicalIncidentIngestionEnabled({ features: {} })).toBe(false);
+    });
+
+    it("fails closed when the feature is explicitly disabled or malformed", () => {
+        expect(
+            isCanonicalIncidentIngestionEnabled({
+                features: { [CANONICAL_INCIDENT_INGESTION_FEATURE]: false },
+            }),
+        ).toBe(false);
+        expect(
+            isCanonicalIncidentIngestionEnabled({
+                features: { [CANONICAL_INCIDENT_INGESTION_FEATURE]: "enabled" },
+            }),
+        ).toBe(false);
+    });
+
+    it("allows only an explicit true entitlement", () => {
+        expect(
+            isCanonicalIncidentIngestionEnabled({
+                features: { [CANONICAL_INCIDENT_INGESTION_FEATURE]: true },
+            }),
+        ).toBe(true);
+    });
+});

--- a/src/lib/admin/__tests__/pagerduty-server.test.ts
+++ b/src/lib/admin/__tests__/pagerduty-server.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { mockAuth } from "@/test/mocks/auth";
+import { createCredential } from "../server/credentials";
+import {
+    completePagerDutyOAuth,
+    connectPagerDutyApiToken,
+    connectPagerDutyClientCredentials,
+    startPagerDutyOAuth,
+} from "../server/pagerduty";
+
+const entitlementWithoutFeature = {
+    org_id: "org-1",
+    tier: "enterprise",
+    licensed_users: null,
+    licensed_repos: null,
+    features: {},
+    features_override: null,
+    limits_override: null,
+    expires_at: null,
+    is_valid: true,
+    limits: {},
+};
+
+describe("PagerDuty server actions", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.stubEnv("BACKEND_URL", "http://test-ops:8000");
+        mockAuth({ user: { id: "u-1", org_id: "org-1" }, access_token: "test-token" });
+    });
+
+    it("fails closed before starting OAuth when an older Ops response omits the entitlement", async () => {
+        const fetchSpy = vi
+            .spyOn(global, "fetch")
+            .mockResolvedValue(
+                new Response(JSON.stringify(entitlementWithoutFeature), { status: 200 }),
+            );
+
+        await expect(
+            startPagerDutyOAuth({
+                credentialName: "production",
+                datasets: ["services"],
+                region: "us",
+                subdomain: "acme",
+            }),
+        ).resolves.toEqual({ error: "PagerDuty connections are currently unavailable." });
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+            "http://test-ops:8000/api/v1/licensing/entitlements/org-1",
+        );
+        fetchSpy.mockRestore();
+    });
+
+    it("fails closed before the generic credential action can create a PagerDuty credential", async () => {
+        const fetchSpy = vi
+            .spyOn(global, "fetch")
+            .mockResolvedValue(
+                new Response(JSON.stringify(entitlementWithoutFeature), { status: 200 }),
+            );
+
+        await expect(
+            createCredential({
+                provider: "pagerduty",
+                name: "production",
+                credentials: { apiToken: "secret" },
+            }),
+        ).resolves.toEqual({ error: "PagerDuty connections are currently unavailable." });
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+            "http://test-ops:8000/api/v1/licensing/entitlements/org-1",
+        );
+        fetchSpy.mockRestore();
+    });
+
+    it.each([
+        [
+            "API token",
+            () =>
+                connectPagerDutyApiToken({
+                    credentialName: "production",
+                    apiToken: "secret",
+                    region: "us",
+                    subdomain: "acme",
+                }),
+        ],
+        [
+            "client credentials",
+            () =>
+                connectPagerDutyClientCredentials({
+                    credentialName: "production",
+                    clientId: "client-id",
+                    clientSecret: "secret",
+                    region: "us",
+                    subdomain: "acme",
+                }),
+        ],
+    ])("fails closed before %s can create a PagerDuty credential", async (_method, connect) => {
+        const fetchSpy = vi
+            .spyOn(global, "fetch")
+            .mockResolvedValue(
+                new Response(JSON.stringify(entitlementWithoutFeature), { status: 200 }),
+            );
+
+        await expect(connect()).resolves.toEqual({
+            error: "PagerDuty connections are currently unavailable.",
+        });
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        fetchSpy.mockRestore();
+    });
+
+    it("starts OAuth only after an explicit true entitlement", async () => {
+        const fetchSpy = vi
+            .spyOn(global, "fetch")
+            .mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        ...entitlementWithoutFeature,
+                        features: { canonical_incident_ingestion: true },
+                    }),
+                    { status: 200 },
+                ),
+            )
+            .mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({ authorize_url: "https://pagerduty.example/authorize" }),
+                    {
+                        status: 200,
+                    },
+                ),
+            );
+
+        await expect(
+            startPagerDutyOAuth({
+                credentialName: "production",
+                datasets: ["services"],
+                region: "us",
+                subdomain: "acme",
+            }),
+        ).resolves.toEqual({ data: { authorize_url: "https://pagerduty.example/authorize" } });
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        fetchSpy.mockRestore();
+    });
+
+    it("completes an OAuth callback started while enabled after the entitlement flips off", async () => {
+        let entitlementEnabled = true;
+        let callbackAttempts = 0;
+        const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+            const url = String(input);
+
+            if (url.endsWith("/api/v1/licensing/entitlements/org-1")) {
+                return new Response(
+                    JSON.stringify({
+                        ...entitlementWithoutFeature,
+                        features: { canonical_incident_ingestion: entitlementEnabled },
+                    }),
+                    { status: 200 },
+                );
+            }
+
+            if (url.endsWith("/api/v1/admin/integrations/pagerduty/authorize")) {
+                return new Response(
+                    JSON.stringify({ authorize_url: "https://pagerduty.example/authorize" }),
+                    { status: 200 },
+                );
+            }
+
+            if (url.endsWith("/api/v1/admin/integrations/pagerduty/callback")) {
+                callbackAttempts += 1;
+                if (callbackAttempts === 1) {
+                    return new Response(
+                        JSON.stringify({
+                            connected: true,
+                            credential_name: "production",
+                            region: "us",
+                            subdomain: "acme",
+                            granted_scopes: ["services.read"],
+                        }),
+                        { status: 200 },
+                    );
+                }
+                return new Response(
+                    JSON.stringify({ detail: "Invalid or expired PagerDuty OAuth state" }),
+                    { status: 400 },
+                );
+            }
+
+            throw new Error(`Unexpected request: ${url}`);
+        });
+
+        await expect(
+            startPagerDutyOAuth({
+                credentialName: "production",
+                datasets: ["services"],
+                region: "us",
+                subdomain: "acme",
+            }),
+        ).resolves.toEqual({ data: { authorize_url: "https://pagerduty.example/authorize" } });
+
+        entitlementEnabled = false;
+
+        await expect(
+            completePagerDutyOAuth({ state: "callback-state", code: "oauth-code" }),
+        ).resolves.toEqual({
+            data: {
+                connected: true,
+                credential_name: "production",
+                region: "us",
+                subdomain: "acme",
+                granted_scopes: ["services.read"],
+            },
+        });
+
+        await expect(
+            completePagerDutyOAuth({ state: "callback-state", code: "oauth-code" }),
+        ).resolves.toEqual({
+            error: "Invalid or expired PagerDuty OAuth state",
+        });
+
+        const entitlementRequests = fetchSpy.mock.calls.filter(([input]) =>
+            String(input).endsWith("/api/v1/licensing/entitlements/org-1"),
+        );
+        const authorizeRequests = fetchSpy.mock.calls.filter(([input]) =>
+            String(input).endsWith("/api/v1/admin/integrations/pagerduty/authorize"),
+        );
+        const callbackRequests = fetchSpy.mock.calls.filter(([input]) =>
+            String(input).endsWith("/api/v1/admin/integrations/pagerduty/callback"),
+        );
+
+        expect(entitlementRequests).toHaveLength(1);
+        expect(authorizeRequests).toHaveLength(1);
+        expect(callbackRequests).toHaveLength(2);
+        expect(callbackAttempts).toBe(2);
+        fetchSpy.mockRestore();
+    });
+
+    it("returns the Ops invalid-state error for an unstarted OAuth callback", async () => {
+        const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+            new Response(JSON.stringify({ detail: "Invalid or expired PagerDuty OAuth state" }), {
+                status: 400,
+            }),
+        );
+
+        await expect(
+            completePagerDutyOAuth({ state: "callback-state", code: "oauth-code" }),
+        ).resolves.toEqual({
+            error: "Invalid or expired PagerDuty OAuth state",
+        });
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+            "http://test-ops:8000/api/v1/admin/integrations/pagerduty/callback",
+        );
+        fetchSpy.mockRestore();
+    });
+});

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -30,6 +30,7 @@ import {
     listRetentionResourceTypes,
     getOrgEntitlements,
     createSyncConfig,
+    batchCreateSyncConfigs,
     getSyncCoverage,
     getSyncJobs,
     triggerBackfill,
@@ -189,6 +190,44 @@ describe("admin/server sync config actions", () => {
             });
             expect(result.data).toBeDefined();
             expect(revalidatePath).toHaveBeenCalledWith("/org/admin/sync");
+            fetchSpy.mockRestore();
+        });
+
+        it.each([{}, { canonical_incident_ingestion: false }])(
+            "rejects PagerDuty creation when the entitlement is unavailable",
+            async (features) => {
+                mockSession();
+                const fetchSpy = vi
+                    .spyOn(global, "fetch")
+                    .mockResolvedValue(new Response(JSON.stringify({ features }), { status: 200 }));
+
+                const result = await createSyncConfig({
+                    name: "PagerDuty incidents",
+                    provider: "pagerduty",
+                });
+
+                expect(result.error).toBe("PagerDuty connections are currently unavailable.");
+                expect(fetchSpy).toHaveBeenCalledTimes(1);
+                fetchSpy.mockRestore();
+            },
+        );
+    });
+
+    describe("batchCreateSyncConfigs", () => {
+        it("rejects PagerDuty batch creation when the entitlement is unavailable", async () => {
+            mockSession();
+            const fetchSpy = vi
+                .spyOn(global, "fetch")
+                .mockResolvedValue(new Response(JSON.stringify({ features: {} }), { status: 200 }));
+
+            const result = await batchCreateSyncConfigs({
+                name: "PagerDuty incidents",
+                provider: "pagerduty",
+                repos: ["service-api"],
+            });
+
+            expect(result.error).toBe("PagerDuty connections are currently unavailable.");
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
             fetchSpy.mockRestore();
         });
     });

--- a/src/lib/admin/canonicalIncidentIngestion.ts
+++ b/src/lib/admin/canonicalIncidentIngestion.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const CANONICAL_INCIDENT_INGESTION_FEATURE = "canonical_incident_ingestion";
+
+const EntitlementFeaturesSchema = z.object({
+    features: z.record(z.string(), z.boolean()),
+});
+
+export function isCanonicalIncidentIngestionEnabled(entitlements: unknown): boolean {
+    const parsed = EntitlementFeaturesSchema.safeParse(entitlements);
+    return parsed.success && parsed.data.features[CANONICAL_INCIDENT_INGESTION_FEATURE] === true;
+}

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -10,4 +10,5 @@ export * from "./server/orgs";
 export * from "./server/billing";
 export * from "./server/setup";
 export * from "./server/customer-push";
+export * from "./server/canonicalIncidentIngestion";
 export * from "./server/pagerduty";

--- a/src/lib/admin/server/canonicalIncidentIngestion.ts
+++ b/src/lib/admin/server/canonicalIncidentIngestion.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { AdminApiError, adminApi } from "../api";
+import { isCanonicalIncidentIngestionEnabled } from "../canonicalIncidentIngestion";
+import type { Result } from "@/lib/result";
+import { getSessionContext, withErrorHandling } from "./_shared";
+
+const PAGERDUTY_CONNECTIONS_UNAVAILABLE_MESSAGE =
+    "PagerDuty connections are currently unavailable.";
+
+type CanonicalIncidentIngestionEntitlement = {
+    readonly enabled: boolean;
+};
+
+export async function getCanonicalIncidentIngestionEntitlement(): Promise<
+    Result<CanonicalIncidentIngestionEntitlement>
+> {
+    return withErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        if (!orgId) {
+            throw new AdminApiError(400, "Bad Request", "No organization ID in session");
+        }
+
+        const entitlements = await adminApi.licensing.entitlements(orgId, token, orgId);
+        return { enabled: isCanonicalIncidentIngestionEnabled(entitlements) };
+    });
+}
+
+export async function requirePagerDutyCreationEntitlement(): Promise<void> {
+    const entitlement = await getCanonicalIncidentIngestionEntitlement();
+    if (entitlement.data?.enabled !== true) {
+        throw new AdminApiError(403, "Forbidden", PAGERDUTY_CONNECTIONS_UNAVAILABLE_MESSAGE);
+    }
+}

--- a/src/lib/admin/server/credentials.ts
+++ b/src/lib/admin/server/credentials.ts
@@ -9,6 +9,7 @@ import type {
     TestConnectionResponse,
 } from "../types";
 import { getSessionContext, withErrorHandling } from "./_shared";
+import { requirePagerDutyCreationEntitlement } from "./canonicalIncidentIngestion";
 
 export async function listCredentials(): Promise<ActionResult<IntegrationCredential[]>> {
     return withErrorHandling(async () => {
@@ -21,6 +22,9 @@ export async function createCredential(
     data: IntegrationCredentialCreate,
 ): Promise<ActionResult<IntegrationCredential>> {
     return withErrorHandling(async () => {
+        if (data.provider === "pagerduty") {
+            await requirePagerDutyCreationEntitlement();
+        }
         const { token, orgId } = await getSessionContext();
         const result = await adminApi.credentials.create(data, token, orgId);
         revalidatePath("/org/admin/integrations", "page");

--- a/src/lib/admin/server/pagerduty.ts
+++ b/src/lib/admin/server/pagerduty.ts
@@ -16,6 +16,7 @@ import type {
     PagerDutyStatusResponse,
 } from "../pagerduty";
 import { getSessionContext, withErrorHandling } from "./_shared";
+import { requirePagerDutyCreationEntitlement } from "./canonicalIncidentIngestion";
 
 type StartPagerDutyOAuthInput = {
     readonly credentialName: string;
@@ -28,6 +29,7 @@ export async function startPagerDutyOAuth(
     input: StartPagerDutyOAuthInput,
 ): Promise<Result<PagerDutyAuthorizeResponse>> {
     return withErrorHandling(async () => {
+        await requirePagerDutyCreationEntitlement();
         const { token, orgId } = await getSessionContext();
         return adminApi.pagerDuty.authorize(
             {
@@ -48,6 +50,9 @@ export async function completePagerDutyOAuth(input: {
     readonly error?: string;
 }): Promise<Result<PagerDutyOAuthCallbackConnectedResponse>> {
     return withErrorHandling(async () => {
+        // Ops created the one-time, organization-scoped state during authorization and
+        // remains the authority that consumes it. Completion must not re-check the
+        // creation entitlement: it may have changed while the user was at PagerDuty.
         const { token, orgId } = await getSessionContext();
         const result = await adminApi.pagerDuty.callback(input, token, orgId);
         revalidatePath("/org/admin/integrations", "page");
@@ -102,6 +107,7 @@ export async function connectPagerDutyClientCredentials(input: {
     readonly region: PagerDutyRegion;
 }): Promise<Result<PagerDutyClientCredentialsConnectedResponse>> {
     return withErrorHandling(async () => {
+        await requirePagerDutyCreationEntitlement();
         const { token, orgId } = await getSessionContext();
         return adminApi.pagerDuty.clientCredentials(
             {
@@ -124,6 +130,7 @@ export async function connectPagerDutyApiToken(input: {
     readonly region: PagerDutyRegion;
 }): Promise<Result<PagerDutyApiTokenConnectedResponse>> {
     return withErrorHandling(async () => {
+        await requirePagerDutyCreationEntitlement();
         const { token, orgId } = await getSessionContext();
         return adminApi.pagerDuty.apiToken(
             {

--- a/src/lib/admin/server/sync.ts
+++ b/src/lib/admin/server/sync.ts
@@ -20,6 +20,7 @@ import type {
     SyncRunUnitSummary,
     SyncCoverageSummary,
 } from "../types";
+import { requirePagerDutyCreationEntitlement } from "./canonicalIncidentIngestion";
 import { getSessionContext, withErrorHandling } from "./_shared";
 
 export async function listSyncConfigs(): Promise<ActionResult<SyncConfig[]>> {
@@ -31,6 +32,9 @@ export async function listSyncConfigs(): Promise<ActionResult<SyncConfig[]>> {
 
 export async function createSyncConfig(data: SyncConfigCreate): Promise<ActionResult<SyncConfig>> {
     return withErrorHandling(async () => {
+        if (data.provider === "pagerduty") {
+            await requirePagerDutyCreationEntitlement();
+        }
         const { token, orgId } = await getSessionContext();
         const result = await adminApi.syncConfigs.create(data, token, orgId);
         revalidatePath("/org/admin/sync");
@@ -56,6 +60,9 @@ export async function batchCreateSyncConfigs(
         // Normalize: accept both flat { name, provider, repos } and nested { base: {...}, repos }
         const normalized: SyncConfigBatchCreate =
             "base" in data ? { ...data.base, repos: data.repos } : data;
+        if (normalized.provider === "pagerduty") {
+            await requirePagerDutyCreationEntitlement();
+        }
         const result = await adminApi.syncConfigs.batchCreate(normalized, token, orgId);
         revalidatePath("/org/admin/sync");
         return result;

--- a/tests/admin-integrations.spec.ts
+++ b/tests/admin-integrations.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { setPagerDutyEntitlement } from "./pagerduty-final-qa.helpers";
 
 test("providers page renders a provider management table", async ({ page }) => {
     await page.goto("/org/admin/integrations");
@@ -91,7 +92,11 @@ test("Linear Add Provider wizard renders manual credential fields immediately", 
     await expect(page.locator("#linear-teams")).toBeVisible();
 });
 
-test("PagerDuty setup exposes OAuth first with supported manual fallbacks", async ({ page }) => {
+test("PagerDuty setup exposes OAuth first with supported manual fallbacks", async ({
+    page,
+    request,
+}) => {
+    await setPagerDutyEntitlement(request, "canonical-enabled");
     await page.goto("/org/admin/integrations/pagerduty");
 
     await expect(page.getByRole("heading", { name: "Connect PagerDuty" })).toBeVisible();

--- a/tests/auth-onboard.spec.ts
+++ b/tests/auth-onboard.spec.ts
@@ -142,7 +142,9 @@ test.describe("guided first-run onboarding", () => {
         await page.getByRole("button", { name: "Create Workspace" }).click();
         await expect(page).toHaveURL(/\/auth\/onboard\/integration/, { timeout: 30_000 });
 
-        await page.getByRole("button", { name: "Skip for now" }).click();
+        const skipButton = page.getByRole("button", { name: "Skip for now" });
+        await expect(page.locator('[data-onboarding-interactive="true"]')).toBeVisible();
+        await skipButton.click();
         await expect(page).toHaveURL(/\/auth\/onboard\/complete/, { timeout: 30_000 });
         await expect(page.getByRole("heading", { name: "You're all set" })).toBeVisible();
 
@@ -196,7 +198,9 @@ test.describe("guided first-run journey (fresh signup)", () => {
         await expect(page).toHaveURL(/\/auth\/onboard\/integration/, { timeout: 30_000 });
 
         // 5. Skip the integration → completion step.
-        await page.getByRole("button", { name: "Skip for now" }).click();
+        const skipButton = page.getByRole("button", { name: "Skip for now" });
+        await expect(page.locator('[data-onboarding-interactive="true"]')).toBeVisible();
+        await skipButton.click();
         await expect(page).toHaveURL(/\/auth\/onboard\/complete/, { timeout: 30_000 });
 
         // 6. Continue into the product.

--- a/tests/mocks/entitlementScenario.ts
+++ b/tests/mocks/entitlementScenario.ts
@@ -1,4 +1,11 @@
-export type EntitlementScenario = "provisioned" | "unprovisioned" | "invalid" | "error";
+export type EntitlementScenario =
+    | "provisioned"
+    | "unprovisioned"
+    | "invalid"
+    | "error"
+    | "canonical-absent"
+    | "canonical-disabled"
+    | "canonical-enabled";
 
 let currentEntitlementScenario: EntitlementScenario = "unprovisioned";
 
@@ -8,6 +15,9 @@ export function setEntitlementScenario(scenario: string): boolean {
         case "unprovisioned":
         case "invalid":
         case "error":
+        case "canonical-absent":
+        case "canonical-disabled":
+        case "canonical-enabled":
             currentEntitlementScenario = scenario;
             return true;
         default:

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -2120,7 +2120,11 @@ export const handlers = [
             features:
                 scenario === "provisioned"
                     ? { ...MOCK_ORG_ENTITLEMENTS.features, agent_context_runtime: true }
-                    : MOCK_ORG_ENTITLEMENTS.features,
+                    : scenario === "canonical-enabled"
+                      ? { ...MOCK_ORG_ENTITLEMENTS.features, canonical_incident_ingestion: true }
+                      : scenario === "canonical-disabled"
+                        ? { ...MOCK_ORG_ENTITLEMENTS.features, canonical_incident_ingestion: false }
+                        : MOCK_ORG_ENTITLEMENTS.features,
         });
     }),
 

--- a/tests/pagerduty-final-qa-p3.spec.ts
+++ b/tests/pagerduty-final-qa-p3.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+    NEXT_DEV_OVERLAY_CAPTURE_STYLE,
+    setPagerDutyEntitlement,
+    setPagerDutyScenario,
+    waitForCaptureReadiness,
+} from "./pagerduty-final-qa.helpers";
+
+const ARTIFACT_ROOT = path.resolve(".omo/start-work/artifacts/chaos-3024/task-1/web-gate");
+
+function collectConsole(page: Page): readonly string[] {
+    const messages: string[] = [];
+    page.on("console", (message) => messages.push(`${message.type()}: ${message.text()}`));
+    return messages;
+}
+
+async function captureArtifact(
+    page: Page,
+    name: string,
+    consoleMessages: readonly string[],
+): Promise<void> {
+    await mkdir(ARTIFACT_ROOT, { recursive: true });
+    await page.screenshot({
+        path: path.join(ARTIFACT_ROOT, `${name}.png`),
+        fullPage: true,
+        style: NEXT_DEV_OVERLAY_CAPTURE_STYLE,
+    });
+    await writeFile(
+        path.join(ARTIFACT_ROOT, `${name}.console.json`),
+        `${JSON.stringify({ console: consoleMessages }, null, 2)}\n`,
+    );
+}
+
+test.describe.configure({ mode: "serial" });
+
+test("P3 hides PagerDuty creation controls when an older Ops response omits the entitlement", async ({
+    page,
+    request,
+}) => {
+    await setPagerDutyScenario(request, "not-connected");
+    await setPagerDutyEntitlement(request, "canonical-absent");
+    await page.setViewportSize({ width: 375, height: 844 });
+    const consoleMessages = collectConsole(page);
+
+    await page.goto("/org/admin/integrations");
+    await expect(page.getByRole("button", { name: "Add Provider" })).toBeVisible();
+    await page.getByRole("button", { name: "Add Provider" }).click();
+    await expect(page.getByRole("link", { name: "PagerDuty" })).toHaveCount(0);
+    await waitForCaptureReadiness(page, "mobile");
+    await captureArtifact(page, "off-no-credentials-375", consoleMessages);
+});
+
+test("P3 keeps a pre-existing PagerDuty connection manageable when the entitlement is false", async ({
+    page,
+    request,
+}) => {
+    await setPagerDutyScenario(request, "mapping-fixture");
+    await setPagerDutyEntitlement(request, "canonical-disabled");
+    await page.setViewportSize({ width: 768, height: 1024 });
+    const consoleMessages = collectConsole(page);
+
+    await page.goto("/org/admin/integrations/pagerduty");
+    await expect(page.getByText("PagerDuty setup is unavailable")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Connect PagerDuty" })).toHaveCount(0);
+    await page.getByLabel("Saved credentials").selectOption({ label: "PagerDuty operations" });
+    await page.getByRole("button", { name: "Check connection status" }).click();
+    await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Create sync configuration" })).toHaveCount(0);
+    await waitForCaptureReadiness(page, "desktop");
+    await captureArtifact(page, "off-existing-manage-only-768", consoleMessages);
+});
+
+test("P3 exposes PagerDuty creation only when the entitlement is explicitly true", async ({
+    page,
+    request,
+}) => {
+    await setPagerDutyScenario(request, "not-connected");
+    await setPagerDutyEntitlement(request, "canonical-enabled");
+    await page.setViewportSize({ width: 1280, height: 900 });
+    const consoleMessages = collectConsole(page);
+
+    await page.goto("/org/admin/integrations/pagerduty");
+    await expect(page.getByRole("heading", { name: "Connect PagerDuty" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Connect PagerDuty" })).toBeVisible();
+    await waitForCaptureReadiness(page, "desktop");
+    await captureArtifact(page, "on-create-path-1280", consoleMessages);
+});

--- a/tests/pagerduty-final-qa.helpers.ts
+++ b/tests/pagerduty-final-qa.helpers.ts
@@ -5,8 +5,10 @@ import { scrubTelemetryText } from "@/lib/sentry/scrubber-value";
 
 export const EVIDENCE_ROOT = path.resolve(".qa-evidence/pagerduty-final-postremediation");
 export const PAGERDUTY_SYNC_CONFIG_EDIT_PATH = "/org/admin/sync/sync-config-pagerduty-1/edit";
-const MOCK_ORIGIN = process.env.PAGERDUTY_QA_MOCK_ORIGIN ?? "http://127.0.0.1:8001";
-const NEXT_DEV_OVERLAY_CAPTURE_STYLE = "nextjs-portal { display: none !important; }";
+const MOCK_ORIGIN =
+    process.env.PAGERDUTY_QA_MOCK_ORIGIN ??
+    `http://127.0.0.1:${process.env.PLAYWRIGHT_MOCK_PORT ?? "8001"}`;
+export const NEXT_DEV_OVERLAY_CAPTURE_STYLE = "nextjs-portal { display: none !important; }";
 
 export type QaScenario = {
     readonly id: string;
@@ -14,6 +16,9 @@ export type QaScenario = {
     readonly title: string;
     readonly viewport: "desktop" | "mobile";
 };
+
+export type PagerDutyEntitlementScenario =
+    "canonical-absent" | "canonical-disabled" | "canonical-enabled";
 
 type BrowserSignals = {
     readonly console: string[];
@@ -72,6 +77,17 @@ export async function setPagerDutyScenario(
     scenario: string,
 ): Promise<void> {
     const response = await request.post(`${MOCK_ORIGIN}/__test/pagerduty`, { data: { scenario } });
+    expect(response.status()).toBe(204);
+    await setPagerDutyEntitlement(request, "canonical-enabled");
+}
+
+export async function setPagerDutyEntitlement(
+    request: APIRequestContext,
+    scenario: PagerDutyEntitlementScenario,
+): Promise<void> {
+    const response = await request.post(`${MOCK_ORIGIN}/__test/entitlements`, {
+        data: { scenario },
+    });
     expect(response.status()).toBe(204);
 }
 
@@ -217,7 +233,7 @@ async function toastOverlappingInteractiveControls(page: Page) {
     });
 }
 
-async function waitForCaptureReadiness(
+export async function waitForCaptureReadiness(
     page: Page,
     viewport: QaScenario["viewport"],
 ): Promise<CaptureReadiness> {


### PR DESCRIPTION
## Linked work

[CHAOS-3025](https://linear.app/fullchaos/issue/CHAOS-3025/gate-pagerduty-and-canonical-incident-ingestion-behind-a-default-off) · [CHAOS-3024](https://linear.app/fullchaos/issue/CHAOS-3024)

## Task 1 summary

- Adds an optional, additive entitlement for canonical incident ingestion.
- Fails closed for older Ops deployments.
- Keeps existing PagerDuty credentials manageable only; it does not permit new customer connections while disabled.
- Guards server actions as well as the UI.
- Completes the callback-after-flip flow once, after the entitlement is enabled.

## Release posture

Default is off. This change provides no customer enablement or rollout.

## Validation

Tests, production build, and P3 final QA passed.

## Visual evidence

### 375px — feature off, no PagerDuty credentials

![375px feature off with no credentials](https://github.com/user-attachments/assets/99d7a4b1-1ae6-43a1-8b37-2812d06ad474)

### 768px — feature off, existing PagerDuty credentials remain manage-only

![768px feature off with existing credential manage-only state](https://github.com/user-attachments/assets/42306362-e998-4b55-92e6-a4d9347c4687)

### 1280px — enabled creation path

![1280px enabled PagerDuty creation path](https://github.com/user-attachments/assets/9072b754-79f3-4555-a70e-5027c9727ad2)
