### PR TITLE
feat(ai-setup): move platform Ask Dev readiness to Platform Admin (CHAOS-3265)

### DIFF
--- a/src/app/(app)/org/admin/ai/ask-dev/page.test.tsx
+++ b/src/app/(app)/org/admin/ai/ask-dev/page.test.tsx
@@ -7,7 +7,6 @@ vi.mock("@/components/admin/ask-dev/AskDevAdminPanel", () => ({
 vi.mock("@/lib/admin/server", () => ({
     getAskDevAdmin: vi.fn(),
     getAskDevUsage: vi.fn(),
-    runAskDevReadiness: vi.fn(),
     updateAskDevAdminSettings: vi.fn(),
 }));
 

--- a/src/app/(app)/org/admin/ai/ask-dev/page.tsx
+++ b/src/app/(app)/org/admin/ai/ask-dev/page.tsx
@@ -1,10 +1,5 @@
 import { AskDevAdminPanel } from "@/components/admin/ask-dev/AskDevAdminPanel";
-import {
-    getAskDevAdmin,
-    getAskDevUsage,
-    runAskDevReadiness,
-    updateAskDevAdminSettings,
-} from "@/lib/admin/server";
+import { getAskDevAdmin, getAskDevUsage, updateAskDevAdminSettings } from "@/lib/admin/server";
 
 export default function AskDevAISetupPage() {
     return (
@@ -12,7 +7,6 @@ export default function AskDevAISetupPage() {
             loadAction={getAskDevAdmin}
             loadUsageAction={getAskDevUsage}
             saveAction={updateAskDevAdminSettings}
-            readinessAction={runAskDevReadiness}
         />
     );
 }

--- a/src/app/(app)/org/admin/ai/byo-llm/page.test.tsx
+++ b/src/app/(app)/org/admin/ai/byo-llm/page.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/lib/admin/server", () => ({
     getLLMSettings: vi.fn(),
     getLLMSettingsStatus: vi.fn(),
     getLLMSpendSummary: vi.fn(),
+    runLLMSettingsReadiness: vi.fn(),
     upsertLLMSettings: vi.fn(),
 }));
 

--- a/src/app/(app)/org/admin/ai/byo-llm/page.tsx
+++ b/src/app/(app)/org/admin/ai/byo-llm/page.tsx
@@ -7,6 +7,7 @@ import {
     getLLMSettings,
     getLLMSettingsStatus,
     getLLMSpendSummary,
+    runLLMSettingsReadiness,
     upsertLLMSettings,
 } from "@/lib/admin/server";
 
@@ -19,6 +20,7 @@ export default function ByoLlmAISetupPage() {
                 loadStatusAction={getLLMSettingsStatus}
                 saveSettingsAction={upsertLLMSettings}
                 removeSettingsAction={deleteLLMSettings}
+                runReadinessAction={runLLMSettingsReadiness}
             />
             <ByoLlmSpendSummary loadSpendAction={getLLMSpendSummary} />
             <ByoLlmErrorStates />

--- a/src/app/(app)/superadmin/ai/ask-dev/page.test.tsx
+++ b/src/app/(app)/superadmin/ai/ask-dev/page.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@/test/utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { requireSuperuserMock, panelSpy } = vi.hoisted(() => ({
+    requireSuperuserMock: vi.fn(),
+    panelSpy: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+    requireSuperuser: requireSuperuserMock,
+}));
+vi.mock("@/lib/admin/server", () => ({
+    getPlatformAskDevReadiness: vi.fn(),
+    runPlatformAskDevReadiness: vi.fn(),
+}));
+vi.mock("@/components/admin/platform/PlatformAskDevReadinessPanel", () => ({
+    PlatformAskDevReadinessPanel: (props: unknown) => {
+        panelSpy(props);
+        return (
+            <section aria-label="Platform Ask Dev readiness">Platform Ask Dev readiness</section>
+        );
+    },
+}));
+
+import PlatformAskDevReadinessPage from "./page";
+import { getPlatformAskDevReadiness, runPlatformAskDevReadiness } from "@/lib/admin/server";
+
+describe("PlatformAskDevReadinessPage", () => {
+    beforeEach(() => {
+        panelSpy.mockClear();
+        requireSuperuserMock.mockReset();
+        requireSuperuserMock.mockResolvedValue({
+            user: { id: "superuser-1", is_superuser: true },
+        });
+    });
+
+    it("gates on requireSuperuser with this route's own callback URL before rendering", async () => {
+        render(await PlatformAskDevReadinessPage());
+
+        expect(requireSuperuserMock).toHaveBeenCalledWith("/superadmin/ai/ask-dev");
+        expect(
+            screen.getByRole("region", { name: "Platform Ask Dev readiness" }),
+        ).toBeInTheDocument();
+        expect(panelSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                loadAction: getPlatformAskDevReadiness,
+                runAction: runPlatformAskDevReadiness,
+            }),
+        );
+    });
+
+    it("propagates the redirect thrown by requireSuperuser instead of rendering the panel", async () => {
+        const redirectError = new Error("NEXT_REDIRECT");
+        requireSuperuserMock.mockRejectedValue(redirectError);
+
+        await expect(PlatformAskDevReadinessPage()).rejects.toThrow("NEXT_REDIRECT");
+        expect(panelSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/(app)/superadmin/ai/ask-dev/page.tsx
+++ b/src/app/(app)/superadmin/ai/ask-dev/page.tsx
@@ -1,0 +1,14 @@
+import { PlatformAskDevReadinessPanel } from "@/components/admin/platform/PlatformAskDevReadinessPanel";
+import { requireSuperuser } from "@/lib/auth";
+import { getPlatformAskDevReadiness, runPlatformAskDevReadiness } from "@/lib/admin/server";
+
+export default async function PlatformAskDevReadinessPage() {
+    await requireSuperuser("/superadmin/ai/ask-dev");
+
+    return (
+        <PlatformAskDevReadinessPanel
+            loadAction={getPlatformAskDevReadiness}
+            runAction={runPlatformAskDevReadiness}
+        />
+    );
+}

--- a/src/components/admin/ask-dev/AskDevAdminPanel.test.tsx
+++ b/src/components/admin/ask-dev/AskDevAdminPanel.test.tsx
@@ -78,14 +78,12 @@ describe("AskDevAdminPanel", () => {
     const loadAction = vi.fn();
     const loadUsageAction = vi.fn();
     const saveAction = vi.fn();
-    const readinessAction = vi.fn();
 
     beforeEach(() => {
         vi.clearAllMocks();
         loadAction.mockResolvedValue({ data: adminResponse });
         loadUsageAction.mockResolvedValue({ data: usageResponse });
         saveAction.mockResolvedValue({ data: adminResponse });
-        readinessAction.mockResolvedValue({ data: adminResponse });
     });
 
     function renderPanel() {
@@ -94,7 +92,6 @@ describe("AskDevAdminPanel", () => {
                 loadAction={loadAction}
                 loadUsageAction={loadUsageAction}
                 saveAction={saveAction}
-                readinessAction={readinessAction}
             />,
         );
     }
@@ -103,10 +100,6 @@ describe("AskDevAdminPanel", () => {
         renderPanel();
 
         expect(await screen.findByRole("heading", { name: "Ask Dev" })).toBeInTheDocument();
-        expect(screen.getByText("Chat window")).toBeInTheDocument();
-        expect(screen.getByText("Full page")).toBeInTheDocument();
-        expect(screen.getByText("OpenAI compatible · platform")).toBeInTheDocument();
-        expect(screen.getByText("Certified model")).toBeInTheDocument();
         expect(screen.getByText("10")).toBeInTheDocument();
         expect(screen.getByText("1,500")).toBeInTheDocument();
         expect(screen.getByText("$1.25")).toBeInTheDocument();
@@ -119,6 +112,25 @@ describe("AskDevAdminPanel", () => {
         expect(screen.getByText(/not used for model training by default/i)).toBeInTheDocument();
         expect(screen.queryByText(/api key/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/base url/i)).not.toBeInTheDocument();
+    });
+
+    it("renders no provider identity, readiness badge, or preflight action (CHAOS-3265)", async () => {
+        renderPanel();
+
+        expect(await screen.findByRole("heading", { name: "Ask Dev" })).toBeInTheDocument();
+        // No platform-provider identity fields (moved to Platform Admin / BYO LLM).
+        expect(screen.queryByText("Chat window")).not.toBeInTheDocument();
+        expect(screen.queryByText("Full page")).not.toBeInTheDocument();
+        expect(screen.queryByText("Availability and provider")).not.toBeInTheDocument();
+        expect(screen.queryByText(/OpenAI compatible/i)).not.toBeInTheDocument();
+        expect(screen.queryByText("Certified model")).not.toBeInTheDocument();
+        // No readiness badge/pill in the header.
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+        expect(screen.queryByText("Ready")).not.toBeInTheDocument();
+        // No preflight action anywhere on the surface.
+        expect(screen.queryByRole("button", { name: "Run preflight" })).not.toBeInTheDocument();
+        expect(screen.queryByText(/last preflight/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/synthetic data only/i)).not.toBeInTheDocument();
     });
 
     it("submits the approved conversation policy and bounded platform allowance", async () => {
@@ -210,14 +222,6 @@ describe("AskDevAdminPanel", () => {
         ).toBeInTheDocument();
     });
 
-    it("runs the non-sensitive readiness action explicitly", async () => {
-        renderPanel();
-
-        fireEvent.click(await screen.findByRole("button", { name: "Run preflight" }));
-        await waitFor(() => expect(readinessAction).toHaveBeenCalledTimes(1));
-        expect(screen.getByText(/synthetic data only/i)).toBeInTheDocument();
-    });
-
     it("keeps organization controls unavailable when Ask Dev is not entitled", async () => {
         loadAction.mockResolvedValue({
             data: {
@@ -232,6 +236,6 @@ describe("AskDevAdminPanel", () => {
         renderPanel();
 
         expect(await screen.findByRole("button", { name: "Save" })).toBeDisabled();
-        expect(screen.getByRole("button", { name: "Run preflight" })).toBeDisabled();
+        expect(screen.queryByRole("button", { name: "Run preflight" })).not.toBeInTheDocument();
     });
 });

--- a/src/components/admin/ask-dev/AskDevAdminPanel.tsx
+++ b/src/components/admin/ask-dev/AskDevAdminPanel.tsx
@@ -7,7 +7,6 @@ import { DataState } from "@/components/ui/DataState";
 import { CTA_LABELS } from "@/lib/design/cta";
 import type { ActionResult } from "@/lib/result";
 import type {
-    AskDevAdminReadiness,
     AskDevAdminResponse,
     AskDevAdminSettingsPatch,
     AskDevAdminUsageResponse,
@@ -19,25 +18,6 @@ type AskDevAdminPanelProps = {
     loadAction: () => Promise<ActionResult<AskDevAdminResponse>>;
     loadUsageAction: () => Promise<ActionResult<AskDevAdminUsageResponse>>;
     saveAction: (settings: AskDevAdminSettingsPatch) => Promise<ActionResult<AskDevAdminResponse>>;
-    readinessAction: () => Promise<ActionResult<AskDevAdminResponse>>;
-};
-
-const READINESS_LABELS: Record<AskDevAdminReadiness, string> = {
-    ready: "Ready",
-    unsupported_model: "Model not certified",
-    missing_credentials: "Credentials required",
-    disabled: "Disabled",
-    degraded: "Provider degraded",
-    stale_readiness: "Readiness check expired",
-};
-
-const READINESS_TONES: Record<AskDevAdminReadiness, string> = {
-    ready: "bg-(--positive)",
-    unsupported_model: "bg-(--negative)",
-    missing_credentials: "bg-(--caution)",
-    disabled: "bg-(--ink-muted)",
-    degraded: "bg-(--caution)",
-    stale_readiness: "bg-(--info)",
 };
 
 function formatCount(value: number): string {
@@ -60,12 +40,6 @@ function formatCost(microusd: number | null): string {
     }).format(microusd / 1_000_000);
 }
 
-function formatCheckedAt(value: string | null): string {
-    if (!value) return "Not checked";
-    const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? "Not checked" : date.toLocaleString();
-}
-
 function formatResetAt(value: string): string {
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return "at the next monthly reset";
@@ -84,11 +58,9 @@ export function AskDevAdminPanel({
     loadAction,
     loadUsageAction,
     saveAction,
-    readinessAction,
 }: AskDevAdminPanelProps) {
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
-    const [checking, setChecking] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [usageError, setUsageError] = useState<string | null>(null);
     const [admin, setAdmin] = useState<AskDevAdminResponse | null>(null);
@@ -165,20 +137,6 @@ export function AskDevAdminPanel({
         toast.success("Ask Dev controls saved.");
     };
 
-    const runReadiness = async () => {
-        setChecking(true);
-        setError(null);
-        const result = await readinessAction();
-        setChecking(false);
-        if ("error" in result) {
-            setError(result.error ?? "Ask Dev readiness could not be checked.");
-            toast.error("Ask Dev readiness check did not complete.");
-            return;
-        }
-        applyAdmin(result.data);
-        toast.success("Ask Dev readiness check completed.");
-    };
-
     if (loading) {
         return <DataState variant="loading" title="Loading Ask Dev controls…" />;
     }
@@ -213,30 +171,19 @@ export function AskDevAdminPanel({
         >
             <header className="relative overflow-hidden border-b border-(--border) px-6 py-6 sm:px-8">
                 <div aria-hidden="true" className="absolute inset-y-0 left-0 w-1 bg-(--accent)" />
-                <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="max-w-2xl">
-                        <p className="text-label-caps text-(--text-muted)">
-                            Context Fabric interaction
-                        </p>
-                        <h2 id="ask-dev-admin-title" className="mt-2 text-h1 text-(--text-primary)">
-                            Ask Dev
-                        </h2>
-                        <p className="mt-2 text-body text-(--text-secondary)">
-                            One organization policy controls the permanent chat window and the full
-                            investigation workspace. Context Fabric Validation remains a separate
-                            platform-admin tool.
-                        </p>
-                    </div>
-                    <div
-                        role="status"
-                        className="inline-flex items-center gap-2 self-start rounded-(--radius-pill) border border-(--border) bg-(--surface) px-3 py-1.5 text-sm font-medium text-(--text-primary)"
-                    >
-                        <span
-                            aria-hidden="true"
-                            className={`h-2.5 w-2.5 rounded-full ${READINESS_TONES[admin.readiness]}`}
-                        />
-                        {READINESS_LABELS[admin.readiness]}
-                    </div>
+                <div className="max-w-2xl">
+                    <p className="text-label-caps text-(--text-muted)">
+                        Context Fabric interaction
+                    </p>
+                    <h2 id="ask-dev-admin-title" className="mt-2 text-h1 text-(--text-primary)">
+                        Ask Dev
+                    </h2>
+                    <p className="mt-2 text-body text-(--text-secondary)">
+                        One organization policy controls the permanent chat window and the full
+                        investigation workspace. Context Fabric Validation remains a separate
+                        platform-admin tool. Provider identity and readiness are managed under
+                        Platform Admin (or, for a BYO provider, in BYO LLM) — not here.
+                    </p>
                 </div>
             </header>
 
@@ -250,76 +197,6 @@ export function AskDevAdminPanel({
             ) : null}
 
             <div className="divide-y divide-(--border)">
-                <section aria-labelledby="ask-dev-availability" className="px-6 py-6 sm:px-8">
-                    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.7fr)]">
-                        <div>
-                            <h3 id="ask-dev-availability" className="text-h3 text-(--text-primary)">
-                                Availability and provider
-                            </h3>
-                            <dl className="mt-4 grid gap-x-8 gap-y-4 sm:grid-cols-2">
-                                <div>
-                                    <dt className="text-label-caps text-(--text-muted)">
-                                        Chat window
-                                    </dt>
-                                    <dd className="mt-1 text-body text-(--text-primary)">
-                                        {admin.chat_window_available ? "Available" : "Unavailable"}
-                                    </dd>
-                                </div>
-                                <div>
-                                    <dt className="text-label-caps text-(--text-muted)">
-                                        Full page
-                                    </dt>
-                                    <dd className="mt-1 text-body text-(--text-primary)">
-                                        {admin.full_page_available ? "Available" : "Unavailable"}
-                                    </dd>
-                                </div>
-                                <div>
-                                    <dt className="text-label-caps text-(--text-muted)">
-                                        Provider
-                                    </dt>
-                                    <dd className="mt-1 text-body text-(--text-primary)">
-                                        {admin.effective_provider_label ?? "Not selected"}
-                                        {admin.provider_source ? ` · ${admin.provider_source}` : ""}
-                                    </dd>
-                                </div>
-                                <div>
-                                    <dt className="text-label-caps text-(--text-muted)">Model</dt>
-                                    <dd className="mt-1 text-body text-(--text-primary)">
-                                        {admin.effective_model_label ?? "Not selected"}
-                                    </dd>
-                                </div>
-                            </dl>
-                            {admin.administrator_safe_failure_reason ? (
-                                <p className="mt-4 border-l-2 border-(--caution) pl-3 text-sm text-(--text-secondary)">
-                                    {admin.administrator_safe_failure_reason}
-                                </p>
-                            ) : null}
-                        </div>
-                        <div className="flex flex-col justify-between gap-4 border-l border-(--border) pl-0 lg:pl-6">
-                            <div>
-                                <p className="text-label-caps text-(--text-muted)">
-                                    Last preflight
-                                </p>
-                                <p className="mt-1 text-sm text-(--text-primary)">
-                                    {formatCheckedAt(admin.readiness_checked_at)}
-                                </p>
-                                <p className="mt-1 text-xs text-(--text-muted)">
-                                    Uses synthetic data only. No organization evidence is
-                                    transmitted.
-                                </p>
-                            </div>
-                            <button
-                                type="button"
-                                disabled={checking || !configurable}
-                                onClick={() => void runReadiness()}
-                                className="self-start rounded-md border border-(--border) bg-(--surface) px-4 py-2 text-sm font-semibold text-(--text-primary) transition-colors hover:border-(--accent) disabled:cursor-not-allowed disabled:opacity-50"
-                            >
-                                {checking ? "Checking…" : CTA_LABELS.runPreflight}
-                            </button>
-                        </div>
-                    </div>
-                </section>
-
                 <section aria-labelledby="ask-dev-policy" className="px-6 py-6 sm:px-8">
                     <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
                         <div className="grid flex-1 gap-5 sm:grid-cols-2">

--- a/src/components/admin/llm/ByoLlmSettings.test.tsx
+++ b/src/components/admin/llm/ByoLlmSettings.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderWithToaster, screen, userEvent, waitFor } from "@/test/utils";
+import { renderWithToaster, screen, userEvent, waitFor, within } from "@/test/utils";
 
 vi.mock("next/link", () => ({
     default: ({ href, children }: { href: string; children: React.ReactNode }) => (
@@ -14,6 +14,7 @@ const mockLoadBudget = vi.fn<ByoLlmSettingsProps["loadBudgetAction"]>();
 const mockLoadStatus = vi.fn<ByoLlmSettingsProps["loadStatusAction"]>();
 const mockSave = vi.fn<ByoLlmSettingsProps["saveSettingsAction"]>();
 const mockRemove = vi.fn<ByoLlmSettingsProps["removeSettingsAction"]>();
+const mockRunReadiness = vi.fn<ByoLlmSettingsProps["runReadinessAction"]>();
 
 function renderForm() {
     return renderWithToaster(
@@ -23,6 +24,7 @@ function renderForm() {
             loadStatusAction={mockLoadStatus}
             saveSettingsAction={mockSave}
             removeSettingsAction={mockRemove}
+            runReadinessAction={mockRunReadiness}
         />,
     );
 }
@@ -34,6 +36,7 @@ describe("ByoLlmSettings", () => {
         mockSave.mockReset();
         mockRemove.mockReset();
         mockLoadStatus.mockReset();
+        mockRunReadiness.mockReset();
         // The CHAOS-2560 status endpoint is being built on a sibling branch;
         // default every test to the "not built yet" failure so the badge falls
         // back to settings-derived Saved/Not configured wording unless a test
@@ -192,6 +195,9 @@ describe("ByoLlmSettings", () => {
                 degraded: false,
                 reason_code: "active",
                 last_fallback_at: null,
+                readiness: "never_checked",
+                readiness_checked_at: null,
+                readiness_safe_failure_reason: null,
             },
         });
         renderForm();
@@ -210,11 +216,233 @@ describe("ByoLlmSettings", () => {
                 degraded: true,
                 reason_code: "invalid_base_url",
                 last_fallback_at: "2026-01-01T00:00:00Z",
+                readiness: "never_checked",
+                readiness_checked_at: null,
+                readiness_safe_failure_reason: null,
             },
         });
         renderForm();
 
         expect(await screen.findByText("Invalid — using platform default")).toBeInTheDocument();
+    });
+
+    describe("BYO preflight (CHAOS-3265)", () => {
+        it("renders no preflight control when no BYO settings are saved", async () => {
+            mockLoad.mockResolvedValue({ data: {} });
+            renderForm();
+
+            expect(await screen.findByText("Not configured")).toBeInTheDocument();
+            expect(screen.queryByTestId("byo-llm-preflight")).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole("button", { name: "Run BYO preflight" }),
+            ).not.toBeInTheDocument();
+        });
+
+        it("renders and allows running the preflight when saved settings are degraded/not currently active", async () => {
+            mockLoad.mockResolvedValue({ data: { provider: "openai", model: "gpt-4o" } });
+            mockLoadStatus.mockResolvedValue({
+                data: {
+                    configured: true,
+                    active: false,
+                    degraded: true,
+                    reason_code: "invalid_base_url",
+                    last_fallback_at: "2026-01-01T00:00:00Z",
+                    readiness: "never_checked",
+                    readiness_checked_at: null,
+                    readiness_safe_failure_reason: null,
+                },
+            });
+            mockRunReadiness.mockResolvedValue({
+                data: {
+                    configured: true,
+                    active: false,
+                    degraded: true,
+                    reason_code: "invalid_base_url",
+                    last_fallback_at: "2026-01-01T00:00:00Z",
+                    readiness: "ready",
+                    readiness_checked_at: "2026-07-30T12:00:00Z",
+                    readiness_safe_failure_reason: null,
+                },
+            });
+            renderForm();
+
+            expect(await screen.findByTestId("byo-llm-preflight")).toBeInTheDocument();
+            expect(screen.getByText("Invalid — using platform default")).toBeInTheDocument();
+            expect(screen.getByText("Not yet checked")).toBeInTheDocument();
+
+            await userEvent.click(screen.getByRole("button", { name: "Run BYO preflight" }));
+
+            expect(mockRunReadiness).toHaveBeenCalledTimes(1);
+            expect(await screen.findByText("Preflight passed")).toBeInTheDocument();
+            await waitFor(() => {
+                expect(screen.getByText("BYO preflight completed.")).toBeInTheDocument();
+            });
+            // Applied the POST response directly rather than re-fetching status.
+            expect(mockLoadStatus).toHaveBeenCalledTimes(1);
+        });
+
+        it("still renders and runs the preflight in edit mode", async () => {
+            mockLoad.mockResolvedValue({ data: { provider: "openai", model: "gpt-4o" } });
+            mockLoadStatus.mockResolvedValue({
+                data: {
+                    configured: true,
+                    active: true,
+                    degraded: false,
+                    reason_code: "active",
+                    last_fallback_at: null,
+                    readiness: "ready",
+                    readiness_checked_at: "2026-07-01T00:00:00Z",
+                    readiness_safe_failure_reason: null,
+                },
+            });
+            mockRunReadiness.mockResolvedValue({
+                data: {
+                    configured: true,
+                    active: true,
+                    degraded: false,
+                    reason_code: "active",
+                    last_fallback_at: null,
+                    readiness: "ready",
+                    readiness_checked_at: "2026-07-30T12:00:00Z",
+                    readiness_safe_failure_reason: null,
+                },
+            });
+            renderForm();
+
+            await screen.findByRole("heading", { name: "BYO LLM", level: 2 });
+            await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+            expect(screen.getByTestId("byo-llm-preflight")).toBeInTheDocument();
+
+            await userEvent.click(screen.getByRole("button", { name: "Run BYO preflight" }));
+            expect(mockRunReadiness).toHaveBeenCalledTimes(1);
+        });
+
+        it("surfaces the readiness_safe_failure_reason and an error toast when the preflight determines the provider is not ready, without leaking raw credentials in the preflight surface itself", async () => {
+            mockLoad.mockResolvedValue({
+                data: {
+                    provider: "openai",
+                    model: "gpt-4o",
+                    api_key: "sk-1…last",
+                    base_url: "https://byo-provider.example.test/v1",
+                },
+            });
+            mockLoadStatus.mockResolvedValue({
+                data: {
+                    configured: true,
+                    active: true,
+                    degraded: false,
+                    reason_code: "active",
+                    last_fallback_at: null,
+                    readiness: "never_checked",
+                    readiness_checked_at: null,
+                    readiness_safe_failure_reason: null,
+                },
+            });
+            // A completed preflight call (no ActionResult.error) whose result
+            // determined the provider is not ready — distinct from a hard
+            // action/network failure.
+            mockRunReadiness.mockResolvedValue({
+                data: {
+                    configured: true,
+                    active: true,
+                    degraded: false,
+                    reason_code: "active",
+                    last_fallback_at: null,
+                    readiness: "failed",
+                    readiness_checked_at: "2026-07-30T12:00:00Z",
+                    readiness_safe_failure_reason: "The provider rejected the request.",
+                },
+            });
+            renderForm();
+
+            const preflightSection = await screen.findByTestId("byo-llm-preflight");
+            await userEvent.click(
+                within(preflightSection).getByRole("button", { name: "Run BYO preflight" }),
+            );
+
+            expect(
+                await within(preflightSection).findByText("Preflight failed"),
+            ).toBeInTheDocument();
+            // The safe failure reason is rendered inline in the preflight
+            // section AND surfaced via an error toast — both use the same
+            // backend-provided string, so at least two occurrences exist.
+            await waitFor(() => {
+                expect(
+                    screen.getAllByText("The provider rejected the request.").length,
+                ).toBeGreaterThanOrEqual(2);
+            });
+            expect(
+                within(preflightSection).getByText("The provider rejected the request."),
+            ).toBeInTheDocument();
+            // The preflight section itself never renders the raw API key or base URL
+            // — only the safe readiness state/remediation copy the backend returns.
+            expect(within(preflightSection).queryByText(/sk-1…last/)).not.toBeInTheDocument();
+            expect(
+                within(preflightSection).queryByText(/byo-provider\.example\.test/),
+            ).not.toBeInTheDocument();
+        });
+
+        it("surfaces a generic error toast when the preflight action itself fails (network/backend error)", async () => {
+            mockLoad.mockResolvedValue({ data: { provider: "openai", model: "gpt-4o" } });
+            mockLoadStatus.mockResolvedValue({
+                data: {
+                    configured: true,
+                    active: true,
+                    degraded: false,
+                    reason_code: "active",
+                    last_fallback_at: null,
+                    readiness: "never_checked",
+                    readiness_checked_at: null,
+                    readiness_safe_failure_reason: null,
+                },
+            });
+            mockRunReadiness.mockResolvedValue({ error: "Upstream error (503)", status: 503 });
+            renderForm();
+
+            await screen.findByTestId("byo-llm-preflight");
+            await userEvent.click(screen.getByRole("button", { name: "Run BYO preflight" }));
+
+            await waitFor(() => {
+                expect(screen.getByText("Upstream error (503)")).toBeInTheDocument();
+            });
+        });
+
+        it("renders a stale certification as a neutral, non-alarming state (CHAOS-3254 READINESS_VERSION bump), not as a failure", async () => {
+            // Genuinely stale: a real prior certification exists (readiness_checked_at
+            // set) that no longer applies (settings/backend requirements changed) —
+            // distinct from never_checked (no prior run) and failed (an active
+            // problem). readiness_safe_failure_reason is only meaningful for
+            // "failed" and must not be rendered as an error here even if present.
+            mockLoad.mockResolvedValue({ data: { provider: "openai", model: "gpt-4o" } });
+            mockLoadStatus.mockResolvedValue({
+                data: {
+                    configured: true,
+                    active: true,
+                    degraded: false,
+                    reason_code: "active",
+                    last_fallback_at: null,
+                    readiness: "stale",
+                    readiness_checked_at: "2026-06-01T00:00:00Z",
+                    readiness_safe_failure_reason: null,
+                },
+            });
+            renderForm();
+
+            const preflightSection = await screen.findByTestId("byo-llm-preflight");
+            const badgeText = within(preflightSection).getByText(
+                "Certification expired — run preflight",
+            );
+            expect(badgeText).toBeInTheDocument();
+            // Non-alarming: never the negative/red tone used for an actual failure,
+            // and no failure-reason paragraph rendered for a stale (non-error) state.
+            expect(badgeText.parentElement?.className ?? "").not.toContain("negative");
+            expect(
+                within(preflightSection).queryByText(/rejected|error|blocked/i),
+            ).not.toBeInTheDocument();
+            expect(
+                within(preflightSection).getByRole("button", { name: "Run BYO preflight" }),
+            ).not.toBeDisabled();
+        });
     });
 
     it("enters edit mode from the summary, edits, and saves", async () => {

--- a/src/components/admin/llm/ByoLlmSettings.test.tsx
+++ b/src/components/admin/llm/ByoLlmSettings.test.tsx
@@ -411,8 +411,11 @@ describe("ByoLlmSettings", () => {
             // Genuinely stale: a real prior certification exists (readiness_checked_at
             // set) that no longer applies (settings/backend requirements changed) —
             // distinct from never_checked (no prior run) and failed (an active
-            // problem). readiness_safe_failure_reason is only meaningful for
-            // "failed" and must not be rendered as an error here even if present.
+            // problem). The backend can populate readiness_safe_failure_reason even
+            // for a stale record (e.g. carried over from the certification that went
+            // stale); that field is only meaningful for "failed" and must NOT be
+            // rendered as an error here despite being non-null — exercise that
+            // explicitly rather than asserting it only for the easy null case.
             mockLoad.mockResolvedValue({ data: { provider: "openai", model: "gpt-4o" } });
             mockLoadStatus.mockResolvedValue({
                 data: {
@@ -423,7 +426,7 @@ describe("ByoLlmSettings", () => {
                     last_fallback_at: null,
                     readiness: "stale",
                     readiness_checked_at: "2026-06-01T00:00:00Z",
-                    readiness_safe_failure_reason: null,
+                    readiness_safe_failure_reason: "The provider rejected the request.",
                 },
             });
             renderForm();
@@ -434,8 +437,12 @@ describe("ByoLlmSettings", () => {
             );
             expect(badgeText).toBeInTheDocument();
             // Non-alarming: never the negative/red tone used for an actual failure,
-            // and no failure-reason paragraph rendered for a stale (non-error) state.
+            // and the failure-reason paragraph must NOT render for a stale (non-error)
+            // state even though readiness_safe_failure_reason is populated.
             expect(badgeText.parentElement?.className ?? "").not.toContain("negative");
+            expect(
+                within(preflightSection).queryByText("The provider rejected the request."),
+            ).not.toBeInTheDocument();
             expect(
                 within(preflightSection).queryByText(/rejected|error|blocked/i),
             ).not.toBeInTheDocument();

--- a/src/components/admin/llm/ByoLlmSettings.tsx
+++ b/src/components/admin/llm/ByoLlmSettings.tsx
@@ -48,6 +48,14 @@ export type ByoLlmSettingsProps = {
         data: LLMSettingsUpsert,
     ) => Promise<LLMSettingsActionResult<LLMSettingsResponse>>;
     removeSettingsAction: () => Promise<LLMSettingsActionResult<{ deleted: boolean }>>;
+    /**
+     * Runs the BYO preflight against the saved configuration (CHAOS-3265).
+     * Independent of `status?.active`/`mode` — rendered whenever a BYO
+     * configuration is saved, even if it is currently degraded or not
+     * selected for Ask Dev. Returns the fresh `LLMSettingsStatusResponse`,
+     * which is applied directly rather than re-fetching status.
+     */
+    runReadinessAction: () => Promise<LLMSettingsActionResult<LLMSettingsStatusResponse>>;
 };
 
 const inputClass =
@@ -158,12 +166,43 @@ function deriveStatusBadge(
     return { label: "Saved", tone: "positive" };
 }
 
+/**
+ * Derives the BYO preflight badge wording/tone from the CHAOS-3265 readiness
+ * fields on the status DTO. Independent of `active`/`degraded` — a saved
+ * configuration can be explicitly checked regardless of whether it currently
+ * wins Ask Dev's provider-selection arbitration.
+ *
+ * `"stale"` (CHAOS-3254 READINESS_VERSION bump) is a neutral/informational
+ * state — a prior certification exists but no longer applies (settings
+ * changed, or the backend's certification requirements changed) — and must
+ * NOT use the negative "failed" tone/copy.
+ */
+function deriveReadinessBadge(status: LLMSettingsStatusResponse | null): BadgeInfo {
+    if (!status || status.readiness === "never_checked") {
+        return { label: "Not yet checked", tone: "muted" };
+    }
+    if (status.readiness === "ready") {
+        return { label: "Preflight passed", tone: "positive" };
+    }
+    if (status.readiness === "stale") {
+        return { label: "Certification expired — run preflight", tone: "muted" };
+    }
+    return { label: "Preflight failed", tone: "negative" };
+}
+
+function formatCheckedAt(value: string | null): string {
+    if (!value) return "Not checked";
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? "Not checked" : date.toLocaleString();
+}
+
 export function ByoLlmSettings({
     loadSettingsAction,
     loadBudgetAction,
     loadStatusAction,
     saveSettingsAction,
     removeSettingsAction,
+    runReadinessAction,
 }: ByoLlmSettingsProps) {
     const [loading, setLoading] = useState(true);
     const [locked, setLocked] = useState<LockState>(null);
@@ -186,6 +225,7 @@ export function ByoLlmSettings({
     const [hasSavedSettings, setHasSavedSettings] = useState(false);
 
     const [saving, setSaving] = useState(false);
+    const [checkingReadiness, setCheckingReadiness] = useState(false);
     const [deleting, setDeleting] = useState(false);
     const [confirmingDelete, setConfirmingDelete] = useState(false);
     const [baseUrlError, setBaseUrlError] = useState<string | null>(null);
@@ -368,6 +408,29 @@ export function ByoLlmSettings({
         toast.success("BYO-LLM settings removed.");
     };
 
+    const runByoPreflight = async () => {
+        setCheckingReadiness(true);
+        const result = await runReadinessAction();
+        setCheckingReadiness(false);
+        if (result.error) {
+            // The action itself failed (network/backend error, or no saved
+            // BYO configuration) — distinct from a completed preflight that
+            // determined the provider is not ready (handled below).
+            toast.error(result.error || "BYO preflight did not complete.");
+            return;
+        }
+        if (result.data) {
+            // The POST already returns the fresh status DTO; apply it
+            // directly instead of re-fetching.
+            setStatus(result.data);
+            if (result.data.readiness === "failed") {
+                toast.error(result.data.readiness_safe_failure_reason ?? "BYO preflight failed.");
+                return;
+            }
+        }
+        toast.success("BYO preflight completed.");
+    };
+
     if (loading) {
         return (
             <div>
@@ -445,6 +508,59 @@ export function ByoLlmSettings({
             {badge.label}
         </span>
     );
+
+    const readinessBadge = deriveReadinessBadge(status);
+    // Rendered whenever a BYO configuration is saved — independent of
+    // `status?.active`/`mode` (CHAOS-3265). A saved-but-degraded or
+    // not-currently-selected configuration is still explicitly checkable.
+    const byoPreflightPanel = hasSavedSettings ? (
+        <section
+            aria-labelledby="byo-preflight-heading"
+            data-testid="byo-llm-preflight"
+            className="mt-6 rounded-xl border border-(--card-stroke) bg-(--card-70) p-4"
+        >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                    <h2
+                        id="byo-preflight-heading"
+                        className="text-sm font-semibold text-foreground"
+                    >
+                        BYO preflight
+                    </h2>
+                    <p className="mt-1 max-w-xl text-xs text-(--ink-muted)">
+                        Tests only this saved BYO configuration. It does not consume Ask Dev&apos;s
+                        platform allowance, does not change which provider Ask Dev currently uses,
+                        and does not send organization evidence — synthetic data only.
+                    </p>
+                </div>
+                <span
+                    className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${BADGE_TONE_CLASSES[readinessBadge.tone]}`}
+                >
+                    <span
+                        aria-hidden="true"
+                        className={`h-2 w-2 rounded-full ${BADGE_DOT_CLASSES[readinessBadge.tone]}`}
+                    />
+                    {readinessBadge.label}
+                </span>
+            </div>
+            <p className="mt-3 text-xs text-(--ink-muted)">
+                Last checked: {formatCheckedAt(status?.readiness_checked_at ?? null)}
+            </p>
+            {status?.readiness === "failed" && status.readiness_safe_failure_reason ? (
+                <p className="mt-2 text-sm text-(--negative)">
+                    {status.readiness_safe_failure_reason}
+                </p>
+            ) : null}
+            <button
+                type="button"
+                onClick={() => void runByoPreflight()}
+                disabled={checkingReadiness}
+                className="mt-4 rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-(--accent)/60 disabled:opacity-50"
+            >
+                {checkingReadiness ? "Checking…" : CTA_LABELS.runByoPreflight}
+            </button>
+        </section>
+    ) : null;
 
     const budgetBadge = budget ? deriveBudgetBadge(budget) : null;
     const budgetPanel = (
@@ -776,6 +892,8 @@ export function ByoLlmSettings({
                     </div>
                 </div>
             )}
+
+            {byoPreflightPanel}
         </div>
     );
 }

--- a/src/components/admin/platform/PlatformAskDevReadinessPanel.test.tsx
+++ b/src/components/admin/platform/PlatformAskDevReadinessPanel.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PlatformAskDevReadinessResponse } from "@/lib/admin/types";
+import { PlatformAskDevReadinessPanel } from "./PlatformAskDevReadinessPanel";
+
+vi.mock("sonner", () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const readyResponse: PlatformAskDevReadinessResponse = {
+    schema_version: "platform_ask_dev_readiness.v1",
+    configured: true,
+    provider_label: "OpenAI compatible",
+    model_label: "gpt-5-nano",
+    readiness: "ready",
+    readiness_checked_at: "2026-07-29T16:00:00Z",
+    readiness_version: "agent-readiness.v1",
+    safe_remediation: null,
+};
+
+describe("PlatformAskDevReadinessPanel", () => {
+    const loadAction = vi.fn();
+    const runAction = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        loadAction.mockResolvedValue({ data: readyResponse });
+        runAction.mockResolvedValue({ data: readyResponse });
+    });
+
+    function renderPanel() {
+        return render(
+            <PlatformAskDevReadinessPanel loadAction={loadAction} runAction={runAction} />,
+        );
+    }
+
+    it("shows a loading state before data resolves", () => {
+        loadAction.mockReturnValue(new Promise(() => {}));
+        renderPanel();
+        expect(screen.getByText(/loading platform ask dev readiness/i)).toBeInTheDocument();
+    });
+
+    it("renders the platform provider identity and a Ready badge", async () => {
+        renderPanel();
+
+        expect(
+            await screen.findByRole("heading", { name: "Ask Dev platform provider" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("OpenAI compatible")).toBeInTheDocument();
+        expect(screen.getByText("gpt-5-nano")).toBeInTheDocument();
+        expect(screen.getByRole("status")).toHaveTextContent("Ready");
+        expect(screen.getByText(/2026/)).toBeInTheDocument();
+    });
+
+    it("renders an error state when the load action fails", async () => {
+        loadAction.mockResolvedValue({ error: "boom" });
+        renderPanel();
+
+        expect(
+            await screen.findByText("Platform Ask Dev readiness is unavailable"),
+        ).toBeInTheDocument();
+        expect(screen.getByText("boom")).toBeInTheDocument();
+    });
+
+    it("runs the platform preflight, disables the button while running, and applies the POST response directly", async () => {
+        let resolveRun: (value: { data: PlatformAskDevReadinessResponse }) => void = () => {};
+        runAction.mockReturnValue(
+            new Promise((resolve) => {
+                resolveRun = resolve;
+            }),
+        );
+        renderPanel();
+
+        const button = await screen.findByRole("button", { name: "Run platform preflight" });
+        fireEvent.click(button);
+        expect(button).toBeDisabled();
+
+        resolveRun({
+            data: {
+                ...readyResponse,
+                readiness: "missing_credentials",
+                safe_remediation: "Configure platform credentials via the operator environment.",
+            },
+        });
+
+        await waitFor(() => expect(runAction).toHaveBeenCalledTimes(1));
+        expect(await screen.findByText("Credentials required")).toBeInTheDocument();
+        expect(
+            screen.getByText("Configure platform credentials via the operator environment."),
+        ).toBeInTheDocument();
+        expect(button).not.toBeDisabled();
+    });
+
+    it("surfaces a safe failure reason and an error toast when the preflight fails", async () => {
+        runAction.mockResolvedValue({ error: "Preflight timed out" });
+        renderPanel();
+
+        fireEvent.click(await screen.findByRole("button", { name: "Run platform preflight" }));
+
+        await waitFor(() =>
+            expect(screen.getByRole("alert")).toHaveTextContent("Preflight timed out"),
+        );
+        // The surface remains usable after a failed preflight.
+        expect(screen.getByRole("button", { name: "Run platform preflight" })).not.toBeDisabled();
+    });
+
+    it("never renders BYO-specific editable fields or credential values", async () => {
+        renderPanel();
+
+        await screen.findByRole("heading", { name: "Ask Dev platform provider" });
+        expect(screen.queryByLabelText(/api key/i)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/base url/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/sk-/)).not.toBeInTheDocument();
+    });
+
+    it("renders a stale certification as a neutral, non-alarming state (CHAOS-3254 READINESS_VERSION bump), not as broken/error", async () => {
+        // Genuinely stale: a real prior certification exists (readiness_checked_at
+        // set, configured true) that no longer applies — distinct from
+        // never_checked (no prior run) and failed (an active problem).
+        loadAction.mockResolvedValue({
+            data: {
+                ...readyResponse,
+                readiness: "stale_readiness",
+                readiness_checked_at: "2026-06-01T00:00:00Z",
+                safe_remediation: null,
+            },
+        });
+        renderPanel();
+
+        await screen.findByRole("heading", { name: "Ask Dev platform provider" });
+        const badge = screen.getByRole("status");
+        expect(badge).toHaveTextContent("Readiness check expired");
+        // Non-alarming tone: never the negative/red dot used for a real failure.
+        expect(badge.innerHTML).not.toContain("bg-(--negative)");
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+        // The preflight CTA remains available to re-certify.
+        expect(screen.getByRole("button", { name: "Run platform preflight" })).not.toBeDisabled();
+    });
+});

--- a/src/components/admin/platform/PlatformAskDevReadinessPanel.tsx
+++ b/src/components/admin/platform/PlatformAskDevReadinessPanel.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { DataState } from "@/components/ui/DataState";
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { ActionResult } from "@/lib/result";
+import type { AskDevAdminReadiness, PlatformAskDevReadinessResponse } from "@/lib/admin/types";
+
+type PlatformAskDevReadinessPanelProps = {
+    loadAction: () => Promise<ActionResult<PlatformAskDevReadinessResponse>>;
+    runAction: () => Promise<ActionResult<PlatformAskDevReadinessResponse>>;
+};
+
+const READINESS_LABELS: Record<AskDevAdminReadiness, string> = {
+    ready: "Ready",
+    unsupported_model: "Model not certified",
+    missing_credentials: "Credentials required",
+    disabled: "Disabled",
+    degraded: "Provider degraded",
+    stale_readiness: "Readiness check expired",
+};
+
+const READINESS_TONES: Record<AskDevAdminReadiness, string> = {
+    ready: "bg-(--positive)",
+    unsupported_model: "bg-(--negative)",
+    missing_credentials: "bg-(--caution)",
+    disabled: "bg-(--ink-muted)",
+    degraded: "bg-(--caution)",
+    stale_readiness: "bg-(--info)",
+};
+
+function formatCheckedAt(value: string | null): string {
+    if (!value) return "Not checked";
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? "Not checked" : date.toLocaleString();
+}
+
+/**
+ * Platform-admin-only surface for the operator/platform-owned Ask Dev
+ * provider (CHAOS-3265). This is env-configured by the operator, is shared
+ * across every organization, and is entirely independent of any
+ * organization's BYO-LLM configuration — it never requires, reads, or
+ * displays a per-organization provider. Organization admins manage their own
+ * BYO preflight separately, from the BYO LLM tab.
+ */
+export function PlatformAskDevReadinessPanel({
+    loadAction,
+    runAction,
+}: PlatformAskDevReadinessPanelProps) {
+    const [loading, setLoading] = useState(true);
+    const [checking, setChecking] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [readiness, setReadiness] = useState<PlatformAskDevReadinessResponse | null>(null);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        const result = await loadAction();
+        if ("error" in result) {
+            setError(result.error ?? "Platform Ask Dev readiness could not be loaded.");
+        } else {
+            setReadiness(result.data);
+        }
+        setLoading(false);
+    }, [loadAction]);
+
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- load coordinates server action state after mount.
+        void load();
+    }, [load]);
+
+    const runPreflight = async () => {
+        setChecking(true);
+        setError(null);
+        const result = await runAction();
+        setChecking(false);
+        if ("error" in result) {
+            setError(result.error ?? "Platform Ask Dev readiness could not be checked.");
+            toast.error("Platform Ask Dev preflight did not complete.");
+            return;
+        }
+        setReadiness(result.data);
+        toast.success("Platform Ask Dev preflight completed.");
+    };
+
+    if (loading) {
+        return <DataState variant="loading" title="Loading platform Ask Dev readiness…" />;
+    }
+
+    if (!readiness) {
+        return (
+            <DataState
+                variant="error"
+                title="Platform Ask Dev readiness is unavailable"
+                message={error ?? "The platform provider status could not be loaded."}
+                action={
+                    <button
+                        type="button"
+                        onClick={() => void load()}
+                        className="rounded-md bg-(--accent) px-4 py-2 text-sm font-semibold text-(--accent-foreground)"
+                    >
+                        {CTA_LABELS.retry}
+                    </button>
+                }
+            />
+        );
+    }
+
+    return (
+        <section
+            aria-labelledby="platform-ask-dev-readiness-title"
+            className="overflow-hidden rounded-(--radius-lg) border border-(--border) bg-(--surface-raised) shadow-(--elevation-card)"
+        >
+            <header className="relative overflow-hidden border-b border-(--border) px-6 py-6 sm:px-8">
+                <div aria-hidden="true" className="absolute inset-y-0 left-0 w-1 bg-(--accent)" />
+                <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="max-w-2xl">
+                        <p className="text-label-caps text-(--text-muted)">
+                            Platform administration
+                        </p>
+                        <h2
+                            id="platform-ask-dev-readiness-title"
+                            className="mt-2 text-h1 text-(--text-primary)"
+                        >
+                            Ask Dev platform provider
+                        </h2>
+                        <p className="mt-2 text-body text-(--text-secondary)">
+                            This is the operator-configured platform LLM provider shared as the
+                            default and approved fallback across every organization&apos;s Ask Dev.
+                            It is entirely independent of any organization&apos;s BYO-LLM
+                            configuration — it never requires, reads, or reflects any
+                            organization&apos;s BYO settings.
+                        </p>
+                    </div>
+                    <div
+                        role="status"
+                        className="inline-flex items-center gap-2 self-start rounded-(--radius-pill) border border-(--border) bg-(--surface) px-3 py-1.5 text-sm font-medium text-(--text-primary)"
+                    >
+                        <span
+                            aria-hidden="true"
+                            className={`h-2.5 w-2.5 rounded-full ${READINESS_TONES[readiness.readiness]}`}
+                        />
+                        {READINESS_LABELS[readiness.readiness]}
+                    </div>
+                </div>
+            </header>
+
+            {error ? (
+                <div
+                    role="alert"
+                    className="border-b border-(--negative)/30 bg-(--negative)/10 px-6 py-3 text-sm text-(--negative) sm:px-8"
+                >
+                    {error}
+                </div>
+            ) : null}
+
+            <div className="px-6 py-6 sm:px-8">
+                <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.7fr)]">
+                    <div>
+                        <dl className="grid gap-x-8 gap-y-4 sm:grid-cols-2">
+                            <div>
+                                <dt className="text-label-caps text-(--text-muted)">Provider</dt>
+                                <dd className="mt-1 text-body text-(--text-primary)">
+                                    {readiness.provider_label ?? "Not configured"}
+                                </dd>
+                            </div>
+                            <div>
+                                <dt className="text-label-caps text-(--text-muted)">Model</dt>
+                                <dd className="mt-1 text-body text-(--text-primary)">
+                                    {readiness.model_label ?? "Not configured"}
+                                </dd>
+                            </div>
+                        </dl>
+                        {readiness.safe_remediation ? (
+                            <p className="mt-4 border-l-2 border-(--caution) pl-3 text-sm text-(--text-secondary)">
+                                {readiness.safe_remediation}
+                            </p>
+                        ) : null}
+                    </div>
+                    <div className="flex flex-col justify-between gap-4 border-l border-(--border) pl-0 lg:pl-6">
+                        <div>
+                            <p className="text-label-caps text-(--text-muted)">Last preflight</p>
+                            <p className="mt-1 text-sm text-(--text-primary)">
+                                {formatCheckedAt(readiness.readiness_checked_at)}
+                            </p>
+                            <p className="mt-1 text-xs text-(--text-muted)">
+                                Uses synthetic data only. Never reads or requires any
+                                organization&apos;s BYO-LLM configuration.
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            disabled={checking}
+                            onClick={() => void runPreflight()}
+                            className="self-start rounded-md border border-(--border) bg-(--surface) px-4 py-2 text-sm font-semibold text-(--text-primary) transition-colors hover:border-(--accent) disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            {checking ? "Checking…" : CTA_LABELS.runPlatformPreflight}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/src/components/superadmin/SuperadminSidebar.tsx
+++ b/src/components/superadmin/SuperadminSidebar.tsx
@@ -20,6 +20,12 @@ const navItems = [
         href: "/superadmin/context-fabric/validation",
         description: "Runtime",
     },
+    {
+        id: "ask-dev",
+        label: "Ask Dev",
+        href: "/superadmin/ai/ask-dev",
+        description: "Platform LLM",
+    },
     { id: "audit", label: "Audit Log", href: "/superadmin/audit", description: "Events" },
     { id: "settings", label: "Settings", href: "/superadmin/settings", description: "Platform" },
     {

--- a/src/lib/__tests__/access-matrix.test.ts
+++ b/src/lib/__tests__/access-matrix.test.ts
@@ -847,3 +847,56 @@ describe("full access matrix — RBAC × tier gates", () => {
         }
     });
 });
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// 8. PLATFORM ASK DEV READINESS ROUTE (CHAOS-3265) — /superadmin/ai/ask-dev
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+// The route's page component re-checks `requireSuperuser("/superadmin/ai/ask-dev")`
+// directly (same defense-in-depth pattern as other superadmin leaf pages,
+// e.g. billing/plans), in addition to the shared `superadmin/layout.tsx`
+// gate. This proves the guard explicitly for this route rather than assuming
+// coverage from the generic requireSuperuser tests above.
+
+describe("requireSuperuser — /superadmin/ai/ask-dev platform readiness page", () => {
+    const CALLBACK_URL = "/superadmin/ai/ask-dev";
+
+    it("denies an ordinary org member", async () => {
+        mockNextAuthAuth.mockResolvedValueOnce(
+            makeSession({ org_id: "org-1", role: "member", is_superuser: false }),
+        );
+        await expectRedirectTo(() => requireSuperuser(CALLBACK_URL), "/dashboard");
+    });
+
+    it("denies an org admin without platform superuser rights", async () => {
+        mockNextAuthAuth.mockResolvedValueOnce(
+            makeSession({ org_id: "org-1", role: "admin", is_superuser: false }),
+        );
+        await expectRedirectTo(() => requireSuperuser(CALLBACK_URL), "/dashboard");
+    });
+
+    it("allows a platform superuser", async () => {
+        mockNextAuthAuth.mockResolvedValueOnce(
+            makeSession({ org_id: "org-1", role: "owner", is_superuser: true }),
+        );
+        const result = await requireSuperuser(CALLBACK_URL);
+        expect(result.user.is_superuser).toBe(true);
+    });
+
+    it("still allows a superuser impersonating an org admin (is_superuser is preserved through impersonation, per the JWT callback contract)", async () => {
+        mockNextAuthAuth.mockResolvedValueOnce(
+            makeSession({
+                id: "impersonated-admin-1",
+                org_id: "org-1",
+                role: "admin",
+                is_superuser: true,
+                is_impersonating: true,
+                impersonated_user_id: "impersonated-admin-1",
+                needs_onboarding: false,
+            }),
+        );
+        const result = await requireSuperuser(CALLBACK_URL);
+        expect(result.user.is_superuser).toBe(true);
+        expect(result.user.is_impersonating).toBe(true);
+    });
+});

--- a/src/lib/admin/api/ask-dev.ts
+++ b/src/lib/admin/api/ask-dev.ts
@@ -17,8 +17,10 @@ export const askDevAdminApi = {
             orgId,
         ),
 
-    runReadiness: (token?: string, orgId?: string) =>
-        request<AskDevAdminResponse>("/ask-dev/readiness", { method: "POST" }, token, orgId),
+    // NOTE (CHAOS-3265): `POST /ask-dev/readiness` was removed entirely — the
+    // org surface no longer exposes any platform-provider preflight action.
+    // Platform preflight now lives under `platformApi.askDevReadiness`;
+    // BYO preflight now lives under `llmSettingsApi.runReadiness`.
 
     usage: (since?: string, token?: string, orgId?: string) => {
         const query = since ? `?since=${encodeURIComponent(since)}` : "";

--- a/src/lib/admin/api/llm-settings.ts
+++ b/src/lib/admin/api/llm-settings.ts
@@ -36,6 +36,17 @@ export const llmSettingsApi = {
     status: (token?: string, orgId?: string) =>
         request<LLMSettingsStatusResponse>("/llm-settings/status", {}, token, orgId),
 
+    // Runs the BYO preflight against the saved configuration (CHAOS-3265).
+    // Independent of Ask Dev's provider-selection arbitration — gated only on
+    // a saved BYO configuration existing (404 otherwise), never on `active`.
+    runReadiness: (token?: string, orgId?: string) =>
+        request<LLMSettingsStatusResponse>(
+            "/llm-settings/readiness",
+            { method: "POST" },
+            token,
+            orgId,
+        ),
+
     // Enforceable calendar-month organization ceiling. This is intentionally
     // separate from the ClickHouse spend-summary endpoint: active reservations
     // participate in admission before provider calls complete.

--- a/src/lib/admin/api/platform.ts
+++ b/src/lib/admin/api/platform.ts
@@ -1,8 +1,21 @@
 import { request } from "./_request";
-import type { PlatformStats } from "../types";
+import type { PlatformAskDevReadinessResponse, PlatformStats } from "../types";
 
 export const platformApi = {
     stats: (token?: string) => request<PlatformStats>("/platform/stats", {}, token),
+
+    // Superuser-only platform Ask Dev readiness (CHAOS-3265). No org scope —
+    // mirrors `stats` by omitting orgId entirely.
+    askDevReadiness: {
+        get: (token?: string) =>
+            request<PlatformAskDevReadinessResponse>("/platform/ask-dev/readiness", {}, token),
+        run: (token?: string) =>
+            request<PlatformAskDevReadinessResponse>(
+                "/platform/ask-dev/readiness",
+                { method: "POST" },
+                token,
+            ),
+    },
 };
 
 export const impersonationApi = {

--- a/src/lib/admin/server.ts
+++ b/src/lib/admin/server.ts
@@ -13,3 +13,4 @@ export * from "./server/customer-push";
 export * from "./server/canonicalIncidentIngestion";
 export * from "./server/pagerduty";
 export * from "./server/ask-dev";
+export * from "./server/platform";

--- a/src/lib/admin/server/ask-dev.ts
+++ b/src/lib/admin/server/ask-dev.ts
@@ -28,14 +28,10 @@ export async function updateAskDevAdminSettings(
     });
 }
 
-export async function runAskDevReadiness(): Promise<ActionResult<AskDevAdminResponse>> {
-    return withErrorHandling(async () => {
-        const { token, orgId } = await getSessionContext();
-        const result = await adminApi.askDev.runReadiness(token, orgId);
-        revalidatePath("/org/admin/ai");
-        return result;
-    });
-}
+// NOTE (CHAOS-3265): `runAskDevReadiness` was removed — the org Ask Dev
+// surface no longer exposes a platform-provider preflight action. See
+// `runPlatformAskDevReadiness` (src/lib/admin/server/platform.ts) and
+// `runLLMSettingsReadiness` (src/lib/admin/server/settings.ts).
 
 export async function getAskDevUsage(
     since?: string,

--- a/src/lib/admin/server/platform.ts
+++ b/src/lib/admin/server/platform.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type { ActionResult } from "@/lib/result";
+import { adminApi } from "../api";
+import type { PlatformAskDevReadinessResponse } from "../types";
+import { requireSuperuserToken, withErrorHandling } from "./_shared";
+
+/**
+ * Platform Ask Dev readiness (CHAOS-3265). Superuser-only, no org scope — the
+ * operator/platform-owned Ask Dev provider, never an organization's BYO
+ * configuration. Mirrors the `getOrgEntitlements`/`requireSuperuserToken`
+ * pattern used for platform-scoped licensing actions.
+ */
+export async function getPlatformAskDevReadiness(): Promise<
+    ActionResult<PlatformAskDevReadinessResponse>
+> {
+    return withErrorHandling(async () => {
+        const token = await requireSuperuserToken();
+        return adminApi.platform.askDevReadiness.get(token);
+    });
+}
+
+export async function runPlatformAskDevReadiness(): Promise<
+    ActionResult<PlatformAskDevReadinessResponse>
+> {
+    return withErrorHandling(async () => {
+        const token = await requireSuperuserToken();
+        const result = await adminApi.platform.askDevReadiness.run(token);
+        revalidatePath("/superadmin/ai/ask-dev");
+        return result;
+    });
+}

--- a/src/lib/admin/server/settings.ts
+++ b/src/lib/admin/server/settings.ts
@@ -296,6 +296,23 @@ export async function deleteLLMSettings(): Promise<LLMSettingsActionResult<{ del
     });
 }
 
+/**
+ * Runs the BYO preflight against the saved configuration (CHAOS-3265).
+ * Independent of Ask Dev's provider-selection arbitration — gated only on a
+ * saved BYO configuration existing (the backend 404s otherwise), never on
+ * whether BYO currently wins Ask Dev's arbitration.
+ */
+export async function runLLMSettingsReadiness(): Promise<
+    LLMSettingsActionResult<LLMSettingsStatusResponse>
+> {
+    return withStatusErrorHandling(async () => {
+        const { token, orgId } = await getSessionContext();
+        const result = await adminApi.llmSettings.runReadiness(token, orgId);
+        revalidatePath("/org/admin/ai/byo-llm");
+        return result;
+    });
+}
+
 // Org-scoped per-run spend summary (CHAOS-2564). Uses withStatusErrorHandling
 // (not the generic withErrorHandling) so a tier/flag gate (402/403) surfaces
 // as a distinguishable locked state rather than a generic load error.

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -869,13 +869,33 @@ export type LLMSettingsStatusReasonCode =
     "not_configured" | "unknown_provider" | "missing_credentials" | "invalid_base_url" | "active";
 
 /**
- * GET /admin/llm-settings/status response (CHAOS-2560). Drives the BYO-LLM
- * status badge on the AI Setup summary (CHAOS-2565): `active` renders
- * "Active", `configured && degraded` renders "Invalid — using platform
- * default", and `!configured` renders "Not configured". This endpoint is a
- * pure evaluator over stored settings + recent fallback audit rows — never a
- * live provider call — so a fetch failure degrades gracefully to the
- * settings-derived Saved/Not configured wording rather than blocking the UI.
+ * BYO preflight outcome (CHAOS-3265, amended for the CHAOS-3254
+ * READINESS_VERSION bump). Independent of `active`/`degraded` — a saved BYO
+ * configuration can be explicitly preflight-checked regardless of whether it
+ * currently wins Ask Dev's provider-selection arbitration.
+ *
+ * `"stale"` means a preflight was run before, but the stored result no
+ * longer corresponds to the current BYO configuration or the backend's
+ * current readiness-version requirement (the org edited BYO settings since
+ * the last check, or the backend's certification requirements changed). This
+ * is NOT an error/failure state — it is "not currently certified, re-run" —
+ * and must render with neutral/informational styling, never the negative
+ * "failed" tone. `readiness_safe_failure_reason` is only meaningful for
+ * `"failed"`; it must not be treated as an error explanation when stale.
+ */
+export type LLMSettingsReadinessState = "ready" | "failed" | "stale" | "never_checked";
+
+/**
+ * GET /admin/llm-settings/status response (CHAOS-2560, extended CHAOS-3265).
+ * Drives the BYO-LLM status badge on the AI Setup summary (CHAOS-2565):
+ * `active` renders "Active", `configured && degraded` renders "Invalid —
+ * using platform default", and `!configured` renders "Not configured". This
+ * endpoint is a pure evaluator over stored settings + recent fallback audit
+ * rows — never a live provider call — so a fetch failure degrades gracefully
+ * to the settings-derived Saved/Not configured wording rather than blocking
+ * the UI. `readiness`/`readiness_checked_at`/`readiness_safe_failure_reason`
+ * (CHAOS-3265) reflect the last explicit BYO preflight run via
+ * `POST /admin/llm-settings/readiness`, independent of this GET.
  */
 export interface LLMSettingsStatusResponse {
     configured: boolean;
@@ -883,6 +903,9 @@ export interface LLMSettingsStatusResponse {
     degraded: boolean;
     reason_code: LLMSettingsStatusReasonCode;
     last_fallback_at: string | null;
+    readiness: LLMSettingsReadinessState;
+    readiness_checked_at: string | null;
+    readiness_safe_failure_reason: string | null;
 }
 
 // ---- Ask Dev administration (CHAOS-3217) ----
@@ -1030,6 +1053,27 @@ export interface PlatformStats {
     active_sync_configs: number;
     recent_syncs_success: number;
     recent_syncs_failed: number;
+}
+
+// ---- Platform Ask Dev Readiness (CHAOS-3265) ----
+
+/**
+ * GET/POST /admin/platform/ask-dev/readiness response. Superuser-only —
+ * describes the operator/platform-owned Ask Dev provider (env-configured),
+ * never an organization's BYO configuration. `readiness` reuses
+ * `AskDevAdminReadiness` because the enum values are identical; do not
+ * duplicate the union.
+ */
+export interface PlatformAskDevReadinessResponse {
+    schema_version: "platform_ask_dev_readiness.v1";
+    configured: boolean;
+    /** Safe label only, e.g. "OpenAI compatible" — never a raw endpoint or credential. */
+    provider_label: string | null;
+    model_label: string | null;
+    readiness: AskDevAdminReadiness;
+    readiness_checked_at: string | null;
+    readiness_version: string | null;
+    safe_remediation: string | null;
 }
 
 // ---- Licensing & Feature Flags ----

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -111,6 +111,10 @@ export const CTA_LABELS = {
     checkConnectionStatus: "Check connection status",
     disconnect: "Disconnect",
     runPreflight: "Run preflight",
+    /** Trigger the platform-admin-only Ask Dev provider preflight (CHAOS-3265). */
+    runPlatformPreflight: "Run platform preflight",
+    /** Trigger the org-scoped BYO-LLM preflight, independent of Ask Dev's active provider (CHAOS-3265). */
+    runByoPreflight: "Run BYO preflight",
     /** Advance to the next step of the guided onboarding flow (CHAOS-2675). */
     continueStep: "Continue",
     /** Continue the guided first-run setup from the dashboard (CHAOS-2678). */


### PR DESCRIPTION
## Summary

Ask Dev's org-facing tab let an org admin see and trigger certification of the operator/platform-owned LLM provider — a boundary violation, since platform provider identity and readiness belong to the platform operator, not any organization. This PR closes that gap by moving the platform-provider surface to a new superuser-only Platform Admin page and giving BYO its own, independently-scoped preflight control.

**Left the org Ask Dev tab** (`src/components/admin/ask-dev/AskDevAdminPanel.tsx`, `/org/admin/ai/ask-dev`):
- Removed the entire "Availability and provider" section (provider/model labels, readiness badge pill in the header, "Run preflight" button), unconditionally.
- Removed the `readinessAction` prop, `runAskDevReadiness` server action, and `POST /ask-dev/readiness` client plumbing entirely — no replacement on the org surface.
- Kept: header, error banner, "Conversation and fallback policy" (retention/fallback/emergency-disable/platform allowance), usage, footer.

**New in Platform Admin** (`src/app/(app)/superadmin/ai/ask-dev/page.tsx`, `src/components/admin/platform/PlatformAskDevReadinessPanel.tsx`, route `/superadmin/ai/ask-dev`):
- Superuser-gated (`requireSuperuser`) page showing the operator-configured platform provider: label, model, readiness badge, last-preflight time, safe remediation text, and a "Run platform preflight" action.
- Copy makes explicit this is the operator/platform provider and never reads/requires any organization's BYO configuration.
- New nav entry in `SuperadminSidebar` next to "Context Fabric Validation".
- New server actions `getPlatformAskDevReadiness`/`runPlatformAskDevReadiness` (`src/lib/admin/server/platform.ts`) and `platformApi.askDevReadiness.{get,run}` client (`src/lib/admin/api/platform.ts`), calling `GET/POST /api/v1/admin/platform/ask-dev/readiness`.

**New in the BYO LLM tab** (`src/components/admin/llm/ByoLlmSettings.tsx`, `/org/admin/ai/byo-llm`):
- A "BYO preflight" control, rendered whenever a BYO configuration is saved (`hasSavedSettings`), independent of `status?.active`/`mode` and of Ask Dev's provider-selection arbitration.
- Readiness badge derived from `LLMSettingsStatusResponse`'s new `readiness`/`readiness_checked_at`/`readiness_safe_failure_reason` fields (4-state: `ready | failed | stale | never_checked`).
- New server action `runLLMSettingsReadiness` (`src/lib/admin/server/settings.ts`) and `llmSettingsApi.runReadiness` client, calling `POST /admin/llm-settings/readiness`.

**4-state readiness contract amendment (CHAOS-3254 READINESS_VERSION bump):** a sibling PR bumps the backend's readiness version, invalidating stored certifications on deploy. `"stale"`/`"stale_readiness"` render with neutral/informational styling (never the negative "failed" tone), and `readiness_safe_failure_reason` is only ever shown for an actual `"failed"` state — verified by a mutation-tested regression case.

Pairs with a separate `dev-health-ops` PR implementing `GET/POST /api/v1/admin/platform/ask-dev/readiness`, `POST /api/v1/admin/llm-settings/readiness`, and the 3-field extension to `GET /api/v1/admin/llm-settings/status`.

Linked: https://linear.app/fullchaos/issue/CHAOS-3265/ask-dev-move-platform-model-readiness-controls-to-platform-admin

## Test plan
- [x] `pnpm typecheck`, `pnpm lint` — clean
- [x] `pnpm exec vitest run` — 408/408 files, 3501 passed, 8 skipped
- [x] `pnpm build`, `pnpm audit`, `pnpm codegen:check`, `pnpm ask-dev:contracts:check` — clean
- [x] Playwright e2e default suite (250 tests), onboarding, context-fabric — all clean on a fresh non-nested checkout of this branch
- [x] `pagerduty-final-qa` suite: 4/23 tests fail identically on this branch AND on a fresh `origin/main` checkout under current environment load — confirmed pre-existing/environmental, unrelated to this diff
- [x] Codex adversarial review: APPROVE-WITH-NITS (no functional/authorization/secret-leakage defects; one P3 test-strength nit, fixed and mutation-verified)
- [x] Visual evidence captured (light/dark) for the stripped org Ask Dev tab, the new Platform Admin page, and the BYO preflight control