### PR TITLE
feat(acr): add device approval surface for self-service MCP login (CHAOS-3096)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "webapp",
     "version": "0.1.0",
     "private": true,
-    "packageManager": "pnpm@11.15.1",
+    "packageManager": "pnpm@11.17.0",
     "engines": {
         "node": ">=22"
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "test:ci": "bash ci/run_tests.sh ci"
     },
     "dependencies": {
-        "@sentry/nextjs": "^10",
+        "@sentry/nextjs": "^10.68.0",
         "@tailwindcss/typography": "^0.5.20",
         "@urql/core": "^6",
         "@urql/next": "^2",
@@ -44,7 +44,7 @@
         "echarts-for-react": "^3.0.6",
         "graphql": "^17",
         "ioredis": "^5.11.1",
-        "next": "^16",
+        "next": "^16.2.11",
         "next-auth": "^5.0.0-beta.32",
         "pino": "^10",
         "pino-pretty": "^13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,16 @@ settings:
 overrides:
   fast-uri: 3.1.4
   sharp: 0.35.3
+  postcss: '>=8.5.18'
+  minimatch@10>brace-expansion: '>=5.0.8'
 
 importers:
 
   .:
     dependencies:
       '@sentry/nextjs':
-        specifier: ^10
-        version: 10.66.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.105.4(lightningcss@1.33.0))
+        specifier: ^10.68.0
+        version: 10.68.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(supports-color@8.1.1)(webpack@5.105.4(lightningcss@1.33.0)(postcss@8.5.20))
       '@tailwindcss/typography':
         specifier: ^0.5.20
         version: 0.5.20(tailwindcss@4.3.3)
@@ -23,7 +25,7 @@ importers:
         version: 6.0.3(graphql@17.0.2)
       '@urql/next':
         specifier: ^2
