### PR TITLE
fix(auth): approve organization-wide ACR access

### DIFF
--- a/scripts/__tests__/sync-acr-contracts.test.mjs
+++ b/scripts/__tests__/sync-acr-contracts.test.mjs
@@ -108,6 +108,27 @@ describe("sync-acr-contracts", () => {
         expect(artifactSnapshot(project.artifactRoot)).toEqual(before);
     });
 
+    sourceTest("generates referenced schemas without relying on pre-existing artifacts", () => {
+        const project = createTemporaryProject();
+        const expectedCommit = JSON.parse(
+            fs.readFileSync(path.join(ARTIFACT_ROOT, "manifest.json"), "utf8"),
+        ).source_commit;
+        const referencedSchema = path.join(
+            project.artifactRoot,
+            "schemas/acr_client_credential.v1.schema.json",
+        );
+        fs.rmSync(referencedSchema);
+
+        const result = run(["generate", "--allow-write", "--expected-commit", expectedCommit], {
+            cwd: project.root,
+            script: project.script,
+            environment: { ACR_ROOT: SOURCE },
+        });
+
+        expect(result.status).toBe(0);
+        expect(fs.existsSync(referencedSchema)).toBe(true);
+    });
+
     it("checks committed artifacts without requiring the sibling ACR checkout", () => {
         const result = run(["check"], { environment: { ACR_ROOT: undefined } });
 
@@ -131,8 +152,22 @@ describe("sync-acr-contracts", () => {
             "schemas/expanded_evidence.v1.schema.json",
             "examples/context_packet.v1.json",
             "examples/expanded_evidence.v1.json",
+            "schemas/acr_client_credential.v1.schema.json",
             "schemas/agent_episode.v1.schema.json",
             "schemas/agent_episode_create.v1.schema.json",
+            "schemas/credential_revoke_request.v1.schema.json",
+            "schemas/credential_revoke_response.v1.schema.json",
+            "schemas/credential_rotate_request.v1.schema.json",
+            "schemas/credential_rotate_response.v1.schema.json",
+            "schemas/device_approval_preview_request.v1.schema.json",
+            "schemas/device_approval_preview_response.v1.schema.json",
+            "schemas/device_approval_request.v1.schema.json",
+            "schemas/device_approval_response.v1.schema.json",
+            "schemas/device_authorization_request.v1.schema.json",
+            "schemas/device_authorization_response.v1.schema.json",
+            "schemas/device_token_request.v1.schema.json",
+            "schemas/device_token_response.v1.schema.json",
+            "schemas/oauth_device_error.v1.schema.json",
         ]);
     });
 

--- a/scripts/acr-contract-artifacts.mjs
+++ b/scripts/acr-contract-artifacts.mjs
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { compile } from "json-schema-to-typescript";
 import { format } from "prettier";
@@ -43,21 +45,31 @@ function symbolName(fileName) {
         .join("");
 }
 
-async function dtoModule(schemaFiles, artifactRoot, prettierOptions) {
-    const declarations = [];
-    for (const schema of schemaFiles) {
-        declarations.push(
-            await compile(JSON.parse(schema.contents), typeName(schema.path), {
-                bannerComment: "",
-                cwd: path.join(artifactRoot, "schemas"),
-                declareExternallyReferenced: false,
-                format: false,
-                strictIndexSignatures: true,
-                unknownAny: false,
-            }),
-        );
+async function dtoModule(schemaFiles, prettierOptions) {
+    const sourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "acr-contract-types-"));
+    try {
+        for (const schema of schemaFiles) {
+            fs.writeFileSync(path.join(sourceRoot, path.basename(schema.path)), schema.contents, {
+                flag: "wx",
+            });
+        }
+        const declarations = [];
+        for (const schema of schemaFiles) {
+            declarations.push(
+                await compile(JSON.parse(schema.contents), typeName(schema.path), {
+                    bannerComment: "",
+                    cwd: sourceRoot,
+                    declareExternallyReferenced: false,
+                    format: false,
+                    strictIndexSignatures: true,
+                    unknownAny: false,
+                }),
+            );
+        }
+        return format(declarations.join("\n").replace(/\bany\b/gu, "unknown"), prettierOptions);
+    } finally {
+        fs.rmSync(sourceRoot, { force: true, recursive: true });
     }
-    return format(declarations.join("\n").replace(/\bany\b/gu, "unknown"), prettierOptions);
 }
 
 async function validatorModule(schemaFiles, exampleFiles, prettierOptions) {
@@ -98,12 +110,7 @@ async function validatorModule(schemaFiles, exampleFiles, prettierOptions) {
     );
 }
 
