### PR TITLE
fix(acr): accept omitted empty repository hints

### DIFF
--- a/src/lib/acr/__tests__/device-approval.test.ts
+++ b/src/lib/acr/__tests__/device-approval.test.ts
@@ -206,6 +206,24 @@ describe("approveDeviceAuthorization", () => {
         expect(assertions[0]).not.toBe(assertions[1]);
     });
 
+    it("Given a preview with no repository hints, when ACR omits the optional field, then returns an empty selection", async () => {
+        installOpsAuthorization();
+        server.use(
+            http.post("https://acr.example.test/api/v1/oauth/device_approval", () =>
+                HttpResponse.json({
+                    schema_version: "device_approval_preview_response.v1",
+                }),
+            ),
+        );
+
+        await expect(
+            previewDeviceAuthorization({
+                signal: new AbortController().signal,
+                userCode: "ABCD2345",
+            }),
+        ).resolves.toEqual({ repositoryHints: [] });
+    });
+
     it.each([
         ["a null hint", null],
         ["an empty hint", ""],

--- a/src/lib/acr/client.ts
+++ b/src/lib/acr/client.ts
@@ -75,7 +75,7 @@ const deviceApprovalPreviewResponseSchema = z
     .object({
         organization_id_hint: z.string().min(1).max(128).optional(),
         schema_version: z.literal("device_approval_preview_response.v1"),
-        repository_hints: z.array(z.string()),
+        repository_hints: z.array(z.string()).default([]),
     })
     .strict();
 


### PR DESCRIPTION
## Summary

- treat an omitted `repository_hints` preview field as the empty list defined by the ACR Go wire contract
- add a regression using the exact response shape observed in the live local failure

## Root cause

ACR declares `DeviceApprovalPreviewResponse.RepositoryHints` with `json:"repository_hints,omitempty"`. For a login without hints it correctly returned only `schema_version`. Web required `repository_hints` in its Zod schema, classified the HTTP 200 response as malformed, returned HTTP 503 from `/api/acr/device`, and left the CLI polling `authorization_pending`.

PR #812 fixed the form behavior after a successful empty-hints preview; this follow-up fixes the client contract so that preview can succeed.

## Validation

- focused device-approval suite: 15 passed
- Prettier check on changed files: passed
- ESLint on changed files: passed
- TypeScript `tsc --noEmit`: passed
- source/test governance: passed
- pre-push Prettier and ESLint: passed
- full-tree design lint reports 252 existing errors in unrelated files; neither changed file appears in that output

Linear: [CHAOS-3232](https://linear.app/fullchaos/issue/CHAOS-3232/acr-device-login-cannot-approve-grants-without-repository-hints)

SCREENSHOT-WAIVER: Response-contract parsing only; no rendered UI change.