### PR TITLE
[CHAOS-3061] PagerDuty setup and sync fail after OAuth connection

### DIFF
--- a/src/components/admin/integrations/ProviderCredentialsList.test.tsx
+++ b/src/components/admin/integrations/ProviderCredentialsList.test.tsx
@@ -118,8 +118,8 @@ describe("ProviderCredentialsList", () => {
 
         expect(screen.getByRole("button", { name: "Add credential" })).toBeInTheDocument();
         await user.click(screen.getByRole("button", { name: "Add credential" }));
-        expect(screen.getByText("OAuth (recommended)")).toBeInTheDocument();
-        await user.click(screen.getByText("OAuth (recommended)"));
+        expect(screen.getByText("OAuth authorization")).toBeInTheDocument();
+        await user.click(screen.getByText("OAuth authorization"));
 
         await waitFor(() => {
             expect(startPagerDutyOAuth).toHaveBeenCalledWith();
@@ -151,8 +151,8 @@ describe("ProviderCredentialsList", () => {
         );
 
         await user.click(screen.getByRole("button", { name: "Add credential" }));
-        const oauthChoice = screen.getByRole("button", { name: /^OAuth \(recommended\)/ });
-        expect(oauthChoice).toHaveAttribute("aria-pressed", "true");
+        const oauthChoice = screen.getByRole("button", { name: /^OAuth authorization/ });
+        expect(oauthChoice).toHaveAttribute("aria-pressed", "false");
         await user.click(oauthChoice);
 
         expect(screen.queryByText("2. Credential")).not.toBeInTheDocument();
@@ -183,7 +183,7 @@ describe("ProviderCredentialsList", () => {
         );
 
         await user.click(screen.getByRole("button", { name: "Add credential" }));
-        await user.click(screen.getByRole("button", { name: /^Client credentials/ }));
+        await user.click(screen.getByRole("button", { name: /^Private app credentials/ }));
         await user.click(screen.getByRole("button", { name: "Continue" }));
 
         expect(screen.getByText("2. Credential")).toBeInTheDocument();
@@ -219,12 +219,12 @@ describe("ProviderCredentialsList", () => {
         );
 
         await user.click(screen.getByRole("button", { name: "Add credential" }));
-        await user.click(screen.getByRole("button", { name: /^OAuth \(recommended\)/ }));
+        await user.click(screen.getByRole("button", { name: /^OAuth authorization/ }));
         expect(
             await screen.findByText("PagerDuty authorization could not be started."),
         ).toBeVisible();
 
-        await user.click(screen.getByRole("button", { name: /^OAuth \(recommended\)/ }));
+        await user.click(screen.getByRole("button", { name: /^OAuth authorization/ }));
         await waitFor(() => {
             expect(startPagerDutyOAuth).toHaveBeenCalledTimes(2);
             expect(locationAssign).toHaveBeenCalledWith("https://pagerduty.example/authorize");

--- a/src/components/admin/integrations/wizard/AddProviderWizard.test.tsx
+++ b/src/components/admin/integrations/wizard/AddProviderWizard.test.tsx
@@ -80,9 +80,19 @@ describe("AddProviderWizard", () => {
         await userEvent.click(screen.getByRole("button", { name: "Continue" }));
 
         expect(screen.queryByRole("link", { name: "PagerDuty" })).not.toBeInTheDocument();
-        expect(screen.getByText("OAuth (recommended)")).toBeInTheDocument();
-        expect(screen.getByText("Client credentials")).toBeInTheDocument();
+        expect(screen.getByText("OAuth authorization")).toBeInTheDocument();
+        expect(screen.getByText(/browser using PKCE/i)).toBeInTheDocument();
+        expect(screen.getByText("Private app credentials")).toBeInTheDocument();
+        expect(screen.getByText(/without a browser callback/i)).toBeInTheDocument();
         expect(screen.getByText("Use API token instead")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /^OAuth authorization/ })).toHaveAttribute(
+            "aria-pressed",
+            "false",
+        );
+        expect(screen.getByRole("button", { name: /^Private app credentials/ })).toHaveAttribute(
+            "aria-pressed",
+            "false",
+        );
     });
 
     it("removes PagerDuty from the global picker when canonical incident ingestion is unavailable", () => {

--- a/src/components/admin/integrations/wizard/AddProviderWizard.tsx
+++ b/src/components/admin/integrations/wizard/AddProviderWizard.tsx
@@ -41,7 +41,7 @@ type TestResult = {
 
 function initialMethod(provider: Provider | "", hasGitHubApp: boolean): AddProviderMethod | null {
     if (!provider) return null;
-    if (provider === "pagerduty") return "pagerduty_oauth";
+    if (provider === "pagerduty") return null;
     return providerHasAuthMethodChoice(provider, hasGitHubApp) ? null : "manual";
 }
 

--- a/src/components/admin/integrations/wizard/AuthMethodStep.tsx
+++ b/src/components/admin/integrations/wizard/AuthMethodStep.tsx
@@ -38,9 +38,9 @@ export function AuthMethodStep({
                             : "border-(--card-stroke) hover:bg-(--card-70)"
                     }`}
                 >
-                    <p className="text-sm font-semibold text-foreground">OAuth (recommended)</p>
+                    <p className="text-sm font-semibold text-foreground">OAuth authorization</p>
                     <p className="mt-1 text-xs text-(--ink-muted)">
-                        Authorize read-only PagerDuty access in a new browser window.
+                        Authorize scoped PagerDuty access in a browser using PKCE.
                     </p>
                 </button>
 
@@ -61,9 +61,10 @@ export function AuthMethodStep({
                             : "border-(--card-stroke) hover:bg-(--card-70)"
                     }`}
                 >
-                    <p className="text-sm font-semibold text-foreground">Client credentials</p>
+                    <p className="text-sm font-semibold text-foreground">Private app credentials</p>
                     <p className="mt-1 text-xs text-(--ink-muted)">
-                        Connect with a PagerDuty OAuth client ID and secret.
+                        Use a private scoped OAuth app&apos;s client ID and secret without a browser
+                        callback.
                     </p>
                 </button>
 
@@ -76,7 +77,7 @@ export function AuthMethodStep({
                         method === "pagerduty_api_token" ? "text-(--accent)" : "text-(--ink-muted)"
                     }`}
                 >
-                    Use API token instead
+                    {CTA_LABELS.usePagerDutyApiToken}
                 </button>
             </div>
         );

--- a/src/components/admin/sync/config-form/PagerDutyServiceMappings.test.tsx
+++ b/src/components/admin/sync/config-form/PagerDutyServiceMappings.test.tsx
@@ -63,6 +63,17 @@ describe("PagerDutyServiceMappings", () => {
         });
     });
 
+    it("explains that repository mappings are required for incident metrics", () => {
+        render(<MappingHarness initialMappings={{}} />);
+
+        expect(
+            screen.getByText(
+                "Incidents sync without a mapping, but repository-scoped incident metrics and correlations require one.",
+                { exact: false },
+            ),
+        ).toBeVisible();
+    });
+
     it("round-trips every repository target and supports adding then removing one target", async () => {
         // Given: a persisted service maps to two repository targets.
         const user = userEvent.setup();

--- a/src/components/admin/sync/config-form/PagerDutyServiceMappings.tsx
+++ b/src/components/admin/sync/config-form/PagerDutyServiceMappings.tsx
@@ -166,7 +166,7 @@ export function PagerDutyServiceMappings({
     return (
         <FormSection
             title="Service repository mappings"
-            description="Connect each PagerDuty service to every repository it supports."
+            description="Connect each PagerDuty service to every repository it supports. Incidents sync without a mapping, but repository-scoped incident metrics and correlations require one."
         >
             <section
                 id="pagerduty-service-repository-mappings"

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -180,6 +180,8 @@ export const CTA_LABELS = {
     useGitHubApp: "Use GitHub App",
     /** Secondary, manual-credential auth method path (CHAOS-2837). */
     useManualToken: "Use a personal access token instead",
+    /** PagerDuty fallback for accounts using a REST API token. */
+    usePagerDutyApiToken: "Use API token instead",
     /** Row action opening the manage/edit modal for a healthy credential (CHAOS-2837). */
     manageCredential: "Manage",
     /** Row action opening the manage/edit modal for a failing/untested credential (CHAOS-2837). */

--- a/tests/admin-integrations.spec.ts
+++ b/tests/admin-integrations.spec.ts
@@ -103,7 +103,7 @@ test("PagerDuty OAuth starts immediately without credential fields", async ({ pa
     await setPagerDutyEntitlement(request, "canonical-enabled");
     await page.goto("/org/admin/integrations/pagerduty");
 
-    const oauth = page.getByRole("button", { name: "OAuth (recommended)" });
+    const oauth = page.getByRole("button", { name: "OAuth authorization" });
     await expect(oauth).toBeVisible();
     await oauth.click();
 
@@ -119,8 +119,8 @@ test("PagerDuty setup retains generic manual credential fallbacks", async ({ pag
     await setPagerDutyEntitlement(request, "canonical-enabled");
     await page.goto("/org/admin/integrations/pagerduty");
 
-    await expect(page.getByRole("button", { name: "OAuth (recommended)" })).toBeVisible();
-    await page.getByRole("button", { name: "Client credentials" }).click();
+    await expect(page.getByRole("button", { name: "OAuth authorization" })).toBeVisible();
+    await page.getByRole("button", { name: "Private app credentials" }).click();
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(page.getByLabel("Client ID")).toBeVisible();
     await expect(page.getByLabel("Client secret")).toBeVisible();

--- a/tests/pagerduty-final-qa-p0.spec.ts
+++ b/tests/pagerduty-final-qa-p0.spec.ts
@@ -36,8 +36,8 @@ test("P0 global Add Provider routes PagerDuty through the shared wizard", async 
     await page.getByText("PagerDuty", { exact: true }).click();
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(page.getByRole("heading", { name: "Auth method" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "OAuth (recommended)" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Client credentials" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "OAuth authorization" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Private app credentials" })).toBeVisible();
     await captureScenario(page, testInfo, scenario, signals);
     const receipt = JSON.parse(
         await readFile(
@@ -81,7 +81,7 @@ test("P0 PagerDuty credential page exposes shared-wizard auth methods", async ({
     const signals = collectBrowserSignals(page);
     await page.goto("/org/admin/integrations/pagerduty");
     await expect(page.getByRole("heading", { name: "Auth method" })).toBeVisible();
-    await page.getByRole("button", { name: "Client credentials" }).click();
+    await page.getByRole("button", { name: "Private app credentials" }).click();
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(page.getByLabel("Client ID")).toBeVisible();
     await page.getByRole("button", { name: "Back" }).click();
@@ -196,7 +196,7 @@ test("P0 EU client credentials persist through the shared wizard", async ({
     await resizeForScenario(page, scenario.viewport);
     const signals = collectBrowserSignals(page);
     await page.goto("/org/admin/integrations/pagerduty");
-    await page.getByRole("button", { name: "Client credentials" }).click();
+    await page.getByRole("button", { name: "Private app credentials" }).click();
     await page.getByRole("button", { name: "Continue" }).click();
     await page.getByLabel("Credential Name").fill("EU Operations");
     await page.getByLabel("Account subdomain").fill("eu-operations");

--- a/tests/pagerduty-final-qa-p3.spec.ts
+++ b/tests/pagerduty-final-qa-p3.spec.ts
@@ -82,8 +82,8 @@ test("P3 exposes PagerDuty creation only when the entitlement is explicitly true
 
     await page.goto("/org/admin/integrations/pagerduty");
     await expect(page.getByRole("heading", { name: "Auth method" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "OAuth (recommended)" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Client credentials" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "OAuth authorization" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Private app credentials" })).toBeVisible();
     await waitForCaptureReadiness(page, "desktop");
     await captureArtifact(page, "on-create-path-1280", consoleMessages);
 });


### PR DESCRIPTION
## Summary

- stop preselecting a PagerDuty authentication method
- distinguish browser OAuth authorization from private scoped-app credentials
- keep the API-token path explicit and covered by the CTA registry/tests
- explain at the sync mapping step that incidents ingest without a repository mapping, while repository-scoped metrics and correlations require one

## Verification

- focused PagerDuty mapping component test: 5 passed
- focused mapping Playwright scenario: 2 passed (auth setup plus mapping editor), with local screenshot capture
- focused Prettier and ESLint checks passed
- existing component, typecheck, lint, and PagerDuty Playwright checks passed before publication
- branch CI is running the full Web matrix

## Incident visibility contract

The backend persists PagerDuty incidents in `operational_incidents`; it does not dual-write the deprecated `incidents` table. Repository-scoped analytics join canonical incidents through `operational_service_repository_mappings`. An open or unmapped incident therefore ingests successfully but does not yet produce resolved-incident, MTTR, or repository-correlation output.

## Visual evidence

VISUAL-EVIDENCE-BLOCKER: The updated UI was captured and verified locally, but GitHub user-attachment upload is blocked until the browser session is authorized for the `full-chaos` organization via SAML SSO. This PR remains draft until the screenshot is attached.

## Risk and rollback

- low UI-only selection and explanatory-copy risk
- rollback by reverting `d9c0ec58` and `2d8c950d`

Linear: https://linear.app/fullchaos/issue/CHAOS-3061/pagerduty-setup-and-sync-fail-after-oauth-connection

Ops: https://github.com/full-chaos/dev-health-ops/pull/1268