-export async function expectedArtifacts({
-    artifactRoot,
-    sourceCommit,
-    sourceFiles,
-    prettierOptions,
-}) {
+export async function expectedArtifacts({ sourceCommit, sourceFiles, prettierOptions }) {
     const schemaFiles = sourceFiles
         .filter((file) => file.path.startsWith("contracts/jsonschema/"))
         .sort((left, right) => left.path.localeCompare(right.path));
@@ -122,6 +129,6 @@ export async function expectedArtifacts({
         ...rawArtifacts,
         "manifest.json": stableJson(manifest),
         "../contracts.ts": await validatorModule(schemaFiles, exampleFiles, prettierOptions),
-        "../generated.ts": await dtoModule(schemaFiles, artifactRoot, prettierOptions),
+        "../generated.ts": await dtoModule(schemaFiles, prettierOptions),
     };
 }

--- a/scripts/sync-acr-contracts.mjs
+++ b/scripts/sync-acr-contracts.mjs
@@ -14,7 +14,7 @@ import {
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ARTIFACT_ROOT = path.join(ROOT, "src/lib/acr/contracts");
-const SOURCE_COMMIT = "b5a76c3c51c9ccd4f6f90031843de874aef1f1f4";
+const SOURCE_COMMIT = "7e7c57be32c2b81bcd94994e584a554e2a05a99a";
 const PRETTIER_OPTIONS = Object.freeze({
     parser: "typescript",
     printWidth: 100,
@@ -39,8 +39,22 @@ const PRIMARY_SOURCE_PATHS = [
 ];
 // The copied OpenAPI document references these response schemas. Keep this closure explicit and ordered.
 const DEPENDENCY_CLOSURE_PATHS = [
+    "contracts/jsonschema/v1/acr_client_credential.v1.schema.json",
     "contracts/jsonschema/v1/agent_episode.v1.schema.json",
     "contracts/jsonschema/v1/agent_episode_create.v1.schema.json",
+    "contracts/jsonschema/v1/credential_revoke_request.v1.schema.json",
+    "contracts/jsonschema/v1/credential_revoke_response.v1.schema.json",
+    "contracts/jsonschema/v1/credential_rotate_request.v1.schema.json",
+    "contracts/jsonschema/v1/credential_rotate_response.v1.schema.json",
+    "contracts/jsonschema/v1/device_approval_preview_request.v1.schema.json",
+    "contracts/jsonschema/v1/device_approval_preview_response.v1.schema.json",
+    "contracts/jsonschema/v1/device_approval_request.v1.schema.json",
+    "contracts/jsonschema/v1/device_approval_response.v1.schema.json",
+    "contracts/jsonschema/v1/device_authorization_request.v1.schema.json",
+    "contracts/jsonschema/v1/device_authorization_response.v1.schema.json",
+    "contracts/jsonschema/v1/device_token_request.v1.schema.json",
+    "contracts/jsonschema/v1/device_token_response.v1.schema.json",
+    "contracts/jsonschema/v1/oauth_device_error.v1.schema.json",
 ];
 const SOURCE_PATHS = [...PRIMARY_SOURCE_PATHS, ...DEPENDENCY_CLOSURE_PATHS];
 

--- a/src/app/acr/device/page.test.tsx
+++ b/src/app/acr/device/page.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const redirectMock = vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+});
+const authMock = vi.fn();
+const listAuthorizedRepositoriesMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+    redirect: (url: string) => redirectMock(url),
+}));
+vi.mock("@/lib/auth", () => ({ auth: () => authMock() }));
+vi.mock("@/lib/acr/service", () => ({
+    listAuthorizedRepositories: listAuthorizedRepositoriesMock,
+}));
+vi.mock("@/components/acr/DeviceApprovalForm", () => ({
+    DeviceApprovalForm: ({ initialState }: { readonly initialState?: string }) => (
+        <div data-initial-state={initialState} data-testid="device-approval-form" />
+    ),
+}));
+
+import DeviceApprovalPage from "./page";
+
+describe("DeviceApprovalPage", () => {
+    beforeEach(() => {
+        authMock.mockResolvedValue({
+            access_token: "ops-token",
+            user: { id: "user-1", org_id: "org-1", real_org_id: "org-1" },
+        });
+    });
+
+    afterEach(() => vi.clearAllMocks());
+
+    it("renders organization-wide approval without consulting the analytics repository catalog", async () => {
+        render(await DeviceApprovalPage());
+
+        expect(screen.getByTestId("device-approval-form")).toBeVisible();
+        expect(listAuthorizedRepositoriesMock).not.toHaveBeenCalled();
+    });
+
+    it("redirects a logged-out user back to device approval after sign-in", async () => {
+        authMock.mockResolvedValue(null);
+
+        await expect(DeviceApprovalPage()).rejects.toThrow(
+            "NEXT_REDIRECT:/auth/signin?callbackUrl=%2Facr%2Fdevice",
+        );
+    });
+
+    it("keeps device approval unavailable while impersonating", async () => {
+        authMock.mockResolvedValue({
+            access_token: "ops-token",
+            user: { id: "user-1", org_id: "org-impersonated", real_org_id: "org-1" },
+        });
+
+        render(await DeviceApprovalPage());
+
+        expect(screen.getByTestId("device-approval-form")).toHaveAttribute(
+            "data-initial-state",
+            "denied",
+        );
+        expect(listAuthorizedRepositoriesMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/acr/device/page.tsx
+++ b/src/app/acr/device/page.tsx
@@ -1,19 +1,9 @@
 import { redirect } from "next/navigation";
 
 import { DeviceApprovalForm } from "@/components/acr/DeviceApprovalForm";
-import { DataState } from "@/components/ui/DataState";
 import { auth } from "@/lib/auth";
-import { listAuthorizedRepositories } from "@/lib/acr/service";
 
 export const dynamic = "force-dynamic";
-
-async function repositoryCatalog(orgId: string): Promise<readonly string[] | null> {
-    try {
-        return await listAuthorizedRepositories(orgId);
-    } catch {
-        return null;
-    }
-}
 
 export default async function DeviceApprovalPage() {
     const session = await auth();
@@ -24,19 +14,7 @@ export default async function DeviceApprovalPage() {
         session.user.real_org_id !== undefined &&
         session.user.real_org_id !== session.user.org_id
     ) {
-        return <DeviceApprovalForm initialState="denied" repositories={[]} />;
+        return <DeviceApprovalForm initialState="denied" />;
     }
-    const repositories = await repositoryCatalog(session.user.org_id);
-    if (repositories === null) {
-        return (
-            <main className="min-h-[100dvh] bg-background px-4 py-8 sm:px-6 sm:py-12">
-                <DataState
-                    description="Your repository access could not be loaded. Please return to your terminal and try again."
-                    title="Approval is unavailable"
-                    variant="error"
-                />
-            </main>
-        );
-    }
-    return <DeviceApprovalForm repositories={repositories} />;
+    return <DeviceApprovalForm />;
 }

--- a/src/app/api/acr/device/route.test.ts
+++ b/src/app/api/acr/device/route.test.ts
@@ -25,11 +25,12 @@ vi.mock("@/lib/client-ip", () => ({
 }));
 vi.mock("@/lib/rate-limit", () => ({ checkRateLimit: checkRateLimitMock }));
 
+import { AcrRuntimeError, acrRuntimeErrorCodes } from "@/lib/acr/errors";
 import { POST } from "./route";
 
 const body = {
     action: "approve",
-    repository_scopes: ["full-chaos/platform"],
+    repository_scopes: ["*"],
     repository_hints: ["full-chaos/platform"],
     user_code: "ABCD2345",
 };
@@ -67,7 +68,7 @@ describe("POST /api/acr/device", () => {
         expect(checkRateLimitMock).toHaveBeenCalledTimes(2);
         expect(approveDeviceAuthorizationMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                repositoryScopes: ["full-chaos/platform"],
+                repositoryScopes: ["*"],
                 userCode: "ABCD2345",
             }),
         );
@@ -119,5 +120,24 @@ describe("POST /api/acr/device", () => {
         expect(response.status).toBe(429);
         expect(response.headers.get("retry-after")).toBe("60");
         expect(approveDeviceAuthorizationMock).not.toHaveBeenCalled();
+    });
+
+    it("Given ACR rejects an approval conflict, when posting, then preserves the 409 status", async () => {
+        approveDeviceAuthorizationMock.mockRejectedValue(
+            new AcrRuntimeError(acrRuntimeErrorCodes.upstream, "redacted upstream conflict", {
+                status: 409,
+            }),
+        );
+
+        const response = await POST(request());
+
+        expect(response.status).toBe(409);
+        expect(await response.json()).toEqual({
+            error: {
+                code: "upstream",
+                message: "Agent Context Runtime is temporarily unavailable.",
+                retryable: false,
+            },
+        });
     });
 });

--- a/src/components/acr/DeviceApprovalForm.test.tsx
+++ b/src/components/acr/DeviceApprovalForm.test.tsx
@@ -13,12 +13,12 @@ describe("DeviceApprovalForm", () => {
         ["denied", "Request not approved"],
         ["expired", "Code expired"],
     ] as const)("Given a %s state, when rendered, then announces %s", (state, title) => {
-        render(<DeviceApprovalForm initialState={state} repositories={["full-chaos/platform"]} />);
+        render(<DeviceApprovalForm initialState={state} />);
 
         expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
     });
 
-    it("Given an approved preview, when confirming, then sends the bounded selected repositories in a fresh request", async () => {
+    it("Given an approved preview, when confirming, then approves all current and future organization repositories", async () => {
         const fetchMock = vi
             .fn()
             .mockResolvedValueOnce(
@@ -31,7 +31,7 @@ describe("DeviceApprovalForm", () => {
             );
         vi.stubGlobal("fetch", fetchMock);
 
-        render(<DeviceApprovalForm repositories={["full-chaos/platform", "full-chaos/private"]} />);
+        render(<DeviceApprovalForm />);
         const verificationCode = screen.getByLabelText("Verification code");
         fireEvent.change(verificationCode, {
             target: { value: "EP23TUGG" },
@@ -41,8 +41,9 @@ describe("DeviceApprovalForm", () => {
         fireEvent.click(screen.getByRole("button", { name: "Preview request" }));
 
         await screen.findByRole("heading", { name: "Review device access" });
-        expect(screen.getByLabelText("full-chaos/platform")).toBeChecked();
-        expect(screen.queryByLabelText("full-chaos/private")).not.toBeInTheDocument();
+        expect(
+            screen.getByText(/all current and future repositories in your organization/i),
+        ).toBeVisible();
 
         fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
 
@@ -61,7 +62,7 @@ describe("DeviceApprovalForm", () => {
             expect.objectContaining({
                 body: JSON.stringify({
                     action: "approve",
-                    repository_scopes: ["full-chaos/platform"],
+                    repository_scopes: ["*"],
                     user_code: "EP23TUGG",
                 }),
                 method: "POST",
@@ -69,28 +70,28 @@ describe("DeviceApprovalForm", () => {
         );
     });
 
-    it("Given a preview with no repository preference, when confirming, then approves from the authorized catalog", async () => {
+    it("Given repository hints, when confirming, then does not narrow the organization-wide grant to analytics inventory", async () => {
         const fetchMock = vi
             .fn()
             .mockResolvedValueOnce(
-                new Response(JSON.stringify({ repositoryHints: [] }), { status: 200 }),
+                new Response(
+                    JSON.stringify({ repositoryHints: ["full-chaos/cataloged-repository"] }),
+                    { status: 200 },
+                ),
             )
             .mockResolvedValueOnce(
                 new Response(JSON.stringify({ status: "approved" }), { status: 200 }),
             );
         vi.stubGlobal("fetch", fetchMock);
 
-        render(
-            <DeviceApprovalForm repositories={["full-chaos/dev-health", "full-chaos/platform"]} />,
-        );
+        render(<DeviceApprovalForm />);
         fireEvent.change(screen.getByLabelText("Verification code"), {
             target: { value: "EP23TUGG" },
         });
         fireEvent.click(screen.getByRole("button", { name: "Preview request" }));
 
         await screen.findByRole("heading", { name: "Review device access" });
-        expect(screen.getByLabelText("full-chaos/dev-health")).toBeChecked();
-        expect(screen.getByLabelText("full-chaos/platform")).toBeChecked();
+        expect(screen.queryByText("full-chaos/cataloged-repository")).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
 
@@ -101,7 +102,7 @@ describe("DeviceApprovalForm", () => {
             expect.objectContaining({
                 body: JSON.stringify({
                     action: "approve",
-                    repository_scopes: ["full-chaos/dev-health", "full-chaos/platform"],
+                    repository_scopes: ["*"],
                     user_code: "EP23TUGG",
                 }),
                 method: "POST",
@@ -115,7 +116,7 @@ describe("DeviceApprovalForm", () => {
             .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 400 }));
         vi.stubGlobal("fetch", fetchMock);
 
-        render(<DeviceApprovalForm repositories={["full-chaos/platform"]} />);
+        render(<DeviceApprovalForm />);
         const verificationCode = screen.getByLabelText("Verification code");
         fireEvent.change(verificationCode, {
             target: { value: "OOOOOOOO" },

--- a/src/components/acr/DeviceApprovalForm.tsx
+++ b/src/components/acr/DeviceApprovalForm.tsx
@@ -9,7 +9,6 @@ type ApprovalState = "denied" | "expired" | "pending" | "review" | "success";
 
 type DeviceApprovalFormProps = {
     readonly initialState?: ApprovalState;
-    readonly repositories: readonly string[];
 };
 
 type ApprovalResponse = {
@@ -36,13 +35,13 @@ function stateCopy(state: ApprovalState): { readonly description: string; readon
             };
         case "review":
             return {
-                description: "Select the repositories to approve for this device.",
+                description: "Review the organization-wide access requested for this device.",
                 title: "Review device access",
             };
         case "success":
             return {
                 description:
-                    "Your selected repositories are approved. Return to your terminal to finish sign-in.",
+                    "All current and future repositories in your organization are approved. Return to your terminal to finish sign-in.",
                 title: "Approval complete",
             };
     }
@@ -54,35 +53,13 @@ function errorState(response: Response): ApprovalState {
     return "pending";
 }
 
-function repositoriesForHints(
-    repositories: readonly string[],
-    hints: readonly string[],
-): readonly string[] {
-    if (hints.length === 0) return repositories;
-    return repositories.filter((repository) => hints.includes(repository));
-}
-
-export function DeviceApprovalForm({
-    initialState = "pending",
-    repositories,
-}: DeviceApprovalFormProps) {
+export function DeviceApprovalForm({ initialState = "pending" }: DeviceApprovalFormProps) {
     const [code, setCode] = useState("");
-    const [selected, setSelected] = useState<readonly string[]>([]);
     const [state, setState] = useState<ApprovalState>(initialState);
     const [message, setMessage] = useState<string | null>(null);
     const [submitting, setSubmitting] = useState(false);
-    const [hints, setHints] = useState<readonly string[]>([]);
     const descriptionId = useId();
     const stateMessage = stateCopy(state);
-    const availableRepositories = repositoriesForHints(repositories, hints);
-
-    function toggleRepository(repository: string): void {
-        setSelected((current) =>
-            current.includes(repository)
-                ? current.filter((selectedRepository) => selectedRepository !== repository)
-                : [...current, repository].sort((left, right) => left.localeCompare(right)),
-        );
-    }
 
     async function submitPreview(event: SyntheticEvent<HTMLFormElement>): Promise<void> {
         event.preventDefault();
@@ -95,10 +72,7 @@ export function DeviceApprovalForm({
                 method: "POST",
             });
             const result = await response.json();
-            if (response.ok && result.repositoryHints) {
-                setHints(result.repositoryHints);
-                const available = repositoriesForHints(repositories, result.repositoryHints);
-                setSelected(available);
+            if (response.ok && Array.isArray(result.repositoryHints)) {
                 setState("review");
                 return;
             }
@@ -117,17 +91,13 @@ export function DeviceApprovalForm({
 
     async function submitApprove(event: SyntheticEvent<HTMLFormElement>): Promise<void> {
         event.preventDefault();
-        if (selected.length === 0) {
-            setMessage("Select at least one repository to continue.");
-            return;
-        }
         setSubmitting(true);
         setMessage(null);
         try {
             const response = await fetch("/api/acr/device", {
                 body: JSON.stringify({
                     action: "approve",
-                    repository_scopes: selected,
+                    repository_scopes: ["*"],
                     user_code: code,
                 }),
                 headers: { "Content-Type": "application/json" },
@@ -200,32 +170,22 @@ export function DeviceApprovalForm({
                         className="mt-6 space-y-6"
                         aria-describedby={descriptionId}
                     >
-                        <fieldset>
-                            <legend className="text-h3 font-medium">Repositories to approve</legend>
+                        <section
+                            aria-labelledby="organization-repositories-title"
+                            className="rounded-(--radius-md) border border-(--card-stroke) bg-background px-4 py-4"
+                        >
+                            <h2
+                                id="organization-repositories-title"
+                                className="text-h3 font-medium"
+                            >
+                                All organization repositories
+                            </h2>
                             <p className="mt-1 text-sm text-(--ink-muted)">
-                                Only repositories you are authorized to access are available.
+                                This device can read context from all current and future
+                                repositories in your organization. Access never extends to another
+                                organization.
                             </p>
-                            <div className="mt-3 divide-y divide-(--card-stroke) rounded-(--radius-md) border border-(--card-stroke)">
-                                {availableRepositories.map((repository) => (
-                                    <label
-                                        key={repository}
-                                        className="flex cursor-pointer items-center gap-3 px-4 py-3 text-body hover:bg-(--card-80)"
-                                    >
-                                        <input
-                                            checked={selected.includes(repository)}
-                                            onChange={() => toggleRepository(repository)}
-                                            type="checkbox"
-                                        />
-                                        <span>{repository}</span>
-                                    </label>
-                                ))}
-                                {availableRepositories.length === 0 && (
-                                    <div className="px-4 py-3 text-body text-(--ink-muted)">
-                                        No authorized repositories match this request.
-                                    </div>
-                                )}
-                            </div>
-                        </fieldset>
+                        </section>
                         <div className="flex gap-3">
                             <Button
                                 disabled={submitting}
@@ -235,11 +195,7 @@ export function DeviceApprovalForm({
                             >
                                 {CTA_LABELS.backButton}
                             </Button>
-                            <Button
-                                disabled={submitting || selected.length === 0}
-                                type="submit"
-                                variant="primary"
-                            >
+                            <Button disabled={submitting} type="submit" variant="primary">
                                 {submitting ? "Approving…" : CTA_LABELS.confirm}
                             </Button>
                         </div>

--- a/src/lib/acr/__tests__/contracts.test.ts
+++ b/src/lib/acr/__tests__/contracts.test.ts
@@ -24,11 +24,25 @@ describe("ACR REST contract boundary", () => {
             "schemas/expanded_evidence.v1.schema.json",
             "examples/context_packet.v1.json",
             "examples/expanded_evidence.v1.json",
+            "schemas/acr_client_credential.v1.schema.json",
             "schemas/agent_episode.v1.schema.json",
             "schemas/agent_episode_create.v1.schema.json",
+            "schemas/credential_revoke_request.v1.schema.json",
+            "schemas/credential_revoke_response.v1.schema.json",
+            "schemas/credential_rotate_request.v1.schema.json",
+            "schemas/credential_rotate_response.v1.schema.json",
+            "schemas/device_approval_preview_request.v1.schema.json",
+            "schemas/device_approval_preview_response.v1.schema.json",
+            "schemas/device_approval_request.v1.schema.json",
+            "schemas/device_approval_response.v1.schema.json",
+            "schemas/device_authorization_request.v1.schema.json",
+            "schemas/device_authorization_response.v1.schema.json",
+            "schemas/device_token_request.v1.schema.json",
+            "schemas/device_token_response.v1.schema.json",
+            "schemas/oauth_device_error.v1.schema.json",
         ]);
         expect(JSON.stringify(manifest)).not.toMatch(/generated_at|timestamp|created_at/u);
-        expect(manifest.source_commit).toBe("b5a76c3c51c9ccd4f6f90031843de874aef1f1f4");
+        expect(manifest.source_commit).toBe("7e7c57be32c2b81bcd94994e584a554e2a05a99a");
     });
 
     it("accepts every committed golden with its paired Draft 2020-12 schema", () => {

--- a/src/lib/acr/__tests__/device-approval.test.ts
+++ b/src/lib/acr/__tests__/device-approval.test.ts
@@ -44,19 +44,22 @@ function authenticate(overrides: Record<string, unknown> = {}): void {
     });
 }
 
-function installOpsAuthorization(
-    scopes = ["full-chaos/dev-health-acr", "full-chaos/platform"],
-): void {
+function installOpsAuthorization(scopes = ["full-chaos/dev-health-acr", "full-chaos/platform"]): {
+    repositoryCatalogRequests: number;
+} {
+    const observations = { repositoryCatalogRequests: 0 };
     server.use(
         http.get("http://ops.example.test/api/v1/licensing/entitlements/:orgId", () =>
             HttpResponse.json({ features: { agent_context_runtime: true }, is_valid: true }),
         ),
-        http.post("http://ops.example.test/graphql", () =>
-            HttpResponse.json({
+        http.post("http://ops.example.test/graphql", () => {
+            observations.repositoryCatalogRequests += 1;
+            return HttpResponse.json({
                 data: { catalog: { values: scopes.map((value) => ({ count: 1, value })) } },
-            }),
-        ),
+            });
+        }),
     );
+    return observations;
 }
 
 function decodeAssertion(value: string): Record<string, unknown> {
@@ -118,7 +121,7 @@ describe("approveDeviceAuthorization", () => {
     });
 
     it("Given an explicit selected repository, when approving, then sends only the bounded grant with a body-bound credential assertion", async () => {
-        installOpsAuthorization();
+        const ops = installOpsAuthorization();
         server.use(
             http.post(
                 "https://acr.example.test/api/v1/oauth/device_approval",
@@ -137,9 +140,11 @@ describe("approveDeviceAuthorization", () => {
                     expect(decodeAssertion(assertion)).toMatchObject({
                         body_sha256: createHash("sha256").update(body).digest("base64url"),
                         method: "POST",
+                        org_id: "org-123",
                         path: "/api/v1/oauth/device_approval",
                         permissions: ["credential:issue"],
                         repository_scopes: ["full-chaos/platform"],
+                        sub: "user-123",
                     });
                     return HttpResponse.json({
                         schema_version: "device_approval_response.v1",
@@ -156,10 +161,11 @@ describe("approveDeviceAuthorization", () => {
                 userCode: "ABCD2345",
             }),
         ).resolves.toEqual({ status: "approved" });
+        expect(ops.repositoryCatalogRequests).toBe(0);
     });
 
-    it("Given a preview followed by approval, when using the same POST endpoint, then issues fresh body-bound credential assertions", async () => {
-        installOpsAuthorization();
+    it("Given organization-wide approval, when previewing and approving, then never derives authorization from the repository catalog", async () => {
+        const ops = installOpsAuthorization();
         const assertions: string[] = [];
         server.use(
             http.post(
@@ -181,9 +187,11 @@ describe("approveDeviceAuthorization", () => {
                         expect(decodeAssertion(assertion)).toMatchObject({
                             body_sha256: createHash("sha256").update(body).digest("base64url"),
                             method: "POST",
+                            org_id: "org-123",
                             path: "/api/v1/oauth/device_approval",
                             permissions: ["credential:issue"],
-                            repository_scopes: ["full-chaos/dev-health-acr", "full-chaos/platform"],
+                            repository_scopes: ["*"],
+                            sub: "user-123",
                         });
                         return HttpResponse.json({
                             organization_id_hint: "org_fullchaos",
@@ -192,16 +200,18 @@ describe("approveDeviceAuthorization", () => {
                         });
                     }
                     expect(requestBody).toEqual({
-                        repository_scopes: ["full-chaos/platform"],
+                        repository_scopes: ["*"],
                         schema_version: "device_approval_request.v1",
                         user_code: "ABCD2345",
                     });
                     expect(decodeAssertion(assertion)).toMatchObject({
                         body_sha256: createHash("sha256").update(body).digest("base64url"),
                         method: "POST",
+                        org_id: "org-123",
                         path: "/api/v1/oauth/device_approval",
                         permissions: ["credential:issue"],
-                        repository_scopes: ["full-chaos/platform"],
+                        repository_scopes: ["*"],
+                        sub: "user-123",
                     });
                     return HttpResponse.json({
                         schema_version: "device_approval_response.v1",
@@ -222,13 +232,43 @@ describe("approveDeviceAuthorization", () => {
         });
         await expect(
             approveDeviceAuthorization({
-                repositoryScopes: ["full-chaos/platform"],
+                repositoryScopes: ["*"],
                 signal: new AbortController().signal,
                 userCode: "ABCD2345",
             }),
         ).resolves.toEqual({ status: "approved" });
         expect(assertions).toHaveLength(2);
         expect(assertions[0]).not.toBe(assertions[1]);
+        expect(ops.repositoryCatalogRequests).toBe(0);
+    });
+
+    it("Given ACR reports a device authorization conflict, when approving, then preserves the 409 response", async () => {
+        installOpsAuthorization();
+        server.use(
+            http.post("https://acr.example.test/api/v1/oauth/device_approval", () =>
+                HttpResponse.json(
+                    {
+                        error: {
+                            code: "device_authorization_conflict",
+                            http_status: 409,
+                            message: "Device authorization is no longer pending",
+                            retryable: false,
+                        },
+                        request_id: "req_device_conflict",
+                        schema_version: "error.v1",
+                    },
+                    { status: 409 },
+                ),
+            ),
+        );
+
+        await expect(
+            approveDeviceAuthorization({
+                repositoryScopes: ["*"],
+                signal: new AbortController().signal,
+                userCode: "ABCD2345",
+            }),
+        ).rejects.toMatchObject({ code: "upstream", retryable: false, status: 409 });
     });
 
     it("Given a preview with no repository hints, when ACR omits the optional field, then returns an empty selection", async () => {
@@ -321,8 +361,18 @@ describe("approveDeviceAuthorization", () => {
 
     it.each([
         ["an empty selection", []],
-        ["a foreign selection", ["foreign/repository"]],
-        ["a wildcard selection", ["full-chaos/*"]],
+        ["a repository-name wildcard", ["full-chaos/*"]],
+        ["a wildcard mixed with an exact scope", ["*", "full-chaos/platform"]],
+        ["unsorted exact scopes", ["full-chaos/zeta", "full-chaos/alpha"]],
+        ["duplicate exact scopes", ["full-chaos/platform", "full-chaos/platform"]],
+        ["an uppercase exact scope", ["Full-Chaos/platform"]],
+        [
+            "more than 100 exact scopes",
+            Array.from(
+                { length: 101 },
+                (_, index) => `full-chaos/repository-${String(index).padStart(3, "0")}`,
+            ),
+        ],
     ])(
         "Given %s, when approving, then fails before the ACR call",
         async (_name, repositoryScopes) => {
@@ -348,6 +398,40 @@ describe("approveDeviceAuthorization", () => {
             expect(approvals).toBe(0);
         },
     );
+
+    it("Given an organization without the ACR entitlement, when approving, then denies before ACR credential issuance", async () => {
+        let approvals = 0;
+        let repositoryCatalogRequests = 0;
+        server.use(
+            http.get("http://ops.example.test/api/v1/licensing/entitlements/:orgId", () =>
+                HttpResponse.json({
+                    features: { agent_context_runtime: false },
+                    is_valid: true,
+                }),
+            ),
+            http.post("http://ops.example.test/graphql", () => {
+                repositoryCatalogRequests += 1;
+                return HttpResponse.json({ data: { catalog: { values: [] } } });
+            }),
+            http.post("https://acr.example.test/api/v1/oauth/device_approval", () => {
+                approvals += 1;
+                return HttpResponse.json({
+                    schema_version: "device_approval_response.v1",
+                    status: "approved",
+                });
+            }),
+        );
+
+        await expect(
+            approveDeviceAuthorization({
+                repositoryScopes: ["*"],
+                signal: new AbortController().signal,
+                userCode: "ABCD2345",
+            }),
+        ).rejects.toMatchObject({ code: "not_entitled", status: 403 });
+        expect(repositoryCatalogRequests).toBe(0);
+        expect(approvals).toBe(0);
+    });
 
     it("Given impersonation, when approving, then rejects before entitlement resolution", async () => {
         authenticate({

--- a/src/lib/acr/contracts.ts
+++ b/src/lib/acr/contracts.ts
@@ -1,39 +1,81 @@
 import Ajv2020 from "ajv/dist/2020";
 import addFormats from "ajv-formats";
+import acrClientCredentialSchema from "./contracts/schemas/acr_client_credential.v1.schema.json";
 import agentEpisodeCreateSchema from "./contracts/schemas/agent_episode_create.v1.schema.json";
 import agentEpisodeSchema from "./contracts/schemas/agent_episode.v1.schema.json";
 import capabilitiesSchema from "./contracts/schemas/capabilities.v1.schema.json";
 import contextPacketItemSchema from "./contracts/schemas/context_packet_item.v1.schema.json";
 import contextPacketRequestSchema from "./contracts/schemas/context_packet_request.v1.schema.json";
 import contextPacketSchema from "./contracts/schemas/context_packet.v1.schema.json";
+import credentialRevokeRequestSchema from "./contracts/schemas/credential_revoke_request.v1.schema.json";
+import credentialRevokeResponseSchema from "./contracts/schemas/credential_revoke_response.v1.schema.json";
+import credentialRotateRequestSchema from "./contracts/schemas/credential_rotate_request.v1.schema.json";
+import credentialRotateResponseSchema from "./contracts/schemas/credential_rotate_response.v1.schema.json";
+import deviceApprovalPreviewRequestSchema from "./contracts/schemas/device_approval_preview_request.v1.schema.json";
+import deviceApprovalPreviewResponseSchema from "./contracts/schemas/device_approval_preview_response.v1.schema.json";
+import deviceApprovalRequestSchema from "./contracts/schemas/device_approval_request.v1.schema.json";
+import deviceApprovalResponseSchema from "./contracts/schemas/device_approval_response.v1.schema.json";
+import deviceAuthorizationRequestSchema from "./contracts/schemas/device_authorization_request.v1.schema.json";
+import deviceAuthorizationResponseSchema from "./contracts/schemas/device_authorization_response.v1.schema.json";
+import deviceTokenRequestSchema from "./contracts/schemas/device_token_request.v1.schema.json";
+import deviceTokenResponseSchema from "./contracts/schemas/device_token_response.v1.schema.json";
 import errorSchema from "./contracts/schemas/error.v1.schema.json";
 import evidenceRefSchema from "./contracts/schemas/evidence_ref.v1.schema.json";
 import expandedEvidenceSchema from "./contracts/schemas/expanded_evidence.v1.schema.json";
+import oauthDeviceErrorSchema from "./contracts/schemas/oauth_device_error.v1.schema.json";
 import contextPacketExample from "./contracts/examples/context_packet.v1.json";
 import expandedEvidenceExample from "./contracts/examples/expanded_evidence.v1.json";
 
 export const acrSchemas = {
+    acrClientCredential: acrClientCredentialSchema,
     agentEpisodeCreate: agentEpisodeCreateSchema,
     agentEpisode: agentEpisodeSchema,
     capabilities: capabilitiesSchema,
     contextPacketItem: contextPacketItemSchema,
     contextPacketRequest: contextPacketRequestSchema,
     contextPacket: contextPacketSchema,
+    credentialRevokeRequest: credentialRevokeRequestSchema,
+    credentialRevokeResponse: credentialRevokeResponseSchema,
+    credentialRotateRequest: credentialRotateRequestSchema,
+    credentialRotateResponse: credentialRotateResponseSchema,
+    deviceApprovalPreviewRequest: deviceApprovalPreviewRequestSchema,
+    deviceApprovalPreviewResponse: deviceApprovalPreviewResponseSchema,
+    deviceApprovalRequest: deviceApprovalRequestSchema,
+    deviceApprovalResponse: deviceApprovalResponseSchema,
+    deviceAuthorizationRequest: deviceAuthorizationRequestSchema,
+    deviceAuthorizationResponse: deviceAuthorizationResponseSchema,
+    deviceTokenRequest: deviceTokenRequestSchema,
+    deviceTokenResponse: deviceTokenResponseSchema,
     error: errorSchema,
     evidenceRef: evidenceRefSchema,
     expandedEvidence: expandedEvidenceSchema,
+    oauthDeviceError: oauthDeviceErrorSchema,
 };
 
 const acrSchemaFiles = {
+    "acr_client_credential.v1.schema.json": acrClientCredentialSchema,
     "agent_episode_create.v1.schema.json": agentEpisodeCreateSchema,
     "agent_episode.v1.schema.json": agentEpisodeSchema,
     "capabilities.v1.schema.json": capabilitiesSchema,
     "context_packet_item.v1.schema.json": contextPacketItemSchema,
     "context_packet_request.v1.schema.json": contextPacketRequestSchema,
     "context_packet.v1.schema.json": contextPacketSchema,
+    "credential_revoke_request.v1.schema.json": credentialRevokeRequestSchema,
+    "credential_revoke_response.v1.schema.json": credentialRevokeResponseSchema,
+    "credential_rotate_request.v1.schema.json": credentialRotateRequestSchema,
+    "credential_rotate_response.v1.schema.json": credentialRotateResponseSchema,
+    "device_approval_preview_request.v1.schema.json": deviceApprovalPreviewRequestSchema,
+    "device_approval_preview_response.v1.schema.json": deviceApprovalPreviewResponseSchema,
+    "device_approval_request.v1.schema.json": deviceApprovalRequestSchema,
+    "device_approval_response.v1.schema.json": deviceApprovalResponseSchema,
+    "device_authorization_request.v1.schema.json": deviceAuthorizationRequestSchema,
+    "device_authorization_response.v1.schema.json": deviceAuthorizationResponseSchema,
+    "device_token_request.v1.schema.json": deviceTokenRequestSchema,
+    "device_token_response.v1.schema.json": deviceTokenResponseSchema,
     "error.v1.schema.json": errorSchema,
     "evidence_ref.v1.schema.json": evidenceRefSchema,
     "expanded_evidence.v1.schema.json": expandedEvidenceSchema,
+    "oauth_device_error.v1.schema.json": oauthDeviceErrorSchema,
 };
 
 export const acrExamples = [

--- a/src/lib/acr/contracts/manifest.json
+++ b/src/lib/acr/contracts/manifest.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "b5a76c3c51c9ccd4f6f90031843de874aef1f1f4",
+  "source_commit": "7e7c57be32c2b81bcd94994e584a554e2a05a99a",
   "files": [
     {
       "path": "openapi/acr-v1.json",
-      "sha256": "4d319b65d17d0bceab28d4f8abe38a97bdc5cc8cdf5b541fa6f5723494abf6dd"
+      "sha256": "02d90038bed1ff5109d16d1e413b862bd0bb6a1694154f4343c32be9af8791bd"
     },
     {
       "path": "schemas/capabilities.v1.schema.json",
@@ -23,7 +23,7 @@
     },
     {
       "path": "schemas/error.v1.schema.json",
-      "sha256": "83eb433d1681249e1a836d6a1c034e8ee68772d2ad36c4fdd29ee59b00614cbb"
+      "sha256": "3e85dfa1fd04644cae3c7d602ee3903971692ba9b6e6904e010a938d27b259fb"
     },
     {
       "path": "schemas/evidence_ref.v1.schema.json",
@@ -42,12 +42,68 @@
       "sha256": "b42ad9b46682f2112964a2f0a4de7e453caf795b746ac4b7ad0377ca2369a26f"
     },
     {
+      "path": "schemas/acr_client_credential.v1.schema.json",
+      "sha256": "9b71754f66263cc76456cad8178ef8677d468de9238b49320b29d12597339b16"
+    },
+    {
       "path": "schemas/agent_episode.v1.schema.json",
       "sha256": "6e41f2131f655c50fc0ae1dbe7701e93757a8b16bb9fc1d6006778761da7ccd8"
     },
     {
       "path": "schemas/agent_episode_create.v1.schema.json",
       "sha256": "461f5d9cfcbbe742df1820cbd40779b0d6d41f9a3b6ddbad34ec18c56ae84c29"
+    },
+    {
+      "path": "schemas/credential_revoke_request.v1.schema.json",
+      "sha256": "1d1402ac3c271b543e807e3f958d03fd927c361db5fdb5afe75687f689e02614"
+    },
+    {
+      "path": "schemas/credential_revoke_response.v1.schema.json",
+      "sha256": "dc457f6fb12b60fb4196d990d3f5927068ffe3162dd315c4328081ff09714bf4"
+    },
+    {
+      "path": "schemas/credential_rotate_request.v1.schema.json",
+      "sha256": "d6e47c9a12a96259b47fe402f5603a3f218e5062fb9b82ee50b2269cd3f7da4d"
+    },
+    {
+      "path": "schemas/credential_rotate_response.v1.schema.json",
+      "sha256": "a4ad79ff46b32868814433fd0421360bcfeb4dc0d5e165c8ffb4f8b4104726d2"
+    },
+    {
+      "path": "schemas/device_approval_preview_request.v1.schema.json",
+      "sha256": "0bd37884ab5225d0371a877e2b6d0018fd25961ede592d9ebb4942c63141649d"
+    },
+    {
+      "path": "schemas/device_approval_preview_response.v1.schema.json",
+      "sha256": "4035f47ea3abcd6b67755496db07b1d24409a11ee1d85a49983f6e3f005a761b"
+    },
+    {
+      "path": "schemas/device_approval_request.v1.schema.json",
+      "sha256": "5fa6e8bc6e109970c3729fb819544eaac360cfee44442ac2a3b7342a169a0a10"
+    },
+    {
+      "path": "schemas/device_approval_response.v1.schema.json",
+      "sha256": "ef39b2928b91e32e37f7cd2eda65cb0debc0a2063618e7936ecada1c13027b3e"
+    },
+    {
+      "path": "schemas/device_authorization_request.v1.schema.json",
+      "sha256": "a10d783d281fdf9edc88d68335272743000e364c725aefef3c1ac537b2676b42"
+    },
+    {
+      "path": "schemas/device_authorization_response.v1.schema.json",
+      "sha256": "e9a2b4f7c4a0fc8c11e2f65db9c0074476fb7e2527c0664c86d19522061e04ff"
+    },
+    {
+      "path": "schemas/device_token_request.v1.schema.json",
+      "sha256": "a4c377a1333c7e766dd8798e8621f3e7743d5df083c13561969b5d52d94d5f78"
+    },
+    {
+      "path": "schemas/device_token_response.v1.schema.json",
+      "sha256": "ec6599f33029a3a58d80409700a17a73dc77172f9621cedda02d8f769dc93dc6"
+    },
+    {
+      "path": "schemas/oauth_device_error.v1.schema.json",
+      "sha256": "0c2a80787e66035f544c316faa1a4ed98b0ee04bdaa5d0382ca82bf7349b4e86"
     }
   ]
 }

--- a/src/lib/acr/contracts/openapi/acr-v1.json
+++ b/src/lib/acr/contracts/openapi/acr-v1.json
@@ -412,6 +412,47 @@
           }
         }
       }
+    },
+    "/api/v1/oauth/device_authorization": {
+      "post": {
+        "security": [],
+        "operationId": "createDeviceAuthorization",
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "../schemas/device_authorization_request.v1.schema.json" } } } },
+        "responses": { "200": { "description": "Device authorization created", "content": { "application/json": { "schema": { "$ref": "../schemas/device_authorization_response.v1.schema.json" } } } }, "400": { "$ref": "#/components/responses/Error" }, "429": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" }, "503": { "$ref": "#/components/responses/Error" } }
+      }
+    },
+    "/api/v1/oauth/token": {
+      "post": {
+        "security": [],
+        "operationId": "exchangeDeviceToken",
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "../schemas/device_token_request.v1.schema.json" } } } },
+        "responses": { "200": { "description": "Device grant redeemed once", "content": { "application/json": { "schema": { "$ref": "../schemas/device_token_response.v1.schema.json" } } } }, "400": { "description": "Pinned RFC device grant error", "content": { "application/json": { "schema": { "$ref": "../schemas/oauth_device_error.v1.schema.json" } } } }, "429": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" }, "503": { "$ref": "#/components/responses/Error" } }
+      }
+    },
+    "/api/v1/oauth/device_approval": {
+      "post": {
+        "security": [{ "webAssertionAuth": [] }],
+        "operationId": "approveDeviceAuthorization",
+        "x-required-permission": "credential:issue",
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "oneOf": [{ "$ref": "../schemas/device_approval_request.v1.schema.json" }, { "$ref": "../schemas/device_approval_preview_request.v1.schema.json" }] } } } },
+        "responses": { "200": { "description": "Bounded device grant approved or advisory hints previewed", "content": { "application/json": { "schema": { "oneOf": [{ "$ref": "../schemas/device_approval_response.v1.schema.json" }, { "$ref": "../schemas/device_approval_preview_response.v1.schema.json" }] } } } }, "400": { "$ref": "#/components/responses/Error" }, "401": { "$ref": "#/components/responses/Error" }, "403": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "429": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" }, "503": { "$ref": "#/components/responses/Error" } }
+      }
+    },
+    "/api/v1/auth/credentials/self/rotate": {
+      "post": {
+        "security": [{ "bearerAuth": [] }],
+        "operationId": "rotateOwnCredential",
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "../schemas/credential_rotate_request.v1.schema.json" } } } },
+        "responses": { "200": { "description": "Current credential rotated with rollback receipt", "content": { "application/json": { "schema": { "$ref": "../schemas/credential_rotate_response.v1.schema.json" } } } }, "400": { "$ref": "#/components/responses/Error" }, "401": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "429": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" }, "503": { "$ref": "#/components/responses/Error" } }
+      }
+    },
+    "/api/v1/auth/credentials/self/revoke": {
+      "post": {
+        "security": [{ "bearerAuth": [] }],
+        "operationId": "revokeOwnCredential",
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "../schemas/credential_revoke_request.v1.schema.json" } } } },
+        "responses": { "200": { "description": "Current credential revoked", "content": { "application/json": { "schema": { "$ref": "../schemas/credential_revoke_response.v1.schema.json" } } } }, "400": { "$ref": "#/components/responses/Error" }, "401": { "$ref": "#/components/responses/Error" }, "409": { "$ref": "#/components/responses/Error" }, "429": { "$ref": "#/components/responses/Error" }, "500": { "$ref": "#/components/responses/Error" }, "503": { "$ref": "#/components/responses/Error" } }
+      }
     }
   },
   "components": {

--- a/src/lib/acr/contracts/schemas/acr_client_credential.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/acr_client_credential.v1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ACR Client Credential Metadata v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "credential_id",
+    "name",
+    "token_prefix",
+    "org_id",
+    "repository_scopes",
+    "scopes",
+    "created_at",
+    "expires_at",
+    "revoked_at",
+    "last_used_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "acr_client_credential.v1"
+    },
+    "credential_id": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 256
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "token_prefix": {
+      "type": "string",
+      "pattern": "^fcacr_[A-Za-z0-9_-]{4,32}$"
+    },
+    "org_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "repository_scopes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "maxLength": 512
+      },
+      "uniqueItems": true
+    },
+    "scopes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "enum": [
+          "context:read",
+          "evidence:read",
+          "episode:write"
+        ]
+      },
+      "uniqueItems": true
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expires_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "revoked_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "last_used_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    }
+  },
+  "$id": "https://contracts.fullchaos.dev/acr/v1/acr_client_credential.v1.schema.json"
+}

--- a/src/lib/acr/contracts/schemas/credential_revoke_request.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/credential_revoke_request.v1.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/credential_revoke_request.v1.schema.json",
+  "title": "Self Credential Revocation Request v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version"],
+  "properties": {
+    "schema_version": { "const": "credential_revoke_request.v1" },
+    "rollback_receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_credential_id", "replacement_credential_id", "rollback_until"],
+      "properties": {
+        "source_credential_id": { "type": "string", "minLength": 8, "maxLength": 256 },
+        "replacement_credential_id": { "type": "string", "minLength": 8, "maxLength": 256 },
+        "rollback_until": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}

--- a/src/lib/acr/contracts/schemas/credential_revoke_response.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/credential_revoke_response.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/credential_revoke_response.v1.schema.json",
+  "title": "Self Credential Revocation Response v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "credential"],
+  "properties": {
+    "schema_version": { "const": "credential_revoke_response.v1" },
+    "credential": { "$ref": "acr_client_credential.v1.schema.json" }
+  }
+}

--- a/src/lib/acr/contracts/schemas/credential_rotate_request.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/credential_rotate_request.v1.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/credential_rotate_request.v1.schema.json",
+  "title": "Self Credential Rotation Request v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version"],
+  "properties": {
+    "schema_version": { "const": "credential_rotate_request.v1" }
+  }
+}

--- a/src/lib/acr/contracts/schemas/credential_rotate_response.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/credential_rotate_response.v1.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/credential_rotate_response.v1.schema.json",
+  "title": "Self Credential Rotation Response v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "access_token", "credential", "receipt"],
+  "properties": {
+    "schema_version": { "const": "credential_rotate_response.v1" },
+    "access_token": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "credential": { "$ref": "acr_client_credential.v1.schema.json" },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_credential_id", "replacement_credential_id", "rollback_until"],
+      "properties": {
+        "source_credential_id": { "type": "string", "minLength": 8, "maxLength": 256 },
+        "replacement_credential_id": { "type": "string", "minLength": 8, "maxLength": 256 },
+        "rollback_until": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}

--- a/src/lib/acr/contracts/schemas/device_approval_preview_request.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/device_approval_preview_request.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/device_approval_preview_request.v1.schema.json",
+  "title": "Device Approval Preview Request v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "user_code"],
+  "properties": {
+    "schema_version": { "const": "device_approval_preview_request.v1" },
+    "user_code": { "type": "string", "pattern": "^[2-9A-HJ-NP-Z]{8}$" }
+  }
+}

--- a/src/lib/acr/contracts/schemas/device_approval_preview_response.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/device_approval_preview_response.v1.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/device_approval_preview_response.v1.schema.json",
+  "title": "Device Approval Preview Response v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version"],
+  "properties": {
+    "schema_version": { "const": "device_approval_preview_response.v1" },
+    "organization_id_hint": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "repository_hints": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 100,
+      "uniqueItems": true,
+      "items": { "type": "string", "pattern": "^[^/*\\s]+/[^/*\\s]+$", "maxLength": 512 }
+    }
+  }
+}

--- a/src/lib/acr/contracts/schemas/device_approval_request.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/device_approval_request.v1.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/device_approval_request.v1.schema.json",
+  "title": "Device Approval Request v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "user_code", "repository_scopes"],
+  "properties": {
+    "schema_version": { "const": "device_approval_request.v1" },
+    "user_code": { "type": "string", "pattern": "^[2-9A-HJ-NP-Z]{8}$" },
+    "repository_scopes": {
+      "anyOf": [
+        {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 100,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[^/*\\s]+/[^/*\\s]+$", "maxLength": 512 }
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": { "const": "*" }
+        }
+      ]
+    }
+  }
+}

--- a/src/lib/acr/contracts/schemas/device_approval_response.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/device_approval_response.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/device_approval_response.v1.schema.json",
+  "title": "Device Approval Response v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "status"],
+  "properties": {
+    "schema_version": { "const": "device_approval_response.v1" },
+    "status": { "const": "approved" }
+  }
+}

--- a/src/lib/acr/contracts/schemas/device_authorization_request.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/device_authorization_request.v1.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/device_authorization_request.v1.schema.json",
+  "title": "Device Authorization Request v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version"],
+  "properties": {
+    "schema_version": { "const": "device_authorization_request.v1" },
+    "organization_id_hint": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "repository_hints": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 100,
+      "uniqueItems": true,
+      "items": { "type": "string", "pattern": "^[^/*\\s]+/[^/*\\s]+$", "maxLength": 512 }
+    }
+  }
+}

--- a/src/lib/acr/contracts/schemas/device_authorization_response.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/device_authorization_response.v1.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/device_authorization_response.v1.schema.json",
+  "title": "Device Authorization Response v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "device_code", "user_code", "verification_uri", "expires_in", "interval"],
+  "properties": {
+    "schema_version": { "const": "device_authorization_response.v1" },
+    "device_code": { "type": "string", "minLength": 32, "maxLength": 256 },
+    "user_code": { "type": "string", "pattern": "^[2-9A-HJ-NP-Z]{8}$" },
+    "verification_uri": { "type": "string", "format": "uri", "minLength": 1, "maxLength": 2048 },
+    "expires_in": { "const": 600 },
+    "interval": { "const": 5 }
+  }
+}

--- a/src/lib/acr/contracts/schemas/device_token_request.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/device_token_request.v1.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/device_token_request.v1.schema.json",
+  "title": "Device Token Request v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "grant_type", "device_code"],
+  "properties": {
+    "schema_version": { "const": "device_token_request.v1" },
+    "grant_type": { "const": "urn:ietf:params:oauth:grant-type:device_code" },
+    "device_code": { "type": "string", "minLength": 32, "maxLength": 256 }
+  }
+}

--- a/src/lib/acr/contracts/schemas/device_token_response.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/device_token_response.v1.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/device_token_response.v1.schema.json",
+  "title": "Device Token Response v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "access_token", "token_type", "expires_in", "credential"],
+  "properties": {
+    "schema_version": { "const": "device_token_response.v1" },
+    "access_token": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "token_type": { "const": "Bearer" },
+    "expires_in": { "const": 2592000 },
+    "credential": { "$ref": "acr_client_credential.v1.schema.json" }
+  }
+}

--- a/src/lib/acr/contracts/schemas/error.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/error.v1.schema.json
@@ -30,6 +30,7 @@
         "code": {
           "enum": [
             "invalid_request",
+            "device_authorization_conflict",
             "invalid_token",
             "insufficient_scope",
             "feature_not_enabled",

--- a/src/lib/acr/contracts/schemas/oauth_device_error.v1.schema.json
+++ b/src/lib/acr/contracts/schemas/oauth_device_error.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/acr/v1/oauth_device_error.v1.schema.json",
+  "title": "OAuth Device Grant Error v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "error"],
+  "properties": {
+    "schema_version": { "const": "oauth_device_error.v1" },
+    "error": { "enum": ["authorization_pending", "slow_down", "access_denied", "expired_token", "invalid_grant"] }
+  }
+}

--- a/src/lib/acr/generated.ts
+++ b/src/lib/acr/generated.ts
@@ -1,3 +1,23 @@
+export interface ACRClientCredentialMetadataV1 {
+    schema_version: "acr_client_credential.v1";
+    credential_id: string;
+    name: string;
+    token_prefix: string;
+    org_id: string;
+    repository_scopes: string[];
+    /**
+     * @minItems 1
+     */
+    scopes: [
+        "context:read" | "evidence:read" | "episode:write",
+        ...("context:read" | "evidence:read" | "episode:write")[],
+    ];
+    created_at: string;
+    expires_at: string | null;
+    revoked_at: string | null;
+    last_used_at: string | null;
+}
+
 export interface ACRAgentEpisodeCreateV1 {
     schema_version: "agent_episode_create.v1";
     client_episode_id: string;
@@ -296,12 +316,101 @@ export interface ACRContextPacketV1 {
     retrieval_debug_summary?: string;
 }
 
+export interface SelfCredentialRevocationRequestV1 {
+    schema_version: "credential_revoke_request.v1";
+    rollback_receipt?: {
+        source_credential_id: string;
+        replacement_credential_id: string;
+        rollback_until: string;
+    };
+}
+
+export interface SelfCredentialRevocationResponseV1 {
+    schema_version: "credential_revoke_response.v1";
+    credential: ACRClientCredentialMetadataV1;
+}
+
+export interface SelfCredentialRotationRequestV1 {
+    schema_version: "credential_rotate_request.v1";
+}
+
+export interface SelfCredentialRotationResponseV1 {
+    schema_version: "credential_rotate_response.v1";
+    access_token: string;
+    credential: ACRClientCredentialMetadataV1;
+    receipt: {
+        source_credential_id: string;
+        replacement_credential_id: string;
+        rollback_until: string;
+    };
+}
+
+export interface DeviceApprovalPreviewRequestV1 {
+    schema_version: "device_approval_preview_request.v1";
+    user_code: string;
+}
+
+export interface DeviceApprovalPreviewResponseV1 {
+    schema_version: "device_approval_preview_response.v1";
+    organization_id_hint?: string;
+    /**
+     * @minItems 1
+     * @maxItems 100
+     */
+    repository_hints?: [string, ...string[]];
+}
+
+export interface DeviceApprovalRequestV1 {
+    schema_version: "device_approval_request.v1";
+    user_code: string;
+    repository_scopes: [string, ...string[]] | ["*"];
+}
+
+export interface DeviceApprovalResponseV1 {
+    schema_version: "device_approval_response.v1";
+    status: "approved";
+}
+
+export interface DeviceAuthorizationRequestV1 {
+    schema_version: "device_authorization_request.v1";
+    organization_id_hint?: string;
+    /**
+     * @minItems 1
+     * @maxItems 100
+     */
+    repository_hints?: [string, ...string[]];
+}
+
+export interface DeviceAuthorizationResponseV1 {
+    schema_version: "device_authorization_response.v1";
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+    expires_in: 600;
+    interval: 5;
+}
+
+export interface DeviceTokenRequestV1 {
+    schema_version: "device_token_request.v1";
+    grant_type: "urn:ietf:params:oauth:grant-type:device_code";
+    device_code: string;
+}
+
+export interface DeviceTokenResponseV1 {
+    schema_version: "device_token_response.v1";
+    access_token: string;
+    token_type: "Bearer";
+    expires_in: 2592000;
+    credential: ACRClientCredentialMetadataV1;
+}
+
 export interface ACRErrorV1 {
     schema_version: "error.v1";
     request_id: string;
     error: {
         code:
             | "invalid_request"
+            | "device_authorization_conflict"
             | "invalid_token"
             | "insufficient_scope"
             | "feature_not_enabled"
@@ -354,4 +463,10 @@ export interface ACRExpandedEvidenceV1 {
         [k: string]: unknown | undefined;
     };
     redaction_reason?: string;
+}
+
+export interface OAuthDeviceGrantErrorV1 {
+    schema_version: "oauth_device_error.v1";
+    error:
+        "authorization_pending" | "slow_down" | "access_denied" | "expired_token" | "invalid_grant";
 }

--- a/src/lib/acr/ops.ts
+++ b/src/lib/acr/ops.ts
@@ -48,6 +48,14 @@ type ResolveOpsAuthorizationInput = {
     readonly subject: string;
 };
 
+type ResolveOpsCredentialIssuanceAuthorizationInput = {
+    readonly accessToken: string;
+    readonly orgId: string;
+    readonly repositoryScopes: readonly string[];
+    readonly signal: AbortSignal;
+    readonly subject: string;
+};
+
 function backendUrl(path: string): URL {
     try {
         return new URL(path, getBackendUrl());
@@ -85,36 +93,60 @@ function opsHeaders(accessToken: string): Readonly<Record<string, string>> {
     };
 }
 
+async function requireAcrEntitlement(input: {
+    readonly accessToken: string;
+    readonly orgId: string;
+    readonly signal: AbortSignal;
+}): Promise<void> {
+    const entitlement = await fetchBoundedJson({
+        headers: opsHeaders(input.accessToken),
+        method: "GET",
+        signal: input.signal,
+        timeoutMs: 5_000,
+        url: backendUrl(`/api/v1/licensing/entitlements/${encodeURIComponent(input.orgId)}`),
+    });
+    if (entitlement.status !== 200) {
+        throw new AcrRuntimeError(
+            acrRuntimeErrorCodes.unavailable,
+            "Agent Context Runtime is temporarily unavailable.",
+            { retryable: true },
+        );
+    }
+    const parsedEntitlement = entitlementSchema.safeParse(entitlement.value);
+    if (
+        !parsedEntitlement.success ||
+        !parsedEntitlement.data.is_valid ||
+        !parsedEntitlement.data.features.agent_context_runtime
+    ) {
+        throw new AcrRuntimeError(
+            acrRuntimeErrorCodes.notEntitled,
+            "Agent Context Runtime is not available for this organization.",
+            { status: 403 },
+        );
+    }
+}
+
+/**
+ * Authorizes credential issuance from authenticated organization identity and
+ * entitlement only. Repository analytics are inventory, never an authorization
+ * source. ACR binds the supplied grant to this organization in the assertion.
+ */
+export async function resolveOpsCredentialIssuanceAuthorization(
+    input: ResolveOpsCredentialIssuanceAuthorizationInput,
+): Promise<OpsAuthorization> {
+    await requireAcrEntitlement(input);
+    return {
+        orgId: input.orgId,
+        repositoryScopes: input.repositoryScopes,
+        subject: input.subject,
+    };
+}
+
 export async function resolveOpsAuthorization(
     input: ResolveOpsAuthorizationInput,
 ): Promise<OpsAuthorization> {
     if (input.platformValidation !== true) {
-        const entitlement = await fetchBoundedJson({
-            headers: opsHeaders(input.accessToken),
-            method: "GET",
-            signal: input.signal,
-            timeoutMs: 5_000,
-            url: backendUrl(`/api/v1/licensing/entitlements/${encodeURIComponent(input.orgId)}`),
-        });
-        if (entitlement.status !== 200) {
-            throw new AcrRuntimeError(
-                acrRuntimeErrorCodes.unavailable,
-                "Agent Context Runtime is temporarily unavailable.",
-                { retryable: true },
-            );
-        }
-        const parsedEntitlement = entitlementSchema.safeParse(entitlement.value);
-        if (
-            !parsedEntitlement.success ||
-            !parsedEntitlement.data.is_valid ||
-            !parsedEntitlement.data.features.agent_context_runtime
-        ) {
-            throw new AcrRuntimeError(
-                acrRuntimeErrorCodes.notEntitled,
-                "Agent Context Runtime is not available for this organization.",
-                { status: 403 },
-            );
-        }
+        await requireAcrEntitlement(input);
     }
     const scopes = await fetchBoundedJson({
         body: JSON.stringify({

--- a/src/lib/acr/service.ts
+++ b/src/lib/acr/service.ts
@@ -4,7 +4,7 @@ import { auth } from "@/lib/auth";
 import { AcrRuntimeClient } from "./client";
 import { loadAcrRuntimeConfig } from "./config";
 import { AcrRuntimeError, acrRuntimeErrorCodes } from "./errors";
-import { resolveOpsAuthorization } from "./ops";
+import { resolveOpsAuthorization, resolveOpsCredentialIssuanceAuthorization } from "./ops";
 import { contextPacketRequest, parseContextPacketForm, parseEvidenceSelection } from "./protocol";
 
 const repositoryScope = /^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/u;
@@ -136,6 +136,7 @@ function invalidApprovalRequest(): AcrRuntimeError {
 }
 
 function canonicalApprovalScopes(scopes: readonly string[]): readonly string[] {
+    if (scopes.length === 1 && scopes[0] === "*") return scopes;
     const sorted = [...scopes].sort((left, right) => left.localeCompare(right));
     if (
         scopes.length === 0 ||
@@ -169,22 +170,20 @@ export async function approveDeviceAuthorization(input: {
             },
         );
     }
-    const authorization = await resolveOpsAuthorization({
+    const authorization = await resolveOpsCredentialIssuanceAuthorization({
         accessToken: session.accessToken,
         orgId: session.orgId,
+        repositoryScopes: requestedScopes,
         signal: input.signal,
         subject: session.subject,
     });
-    if (requestedScopes.some((scope) => !authorization.repositoryScopes.includes(scope))) {
-        throw invalidApprovalRequest();
-    }
     const body = JSON.stringify({
         repository_scopes: requestedScopes,
         schema_version: "device_approval_request.v1",
         user_code: input.userCode,
     });
     return new AcrRuntimeClient(loadAcrRuntimeConfig()).deviceApproval({
-        authorization: { ...authorization, repositoryScopes: requestedScopes },
+        authorization,
         body,
         signal: input.signal,
     });
@@ -211,9 +210,10 @@ export async function previewDeviceAuthorization(input: {
             },
         );
     }
-    const authorization = await resolveOpsAuthorization({
+    const authorization = await resolveOpsCredentialIssuanceAuthorization({
         accessToken: session.accessToken,
         orgId: session.orgId,
+        repositoryScopes: ["*"],
         signal: input.signal,
         subject: session.subject,
     });

--- a/tests/acr-context-fabric.production.spec.ts
+++ b/tests/acr-context-fabric.production.spec.ts
@@ -161,7 +161,7 @@ test.describe("Context Fabric production entitlement boundary", () => {
         await setAcrMockControls(request);
     });
 
-    test("approves an ACR device code without a duplicated alphabet or repository hint", async ({
+    test("renders and submits the organization-wide device grant in the browser", async ({
         page,
     }, testInfo) => {
         await setEntitlementScenario(page.request, "provisioned");
@@ -189,7 +189,9 @@ test.describe("Context Fabric production entitlement boundary", () => {
         await page.getByRole("button", { name: "Preview request" }).click();
 
         await expect(page.getByRole("heading", { name: "Review device access" })).toBeVisible();
-        await expect(page.getByLabel("full-chaos/dev-health-acr")).toBeChecked();
+        await expect(
+            page.getByText(/all current and future repositories in your organization/i),
+        ).toBeVisible();
         await page.screenshot({
             path: testInfo.outputPath("device-approval-valid-code.png"),
             fullPage: true,
@@ -201,7 +203,7 @@ test.describe("Context Fabric production entitlement boundary", () => {
             { action: "preview", user_code: "EP23TUGG" },
             {
                 action: "approve",
-                repository_scopes: ["full-chaos/dev-health-acr"],
+                repository_scopes: ["*"],
                 user_code: "EP23TUGG",
             },
         ]);


### PR DESCRIPTION
## Summary

- remove analytics repository discovery from the ACR device approval path
- redirect logged-out visitors back to `/acr/device` after sign-in and keep impersonation fail-closed
- approve the sole organization-wide `*` repository scope with clear current/future same-org copy
- sync and validate the expanded canonical ACR device and credential contracts

## Verification

- focused device/page/route/contract suites: 110 tests passed
- TypeScript, ESLint, Prettier, and contract drift checks passed for the changed surface
- production `next build` passed
- authenticated Playwright device approval passed

The repository-wide design-lint baseline reports 249 existing errors outside the files changed here.

## Screenshot

![device-approval-valid-code.png](https://github.com/user-attachments/assets/2b2b4c9c-5845-4cfa-aeb4-8826483c244f)

Linear: [CHAOS-3239](https://linear.app/fullchaos/issue/CHAOS-3239/acr-login-make-all-repositories-organization-wide-and-independent-of)