-        version: 2.0.1(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(urql@5.0.3(@urql/core@6.0.3(graphql@17.0.2))(react@19.2.7))
+        version: 2.0.1(next@16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(urql@5.0.3(@urql/core@6.0.3(graphql@17.0.2))(react@19.2.7))
       ajv:
         specifier: 8.20.0
         version: 8.20.0
@@ -41,13 +43,13 @@ importers:
         version: 17.0.2
       ioredis:
         specifier: ^5.11.1
-        version: 5.11.1
+        version: 5.11.1(supports-color@8.1.1)
       next:
-        specifier: ^16
-        version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^16.2.11
+        version: 16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
         specifier: ^5.0.0-beta.32
-        version: 5.0.0-beta.32(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 5.0.0-beta.32(next@16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       pino:
         specifier: ^10
         version: 10.3.1
@@ -62,10 +64,10 @@ importers:
         version: 19.2.7(react@19.2.7)
       react-markdown:
         specifier: ^10.1.0
-        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       remark-gfm:
         specifier: ^4.0.1
-        version: 4.0.1
+        version: 4.0.1(supports-color@8.1.1)
       server-only:
         specifier: 0.0.1
         version: 0.0.1
@@ -84,7 +86,7 @@ importers:
     devDependencies:
       '@graphql-codegen/cli':
         specifier: ^7.2.0
-        version: 7.2.0(@types/node@26.1.1)(graphql@17.0.2)(typescript@6.0.3)
+        version: 7.2.0(@types/node@26.1.1)(graphql@17.0.2)(supports-color@8.1.1)(typescript@6.0.3)
       '@graphql-codegen/client-preset':
         specifier: ^6.1.0
         version: 6.1.0(graphql@17.0.2)
@@ -96,7 +98,7 @@ importers:
         version: 3.2.0(graphql@17.0.2)
       '@mswjs/http-middleware':
         specifier: ^0.10.3
-        version: 0.10.3(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))
+        version: 0.10.3(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(supports-color@8.1.1)
       '@next/eslint-plugin-next':
         specifier: ^16.2.10
         version: 16.2.10
@@ -129,16 +131,16 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       eslint:
         specifier: ^9
-        version: 9.39.5(jiti@2.7.0)
+        version: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-config-next:
         specifier: ^16
-        version: 16.2.10(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.2.10(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.5(jiti@2.7.0))
+        version: 10.1.8(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       express:
         specifier: ^5.2.1
-        version: 5.2.1
+        version: 5.2.1(supports-color@8.1.1)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -191,8 +193,8 @@ packages:
     resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
     engines: {node: '>= 16'}
 
-  '@apm-js-collab/code-transformer-bundler-plugins@0.6.2':
-    resolution: {integrity: sha512-5vBrtIEL+UVbO0YWWoyYG4QMgR+ZfnIL3xlteIkAmU7YaAPhc28k3md/NM14tnkfXKjKOn9yUzEA9AYUmNpvJg==}
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.1':
+    resolution: {integrity: sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==}
     engines: {node: '>=18.0.0'}
 
   '@apm-js-collab/code-transformer@0.18.0':
@@ -1183,60 +1185,60 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@16.2.10':
-    resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
+  '@next/env@16.2.11':
+    resolution: {integrity: sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==}
 
   '@next/eslint-plugin-next@16.2.10':
     resolution: {integrity: sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==}
 
-  '@next/swc-darwin-arm64@16.2.10':
-    resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
+  '@next/swc-darwin-arm64@16.2.11':
+    resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.10':
-    resolution: {integrity: sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==}
+  '@next/swc-darwin-x64@16.2.11':
+    resolution: {integrity: sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.10':
-    resolution: {integrity: sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==}
+  '@next/swc-linux-arm64-gnu@16.2.11':
+    resolution: {integrity: sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.10':
-    resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
+  '@next/swc-linux-arm64-musl@16.2.11':
+    resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.10':
-    resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
+  '@next/swc-linux-x64-gnu@16.2.11':
+    resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.10':
-    resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
+  '@next/swc-linux-x64-musl@16.2.11':
+    resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.10':
-    resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
+  '@next/swc-win32-arm64-msvc@16.2.11':
+    resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.10':
-    resolution: {integrity: sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==}
+  '@next/swc-win32-x64-msvc@16.2.11':
+    resolution: {integrity: sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1589,12 +1591,12 @@ packages:
     resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
     engines: {node: '>= 18'}
 
-  '@sentry/browser-utils@10.66.0':
-    resolution: {integrity: sha512-sHuALvJMMEilUz84F1ZOQuDoZ3MhjwUHWHkXcElcVMrDIlnTO7Ra0E6Kh0e8JyJaLBMk4Sy9srKSqH9zimQVTQ==}
+  '@sentry/browser-utils@10.68.0':
+    resolution: {integrity: sha512-be8VtdjCngKc77cstJeV+gO15iH+blyXpBDk8yOehmtX4BkFO33mfTMNCWVR2LA0oOxjIHWRAhf77fIUEhzxPg==}
     engines: {node: '>=18'}
 
-  '@sentry/browser@10.66.0':
-    resolution: {integrity: sha512-MaPoBqKvI7O3UhexSJ/KO/o6T4Tr3A+vQWLZYTos0mxd59jVKMKbbJ6LxM/0uWQ5JAO2XYC/kCMRvk6VqQ5QZw==}
+  '@sentry/browser@10.68.0':
+    resolution: {integrity: sha512-8xVgk7oG2lajXnbXF6a7H1xMZ/U6icqSldHGzQu1+bajfrK8Gan9ULG/Xsj1VM1LlNeK6/7znDJ3u1jgvIwznw==}
     engines: {node: '>=18'}
 
   '@sentry/bundler-plugin-core@5.3.0':
@@ -1673,18 +1675,22 @@ packages:
     resolution: {integrity: sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==}
     engines: {node: '>=18'}
 
-  '@sentry/feedback@10.66.0':
-    resolution: {integrity: sha512-fr69K76Gz7RRyfMerChdNjWIeQdFh+k21GJcmPCqk43dscUChOsLc3cYLS5cK7iZ/XiUmH9lVzf7EYL2kf2qsA==}
+  '@sentry/core@10.68.0':
+    resolution: {integrity: sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==}
     engines: {node: '>=18'}
 
-  '@sentry/nextjs@10.66.0':
-    resolution: {integrity: sha512-t+FodSqOWII61kbkgeGkcT6Aii8eDnpQAEmky28w/rBfl715fPN3K/qeGhP2D1Q+DsjdvkJfHDRL1jZBVwFWZQ==}
+  '@sentry/feedback@10.68.0':
+    resolution: {integrity: sha512-XbdcXiBnpC3vgw46eHOPeD/ZQ+XzluP75ubdUcaPDW02hCh2nsdXiwjZ2DBImbpvIpTbJgjHf/sIlHWvcZJ2Mg==}
+    engines: {node: '>=18'}
+
+  '@sentry/nextjs@10.68.0':
+    resolution: {integrity: sha512-oMDl9F8jkCgAsd8U9gLTAWr7u/j9/nUw0sBRHoAvK7HXfdrg9fPlsDd3wsHgYDC0U2tIDTXICXAwT2zJ7OHHWg==}
     engines: {node: '>=18'}
     peerDependencies:
       next: ^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0
 
-  '@sentry/node-core@10.66.0':
-    resolution: {integrity: sha512-SUnXHROqSdSetKgZC1goDEKCuMz3OmQ1h4rxzWeexLyqan+pensZXfLouP6jzZXlA8e/HP7uQg78LnfqYDcZlQ==}
+  '@sentry/node-core@10.68.0':
+    resolution: {integrity: sha512-VreORXnruy8A2SyprZKENAq3ArGwn35KPewLQSQ5dgDXSFtUj2scLuzZoVsZ/Uyt83td0WPvD6Lv0X7MvSYAMQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -1704,38 +1710,38 @@ packages:
       '@opentelemetry/sdk-trace-base':
         optional: true
 
-  '@sentry/node@10.66.0':
-    resolution: {integrity: sha512-5Ow7iQiRjaSaEOmqEIkYV368hFFzShIZCXPoj+wX3JtOmKFrsNu6lr8/VJlQs7cyjFS6tzE50PrLrD8iAPS/8w==}
+  '@sentry/node@10.68.0':
+    resolution: {integrity: sha512-bnvRzEehquG/894DD3BWNCBUbDWsLQfYPU+SNCMd6G4Ext75RthVkRs8R0sRaE6b8Tw9HSEgySHL834Tf8lVsA==}
     engines: {node: '>=18'}
 
-  '@sentry/opentelemetry@10.66.0':
-    resolution: {integrity: sha512-K5Y9IettN9yIOnpqCs40HRLGqaGUoaQ50+ZsLqX2kPCk3TzJVpKZ9icKwaJ4Nxm72QgGVT5Ovfr/9FXbgd3b/Q==}
+  '@sentry/opentelemetry@10.68.0':
+    resolution: {integrity: sha512-JDNH9dacX0MSi7FRvabPCJUAXRMTe16bE/Gajc/7Gfcw7Rwvo4DZ0nd162PCSAW9QoEjUT12upDehEHJuFmsXg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
       '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
 
-  '@sentry/react@10.66.0':
-    resolution: {integrity: sha512-aodV9C2NnaZBqJvaBceIIaVyMVEisO38EWtH5xL7IMbD6QSmBYsuNU7yYzRcdOj/+99FxJYRPaqwzGnIWnNTHw==}
+  '@sentry/react@10.68.0':
+    resolution: {integrity: sha512-rIq4QR4ScMHHx9JJZv7Jgw31bMdUVJMx+ykHIJb7htjY6mj78sjKs+KpCsMDnvJxDhSmvftGM1KfKD4BggL7OQ==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
 
-  '@sentry/replay-canvas@10.66.0':
-    resolution: {integrity: sha512-z7fPWEIfAJMJySKXFIqXAzFpkHjp13WGMAmB9+hlHhi9+gjAO8owD9R4XTd86lBswveGwMHKvIx5lFKNVqDcow==}
+  '@sentry/replay-canvas@10.68.0':
+    resolution: {integrity: sha512-HusYcr+He+ohnUDHunYrc5St6vdDnBXpUAndnT5ReyUMVSCiWKfY3paXowU/0787HwYfxdcpZgwC5u79+XbEIg==}
     engines: {node: '>=18'}
 
-  '@sentry/replay@10.66.0':
-    resolution: {integrity: sha512-Djb4FxQa9bF8z3PoCO00Nw1u+6hma2YuI8JkMoE+F14KWRfCZKQ28sScsvk+OokbXgjtuIsxDEZj/qFGY0w01w==}
+  '@sentry/replay@10.68.0':
+    resolution: {integrity: sha512-ZoG2n16vbkx4GWSCnLIqUUN9xlUmccQFbQ2US2rhruQeHTUnHl/ukr8NHOQXZaEbwKyMkX9bEMwfmZHJm+wSTQ==}
     engines: {node: '>=18'}
 
-  '@sentry/server-utils@10.66.0':
-    resolution: {integrity: sha512-h9EM9Wz9Mc6w2Vn7Fyh6ozjy4JC2UbUvWf9Ra1HYA4KMeYqjFA5/o0oB4pg4w/TF+rb+9OF/HNqxjuczxpudpA==}
+  '@sentry/server-utils@10.68.0':
+    resolution: {integrity: sha512-lp1ZSs1auw7HrCESSYt/n4dOUaKPVUIAKyVYRk6xVr4bMIN3RPub/H5Wm7QPj9CpXVC5bQFvB6+dHZXz809oMg==}
     engines: {node: '>=18'}
 
-  '@sentry/vercel-edge@10.66.0':
-    resolution: {integrity: sha512-uNctdCoSDFgbm7Cg+8tMOBIRT1R5Xt6oU3J0WyJkD1DDmJ/8SDlLNdAbckZwPr96KFFF4MavuP2Uf7zXxratfQ==}
+  '@sentry/vercel-edge@10.68.0':
+    resolution: {integrity: sha512-6FukkfH1b3T7jMgPVE7todrKcC92zA0gwUA3kyTG645eOdfMTIQ9o5lr5UECixALmzTB0GAgrr2gH9xlR0R9bA==}
     engines: {node: '>=18'}
 
   '@sentry/webpack-plugin@5.4.0':
@@ -2457,9 +2463,9 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4248,8 +4254,8 @@ packages:
       nodemailer:
         optional: true
 
-  next@16.2.10:
-    resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
+  next@16.2.11:
+    resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4475,10 +4481,6 @@ packages:
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.20:
     resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
@@ -5554,7 +5556,7 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.3.0
 
-  '@apm-js-collab/code-transformer-bundler-plugins@0.6.2':
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.1':
     dependencies:
       '@apm-js-collab/code-transformer': 0.18.0
       es-module-lexer: 2.3.1
@@ -5570,10 +5572,10 @@ snapshots:
       semifies: 1.0.0
       source-map: 0.6.1
 
-  '@apm-js-collab/tracing-hooks@0.13.0':
+  '@apm-js-collab/tracing-hooks@0.13.0(supports-color@8.1.1)':
     dependencies:
       '@apm-js-collab/code-transformer': 0.18.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -5621,20 +5623,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5659,19 +5661,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5692,9 +5694,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.29.2': {}
@@ -5709,7 +5711,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -5717,7 +5719,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5870,17 +5872,17 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))':
     dependencies:
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -5893,10 +5895,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.6':
+  '@eslint/eslintrc@3.3.6(supports-color@8.1.1)':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -5926,7 +5928,7 @@ snapshots:
       graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-codegen/cli@7.2.0(@types/node@26.1.1)(graphql@17.0.2)(typescript@6.0.3)':
+  '@graphql-codegen/cli@7.2.0(@types/node@26.1.1)(graphql@17.0.2)(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/template': 7.29.7
@@ -5935,9 +5937,9 @@ snapshots:
       '@graphql-codegen/core': 6.2.0(graphql@17.0.2)
       '@graphql-codegen/plugin-helpers': 7.1.0(graphql@17.0.2)
       '@graphql-tools/apollo-engine-loader': 8.0.34(graphql@17.0.2)
-      '@graphql-tools/code-file-loader': 8.1.36(graphql@17.0.2)
-      '@graphql-tools/git-loader': 8.0.40(graphql@17.0.2)
-      '@graphql-tools/github-loader': 9.1.6(@types/node@26.1.1)(graphql@17.0.2)
+      '@graphql-tools/code-file-loader': 8.1.36(graphql@17.0.2)(supports-color@8.1.1)
+      '@graphql-tools/git-loader': 8.0.40(graphql@17.0.2)(supports-color@8.1.1)
+      '@graphql-tools/github-loader': 9.1.6(@types/node@26.1.1)(graphql@17.0.2)(supports-color@8.1.1)
       '@graphql-tools/graphql-file-loader': 8.1.18(graphql@17.0.2)
       '@graphql-tools/json-file-loader': 8.0.32(graphql@17.0.2)
       '@graphql-tools/load': 8.1.15(graphql@17.0.2)
@@ -6084,9 +6086,9 @@ snapshots:
       graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/code-file-loader@8.1.36(graphql@17.0.2)':
+  '@graphql-tools/code-file-loader@8.1.36(graphql@17.0.2)(supports-color@8.1.1)':
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 8.3.35(graphql@17.0.2)
+      '@graphql-tools/graphql-tag-pluck': 8.3.35(graphql@17.0.2)(supports-color@8.1.1)
       '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       globby: 11.1.0
       graphql: 17.0.2
@@ -6172,9 +6174,9 @@ snapshots:
       graphql: 17.0.2
       tslib: 2.8.1
 
-  '@graphql-tools/git-loader@8.0.40(graphql@17.0.2)':
+  '@graphql-tools/git-loader@8.0.40(graphql@17.0.2)(supports-color@8.1.1)':
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 8.3.35(graphql@17.0.2)
+      '@graphql-tools/graphql-tag-pluck': 8.3.35(graphql@17.0.2)(supports-color@8.1.1)
       '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       graphql: 17.0.2
       is-glob: 4.0.3
@@ -6184,10 +6186,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/github-loader@9.1.6(@types/node@26.1.1)(graphql@17.0.2)':
+  '@graphql-tools/github-loader@9.1.6(@types/node@26.1.1)(graphql@17.0.2)(supports-color@8.1.1)':
     dependencies:
       '@graphql-tools/executor-http': 3.3.0(@types/node@26.1.1)(graphql@17.0.2)
-      '@graphql-tools/graphql-tag-pluck': 8.3.35(graphql@17.0.2)
+      '@graphql-tools/graphql-tag-pluck': 8.3.35(graphql@17.0.2)(supports-color@8.1.1)
       '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
@@ -6207,12 +6209,12 @@ snapshots:
       tslib: 2.8.1
       unixify: 1.0.0
 
-  '@graphql-tools/graphql-tag-pluck@8.3.35(graphql@17.0.2)':
+  '@graphql-tools/graphql-tag-pluck@8.3.35(graphql@17.0.2)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
-      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.7)
-      '@babel/traverse': 7.29.7
+      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
       graphql: 17.0.2
@@ -6581,9 +6583,9 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
-  '@mswjs/http-middleware@0.10.3(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))':
+  '@mswjs/http-middleware@0.10.3(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(supports-color@8.1.1)':
     dependencies:
-      express: 4.22.1
+      express: 4.22.1(supports-color@8.1.1)
       msw: 2.15.0(@types/node@26.1.1)(typescript@6.0.3)
       strict-event-emitter: 0.5.1
     transitivePeerDependencies:
@@ -6605,34 +6607,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@next/env@16.2.10': {}
+  '@next/env@16.2.11': {}
 
   '@next/eslint-plugin-next@16.2.10':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.10':
+  '@next/swc-darwin-arm64@16.2.11':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.10':
+  '@next/swc-darwin-x64@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.10':
+  '@next/swc-linux-arm64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.10':
+  '@next/swc-linux-arm64-musl@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.10':
+  '@next/swc-linux-x64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.10':
+  '@next/swc-linux-x64-musl@16.2.11':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.10':
+  '@next/swc-win32-arm64-msvc@16.2.11':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.10':
+  '@next/swc-win32-x64-msvc@16.2.11':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6671,12 +6673,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.220.0
       import-in-the-middle: 3.3.1
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6866,25 +6868,25 @@ snapshots:
 
   '@sentry/babel-plugin-component-annotate@5.3.0': {}
 
-  '@sentry/browser-utils@10.66.0':
+  '@sentry/browser-utils@10.68.0':
     dependencies:
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.66.0
+      '@sentry/core': 10.68.0
 
-  '@sentry/browser@10.66.0':
+  '@sentry/browser@10.68.0':
     dependencies:
-      '@sentry/browser-utils': 10.66.0
+      '@sentry/browser-utils': 10.68.0
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.66.0
-      '@sentry/feedback': 10.66.0
-      '@sentry/replay': 10.66.0
-      '@sentry/replay-canvas': 10.66.0
+      '@sentry/core': 10.68.0
+      '@sentry/feedback': 10.68.0
+      '@sentry/replay': 10.68.0
+      '@sentry/replay-canvas': 10.68.0
 
-  '@sentry/bundler-plugin-core@5.3.0':
+  '@sentry/bundler-plugin-core@5.3.0(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@sentry/babel-plugin-component-annotate': 5.3.0
-      '@sentry/cli': 2.58.6
+      '@sentry/cli': 2.58.6(supports-color@8.1.1)
       dotenv: 16.6.1
       find-up: 5.0.0
       glob: 13.0.6
@@ -6893,10 +6895,10 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/bundler-plugins@10.66.0(rollup@4.62.2)(webpack@5.105.4(lightningcss@1.33.0))':
+  '@sentry/bundler-plugins@10.66.0(rollup@4.62.2)(supports-color@8.1.1)(webpack@5.105.4(lightningcss@1.33.0)(postcss@8.5.20))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@sentry/cli': 2.58.6
+      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@sentry/cli': 2.58.6(supports-color@8.1.1)
       '@sentry/core': 10.66.0
       dotenv: 17.4.2
       find-up: 5.0.0
@@ -6904,7 +6906,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.62.2
-      webpack: 5.105.4(lightningcss@1.33.0)
+      webpack: 5.105.4(lightningcss@1.33.0)(postcss@8.5.20)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6933,9 +6935,9 @@ snapshots:
   '@sentry/cli-win32-x64@2.58.6':
     optional: true
 
-  '@sentry/cli@2.58.6':
+  '@sentry/cli@2.58.6(supports-color@8.1.1)':
     dependencies:
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       node-fetch: 2.7.0
       progress: 2.0.3
       proxy-from-env: 1.1.0
@@ -6959,25 +6961,29 @@ snapshots:
     dependencies:
       '@sentry/conventions': 0.16.0
 
-  '@sentry/feedback@10.66.0':
+  '@sentry/core@10.68.0':
     dependencies:
-      '@sentry/core': 10.66.0
+      '@sentry/conventions': 0.16.0
 
-  '@sentry/nextjs@10.66.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.105.4(lightningcss@1.33.0))':
+  '@sentry/feedback@10.68.0':
+    dependencies:
+      '@sentry/core': 10.68.0
+
+  '@sentry/nextjs@10.68.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(supports-color@8.1.1)(webpack@5.105.4(lightningcss@1.33.0)(postcss@8.5.20))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
-      '@sentry/browser-utils': 10.66.0
-      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/browser-utils': 10.68.0
+      '@sentry/bundler-plugin-core': 5.3.0(supports-color@8.1.1)
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.66.0
-      '@sentry/node': 10.66.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
-      '@sentry/opentelemetry': 10.66.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
-      '@sentry/react': 10.66.0(react@19.2.7)
-      '@sentry/server-utils': 10.66.0
-      '@sentry/vercel-edge': 10.66.0
-      '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.105.4(lightningcss@1.33.0))
-      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@sentry/core': 10.68.0
+      '@sentry/node': 10.68.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)
+      '@sentry/opentelemetry': 10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/react': 10.68.0(react@19.2.7)
+      '@sentry/server-utils': 10.68.0(supports-color@8.1.1)
+      '@sentry/vercel-edge': 10.68.0
+      '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(supports-color@8.1.1)(webpack@5.105.4(lightningcss@1.33.0)(postcss@8.5.20))
+      next: 16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rollup: 4.62.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -6989,78 +6995,78 @@ snapshots:
       - supports-color
       - webpack
 
-  '@sentry/node-core@10.66.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.66.0
-      '@sentry/opentelemetry': 10.66.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/core': 10.68.0
+      '@sentry/opentelemetry': 10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
       import-in-the-middle: 3.3.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
 
-  '@sentry/node@10.66.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node@10.68.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.66.0
-      '@sentry/node-core': 10.66.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
-      '@sentry/opentelemetry': 10.66.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
-      '@sentry/server-utils': 10.66.0
+      '@sentry/core': 10.68.0
+      '@sentry/node-core': 10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.68.0(supports-color@8.1.1)
       import-in-the-middle: 3.3.1
     transitivePeerDependencies:
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/opentelemetry@10.66.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
+  '@sentry/opentelemetry@10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.66.0
+      '@sentry/core': 10.68.0
 
-  '@sentry/react@10.66.0(react@19.2.7)':
+  '@sentry/react@10.68.0(react@19.2.7)':
     dependencies:
-      '@sentry/browser': 10.66.0
+      '@sentry/browser': 10.68.0
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.66.0
+      '@sentry/core': 10.68.0
       react: 19.2.7
 
-  '@sentry/replay-canvas@10.66.0':
+  '@sentry/replay-canvas@10.68.0':
     dependencies:
-      '@sentry/core': 10.66.0
-      '@sentry/replay': 10.66.0
+      '@sentry/core': 10.68.0
+      '@sentry/replay': 10.68.0
 
-  '@sentry/replay@10.66.0':
+  '@sentry/replay@10.68.0':
     dependencies:
-      '@sentry/browser-utils': 10.66.0
-      '@sentry/core': 10.66.0
+      '@sentry/browser-utils': 10.68.0
+      '@sentry/core': 10.68.0
 
-  '@sentry/server-utils@10.66.0':
+  '@sentry/server-utils@10.68.0(supports-color@8.1.1)':
     dependencies:
-      '@apm-js-collab/code-transformer': 0.18.0
-      '@apm-js-collab/code-transformer-bundler-plugins': 0.6.2
-      '@apm-js-collab/tracing-hooks': 0.13.0
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.1
+      '@apm-js-collab/tracing-hooks': 0.13.0(supports-color@8.1.1)
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.66.0
+      '@sentry/core': 10.68.0
+      meriyah: 6.1.4
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/vercel-edge@10.66.0':
+  '@sentry/vercel-edge@10.68.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@sentry/core': 10.66.0
+      '@sentry/core': 10.68.0
 
-  '@sentry/webpack-plugin@5.4.0(rollup@4.62.2)(webpack@5.105.4(lightningcss@1.33.0))':
+  '@sentry/webpack-plugin@5.4.0(rollup@4.62.2)(supports-color@8.1.1)(webpack@5.105.4(lightningcss@1.33.0)(postcss@8.5.20))':
     dependencies:
-      '@sentry/bundler-plugins': 10.66.0(rollup@4.62.2)(webpack@5.105.4(lightningcss@1.33.0))
-      webpack: 5.105.4(lightningcss@1.33.0)
+      '@sentry/bundler-plugins': 10.66.0(rollup@4.62.2)(supports-color@8.1.1)(webpack@5.105.4(lightningcss@1.33.0)(postcss@8.5.20))
+      webpack: 5.105.4(lightningcss@1.33.0)(postcss@8.5.20)
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -7294,15 +7300,15 @@ snapshots:
     dependencies:
       '@types/node': 26.1.1
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.64.0
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -7310,23 +7316,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3
-      eslint: 9.39.5(jiti@2.7.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.64.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.64.0(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.64.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -7340,13 +7346,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
-      debug: 4.4.3
-      eslint: 9.39.5(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -7354,13 +7360,13 @@ snapshots:
 
   '@typescript-eslint/types@8.64.0': {}
 
-  '@typescript-eslint/typescript-estree@8.64.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.64.0(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.64.0(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -7369,13 +7375,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
-      eslint: 9.39.5(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@8.1.1)(typescript@6.0.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -7464,9 +7470,9 @@ snapshots:
     transitivePeerDependencies:
       - graphql
 
-  '@urql/next@2.0.1(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(urql@5.0.3(@urql/core@6.0.3(graphql@17.0.2))(react@19.2.7))':
+  '@urql/next@2.0.1(next@16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(urql@5.0.3(@urql/core@6.0.3(graphql@17.0.2))(react@19.2.7))':
     dependencies:
-      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       urql: 5.0.3(@urql/core@6.0.3(graphql@17.0.2))(react@19.2.7)
 
@@ -7633,9 +7639,9 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7793,11 +7799,11 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  body-parser@1.20.4:
+  body-parser@1.20.4(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -7810,11 +7816,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -7829,7 +7835,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8041,17 +8047,23 @@ snapshots:
 
   debounce@3.0.0: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@3.2.7:
+  debug@3.2.7(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decimal.js@10.6.0: {}
 
@@ -8306,18 +8318,18 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.2.10(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3):
+  eslint-config-next@16.2.10(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.10
-      eslint: 9.39.5(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       globals: 16.4.0
-      typescript-eslint: 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
+      typescript-eslint: 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -8326,56 +8338,56 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
 
-  eslint-import-resolver-node@0.3.10:
+  eslint-import-resolver-node@0.3.10(supports-color@8.1.1):
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       is-core-module: 2.16.2
       resolve: 2.0.0-next.7
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.5(jiti@2.7.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 9.39.5(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       doctrine: 2.1.0
-      eslint: 9.39.5(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-import-resolver-node: 0.3.10(supports-color@8.1.1)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -8387,13 +8399,13 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -8403,7 +8415,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -8412,18 +8424,18 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.1.1(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.29.7
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-react@7.37.5(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -8431,7 +8443,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.4.0
-      eslint: 9.39.5(jiti@2.7.0)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       estraverse: 5.3.0
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
@@ -8461,14 +8473,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.5(jiti@2.7.0):
+  eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@8.1.1)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.6
+      '@eslint/eslintrc': 3.3.6(supports-color@8.1.1)
       '@eslint/js': 9.39.5
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -8478,7 +8490,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -8538,21 +8550,21 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express@4.22.1:
+  express@4.22.1(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.4
+      body-parser: 1.20.4(supports-color@8.1.1)
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2
+      finalhandler: 1.3.2(supports-color@8.1.1)
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -8564,8 +8576,8 @@ snapshots:
       qs: 6.14.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.2
-      serve-static: 1.16.3
+      send: 0.19.2(supports-color@8.1.1)
+      serve-static: 1.16.3(supports-color@8.1.1)
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -8574,20 +8586,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@8.1.1)
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -8598,9 +8610,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.0
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
+      serve-static: 2.2.1(supports-color@8.1.1)
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
@@ -8668,9 +8680,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.3.2:
+  finalhandler@1.3.2(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -8680,9 +8692,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -8872,7 +8884,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hast-util-to-jsx-runtime@2.3.6:
+  hast-util-to-jsx-runtime@2.3.6(supports-color@8.1.1):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.4
@@ -8881,9 +8893,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -8925,10 +8937,10 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8981,11 +8993,11 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ioredis@5.11.1:
+  ioredis@5.11.1(supports-color@8.1.1):
     dependencies:
       '@ioredis/commands': 1.10.0
       cluster-key-slot: 1.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       denque: 2.1.0
       redis-errors: 1.2.0
       redis-parser: 3.0.0
@@ -9490,14 +9502,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -9515,67 +9527,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@8.1.1):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@8.1.1)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-table: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1:
+  mdast-util-mdx-expression@2.0.1(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0:
+  mdast-util-mdx-jsx@3.2.0(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -9583,7 +9595,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -9592,13 +9604,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1:
+  mdast-util-mdxjs-esm@2.0.1(supports-color@8.1.1):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -9827,10 +9839,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@8.1.1):
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -9874,7 +9886,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
@@ -9929,31 +9941,31 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-auth@5.0.0-beta.32(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  next-auth@5.0.0-beta.32(next@16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@auth/core': 0.41.3
-      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
-  next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.11(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 16.2.10
+      '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001806
-      postcss: 8.4.31
+      postcss: 8.5.20
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.10
-      '@next/swc-darwin-x64': 16.2.10
-      '@next/swc-linux-arm64-gnu': 16.2.10
-      '@next/swc-linux-arm64-musl': 16.2.10
-      '@next/swc-linux-x64-gnu': 16.2.10
-      '@next/swc-linux-x64-musl': 16.2.10
-      '@next/swc-win32-arm64-msvc': 16.2.10
-      '@next/swc-win32-x64-msvc': 16.2.10
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.61.1
       sharp: 0.35.3(@types/node@26.1.1)
@@ -10189,12 +10201,6 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.20:
     dependencies:
       nanoid: 3.3.16
@@ -10282,17 +10288,17 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
+  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       '@types/react': 19.2.17
       devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.1
       react: 19.2.7
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-rehype: 11.1.2
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -10335,21 +10341,21 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@8.1.1)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@8.1.1):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -10379,9 +10385,9 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -10467,9 +10473,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -10527,9 +10533,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@0.19.2:
+  send@0.19.2(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -10545,9 +10551,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1:
+  send@1.2.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -10561,21 +10567,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.3:
+  serve-static@1.16.3(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2
+      send: 0.19.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10854,12 +10860,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
+  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
     optionalDependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
 
   supports-color@7.2.0:
     dependencies:
@@ -10887,15 +10893,16 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.1(lightningcss@1.33.0)(webpack@5.105.4(lightningcss@1.33.0)):
+  terser-webpack-plugin@5.6.1(lightningcss@1.33.0)(postcss@8.5.20)(webpack@5.105.4(lightningcss@1.33.0)(postcss@8.5.20)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.105.4(lightningcss@1.33.0)
+      webpack: 5.105.4(lightningcss@1.33.0)(postcss@8.5.20)
     optionalDependencies:
       lightningcss: 1.33.0
+      postcss: 8.5.20
 
   terser@5.49.0:
     dependencies:
@@ -11038,13 +11045,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3):
+  typescript-eslint@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 9.39.5(jiti@2.7.0)
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -11231,7 +11238,7 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
-  webpack@5.105.4(lightningcss@1.33.0):
+  webpack@5.105.4(lightningcss@1.33.0)(postcss@8.5.20):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -11255,7 +11262,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(lightningcss@1.33.0)(webpack@5.105.4(lightningcss@1.33.0))
+      terser-webpack-plugin: 5.6.1(lightningcss@1.33.0)(postcss@8.5.20)(webpack@5.105.4(lightningcss@1.33.0)(postcss@8.5.20))
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,12 @@ allowBuilds:
 overrides:
     fast-uri: 3.1.4
     sharp: 0.35.3
+    # Security floors for advisories reachable only transitively (CHAOS-3096 audit gate).
+    # postcss: next pins 8.4.31 exactly, so GHSA-6g55-p6wh-862q / GHSA-r28c-9q8g-f849
+    # cannot be cleared by upgrading a direct dependency.
+    postcss: ">=8.5.18"
+    # brace-expansion: reached via @sentry/nextjs > @sentry/bundler-plugin-core > glob >
+    # minimatch; 10.68.0 is the newest release in the declared ^10 range (GHSA-mh99-v99m-4gvg).
+    # Scoped to minimatch@10 deliberately: an unscoped floor also hits minimatch@3, whose
+    # v1 brace-expansion API differs, breaking ESLint with "expand is not a function".
+    minimatch@10>brace-expansion: ">=5.0.8"

--- a/scripts/__tests__/package-manager.test.mjs
+++ b/scripts/__tests__/package-manager.test.mjs
@@ -29,6 +29,16 @@ describe("resolvePackageManagerCommand", () => {
         });
     });
 
+    it("accepts a readable extensionless pnpm shim", () => {
+        const entrypoint = temporaryPath("pnpm");
+        writeFileSync(entrypoint, "#!/usr/bin/env node\n");
+
+        expect(resolvePackageManagerCommand({ npmExecPath: entrypoint })).toEqual({
+            command: process.execPath,
+            args: [entrypoint],
+        });
+    });
+
     it("accepts a readable symlink entrypoint", (context) => {
         const target = temporaryPath("pnpm-target.mjs");
         const entrypoint = temporaryPath("pnpm.mjs");
@@ -96,7 +106,7 @@ describe("resolvePackageManagerCommand", () => {
         );
     });
 
-    it.each(["pnpm.txt", "pnpm", "pnpm.mjs/"])(
+    it.each(["pnpm.txt", "pnpm-shim", "pnpm.mjs/"])(
         "rejects a non-JavaScript or directory entrypoint: %s",
         (fileName) => {
             const entrypoint = temporaryPath(fileName);

--- a/scripts/package-manager.mjs
+++ b/scripts/package-manager.mjs
@@ -25,7 +25,8 @@ export function resolvePackageManagerCommand(options = {}) {
     }
 
     const extension = pathApi.extname(npmExecPath).toLowerCase();
-    if (extension !== ".js" && extension !== ".cjs" && extension !== ".mjs") {
+    const isPnpmShim = pathApi.basename(npmExecPath) === "pnpm";
+    if (!isPnpmShim && extension !== ".js" && extension !== ".cjs" && extension !== ".mjs") {
         throw new Error(
             "Package-manager QA requires npm_execpath to reference a JavaScript (.js, .cjs, or .mjs) file.",
         );

--- a/src/app/acr/device/page.tsx
+++ b/src/app/acr/device/page.tsx
@@ -1,0 +1,42 @@
+import { redirect } from "next/navigation";
+
+import { DeviceApprovalForm } from "@/components/acr/DeviceApprovalForm";
+import { DataState } from "@/components/ui/DataState";
+import { auth } from "@/lib/auth";
+import { listAuthorizedRepositories } from "@/lib/acr/service";
+
+export const dynamic = "force-dynamic";
+
+async function repositoryCatalog(orgId: string): Promise<readonly string[] | null> {
+    try {
+        return await listAuthorizedRepositories(orgId);
+    } catch {
+        return null;
+    }
+}
+
+export default async function DeviceApprovalPage() {
+    const session = await auth();
+    if (!session?.access_token || !session.user.id || !session.user.org_id) {
+        redirect("/auth/signin?callbackUrl=%2Facr%2Fdevice");
+    }
+    if (
+        session.user.real_org_id !== undefined &&
+        session.user.real_org_id !== session.user.org_id
+    ) {
+        return <DeviceApprovalForm initialState="denied" repositories={[]} />;
+    }
+    const repositories = await repositoryCatalog(session.user.org_id);
+    if (repositories === null) {
+        return (
+            <main className="min-h-[100dvh] bg-background px-4 py-8 sm:px-6 sm:py-12">
+                <DataState
+                    description="Your repository access could not be loaded. Please return to your terminal and try again."
+                    title="Approval is unavailable"
+                    variant="error"
+                />
+            </main>
+        );
+    }
+    return <DeviceApprovalForm repositories={repositories} />;
+}

--- a/src/app/api/acr/device/route.test.ts
+++ b/src/app/api/acr/device/route.test.ts
@@ -1,15 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { approveDeviceAuthorizationMock, authMock, checkRateLimitMock, getClientIpMock } =
-    vi.hoisted(() => ({
-        approveDeviceAuthorizationMock: vi.fn(),
-        authMock: vi.fn(),
-        checkRateLimitMock: vi.fn(),
-        getClientIpMock: vi.fn(),
-    }));
+const {
+    approveDeviceAuthorizationMock,
+    authMock,
+    checkRateLimitMock,
+    getClientIpMock,
+    previewDeviceAuthorizationMock,
+} = vi.hoisted(() => ({
+    approveDeviceAuthorizationMock: vi.fn(),
+    authMock: vi.fn(),
+    checkRateLimitMock: vi.fn(),
+    getClientIpMock: vi.fn(),
+    previewDeviceAuthorizationMock: vi.fn(),
+}));
 
 vi.mock("@/lib/acr/service", () => ({
     approveDeviceAuthorization: approveDeviceAuthorizationMock,
+    previewDeviceAuthorization: previewDeviceAuthorizationMock,
 }));
 vi.mock("@/lib/auth", () => ({ auth: authMock }));
 vi.mock("@/lib/client-ip", () => ({
@@ -21,14 +28,15 @@ vi.mock("@/lib/rate-limit", () => ({ checkRateLimit: checkRateLimitMock }));
 import { POST } from "./route";
 
 const body = {
+    action: "approve",
     repository_scopes: ["full-chaos/platform"],
     repository_hints: ["full-chaos/platform"],
     user_code: "ABCD2345",
 };
 
-function request(origin = "https://app.example.test"): Request {
+function request(origin = "https://app.example.test", customBody: unknown = body): Request {
     return new Request("https://app.example.test/api/acr/device", {
-        body: JSON.stringify(body),
+        body: JSON.stringify(customBody),
         headers: { "content-type": "application/json", origin },
         method: "POST",
     });
@@ -63,6 +71,35 @@ describe("POST /api/acr/device", () => {
                 userCode: "ABCD2345",
             }),
         );
+    });
+
+    it("Given a preview request, when it is within both limits, then previews", async () => {
+        previewDeviceAuthorizationMock.mockResolvedValue({
+            repositoryHints: ["full-chaos/platform"],
+        });
+
+        const response = await POST(
+            request("https://app.example.test", { action: "preview", user_code: "ABCD2345" }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ repositoryHints: ["full-chaos/platform"] });
+        expect(checkRateLimitMock).toHaveBeenCalledTimes(2);
+        expect(previewDeviceAuthorizationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                userCode: "ABCD2345",
+            }),
+        );
+    });
+
+    it("Given an unsupported action, when posting, then rejects before either approval operation", async () => {
+        const response = await POST(
+            request("https://app.example.test", { action: "grant", user_code: "ABCD2345" }),
+        );
+
+        expect(response.status).toBe(400);
+        expect(approveDeviceAuthorizationMock).not.toHaveBeenCalled();
+        expect(previewDeviceAuthorizationMock).not.toHaveBeenCalled();
     });
 
     it("Given a cross-origin request, when posting, then rejects before approval", async () => {

--- a/src/app/api/acr/device/route.test.ts
+++ b/src/app/api/acr/device/route.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { approveDeviceAuthorizationMock, authMock, checkRateLimitMock, getClientIpMock } =
+    vi.hoisted(() => ({
+        approveDeviceAuthorizationMock: vi.fn(),
+        authMock: vi.fn(),
+        checkRateLimitMock: vi.fn(),
+        getClientIpMock: vi.fn(),
+    }));
+
+vi.mock("@/lib/acr/service", () => ({
+    approveDeviceAuthorization: approveDeviceAuthorizationMock,
+}));
+vi.mock("@/lib/auth", () => ({ auth: authMock }));
+vi.mock("@/lib/client-ip", () => ({
+    getClientIp: getClientIpMock,
+    isTrustProxyEnabled: () => false,
+}));
+vi.mock("@/lib/rate-limit", () => ({ checkRateLimit: checkRateLimitMock }));
+
+import { POST } from "./route";
+
+const body = {
+    repository_scopes: ["full-chaos/platform"],
+    repository_hints: ["full-chaos/platform"],
+    user_code: "ABCD2345",
+};
+
+function request(origin = "https://app.example.test"): Request {
+    return new Request("https://app.example.test/api/acr/device", {
+        body: JSON.stringify(body),
+        headers: { "content-type": "application/json", origin },
+        method: "POST",
+    });
+}
+
+describe("POST /api/acr/device", () => {
+    beforeEach(() => {
+        vi.stubEnv("AUTH_URL", "https://app.example.test");
+        authMock.mockResolvedValue({
+            access_token: "ops-token",
+            user: { id: "user-123", org_id: "org-123" },
+        });
+        checkRateLimitMock.mockResolvedValue({ limited: false, retryAfter: 0 });
+        getClientIpMock.mockReturnValue("127.0.0.1");
+        approveDeviceAuthorizationMock.mockResolvedValue({ status: "approved" });
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.clearAllMocks();
+    });
+
+    it("Given a same-origin authenticated request, when it is within both limits, then approves", async () => {
+        const response = await POST(request());
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ status: "approved" });
+        expect(checkRateLimitMock).toHaveBeenCalledTimes(2);
+        expect(approveDeviceAuthorizationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                repositoryScopes: ["full-chaos/platform"],
+                userCode: "ABCD2345",
+            }),
+        );
+    });
+
+    it("Given a cross-origin request, when posting, then rejects before approval", async () => {
+        const response = await POST(request("https://evil.example.test"));
+
+        expect(response.status).toBe(403);
+        expect(approveDeviceAuthorizationMock).not.toHaveBeenCalled();
+    });
+
+    it("Given a limited user-code attempt, when posting, then rejects before approval", async () => {
+        checkRateLimitMock
+            .mockResolvedValueOnce({ limited: false, retryAfter: 0 })
+            .mockResolvedValueOnce({ limited: true, retryAfter: 60 });
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(429);
+        expect(response.headers.get("retry-after")).toBe("60");
+        expect(approveDeviceAuthorizationMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/api/acr/device/route.ts
+++ b/src/app/api/acr/device/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { createHash } from "node:crypto";
 
-import { approveDeviceAuthorization } from "@/lib/acr/service";
+import { approveDeviceAuthorization, previewDeviceAuthorization } from "@/lib/acr/service";
 import { AcrRuntimeError, safeAcrRuntimeMessage } from "@/lib/acr/errors";
 import { getClientIp, isTrustProxyEnabled } from "@/lib/client-ip";
 import { checkRateLimit } from "@/lib/rate-limit";
@@ -104,10 +104,8 @@ export async function POST(request: Request): Promise<NextResponse> {
     if (general.limited) return limitedResponse(general.retryAfter);
     const body = await parseBody(request);
     const userCode = asUserCode(body?.["user_code"]);
-    const repositoryScopes = asScopeList(body?.["repository_scopes"]);
-    const hintsValue = body?.["repository_hints"];
-    const repositoryHints = hintsValue === undefined ? undefined : asScopeList(hintsValue);
-    if (!userCode || !repositoryScopes || (hintsValue !== undefined && !repositoryHints)) {
+    const action = body?.["action"];
+    if (!userCode || (action !== "preview" && action !== "approve")) {
         return NextResponse.json(
             { error: { code: "invalid_request", message: "Request rejected." } },
             { status: 400 },
@@ -117,8 +115,21 @@ export async function POST(request: Request): Promise<NextResponse> {
     const codeAttempt = await checkRateLimit(`${clientIp}:${codeFingerprint}`, CODE_LIMIT);
     if (codeAttempt.limited) return limitedResponse(codeAttempt.retryAfter);
     try {
+        if (action === "preview") {
+            const preview = await previewDeviceAuthorization({
+                signal: request.signal,
+                userCode,
+            });
+            return NextResponse.json(preview, { headers: { "Cache-Control": "no-store" } });
+        }
+        const repositoryScopes = asScopeList(body?.["repository_scopes"]);
+        if (!repositoryScopes) {
+            return NextResponse.json(
+                { error: { code: "invalid_request", message: "Request rejected." } },
+                { status: 400 },
+            );
+        }
         const approval = await approveDeviceAuthorization({
-            ...(repositoryHints === undefined ? {} : { repositoryHints }),
             repositoryScopes,
             signal: request.signal,
             userCode,

--- a/src/app/api/acr/device/route.ts
+++ b/src/app/api/acr/device/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from "next/server";
+import { createHash } from "node:crypto";
+
+import { approveDeviceAuthorization } from "@/lib/acr/service";
+import { AcrRuntimeError, safeAcrRuntimeMessage } from "@/lib/acr/errors";
+import { getClientIp, isTrustProxyEnabled } from "@/lib/client-ip";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const GENERAL_LIMIT = {
+    failClosed: true,
+    maxRequests: 20,
+    namespace: "acr-device-general",
+    windowMs: 60_000,
+};
+const CODE_LIMIT = {
+    failClosed: true,
+    maxRequests: 5,
+    namespace: "acr-device-code",
+    windowMs: 60_000,
+};
+
+type ApprovalRequest = Readonly<Record<string, unknown>>;
+
+function safeError(error: AcrRuntimeError): NextResponse {
+    return NextResponse.json(
+        {
+            error: {
+                code: error.code,
+                message: safeAcrRuntimeMessage(error.code),
+                retryable: error.retryable,
+            },
+        },
+        { headers: { "Cache-Control": "no-store" }, status: error.status },
+    );
+}
+
+function requestOrigin(request: Request): string | undefined {
+    const origin = request.headers.get("origin");
+    if (origin === null) return undefined;
+    try {
+        return new URL(origin).origin;
+    } catch {
+        return undefined;
+    }
+}
+
+function expectedOrigin(request: Request): string {
+    const configured = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL;
+    if (configured !== undefined) {
+        try {
+            return new URL(configured).origin;
+        } catch {
+            return "";
+        }
+    }
+    return new URL(request.url).origin;
+}
+
+function asScopeList(value: unknown): readonly string[] | undefined {
+    if (!Array.isArray(value) || !value.every((scope) => typeof scope === "string"))
+        return undefined;
+    return value;
+}
+
+function asUserCode(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+async function parseBody(request: Request): Promise<ApprovalRequest | undefined> {
+    try {
+        const value: unknown = await request.json();
+        return typeof value === "object" && value !== null && !Array.isArray(value)
+            ? Object.freeze({ ...value })
+            : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function limitedResponse(retryAfter: number): NextResponse {
+    return NextResponse.json(
+        { error: { code: "rate_limited", message: "Please try again later." } },
+        {
+            headers: { "Cache-Control": "no-store", "Retry-After": String(retryAfter) },
+            status: 429,
+        },
+    );
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+    if (requestOrigin(request) !== expectedOrigin(request)) {
+        return NextResponse.json(
+            { error: { code: "forbidden", message: "Request rejected." } },
+            { status: 403 },
+        );
+    }
+    const clientIp = getClientIp(request, {
+        trustProxy: isTrustProxyEnabled(process.env.TRUST_PROXY),
+    });
+    const general = await checkRateLimit(clientIp, GENERAL_LIMIT);
+    if (general.limited) return limitedResponse(general.retryAfter);
+    const body = await parseBody(request);
+    const userCode = asUserCode(body?.["user_code"]);
+    const repositoryScopes = asScopeList(body?.["repository_scopes"]);
+    const hintsValue = body?.["repository_hints"];
+    const repositoryHints = hintsValue === undefined ? undefined : asScopeList(hintsValue);
+    if (!userCode || !repositoryScopes || (hintsValue !== undefined && !repositoryHints)) {
+        return NextResponse.json(
+            { error: { code: "invalid_request", message: "Request rejected." } },
+            { status: 400 },
+        );
+    }
+    const codeFingerprint = createHash("sha256").update(userCode).digest("hex");
+    const codeAttempt = await checkRateLimit(`${clientIp}:${codeFingerprint}`, CODE_LIMIT);
+    if (codeAttempt.limited) return limitedResponse(codeAttempt.retryAfter);
+    try {
+        const approval = await approveDeviceAuthorization({
+            ...(repositoryHints === undefined ? {} : { repositoryHints }),
+            repositoryScopes,
+            signal: request.signal,
+            userCode,
+        });
+        return NextResponse.json(approval, { headers: { "Cache-Control": "no-store" } });
+    } catch (error) {
+        if (error instanceof AcrRuntimeError) return safeError(error);
+        return NextResponse.json(
+            { error: { code: "unavailable", message: "Approval is temporarily unavailable." } },
+            { headers: { "Cache-Control": "no-store" }, status: 503 },
+        );
+    }
+}

--- a/src/components/acr/DeviceApprovalForm.test.tsx
+++ b/src/components/acr/DeviceApprovalForm.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DeviceApprovalForm } from "./DeviceApprovalForm";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("DeviceApprovalForm", () => {
+    it.each([
+        ["pending", "Approve device access"],
+        ["success", "Approval complete"],
+        ["denied", "Request not approved"],
+        ["expired", "Code expired"],
+    ] as const)("Given a %s state, when rendered, then announces %s", (state, title) => {
+        render(<DeviceApprovalForm initialState={state} repositories={["full-chaos/platform"]} />);
+
+        expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
+    });
+
+    it("Given no selected repository, when confirming, then prevents an unbounded approval request", () => {
+        render(<DeviceApprovalForm repositories={["full-chaos/platform"]} />);
+        fireEvent.change(screen.getByLabelText("Verification code"), {
+            target: { value: "ABCD2345" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+        expect(screen.getByRole("status")).toHaveTextContent("Select at least one repository");
+    });
+});

--- a/src/components/acr/DeviceApprovalForm.test.tsx
+++ b/src/components/acr/DeviceApprovalForm.test.tsx
@@ -8,6 +8,7 @@ afterEach(() => vi.unstubAllGlobals());
 describe("DeviceApprovalForm", () => {
     it.each([
         ["pending", "Approve device access"],
+        ["review", "Review device access"],
         ["success", "Approval complete"],
         ["denied", "Request not approved"],
         ["expired", "Code expired"],
@@ -17,13 +18,70 @@ describe("DeviceApprovalForm", () => {
         expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
     });
 
-    it("Given no selected repository, when confirming, then prevents an unbounded approval request", () => {
+    it("Given an approved preview, when confirming, then sends the bounded selected repositories in a fresh request", async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ repositoryHints: ["full-chaos/platform"] }), {
+                    status: 200,
+                }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ status: "approved" }), { status: 200 }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        render(<DeviceApprovalForm repositories={["full-chaos/platform", "full-chaos/private"]} />);
+        fireEvent.change(screen.getByLabelText("Verification code"), {
+            target: { value: "ABCD2345" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Preview request" }));
+
+        await screen.findByRole("heading", { name: "Review device access" });
+        expect(screen.getByLabelText("full-chaos/platform")).toBeChecked();
+        expect(screen.queryByLabelText("full-chaos/private")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+        await screen.findByRole("heading", { name: "Approval complete" });
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            1,
+            "/api/acr/device",
+            expect.objectContaining({
+                body: JSON.stringify({ action: "preview", user_code: "ABCD2345" }),
+                method: "POST",
+            }),
+        );
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            2,
+            "/api/acr/device",
+            expect.objectContaining({
+                body: JSON.stringify({
+                    action: "approve",
+                    repository_scopes: ["full-chaos/platform"],
+                    user_code: "ABCD2345",
+                }),
+                method: "POST",
+            }),
+        );
+    });
+
+    it("Given a preview with no available repositories, when rendered, then prevents an unbounded approval request", async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ repositoryHints: [] }), { status: 200 }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
         render(<DeviceApprovalForm repositories={["full-chaos/platform"]} />);
         fireEvent.change(screen.getByLabelText("Verification code"), {
             target: { value: "ABCD2345" },
         });
-        fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+        fireEvent.click(screen.getByRole("button", { name: "Preview request" }));
 
-        expect(screen.getByRole("status")).toHaveTextContent("Select at least one repository");
+        await screen.findByText("No authorized repositories match this request.");
+        expect(screen.getByRole("button", { name: "Confirm" })).toBeDisabled();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/components/acr/DeviceApprovalForm.tsx
+++ b/src/components/acr/DeviceApprovalForm.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useId, useState } from "react";
+import { type SyntheticEvent, useId, useState } from "react";
 
 import { Button } from "@/components/shared/Button";
 import { CTA_LABELS } from "@/lib/design/cta";
 
-type ApprovalState = "denied" | "expired" | "pending" | "success";
+type ApprovalState = "denied" | "expired" | "pending" | "review" | "success";
 
 type DeviceApprovalFormProps = {
     readonly initialState?: ApprovalState;
@@ -31,9 +31,13 @@ function stateCopy(state: ApprovalState): { readonly description: string; readon
             };
         case "pending":
             return {
-                description:
-                    "Enter the code from your terminal, then select the repositories to approve.",
+                description: "Enter the code from your terminal to review the request.",
                 title: "Approve device access",
+            };
+        case "review":
+            return {
+                description: "Select the repositories to approve for this device.",
+                title: "Review device access",
             };
         case "success":
             return {
@@ -59,8 +63,10 @@ export function DeviceApprovalForm({
     const [state, setState] = useState<ApprovalState>(initialState);
     const [message, setMessage] = useState<string | null>(null);
     const [submitting, setSubmitting] = useState(false);
+    const [hints, setHints] = useState<readonly string[]>([]);
     const descriptionId = useId();
     const stateMessage = stateCopy(state);
+    const availableRepositories = repositories.filter((repository) => hints.includes(repository));
 
     function toggleRepository(repository: string): void {
         setSelected((current) =>
@@ -70,7 +76,40 @@ export function DeviceApprovalForm({
         );
     }
 
-    async function submit(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+    async function submitPreview(event: SyntheticEvent<HTMLFormElement>): Promise<void> {
+        event.preventDefault();
+        setSubmitting(true);
+        setMessage(null);
+        try {
+            const response = await fetch("/api/acr/device", {
+                body: JSON.stringify({ action: "preview", user_code: code }),
+                headers: { "Content-Type": "application/json" },
+                method: "POST",
+            });
+            const result = await response.json();
+            if (response.ok && result.repositoryHints) {
+                setHints(result.repositoryHints);
+                const available = repositories.filter((repo) =>
+                    result.repositoryHints.includes(repo),
+                );
+                setSelected(available);
+                setState("review");
+                return;
+            }
+            setState(errorState(response));
+            setMessage(
+                response.status === 429
+                    ? "Too many attempts. Please wait before trying again."
+                    : "We could not preview this request.",
+            );
+        } catch {
+            setMessage("We could not reach the approval service. Please try again.");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    async function submitApprove(event: SyntheticEvent<HTMLFormElement>): Promise<void> {
         event.preventDefault();
         if (selected.length === 0) {
             setMessage("Select at least one repository to continue.");
@@ -80,7 +119,11 @@ export function DeviceApprovalForm({
         setMessage(null);
         try {
             const response = await fetch("/api/acr/device", {
-                body: JSON.stringify({ repository_scopes: selected, user_code: code }),
+                body: JSON.stringify({
+                    action: "approve",
+                    repository_scopes: selected,
+                    user_code: code,
+                }),
                 headers: { "Content-Type": "application/json" },
                 method: "POST",
             });
@@ -115,7 +158,7 @@ export function DeviceApprovalForm({
                 </div>
                 {state === "pending" ? (
                     <form
-                        onSubmit={submit}
+                        onSubmit={submitPreview}
                         className="mt-6 space-y-6"
                         aria-describedby={descriptionId}
                     >
@@ -137,13 +180,28 @@ export function DeviceApprovalForm({
                                 value={code}
                             />
                         </div>
+                        <Button
+                            disabled={submitting || code.length !== 8}
+                            type="submit"
+                            variant="primary"
+                        >
+                            {submitting ? "Loading…" : "Preview request"}
+                        </Button>
+                    </form>
+                ) : null}
+                {state === "review" ? (
+                    <form
+                        onSubmit={submitApprove}
+                        className="mt-6 space-y-6"
+                        aria-describedby={descriptionId}
+                    >
                         <fieldset>
                             <legend className="text-h3 font-medium">Repositories to approve</legend>
                             <p className="mt-1 text-sm text-(--ink-muted)">
                                 Only repositories you are authorized to access are available.
                             </p>
                             <div className="mt-3 divide-y divide-(--card-stroke) rounded-(--radius-md) border border-(--card-stroke)">
-                                {repositories.map((repository) => (
+                                {availableRepositories.map((repository) => (
                                     <label
                                         key={repository}
                                         className="flex cursor-pointer items-center gap-3 px-4 py-3 text-body hover:bg-(--card-80)"
@@ -156,15 +214,30 @@ export function DeviceApprovalForm({
                                         <span>{repository}</span>
                                     </label>
                                 ))}
+                                {availableRepositories.length === 0 && (
+                                    <div className="px-4 py-3 text-body text-(--ink-muted)">
+                                        No authorized repositories match this request.
+                                    </div>
+                                )}
                             </div>
                         </fieldset>
-                        <Button
-                            disabled={submitting || code.length !== 8}
-                            type="submit"
-                            variant="primary"
-                        >
-                            {submitting ? "Approving…" : CTA_LABELS.confirm}
-                        </Button>
+                        <div className="flex gap-3">
+                            <Button
+                                disabled={submitting}
+                                onClick={() => setState("pending")}
+                                type="button"
+                                variant="secondary"
+                            >
+                                {CTA_LABELS.backButton}
+                            </Button>
+                            <Button
+                                disabled={submitting || selected.length === 0}
+                                type="submit"
+                                variant="primary"
+                            >
+                                {submitting ? "Approving…" : CTA_LABELS.confirm}
+                            </Button>
+                        </div>
                     </form>
                 ) : null}
             </section>

--- a/src/components/acr/DeviceApprovalForm.tsx
+++ b/src/components/acr/DeviceApprovalForm.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useId, useState } from "react";
+
+import { Button } from "@/components/shared/Button";
+import { CTA_LABELS } from "@/lib/design/cta";
+
+type ApprovalState = "denied" | "expired" | "pending" | "success";
+
+type DeviceApprovalFormProps = {
+    readonly initialState?: ApprovalState;
+    readonly repositories: readonly string[];
+};
+
+type ApprovalResponse = {
+    readonly status?: "approved";
+};
+
+function stateCopy(state: ApprovalState): { readonly description: string; readonly title: string } {
+    switch (state) {
+        case "denied":
+            return {
+                description:
+                    "This request was not approved. Return to your terminal to start again.",
+                title: "Request not approved",
+            };
+        case "expired":
+            return {
+                description: "This code has expired. Return to your terminal to request a new one.",
+                title: "Code expired",
+            };
+        case "pending":
+            return {
+                description:
+                    "Enter the code from your terminal, then select the repositories to approve.",
+                title: "Approve device access",
+            };
+        case "success":
+            return {
+                description:
+                    "Your selected repositories are approved. Return to your terminal to finish sign-in.",
+                title: "Approval complete",
+            };
+    }
+}
+
+function errorState(response: Response): ApprovalState {
+    if (response.status === 410) return "expired";
+    if (response.status === 403 || response.status === 409) return "denied";
+    return "pending";
+}
+
+export function DeviceApprovalForm({
+    initialState = "pending",
+    repositories,
+}: DeviceApprovalFormProps) {
+    const [code, setCode] = useState("");
+    const [selected, setSelected] = useState<readonly string[]>([]);
+    const [state, setState] = useState<ApprovalState>(initialState);
+    const [message, setMessage] = useState<string | null>(null);
+    const [submitting, setSubmitting] = useState(false);
+    const descriptionId = useId();
+    const stateMessage = stateCopy(state);
+
+    function toggleRepository(repository: string): void {
+        setSelected((current) =>
+            current.includes(repository)
+                ? current.filter((selectedRepository) => selectedRepository !== repository)
+                : [...current, repository].sort((left, right) => left.localeCompare(right)),
+        );
+    }
+
+    async function submit(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+        event.preventDefault();
+        if (selected.length === 0) {
+            setMessage("Select at least one repository to continue.");
+            return;
+        }
+        setSubmitting(true);
+        setMessage(null);
+        try {
+            const response = await fetch("/api/acr/device", {
+                body: JSON.stringify({ repository_scopes: selected, user_code: code }),
+                headers: { "Content-Type": "application/json" },
+                method: "POST",
+            });
+            const result: ApprovalResponse = await response.json();
+            if (response.ok && result.status === "approved") {
+                setState("success");
+                return;
+            }
+            setState(errorState(response));
+            setMessage(
+                response.status === 429
+                    ? "Too many attempts. Please wait before trying again."
+                    : "We could not approve this request.",
+            );
+        } catch {
+            setMessage("We could not reach the approval service. Please try again.");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <main className="min-h-[100dvh] bg-background px-4 py-8 text-foreground sm:px-6 sm:py-12">
+            <section className="mx-auto w-full max-w-2xl rounded-(--radius-lg) border border-(--card-stroke) bg-(--card-90) p-6 shadow-(--elevation-card) sm:p-8">
+                <p className="text-label-caps text-(--ink-muted)">Device approval</p>
+                <h1 className="mt-2 text-h1 font-semibold">{stateMessage.title}</h1>
+                <p id={descriptionId} className="mt-2 text-body text-(--ink-muted)">
+                    {stateMessage.description}
+                </p>
+                <div role="status" aria-live="polite" className="mt-4 text-sm text-(--ink-muted)">
+                    {message}
+                </div>
+                {state === "pending" ? (
+                    <form
+                        onSubmit={submit}
+                        className="mt-6 space-y-6"
+                        aria-describedby={descriptionId}
+                    >
+                        <div>
+                            <label htmlFor="device-code" className="text-h3 font-medium">
+                                Verification code
+                            </label>
+                            <input
+                                id="device-code"
+                                autoCapitalize="characters"
+                                autoComplete="one-time-code"
+                                className="mt-2 w-full rounded-(--radius-md) border border-(--card-stroke) bg-background px-4 py-3 font-mono tracking-[0.16em] uppercase outline-none focus-visible:ring-2 focus-visible:ring-(--accent)"
+                                maxLength={8}
+                                onChange={(event) =>
+                                    setCode(event.target.value.trim().toUpperCase())
+                                }
+                                pattern="[ABCDEFGHJKMNPQRSTVWXYZ23456789]{8}"
+                                required
+                                value={code}
+                            />
+                        </div>
+                        <fieldset>
+                            <legend className="text-h3 font-medium">Repositories to approve</legend>
+                            <p className="mt-1 text-sm text-(--ink-muted)">
+                                Only repositories you are authorized to access are available.
+                            </p>
+                            <div className="mt-3 divide-y divide-(--card-stroke) rounded-(--radius-md) border border-(--card-stroke)">
+                                {repositories.map((repository) => (
+                                    <label
+                                        key={repository}
+                                        className="flex cursor-pointer items-center gap-3 px-4 py-3 text-body hover:bg-(--card-80)"
+                                    >
+                                        <input
+                                            checked={selected.includes(repository)}
+                                            onChange={() => toggleRepository(repository)}
+                                            type="checkbox"
+                                        />
+                                        <span>{repository}</span>
+                                    </label>
+                                ))}
+                            </div>
+                        </fieldset>
+                        <Button
+                            disabled={submitting || code.length !== 8}
+                            type="submit"
+                            variant="primary"
+                        >
+                            {submitting ? "Approving…" : CTA_LABELS.confirm}
+                        </Button>
+                    </form>
+                ) : null}
+            </section>
+        </main>
+    );
+}

--- a/src/lib/__tests__/proxy.test.ts
+++ b/src/lib/__tests__/proxy.test.ts
@@ -256,6 +256,14 @@ describe("proxy rate limiting", () => {
         expect(res.headers.get("x-middleware-rewrite")).toBeNull();
     });
 
+    it("keeps device-approval BFF routes local instead of rewriting them to the backend", async () => {
+        mockAuth.mockResolvedValue(session);
+
+        const res = await proxy(makeRequest("/api/acr/device"));
+
+        expect(res.headers.get("x-middleware-rewrite")).toBeNull();
+    });
+
     it("bypasses proxy limiter in non-production test mode", async () => {
         vi.stubEnv("DEV_HEALTH_TEST_MODE", "true");
         vi.stubEnv("NODE_ENV", "test");

--- a/src/lib/acr/__tests__/device-approval.test.ts
+++ b/src/lib/acr/__tests__/device-approval.test.ts
@@ -9,7 +9,7 @@ import { setupServer } from "msw/node";
 vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
 
 import { auth } from "@/lib/auth";
-import { approveDeviceAuthorization } from "../service";
+import { approveDeviceAuthorization, previewDeviceAuthorization } from "../service";
 
 const server = setupServer();
 const temporaryPaths: string[] = [];
@@ -92,7 +92,7 @@ afterEach(() => {
 });
 
 describe("approveDeviceAuthorization", () => {
-    it("Given canonical hint intersection, when approving, then sends only the bounded grant with a body-bound credential assertion", async () => {
+    it("Given an explicit selected repository, when approving, then sends only the bounded grant with a body-bound credential assertion", async () => {
         installOpsAuthorization();
         server.use(
             http.post(
@@ -127,11 +127,79 @@ describe("approveDeviceAuthorization", () => {
         await expect(
             approveDeviceAuthorization({
                 repositoryScopes: ["full-chaos/platform"],
-                repositoryHints: ["full-chaos/platform"],
                 signal: new AbortController().signal,
                 userCode: "ABCD2345",
             }),
         ).resolves.toEqual({ status: "approved" });
+    });
+
+    it("Given a preview followed by approval, when using the same POST endpoint, then issues fresh body-bound credential assertions", async () => {
+        installOpsAuthorization();
+        const assertions: string[] = [];
+        server.use(
+            http.post(
+                "https://acr.example.test/api/v1/oauth/device_approval",
+                async ({ request }) => {
+                    const body = await request.text();
+                    expect(request.headers.get("authorization")).toBeNull();
+                    expect(new URL(request.url).search).toBe("");
+                    const assertion = request.headers.get("x-acr-web-assertion");
+                    expect(assertion).not.toBeNull();
+                    if (!assertion) return HttpResponse.json({}, { status: 401 });
+                    assertions.push(assertion);
+                    const requestBody = JSON.parse(body) as { readonly schema_version: string };
+                    if (requestBody.schema_version === "device_approval_preview_request.v1") {
+                        expect(requestBody).toEqual({
+                            schema_version: "device_approval_preview_request.v1",
+                            user_code: "ABCD2345",
+                        });
+                        expect(decodeAssertion(assertion)).toMatchObject({
+                            body_sha256: createHash("sha256").update(body).digest("base64url"),
+                            method: "POST",
+                            path: "/api/v1/oauth/device_approval",
+                            permissions: ["credential:issue"],
+                            repository_scopes: ["full-chaos/dev-health-acr", "full-chaos/platform"],
+                        });
+                        return HttpResponse.json({
+                            schema_version: "device_approval_preview_response.v1",
+                            repository_hints: ["full-chaos/platform"],
+                        });
+                    }
+                    expect(requestBody).toEqual({
+                        repository_scopes: ["full-chaos/platform"],
+                        schema_version: "device_approval_request.v1",
+                        user_code: "ABCD2345",
+                    });
+                    expect(decodeAssertion(assertion)).toMatchObject({
+                        body_sha256: createHash("sha256").update(body).digest("base64url"),
+                        method: "POST",
+                        path: "/api/v1/oauth/device_approval",
+                        permissions: ["credential:issue"],
+                        repository_scopes: ["full-chaos/platform"],
+                    });
+                    return HttpResponse.json({
+                        schema_version: "device_approval_response.v1",
+                        status: "approved",
+                    });
+                },
+            ),
+        );
+
+        await expect(
+            previewDeviceAuthorization({
+                signal: new AbortController().signal,
+                userCode: "ABCD2345",
+            }),
+        ).resolves.toEqual({ repositoryHints: ["full-chaos/platform"] });
+        await expect(
+            approveDeviceAuthorization({
+                repositoryScopes: ["full-chaos/platform"],
+                signal: new AbortController().signal,
+                userCode: "ABCD2345",
+            }),
+        ).resolves.toEqual({ status: "approved" });
+        expect(assertions).toHaveLength(2);
+        expect(assertions[0]).not.toBe(assertions[1]);
     });
 
     it.each([
@@ -156,7 +224,6 @@ describe("approveDeviceAuthorization", () => {
             await expect(
                 approveDeviceAuthorization({
                     repositoryScopes,
-                    repositoryHints: ["full-chaos/platform"],
                     signal: new AbortController().signal,
                     userCode: "ABCD2345",
                 }),
@@ -185,7 +252,6 @@ describe("approveDeviceAuthorization", () => {
         await expect(
             approveDeviceAuthorization({
                 repositoryScopes: ["full-chaos/platform"],
-                repositoryHints: ["full-chaos/platform"],
                 signal: new AbortController().signal,
                 userCode: "ABCD2345",
             }),

--- a/src/lib/acr/__tests__/device-approval.test.ts
+++ b/src/lib/acr/__tests__/device-approval.test.ts
@@ -161,6 +161,7 @@ describe("approveDeviceAuthorization", () => {
                             repository_scopes: ["full-chaos/dev-health-acr", "full-chaos/platform"],
                         });
                         return HttpResponse.json({
+                            organization_id_hint: "org_fullchaos",
                             schema_version: "device_approval_preview_response.v1",
                             repository_hints: ["full-chaos/platform"],
                         });
@@ -190,7 +191,10 @@ describe("approveDeviceAuthorization", () => {
                 signal: new AbortController().signal,
                 userCode: "ABCD2345",
             }),
-        ).resolves.toEqual({ repositoryHints: ["full-chaos/platform"] });
+        ).resolves.toEqual({
+            organizationIdHint: "org_fullchaos",
+            repositoryHints: ["full-chaos/platform"],
+        });
         await expect(
             approveDeviceAuthorization({
                 repositoryScopes: ["full-chaos/platform"],
@@ -201,6 +205,34 @@ describe("approveDeviceAuthorization", () => {
         expect(assertions).toHaveLength(2);
         expect(assertions[0]).not.toBe(assertions[1]);
     });
+
+    it.each([
+        ["a null hint", null],
+        ["an empty hint", ""],
+        ["an oversized hint", "o".repeat(129)],
+        ["a non-string hint", 42],
+    ])(
+        "Given %s, when previewing, then rejects the malformed response",
+        async (_name, organizationIdHint) => {
+            installOpsAuthorization();
+            server.use(
+                http.post("https://acr.example.test/api/v1/oauth/device_approval", () =>
+                    HttpResponse.json({
+                        organization_id_hint: organizationIdHint,
+                        repository_hints: ["full-chaos/platform"],
+                        schema_version: "device_approval_preview_response.v1",
+                    }),
+                ),
+            );
+
+            await expect(
+                previewDeviceAuthorization({
+                    signal: new AbortController().signal,
+                    userCode: "ABCD2345",
+                }),
+            ).rejects.toMatchObject({ code: "malformed_response" });
+        },
+    );
 
     it.each([
         ["an empty selection", []],

--- a/src/lib/acr/__tests__/device-approval.test.ts
+++ b/src/lib/acr/__tests__/device-approval.test.ts
@@ -1,0 +1,218 @@
+import { createHash, generateKeyPairSync, verify } from "node:crypto";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+
+import { auth } from "@/lib/auth";
+import { approveDeviceAuthorization } from "../service";
+
+const server = setupServer();
+const temporaryPaths: string[] = [];
+let publicKey = generateKeyPairSync("ed25519").publicKey;
+
+function writeSigningKey(): string {
+    const pair = generateKeyPairSync("ed25519");
+    publicKey = pair.publicKey;
+    const directory = mkdtempSync(join(tmpdir(), "acr-device-approval-"));
+    temporaryPaths.push(directory);
+    const keyFile = join(directory, "web-assertion.key");
+    writeFileSync(keyFile, pair.privateKey.export({ format: "pem", type: "pkcs8" }));
+    chmodSync(keyFile, 0o600);
+    return keyFile;
+}
+
+function configure(): void {
+    vi.stubEnv("ACR_API_ORIGIN", "https://acr.example.test");
+    vi.stubEnv("ACR_REQUEST_TIMEOUT_MS", "5000");
+    vi.stubEnv("ACR_WEB_ASSERTION_AUDIENCE", "dev-health-acr");
+    vi.stubEnv("ACR_WEB_ASSERTION_ISSUER", "dev-health-web");
+    vi.stubEnv("ACR_WEB_ASSERTION_KEY_FILE", writeSigningKey());
+    vi.stubEnv("ACR_WEB_ASSERTION_KID", "web-key-2026");
+    vi.stubEnv("BACKEND_URL", "http://ops.example.test");
+}
+
+function authenticate(overrides: Record<string, unknown> = {}): void {
+    vi.mocked(auth).mockResolvedValue({
+        access_token: "ops-session-token",
+        expires: "2026-07-16T00:00:00.000Z",
+        user: { id: "user-123", org_id: "org-123", real_org_id: "org-123", ...overrides },
+    });
+}
+
+function installOpsAuthorization(
+    scopes = ["full-chaos/dev-health-acr", "full-chaos/platform"],
+): void {
+    server.use(
+        http.get("http://ops.example.test/api/v1/licensing/entitlements/:orgId", () =>
+            HttpResponse.json({ features: { agent_context_runtime: true }, is_valid: true }),
+        ),
+        http.post("http://ops.example.test/graphql", () =>
+            HttpResponse.json({
+                data: { catalog: { values: scopes.map((value) => ({ count: 1, value })) } },
+            }),
+        ),
+    );
+}
+
+function decodeAssertion(value: string): Record<string, unknown> {
+    const [header, payload, signature] = value.split(".");
+    if (!header || !payload || !signature) throw new Error("malformed assertion");
+    expect(
+        verify(
+            null,
+            Buffer.from(`${header}.${payload}`),
+            publicKey,
+            Buffer.from(signature, "base64url"),
+        ),
+    ).toBe(true);
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<
+        string,
+        unknown
+    >;
+}
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+beforeEach(() => {
+    configure();
+    authenticate();
+});
+afterEach(() => {
+    server.resetHandlers();
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+    for (const temporaryPath of temporaryPaths.splice(0)) {
+        rmSync(temporaryPath, { force: true, recursive: true });
+    }
+});
+
+describe("approveDeviceAuthorization", () => {
+    it("Given canonical hint intersection, when approving, then sends only the bounded grant with a body-bound credential assertion", async () => {
+        installOpsAuthorization();
+        server.use(
+            http.post(
+                "https://acr.example.test/api/v1/oauth/device_approval",
+                async ({ request }) => {
+                    const body = await request.text();
+                    expect(request.headers.get("authorization")).toBeNull();
+                    expect(new URL(request.url).search).toBe("");
+                    expect(JSON.parse(body)).toEqual({
+                        repository_scopes: ["full-chaos/platform"],
+                        schema_version: "device_approval_request.v1",
+                        user_code: "ABCD2345",
+                    });
+                    const assertion = request.headers.get("x-acr-web-assertion");
+                    expect(assertion).not.toBeNull();
+                    if (!assertion) return HttpResponse.json({}, { status: 401 });
+                    expect(decodeAssertion(assertion)).toMatchObject({
+                        body_sha256: createHash("sha256").update(body).digest("base64url"),
+                        method: "POST",
+                        path: "/api/v1/oauth/device_approval",
+                        permissions: ["credential:issue"],
+                        repository_scopes: ["full-chaos/platform"],
+                    });
+                    return HttpResponse.json({
+                        schema_version: "device_approval_response.v1",
+                        status: "approved",
+                    });
+                },
+            ),
+        );
+
+        await expect(
+            approveDeviceAuthorization({
+                repositoryScopes: ["full-chaos/platform"],
+                repositoryHints: ["full-chaos/platform"],
+                signal: new AbortController().signal,
+                userCode: "ABCD2345",
+            }),
+        ).resolves.toEqual({ status: "approved" });
+    });
+
+    it.each([
+        ["an empty selection", []],
+        ["a foreign selection", ["foreign/repository"]],
+        ["a wildcard selection", ["full-chaos/*"]],
+    ])(
+        "Given %s, when approving, then fails before the ACR call",
+        async (_name, repositoryScopes) => {
+            installOpsAuthorization();
+            let approvals = 0;
+            server.use(
+                http.post("https://acr.example.test/api/v1/oauth/device_approval", () => {
+                    approvals += 1;
+                    return HttpResponse.json({
+                        schema_version: "device_approval_response.v1",
+                        status: "approved",
+                    });
+                }),
+            );
+
+            await expect(
+                approveDeviceAuthorization({
+                    repositoryScopes,
+                    repositoryHints: ["full-chaos/platform"],
+                    signal: new AbortController().signal,
+                    userCode: "ABCD2345",
+                }),
+            ).rejects.toMatchObject({ status: 400 });
+            expect(approvals).toBe(0);
+        },
+    );
+
+    it("Given impersonation, when approving, then rejects before entitlement resolution", async () => {
+        authenticate({
+            is_impersonating: true,
+            org_id: "org-impersonated",
+            real_org_id: "org-123",
+        });
+        let entitlementRequests = 0;
+        server.use(
+            http.get("http://ops.example.test/api/v1/licensing/entitlements/:orgId", () => {
+                entitlementRequests += 1;
+                return HttpResponse.json({
+                    features: { agent_context_runtime: true },
+                    is_valid: true,
+                });
+            }),
+        );
+
+        await expect(
+            approveDeviceAuthorization({
+                repositoryScopes: ["full-chaos/platform"],
+                repositoryHints: ["full-chaos/platform"],
+                signal: new AbortController().signal,
+                userCode: "ABCD2345",
+            }),
+        ).rejects.toMatchObject({ status: 403 });
+        expect(entitlementRequests).toBe(0);
+    });
+
+    it("Given no session, when approving, then rejects before entitlement resolution", async () => {
+        vi.mocked(auth).mockResolvedValue(null);
+        let entitlementRequests = 0;
+        server.use(
+            http.get("http://ops.example.test/api/v1/licensing/entitlements/:orgId", () => {
+                entitlementRequests += 1;
+                return HttpResponse.json({
+                    features: { agent_context_runtime: true },
+                    is_valid: true,
+                });
+            }),
+        );
+
+        await expect(
+            approveDeviceAuthorization({
+                repositoryScopes: ["full-chaos/platform"],
+                signal: new AbortController().signal,
+                userCode: "ABCD2345",
+            }),
+        ).rejects.toMatchObject({ status: 401 });
+        expect(entitlementRequests).toBe(0);
+    });
+});

--- a/src/lib/acr/__tests__/device-approval.test.ts
+++ b/src/lib/acr/__tests__/device-approval.test.ts
@@ -235,6 +235,48 @@ describe("approveDeviceAuthorization", () => {
     );
 
     it.each([
+        [
+            "a different schema version",
+            {
+                repository_hints: ["full-chaos/platform"],
+                schema_version: "device_approval_preview_response.v2",
+            },
+        ],
+        [
+            "a non-array repository hint value",
+            {
+                repository_hints: "full-chaos/platform",
+                schema_version: "device_approval_preview_response.v1",
+            },
+        ],
+        [
+            "an unexpected field",
+            {
+                repository_hints: ["full-chaos/platform"],
+                schema_version: "device_approval_preview_response.v1",
+                unbounded_scope: true,
+            },
+        ],
+    ])(
+        "Given %s, when previewing, then rejects the malformed response contract",
+        async (_name, response) => {
+            installOpsAuthorization();
+            server.use(
+                http.post("https://acr.example.test/api/v1/oauth/device_approval", () =>
+                    HttpResponse.json(response),
+                ),
+            );
+
+            await expect(
+                previewDeviceAuthorization({
+                    signal: new AbortController().signal,
+                    userCode: "ABCD2345",
+                }),
+            ).rejects.toMatchObject({ code: "malformed_response" });
+        },
+    );
+
+    it.each([
         ["an empty selection", []],
         ["a foreign selection", ["foreign/repository"]],
         ["a wildcard selection", ["full-chaos/*"]],

--- a/src/lib/acr/assertion.ts
+++ b/src/lib/acr/assertion.ts
@@ -4,7 +4,7 @@ import { createHash, randomUUID, sign, type KeyObject } from "node:crypto";
 
 import type { AcrRuntimeConfig } from "./config";
 
-type AssertionPermission = "context:read" | "evidence:read";
+type AssertionPermission = "context:read" | "credential:issue" | "evidence:read";
 
 type WebAssertionInput = {
     readonly body: string;

--- a/src/lib/acr/client.ts
+++ b/src/lib/acr/client.ts
@@ -73,6 +73,7 @@ const deviceApprovalResponseSchema = z
 
 const deviceApprovalPreviewResponseSchema = z
     .object({
+        organization_id_hint: z.string().min(1).max(128).optional(),
         schema_version: z.literal("device_approval_preview_response.v1"),
         repository_hints: z.array(z.string()),
     })
@@ -225,9 +226,10 @@ export class AcrRuntimeClient {
         return { status: parsed.data.status };
     }
 
-    async deviceApprovalPreview(
-        input: DeviceApprovalRequest,
-    ): Promise<{ readonly repositoryHints: readonly string[] }> {
+    async deviceApprovalPreview(input: DeviceApprovalRequest): Promise<{
+        readonly organizationIdHint?: string;
+        readonly repositoryHints: readonly string[];
+    }> {
         const value = await this.request({
             ...input,
             method: "POST",
@@ -241,7 +243,12 @@ export class AcrRuntimeClient {
                 "Agent Context Runtime returned an invalid response.",
             );
         }
-        return { repositoryHints: parsed.data.repository_hints };
+        return {
+            ...(parsed.data.organization_id_hint === undefined
+                ? {}
+                : { organizationIdHint: parsed.data.organization_id_hint }),
+            repositoryHints: parsed.data.repository_hints,
+        };
     }
 
     private async request(input: AcrRequest): Promise<unknown> {

--- a/src/lib/acr/client.ts
+++ b/src/lib/acr/client.ts
@@ -71,6 +71,13 @@ const deviceApprovalResponseSchema = z
     })
     .strict();
 
+const deviceApprovalPreviewResponseSchema = z
+    .object({
+        schema_version: z.literal("device_approval_preview_response.v1"),
+        repository_hints: z.array(z.string()),
+    })
+    .strict();
+
 function clientUrl(config: AcrRuntimeConfig, path: string): URL {
     const url = new URL(path, config.apiOrigin);
     if (url.origin !== config.apiOrigin.origin || url.search !== "" || url.hash !== "") {
@@ -216,6 +223,25 @@ export class AcrRuntimeClient {
             );
         }
         return { status: parsed.data.status };
+    }
+
+    async deviceApprovalPreview(
+        input: DeviceApprovalRequest,
+    ): Promise<{ readonly repositoryHints: readonly string[] }> {
+        const value = await this.request({
+            ...input,
+            method: "POST",
+            path: "/api/v1/oauth/device_approval",
+            permissions: ["credential:issue"],
+        });
+        const parsed = deviceApprovalPreviewResponseSchema.safeParse(value);
+        if (!parsed.success) {
+            throw new AcrRuntimeError(
+                acrRuntimeErrorCodes.malformedResponse,
+                "Agent Context Runtime returned an invalid response.",
+            );
+        }
+        return { repositoryHints: parsed.data.repository_hints };
     }
 
     private async request(input: AcrRequest): Promise<unknown> {

--- a/src/lib/acr/client.ts
+++ b/src/lib/acr/client.ts
@@ -42,7 +42,7 @@ type AcrRequest = {
     readonly body?: string;
     readonly method: "GET" | "POST";
     readonly path: string;
-    readonly permissions: readonly ("context:read" | "evidence:read")[];
+    readonly permissions: readonly ("context:read" | "credential:issue" | "evidence:read")[];
     readonly signal: AbortSignal;
 };
 
@@ -57,6 +57,19 @@ type EvidenceRequest = {
     readonly evidenceRefId: string;
     readonly signal: AbortSignal;
 };
+
+type DeviceApprovalRequest = {
+    readonly authorization: OpsAuthorization;
+    readonly body: string;
+    readonly signal: AbortSignal;
+};
+
+const deviceApprovalResponseSchema = z
+    .object({
+        schema_version: z.literal("device_approval_response.v1"),
+        status: z.literal("approved"),
+    })
+    .strict();
 
 function clientUrl(config: AcrRuntimeConfig, path: string): URL {
     const url = new URL(path, config.apiOrigin);
@@ -186,6 +199,23 @@ export class AcrRuntimeClient {
             );
         }
         return value;
+    }
+
+    async deviceApproval(input: DeviceApprovalRequest): Promise<{ readonly status: "approved" }> {
+        const value = await this.request({
+            ...input,
+            method: "POST",
+            path: "/api/v1/oauth/device_approval",
+            permissions: ["credential:issue"],
+        });
+        const parsed = deviceApprovalResponseSchema.safeParse(value);
+        if (!parsed.success) {
+            throw new AcrRuntimeError(
+                acrRuntimeErrorCodes.malformedResponse,
+                "Agent Context Runtime returned an invalid response.",
+            );
+        }
+        return { status: parsed.data.status };
     }
 
     private async request(input: AcrRequest): Promise<unknown> {

--- a/src/lib/acr/service.ts
+++ b/src/lib/acr/service.ts
@@ -142,17 +142,12 @@ function canonicalApprovalScopes(scopes: readonly string[]): readonly string[] {
 }
 
 export async function approveDeviceAuthorization(input: {
-    readonly repositoryHints?: readonly string[];
     readonly repositoryScopes: readonly string[];
     readonly signal: AbortSignal;
     readonly userCode: string;
 }): Promise<{ readonly status: "approved" }> {
     if (!deviceUserCode.test(input.userCode)) throw invalidApprovalRequest();
     const requestedScopes = canonicalApprovalScopes(input.repositoryScopes);
-    const hintedScopes =
-        input.repositoryHints === undefined
-            ? undefined
-            : canonicalApprovalScopes(input.repositoryHints);
     const rawSession = await auth();
     const session = sessionOrError(rawSession);
     if (
@@ -173,11 +168,7 @@ export async function approveDeviceAuthorization(input: {
         signal: input.signal,
         subject: session.subject,
     });
-    if (
-        requestedScopes.some((scope) => !authorization.repositoryScopes.includes(scope)) ||
-        (hintedScopes !== undefined &&
-            requestedScopes.some((scope) => !hintedScopes.includes(scope)))
-    ) {
+    if (requestedScopes.some((scope) => !authorization.repositoryScopes.includes(scope))) {
         throw invalidApprovalRequest();
     }
     const body = JSON.stringify({
@@ -187,6 +178,42 @@ export async function approveDeviceAuthorization(input: {
     });
     return new AcrRuntimeClient(loadAcrRuntimeConfig()).deviceApproval({
         authorization: { ...authorization, repositoryScopes: requestedScopes },
+        body,
+        signal: input.signal,
+    });
+}
+
+export async function previewDeviceAuthorization(input: {
+    readonly signal: AbortSignal;
+    readonly userCode: string;
+}): Promise<{ readonly repositoryHints: readonly string[] }> {
+    if (!deviceUserCode.test(input.userCode)) throw invalidApprovalRequest();
+    const rawSession = await auth();
+    const session = sessionOrError(rawSession);
+    if (
+        rawSession?.user.real_org_id !== undefined &&
+        session.orgId !== rawSession.user.real_org_id
+    ) {
+        throw new AcrRuntimeError(
+            acrRuntimeErrorCodes.notEntitled,
+            "Approval is unavailable while impersonating.",
+            {
+                status: 403,
+            },
+        );
+    }
+    const authorization = await resolveOpsAuthorization({
+        accessToken: session.accessToken,
+        orgId: session.orgId,
+        signal: input.signal,
+        subject: session.subject,
+    });
+    const body = JSON.stringify({
+        schema_version: "device_approval_preview_request.v1",
+        user_code: input.userCode,
+    });
+    return new AcrRuntimeClient(loadAcrRuntimeConfig()).deviceApprovalPreview({
+        authorization,
         body,
         signal: input.signal,
     });

--- a/src/lib/acr/service.ts
+++ b/src/lib/acr/service.ts
@@ -186,7 +186,10 @@ export async function approveDeviceAuthorization(input: {
 export async function previewDeviceAuthorization(input: {
     readonly signal: AbortSignal;
     readonly userCode: string;
-}): Promise<{ readonly repositoryHints: readonly string[] }> {
+}): Promise<{
+    readonly organizationIdHint?: string;
+    readonly repositoryHints: readonly string[];
+}> {
     if (!deviceUserCode.test(input.userCode)) throw invalidApprovalRequest();
     const rawSession = await auth();
     const session = sessionOrError(rawSession);

--- a/src/lib/acr/service.ts
+++ b/src/lib/acr/service.ts
@@ -7,6 +7,9 @@ import { AcrRuntimeError, acrRuntimeErrorCodes } from "./errors";
 import { resolveOpsAuthorization } from "./ops";
 import { contextPacketRequest, parseContextPacketForm, parseEvidenceSelection } from "./protocol";
 
+const deviceUserCode = /^[ABCDEFGHJKMNPQRSTVWXYZ23456789]{8}$/u;
+const repositoryScope = /^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/u;
+
 type WebSession = {
     readonly accessToken: string;
     readonly orgId: string;
@@ -110,6 +113,81 @@ export async function getExpandedEvidence(input: {
     return runtime.client.evidence({
         authorization: runtime.authorization,
         evidenceRefId: selection.evidenceRefId,
+        signal: input.signal,
+    });
+}
+
+function invalidApprovalRequest(): AcrRuntimeError {
+    return new AcrRuntimeError(
+        acrRuntimeErrorCodes.invalidRequest,
+        "The device approval request is invalid.",
+        {
+            status: 400,
+        },
+    );
+}
+
+function canonicalApprovalScopes(scopes: readonly string[]): readonly string[] {
+    const sorted = [...scopes].sort((left, right) => left.localeCompare(right));
+    if (
+        scopes.length === 0 ||
+        scopes.length > 100 ||
+        scopes.some((scope) => !repositoryScope.test(scope)) ||
+        sorted.some((scope, index) => scope !== scopes[index]) ||
+        new Set(scopes).size !== scopes.length
+    ) {
+        throw invalidApprovalRequest();
+    }
+    return scopes;
+}
+
+export async function approveDeviceAuthorization(input: {
+    readonly repositoryHints?: readonly string[];
+    readonly repositoryScopes: readonly string[];
+    readonly signal: AbortSignal;
+    readonly userCode: string;
+}): Promise<{ readonly status: "approved" }> {
+    if (!deviceUserCode.test(input.userCode)) throw invalidApprovalRequest();
+    const requestedScopes = canonicalApprovalScopes(input.repositoryScopes);
+    const hintedScopes =
+        input.repositoryHints === undefined
+            ? undefined
+            : canonicalApprovalScopes(input.repositoryHints);
+    const rawSession = await auth();
+    const session = sessionOrError(rawSession);
+    if (
+        rawSession?.user.real_org_id !== undefined &&
+        session.orgId !== rawSession.user.real_org_id
+    ) {
+        throw new AcrRuntimeError(
+            acrRuntimeErrorCodes.notEntitled,
+            "Approval is unavailable while impersonating.",
+            {
+                status: 403,
+            },
+        );
+    }
+    const authorization = await resolveOpsAuthorization({
+        accessToken: session.accessToken,
+        orgId: session.orgId,
+        signal: input.signal,
+        subject: session.subject,
+    });
+    if (
+        requestedScopes.some((scope) => !authorization.repositoryScopes.includes(scope)) ||
+        (hintedScopes !== undefined &&
+            requestedScopes.some((scope) => !hintedScopes.includes(scope)))
+    ) {
+        throw invalidApprovalRequest();
+    }
+    const body = JSON.stringify({
+        repository_scopes: requestedScopes,
+        schema_version: "device_approval_request.v1",
+        user_code: input.userCode,
+    });
+    return new AcrRuntimeClient(loadAcrRuntimeConfig()).deviceApproval({
+        authorization: { ...authorization, repositoryScopes: requestedScopes },
+        body,
         signal: input.signal,
     });
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -285,6 +285,7 @@ async function handleRequest(request: NextRequest) {
         pathname === "/graphql" ||
         (pathname.startsWith("/api/") &&
             !pathname.startsWith("/api/auth") &&
+            !pathname.startsWith("/api/acr") &&
             !pathname.startsWith("/api/agent-context") &&
             !pathname.startsWith("/api/v1/llm-proxy"));
 

--- a/test_schema.ts
+++ b/test_schema.ts
@@ -1,7 +1,0 @@
-import { z } from "zod";
-const deviceApprovalPreviewResponseSchema = z
-    .object({
-        schema_version: z.literal("device_approval_preview_response.v1"),
-        repository_hints: z.array(z.string()),
-    })
-    .strict();

--- a/test_schema.ts
+++ b/test_schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+const deviceApprovalPreviewResponseSchema = z
+    .object({
+        schema_version: z.literal("device_approval_preview_response.v1"),
+        repository_hints: z.array(z.string()),
+    })
+    .strict();


### PR DESCRIPTION
## Summary

Adds the **device approval surface** (CHAOS-3096) that an operator uses to approve a self-service `acr-mcp login` from the Agent Context Runtime CLI. A signed-in user enters the device user code, previews what the code is asking for, confirms the repository scopes, and approves — completing the device-authorization handshake.

Companion ACR PR (the CLI and device-flow backend this screen drives): **full-chaos/dev-health-acr#50**

### What is in the change

6 commits off `main`, 11 files, +1183/−2.

| Path | Purpose |
| --- | --- |
| `src/app/acr/device/page.tsx` | Device approval route |
| `src/components/acr/DeviceApprovalForm.tsx` | Preview → confirm → approve flow with pending / review / success states |
| `src/app/api/acr/device/route.ts` | Node-runtime API route handling `preview` and `approve` |
| `src/lib/acr/service.ts` | `previewDeviceAuthorization` / `approveDeviceAuthorization` |
| `src/lib/acr/client.ts` | `deviceApproval` / `deviceApprovalPreview` with strict Zod response schemas |
| `src/lib/acr/assertion.ts` | Adds `credential:issue` to the web-assertion permission union |
| `src/proxy.ts` | Excludes `/api/acr` from the ops proxy so approval stays a local route |

### Security posture

- **Same-origin enforced** — the request `Origin` must equal the configured `AUTH_URL`/`NEXTAUTH_URL` origin (falling back to the request origin); mismatches are `403` before any work happens.
- **Two fail-closed rate limits** — 20 req/min per client IP, plus 5 req/min per `IP + SHA-256(user_code)` so a code cannot be brute-forced across a shared address.
- **Impersonation blocked** — approval and preview both reject when the session's `org_id` differs from `real_org_id`.
- **Scope canonicalization** — repository scopes must be non-empty, ≤ 100, `owner/name`-shaped, lexicographically sorted, and duplicate-free; anything else is `400`.
- **Scope subset check** — every requested scope must already be present in the caller's resolved ops authorization.
- **Strict response parsing** — both ACR responses are `z.object(...).strict()`; a schema mismatch surfaces as `malformedResponse` rather than being forwarded.
- **No cache leakage** — every response carries `Cache-Control: no-store`; error bodies use safe, non-reflecting messages.

## Verification

Run locally on `5b03b71`:

| Gate | Result |
| --- | --- |
| `tsc --noEmit` | pass (exit 0, no diagnostics) |
| `vitest run` on the 4 changed suites | pass — **47/47 tests, 4/4 files** |
| `eslint src` | pass — 0 errors (1 pre-existing warning in `src/lib/navigation/__tests__/ia-preservation-invariants.test.ts`, untouched by this PR) |
| `format:check:changed` | pass — 11 changed files Prettier-clean |
| `acr:contracts:check` | pass — "ACR contracts are current" |

Suites covered: `src/app/api/acr/device/route.test.ts`, `src/components/acr/DeviceApprovalForm.test.tsx`, `src/lib/acr/__tests__/device-approval.test.ts`, `src/lib/__tests__/proxy.test.ts`.

## CI status — all green

The earlier billing state that prevented runners from starting has been resolved and both repositories are public, so CI now executes for real. On `77b5808f`, the current head:

**27 checks pass, 0 fail** (2 skipped by path filters) — including `Quality`, `Unit tests`, `Build`, `Build Static Assets`, both `Build Image` architectures, `Integration tests`, `live-e2e`, all three default E2E shards, `E2E tests (onboarding)`, `E2E tests (Context Fabric)`, `PagerDuty final QA matrix`, `Format`, `Design lint advisory`, `enforce-src-test-policy`, and CodeQL.

`Quality` previously failed here; see the dependency section below.

## ⛔ Deferred: OpenCode fullstack acceptance has NOT been run

The canonical end-to-end proof for this screen does not live in this repository — it is the **device-login approval lifecycle** stage of the ACR fullstack OpenCode gate (`docs/fullstack-acceptance.md` §7.1 in `dev-health-acr`). That harness signs the browser in to the seeded admin account, previews one code, confirms a single repository scope, approves, and then exercises `doctor --live` → refresh → doctor → logout → expected post-logout failure, replaying the consumed code and requiring a conflict. It also enforces the network receipt for this route: no bearer header, no query string, no wildcard or unbounded repository scope, no console or request failure, and no device-route 5xx.

**That gate has not been executed against this branch.** It is blocked on the same billing state, since it runs in GitHub Actions (or needs a local Docker + OpenCode stack). This is an explicit, known gap.

Once billing is restored, this branch can be proven in the canonical gate without merging first, using the `web_ref` input added by the companion ACR PR:

```bash
gh workflow run fullstack-acceptance.yml --repo full-chaos/dev-health-acr \
  --ref feat/chaos-3096-acr-mcp-login \
  -f scenario=full \
  -f web_ref=feat/chaos-3096-device-approval
```

The sibling-repository reference used by that dispatch is tracked in **CHAOS-3153** and must be resolved before the run can actually reach this branch.


## Production audit remediation (`1df7bd76`)

The `Quality` job runs `pnpm audit --audit-level=high --prod` as its first step, and it was failing with **13 vulnerabilities (6 moderate, 7 high)**, which aborted the job before lint or typecheck ever ran. It now reports **no known vulnerabilities**.

Direct production upgrades, both inside their declared majors:

| Package | Change | Clears |
| --- | --- | --- |
| `next` | 16.2.10 → 16.2.11 | GHSA-6gpp-xcg3-4w24 (middleware/proxy bypass), GHSA-m99w-x7hq-7vfj (DoS), GHSA-89xv-2m56-2m9x and GHSA-p9j2-gv94-2wf4 (SSRF) |
| `@sentry/nextjs` | 10.66.0 → 10.68.0 | newest release in `^10` |

The declared ranges were raised to the patched floor so a fresh resolution cannot select a vulnerable version again.

Three high advisories remained that **no direct-dependency upgrade can reach**: `next` pins `postcss` to exactly `8.4.31` in every 16.2.x release (including 16.2.12), and `brace-expansion` sits under `@sentry/nextjs`, which is already at its range ceiling. Those are pinned as narrow version floors in `pnpm-workspace.yaml`, in the same style as the existing `serialize-javascript` floor — no audit ignores, no severity lowering, no blanket overrides:

- `postcss: ">=8.5.18"` → resolves 8.5.20
- `minimatch@10>brace-expansion: ">=5.0.8"` → resolves 5.0.8

The brace-expansion floor is **scoped to `minimatch@10` deliberately**. An unscoped floor also rewrites `minimatch@3`, whose v1 `brace-expansion` API differs, and ESLint then fails with `expand is not a function`. Scoped, the tree correctly keeps `brace-expansion@1.1.16` under `minimatch@3` and `5.0.8` under `minimatch@10`.

> Note for maintainers: pnpm reads overrides from `pnpm-workspace.yaml` in this repository, not from `package.json`. The `overrides` block in `package.json` (`serialize-javascript`, `@graphql-codegen/plugin-helpers`, `size-sensor`) does not appear in the lockfile and is inert — `serialize-javascript` has no effective security floor today. Left untouched here to keep this change minimal, but it should be fixed separately.

Locally verified on the committed tree: audit exit 0, `install --frozen-lockfile`, `ci/run_tests.sh quality`, `build`, 3315 unit tests across 377 files, `format:check:changed`, `acr:contracts:check` — all pass.

## Toolchain (`25357cb6`, `77b5808f`)

`packageManager` is pinned to exactly **`pnpm@11.17.0`** (the only 11.17.x release, and the current registry `latest`). Installing under 11.17.0 leaves `pnpm-lock.yaml` **byte-identical** to `1df7bd76` — sha256 `91984982…40807` before and after — so the pin changes no dependency resolution.

The pin exposed a genuine incompatibility: pnpm 11.17 invokes run-scripts through an **extensionless** shim, so `npm_execpath` no longer points at a `.js`/`.cjs`/`.mjs` file, and `scripts/package-manager.mjs` rejected it — which would have failed the `Format` job, since `ci/run_tests.sh format` runs `format:check:changed`. `77b5808f` teaches that resolver to accept an extensionless pnpm shim. Both `Format` and `Quality` pass at the current head.

## Visual evidence

Re-captured at `77b5808f`, the current head of this PR — these supersede the earlier `5b03b71` set, so the screenshots match the code as it now stands. Three device-approval states across 375px / 768px / 1280px, full-page, no horizontal overflow at any width.

| State | 375px | 768px | 1280px |
| --- | --- | --- | --- |
| **Pending** — code entry | <img width="320" alt="device approval pending at 375px" src="https://github.com/user-attachments/assets/61bb4f53-3a48-4292-b4fe-c882200d989c" /> | <img width="420" alt="device approval pending at 768px" src="https://github.com/user-attachments/assets/a869444a-78a9-4b90-ba42-1e5a59eb592d" /> | <img width="520" alt="device approval pending at 1280px" src="https://github.com/user-attachments/assets/c82065af-1f62-4da0-a01c-2fbc4972d984" /> |
| **Review** — repository scope confirmation | <img width="320" alt="device approval review at 375px" src="https://github.com/user-attachments/assets/1c832909-6145-4327-b228-9a76b4fcdacc" /> | <img width="420" alt="device approval review at 768px" src="https://github.com/user-attachments/assets/07c7135e-2147-4616-a509-32dfc366e21b" /> | <img width="520" alt="device approval review at 1280px" src="https://github.com/user-attachments/assets/7937f8f6-cf0e-4015-9d6e-3f13d48a2951" /> |
| **Success** — approval complete | <img width="320" alt="device approval success at 375px" src="https://github.com/user-attachments/assets/7c86d6ae-d859-422b-aedd-91a627b38158" /> | <img width="420" alt="device approval success at 768px" src="https://github.com/user-attachments/assets/3620eff3-d946-478f-8e33-443b746cc4f0" /> | <img width="520" alt="device approval success at 1280px" src="https://github.com/user-attachments/assets/069de286-7475-4180-aad1-ed36b3d82cd5" /> |

**Classification: UI-only — this is NOT connected-lifecycle evidence.** The local `acr-api` container has no host-published port, so `/api/acr/device` was intercepted and served by **schema-accurate Playwright route fixtures** rather than a live ACR. The fixtures return the real contract shapes — `device_approval_preview_response.v1` for the review state, and `device_approval_preview_response.v1` + `device_approval_response.v1` for the success state — so these prove the rendering, layout, responsive behaviour and state machine of the approval surface, and nothing about the backend handshake.

Consequently they **do not satisfy** the connected screenshot requirement in `docs/fullstack-acceptance.md` §7.1 of the companion ACR repository; that remains outstanding and is part of the deferred OpenCode validation described above.

The small circular **`N` badge at the bottom-left of every screenshot is the Next.js dev-mode indicator**, an artifact of capturing against `next dev`. It is not part of the device-approval UI and does not render in a production build.

Receipts, redacted: zero browser console errors were emitted by the device-approval route across all nine captures. Device codes, credentials, cookies, authorization headers and assertion headers are redacted from the retained console and network receipts.

## Review notes

- `deviceApproval` and `deviceApprovalPreview` both `POST` to `/api/v1/oauth/device_approval`; the server distinguishes them by the request body's `schema_version`, and each has its own strict response schema. Flagging the shared path as intentional rather than a copy-paste artifact.
- The `/api/acr` proxy exclusion in `src/proxy.ts` is what keeps approval a local Node-runtime route; without it the request would be forwarded to ops and lose the session-derived assertion.

Linear: CHAOS-3096



## Final evidence checkpoint

- Exact head: `77b5808fe9dc0e640724a6a550272e6750e126e6`
- Hosted CI at that exact SHA: **27 checks pass / 0 fail** (2 path-filter skips).
- Fresh hosted images above were captured at this exact SHA; the evidence is **UI-only / non-connected**, using schema-accurate Playwright route fixtures because local `acr-api` has no host-published port. These images do not prove the connected login → approval → doctor journey.

