### PR TITLE
fix(auth): restore protected destination after login (CHAOS-3237)

### DIFF
--- a/docs/auth-system.md
+++ b/docs/auth-system.md
@@ -112,6 +112,7 @@ sequenceDiagram
     participant NA as NextAuth authorize
     participant L as Backend /login
     participant S as NextAuth session
+    participant C as callbackUrl
     participant D as /dashboard
     participant O as /auth/onboard
 
@@ -121,10 +122,12 @@ sequenceDiagram
     L->>L: check_lockout, bcrypt verify
     L-->>NA: LoginResponse {access_token, refresh_token, needs_onboarding, user}
     NA->>S: Create session/JWT with backend token
-    alt needs_onboarding is false
-        LF->>D: router.push("/dashboard")
-    else needs_onboarding is true
-        LF->>O: router.push("/auth/onboard")
+    alt needs_onboarding is true
+        LF->>O: hard-navigate to /auth/onboard
+    else safe callbackUrl is present
+        LF->>C: hard-navigate to callbackUrl
+    else
+        LF->>D: hard-navigate to /dashboard
     end
 ```
 
@@ -133,8 +136,10 @@ sequenceDiagram
 | Backend unit        | `tests/api/auth/test_email_normalization.py`            | Case-insensitive lookup                    |
 | Backend unit        | `tests/api/auth/test_email_verification_enforcement.py` | Verified user can login                    |
 | Backend integration | `tests/api/test_new_user_journey.py`                    | Register then login returns tokens         |
-| Frontend unit       | `src/components/auth/LoginForm.test.tsx`                | Dashboard redirect on success              |
-| Frontend E2E        | `tests/auth-signin.spec.ts`                             | Form renders, error toast                  |
+| Frontend unit       | `src/components/auth/LoginForm.test.tsx`                | Dashboard/callbackUrl redirect on success  |
+| Frontend unit       | `src/components/auth/SocialLoginButtons.test.tsx`       | Provider sign-in preserves callbackUrl     |
+| Frontend unit       | `src/app/(auth)/auth/signin/page.test.tsx`              | Sign-in page threads callbackUrl into form |
+| Frontend E2E        | `tests/auth-signin.spec.ts`                             | Form, errors, protected-route return       |
 | Frontend E2E        | `tests/account-creation-journey.spec.ts` (step 2-3)     | Login then onboard then dashboard          |
 | Live E2E            | `tests/live/onboarding-ui.spec.ts`                      | Login with verified user reaches dashboard |
 

--- a/src/app/(auth)/auth/signin/page.test.tsx
+++ b/src/app/(auth)/auth/signin/page.test.tsx
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const redirectMock = vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+});
+const authMock = vi.fn();
+const providersMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+    redirect: (url: string) => redirectMock(url),
+}));
+
+vi.mock("@/lib/auth", () => ({
+    auth: () => authMock(),
+    getAvailableSocialProviders: () => providersMock(),
+}));
+
+vi.mock("@/components/auth/LoginForm", () => ({
+    LoginForm: (props: { callbackUrl?: string; plan?: string; trialIntent?: boolean }) => (
+        <div
+            data-testid="login-form"
+            data-callback-url={props.callbackUrl ?? ""}
+            data-plan={props.plan ?? ""}
+            data-trial-intent={props.trialIntent ? "true" : "false"}
+        />
+    ),
+}));
+
+vi.mock("@/components/auth/AuthCard", () => ({
+    AuthCard: ({
+        children,
+        callbackUrl,
+        signUpHref,
+    }: {
+        callbackUrl?: string;
+        children: React.ReactNode;
+        signUpHref?: string;
+    }) => (
+        <section
+            data-testid="auth-card"
+            data-callback-url={callbackUrl ?? ""}
+            data-signup-href={signUpHref ?? ""}
+        >
+            {children}
+        </section>
+    ),
+}));
+
+vi.mock("@/components/auth/SocialLoginError", () => ({
+    SocialLoginError: ({ error }: { error: string }) => <span>{error}</span>,
+}));
+
+import SignInPage from "./page";
+
+async function renderPage(params: Record<string, string> = {}) {
+    return SignInPage({ searchParams: Promise.resolve(params) });
+}
+
+describe("SignInPage", () => {
+    beforeEach(() => {
+        authMock.mockResolvedValue(null);
+        providersMock.mockReturnValue(["github"]);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("passes the callbackUrl to the login form and auth card", async () => {
+        const ui = await renderPage({ callbackUrl: "/acr/device" });
+        render(ui as React.ReactElement);
+
+        expect(screen.getByTestId("auth-card")).toHaveAttribute("data-callback-url", "/acr/device");
+        expect(screen.getByTestId("auth-card")).toHaveAttribute(
+            "data-signup-href",
+            "/auth/signup?callbackUrl=%2Facr%2Fdevice",
+        );
+        expect(screen.getByTestId("login-form")).toHaveAttribute(
+            "data-callback-url",
+            "/acr/device",
+        );
+    });
+
+    it("redirects an already-authenticated user to the callbackUrl", async () => {
+        authMock.mockResolvedValue({
+            user: { needs_onboarding: false },
+        });
+
+        await expect(renderPage({ callbackUrl: "/acr/device" })).rejects.toThrow(
+            "NEXT_REDIRECT:/acr/device",
+        );
+    });
+
+    it("keeps required onboarding ahead of the callbackUrl", async () => {
+        authMock.mockResolvedValue({
+            user: { needs_onboarding: true },
+        });
+
+        await expect(renderPage({ callbackUrl: "/acr/device" })).rejects.toThrow(
+            "NEXT_REDIRECT:/auth/onboard",
+        );
+    });
+
+    it("ignores auth-page callback targets and falls back to the dashboard", async () => {
+        const ui = await renderPage({ callbackUrl: "/auth/signin" });
+        render(ui as React.ReactElement);
+
+        expect(screen.getByTestId("login-form")).toHaveAttribute("data-callback-url", "");
+        expect(screen.getByTestId("auth-card")).toHaveAttribute("data-signup-href", "/auth/signup");
+    });
+});

--- a/src/app/(auth)/auth/signin/page.tsx
+++ b/src/app/(auth)/auth/signin/page.tsx
@@ -3,6 +3,7 @@ import { auth, getAvailableSocialProviders } from "@/lib/auth";
 import { LoginForm } from "@/components/auth/LoginForm";
 import { AuthCard } from "@/components/auth/AuthCard";
 import { SocialLoginError } from "@/components/auth/SocialLoginError";
+import { appendCallbackUrl, safePostLoginRedirect } from "@/lib/post-login-redirect";
 
 type SearchParams = Promise<{
     registered?: string;
@@ -10,20 +11,25 @@ type SearchParams = Promise<{
     trial?: string;
     error?: string;
     from?: string;
+    callbackUrl?: string;
 }>;
 
 export default async function SignInPage({ searchParams }: { searchParams: SearchParams }) {
     const params = await searchParams;
     const plan = params.plan?.toLowerCase();
     const trialIntent = plan === "team" && params.trial === "true";
-    const signupHref = trialIntent ? "/auth/signup?plan=team&trial=true" : "/auth/signup";
+    const callbackUrl = safePostLoginRedirect(params.callbackUrl);
+    const signupHref = appendCallbackUrl(
+        trialIntent ? "/auth/signup?plan=team&trial=true" : "/auth/signup",
+        callbackUrl,
+    );
 
     const session = await auth();
     if (session?.user && params.from !== "reset") {
         if (session.user.needs_onboarding) {
             redirect(trialIntent ? "/auth/onboard?plan=team&trial=true" : "/auth/onboard");
         }
-        redirect("/dashboard");
+        redirect(callbackUrl ?? "/dashboard");
     }
 
     const justRegistered = params.registered === "true";
@@ -42,8 +48,8 @@ export default async function SignInPage({ searchParams }: { searchParams: Searc
                     <SocialLoginError error={socialError} />
                 </div>
             )}
-            <AuthCard signUpHref={signupHref} providers={providers}>
-                <LoginForm plan={plan} trialIntent={trialIntent} />
+            <AuthCard callbackUrl={callbackUrl} signUpHref={signupHref} providers={providers}>
+                <LoginForm callbackUrl={callbackUrl} plan={plan} trialIntent={trialIntent} />
             </AuthCard>
         </div>
     );

--- a/src/app/(auth)/auth/signup/page.test.tsx
+++ b/src/app/(auth)/auth/signup/page.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const providersMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+    getAvailableSocialProviders: () => providersMock(),
+}));
+
+vi.mock("@/components/auth/SignupForm", () => ({
+    SignupForm: (props: { callbackUrl?: string; plan?: string; trialIntent?: boolean }) => (
+        <div
+            data-testid="signup-form"
+            data-callback-url={props.callbackUrl ?? ""}
+            data-plan={props.plan ?? ""}
+            data-trial-intent={props.trialIntent ? "true" : "false"}
+        />
+    ),
+}));
+
+vi.mock("@/components/auth/AuthCard", () => ({
+    AuthCard: ({
+        children,
+        callbackUrl,
+        signInHref,
+    }: {
+        callbackUrl?: string;
+        children: React.ReactNode;
+        signInHref?: string;
+    }) => (
+        <section
+            data-testid="auth-card"
+            data-callback-url={callbackUrl ?? ""}
+            data-signin-href={signInHref ?? ""}
+        >
+            {children}
+        </section>
+    ),
+}));
+
+import SignUpPage from "./page";
+
+async function renderPage(params: Record<string, string> = {}) {
+    return SignUpPage({ searchParams: Promise.resolve(params) });
+}
+
+describe("SignUpPage", () => {
+    beforeEach(() => {
+        providersMock.mockReturnValue(["github"]);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("threads callbackUrl through the sign-in tab target", async () => {
+        const ui = await renderPage({ callbackUrl: "/dashboard" });
+        render(ui as React.ReactElement);
+
+        expect(screen.getByTestId("auth-card")).toHaveAttribute("data-callback-url", "/dashboard");
+        expect(screen.getByTestId("auth-card")).toHaveAttribute(
+            "data-signin-href",
+            "/auth/signin?callbackUrl=%2Fdashboard",
+        );
+        expect(screen.getByTestId("signup-form")).toHaveAttribute(
+            "data-callback-url",
+            "/dashboard",
+        );
+    });
+
+    it("preserves callbackUrl alongside team-trial intent", async () => {
+        const ui = await renderPage({ callbackUrl: "/dashboard", plan: "team", trial: "true" });
+        render(ui as React.ReactElement);
+
+        expect(screen.getByTestId("auth-card")).toHaveAttribute(
+            "data-signin-href",
+            "/auth/signin?plan=team&trial=true&callbackUrl=%2Fdashboard",
+        );
+        expect(screen.getByTestId("signup-form")).toHaveAttribute("data-trial-intent", "true");
+    });
+});

--- a/src/app/(auth)/auth/signup/page.tsx
+++ b/src/app/(auth)/auth/signup/page.tsx
@@ -1,20 +1,25 @@
 import { SignupForm } from "@/components/auth/SignupForm";
 import { AuthCard } from "@/components/auth/AuthCard";
 import { getAvailableSocialProviders } from "@/lib/auth";
+import { appendCallbackUrl, safePostLoginRedirect } from "@/lib/post-login-redirect";
 
-type SearchParams = Promise<{ plan?: string; trial?: string }>;
+type SearchParams = Promise<{ plan?: string; trial?: string; callbackUrl?: string }>;
 
 export default async function SignUpPage({ searchParams }: { searchParams: SearchParams }) {
     const params = await searchParams;
     const plan = params.plan?.toLowerCase();
     const trialIntent = plan === "team" && params.trial === "true";
-    const signInHref = trialIntent ? "/auth/signin?plan=team&trial=true" : "/auth/signin";
+    const callbackUrl = safePostLoginRedirect(params.callbackUrl);
+    const signInHref = appendCallbackUrl(
+        trialIntent ? "/auth/signin?plan=team&trial=true" : "/auth/signin",
+        callbackUrl,
+    );
     const providers = getAvailableSocialProviders();
 
     return (
         <div className="flex min-h-screen flex-col items-center justify-center py-12 px-4 sm:px-6 lg:px-8 bg-[var(--background)]">
-            <AuthCard signInHref={signInHref} providers={providers}>
-                <SignupForm plan={plan} trialIntent={trialIntent} />
+            <AuthCard callbackUrl={callbackUrl} signInHref={signInHref} providers={providers}>
+                <SignupForm callbackUrl={callbackUrl} plan={plan} trialIntent={trialIntent} />
             </AuthCard>
         </div>
     );

--- a/src/components/auth/AuthCard.tsx
+++ b/src/components/auth/AuthCard.tsx
@@ -8,14 +8,21 @@ type AuthCardProps = {
     signInHref?: string;
     signUpHref?: string;
     providers?: string[];
+    callbackUrl?: string;
 };
 
-export function AuthCard({ children, signInHref, signUpHref, providers = [] }: AuthCardProps) {
+export function AuthCard({
+    children,
+    signInHref,
+    signUpHref,
+    providers = [],
+    callbackUrl,
+}: AuthCardProps) {
     return (
         <div className="w-full max-w-md rounded-2xl border border-[var(--card-stroke)] bg-[var(--card)] p-6 sm:p-8 shadow-lg space-y-6">
             <AuthTabs signInHref={signInHref} signUpHref={signUpHref} />
 
-            <SocialLoginButtons providers={providers} />
+            <SocialLoginButtons callbackUrl={callbackUrl} providers={providers} />
 
             <div className="flex items-center gap-3">
                 <div className="h-px flex-1 bg-[var(--card-stroke)]" />

--- a/src/components/auth/LoginForm.test.tsx
+++ b/src/components/auth/LoginForm.test.tsx
@@ -108,6 +108,26 @@ describe("LoginForm", () => {
         });
     });
 
+    test("hard-navigates to the callbackUrl on successful login when one is provided", async () => {
+        mockSignIn.mockResolvedValue({
+            error: undefined,
+            code: undefined,
+            status: 200,
+            ok: true,
+            url: null,
+        });
+        mockGetSession.mockResolvedValue({ user: { needs_onboarding: false } });
+        renderWithToaster(<LoginForm callbackUrl="/acr/device" />);
+
+        await userEvent.type(screen.getByLabelText(/email/i), "tester@example.com");
+        await userEvent.type(screen.getByLabelText(/password/i), "password");
+        await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+        await waitFor(() => {
+            expect(locationAssign).toHaveBeenCalledWith("/acr/device");
+        });
+    });
+
     test("submits when Enter is pressed in the email field", async () => {
         mockSignIn.mockResolvedValue({
             error: "CredentialsSignin",
@@ -164,6 +184,26 @@ describe("LoginForm", () => {
         });
         mockGetSession.mockResolvedValue({ user: { needs_onboarding: true } });
         renderWithToaster(<LoginForm />);
+
+        await userEvent.type(screen.getByLabelText(/email/i), "tester@example.com");
+        await userEvent.type(screen.getByLabelText(/password/i), "password");
+        await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+        await waitFor(() => {
+            expect(locationAssign).toHaveBeenCalledWith("/auth/onboard");
+        });
+    });
+
+    test("does not let callbackUrl bypass required onboarding", async () => {
+        mockSignIn.mockResolvedValue({
+            error: undefined,
+            code: undefined,
+            status: 200,
+            ok: true,
+            url: null,
+        });
+        mockGetSession.mockResolvedValue({ user: { needs_onboarding: true } });
+        renderWithToaster(<LoginForm callbackUrl="/acr/device" />);
 
         await userEvent.type(screen.getByLabelText(/email/i), "tester@example.com");
         await userEvent.type(screen.getByLabelText(/password/i), "password");

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -4,10 +4,12 @@ import { useState } from "react";
 import { signIn, getSession } from "next-auth/react";
 import Link from "next/link";
 import { toast } from "sonner";
+import { safePostLoginRedirect } from "@/lib/post-login-redirect";
 
 type LoginFormProps = {
     plan?: string;
     trialIntent?: boolean;
+    callbackUrl?: string;
 };
 
 async function getSessionWithRetry(attempts = 2, delayMs = 150) {
@@ -19,12 +21,13 @@ async function getSessionWithRetry(attempts = 2, delayMs = 150) {
     return null;
 }
 
-export function LoginForm({ plan, trialIntent = false }: LoginFormProps) {
+export function LoginForm({ plan, trialIntent = false, callbackUrl }: LoginFormProps) {
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [loading, setLoading] = useState(false);
     const [verifyEmail, setVerifyEmail] = useState(false);
     const isTeamTrialIntent = trialIntent && plan?.toLowerCase() === "team";
+    const postLoginTarget = safePostLoginRedirect(callbackUrl);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -58,7 +61,7 @@ export function LoginForm({ plan, trialIntent = false }: LoginFormProps) {
                     ? isTeamTrialIntent
                         ? "/auth/onboard?plan=team&trial=true"
                         : "/auth/onboard"
-                    : "/dashboard";
+                    : (postLoginTarget ?? "/dashboard");
                 // Hard navigation (not router.push) guarantees the new auth cookie
                 // is attached to the request for `destination`. Soft App Router
                 // navigation is racy immediately after signIn in e2e environments.

--- a/src/components/auth/SignupForm.test.tsx
+++ b/src/components/auth/SignupForm.test.tsx
@@ -148,6 +148,26 @@ describe("SignupForm", () => {
         });
     });
 
+    it("preserves the post-login callback when redirecting to signin", async () => {
+        vi.spyOn(global, "fetch").mockResolvedValue(
+            new Response(JSON.stringify({}), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+
+        renderWithToaster(<SignupForm callbackUrl="/acr/device?from=signup" />);
+        const user = userEvent.setup();
+
+        await fillAndSubmit(user);
+
+        await waitFor(() => {
+            expect(mockPush).toHaveBeenCalledWith(
+                "/auth/signin?registered=true&callbackUrl=%2Facr%2Fdevice%3Ffrom%3Dsignup",
+            );
+        });
+    });
+
     it("shows server error on failed registration", async () => {
         const fetchSpy = vi.spyOn(global, "fetch");
         fetchSpy.mockResolvedValue(

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -5,14 +5,16 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { resolveOrigin } from "@/lib/origin";
 import { extractErrorMessage } from "@/lib/errorMessages";
+import { appendCallbackUrl, safePostLoginRedirect } from "@/lib/post-login-redirect";
 import { PasswordStrength } from "./PasswordStrength";
 
 type SignupFormProps = {
     plan?: string;
     trialIntent?: boolean;
+    callbackUrl?: string;
 };
 
-export function SignupForm({ plan, trialIntent = false }: SignupFormProps) {
+export function SignupForm({ plan, trialIntent = false, callbackUrl }: SignupFormProps) {
     const router = useRouter();
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
@@ -22,6 +24,7 @@ export function SignupForm({ plan, trialIntent = false }: SignupFormProps) {
 
     const normalizedPlan = plan?.toLowerCase();
     const isTeamTrialIntent = trialIntent && normalizedPlan === "team";
+    const postLoginTarget = safePostLoginRedirect(callbackUrl);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -65,9 +68,12 @@ export function SignupForm({ plan, trialIntent = false }: SignupFormProps) {
             }
 
             router.push(
-                isTeamTrialIntent
-                    ? "/auth/signin?registered=true&plan=team&trial=true"
-                    : "/auth/signin?registered=true",
+                appendCallbackUrl(
+                    isTeamTrialIntent
+                        ? "/auth/signin?registered=true&plan=team&trial=true"
+                        : "/auth/signin?registered=true",
+                    postLoginTarget,
+                ),
             );
         } catch {
             toast.error("An error occurred. Please try again.");

--- a/src/components/auth/SocialLoginButtons.test.tsx
+++ b/src/components/auth/SocialLoginButtons.test.tsx
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { renderWithToaster, screen, userEvent, cleanup } from "@/test/utils";
+
+const { mockSignIn } = vi.hoisted(() => ({
+    mockSignIn: vi.fn(),
+}));
+
+vi.mock("next-auth/react", () => ({
+    signIn: mockSignIn,
+}));
+
+import { SocialLoginButtons } from "@/components/auth/SocialLoginButtons";
+
+describe("SocialLoginButtons", () => {
+    beforeEach(() => {
+        cleanup();
+        mockSignIn.mockReset();
+    });
+
+    test("passes callbackUrl through to provider sign-in", async () => {
+        renderWithToaster(
+            <SocialLoginButtons callbackUrl="/dashboard" providers={["github", "google"]} />,
+        );
+
+        await userEvent.click(screen.getByRole("button", { name: /continue with github/i }));
+
+        expect(mockSignIn).toHaveBeenCalledWith("github", { redirectTo: "/dashboard" });
+    });
+
+    test("omits callbackUrl when none is provided", async () => {
+        renderWithToaster(<SocialLoginButtons providers={["gitlab"]} />);
+
+        await userEvent.click(screen.getByRole("button", { name: /continue with gitlab/i }));
+
+        expect(mockSignIn).toHaveBeenCalledWith("gitlab", undefined);
+    });
+});

--- a/src/components/auth/SocialLoginButtons.tsx
+++ b/src/components/auth/SocialLoginButtons.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { signIn } from "next-auth/react";
+import { safePostLoginRedirect } from "@/lib/post-login-redirect";
 
 function GitHubIcon() {
     return (
@@ -43,10 +44,12 @@ function GitLabIcon() {
 
 type SocialLoginButtonsProps = {
     providers?: string[];
+    callbackUrl?: string;
 };
 
-export function SocialLoginButtons({ providers = [] }: SocialLoginButtonsProps) {
+export function SocialLoginButtons({ providers = [], callbackUrl }: SocialLoginButtonsProps) {
     if (providers.length === 0) return null;
+    const postLoginTarget = safePostLoginRedirect(callbackUrl);
 
     const buttonClass =
         "w-full rounded-lg border border-[var(--card-stroke)] bg-transparent py-3 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--card-stroke)]/20 transition-colors flex items-center justify-center gap-2";
@@ -54,17 +57,41 @@ export function SocialLoginButtons({ providers = [] }: SocialLoginButtonsProps) 
     return (
         <div className="space-y-3">
             {providers.includes("github") && (
-                <button onClick={() => signIn("github")} className={buttonClass}>
+                <button
+                    onClick={() =>
+                        signIn(
+                            "github",
+                            postLoginTarget ? { redirectTo: postLoginTarget } : undefined,
+                        )
+                    }
+                    className={buttonClass}
+                >
                     <GitHubIcon /> Continue with GitHub
                 </button>
             )}
             {providers.includes("google") && (
-                <button onClick={() => signIn("google")} className={buttonClass}>
+                <button
+                    onClick={() =>
+                        signIn(
+                            "google",
+                            postLoginTarget ? { redirectTo: postLoginTarget } : undefined,
+                        )
+                    }
+                    className={buttonClass}
+                >
                     <GoogleIcon /> Continue with Google
                 </button>
             )}
             {providers.includes("gitlab") && (
-                <button onClick={() => signIn("gitlab")} className={buttonClass}>
+                <button
+                    onClick={() =>
+                        signIn(
+                            "gitlab",
+                            postLoginTarget ? { redirectTo: postLoginTarget } : undefined,
+                        )
+                    }
+                    className={buttonClass}
+                >
                     <GitLabIcon /> Continue with GitLab
                 </button>
             )}

--- a/src/lib/__tests__/post-login-redirect.test.ts
+++ b/src/lib/__tests__/post-login-redirect.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { appendCallbackUrl, safePostLoginRedirect } from "@/lib/post-login-redirect";
+
+describe("post-login redirect helpers", () => {
+    it("allows local post-login redirects", () => {
+        expect(safePostLoginRedirect("/dashboard")).toBe("/dashboard");
+        expect(safePostLoginRedirect("/org/123?tab=settings")).toBe("/org/123?tab=settings");
+    });
+
+    it("rejects open redirects and auth-page bounce backs", () => {
+        expect(safePostLoginRedirect("https://evil.example/steal")).toBeUndefined();
+        expect(safePostLoginRedirect("//evil.example/steal")).toBeUndefined();
+        expect(safePostLoginRedirect("/auth/signin")).toBeUndefined();
+        expect(safePostLoginRedirect("/auth/onboard?plan=team")).toBeUndefined();
+        expect(safePostLoginRedirect("/login?next=/dashboard")).toBeUndefined();
+    });
+
+    it("preserves callbackUrl when threading auth tabs", () => {
+        expect(appendCallbackUrl("/auth/signup", "/dashboard")).toBe(
+            "/auth/signup?callbackUrl=%2Fdashboard",
+        );
+        expect(appendCallbackUrl("/auth/signin?plan=team&trial=true", "/dashboard")).toBe(
+            "/auth/signin?plan=team&trial=true&callbackUrl=%2Fdashboard",
+        );
+    });
+});

--- a/src/lib/__tests__/proxy.test.ts
+++ b/src/lib/__tests__/proxy.test.ts
@@ -129,6 +129,17 @@ describe("org-scoped route guard", () => {
         expect(res.status).not.toBe(303);
     });
 
+    it("preserves the requested path and query when redirecting to sign in", async () => {
+        mockAuth.mockResolvedValue(null);
+
+        const res = await proxy(makeRequest("/settings?tab=integrations"));
+        const location = new URL(res.headers.get("Location")!);
+
+        expect(res.status).toBe(303);
+        expect(location.pathname).toBe("/auth/signin");
+        expect(location.searchParams.get("callbackUrl")).toBe("/settings?tab=integrations");
+    });
+
     it("redirects superuser without org from non-exempt path to /superadmin", async () => {
         mockAuth.mockResolvedValue(superuserNoOrg);
         const res = await proxy(makeRequest("/dashboard"));

--- a/src/lib/post-login-redirect.ts
+++ b/src/lib/post-login-redirect.ts
@@ -1,0 +1,30 @@
+import { safeReturnTo } from "@/lib/onboarding/returnTo";
+
+function isBlockedAuthPath(target: string): boolean {
+    const pathname = target.split(/[?#]/, 1)[0];
+    return (
+        pathname === "/auth" ||
+        pathname.startsWith("/auth/") ||
+        pathname === "/login" ||
+        pathname.startsWith("/login/")
+    );
+}
+
+/**
+ * Post-login redirect targets must remain local and must not bounce users back
+ * onto a login surface.
+ */
+export function safePostLoginRedirect(value: string | null | undefined): string | undefined {
+    const target = safeReturnTo(value);
+    if (!target || isBlockedAuthPath(target)) {
+        return undefined;
+    }
+    return target;
+}
+
+export function appendCallbackUrl(href: string, callbackUrl: string | undefined): string {
+    if (!callbackUrl) return href;
+    const url = new URL(href, "http://localhost");
+    url.searchParams.set("callbackUrl", callbackUrl);
+    return `${url.pathname}${url.search}`;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -251,7 +251,10 @@ async function handleRequest(request: NextRequest) {
         const session = await auth();
         if (!session || !session.access_token) {
             const signInUrl = new URL("/auth/signin", request.url);
-            signInUrl.searchParams.set("callbackUrl", sanitizeCallbackUrl(pathname));
+            signInUrl.searchParams.set(
+                "callbackUrl",
+                sanitizeCallbackUrl(`${pathname}${request.nextUrl.search}`),
+            );
             const redirect = NextResponse.redirect(signInUrl, 303);
             redirect.headers.set("Content-Security-Policy", csp);
             return redirect;

--- a/tests/auth-signin.spec.ts
+++ b/tests/auth-signin.spec.ts
@@ -40,3 +40,17 @@ test("/auth/signin tab navigates to signup", async ({ page }) => {
 
     await expect(page).toHaveURL(/\/auth\/signup/);
 });
+
+test("successful sign-in returns to the protected URL including its query", async ({ page }) => {
+    await page.goto("/settings?tab=integrations");
+
+    const signInUrl = new URL(page.url());
+    expect(signInUrl.pathname).toBe("/auth/signin");
+    expect(signInUrl.searchParams.get("callbackUrl")).toBe("/settings?tab=integrations");
+
+    await page.getByLabel("Email").fill("admin@devhealth.example");
+    await page.getByLabel("Password").fill("devhealth123");
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await expect(page).toHaveURL(/\/settings\?tab=integrations$/);
+});


### PR DESCRIPTION
## Summary

- preserve a validated local `callbackUrl` through credentials and OAuth sign-in
- preserve the destination across sign-in/sign-up tabs and post-registration sign-in
- retain protected-route query strings and keep onboarding ahead of the requested destination
- reject external and auth-page callback targets to prevent open redirects and loops

## Validation

- `vitest`: 65 targeted auth/proxy tests passed
- targeted ESLint passed
- TypeScript `tsc --noEmit` passed
- `npm run build` passed
- Playwright unauthenticated auth suite passed: 5/5, including protected URL -> sign-in -> original URL with query

SCREENSHOT-WAIVER: behavior-only redirect fix; rendered UI is unchanged.

Linear: CHAOS-3237