### PR TITLE
fix(acr): approve device grants without repo hints

### DIFF
--- a/src/components/acr/DeviceApprovalForm.test.tsx
+++ b/src/components/acr/DeviceApprovalForm.test.tsx
@@ -69,23 +69,44 @@ describe("DeviceApprovalForm", () => {
         );
     });
 
-    it("Given a preview with no available repositories, when rendered, then prevents an unbounded approval request", async () => {
+    it("Given a preview with no repository preference, when confirming, then approves from the authorized catalog", async () => {
         const fetchMock = vi
             .fn()
             .mockResolvedValueOnce(
                 new Response(JSON.stringify({ repositoryHints: [] }), { status: 200 }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ status: "approved" }), { status: 200 }),
             );
         vi.stubGlobal("fetch", fetchMock);
 
-        render(<DeviceApprovalForm repositories={["full-chaos/platform"]} />);
+        render(
+            <DeviceApprovalForm repositories={["full-chaos/dev-health", "full-chaos/platform"]} />,
+        );
         fireEvent.change(screen.getByLabelText("Verification code"), {
-            target: { value: "ABCD2345" },
+            target: { value: "EP23TUGG" },
         });
         fireEvent.click(screen.getByRole("button", { name: "Preview request" }));
 
-        await screen.findByText("No authorized repositories match this request.");
-        expect(screen.getByRole("button", { name: "Confirm" })).toBeDisabled();
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        await screen.findByRole("heading", { name: "Review device access" });
+        expect(screen.getByLabelText("full-chaos/dev-health")).toBeChecked();
+        expect(screen.getByLabelText("full-chaos/platform")).toBeChecked();
+
+        fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+        await screen.findByRole("heading", { name: "Approval complete" });
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            2,
+            "/api/acr/device",
+            expect.objectContaining({
+                body: JSON.stringify({
+                    action: "approve",
+                    repository_scopes: ["full-chaos/dev-health", "full-chaos/platform"],
+                    user_code: "EP23TUGG",
+                }),
+                method: "POST",
+            }),
+        );
     });
 
     it("Given a malformed eight-character code, when ACR rejects it, then shows the rejection", async () => {

--- a/src/components/acr/DeviceApprovalForm.tsx
+++ b/src/components/acr/DeviceApprovalForm.tsx
@@ -54,6 +54,14 @@ function errorState(response: Response): ApprovalState {
     return "pending";
 }
 
+function repositoriesForHints(
+    repositories: readonly string[],
+    hints: readonly string[],
+): readonly string[] {
+    if (hints.length === 0) return repositories;
+    return repositories.filter((repository) => hints.includes(repository));
+}
+
 export function DeviceApprovalForm({
     initialState = "pending",
     repositories,
@@ -66,7 +74,7 @@ export function DeviceApprovalForm({
     const [hints, setHints] = useState<readonly string[]>([]);
     const descriptionId = useId();
     const stateMessage = stateCopy(state);
-    const availableRepositories = repositories.filter((repository) => hints.includes(repository));
+    const availableRepositories = repositoriesForHints(repositories, hints);
 
     function toggleRepository(repository: string): void {
         setSelected((current) =>
@@ -89,9 +97,7 @@ export function DeviceApprovalForm({
             const result = await response.json();
             if (response.ok && result.repositoryHints) {
                 setHints(result.repositoryHints);
-                const available = repositories.filter((repo) =>
-                    result.repositoryHints.includes(repo),
-                );
+                const available = repositoriesForHints(repositories, result.repositoryHints);
                 setSelected(available);
                 setState("review");
                 return;

--- a/tests/acr-context-fabric.production.spec.ts
+++ b/tests/acr-context-fabric.production.spec.ts
@@ -161,15 +161,18 @@ test.describe("Context Fabric production entitlement boundary", () => {
         await setAcrMockControls(request);
     });
 
-    test("accepts a device code produced by ACR without a duplicated browser alphabet", async ({
+    test("approves an ACR device code without a duplicated alphabet or repository hint", async ({
         page,
     }, testInfo) => {
         await setEntitlementScenario(page.request, "provisioned");
-        const previewBodies: unknown[] = [];
+        const approvalBodies: unknown[] = [];
         await page.route("**/api/acr/device", async (route) => {
-            previewBodies.push(route.request().postDataJSON());
+            const body = route.request().postDataJSON();
+            approvalBodies.push(body);
             await route.fulfill({
-                body: JSON.stringify({ repositoryHints: ["full-chaos/dev-health-acr"] }),
+                body: JSON.stringify(
+                    body.action === "approve" ? { status: "approved" } : { repositoryHints: [] },
+                ),
                 contentType: "application/json",
                 status: 200,
             });
@@ -186,11 +189,22 @@ test.describe("Context Fabric production entitlement boundary", () => {
         await page.getByRole("button", { name: "Preview request" }).click();
 
         await expect(page.getByRole("heading", { name: "Review device access" })).toBeVisible();
-        expect(previewBodies).toEqual([{ action: "preview", user_code: "EP23TUGG" }]);
+        await expect(page.getByLabel("full-chaos/dev-health-acr")).toBeChecked();
         await page.screenshot({
             path: testInfo.outputPath("device-approval-valid-code.png"),
             fullPage: true,
         });
+        await page.getByRole("button", { name: "Confirm" }).click();
+
+        await expect(page.getByRole("heading", { name: "Approval complete" })).toBeVisible();
+        expect(approvalBodies).toEqual([
+            { action: "preview", user_code: "EP23TUGG" },
+            {
+                action: "approve",
+                repository_scopes: ["full-chaos/dev-health-acr"],
+                user_code: "EP23TUGG",
+            },
+        ]);
     });
 
     test("shows one current Context Fabric destination for a provisioned organization at every viewport", async ({


### PR DESCRIPTION
## Summary

- treat empty ACR repository hints as "no client preference" instead of "no repositories"
- keep non-empty hints as a strict intersection with the user's authorized repository catalog
- exercise the complete empty-hint Preview → selection → Confirm → Approval complete browser flow

## Root cause

`acr-mcp login` sends no repository hints when it is run without `--repo` (including from a home directory). ACR correctly returns `repository_hints: []`, but Web filtered the authorized catalog with that empty list. The review screen contained no repositories, Confirm stayed disabled, and the grant remained pending until expiry.

The observed ACR `status=400 bytes=75` responses were not datastore failures: 75 bytes is the exact encoded OAuth `authorization_pending` response. Store/runtime failures map to HTTP 503. The supplied Compose file points `acr-api`, `acr-migrate`, and device authorization storage at the same `acr` database and schema.

## Validation

- red reproduction: the component regression reached Review but found no authorized repository under the old behavior
- focused component/API/service tests: 27 passed
- production Next.js build: passed
- production-style Playwright flow: auth setup + empty-hint device approval passed (2 tests)
- typecheck, ESLint, scoped design lint, Prettier, and `git diff --check`: passed
- repository-wide design lint remains red on 252 pre-existing violations; changed files pass scoped design lint

Linear: [CHAOS-3232](https://linear.app/fullchaos/issue/CHAOS-3232/acr-device-login-cannot-approve-grants-without-repository-hints)

## Visual evidence

Device approval flow under production styling (one screenshot, per review request):

![device-approval-valid-code-entry.png](https://github.com/user-attachments/assets/a5adc0cd-dad3-4e86-93ad-2d415a1a4cae)
