### PR TITLE
fix(admin): stop sidebar from fetching every admin surface

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -132,8 +132,7 @@ jobs:
             - name: Run dev-health-ops migrations
               env:
                   DATABASE_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
-                  DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER: "1"
-              run: alembic -c alembic.ini upgrade head
+              run: python -m dev_health_ops.cli --db "$DATABASE_URI" migrate postgres
               working-directory: dev-health-ops
 
             - name: Seed dev-health-ops fixtures

--- a/scripts/__tests__/chaos-3017-ci-contract.test.mjs
+++ b/scripts/__tests__/chaos-3017-ci-contract.test.mjs
@@ -265,10 +265,17 @@ describe("CHAOS-3017 CI contracts", () => {
         }
     });
 
-    it("opts the live backend fixture into the reviewed Celery-to-River cutover", () => {
-        const workflow = contents(LIVE_E2E_WORKFLOW);
+    it("uses the application migrator without authorizing the River cutover", () => {
+        const migrationStep = step(
+            job(contents(LIVE_E2E_WORKFLOW), "live-e2e"),
+            "Run dev-health-ops migrations",
+        );
 
-        expect(workflow).toContain('DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER: "1"');
+        expect(migrationStep).toContain("python -m dev_health_ops.cli");
+        expect(migrationStep).toContain('--db "$DATABASE_URI"');
+        expect(migrationStep).toContain("migrate postgres");
+        expect(migrationStep).not.toContain("alembic");
+        expect(migrationStep).not.toContain("DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER");
     });
 
     it("pins paths-filter to the reviewed commit in every touched workflow", () => {

--- a/src/app/(app)/org/admin/sync/[configId]/page.tsx
+++ b/src/app/(app)/org/admin/sync/[configId]/page.tsx
@@ -27,7 +27,8 @@ interface PageProps {
     params: Promise<{ configId: string }>;
     /**
      * `coverage_scenario` / `backfill_scenario` select sample scenarios in
-     * DEV_HEALTH_TEST_MODE only.
+     * DEV_HEALTH_TEST_MODE only. `coverage_scenario=unavailable` exercises
+     * the transport-failure recovery controls without calling the admin API.
      */
     searchParams: Promise<{
         coverage_scenario?: string | string[];
@@ -61,7 +62,13 @@ export default async function SyncConfigDetailPage({ params, searchParams }: Pag
         // page is exercisable in Playwright/test mode (web AGENTS test-mode rule).
         config = SAMPLE_SYNC_CONFIG;
         jobs = SAMPLE_SYNC_JOBS;
-        coverage = SYNC_COVERAGE_SAMPLES[resolveSyncCoverageSampleScenario(coverageScenarioParam)];
+        if (coverageScenarioParam === "unavailable") {
+            coverage = null;
+            coverageError = "Coverage request failed. Retry or run a backfill.";
+        } else {
+            coverage =
+                SYNC_COVERAGE_SAMPLES[resolveSyncCoverageSampleScenario(coverageScenarioParam)];
+        }
         activeBackfillJob =
             SAMPLE_BACKFILL_JOBS[resolveSampleBackfillScenario(backfillScenarioParam)];
     } else {

--- a/src/components/admin/AdminSidebar.test.tsx
+++ b/src/components/admin/AdminSidebar.test.tsx
@@ -13,14 +13,16 @@ vi.mock("next/navigation", () => ({
 vi.mock("next/link", () => ({
     default: ({
         href,
+        prefetch,
         children,
         ...props
     }: {
         href: string;
+        prefetch?: boolean;
         children: ReactNode;
         [key: string]: unknown;
     }) => (
-        <a href={href} {...props}>
+        <a href={href} data-prefetch={String(prefetch)} {...props}>
             {children}
         </a>
     ),
@@ -48,6 +50,24 @@ describe("AdminSidebar", () => {
             "aria-current",
             "page",
         );
+    });
+
+    it("does not prefetch every admin surface when the sidebar renders", () => {
+        render(
+            <AdminSidebar
+                isSuperuser
+                features={{
+                    audit_log: true,
+                    ip_allowlist: true,
+                    custom_retention: true,
+                    ask_dev: true,
+                }}
+            />,
+        );
+
+        const navigationLinks = screen.getAllByRole("link");
+        expect(navigationLinks.length).toBeGreaterThan(1);
+        expect(navigationLinks.every((link) => link.dataset.prefetch === "false")).toBe(true);
     });
 
     it("renders superuser mode with platform admin links and hides organization nav", () => {

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -164,6 +164,7 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                                 <Link
                                     key={item.id}
                                     href={item.href}
+                                    prefetch={false}
                                     aria-current={isActive ? "page" : undefined}
                                     className={`group flex items-center justify-between rounded-2xl border px-3 py-2 transition ${
                                         isActive
@@ -185,6 +186,7 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                         {isSuperuser && (
                             <Link
                                 href="/superadmin"
+                                prefetch={false}
                                 className="group flex items-center justify-between rounded-2xl border border-purple-500/20 bg-purple-500/10 px-3 py-2 text-purple-400 hover:bg-purple-500/20 transition"
                             >
                                 <span className="font-medium">Platform Admin</span>
@@ -194,7 +196,11 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                     </nav>
                     <div className="mt-5 rounded-2xl border border-dashed border-(--card-stroke) bg-(--card-70) px-3 py-3 text-xs text-(--ink-muted)">
                         Return to{" "}
-                        <Link href="/dashboard" className="underline hover:text-foreground">
+                        <Link
+                            href="/dashboard"
+                            prefetch={false}
+                            className="underline hover:text-foreground"
+                        >
                             main app
                         </Link>
                         .

--- a/src/components/admin/sync/BackfillOperations.test.tsx
+++ b/src/components/admin/sync/BackfillOperations.test.tsx
@@ -51,6 +51,26 @@ describe("BackfillOperations", () => {
         expect(screen.getByLabelText("To")).toHaveValue("2026-01-03");
     });
 
+    it("opens an unscoped recovery backfill when coverage cannot load", async () => {
+        const user = userEvent.setup();
+        render(
+            <BackfillOperations
+                configId="cfg-1"
+                coverage={null}
+                coverageError="fetch failed"
+                isActive
+                activeBackfillJob={null}
+                testMode
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Backfill" }));
+
+        expect(screen.getByRole("dialog", { name: "Run historical backfill" })).toBeInTheDocument();
+        expect(screen.getByLabelText("From")).toHaveValue("");
+        expect(screen.getAllByText("No coverage data yet")).toHaveLength(2);
+    });
+
     it("closes the wizard via its Cancel action", async () => {
         const user = userEvent.setup();
         renderOperations();

--- a/src/components/admin/sync/SyncCoverageSummaryCard.test.tsx
+++ b/src/components/admin/sync/SyncCoverageSummaryCard.test.tsx
@@ -8,8 +8,9 @@ import {
 } from "@/lib/admin/__tests__/syncCoverageFixtures";
 
 const mockPush = vi.fn();
+const mockRefresh = vi.fn();
 vi.mock("next/navigation", () => ({
-    useRouter: () => ({ push: mockPush, refresh: vi.fn() }),
+    useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
 }));
 vi.mock("@/lib/admin/server", () => ({
     triggerSync: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock("@/lib/admin/server", () => ({
 
 beforeEach(() => {
     mockPush.mockClear();
+    mockRefresh.mockClear();
 });
 
 describe("SyncCoverageSummaryCard", () => {
@@ -36,19 +38,27 @@ describe("SyncCoverageSummaryCard", () => {
         expect(screen.getByTestId("coverage-summary-loading")).toBeInTheDocument();
     });
 
-    it("renders an explicit error state instead of fabricating a summary", () => {
+    it("keeps retry and backfill recovery available when coverage fails", async () => {
+        const onBackfillAction = vi.fn();
+        const user = userEvent.setup();
         render(
             <SyncCoverageSummaryCard
                 configId="cfg-1"
                 coverage={null}
                 error="Request failed with 500"
                 isActive
-                onBackfillAction={vi.fn()}
+                onBackfillAction={onBackfillAction}
             />,
         );
 
         expect(screen.getByTestId("coverage-summary-error")).toBeInTheDocument();
         expect(screen.getByText("Request failed with 500")).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: "Backfill" }));
+        expect(onBackfillAction).toHaveBeenCalledOnce();
+
+        await user.click(screen.getByRole("button", { name: "Retry" }));
+        expect(mockRefresh).toHaveBeenCalledOnce();
     });
 
     it("renders the healthy health badge and key stats, and opens the wizard on Backfill", async () => {

--- a/src/components/admin/sync/SyncCoverageSummaryCard.tsx
+++ b/src/components/admin/sync/SyncCoverageSummaryCard.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import type { ReactNode } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { ClientTimestamp } from "@/components/ClientTimestamp";
 import { DataState } from "@/components/ui/DataState";
 import { formatNumber } from "@/lib/formatters";
@@ -37,6 +40,7 @@ export function SyncCoverageSummaryCard({
     isActive,
     onBackfillAction,
 }: SyncCoverageSummaryCardProps) {
+    const router = useRouter();
     const editHref = `/org/admin/sync/${configId}/edit`;
 
     if (error) {
@@ -46,6 +50,24 @@ export function SyncCoverageSummaryCard({
                     variant="error"
                     title="Coverage summary unavailable"
                     message={error}
+                    action={
+                        <div className="flex flex-wrap items-center justify-center gap-3">
+                            <button
+                                type="button"
+                                onClick={onBackfillAction}
+                                className="rounded-md border border-(--card-stroke) bg-(--card-70) px-4 py-2 text-sm font-medium text-foreground hover:border-(--accent) hover:text-(--accent)"
+                            >
+                                {CTA_LABELS.backfill}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => router.refresh()}
+                                className="rounded-md bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+                            >
+                                {CTA_LABELS.retry}
+                            </button>
+                        </div>
+                    }
                     data-testid="coverage-summary-error"
                 />
             </div>

--- a/tests/acr-context-fabric.production.spec.ts
+++ b/tests/acr-context-fabric.production.spec.ts
@@ -539,7 +539,7 @@ test.describe("Context Fabric production entitlement boundary", () => {
         await page.context().clearCookies();
         await signIn(page, "member@example.com");
         await page.goto("/superadmin/context-fabric/validation");
-        await expect(page).toHaveURL(/\/dashboard$/);
+        await expect(page).toHaveURL(/\/dashboard(?:\?|$)/u);
         await expect(page.getByRole("heading", { name: "Context Fabric Validation" })).toHaveCount(
             0,
         );


### PR DESCRIPTION
## Summary

Companion API fix: https://github.com/full-chaos/dev-health-ops/pull/1337

- disable Next.js prefetch on every organization-admin sidebar destination, including Platform Admin and the main-app link
- keep Backfill available when coverage cannot load, using the existing in-place date-range wizard
- add Retry to refresh the failed server-rendered coverage request
- add deterministic test-mode coverage failure rendering for browser verification
- repair live-backend CI by using the ops application-schema migrator instead of raw Alembic with the River cutover authorized

## Root cause

The production HAR showed that opening one sync detail page immediately issued React Server Component GETs for Dashboard, Superadmin, AI, Retention, IP allowlist, Audit, Identities, Teams, Sync, Integrations, Users, and the organization admin root. The shared sidebar rendered every destination as a default Next.js `<Link>`, so one admin page eagerly executed server-side data loading for essentially every admin surface.

This compounded the backend coverage allocation spike and made a single navigation capable of exhausting the API container. The fix is intentionally broader than sync: all links emitted by `AdminSidebar` opt out of prefetch.

The first PR run also exposed a separate migration-contract failure. Current dev-health-ops intentionally has independent `application_schema` and `river_cutover` heads, so `alembic upgrade head` is ambiguous. The web fixture workflow was additionally setting `DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1` even though it does not run River workers. It now calls the canonical ops migration CLI with the cutover flag absent, which advances only `application_schema`.

## Recovery UI

![Coverage failure with Backfill and Retry](https://github.com/user-attachments/assets/088ad82d-3823-434a-b0fa-6858a3b1a433)

![Backfill wizard opened without coverage data](https://github.com/user-attachments/assets/b8bb7c18-1a97-43cf-a266-a93b51dc39a9)

Browser request inspection after the change showed the current page and its auth/org/capability requests only; no sidebar destination pages were requested. Backfill opens the date-range wizard even when coverage is unavailable.

## Verification

- targeted admin unit suite: 24 passed
- migration CI contract suite: 23 passed
- canonical migrator reproduced against fresh PostgreSQL 17: application revision `0071`, River cutover `0066` deferred, status check current
- changed-file Prettier and ESLint checks passed
- TypeScript `--noEmit` passed
- Next.js production build passed
- Playwright visual and request inspection passed with 0 console errors
- repository-wide unit inventory reached 3,478 passed and 8 skipped; six unchanged `scripts/__tests__/run-owned-process.test.mjs` process-guardian tests reproduce in isolation as exact 15-second timeouts in this environment
- repository-wide design lint continues to report 249 existing errors outside the changed files
