### PR TITLE
feat(admin): CHAOS-3238 add BYO LLM organization budget controls

### DIFF
--- a/src/app/(app)/org/admin/ai/page.tsx
+++ b/src/app/(app)/org/admin/ai/page.tsx
@@ -5,6 +5,7 @@ import { AskDevAdminPanel } from "@/components/admin/ask-dev/AskDevAdminPanel";
 import {
     getLLMSettings,
     getLLMSettingsStatus,
+    getLLMBudget,
     upsertLLMSettings,
     deleteLLMSettings,
     getLLMSpendSummary,
@@ -31,6 +32,7 @@ export default function ByoLlmAdminPage() {
             />
             <ByoLlmSettings
                 loadSettingsAction={getLLMSettings}
+                loadBudgetAction={getLLMBudget}
                 loadStatusAction={getLLMSettingsStatus}
                 saveSettingsAction={upsertLLMSettings}
                 removeSettingsAction={deleteLLMSettings}

--- a/src/components/admin/llm/ByoLlmSettings.test.tsx
+++ b/src/components/admin/llm/ByoLlmSettings.test.tsx
@@ -10,6 +10,7 @@ vi.mock("next/link", () => ({
 import { ByoLlmSettings, type ByoLlmSettingsProps } from "./ByoLlmSettings";
 
 const mockLoad = vi.fn<ByoLlmSettingsProps["loadSettingsAction"]>();
+const mockLoadBudget = vi.fn<ByoLlmSettingsProps["loadBudgetAction"]>();
 const mockLoadStatus = vi.fn<ByoLlmSettingsProps["loadStatusAction"]>();
 const mockSave = vi.fn<ByoLlmSettingsProps["saveSettingsAction"]>();
 const mockRemove = vi.fn<ByoLlmSettingsProps["removeSettingsAction"]>();
@@ -18,6 +19,7 @@ function renderForm() {
     return renderWithToaster(
         <ByoLlmSettings
             loadSettingsAction={mockLoad}
+            loadBudgetAction={mockLoadBudget}
             loadStatusAction={mockLoadStatus}
             saveSettingsAction={mockSave}
             removeSettingsAction={mockRemove}
@@ -28,6 +30,7 @@ function renderForm() {
 describe("ByoLlmSettings", () => {
     beforeEach(() => {
         mockLoad.mockReset();
+        mockLoadBudget.mockReset();
         mockSave.mockReset();
         mockRemove.mockReset();
         mockLoadStatus.mockReset();
@@ -36,6 +39,19 @@ describe("ByoLlmSettings", () => {
         // back to settings-derived Saved/Not configured wording unless a test
         // explicitly exercises the happy-path status DTO.
         mockLoadStatus.mockResolvedValue({ error: "Not implemented", status: 501 });
+        mockLoadBudget.mockResolvedValue({
+            data: {
+                used_micro_usd: 0,
+                limit_micro_usd: null,
+                remaining_micro_usd: null,
+                window: "calendar_month_utc",
+                reset_at: "2026-08-01T00:00:00Z",
+                enforcement_available: false,
+                reason: "budget_not_configured",
+                maximum_limit_micro_usd: 500_000_000,
+                pricing_version: "openai-public-2025-08-07.v1",
+            },
+        });
     });
 
     it("renders the form with a Not configured status for an empty config", async () => {
@@ -46,6 +62,102 @@ describe("ByoLlmSettings", () => {
         expect(screen.getByRole("heading", { name: "AI Setup" })).toBeInTheDocument();
         expect(screen.getByLabelText("Provider")).toBeInTheDocument();
         expect(screen.getByLabelText("API Key")).toBeInTheDocument();
+        expect(await screen.findByText("No budget configured")).toBeInTheDocument();
+        expect(screen.getByLabelText("Monthly organization budget (USD)")).toHaveValue("");
+    });
+
+    it("renders reserved usage, warning state, monthly reset, and provisioned maximum", async () => {
+        mockLoad.mockResolvedValue({ data: { provider: "openai", model: "gpt-5-mini" } });
+        mockLoadBudget.mockResolvedValue({
+            data: {
+                used_micro_usd: 85_000_000,
+                limit_micro_usd: 100_000_000,
+                remaining_micro_usd: 15_000_000,
+                window: "calendar_month_utc",
+                reset_at: "2026-08-01T00:00:00Z",
+                enforcement_available: true,
+                reason: "available",
+                maximum_limit_micro_usd: 500_000_000,
+                pricing_version: "openai-public-2025-08-07.v1",
+            },
+        });
+
+        renderForm();
+
+        expect(await screen.findByText("Approaching budget")).toBeInTheDocument();
+        expect(screen.getByText("$85.00")).toBeInTheDocument();
+        expect(screen.getByText("$100.00")).toBeInTheDocument();
+        expect(screen.getByText("$15.00")).toBeInTheDocument();
+        expect(screen.getByText(/At least 80%/)).toBeInTheDocument();
+        expect(screen.getByText(/maximum provisioned limit \$500.00/)).toBeInTheDocument();
+    });
+
+    it("keeps provider settings usable when budget status is temporarily unavailable", async () => {
+        mockLoad.mockResolvedValue({ data: { provider: "openai", model: "gpt-5-mini" } });
+        mockLoadBudget
+            .mockResolvedValueOnce({ error: "Budget service unavailable", status: 503 })
+            .mockResolvedValueOnce({
+                data: {
+                    used_micro_usd: 0,
+                    limit_micro_usd: 10_000_000,
+                    remaining_micro_usd: 10_000_000,
+                    window: "calendar_month_utc",
+                    reset_at: "2026-08-01T00:00:00Z",
+                    enforcement_available: true,
+                    reason: "available",
+                    maximum_limit_micro_usd: 500_000_000,
+                    pricing_version: "openai-public-2025-08-07.v1",
+                },
+            });
+
+        renderForm();
+
+        expect(await screen.findByText("Budget service unavailable")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+        await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+        expect(await screen.findByText("Budget enforced")).toBeInTheDocument();
+    });
+
+    it.each([
+        {
+            reason: "budget_exhausted" as const,
+            label: "Budget exhausted",
+            explanation: /New budgeted BYO-LLM calls are blocked/,
+            used: 100_000_000,
+        },
+        {
+            reason: "usage_unavailable" as const,
+            label: "Usage unavailable — calls blocked",
+            explanation: /did not report usable token data/,
+            used: null,
+        },
+        {
+            reason: "pricing_unavailable" as const,
+            label: "Pricing unavailable — calls blocked",
+            explanation: /has no reliable price/,
+            used: null,
+        },
+    ])("renders the $reason enforcement state", async ({ reason, label, explanation, used }) => {
+        mockLoad.mockResolvedValue({ data: { provider: "openai", model: "custom-model" } });
+        mockLoadBudget.mockResolvedValue({
+            data: {
+                used_micro_usd: used,
+                limit_micro_usd: 100_000_000,
+                remaining_micro_usd: reason === "budget_exhausted" ? 0 : null,
+                window: "calendar_month_utc",
+                reset_at: "2026-08-01T00:00:00Z",
+                enforcement_available: reason === "budget_exhausted",
+                reason,
+                maximum_limit_micro_usd: 500_000_000,
+                pricing_version:
+                    reason === "pricing_unavailable" ? null : "openai-public-2025-08-07.v1",
+            },
+        });
+
+        renderForm();
+
+        expect(await screen.findByText(label)).toBeInTheDocument();
+        expect(screen.getByText(explanation)).toBeInTheDocument();
     });
 
     it("renders a read-only summary with a Saved badge when settings are persisted", async () => {
@@ -259,6 +371,92 @@ describe("ByoLlmSettings", () => {
         await waitFor(() => {
             expect(screen.getByText("BYO-LLM settings saved.")).toBeInTheDocument();
         });
+    });
+
+    it("submits an exact micro-USD budget and supports an explicit zero hard stop", async () => {
+        mockLoad.mockResolvedValue({ data: {} });
+        mockSave.mockResolvedValue({ data: { provider: "openai" } });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        const budgetInput = screen.getByLabelText("Monthly organization budget (USD)");
+        await userEvent.type(budgetInput, "12.345678");
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(mockSave).toHaveBeenCalledWith(
+            expect.objectContaining({ budget_limit_micro_usd: 12_345_678 }),
+        );
+
+        await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+        await userEvent.clear(screen.getByLabelText("Monthly organization budget (USD)"));
+        await userEvent.type(screen.getByLabelText("Monthly organization budget (USD)"), "0");
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(mockSave).toHaveBeenLastCalledWith(
+            expect.objectContaining({ budget_limit_micro_usd: 0 }),
+        );
+    });
+
+    it("omits a blank budget so the backend preserves the current value", async () => {
+        mockLoad.mockResolvedValue({ data: {} });
+        mockSave.mockResolvedValue({ data: { provider: "openai" } });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        const payload = mockSave.mock.calls[0][0];
+        expect("budget_limit_micro_usd" in payload).toBe(false);
+    });
+
+    it("rejects malformed or over-provisioned budgets before saving", async () => {
+        mockLoad.mockResolvedValue({ data: {} });
+        mockLoadBudget.mockResolvedValue({
+            data: {
+                used_micro_usd: 0,
+                limit_micro_usd: null,
+                remaining_micro_usd: null,
+                window: "calendar_month_utc",
+                reset_at: "2026-08-01T00:00:00Z",
+                enforcement_available: false,
+                reason: "budget_not_configured",
+                maximum_limit_micro_usd: 5_000_000,
+                pricing_version: "openai-public-2025-08-07.v1",
+            },
+        });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        const input = screen.getByLabelText("Monthly organization budget (USD)");
+        await userEvent.type(input, "1.0000001");
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+        expect(screen.getByText(/no more than 6 decimal places/)).toBeInTheDocument();
+        expect(mockSave).not.toHaveBeenCalled();
+
+        await userEvent.clear(input);
+        await userEvent.type(input, "6");
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+        expect(screen.getByText("The maximum provisioned budget is $5.00.")).toBeInTheDocument();
+        expect(mockSave).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a backend budget maximum rejection on the budget field", async () => {
+        mockLoad.mockResolvedValue({ data: { provider: "openai" } });
+        mockSave.mockResolvedValue({
+            error: "budget_limit_micro_usd must be between 0 and 5000000",
+            status: 400,
+        });
+        renderForm();
+
+        await screen.findByRole("heading", { name: "AI Setup" });
+        await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+        await userEvent.type(screen.getByLabelText("Monthly organization budget (USD)"), "1");
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(
+            await screen.findByText("budget_limit_micro_usd must be between 0 and 5000000"),
+        ).toBeInTheDocument();
+        expect(screen.getByLabelText("Base URL")).not.toHaveAttribute("aria-invalid", "true");
     });
 
     it("surfaces a 400 base_url validation error inline", async () => {

--- a/src/components/admin/llm/ByoLlmSettings.tsx
+++ b/src/components/admin/llm/ByoLlmSettings.tsx
@@ -3,10 +3,12 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { toast } from "sonner";
+import { DataState } from "@/components/ui/DataState";
 import { CTA_LABELS } from "@/lib/design/cta";
 import {
     LLM_PROVIDERS,
     LLM_PROVIDER_LABELS,
+    type LLMBudgetResponse,
     type LLMProvider,
     type LLMSettingsActionResult,
     type LLMSettingsResponse,
@@ -25,7 +27,7 @@ type LockState = {
 /** Read-only summary vs. editable-form view of the saved configuration (CHAOS-2565). */
 type Mode = "view" | "edit";
 
-type BadgeTone = "positive" | "caution" | "muted";
+type BadgeTone = "positive" | "caution" | "negative" | "muted";
 
 type BadgeInfo = {
     label: string;
@@ -34,6 +36,7 @@ type BadgeInfo = {
 
 export type ByoLlmSettingsProps = {
     loadSettingsAction: () => Promise<LLMSettingsActionResult<LLMSettingsResponse>>;
+    loadBudgetAction: () => Promise<LLMSettingsActionResult<LLMBudgetResponse>>;
     /**
      * BYO-LLM status badge read (CHAOS-2560/2565). The backend endpoint is
      * built on a sibling branch; a failed/errored result degrades gracefully
@@ -55,14 +58,78 @@ const captionClass = "mt-1 text-xs text-(--ink-muted)";
 const BADGE_TONE_CLASSES: Record<BadgeTone, string> = {
     positive: "bg-(--positive)/10 text-(--positive)",
     caution: "bg-(--caution)/10 text-(--caution)",
+    negative: "bg-(--negative)/10 text-(--negative)",
     muted: "bg-(--card-70) text-(--ink-muted)",
 };
 
 const BADGE_DOT_CLASSES: Record<BadgeTone, string> = {
     positive: "bg-(--positive)",
     caution: "bg-(--caution)",
+    negative: "bg-(--negative)",
     muted: "bg-(--ink-muted)",
 };
+
+const MICRO_USD_PER_USD = 1_000_000;
+
+function formatMicroUsd(value: number | null): string {
+    if (value === null) return "Unavailable";
+    return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 6,
+    }).format(value / MICRO_USD_PER_USD);
+}
+
+function formatMicroUsdInput(value: number | null): string {
+    if (value === null) return "";
+    return (value / MICRO_USD_PER_USD).toFixed(6).replace(/(\.\d*?[1-9])0+$|\.0+$/, "$1");
+}
+
+function parseMicroUsdInput(value: string): number | null {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (!/^\d+(?:\.\d{1,6})?$/.test(trimmed)) return Number.NaN;
+    const [whole, fraction = ""] = trimmed.split(".");
+    const microUsd = Number(whole) * MICRO_USD_PER_USD + Number(fraction.padEnd(6, "0"));
+    return Number.isSafeInteger(microUsd) ? microUsd : Number.NaN;
+}
+
+function formatResetAt(value: string): string {
+    const reset = new Date(value);
+    if (Number.isNaN(reset.getTime())) return value;
+    return new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        timeZone: "UTC",
+        timeZoneName: "short",
+    }).format(reset);
+}
+
+function deriveBudgetBadge(budget: LLMBudgetResponse): BadgeInfo {
+    if (budget.reason === "budget_exhausted") {
+        return { label: "Budget exhausted", tone: "negative" };
+    }
+    if (budget.reason === "usage_unavailable") {
+        return { label: "Usage unavailable — calls blocked", tone: "negative" };
+    }
+    if (budget.reason === "pricing_unavailable") {
+        return { label: "Pricing unavailable — calls blocked", tone: "negative" };
+    }
+    if (budget.reason === "budget_not_configured") {
+        return { label: "No budget configured", tone: "muted" };
+    }
+    const fractionUsed =
+        budget.limit_micro_usd && budget.used_micro_usd !== null
+            ? budget.used_micro_usd / budget.limit_micro_usd
+            : 0;
+    return fractionUsed >= 0.8
+        ? { label: "Approaching budget", tone: "caution" }
+        : { label: "Budget enforced", tone: "positive" };
+}
 
 /**
  * Derives the status badge wording/tone from the CHAOS-2560 status DTO.
@@ -93,6 +160,7 @@ function deriveStatusBadge(
 
 export function ByoLlmSettings({
     loadSettingsAction,
+    loadBudgetAction,
     loadStatusAction,
     saveSettingsAction,
     removeSettingsAction,
@@ -104,11 +172,15 @@ export function ByoLlmSettings({
     const [mode, setMode] = useState<Mode>("edit");
     const [savedSettings, setSavedSettings] = useState<LLMSettingsResponse | null>(null);
     const [status, setStatus] = useState<LLMSettingsStatusResponse | null>(null);
+    const [budget, setBudget] = useState<LLMBudgetResponse | null>(null);
+    const [budgetLoading, setBudgetLoading] = useState(true);
+    const [budgetLoadError, setBudgetLoadError] = useState<string | null>(null);
 
     const [provider, setProvider] = useState<string>(DEFAULT_PROVIDER);
     const [model, setModel] = useState("");
     const [apiKey, setApiKey] = useState("");
     const [baseUrl, setBaseUrl] = useState("");
+    const [budgetUsd, setBudgetUsd] = useState("");
     const [hasStoredKey, setHasStoredKey] = useState(false);
     const [maskedKey, setMaskedKey] = useState<string | null>(null);
     const [hasSavedSettings, setHasSavedSettings] = useState(false);
@@ -117,12 +189,27 @@ export function ByoLlmSettings({
     const [deleting, setDeleting] = useState(false);
     const [confirmingDelete, setConfirmingDelete] = useState(false);
     const [baseUrlError, setBaseUrlError] = useState<string | null>(null);
+    const [budgetInputError, setBudgetInputError] = useState<string | null>(null);
     const [formError, setFormError] = useState<string | null>(null);
 
     const fetchStatus = useCallback(async () => {
         const result = await loadStatusAction();
         setStatus(result.data ?? null);
     }, [loadStatusAction]);
+
+    const fetchBudget = useCallback(async () => {
+        setBudgetLoading(true);
+        setBudgetLoadError(null);
+        const result = await loadBudgetAction();
+        if (result.data) {
+            setBudget(result.data);
+            setBudgetUsd(formatMicroUsdInput(result.data.limit_micro_usd));
+        } else {
+            setBudget(null);
+            setBudgetLoadError(result.error ?? "Could not load the organization budget.");
+        }
+        setBudgetLoading(false);
+    }, [loadBudgetAction]);
 
     const applySettings = useCallback((data: LLMSettingsResponse) => {
         setSavedSettings(data);
@@ -140,6 +227,8 @@ export function ByoLlmSettings({
         setLoading(true);
         setLoadError(null);
         setLocked(null);
+        setBudgetLoading(true);
+        setBudgetLoadError(null);
         const result = await loadSettingsAction();
         if (result.status === 402) {
             setLocked({
@@ -157,9 +246,10 @@ export function ByoLlmSettings({
         } else if (result.data) {
             applySettings(result.data);
             void fetchStatus();
+            void fetchBudget();
         }
         setLoading(false);
-    }, [loadSettingsAction, applySettings, fetchStatus]);
+    }, [loadSettingsAction, applySettings, fetchStatus, fetchBudget]);
 
     useEffect(() => {
         // eslint-disable-next-line react-hooks/set-state-in-effect -- fetchSettings coordinates async loading state after mount.
@@ -169,6 +259,7 @@ export function ByoLlmSettings({
     const handleEdit = () => {
         setFormError(null);
         setBaseUrlError(null);
+        setBudgetInputError(null);
         setConfirmingDelete(false);
         setMode("edit");
     };
@@ -179,9 +270,11 @@ export function ByoLlmSettings({
             setModel(savedSettings.model ?? "");
             setBaseUrl(savedSettings.base_url ?? "");
             setApiKey("");
+            setBudgetUsd(formatMicroUsdInput(budget?.limit_micro_usd ?? null));
         }
         setFormError(null);
         setBaseUrlError(null);
+        setBudgetInputError(null);
         setConfirmingDelete(false);
         setMode("view");
     };
@@ -191,9 +284,23 @@ export function ByoLlmSettings({
             setFormError("Select a provider before saving.");
             return;
         }
+        const parsedBudget = parseMicroUsdInput(budgetUsd);
+        if (Number.isNaN(parsedBudget)) {
+            setBudgetInputError(
+                "Enter a non-negative USD amount with no more than 6 decimal places.",
+            );
+            return;
+        }
+        if (parsedBudget !== null && budget && parsedBudget > budget.maximum_limit_micro_usd) {
+            setBudgetInputError(
+                `The maximum provisioned budget is ${formatMicroUsd(budget.maximum_limit_micro_usd)}.`,
+            );
+            return;
+        }
         setSaving(true);
         setFormError(null);
         setBaseUrlError(null);
+        setBudgetInputError(null);
         const payload: LLMSettingsUpsert = {
             provider: provider.trim(),
             model: model.trim() ? model.trim() : null,
@@ -204,10 +311,19 @@ export function ByoLlmSettings({
         if (apiKey.trim()) {
             payload.api_key = apiKey.trim();
         }
+        // Blank preserves the existing backend value. Zero is intentionally
+        // included because it is the explicit hard-stop configuration.
+        if (parsedBudget !== null) {
+            payload.budget_limit_micro_usd = parsedBudget;
+        }
         const result = await saveSettingsAction(payload);
         setSaving(false);
         if (result.status === 400) {
-            setBaseUrlError(result.error ?? "The base URL is invalid.");
+            if (parsedBudget !== null && result.error?.toLowerCase().includes("budget")) {
+                setBudgetInputError(result.error);
+            } else {
+                setBaseUrlError(result.error ?? "The base URL is invalid.");
+            }
             toast.error("Could not save BYO-LLM settings.");
             return;
         }
@@ -219,6 +335,7 @@ export function ByoLlmSettings({
         if (result.data) {
             applySettings(result.data);
             void fetchStatus();
+            void fetchBudget();
         }
         toast.success("BYO-LLM settings saved.");
     };
@@ -338,6 +455,116 @@ export function ByoLlmSettings({
         </span>
     );
 
+    const budgetBadge = budget ? deriveBudgetBadge(budget) : null;
+    const budgetPanel = (
+        <section
+            aria-labelledby="byo-budget-heading"
+            data-testid="byo-llm-budget-status"
+            className="mt-6 rounded-xl border border-(--card-stroke) bg-(--card-70) p-4"
+        >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                    <h2 id="byo-budget-heading" className="text-sm font-semibold text-foreground">
+                        Organization budget
+                    </h2>
+                    <p className="mt-1 text-xs text-(--ink-muted)">
+                        Hard monthly cap for calls made with this organization&apos;s provider
+                        credentials.
+                    </p>
+                </div>
+                {budgetBadge ? (
+                    <span
+                        className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${BADGE_TONE_CLASSES[budgetBadge.tone]}`}
+                    >
+                        <span
+                            aria-hidden="true"
+                            className={`h-2 w-2 rounded-full ${BADGE_DOT_CLASSES[budgetBadge.tone]}`}
+                        />
+                        {budgetBadge.label}
+                    </span>
+                ) : null}
+            </div>
+
+            {budgetLoading ? (
+                <DataState
+                    variant="loading"
+                    title="Loading budget status…"
+                    className="mt-4"
+                    data-testid="byo-llm-budget-loading"
+                />
+            ) : budgetLoadError ? (
+                <DataState
+                    variant="error"
+                    title="Budget status unavailable"
+                    message={budgetLoadError}
+                    className="mt-4"
+                    data-testid="byo-llm-budget-error"
+                    action={
+                        <button
+                            type="button"
+                            onClick={fetchBudget}
+                            className="rounded-lg border border-(--negative)/30 bg-(--card-80) px-3 py-1.5 text-xs font-medium text-foreground"
+                        >
+                            {CTA_LABELS.retry}
+                        </button>
+                    }
+                />
+            ) : budget ? (
+                <div className="mt-4 space-y-3">
+                    {budget.limit_micro_usd !== null ? (
+                        <dl className="grid gap-3 text-sm sm:grid-cols-3">
+                            <div>
+                                <dt className={labelClass}>Used or reserved</dt>
+                                <dd>{formatMicroUsd(budget.used_micro_usd)}</dd>
+                            </div>
+                            <div>
+                                <dt className={labelClass}>Monthly limit</dt>
+                                <dd>{formatMicroUsd(budget.limit_micro_usd)}</dd>
+                            </div>
+                            <div>
+                                <dt className={labelClass}>Remaining</dt>
+                                <dd>{formatMicroUsd(budget.remaining_micro_usd)}</dd>
+                            </div>
+                        </dl>
+                    ) : (
+                        <p className="text-sm text-(--ink-muted)">
+                            Set a limit to prevent BYO-LLM spend from exceeding an organization
+                            ceiling.
+                        </p>
+                    )}
+
+                    {budget.reason === "budget_exhausted" ? (
+                        <p className="text-sm text-(--negative)">
+                            New budgeted BYO-LLM calls are blocked until the limit is increased or
+                            the monthly window resets.
+                        </p>
+                    ) : budget.reason === "usage_unavailable" ? (
+                        <p className="text-sm text-(--negative)">
+                            A completed call did not report usable token data. New budgeted calls
+                            are blocked so missing usage cannot bypass the cap.
+                        </p>
+                    ) : budget.reason === "pricing_unavailable" ? (
+                        <p className="text-sm text-(--negative)">
+                            The current provider, model, or custom base URL has no reliable price.
+                            New budgeted calls are blocked because the cap cannot be safely enforced
+                            for that configuration.
+                        </p>
+                    ) : budget.reason === "available" && budgetBadge?.tone === "caution" ? (
+                        <p className="text-sm text-(--caution)">
+                            At least 80% of the monthly organization budget has been used or
+                            reserved.
+                        </p>
+                    ) : null}
+
+                    <p className="text-xs text-(--ink-muted)">
+                        Calendar month (UTC) · resets {formatResetAt(budget.reset_at)} · maximum
+                        provisioned limit {formatMicroUsd(budget.maximum_limit_micro_usd)}
+                    </p>
+                </div>
+            ) : null}
+        </section>
+    );
+
     const deleteButton = (
         <button
             type="button"
@@ -393,6 +620,8 @@ export function ByoLlmSettings({
                             <dd className="text-sm text-foreground">{baseUrl || "Not set"}</dd>
                         </div>
                     </dl>
+
+                    {budgetPanel}
 
                     <div className="mt-6 rounded-xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-xs text-(--ink-muted)">
                         BYO-LLM requires Team tier or higher. Keys are encrypted with the org
@@ -486,7 +715,48 @@ export function ByoLlmSettings({
                                 </p>
                             )}
                         </div>
+
+                        <div className="sm:col-span-2">
+                            <label htmlFor="byo-budget-usd" className={labelClass}>
+                                Monthly organization budget (USD)
+                            </label>
+                            <div className="relative max-w-sm">
+                                <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-sm text-(--ink-muted)">
+                                    $
+                                </span>
+                                <input
+                                    id="byo-budget-usd"
+                                    type="text"
+                                    inputMode="decimal"
+                                    value={budgetUsd}
+                                    disabled={budgetLoading || saving}
+                                    placeholder="Leave blank to preserve current limit"
+                                    onChange={(event) => {
+                                        setBudgetUsd(event.target.value);
+                                        setBudgetInputError(null);
+                                    }}
+                                    className={`${inputClass} pl-7 disabled:opacity-50 ${budgetInputError ? "border-(--negative)/60" : ""}`}
+                                    aria-invalid={budgetInputError ? true : undefined}
+                                    aria-describedby="byo-budget-caption"
+                                />
+                            </div>
+                            {budgetInputError ? (
+                                <p
+                                    id="byo-budget-caption"
+                                    className="mt-1 text-xs text-(--negative)"
+                                >
+                                    {budgetInputError}
+                                </p>
+                            ) : (
+                                <p id="byo-budget-caption" className={captionClass}>
+                                    Blank preserves the current limit. Enter 0 for an immediate hard
+                                    stop. Up to 6 decimal places are supported.
+                                </p>
+                            )}
+                        </div>
                     </div>
+
+                    {budgetPanel}
 
                     <div className="mt-6 rounded-xl border border-dashed border-(--card-stroke) bg-(--card-70) px-4 py-3 text-xs text-(--ink-muted)">
                         BYO-LLM requires Team tier or higher. Keys are encrypted with the org

--- a/src/lib/admin/api/__tests__/admin-api-paths.test.ts
+++ b/src/lib/admin/api/__tests__/admin-api-paths.test.ts
@@ -16,6 +16,7 @@ vi.mock("../_request", () => ({
 import { request } from "../_request";
 import { retentionApi } from "../retention";
 import { auditApi, platformAuditApi } from "../audit";
+import { llmSettingsApi } from "../llm-settings";
 
 const mockRequest = vi.mocked(request);
 
@@ -115,5 +116,31 @@ describe("platformAuditApi path contract (must not be changed)", () => {
         expect(mockRequest).toHaveBeenCalledOnce();
         const path = mockRequest.mock.calls[0][0] as string;
         expect(path).toMatch(/^\/platform\/audit-logs\?/);
+    });
+});
+
+describe("llmSettingsApi budget contract", () => {
+    it("reads the enforceable organization budget from the v1 admin path", async () => {
+        await llmSettingsApi.budget("token", "org-1");
+
+        expect(mockRequest).toHaveBeenCalledWith("/llm-settings/budget", {}, "token", "org-1");
+    });
+
+    it("preserves an explicit zero hard stop in the settings payload", async () => {
+        await llmSettingsApi.upsert(
+            { provider: "openai", budget_limit_micro_usd: 0 },
+            "token",
+            "org-1",
+        );
+
+        expect(mockRequest).toHaveBeenCalledWith(
+            "/llm-settings",
+            {
+                method: "PUT",
+                body: JSON.stringify({ provider: "openai", budget_limit_micro_usd: 0 }),
+            },
+            "token",
+            "org-1",
+        );
     });
 });

--- a/src/lib/admin/api/llm-settings.ts
+++ b/src/lib/admin/api/llm-settings.ts
@@ -1,5 +1,6 @@
 import { request } from "./_request";
 import type {
+    LLMBudgetResponse,
     LLMSettingsResponse,
     LLMSettingsStatusResponse,
     LLMSettingsUpsert,
@@ -34,4 +35,10 @@ export const llmSettingsApi = {
     // rather than blocking the UI.
     status: (token?: string, orgId?: string) =>
         request<LLMSettingsStatusResponse>("/llm-settings/status", {}, token, orgId),
+
+    // Enforceable calendar-month organization ceiling. This is intentionally
+    // separate from the ClickHouse spend-summary endpoint: active reservations
+    // participate in admission before provider calls complete.
+    budget: (token?: string, orgId?: string) =>
+        request<LLMBudgetResponse>("/llm-settings/budget", {}, token, orgId),
 };

--- a/src/lib/admin/server/settings.ts
+++ b/src/lib/admin/server/settings.ts
@@ -25,6 +25,7 @@ import type {
     LLMSettingsStatusResponse,
     LLMSettingsUpsert,
     LLMSettingsActionResult,
+    LLMBudgetResponse,
     LLMSpendSummaryResponse,
 } from "../types";
 import { getSessionContext, withErrorHandling } from "./_shared";
@@ -261,6 +262,17 @@ export async function getLLMSettingsStatus(): Promise<
     return withStatusErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
         return adminApi.llmSettings.status(token, orgId);
+    });
+}
+
+/**
+ * Enforceable BYO-LLM organization budget status. Unlike the historical spend
+ * summary this includes active reservations and is the admission-control view.
+ */
+export async function getLLMBudget(): Promise<LLMSettingsActionResult<LLMBudgetResponse>> {
+    return withStatusErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        return adminApi.llmSettings.budget(token, orgId);
     });
 }
 

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -759,6 +759,11 @@ export interface LLMSettingsUpsert {
     api_key?: string | null;
     base_url?: string | null;
     concurrency?: number | null;
+    /**
+     * Calendar-month organization hard cap in integer micro-USD. Omit to
+     * preserve the existing budget; zero is an explicit hard stop.
+     */
+    budget_limit_micro_usd?: number | null;
 }
 
 /**
@@ -770,6 +775,31 @@ export interface LLMSettingsActionResult<T> {
     data?: T;
     error?: string;
     status?: number;
+}
+
+// ---- BYO LLM Organization Budget (CHAOS-3238) ----
+
+export type LLMBudgetReason =
+    | "available"
+    | "budget_not_configured"
+    | "pricing_unavailable"
+    | "usage_unavailable"
+    | "budget_exhausted";
+
+/**
+ * GET /admin/llm-settings/budget response. Monetary values use integer
+ * micro-USD so the browser never treats provider spend as binary floats.
+ */
+export interface LLMBudgetResponse {
+    used_micro_usd: number | null;
+    limit_micro_usd: number | null;
+    remaining_micro_usd: number | null;
+    window: "calendar_month_utc";
+    reset_at: string;
+    enforcement_available: boolean;
+    reason: LLMBudgetReason;
+    maximum_limit_micro_usd: number;
+    pricing_version: string | null;
 }
 
 // ---- BYO LLM Spend Summary (CHAOS-2564) ----


### PR DESCRIPTION
## Summary

- add organization-admin controls for a shared monthly BYO LLM monetary budget
- preserve the existing limit when the field is blank and support an explicit zero-dollar hard stop
- show used-or-reserved spend, remaining budget, UTC reset, and the provisioned maximum
- surface approaching, exhausted, pricing-unavailable, usage-unavailable, unconfigured, and load-error states
- keep BYO organization budgets independent from the Ask Dev platform allowance

Backend: full-chaos/dev-health-ops#1329.

## Contract

- `PUT /api/v1/admin/llm-settings` accepts optional `budget_limit_micro_usd`
- `GET /api/v1/admin/llm-settings/budget` returns durable usage/reservation status
- blank input omits the field and preserves the stored limit
- zero explicitly blocks new budgeted BYO calls
- USD conversion is exact to integer micro-USD
- unknown pricing or missing usage fails closed when a budget is configured

## Validation

- Next production build with webpack — passed
- TypeScript — passed
- 49 affected tests across four files — passed
- focused final suite — 22 passed
- targeted ESLint — passed
- Prettier — passed
- design lint — zero violations
- diff validation — passed

The repository hook wrapper could not complete because its pnpm dependency guard attempted an interactive modules purge in a non-TTY. The underlying checks above were run directly before the explicit-refspec push; GitHub CI is the authoritative full gate.

## Visual evidence

Captured from the production build at 1440×1100:

- `output/playwright/chaos-3238-byo-llm-budget-after.png`
- shows $84.25 used or reserved against a $100 monthly limit, $15.75 remaining, the 80% warning, UTC reset, and $500 provisioned maximum

The image artifact is ready locally. The GitHub image helper still requires Codex to restart after receiving macOS Full Disk Access before it can read the browser session.

Canonical issue: CHAOS-3238
