### PR TITLE
fix(acr): accept every generated device code

### DIFF
--- a/src/lib/acr/__tests__/device-approval.test.ts
+++ b/src/lib/acr/__tests__/device-approval.test.ts
@@ -92,6 +92,31 @@ afterEach(() => {
 });
 
 describe("approveDeviceAuthorization", () => {
+    it("Given ACR-generated L and U characters, when previewing, then forwards the valid code", async () => {
+        installOpsAuthorization();
+        server.use(
+            http.post(
+                "https://acr.example.test/api/v1/oauth/device_approval",
+                async ({ request }) => {
+                    expect(await request.json()).toEqual({
+                        schema_version: "device_approval_preview_request.v1",
+                        user_code: "ALU23456",
+                    });
+                    return HttpResponse.json({
+                        schema_version: "device_approval_preview_response.v1",
+                    });
+                },
+            ),
+        );
+
+        await expect(
+            previewDeviceAuthorization({
+                signal: new AbortController().signal,
+                userCode: "ALU23456",
+            }),
+        ).resolves.toEqual({ repositoryHints: [] });
+    });
+
     it("Given an explicit selected repository, when approving, then sends only the bounded grant with a body-bound credential assertion", async () => {
         installOpsAuthorization();
         server.use(

--- a/src/lib/acr/service.ts
+++ b/src/lib/acr/service.ts
@@ -7,7 +7,6 @@ import { AcrRuntimeError, acrRuntimeErrorCodes } from "./errors";
 import { resolveOpsAuthorization } from "./ops";
 import { contextPacketRequest, parseContextPacketForm, parseEvidenceSelection } from "./protocol";
 
-const deviceUserCode = /^[ABCDEFGHJKMNPQRSTVWXYZ23456789]{8}$/u;
 const repositoryScope = /^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/u;
 
 type WebSession = {
@@ -146,7 +145,6 @@ export async function approveDeviceAuthorization(input: {
     readonly signal: AbortSignal;
     readonly userCode: string;
 }): Promise<{ readonly status: "approved" }> {
-    if (!deviceUserCode.test(input.userCode)) throw invalidApprovalRequest();
     const requestedScopes = canonicalApprovalScopes(input.repositoryScopes);
     const rawSession = await auth();
     const session = sessionOrError(rawSession);
@@ -190,7 +188,6 @@ export async function previewDeviceAuthorization(input: {
     readonly organizationIdHint?: string;
     readonly repositoryHints: readonly string[];
 }> {
-    if (!deviceUserCode.test(input.userCode)) throw invalidApprovalRequest();
     const rawSession = await auth();
     const session = sessionOrError(rawSession);
     if (


### PR DESCRIPTION
## Summary

- remove Web server's duplicated semantic device-code alphabet validator
- forward device codes to ACR, the protocol authority, for validation
- add service-boundary regression coverage proving ACR-generated `L` and `U` codes reach the signed approval request

## Root cause

PR #811 removed the browser pattern and tested `EP23TUGG`, but the Playwright test intercepted `/api/acr/device`. It therefore bypassed Web's server validator, which still rejected `U` (and `L`) before calling ACR.

## Verification

- red proof: the new service test fails with the old regex before any ACR request
- `node_modules/.bin/vitest run src/lib/acr/__tests__/device-approval.test.ts src/app/api/acr/device/route.test.ts src/components/acr/DeviceApprovalForm.test.tsx` (29 passed)
- scoped ESLint passed
- `node_modules/.bin/tsc --noEmit` passed
- repo-wide pre-push design lint currently reports 252 unrelated existing violations; neither changed file appears in that failure list

SCREENSHOT-WAIVER: server-only validation behavior; rendered UI is unchanged.

Tracks [CHAOS-3235](https://linear.app/fullchaos/issue/CHAOS-3235/acr-generated-device-codes-are-rejected-by-web-and-published-schemas).
Follow-up contract-hardening audit: [CHAOS-3236](https://linear.app/fullchaos/issue/CHAOS-3236/harden-acr-login-contract-parity-across-api-web-cli-and-schemas).