### PR TITLE
fix(acr): accept generated device codes

### DIFF
--- a/src/components/acr/DeviceApprovalForm.test.tsx
+++ b/src/components/acr/DeviceApprovalForm.test.tsx
@@ -32,9 +32,12 @@ describe("DeviceApprovalForm", () => {
         vi.stubGlobal("fetch", fetchMock);
 
         render(<DeviceApprovalForm repositories={["full-chaos/platform", "full-chaos/private"]} />);
-        fireEvent.change(screen.getByLabelText("Verification code"), {
-            target: { value: "ABCD2345" },
+        const verificationCode = screen.getByLabelText("Verification code");
+        fireEvent.change(verificationCode, {
+            target: { value: "EP23TUGG" },
         });
+        expect(verificationCode).toBeValid();
+        expect(verificationCode).not.toHaveAttribute("pattern");
         fireEvent.click(screen.getByRole("button", { name: "Preview request" }));
 
         await screen.findByRole("heading", { name: "Review device access" });
@@ -48,7 +51,7 @@ describe("DeviceApprovalForm", () => {
             1,
             "/api/acr/device",
             expect.objectContaining({
-                body: JSON.stringify({ action: "preview", user_code: "ABCD2345" }),
+                body: JSON.stringify({ action: "preview", user_code: "EP23TUGG" }),
                 method: "POST",
             }),
         );
@@ -59,7 +62,7 @@ describe("DeviceApprovalForm", () => {
                 body: JSON.stringify({
                     action: "approve",
                     repository_scopes: ["full-chaos/platform"],
-                    user_code: "ABCD2345",
+                    user_code: "EP23TUGG",
                 }),
                 method: "POST",
             }),
@@ -83,5 +86,28 @@ describe("DeviceApprovalForm", () => {
         await screen.findByText("No authorized repositories match this request.");
         expect(screen.getByRole("button", { name: "Confirm" })).toBeDisabled();
         expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("Given a malformed eight-character code, when ACR rejects it, then shows the rejection", async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 400 }));
+        vi.stubGlobal("fetch", fetchMock);
+
+        render(<DeviceApprovalForm repositories={["full-chaos/platform"]} />);
+        const verificationCode = screen.getByLabelText("Verification code");
+        fireEvent.change(verificationCode, {
+            target: { value: "OOOOOOOO" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Preview request" }));
+
+        await screen.findByText("We could not preview this request.");
+        expect(fetchMock).toHaveBeenCalledWith(
+            "/api/acr/device",
+            expect.objectContaining({
+                body: JSON.stringify({ action: "preview", user_code: "OOOOOOOO" }),
+                method: "POST",
+            }),
+        );
     });
 });

--- a/src/components/acr/DeviceApprovalForm.tsx
+++ b/src/components/acr/DeviceApprovalForm.tsx
@@ -175,7 +175,6 @@ export function DeviceApprovalForm({
                                 onChange={(event) =>
                                     setCode(event.target.value.trim().toUpperCase())
                                 }
-                                pattern="[ABCDEFGHJKMNPQRSTVWXYZ23456789]{8}"
                                 required
                                 value={code}
                             />

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -773,6 +773,547 @@ export type DateRangeInput = {
   startDate: Scalars['Date']['input'];
 };
 
+export type DevActualCompletion = {
+  __typename?: 'DevActualCompletion';
+  conflicts: Array<DevStatusConflict>;
+  evidenceRefIds: Array<Scalars['ID']['output']>;
+  reasonCodes: Array<Scalars['String']['output']>;
+  requiredChildren: Array<DevStatusFact>;
+  ruleId: Scalars['String']['output'];
+  ruleVersion: Scalars['String']['output'];
+  sourceRefIds: Array<Scalars['ID']['output']>;
+  state: DevCompletionState;
+};
+
+export type DevCiStatusFact = {
+  __typename?: 'DevCIStatusFact';
+  conclusion: Scalars['String']['output'];
+  displayLabel: Scalars['String']['output'];
+  entityId: Scalars['ID']['output'];
+  evidenceRefIds: Array<Scalars['ID']['output']>;
+  observedAt: Scalars['DateTime']['output'];
+  required?: Maybe<Scalars['Boolean']['output']>;
+  skippedRequiredWork?: Maybe<Scalars['Boolean']['output']>;
+  sourceRefId: Scalars['ID']['output'];
+};
+
+export type DevChangeSummary = {
+  __typename?: 'DevChangeSummary';
+  changes: Array<DevObservedChange>;
+  comparisonWindow: DevChangeWindow;
+  contractVersion: Scalars['String']['output'];
+  currentWindow: DevChangeWindow;
+  sourceRefs: Array<DevStatusSourceRef>;
+  state: Scalars['String']['output'];
+  warnings: Array<Scalars['String']['output']>;
+};
+
+export type DevChangeSummaryInput = {
+  comparisonEnd: Scalars['DateTime']['input'];
+  comparisonStart: Scalars['DateTime']['input'];
+  maxItems?: Scalars['Int']['input'];
+  scope: DevMetricScopeInput;
+};
+
+export type DevChangeWindow = {
+  __typename?: 'DevChangeWindow';
+  end: Scalars['DateTime']['output'];
+  start: Scalars['DateTime']['output'];
+};
+
+export type DevCompletionState =
+  | 'INDETERMINATE'
+  | 'NOT_READY'
+  | 'READY';
+
+export type DevDataHealthInput = {
+  requiredSources?: Array<Scalars['String']['input']>;
+  scope: DevEvidenceScopeInput;
+};
+
+export type DevDataHealthResult = {
+  __typename?: 'DevDataHealthResult';
+  completeEligible: Scalars['Boolean']['output'];
+  queryVersion: Scalars['String']['output'];
+  sources: Array<DevDataHealthSource>;
+};
+
+export type DevDataHealthSource = {
+  __typename?: 'DevDataHealthSource';
+  confidenceImpact?: Maybe<Scalars['String']['output']>;
+  coverage: Scalars['Float']['output'];
+  freshnessPolicyVersion?: Maybe<Scalars['String']['output']>;
+  lastSuccessfulAt?: Maybe<Scalars['DateTime']['output']>;
+  missingEntityIds: Array<Scalars['ID']['output']>;
+  missingRepositoryIds: Array<Scalars['ID']['output']>;
+  required: Scalars['Boolean']['output'];
+  sourceSystem: Scalars['String']['output'];
+  state: Scalars['String']['output'];
+  warning?: Maybe<Scalars['String']['output']>;
+  watermark?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type DevDeploymentStatusFact = {
+  __typename?: 'DevDeploymentStatusFact';
+  displayLabel: Scalars['String']['output'];
+  entityId: Scalars['ID']['output'];
+  environment?: Maybe<Scalars['String']['output']>;
+  evidenceRefIds: Array<Scalars['ID']['output']>;
+  observedAt: Scalars['DateTime']['output'];
+  required: Scalars['Boolean']['output'];
+  sourceRefId: Scalars['ID']['output'];
+  status: Scalars['String']['output'];
+};
+
+export type DevEvidence = {
+  __typename?: 'DevEvidence';
+  citationText?: Maybe<Scalars['String']['output']>;
+  confidence: Scalars['Float']['output'];
+  displayLabel: Scalars['String']['output'];
+  entityId: Scalars['ID']['output'];
+  entityType: Scalars['String']['output'];
+  evidenceRefId: Scalars['ID']['output'];
+  flags: DevEvidenceFlags;
+  freshness: Scalars['String']['output'];
+  link?: Maybe<DevEvidenceLink>;
+  observedAt: Scalars['DateTime']['output'];
+  provenance: Scalars['String']['output'];
+  repositoryIds: Array<Scalars['ID']['output']>;
+  sourceSystem: Scalars['String']['output'];
+  sourceVersion: Scalars['String']['output'];
+  validEntityIds: Array<Scalars['ID']['output']>;
+};
+
+export type DevEvidenceFlags = {
+  __typename?: 'DevEvidenceFlags';
+  conflicting: Scalars['Boolean']['output'];
+  deleted: Scalars['Boolean']['output'];
+  redacted: Scalars['Boolean']['output'];
+  stale: Scalars['Boolean']['output'];
+  unavailable: Scalars['Boolean']['output'];
+  uncertain: Scalars['Boolean']['output'];
+  untrustedContent: Scalars['Boolean']['output'];
+};
+
+export type DevEvidenceLink = {
+  __typename?: 'DevEvidenceLink';
+  internalPath?: Maybe<Scalars['String']['output']>;
+  sourceUrl?: Maybe<Scalars['String']['output']>;
+};
+
+export type DevEvidenceScopeInput = {
+  directScope: DevEvidenceScopeKind;
+  endDate?: InputMaybe<Scalars['Date']['input']>;
+  presetDays?: InputMaybe<Scalars['Int']['input']>;
+  refs?: Array<DevEvidenceScopeRefInput>;
+  startDate?: InputMaybe<Scalars['Date']['input']>;
+  teamIds?: Array<Scalars['String']['input']>;
+  timezone?: Scalars['String']['input'];
+};
+
+export type DevEvidenceScopeKind =
+  | 'ISSUE'
+  | 'ORGANIZATION'
+  | 'PROJECT'
+  | 'PULL_REQUEST'
+  | 'REPOSITORY'
+  | 'WORK_UNIT';
+
+export type DevEvidenceScopeRefInput = {
+  kind: DevEvidenceScopeKind;
+  value: Scalars['String']['input'];
+};
+
+export type DevEvidenceSearchInput = {
+  limit?: Scalars['Int']['input'];
+  query: Scalars['String']['input'];
+  scope: DevEvidenceScopeInput;
+};
+
+export type DevEvidenceSearchResult = {
+  __typename?: 'DevEvidenceSearchResult';
+  evidence: Array<DevEvidence>;
+  queryVersion: Scalars['String']['output'];
+  rankingVersion: Scalars['String']['output'];
+  sources: Array<DevEvidenceSourceState>;
+};
+
+export type DevEvidenceSourceState = {
+  __typename?: 'DevEvidenceSourceState';
+  sourceSystem: Scalars['String']['output'];
+  state: Scalars['String']['output'];
+  warning?: Maybe<Scalars['String']['output']>;
+  watermark?: Maybe<Scalars['String']['output']>;
+};
+
+export type DevIncidentStatusFact = {
+  __typename?: 'DevIncidentStatusFact';
+  active: Scalars['Boolean']['output'];
+  blocking: Scalars['Boolean']['output'];
+  displayLabel: Scalars['String']['output'];
+  entityId: Scalars['ID']['output'];
+  evidenceRefIds: Array<Scalars['ID']['output']>;
+  observedAt: Scalars['DateTime']['output'];
+  sourceRefId: Scalars['ID']['output'];
+  status: Scalars['String']['output'];
+};
+
+export type DevMetricCatalog = {
+  __typename?: 'DevMetricCatalog';
+  metrics: Array<DevMetricDefinition>;
+  registryVersion: Scalars['String']['output'];
+};
+
+export type DevMetricCatalogInput = {
+  directScope?: InputMaybe<DevMetricDirectScope>;
+  hasTeamFilter?: Scalars['Boolean']['input'];
+};
+
+export type DevMetricDataState =
+  | 'INSUFFICIENT_EVIDENCE'
+  | 'NO_MATCH'
+  | 'PARTIAL'
+  | 'STALE'
+  | 'UNAVAILABLE'
+  | 'UNCONFIGURED'
+  | 'VALUE'
+  | 'ZERO';
+
+export type DevMetricDefinition = {
+  __typename?: 'DevMetricDefinition';
+  aggregation: Scalars['String']['output'];
+  comparisonRule: Scalars['String']['output'];
+  definitionVersion: Scalars['String']['output'];
+  description: Scalars['String']['output'];
+  displayPrecision: Scalars['Int']['output'];
+  entitlement: Scalars['String']['output'];
+  expectedMaterialization: Scalars['String']['output'];
+  freshnessPolicy: Scalars['String']['output'];
+  label: Scalars['String']['output'];
+  maxRangeDays: Scalars['Int']['output'];
+  metricId: DevMetricId;
+  minRangeDays: Scalars['Int']['output'];
+  nullSemantics: Scalars['String']['output'];
+  owner: Scalars['String']['output'];
+  queryVersion: Scalars['String']['output'];
+  sensitivity: Scalars['String']['output'];
+  sourceTable: Scalars['String']['output'];
+  sourceVersion: Scalars['String']['output'];
+  supportedDimensions: Array<Scalars['String']['output']>;
+  supportedPresets: Array<Scalars['Int']['output']>;
+  supportedScopes: Array<DevMetricDirectScope>;
+  supportedTimeGrains: Array<Scalars['String']['output']>;
+  supportsTeamFilter: Scalars['Boolean']['output'];
+  unit: Scalars['String']['output'];
+  upstreamSources: Array<Scalars['String']['output']>;
+  zeroSemantics: Scalars['String']['output'];
+};
+
+export type DevMetricDimensionValue = {
+  __typename?: 'DevMetricDimensionValue';
+  key: Scalars['String']['output'];
+  value: Scalars['String']['output'];
+};
+
+export type DevMetricDirectScope =
+  | 'ISSUE'
+  | 'ORGANIZATION'
+  | 'PROJECT'
+  | 'PULL_REQUEST'
+  | 'REPOSITORY'
+  | 'WORK_UNIT';
+
+export type DevMetricFreshness =
+  | 'FRESH'
+  | 'STALE'
+  | 'UNAVAILABLE'
+  | 'UNKNOWN';
+
+export type DevMetricId =
+  | 'AVG_WIP'
+  | 'CHANGE_FAILURE_RATE'
+  | 'COMPOUNDING_RISK_SCORE'
+  | 'CYCLE_TIME_P50_HOURS'
+  | 'CYCLOMATIC_PER_KLOC'
+  | 'DEPLOYMENTS_COUNT'
+  | 'INVESTMENT_ALLOCATION_PCT'
+  | 'ITEMS_COMPLETED';
+
+export type DevMetricMetadata = {
+  __typename?: 'DevMetricMetadata';
+  key: Scalars['String']['output'];
+  value: Scalars['String']['output'];
+};
+
+export type DevMetricQueryInput = {
+  dimensions?: Array<Scalars['String']['input']>;
+  includeComparison?: Scalars['Boolean']['input'];
+  includeSeries?: Scalars['Boolean']['input'];
+  maxSeriesPoints?: Scalars['Int']['input'];
+  metricId: DevMetricId;
+  scope: DevMetricScopeInput;
+};
+
+export type DevMetricResult = {
+  __typename?: 'DevMetricResult';
+  comparisonWindowEnd?: Maybe<Scalars['DateTime']['output']>;
+  comparisonWindowStart?: Maybe<Scalars['DateTime']['output']>;
+  coverage: Scalars['Float']['output'];
+  currentWindowEnd: Scalars['DateTime']['output'];
+  currentWindowStart: Scalars['DateTime']['output'];
+  definition: DevMetricDefinition;
+  freshness: DevMetricFreshness;
+  metadata: Array<DevMetricMetadata>;
+  sourceRefs: Array<DevMetricSourceRef>;
+  state: DevMetricDataState;
+  timezone: Scalars['String']['output'];
+  values: Array<DevMetricValue>;
+  warnings: Array<Scalars['String']['output']>;
+  watermark?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type DevMetricScopeInput = {
+  directScope: DevMetricDirectScope;
+  endDate: Scalars['Date']['input'];
+  refs?: Array<Scalars['ID']['input']>;
+  startDate: Scalars['Date']['input'];
+  teamIds?: Array<Scalars['ID']['input']>;
+  timezone?: Scalars['String']['input'];
+};
+
+export type DevMetricSeriesPoint = {
+  __typename?: 'DevMetricSeriesPoint';
+  timestamp: Scalars['DateTime']['output'];
+  value: Scalars['Float']['output'];
+};
+
+export type DevMetricSourceRef = {
+  __typename?: 'DevMetricSourceRef';
+  queryVersion: Scalars['String']['output'];
+  refId: Scalars['ID']['output'];
+  sourceTable: Scalars['String']['output'];
+  sourceVersion: Scalars['String']['output'];
+  watermark?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type DevMetricValue = {
+  __typename?: 'DevMetricValue';
+  comparisonValue?: Maybe<Scalars['Float']['output']>;
+  dimensions: Array<DevMetricDimensionValue>;
+  series: Array<DevMetricSeriesPoint>;
+  value: Scalars['Float']['output'];
+};
+
+export type DevObservedChange = {
+  __typename?: 'DevObservedChange';
+  after?: Maybe<Scalars['String']['output']>;
+  before?: Maybe<Scalars['String']['output']>;
+  category: Scalars['String']['output'];
+  changeId: Scalars['ID']['output'];
+  claimKind: Scalars['String']['output'];
+  confidence?: Maybe<Scalars['Float']['output']>;
+  displayLabel: Scalars['String']['output'];
+  entityId: Scalars['ID']['output'];
+  entityType: Scalars['String']['output'];
+  evidenceRefIds: Array<Scalars['ID']['output']>;
+  metricComparisonValue?: Maybe<Scalars['Float']['output']>;
+  metricId?: Maybe<DevMetricId>;
+  metricValue?: Maybe<Scalars['Float']['output']>;
+  observedAt: Scalars['DateTime']['output'];
+  relationshipChain: Array<Scalars['String']['output']>;
+  sourceRefIds: Array<Scalars['ID']['output']>;
+};
+
+export type DevPullRequestStatusFact = {
+  __typename?: 'DevPullRequestStatusFact';
+  changesRequested: Scalars['Int']['output'];
+  displayLabel: Scalars['String']['output'];
+  entityId: Scalars['ID']['output'];
+  evidenceRefIds: Array<Scalars['ID']['output']>;
+  merged: Scalars['Boolean']['output'];
+  observedAt: Scalars['DateTime']['output'];
+  required: Scalars['Boolean']['output'];
+  reviewState?: Maybe<Scalars['String']['output']>;
+  sourceRefId: Scalars['ID']['output'];
+  state: Scalars['String']['output'];
+};
+
+export type DevScopeCandidate = {
+  __typename?: 'DevScopeCandidate';
+  canonicalId: Scalars['ID']['output'];
+  kind: DevScopeEntityKind;
+  label: Scalars['String']['output'];
+  repositoryId?: Maybe<Scalars['ID']['output']>;
+};
+
+export type DevScopeEntityKind =
+  | 'ISSUE'
+  | 'PROJECT'
+  | 'PULL_REQUEST'
+  | 'REPOSITORY'
+  | 'WORK_UNIT';
+
+export type DevScopeSearchInput = {
+  kinds: Array<DevScopeEntityKind>;
+  limit?: Scalars['Int']['input'];
+  query: Scalars['String']['input'];
+};
+
+export type DevScopeSearchResult = {
+  __typename?: 'DevScopeSearchResult';
+  candidates: Array<DevScopeCandidate>;
+  catalogWatermark: Scalars['String']['output'];
+  queryVersion: Scalars['String']['output'];
+};
+
+export type DevStatusConflict = {
+  __typename?: 'DevStatusConflict';
+  code: Scalars['String']['output'];
+  evidenceRefIds: Array<Scalars['ID']['output']>;
+  message: Scalars['String']['output'];
+  severity: Scalars['String']['output'];
+  sourceRefIds: Array<Scalars['ID']['output']>;
+};
+
+export type DevStatusFact = {
+  __typename?: 'DevStatusFact';
+  displayLabel: Scalars['String']['output'];
+  entityId: Scalars['ID']['output'];
+  entityType: Scalars['String']['output'];
+  evidenceRefIds: Array<Scalars['ID']['output']>;
+  observedAt: Scalars['DateTime']['output'];
+  required?: Maybe<Scalars['Boolean']['output']>;
+  sourceRefId: Scalars['ID']['output'];
+  status: Scalars['String']['output'];
+};
+
+export type DevStatusScope = {
+  __typename?: 'DevStatusScope';
+  comparisonEnd?: Maybe<Scalars['DateTime']['output']>;
+  comparisonStart?: Maybe<Scalars['DateTime']['output']>;
+  currentEnd: Scalars['DateTime']['output'];
+  currentStart: Scalars['DateTime']['output'];
+  directScope: Scalars['String']['output'];
+  entities: Array<DevStatusScopeEntity>;
+  organizationId: Scalars['ID']['output'];
+  repositoryIds: Array<Scalars['ID']['output']>;
+  schemaVersion: Scalars['String']['output'];
+  teamIds: Array<Scalars['ID']['output']>;
+  timezone: Scalars['String']['output'];
+};
+
+export type DevStatusScopeEntity = {
+  __typename?: 'DevStatusScopeEntity';
+  displayLabel: Scalars['String']['output'];
+  entityId: Scalars['ID']['output'];
+  entityType: Scalars['String']['output'];
+  repositoryId?: Maybe<Scalars['ID']['output']>;
+};
+
+export type DevStatusSnapshot = {
+  __typename?: 'DevStatusSnapshot';
+  actual: DevActualCompletion;
+  asOf: Scalars['DateTime']['output'];
+  blockers: Array<DevStatusFact>;
+  children: Array<DevStatusFact>;
+  ci: Array<DevCiStatusFact>;
+  contractVersion: Scalars['String']['output'];
+  declared?: Maybe<DevStatusFact>;
+  deployments: Array<DevDeploymentStatusFact>;
+  incidents: Array<DevIncidentStatusFact>;
+  pullRequests: Array<DevPullRequestStatusFact>;
+  scope: DevStatusScope;
+  sourceRefs: Array<DevStatusSourceRef>;
+  state: Scalars['String']['output'];
+  warnings: Array<Scalars['String']['output']>;
+};
+
+export type DevStatusSnapshotInput = {
+  asOf?: InputMaybe<Scalars['DateTime']['input']>;
+  maxItems?: Scalars['Int']['input'];
+  scope: DevMetricScopeInput;
+};
+
+export type DevStatusSourceRef = {
+  __typename?: 'DevStatusSourceRef';
+  evidenceRefIds: Array<Scalars['ID']['output']>;
+  freshness: Scalars['String']['output'];
+  refId: Scalars['ID']['output'];
+  sourceSystem: Scalars['String']['output'];
+  sourceVersion: Scalars['String']['output'];
+  watermark?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type DevWorkGraphDirection =
+  | 'BOTH'
+  | 'INCOMING'
+  | 'OUTGOING';
+
+export type DevWorkGraphNeighborEdge = {
+  __typename?: 'DevWorkGraphNeighborEdge';
+  confidence: Scalars['Float']['output'];
+  direction: DevWorkGraphDirection;
+  edgeId: Scalars['ID']['output'];
+  evidenceRefIds: Array<Scalars['ID']['output']>;
+  freshness: Scalars['String']['output'];
+  observedAt: Scalars['DateTime']['output'];
+  provenance: Scalars['String']['output'];
+  relationshipType: Scalars['String']['output'];
+  sourceId: Scalars['ID']['output'];
+  sourceRefId: Scalars['ID']['output'];
+  sourceType: Scalars['String']['output'];
+  targetId: Scalars['ID']['output'];
+  targetType: Scalars['String']['output'];
+};
+
+export type DevWorkGraphNeighborNode = {
+  __typename?: 'DevWorkGraphNeighborNode';
+  displayLabel: Scalars['String']['output'];
+  nodeId: Scalars['ID']['output'];
+  nodeType: Scalars['String']['output'];
+  repositoryId?: Maybe<Scalars['ID']['output']>;
+  resolutionState: Scalars['String']['output'];
+};
+
+export type DevWorkGraphNeighborsInput = {
+  depth?: Scalars['Int']['input'];
+  direction?: DevWorkGraphDirection;
+  limit?: Scalars['Int']['input'];
+  relationshipTypes: Array<Scalars['String']['input']>;
+  rootRefs: Array<DevWorkGraphRootRefInput>;
+  scope: DevEvidenceScopeInput;
+};
+
+export type DevWorkGraphNeighborsResult = {
+  __typename?: 'DevWorkGraphNeighborsResult';
+  depth: Scalars['Int']['output'];
+  edges: Array<DevWorkGraphNeighborEdge>;
+  nodes: Array<DevWorkGraphNeighborNode>;
+  queryVersion: Scalars['String']['output'];
+  returnedCount: Scalars['Int']['output'];
+  schemaVersion: Scalars['String']['output'];
+  sourceRefs: Array<DevWorkGraphSourceRef>;
+  state: Scalars['String']['output'];
+  totalCount: Scalars['Int']['output'];
+  truncated: Scalars['Boolean']['output'];
+  warnings: Array<Scalars['String']['output']>;
+  watermark?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type DevWorkGraphRootRefInput = {
+  nodeId: Scalars['ID']['input'];
+  nodeType: Scalars['String']['input'];
+};
+
+export type DevWorkGraphSourceRef = {
+  __typename?: 'DevWorkGraphSourceRef';
+  queryVersion: Scalars['String']['output'];
+  refId: Scalars['ID']['output'];
+  sourceTable: Scalars['String']['output'];
+  sourceVersion: Scalars['String']['output'];
+  watermark?: Maybe<Scalars['DateTime']['output']>;
+};
+
 export type DimensionInput =
   | 'AUTHOR'
   | 'REPO'
@@ -1334,6 +1875,22 @@ export type Query = {
   compoundingRisk: CompoundingRiskResult;
   /** Operator data-health and trust surface */
   dataHealth: DataHealth;
+  /** Return reproducible observed changes across explicit equal-duration windows without upgrading correlation to cause. */
+  devChangeSummary: DevChangeSummary;
+  /** Report source-specific Ask Dev coverage, freshness, failures, and whether required sources permit a complete answer. Requires the canonical explicit-enable ask_dev entitlement. */
+  devDataHealth: DevDataHealthResult;
+  /** Search bounded authorized Ask Dev evidence. Source text is sanitized and explicitly untrusted; results are capped at 25. Requires the canonical explicit-enable ask_dev entitlement. */
+  devEvidenceSearch: DevEvidenceSearchResult;
+  /** Query one registered Ask Dev V1 metric through the shared bounded service, including prior-equivalent comparison and source state. */
+  devMetric: DevMetricResult;
+  /** List the exact authorized Ask Dev V1 metric registry. */
+  devMetricCatalog: DevMetricCatalog;
+  /** Search authorized Ask Dev V1 direct-scope entities. Results are tenant-scoped, deterministic, and capped at 25 candidates. */
+  devScopeSearch: DevScopeSearchResult;
+  /** Return declared status separately from deterministic, evidence-backed completion using the versioned Ask Dev status rules. */
+  devStatusSnapshot: DevStatusSnapshot;
+  /** Return persisted, tenant-scoped work-graph neighbors with depth fixed to one and code-owned relationship/result bounds. */
+  devWorkGraphNeighbors: DevWorkGraphNeighborsResult;
   /** Experiments derived from opportunity suggested_experiments (CHAOS-2219). v1: computed at query-time — no persistence table. Each experiment is a typed promotion of a suggestion string with hypothesis / metric / owner / stop_condition. ``derived_from_opportunities`` is False when the opportunities service was unavailable; items will be empty in that case. */
   experiments: ExperimentsResult;
   /** List feature flag state-change events */
@@ -1504,6 +2061,54 @@ export type QueryCompoundingRiskArgs = {
 
 export type QueryDataHealthArgs = {
   team: Scalars['ID']['input'];
+};
+
+
+export type QueryDevChangeSummaryArgs = {
+  input: DevChangeSummaryInput;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryDevDataHealthArgs = {
+  input: DevDataHealthInput;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryDevEvidenceSearchArgs = {
+  input: DevEvidenceSearchInput;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryDevMetricArgs = {
+  input: DevMetricQueryInput;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryDevMetricCatalogArgs = {
+  input?: InputMaybe<DevMetricCatalogInput>;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryDevScopeSearchArgs = {
+  input: DevScopeSearchInput;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryDevStatusSnapshotArgs = {
+  input: DevStatusSnapshotInput;
+  orgId: Scalars['String']['input'];
+};
+
+
+export type QueryDevWorkGraphNeighborsArgs = {
+  input: DevWorkGraphNeighborsInput;
+  orgId: Scalars['String']['input'];
 };
 
 

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -704,6 +704,520 @@ input DateRangeInput {
 """Date with time (isoformat)"""
 scalar DateTime
 
+type DevActualCompletion {
+  state: DevCompletionState!
+  ruleId: String!
+  ruleVersion: String!
+  reasonCodes: [String!]!
+  requiredChildren: [DevStatusFact!]!
+  conflicts: [DevStatusConflict!]!
+  sourceRefIds: [ID!]!
+  evidenceRefIds: [ID!]!
+}
+
+type DevCIStatusFact {
+  entityId: ID!
+  displayLabel: String!
+  conclusion: String!
+  required: Boolean
+  skippedRequiredWork: Boolean
+  observedAt: DateTime!
+  sourceRefId: ID!
+  evidenceRefIds: [ID!]!
+}
+
+type DevChangeSummary {
+  contractVersion: String!
+  state: String!
+  currentWindow: DevChangeWindow!
+  comparisonWindow: DevChangeWindow!
+  changes: [DevObservedChange!]!
+  sourceRefs: [DevStatusSourceRef!]!
+  warnings: [String!]!
+}
+
+input DevChangeSummaryInput {
+  scope: DevMetricScopeInput!
+  comparisonStart: DateTime!
+  comparisonEnd: DateTime!
+  maxItems: Int! = 100
+}
+
+type DevChangeWindow {
+  start: DateTime!
+  end: DateTime!
+}
+
+enum DevCompletionState {
+  READY
+  NOT_READY
+  INDETERMINATE
+}
+
+input DevDataHealthInput {
+  scope: DevEvidenceScopeInput!
+  requiredSources: [String!]! = []
+}
+
+type DevDataHealthResult {
+  sources: [DevDataHealthSource!]!
+  completeEligible: Boolean!
+  queryVersion: String!
+}
+
+type DevDataHealthSource {
+  sourceSystem: String!
+  state: String!
+  required: Boolean!
+  lastSuccessfulAt: DateTime
+  watermark: DateTime
+  missingRepositoryIds: [ID!]!
+  missingEntityIds: [ID!]!
+  coverage: Float!
+  confidenceImpact: String
+  freshnessPolicyVersion: String
+  warning: String
+}
+
+type DevDeploymentStatusFact {
+  entityId: ID!
+  displayLabel: String!
+  status: String!
+  environment: String
+  required: Boolean!
+  observedAt: DateTime!
+  sourceRefId: ID!
+  evidenceRefIds: [ID!]!
+}
+
+type DevEvidence {
+  evidenceRefId: ID!
+  sourceSystem: String!
+  sourceVersion: String!
+  entityType: String!
+  entityId: ID!
+  displayLabel: String!
+  link: DevEvidenceLink
+  observedAt: DateTime!
+  freshness: String!
+  provenance: String!
+  confidence: Float!
+  citationText: String
+  repositoryIds: [ID!]!
+  validEntityIds: [ID!]!
+  flags: DevEvidenceFlags!
+}
+
+type DevEvidenceFlags {
+  stale: Boolean!
+  unavailable: Boolean!
+  redacted: Boolean!
+  deleted: Boolean!
+  uncertain: Boolean!
+  conflicting: Boolean!
+  untrustedContent: Boolean!
+}
+
+type DevEvidenceLink {
+  internalPath: String
+  sourceUrl: String
+}
+
+input DevEvidenceScopeInput {
+  directScope: DevEvidenceScopeKind!
+  refs: [DevEvidenceScopeRefInput!]! = []
+  teamIds: [String!]! = []
+  presetDays: Int = 30
+  startDate: Date = null
+  endDate: Date = null
+  timezone: String! = "UTC"
+}
+
+enum DevEvidenceScopeKind {
+  ORGANIZATION
+  REPOSITORY
+  PROJECT
+  WORK_UNIT
+  ISSUE
+  PULL_REQUEST
+}
+
+input DevEvidenceScopeRefInput {
+  kind: DevEvidenceScopeKind!
+  value: String!
+}
+
+input DevEvidenceSearchInput {
+  query: String!
+  scope: DevEvidenceScopeInput!
+  limit: Int! = 25
+}
+
+type DevEvidenceSearchResult {
+  evidence: [DevEvidence!]!
+  sources: [DevEvidenceSourceState!]!
+  queryVersion: String!
+  rankingVersion: String!
+}
+
+type DevEvidenceSourceState {
+  sourceSystem: String!
+  state: String!
+  watermark: String
+  warning: String
+}
+
+type DevIncidentStatusFact {
+  entityId: ID!
+  displayLabel: String!
+  status: String!
+  active: Boolean!
+  blocking: Boolean!
+  observedAt: DateTime!
+  sourceRefId: ID!
+  evidenceRefIds: [ID!]!
+}
+
+type DevMetricCatalog {
+  metrics: [DevMetricDefinition!]!
+  registryVersion: String!
+}
+
+input DevMetricCatalogInput {
+  directScope: DevMetricDirectScope = null
+  hasTeamFilter: Boolean! = false
+}
+
+enum DevMetricDataState {
+  VALUE
+  ZERO
+  NO_MATCH
+  INSUFFICIENT_EVIDENCE
+  PARTIAL
+  STALE
+  UNCONFIGURED
+  UNAVAILABLE
+}
+
+type DevMetricDefinition {
+  metricId: DevMetricID!
+  label: String!
+  owner: String!
+  description: String!
+  definitionVersion: String!
+  sourceTable: String!
+  sourceVersion: String!
+  queryVersion: String!
+  unit: String!
+  aggregation: String!
+  displayPrecision: Int!
+  nullSemantics: String!
+  zeroSemantics: String!
+  supportedScopes: [DevMetricDirectScope!]!
+  supportsTeamFilter: Boolean!
+  supportedDimensions: [String!]!
+  supportedPresets: [Int!]!
+  supportedTimeGrains: [String!]!
+  minRangeDays: Int!
+  maxRangeDays: Int!
+  comparisonRule: String!
+  freshnessPolicy: String!
+  expectedMaterialization: String!
+  upstreamSources: [String!]!
+  sensitivity: String!
+  entitlement: String!
+}
+
+type DevMetricDimensionValue {
+  key: String!
+  value: String!
+}
+
+enum DevMetricDirectScope {
+  ORGANIZATION
+  REPOSITORY
+  PROJECT
+  WORK_UNIT
+  ISSUE
+  PULL_REQUEST
+}
+
+enum DevMetricFreshness {
+  FRESH
+  STALE
+  UNAVAILABLE
+  UNKNOWN
+}
+
+enum DevMetricID {
+  ITEMS_COMPLETED
+  CYCLE_TIME_P50_HOURS
+  AVG_WIP
+  DEPLOYMENTS_COUNT
+  CHANGE_FAILURE_RATE
+  INVESTMENT_ALLOCATION_PCT
+  CYCLOMATIC_PER_KLOC
+  COMPOUNDING_RISK_SCORE
+}
+
+type DevMetricMetadata {
+  key: String!
+  value: String!
+}
+
+input DevMetricQueryInput {
+  metricId: DevMetricID!
+  scope: DevMetricScopeInput!
+  dimensions: [String!]! = []
+  includeComparison: Boolean! = true
+  includeSeries: Boolean! = false
+  maxSeriesPoints: Int! = 90
+}
+
+type DevMetricResult {
+  definition: DevMetricDefinition!
+  state: DevMetricDataState!
+  freshness: DevMetricFreshness!
+  values: [DevMetricValue!]!
+  coverage: Float!
+  currentWindowStart: DateTime!
+  currentWindowEnd: DateTime!
+  comparisonWindowStart: DateTime
+  comparisonWindowEnd: DateTime
+  timezone: String!
+  watermark: DateTime
+  sourceRefs: [DevMetricSourceRef!]!
+  metadata: [DevMetricMetadata!]!
+  warnings: [String!]!
+}
+
+input DevMetricScopeInput {
+  directScope: DevMetricDirectScope!
+  startDate: Date!
+  endDate: Date!
+  refs: [ID!]! = []
+  teamIds: [ID!]! = []
+  timezone: String! = "UTC"
+}
+
+type DevMetricSeriesPoint {
+  timestamp: DateTime!
+  value: Float!
+}
+
+type DevMetricSourceRef {
+  refId: ID!
+  sourceTable: String!
+  sourceVersion: String!
+  watermark: DateTime
+  queryVersion: String!
+}
+
+type DevMetricValue {
+  dimensions: [DevMetricDimensionValue!]!
+  value: Float!
+  comparisonValue: Float
+  series: [DevMetricSeriesPoint!]!
+}
+
+type DevObservedChange {
+  changeId: ID!
+  category: String!
+  entityType: String!
+  entityId: ID!
+  displayLabel: String!
+  before: String
+  after: String
+  observedAt: DateTime!
+  claimKind: String!
+  relationshipChain: [String!]!
+  metricId: DevMetricID
+  metricValue: Float
+  metricComparisonValue: Float
+  sourceRefIds: [ID!]!
+  evidenceRefIds: [ID!]!
+  confidence: Float
+}
+
+type DevPullRequestStatusFact {
+  entityId: ID!
+  displayLabel: String!
+  state: String!
+  reviewState: String
+  changesRequested: Int!
+  merged: Boolean!
+  observedAt: DateTime!
+  sourceRefId: ID!
+  evidenceRefIds: [ID!]!
+  required: Boolean!
+}
+
+type DevScopeCandidate {
+  kind: DevScopeEntityKind!
+  canonicalId: ID!
+  label: String!
+  repositoryId: ID
+}
+
+enum DevScopeEntityKind {
+  REPOSITORY
+  PROJECT
+  WORK_UNIT
+  ISSUE
+  PULL_REQUEST
+}
+
+input DevScopeSearchInput {
+  query: String!
+  kinds: [DevScopeEntityKind!]!
+  limit: Int! = 25
+}
+
+type DevScopeSearchResult {
+  candidates: [DevScopeCandidate!]!
+  queryVersion: String!
+  catalogWatermark: String!
+}
+
+type DevStatusConflict {
+  code: String!
+  message: String!
+  severity: String!
+  sourceRefIds: [ID!]!
+  evidenceRefIds: [ID!]!
+}
+
+type DevStatusFact {
+  entityType: String!
+  entityId: ID!
+  displayLabel: String!
+  status: String!
+  observedAt: DateTime!
+  sourceRefId: ID!
+  evidenceRefIds: [ID!]!
+  required: Boolean
+}
+
+type DevStatusScope {
+  schemaVersion: String!
+  organizationId: ID!
+  directScope: String!
+  repositoryIds: [ID!]!
+  entities: [DevStatusScopeEntity!]!
+  teamIds: [ID!]!
+  currentStart: DateTime!
+  currentEnd: DateTime!
+  comparisonStart: DateTime
+  comparisonEnd: DateTime
+  timezone: String!
+}
+
+type DevStatusScopeEntity {
+  entityType: String!
+  entityId: ID!
+  displayLabel: String!
+  repositoryId: ID
+}
+
+type DevStatusSnapshot {
+  contractVersion: String!
+  state: String!
+  scope: DevStatusScope!
+  asOf: DateTime!
+  declared: DevStatusFact
+  actual: DevActualCompletion!
+  children: [DevStatusFact!]!
+  blockers: [DevStatusFact!]!
+  pullRequests: [DevPullRequestStatusFact!]!
+  ci: [DevCIStatusFact!]!
+  deployments: [DevDeploymentStatusFact!]!
+  incidents: [DevIncidentStatusFact!]!
+  sourceRefs: [DevStatusSourceRef!]!
+  warnings: [String!]!
+}
+
+input DevStatusSnapshotInput {
+  scope: DevMetricScopeInput!
+  asOf: DateTime = null
+  maxItems: Int! = 100
+}
+
+type DevStatusSourceRef {
+  refId: ID!
+  sourceSystem: String!
+  sourceVersion: String!
+  freshness: String!
+  watermark: DateTime
+  evidenceRefIds: [ID!]!
+}
+
+enum DevWorkGraphDirection {
+  INCOMING
+  OUTGOING
+  BOTH
+}
+
+type DevWorkGraphNeighborEdge {
+  edgeId: ID!
+  sourceType: String!
+  sourceId: ID!
+  targetType: String!
+  targetId: ID!
+  relationshipType: String!
+  direction: DevWorkGraphDirection!
+  provenance: String!
+  confidence: Float!
+  sourceRefId: ID!
+  evidenceRefIds: [ID!]!
+  observedAt: DateTime!
+  freshness: String!
+}
+
+type DevWorkGraphNeighborNode {
+  nodeType: String!
+  nodeId: ID!
+  displayLabel: String!
+  resolutionState: String!
+  repositoryId: ID
+}
+
+input DevWorkGraphNeighborsInput {
+  scope: DevEvidenceScopeInput!
+  rootRefs: [DevWorkGraphRootRefInput!]!
+  relationshipTypes: [String!]!
+  direction: DevWorkGraphDirection! = BOTH
+  limit: Int! = 25
+  depth: Int! = 1
+}
+
+type DevWorkGraphNeighborsResult {
+  schemaVersion: String!
+  state: String!
+  nodes: [DevWorkGraphNeighborNode!]!
+  edges: [DevWorkGraphNeighborEdge!]!
+  sourceRefs: [DevWorkGraphSourceRef!]!
+  warnings: [String!]!
+  totalCount: Int!
+  returnedCount: Int!
+  truncated: Boolean!
+  depth: Int!
+  queryVersion: String!
+  watermark: DateTime
+}
+
+input DevWorkGraphRootRefInput {
+  nodeType: String!
+  nodeId: ID!
+}
+
+type DevWorkGraphSourceRef {
+  refId: ID!
+  sourceTable: String!
+  sourceVersion: String!
+  watermark: DateTime
+  queryVersion: String!
+}
+
 enum DimensionInput {
   TEAM
   REPO
@@ -1167,6 +1681,44 @@ type PullRequestReview {
 }
 
 type Query {
+  """
+  Search authorized Ask Dev V1 direct-scope entities. Results are tenant-scoped, deterministic, and capped at 25 candidates.
+  """
+  devScopeSearch(orgId: String!, input: DevScopeSearchInput!): DevScopeSearchResult!
+
+  """List the exact authorized Ask Dev V1 metric registry."""
+  devMetricCatalog(orgId: String!, input: DevMetricCatalogInput = null): DevMetricCatalog!
+
+  """
+  Query one registered Ask Dev V1 metric through the shared bounded service, including prior-equivalent comparison and source state.
+  """
+  devMetric(orgId: String!, input: DevMetricQueryInput!): DevMetricResult!
+
+  """
+  Search bounded authorized Ask Dev evidence. Source text is sanitized and explicitly untrusted; results are capped at 25. Requires the canonical explicit-enable ask_dev entitlement.
+  """
+  devEvidenceSearch(orgId: String!, input: DevEvidenceSearchInput!): DevEvidenceSearchResult!
+
+  """
+  Report source-specific Ask Dev coverage, freshness, failures, and whether required sources permit a complete answer. Requires the canonical explicit-enable ask_dev entitlement.
+  """
+  devDataHealth(orgId: String!, input: DevDataHealthInput!): DevDataHealthResult!
+
+  """
+  Return declared status separately from deterministic, evidence-backed completion using the versioned Ask Dev status rules.
+  """
+  devStatusSnapshot(orgId: String!, input: DevStatusSnapshotInput!): DevStatusSnapshot!
+
+  """
+  Return reproducible observed changes across explicit equal-duration windows without upgrading correlation to cause.
+  """
+  devChangeSummary(orgId: String!, input: DevChangeSummaryInput!): DevChangeSummary!
+
+  """
+  Return persisted, tenant-scoped work-graph neighbors with depth fixed to one and code-owned relationship/result bounds.
+  """
+  devWorkGraphNeighbors(orgId: String!, input: DevWorkGraphNeighborsInput!): DevWorkGraphNeighborsResult!
+
   """Get catalog of available dimensions, measures, and limits"""
   catalog(orgId: String!, dimension: DimensionInput = null, filters: FilterInput = null): CatalogResult!
 

--- a/tests/acr-context-fabric.production.spec.ts
+++ b/tests/acr-context-fabric.production.spec.ts
@@ -161,6 +161,38 @@ test.describe("Context Fabric production entitlement boundary", () => {
         await setAcrMockControls(request);
     });
 
+    test("accepts a device code produced by ACR without a duplicated browser alphabet", async ({
+        page,
+    }, testInfo) => {
+        await setEntitlementScenario(page.request, "provisioned");
+        const previewBodies: unknown[] = [];
+        await page.route("**/api/acr/device", async (route) => {
+            previewBodies.push(route.request().postDataJSON());
+            await route.fulfill({
+                body: JSON.stringify({ repositoryHints: ["full-chaos/dev-health-acr"] }),
+                contentType: "application/json",
+                status: 200,
+            });
+        });
+        await page.goto("/acr/device");
+
+        const code = page.getByLabel("Verification code");
+        await code.fill("EP23TUGG");
+        expect(await code.evaluate((input: HTMLInputElement) => input.checkValidity())).toBe(true);
+        await page.screenshot({
+            path: testInfo.outputPath("device-approval-valid-code-entry.png"),
+            fullPage: true,
+        });
+        await page.getByRole("button", { name: "Preview request" }).click();
+
+        await expect(page.getByRole("heading", { name: "Review device access" })).toBeVisible();
+        expect(previewBodies).toEqual([{ action: "preview", user_code: "EP23TUGG" }]);
+        await page.screenshot({
+            path: testInfo.outputPath("device-approval-valid-code.png"),
+            fullPage: true,
+        });
+    });
+
     test("shows one current Context Fabric destination for a provisioned organization at every viewport", async ({
         page,
     }, testInfo) => {


### PR DESCRIPTION
## Summary

- remove Web's hand-copied device-code alphabet so ACR remains the single authority for code validity
- cover the exact ACR-generated code `EP23TUGG` through preview and approval
- add a production-mode browser regression that proves the code is natively valid and reaches the review screen

## Root cause

ACR generates codes from `23456789ABCDEFGHJKLMNPQRSTUVWXYZ`, but Web's HTML `pattern` independently omitted `U`. The previous tests used only `ABCD2345`, which sat inside both alphabets and could not expose the contract drift.

## Validation

- red reproduction: component regression failed on untouched behavior because `EP23TUGG` was natively invalid
- focused unit/API tests: 27 passed
- production Next.js build: passed
- focused production Playwright flow: auth setup + device approval passed
- lint, typecheck, changed-file formatting, and scoped design lint: passed
- synchronized the checked-in GraphQL schema and generated types with the current Ops exporter; exact exporter diff, `pnpm codegen:check`, and typecheck pass
- full unit suite: 3,316 passed; 6 unrelated owned-process tests timed out under the local process sandbox
- repository-wide design lint remains red on 252 pre-existing violations; the changed ACR files pass scoped design lint

Linear: [CHAOS-3231](https://linear.app/fullchaos/issue/CHAOS-3231/web-device-approval-rejects-valid-acr-verification-codes)

## Visual evidence

Valid ACR-generated code accepted by the browser form:

![Valid ACR device code entry](https://github.com/user-attachments/assets/a5adc0cd-dad3-4e86-93ad-2d415a1a4cae)
