### PR TITLE
fix(ask-dev): harden cross-tenant isolation, focus management, and accessibility

### DIFF
--- a/src/components/ask-dev/AskDevAnswer.test.tsx
+++ b/src/components/ask-dev/AskDevAnswer.test.tsx
@@ -123,7 +123,9 @@ describe("AskDevAnswer citations", () => {
 
         expect(actions.expandEvidence).toHaveBeenCalledWith("evidence-internal-1", "answer-1");
         expect(await screen.findByText("The authorized evidence excerpt.")).toBeVisible();
-        await waitFor(() => expect(document.getElementById("ask-dev-evidence-1")).toHaveFocus());
+        await waitFor(() =>
+            expect(document.getElementById("ask-dev-evidence-answer-1-1")).toHaveFocus(),
+        );
 
         await user.click(
             screen.getByRole("button", {
@@ -133,7 +135,7 @@ describe("AskDevAnswer citations", () => {
 
         const metricDefinition = screen.getByText("Metric definition").closest("details");
         expect(metricDefinition).toHaveAttribute("open");
-        expect(document.getElementById("ask-dev-metric-1")).toHaveFocus();
+        expect(document.getElementById("ask-dev-metric-answer-1-1")).toHaveFocus();
         expect(screen.queryByText("evidence-internal-1")).not.toBeInTheDocument();
         expect(screen.queryByText("metric-internal-1")).not.toBeInTheDocument();
         expect(screen.getByText("Applies to Web application")).toBeVisible();
@@ -156,5 +158,103 @@ describe("AskDevAnswer citations", () => {
 
         expect(actions.expandEvidence).toHaveBeenCalledWith("evidence-internal-1", "answer-1");
         expect(await screen.findByText("The authorized evidence excerpt.")).toBeVisible();
+    });
+
+    it("scopes detail-panel and article ids to the answer id so multiple answers in a transcript never collide, and actually activates the second answer's panel", async () => {
+        const user = userEvent.setup();
+        const secondAnswer = { ...answer, answer_id: "answer-2" } as unknown as DevAnswer;
+        render(
+            <>
+                <AskDevAnswer answer={answer} />
+                <AskDevAnswer answer={secondAnswer} />
+            </>,
+        );
+
+        // Position-based ids (pre-fix: "ask-dev-evidence-1"/"ask-dev-metric-1")
+        // would collide across every answer in the transcript, so
+        // getElementById would silently resolve to the first answer's panel
+        // for both. Scoping by answer_id keeps each answer's ids unique.
+        expect(document.getElementById("ask-dev-evidence-answer-1-1")).toBeInTheDocument();
+        expect(document.getElementById("ask-dev-evidence-answer-2-1")).toBeInTheDocument();
+        expect(document.getElementById("ask-dev-metric-answer-1-1")).toBeInTheDocument();
+        expect(document.getElementById("ask-dev-metric-answer-2-1")).toBeInTheDocument();
+        expect(document.getElementById("ask-dev-answer-answer-1")).toBeInTheDocument();
+        expect(document.getElementById("ask-dev-answer-answer-2")).toBeInTheDocument();
+
+        // Each answer's "Evidence" section heading is linked via
+        // aria-labelledby to *that answer's own* heading id, not shared or
+        // swapped with the other answer's section.
+        const firstHeading = document.getElementById("ask-dev-evidence-heading-answer-1");
+        const secondHeading = document.getElementById("ask-dev-evidence-heading-answer-2");
+        expect(firstHeading?.closest("section")).toHaveAttribute(
+            "aria-labelledby",
+            "ask-dev-evidence-heading-answer-1",
+        );
+        expect(secondHeading?.closest("section")).toHaveAttribute(
+            "aria-labelledby",
+            "ask-dev-evidence-heading-answer-2",
+        );
+
+        // Both answers share the same underlying evidence_ref_id, so both
+        // citation buttons have the identical accessible name — activating
+        // the *second* answer's button must open and focus the second
+        // answer's own detail panel, never the first answer's.
+        const openButtons = screen.getAllByRole("button", {
+            name: "Open evidence citation 1 for claim",
+        });
+        expect(openButtons).toHaveLength(2);
+        await user.click(openButtons[1]!);
+
+        await waitFor(() =>
+            expect(document.getElementById("ask-dev-evidence-answer-2-1")).toHaveFocus(),
+        );
+        expect(document.getElementById("ask-dev-evidence-answer-1-1")).not.toHaveFocus();
+    });
+});
+
+describe("AskDevAnswer status explanations (CHAOS-3215)", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    beforeEach(() => {
+        Object.values(actions).forEach((action) => action.mockReset());
+    });
+
+    // Copy grounded in ops/docs/use/ai-workflows/index.md ("Ask Dev: window
+    // and full-page workspace"): "A partial, degraded, refused, or
+    // insufficient-evidence answer is a result with limitations, not a
+    // silent success."
+    it.each([
+        [
+            "partial",
+            "Partial: the investigation did not fully complete. A result with limitations, not a silent success.",
+        ],
+        [
+            "degraded",
+            "Degraded: part of the investigation could not complete as expected. A result with limitations, not a silent success.",
+        ],
+        [
+            "insufficient_evidence",
+            "Insufficient evidence: there isn't enough evidence to answer with confidence. A result with limitations, not a silent success.",
+        ],
+        [
+            "refused",
+            "Refused: Ask Dev did not answer this question. A result with limitations, not a silent success.",
+        ],
+    ] as const)("shows the sanctioned explanation for a %s answer", (status, expectedText) => {
+        const statusAnswer = { ...answer, status } as unknown as DevAnswer;
+        render(<AskDevAnswer answer={statusAnswer} />);
+
+        expect(screen.getByText(expectedText)).toBeVisible();
+    });
+
+    it("renders no status explanation for a complete answer", () => {
+        render(<AskDevAnswer answer={answer} />);
+
+        expect(screen.queryByText(/not a silent success/u)).not.toBeInTheDocument();
     });
 });

--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -19,6 +19,33 @@ function safeExcerpt(value: string | null | undefined): string | null {
     return value.replace(/^UNTRUSTED_DATA\r?\n/u, "").replace(/\r?\nEND_UNTRUSTED_DATA$/u, "");
 }
 
+// Grounded in the sanctioned framing from ops/docs/use/ai-workflows/index.md
+// ("Ask Dev: window and full-page workspace"): "A partial, degraded,
+// refused, or insufficient-evidence answer is a result with limitations,
+// not a silent success." `complete` needs no caption (no limitation to
+// explain). `error` is also intentionally absent, but for a different reason
+// than `complete`: AskDevConversation now routes any transcript entry whose
+// `answer.status === "error"` through the same failed/alert treatment as a
+// live run failure, so it is never rendered by this component at all
+// (CHAOS-3215 M-error-status).
+//
+// `partial`'s wording must not claim a specific cause: per
+// ops/src/dev_health_ops/api/dev/orchestrator.py (`_budget_answer`), PARTIAL
+// is also returned when the provider budget/round limit is reached with
+// *full* evidence coverage (available_source_count === required_source_count)
+// — not only when required evidence was unavailable. That specific claim
+// belongs to `insufficient_evidence`, where it is accurate.
+const STATUS_EXPLANATIONS: Partial<Record<DevAnswer["status"], string>> = {
+    partial:
+        "Partial: the investigation did not fully complete. A result with limitations, not a silent success.",
+    degraded:
+        "Degraded: part of the investigation could not complete as expected. A result with limitations, not a silent success.",
+    insufficient_evidence:
+        "Insufficient evidence: there isn't enough evidence to answer with confidence. A result with limitations, not a silent success.",
+    refused:
+        "Refused: Ask Dev did not answer this question. A result with limitations, not a silent success.",
+};
+
 function validityScopeLabel(scope: DevScope | null | undefined): string | null {
     if (!scope) return null;
     const namedEntity = scope.entity_refs?.find(
@@ -129,6 +156,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     );
     const [openMetricIds, setOpenMetricIds] = useState<ReadonlySet<string>>(() => new Set());
     const scopeResolution = answer.resolved_scope;
+    const statusExplanation = STATUS_EXPLANATIONS[answer.status];
     const evidenceById = useMemo(
         () =>
             new Map(
@@ -148,6 +176,22 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         [answer.metrics],
     );
 
+    // Detail-panel ids are scoped by answer.answer_id, not just position: a
+    // transcript can contain many answers, and position-only ids (e.g.
+    // "ask-dev-evidence-1") collide across every one of them, so
+    // focusDetail()/getElementById can jump focus to an earlier answer's panel
+    // instead of this one (CHAOS-3215 M6).
+    const evidenceAnchorId = (position: number) =>
+        `ask-dev-evidence-${answer.answer_id}-${position + 1}`;
+    const metricAnchorId = (position: number) =>
+        `ask-dev-metric-${answer.answer_id}-${position + 1}`;
+    // Section heading ids (used only for aria-labelledby) are static per
+    // section kind, so they need the same per-answer scoping to stay unique
+    // across a transcript with multiple answers.
+    const findingsHeadingId = `ask-dev-findings-${answer.answer_id}`;
+    const metricsHeadingId = `ask-dev-metrics-${answer.answer_id}`;
+    const evidenceHeadingId = `ask-dev-evidence-heading-${answer.answer_id}`;
+
     const focusDetail = (anchorId: string) => {
         requestAnimationFrame(() => {
             document.getElementById(anchorId)?.focus({ preventScroll: false });
@@ -157,7 +201,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     const openEvidenceDetail = async (evidenceRefId: string) => {
         const position = evidencePositionById.get(evidenceRefId);
         if (position === undefined || !evidenceById.has(evidenceRefId)) return;
-        const anchorId = `ask-dev-evidence-${position + 1}`;
+        const anchorId = evidenceAnchorId(position);
         setLoadingEvidenceIds((current) => new Set(current).add(evidenceRefId));
         setEvidenceErrors((current) => {
             const next = { ...current };
@@ -188,7 +232,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         const position = metricPositionById.get(metricRefId);
         if (position === undefined) return;
         setOpenMetricIds((current) => new Set(current).add(metricRefId));
-        focusDetail(`ask-dev-metric-${position + 1}`);
+        focusDetail(metricAnchorId(position));
     };
 
     const renderInlineCitations = (
@@ -253,7 +297,12 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     };
 
     return (
-        <article className="space-y-5" aria-label="Ask Dev answer">
+        <article
+            id={`ask-dev-answer-${answer.answer_id}`}
+            tabIndex={-1}
+            className="space-y-5 outline-none"
+            aria-label="Ask Dev answer"
+        >
             <div className="flex flex-wrap items-center gap-2">
                 <span className="rounded-(--radius-pill) bg-(--accent-ai)/12 px-2.5 py-1 text-label-caps text-(--accent-ai)">
                     AI-generated
@@ -265,6 +314,10 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                     As of {formatTimestamp(answer.as_of)}
                 </span>
             </div>
+
+            {statusExplanation ? (
+                <p className="text-xs text-(--text-muted)">{statusExplanation}</p>
+            ) : null}
 
             <p className="text-body leading-7 text-(--text-primary)">{answer.direct_summary}</p>
 
@@ -352,9 +405,9 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
             {answer.claims?.length ? (
                 <section
                     className="space-y-3 border-t border-(--border) pt-4"
-                    aria-labelledby="ask-dev-findings"
+                    aria-labelledby={findingsHeadingId}
                 >
-                    <h3 id="ask-dev-findings" className="text-label-caps text-(--text-muted)">
+                    <h3 id={findingsHeadingId} className="text-label-caps text-(--text-muted)">
                         What the evidence suggests
                     </h3>
                     <ul className="space-y-3">
@@ -426,16 +479,18 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
             {answer.metrics?.length ? (
                 <section
                     className="border-t border-(--border) pt-4"
-                    aria-labelledby="ask-dev-metrics"
+                    aria-labelledby={metricsHeadingId}
                 >
-                    <h3 id="ask-dev-metrics" className="text-label-caps text-(--text-muted)">
+                    <h3 id={metricsHeadingId} className="text-label-caps text-(--text-muted)">
                         Metrics
                     </h3>
                     <dl className="mt-2 divide-y divide-(--border)">
                         {answer.metrics.map((metric) => (
                             <div
                                 key={metric.metric_ref_id}
-                                id={`ask-dev-metric-${(metricPositionById.get(metric.metric_ref_id) ?? 0) + 1}`}
+                                id={metricAnchorId(
+                                    metricPositionById.get(metric.metric_ref_id) ?? 0,
+                                )}
                                 tabIndex={-1}
                                 className="scroll-mt-6 grid gap-1 py-3 outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-baseline"
                             >
@@ -513,16 +568,18 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
             {answer.evidence?.length ? (
                 <section
                     className="space-y-3 border-t border-(--border) pt-4"
-                    aria-labelledby="ask-dev-evidence"
+                    aria-labelledby={evidenceHeadingId}
                 >
-                    <h3 id="ask-dev-evidence" className="text-label-caps text-(--text-muted)">
+                    <h3 id={evidenceHeadingId} className="text-label-caps text-(--text-muted)">
                         Evidence
                     </h3>
                     <div className="space-y-4">
                         {answer.evidence.map((evidence) => (
                             <EvidenceRow
                                 key={evidence.evidence_ref_id}
-                                anchorId={`ask-dev-evidence-${(evidencePositionById.get(evidence.evidence_ref_id) ?? 0) + 1}`}
+                                anchorId={evidenceAnchorId(
+                                    evidencePositionById.get(evidence.evidence_ref_id) ?? 0,
+                                )}
                                 error={evidenceErrors[evidence.evidence_ref_id] ?? null}
                                 evidence={evidence}
                                 expansion={evidenceExpansions[evidence.evidence_ref_id] ?? null}

--- a/src/components/ask-dev/AskDevConversation.test.tsx
+++ b/src/components/ask-dev/AskDevConversation.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { AskDevConversation } from "./AskDevConversation";
+
+vi.mock("next/navigation", () => ({
+    usePathname: () => "/cockpit",
+    useRouter: () => ({ replace: vi.fn() }),
+    useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("./AskDevProvider", () => ({
+    useAskDev: () => ({
+        availability: { state: "ready" as const },
+        committedScopeLabel: null,
+        cancelRun: vi.fn(),
+        clearProposedContext: vi.fn(),
+        conversations: [],
+        deleteConversation: vi.fn(),
+        historyError: null,
+        historyLoading: false,
+        loadHistory: vi.fn(),
+        openConversation: vi.fn(),
+        proposedContext: null,
+        proposedQuestions: [],
+        proposedScope: {
+            schema_version: "dev_scope.v1",
+            organization_id: "org-1",
+            direct_scope: "organization",
+            repositories: [],
+            entity_refs: [],
+            team_ids: [],
+            time_range: {
+                start: "2026-06-29T00:00:00Z",
+                end: "2026-07-29T00:00:00Z",
+                timezone: "UTC",
+            },
+        },
+        proposedScopeLabel: "Organization",
+        renameConversation: vi.fn(),
+        retryLastQuestion: vi.fn(),
+        startNewConversation: vi.fn(),
+        stream: { phase: "idle" as const, delta: "", warnings: [], error: null, progress: null },
+        submitQuestion: vi.fn(),
+        transcript: [],
+    }),
+}));
+
+describe("AskDevConversation empty state (CHAOS-3215)", () => {
+    beforeAll(() => {
+        // jsdom does not implement scrollIntoView; the transcript-follow
+        // effect calls it unconditionally on mount (same stub used by
+        // AskDevProvider.test.tsx and AskDevTrigger.integration.test.tsx).
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it("frames the Ask Dev / Context Fabric relationship and links to the customer doc, opening in a new tab", () => {
+        const { container } = render(<AskDevConversation />);
+
+        // The lead-in sentence sits beside the link inside the same <p>, so
+        // it is checked against the rendered container text rather than via
+        // getByText — an exact/regex element match here would be ambiguous
+        // across the paragraph and its ancestors.
+        expect(container.textContent).toContain("Powered by Context Fabric.");
+
+        const link = screen.getByRole("link", { name: "Learn more — opens in new tab" });
+        expect(link).toHaveAttribute("href", "/docs/use/ai-workflows/");
+        expect(link).toHaveAttribute("target", "_blank");
+        expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+});

--- a/src/components/ask-dev/AskDevConversation.tsx
+++ b/src/components/ask-dev/AskDevConversation.tsx
@@ -6,6 +6,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { CTA_LABELS } from "@/lib/design/cta";
 import { decodeFilter, encodeFilterParam } from "@/lib/filters/encode";
 import { formatDateUTC } from "@/lib/formatters";
+import { runtimeConfig } from "@/lib/runtimeConfig";
 import { DataState } from "@/components/ui/DataState";
 
 import { AskDevAnswer } from "./AskDevAnswer";
@@ -62,14 +63,13 @@ export function AskDevConversation({
         historyLoading,
         loadHistory,
         openConversation,
+        orgId,
         proposedContext,
         proposedQuestions,
         proposedScope,
         proposedScopeLabel,
         renameConversation,
         retryLastQuestion,
-        retentionDays,
-        setRetentionDays,
         startNewConversation,
         stream,
         submitQuestion,
@@ -80,21 +80,117 @@ export function AskDevConversation({
     const [editingTitle, setEditingTitle] = useState("");
     const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
     const [historyActionError, setHistoryActionError] = useState<string | null>(null);
+    const [historyPanelOpen, setHistoryPanelOpen] = useState(false);
     const composerId = useId();
+    const historyPanelId = useId();
     const transcriptEnd = useRef<HTMLDivElement>(null);
+    const composerRef = useRef<HTMLTextAreaElement>(null);
+    const renameInputRef = useRef<HTMLInputElement>(null);
+    // Declared here (ahead of the effects below that reference it) rather than
+    // inline where it was originally introduced, so the org-switch reset
+    // effect can clear it too — see that effect's comment (CHAOS-3215).
+    const runInProgress = useRef(false);
     const pathname = usePathname();
     const router = useRouter();
     const searchParams = useSearchParams();
     const filters = useMemo(() => decodeFilter(searchParams.get("f")), [searchParams]);
     const allowanceGuidance = platformAllowanceGuidance(stream.error);
+    // "Powered by Context Fabric" is the sanctioned relationship framing
+    // (CHAOS-3215): Ask Dev is the customer interaction layer, Context
+    // Fabric Validation is a separate platform-administrator diagnostic
+    // surface. This links out to the customer doc for that relationship —
+    // never to the admin-only validation surface.
+    const askDevDocsHref = `${runtimeConfig.docsUrl()}/use/ai-workflows/`;
 
     useEffect(() => {
         if (showHistory && availability.state === "ready") void loadHistory();
     }, [availability.state, loadHistory, showHistory]);
 
+    // This conversation subtree owns its own draft/history-edit UI state, so
+    // the provider's organization-switch reset (which clears transcript,
+    // conversationId, etc. synchronously at render time) cannot reach it. An
+    // unsent draft typed under one organization must not persist after
+    // switching to another (CHAOS-3215 H1). `orgId` is exposed on context for
+    // exactly this purpose. This mirrors the provider's own render-time
+    // "adjusting state while rendering" reset (see AskDevProvider.tsx) rather
+    // than a `useEffect`, for the same reason: a passive effect fires only
+    // after the previous organization's draft has already been painted once.
+    const [previousOrgId, setPreviousOrgId] = useState(orgId);
+    if (orgId !== previousOrgId) {
+        setPreviousOrgId(orgId);
+        setDraft("");
+        setEditingConversationId(null);
+        setEditingTitle("");
+        setPendingDeleteId(null);
+        setHistoryActionError(null);
+        setHistoryPanelOpen(false);
+    }
+
+    // `runInProgress` is a ref, not visible state, so clearing it does not
+    // need (and per the project's lint rules, must not use) the render-time
+    // escape hatch above — a plain effect is fine here, unlike the setState
+    // calls above it.
+    useEffect(() => {
+        runInProgress.current = false;
+    }, [orgId]);
+
     useEffect(() => {
         transcriptEnd.current?.scrollIntoView({ block: "nearest" });
     }, [stream.delta, stream.phase, transcript]);
+
+    // The rAF focus-move callbacks below bail if the user has moved on to
+    // something else by the time they fire — either the composer (typing the
+    // next question) or the conversation-rename input (mid-edit of a saved
+    // title while a run streams in the background). Stealing focus from
+    // either would corrupt what the user is doing (CHAOS-3215 L2 / M-rename).
+    const isUserActivelyEditingElsewhere = () =>
+        document.activeElement === composerRef.current ||
+        document.activeElement === renameInputRef.current;
+
+    // Move keyboard focus to a newly-completed answer (or to the terminal
+    // failure alert) once a run that was actually running reaches a terminal
+    // state — mirrors AskDevAnswer's focusDetail() pattern (requestAnimationFrame
+    // + .focus() on a tabIndex={-1} element). Split into two effects because the
+    // "answer.completed" stream event (which flips stream.phase) and the actual
+    // transcript push happen on different renders: a single effect keyed on both
+    // dependencies would already have advanced its "was running" tracking ref
+    // past "running" by the time the transcript update it needs to react to
+    // arrives. `runInProgress` bridges that gap. Reopening a saved conversation
+    // never sets `runInProgress`, so it never steals focus (CHAOS-3215 L2).
+    useEffect(() => {
+        if (stream.phase === "running") {
+            runInProgress.current = true;
+            return;
+        }
+        if (!runInProgress.current) return;
+        if (stream.phase === "idle") {
+            // The run was superseded (an organization switch or "New
+            // conversation") rather than reaching a terminal state of its
+            // own — clear tracking without moving focus, otherwise a later,
+            // unrelated transcript-open could incorrectly steal focus by
+            // satisfying the effect below (CHAOS-3215 M-runInProgress).
+            runInProgress.current = false;
+            return;
+        }
+        if (stream.phase !== "failed") return;
+        runInProgress.current = false;
+        requestAnimationFrame(() => {
+            if (isUserActivelyEditingElsewhere()) return;
+            document.getElementById("ask-dev-run-failed")?.focus({ preventScroll: true });
+        });
+    }, [stream.phase]);
+
+    useEffect(() => {
+        if (!runInProgress.current) return;
+        const lastEntry = transcript[transcript.length - 1];
+        if (!lastEntry || lastEntry.role !== "assistant") return;
+        runInProgress.current = false;
+        const answerId = lastEntry.answer.answer_id;
+        requestAnimationFrame(() => {
+            if (isUserActivelyEditingElsewhere()) return;
+            document.getElementById(`ask-dev-answer-${answerId}`)?.focus({ preventScroll: true });
+        });
+    }, [transcript]);
 
     const submit = async () => {
         const question = draft.trim();
@@ -185,11 +281,33 @@ export function AskDevConversation({
 
     return (
         <div
-            className={`flex min-h-0 flex-1 ${showHistory ? "lg:grid lg:grid-cols-[15rem_minmax(0,1fr)]" : ""}`}
+            // Base `flex-col` stacks the mobile toggle bar, the (conditionally
+            // shown) history aside, and the conversation column vertically —
+            // without it these were unstyled row siblings below `lg`, so a
+            // narrow viewport could squeeze/collapse the primary workspace.
+            // `lg:grid` replaces that stacked layout with the two-column
+            // desktop layout (CHAOS-3215 M-mobile-layout).
+            className={`flex min-h-0 flex-1 flex-col ${showHistory ? "lg:grid lg:grid-cols-[15rem_minmax(0,1fr)]" : ""}`}
         >
             {showHistory ? (
+                <div className="border-b border-(--border) bg-(--surface)/65 px-4 py-2 lg:hidden">
+                    <button
+                        type="button"
+                        aria-expanded={historyPanelOpen}
+                        aria-controls={historyPanelId}
+                        onClick={() => setHistoryPanelOpen((open) => !open)}
+                        className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs font-medium text-(--text-secondary) transition hover:border-(--accent)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                    >
+                        {historyPanelOpen
+                            ? CTA_LABELS.hideAskDevHistory
+                            : CTA_LABELS.showAskDevHistory}
+                    </button>
+                </div>
+            ) : null}
+            {showHistory ? (
                 <aside
-                    className="hidden border-r border-(--border) bg-(--surface)/65 p-4 lg:block"
+                    id={historyPanelId}
+                    className={`${historyPanelOpen ? "block" : "hidden"} border-r border-(--border) bg-(--surface)/65 p-4 lg:block`}
                     aria-label="Ask Dev history"
                 >
                     <div className="flex items-center justify-between gap-2">
@@ -230,6 +348,7 @@ export function AskDevConversation({
                                                 Conversation title
                                             </label>
                                             <input
+                                                ref={renameInputRef}
                                                 id={`title-${conversation.conversation_id}`}
                                                 value={editingTitle}
                                                 onChange={(event) =>
@@ -391,9 +510,15 @@ export function AskDevConversation({
                     </div>
                 </div>
 
+                {/*
+                 * No aria-live here: the transcript's running/failed states carry
+                 * their own role="status"/role="alert" regions below, which
+                 * announce at coarse phase transitions. Wrapping the whole
+                 * scrollable transcript in aria-live would additionally announce
+                 * every streamed answer.delta chunk as it arrives (CHAOS-3215 M3).
+                 */}
                 <div
                     className={`min-h-0 flex-1 overflow-y-auto px-4 ${compact ? "py-4" : "py-6 sm:px-6"}`}
-                    aria-live="polite"
                     aria-label="Ask Dev transcript"
                 >
                     {transcript.length === 0 && stream.phase === "idle" ? (
@@ -407,6 +532,28 @@ export function AskDevConversation({
                             <p className="mt-3 text-sm leading-6 text-(--text-secondary)">
                                 Ask Dev works from persisted metrics and evidence. It shows the
                                 scope it used and calls out missing or stale sources.
+                            </p>
+                            <p className="mt-2 text-xs text-(--text-muted)">
+                                Powered by Context Fabric.{" "}
+                                {/*
+                                 * Plain <a>, not next/link's <Link>: this
+                                 * points at the separately-hosted customer
+                                 * docs site (a different origin from the
+                                 * app), and Link's client-side route
+                                 * normalization can rewrite the target path
+                                 * (e.g. trailing-slash handling) in ways that
+                                 * do not apply to genuinely external URLs.
+                                 */}
+                                <a
+                                    href={askDevDocsHref}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    aria-label={`${CTA_LABELS.viewAskDevDocs} — opens in new tab`}
+                                    className="font-medium text-(--accent) underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                                >
+                                    {CTA_LABELS.viewAskDevDocs}
+                                    <span aria-hidden="true"> ↗</span>
+                                </a>
                             </p>
                             {proposedQuestions.length ? (
                                 <div
@@ -439,6 +586,29 @@ export function AskDevConversation({
                                         <div className="rounded-(--radius-lg) rounded-br-(--radius-sm) bg-(--accent)/13 px-4 py-3 text-sm leading-6 text-(--text-primary)">
                                             {entry.text}
                                         </div>
+                                    ) : entry.answer.status === "error" ? (
+                                        // A persisted answer with `status: "error"` must render
+                                        // through the same failed/alert treatment as a live run
+                                        // failure, not as ordinary completed output — otherwise
+                                        // a genuine failure reads as a silent success (CHAOS-3215
+                                        // M-error-status). Reuses the same id convention
+                                        // (`ask-dev-answer-<id>`) that AskDevAnswer would have
+                                        // used, so the completion focus-move effect above still
+                                        // finds it.
+                                        <div
+                                            id={`ask-dev-answer-${entry.answer.answer_id}`}
+                                            tabIndex={-1}
+                                            className="rounded-(--radius-md) border border-(--negative)/30 bg-(--negative)/8 p-4 outline-none"
+                                            role="alert"
+                                        >
+                                            <p className="text-sm font-medium text-(--negative)">
+                                                The investigation stopped safely.
+                                            </p>
+                                            <p className="mt-1 text-sm text-(--text-secondary)">
+                                                {entry.answer.direct_summary ||
+                                                    "Ask Dev could not complete that request."}
+                                            </p>
+                                        </div>
                                     ) : (
                                         <AskDevAnswer answer={entry.answer} />
                                     )}
@@ -446,25 +616,39 @@ export function AskDevConversation({
                             ))}
 
                             {stream.phase === "running" ? (
-                                <li
-                                    className="space-y-3 border-l-2 border-(--accent-ai)/45 pl-4"
-                                    role="status"
-                                >
-                                    <p className="text-sm font-medium text-(--text-primary)">
-                                        {stream.progress
-                                            ? (PROGRESS_LABELS[stream.progress] ?? "Investigating")
-                                            : "Starting the investigation"}
-                                    </p>
-                                    {stream.delta ? (
-                                        <p className="whitespace-pre-wrap text-sm leading-6 text-(--text-secondary)">
-                                            {stream.delta}
+                                <li className="space-y-3 border-l-2 border-(--accent-ai)/45 pl-4">
+                                    {/*
+                                     * The interactive Cancel button below is deliberately kept
+                                     * outside this role="status" region: an interactive element
+                                     * inside a live region can be difficult for assistive
+                                     * technology to operate, since the region may re-announce
+                                     * around it. Only the announced progress text lives inside
+                                     * (CHAOS-3215 L-cancel-live-region).
+                                     */}
+                                    <div role="status" className="space-y-3">
+                                        <p className="text-sm font-medium text-(--text-primary)">
+                                            {stream.progress
+                                                ? (PROGRESS_LABELS[stream.progress] ??
+                                                  "Investigating")
+                                                : "Starting the investigation"}
                                         </p>
-                                    ) : (
-                                        <div
-                                            className="h-2 w-32 animate-pulse rounded-(--radius-pill) bg-(--accent-ai)/25"
-                                            aria-hidden="true"
-                                        />
-                                    )}
+                                        {/*
+                                         * Streamed delta text is visually rendered but excluded
+                                         * from the announced role="status" region (aria-hidden) —
+                                         * only the progress label above should be announced, at
+                                         * phase transitions, not on every answer.delta chunk
+                                         * (CHAOS-3215 M3).
+                                         */}
+                                        <div aria-hidden="true">
+                                            {stream.delta ? (
+                                                <p className="whitespace-pre-wrap text-sm leading-6 text-(--text-secondary)">
+                                                    {stream.delta}
+                                                </p>
+                                            ) : (
+                                                <div className="h-2 w-32 animate-pulse rounded-(--radius-pill) bg-(--accent-ai)/25 motion-reduce:animate-none" />
+                                            )}
+                                        </div>
+                                    </div>
                                     <button
                                         type="button"
                                         onClick={cancelRun}
@@ -477,7 +661,9 @@ export function AskDevConversation({
 
                             {stream.phase === "failed" ? (
                                 <li
-                                    className="rounded-(--radius-md) border border-(--negative)/30 bg-(--negative)/8 p-4"
+                                    id="ask-dev-run-failed"
+                                    tabIndex={-1}
+                                    className="rounded-(--radius-md) border border-(--negative)/30 bg-(--negative)/8 p-4 outline-none"
                                     role="alert"
                                 >
                                     <p className="text-sm font-medium text-(--negative)">
@@ -526,6 +712,7 @@ export function AskDevConversation({
                     </label>
                     <div className="flex items-end gap-2 rounded-(--radius-lg) border border-(--border) bg-(--background)/75 p-2 focus-within:border-(--accent)/60 focus-within:ring-2 focus-within:ring-(--accent)/15">
                         <textarea
+                            ref={composerRef}
                             id={composerId}
                             value={draft}
                             onChange={(event) => setDraft(event.target.value)}
@@ -549,23 +736,17 @@ export function AskDevConversation({
                             {CTA_LABELS.askDev}
                         </button>
                     </div>
-                    <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-(--text-muted)">
+                    {/*
+                     * No per-conversation retention selector: retention is an
+                     * org-admin-only 0/30-day policy (PATCH
+                     * /api/v1/admin/ask-dev/settings). The backend always applied
+                     * org policy and silently ignored any per-conversation
+                     * `retention_days` sent from here, so the selector was a
+                     * misleading affordance — removed per CHAOS-3215 M7 /
+                     * CHAOS-3217.
+                     */}
+                    <div className="mt-2 text-xs text-(--text-muted)">
                         <span>Enter to ask · Shift+Enter for a new line</span>
-                        <label className="flex items-center gap-2">
-                            History
-                            <select
-                                value={retentionDays}
-                                onChange={(event) =>
-                                    setRetentionDays(event.target.value === "0" ? 0 : 30)
-                                }
-                                disabled={transcript.length > 0}
-                                className="rounded-(--radius-sm) border border-(--border) bg-(--surface) px-2 py-1 text-xs text-(--text-secondary)"
-                                aria-label="Conversation retention"
-                            >
-                                <option value="30">30 days</option>
-                                <option value="0">Do not retain</option>
-                            </select>
-                        </label>
                     </div>
                 </form>
             </div>

--- a/src/components/ask-dev/AskDevProvider.test.tsx
+++ b/src/components/ask-dev/AskDevProvider.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLayoutEffect } from "react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { DevApiClient } from "@/lib/dev/client";
+import type { DevApiClient, DevConversationList } from "@/lib/dev/client";
 import type {
     DevAnswer,
     DevConversation,
@@ -104,6 +105,22 @@ function makeClient(): DevApiClient {
     };
 }
 
+/**
+ * Fires a `useLayoutEffect`, which always runs before any passive
+ * `useEffect` in the same commit (regardless of tree position). This lets a
+ * test observe the DOM exactly as of commit — before any `useEffect`
+ * (including AskDevProvider's own post-commit cleanup effect) has run — which
+ * is what actually distinguishes "cleared synchronously during render" from
+ * "cleared by a passive effect that RTL's `act()`-wrapped `rerender()` would
+ * flush before assertions run anyway" (CHAOS-3215 H1).
+ */
+function LayoutProbe({ onLayout }: { onLayout: () => void }) {
+    useLayoutEffect(() => {
+        onLayout();
+    });
+    return null;
+}
+
 describe("AskDevProvider permanent window", () => {
     beforeAll(() => {
         Element.prototype.scrollIntoView = vi.fn();
@@ -113,6 +130,12 @@ describe("AskDevProvider permanent window", () => {
         navigation.pathname = "/dashboard";
         navigation.query = "";
         navigation.replace.mockClear();
+    });
+
+    afterEach(() => {
+        // jsdom does not implement matchMedia by default; remove any per-test stub.
+        // @ts-expect-error test cleanup
+        delete window.matchMedia;
     });
 
     it("opens without creating a conversation or submitting a run", async () => {
@@ -238,6 +261,52 @@ describe("AskDevProvider permanent window", () => {
         expect(await screen.findByText("Ask Dev is currently unavailable")).toBeVisible();
         expect(client.createConversation).not.toHaveBeenCalled();
         expect(client.streamMessage).not.toHaveBeenCalled();
+    });
+
+    it("hides the permanent launcher after switching from an available organization to a genuinely disabled one (CHAOS-3215)", async () => {
+        const client = makeClient();
+        // First call (org-1, on mount) resolves ready; second call (org-2,
+        // after the org switch) resolves disabled. `everAvailable` latching
+        // permanently `true` from org-1's "ready" state must not survive
+        // org-2's resolved "disabled" capabilities — the launcher is a
+        // control surface, not just conversation content, and must be fully
+        // absent once we know org-2 was never actually available.
+        vi.mocked(client.getCapabilities)
+            .mockResolvedValueOnce({
+                schema_version: "dev_capabilities.v1",
+                ask_dev: true,
+                can_read: true,
+                readiness: "ready",
+            })
+            .mockResolvedValueOnce({
+                schema_version: "dev_capabilities.v1",
+                ask_dev: false,
+                can_read: false,
+                readiness: "disabled",
+            });
+        const rendered = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        // Confirm org-1 actually reached "ready" (and not just "loading"),
+        // which is what latches `everAvailable` to true in the first place.
+        expect(await screen.findByRole("button", { name: "Open Ask Dev" })).toBeVisible();
+
+        // The provider is mounted once in the app shell layout; switching
+        // organizations updates the `orgId` prop on this already-mounted
+        // instance rather than remounting it.
+        rendered.rerender(
+            <AskDevProvider client={client} orgId="org-2">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await waitFor(() => expect(client.getCapabilities).toHaveBeenCalledTimes(2));
+        await waitFor(() =>
+            expect(screen.queryByRole("button", { name: "Open Ask Dev" })).not.toBeInTheDocument(),
+        );
     });
 
     it("shows the same controlled remediation in the window and /dev when not ready", async () => {
@@ -651,6 +720,735 @@ describe("AskDevProvider permanent window", () => {
         expect(client.getConversationTranscript).not.toHaveBeenCalledWith(
             "conversation-first",
             expect.anything(),
+        );
+    });
+
+    it("resets conversation, transcript, and history when the active organization changes (CHAOS-3215 H1)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        const rendered = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What remains?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+        expect(await screen.findByText(answer.direct_summary)).toBeVisible();
+        expect(client.createConversation).toHaveBeenCalledOnce();
+
+        // The provider is mounted once in the app shell layout; switching
+        // organizations updates the `orgId` prop on this already-mounted
+        // instance (via router.refresh()) rather than remounting it.
+        rendered.rerender(
+            <AskDevProvider client={client} orgId="org-2">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        // The window itself (UI-only state) stays open, but every
+        // conversation-scoped piece of state must be gone. Availability also
+        // fails closed to a loading state until the new organization's
+        // capabilities are (re)fetched (CHAOS-3215 M-capabilities), so the
+        // conversation UI itself only reappears once that resolves.
+        expect(screen.getByRole("region", { name: "Ask Dev" })).toBeVisible();
+        expect(screen.queryByText(answer.direct_summary)).not.toBeInTheDocument();
+        expect(screen.getByText("Checking Ask Dev availability…")).toBeVisible();
+
+        expect(await screen.findByText("Committed scope:")).toHaveTextContent(
+            "Commits when you ask",
+        );
+
+        await user.type(
+            screen.getByRole("textbox", { name: "Ask Dev question" }),
+            "New org question",
+        );
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+        await waitFor(() => expect(client.createConversation).toHaveBeenCalledTimes(2));
+    });
+
+    it("does not let a superseded conversation-creation response overwrite a reset conversation (CHAOS-3215 H2)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        let resolveStaleCreate!: (value: DevConversation) => void;
+        const staleCreate = new Promise<DevConversation>((resolve) => {
+            resolveStaleCreate = resolve;
+        });
+        const staleConversation = { ...conversation, conversation_id: "conversation-stale" };
+        const freshConversation = { ...conversation, conversation_id: "conversation-fresh" };
+        vi.mocked(client.createConversation)
+            .mockImplementationOnce(() => staleCreate)
+            .mockResolvedValueOnce(freshConversation);
+        navigation.pathname = "/dev";
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        await user.type(
+            await screen.findByRole("textbox", { name: "Ask Dev question" }),
+            "First question",
+        );
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        // Reset while the first conversation-creation request is still in flight.
+        await user.click(await screen.findByRole("button", { name: "New conversation" }));
+        resolveStaleCreate(staleConversation);
+        await waitFor(() => expect(client.createConversation).toHaveBeenCalledTimes(1));
+
+        await user.type(
+            screen.getByRole("textbox", { name: "Ask Dev question" }),
+            "Second question",
+        );
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        await waitFor(() => expect(client.createConversation).toHaveBeenCalledTimes(2));
+        expect(client.streamMessage).toHaveBeenCalledWith(
+            "conversation-fresh",
+            expect.objectContaining({ question: "Second question" }),
+            expect.anything(),
+        );
+        expect(client.streamMessage).not.toHaveBeenCalledWith(
+            "conversation-stale",
+            expect.anything(),
+            expect.anything(),
+        );
+    });
+
+    it("moves focus to the newly-completed answer when a run finishes (CHAOS-3215 L2)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What remains?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        await waitFor(() =>
+            expect(document.getElementById(`ask-dev-answer-${answer.answer_id}`)).toHaveFocus(),
+        );
+    });
+
+    it("keeps streamed answer deltas out of the announced live region (CHAOS-3215 M3)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        vi.mocked(client.streamMessage).mockImplementationOnce(
+            (_conversationId, _request, options) =>
+                new Promise<DevAnswer>(() => {
+                    options?.onEvent?.({
+                        event: "run.started",
+                        run_id: "run-delta",
+                        sequence: 0,
+                    } as DevStreamEvent);
+                    options?.onEvent?.({
+                        event: "answer.delta",
+                        delta: "Partial ",
+                        run_id: "run-delta",
+                        sequence: 1,
+                    } as DevStreamEvent);
+                    options?.onEvent?.({
+                        event: "answer.delta",
+                        delta: "streamed text",
+                        run_id: "run-delta",
+                        sequence: 2,
+                    } as DevStreamEvent);
+                    // Intentionally never resolves: keeps the run "running" so the
+                    // transcript still shows the streamed delta.
+                }),
+        );
+        const { container } = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What changed?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        const deltaText = await screen.findByText("Partial streamed text");
+        const transcriptRegion = container.querySelector('[aria-label="Ask Dev transcript"]');
+        expect(transcriptRegion).not.toBeNull();
+        expect(transcriptRegion).not.toHaveAttribute("aria-live");
+        expect(deltaText.closest('[aria-hidden="true"]')).not.toBeNull();
+    });
+
+    it("disables the thinking pulse animation under prefers-reduced-motion (CHAOS-3215 L1)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        vi.mocked(client.streamMessage).mockImplementationOnce(
+            (_conversationId, _request, options) =>
+                new Promise<DevAnswer>(() => {
+                    options?.onEvent?.({
+                        event: "run.started",
+                        run_id: "run-pulse",
+                        sequence: 0,
+                    } as DevStreamEvent);
+                }),
+        );
+        const { container } = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What changed?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        const pulse = await waitFor(() => {
+            const found = container.querySelector(".animate-pulse");
+            expect(found).not.toBeNull();
+            return found!;
+        });
+        expect(pulse).toHaveClass("motion-reduce:animate-none");
+    });
+
+    it("exposes a togglable history panel instead of hard-hiding controls below `lg` (CHAOS-3215 M4)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        vi.mocked(client.listConversations).mockResolvedValue({
+            items: [
+                {
+                    conversation_id: "conversation-1",
+                    direct_scope: "organization",
+                    message_count: 1,
+                    schema_version: "dev_conversation_summary.v1",
+                    state: "active",
+                    title: "Delivery status",
+                    updated_at: "2026-07-29T00:00:00Z",
+                },
+            ],
+            next_cursor: null,
+        });
+        navigation.pathname = "/dev";
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        const toggle = await screen.findByRole("button", { name: "Show conversations" });
+        expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+        await user.click(toggle);
+
+        expect(await screen.findByRole("button", { name: "Hide conversations" })).toHaveAttribute(
+            "aria-expanded",
+            "true",
+        );
+        expect(await screen.findByRole("button", { name: /Delivery status/i })).toBeVisible();
+    });
+
+    it("applies modal dialog semantics and traps Tab focus only when the window renders full-screen on mobile (CHAOS-3215 M5)", async () => {
+        Object.defineProperty(window, "matchMedia", {
+            writable: true,
+            configurable: true,
+            value: vi.fn().mockImplementation((query: string) => ({
+                matches: true,
+                media: query,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+            })),
+        });
+        const user = userEvent.setup();
+        const client = makeClient();
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+
+        const dialog = screen.getByRole("dialog", { name: "Ask Dev" });
+        expect(dialog).toHaveAttribute("aria-modal", "true");
+
+        const workspaceLink = screen.getByRole("link", { name: "Ask Dev workspace" });
+        const composer = screen.getByRole("textbox", { name: "Ask Dev question" });
+
+        workspaceLink.focus();
+        fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+        expect(composer).toHaveFocus();
+
+        composer.focus();
+        fireEvent.keyDown(dialog, { key: "Tab" });
+        expect(workspaceLink).toHaveFocus();
+    });
+
+    it("does not apply modal dialog semantics to the docked desktop panel (CHAOS-3215 M5)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+
+        expect(screen.queryByRole("dialog", { name: "Ask Dev" })).not.toBeInTheDocument();
+        expect(screen.getByRole("region", { name: "Ask Dev" })).toBeInTheDocument();
+    });
+
+    it("removes the per-conversation retention selector (CHAOS-3215 M7)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+
+        expect(screen.queryByLabelText("Conversation retention")).not.toBeInTheDocument();
+        expect(screen.queryByText("Do not retain")).not.toBeInTheDocument();
+
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What remains?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        expect(await screen.findByText(answer.direct_summary)).toBeVisible();
+        expect(client.createConversation).toHaveBeenCalledWith(
+            expect.not.objectContaining({ retention_days: expect.anything() }),
+            expect.anything(),
+        );
+    });
+
+    it("clears the previous organization's transcript synchronously at render time, before any passive effect can run (CHAOS-3215 H1)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        const probe = { org2: false, sawStaleAnswerAtLayoutTime: null as boolean | null };
+        const onLayout = () => {
+            if (!probe.org2) return;
+            probe.sawStaleAnswerAtLayoutTime =
+                document.body.textContent?.includes(answer.direct_summary) ?? false;
+        };
+        const rendered = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+                <LayoutProbe onLayout={onLayout} />
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What remains?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+        expect(await screen.findByText(answer.direct_summary)).toBeVisible();
+
+        probe.org2 = true;
+        rendered.rerender(
+            <AskDevProvider client={client} orgId="org-2">
+                <main>Dashboard</main>
+                <LayoutProbe onLayout={onLayout} />
+            </AskDevProvider>,
+        );
+
+        // A `useLayoutEffect` in this same commit already observed the DOM
+        // with the previous organization's answer gone — proving the reset
+        // did not depend on any `useEffect` having fired yet.
+        expect(probe.sawStaleAnswerAtLayoutTime).toBe(false);
+    });
+
+    it("clears an unsent composer draft when the active organization changes (CHAOS-3215 H1)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        const rendered = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        const composer = screen.getByRole("textbox", { name: "Ask Dev question" });
+        await user.type(composer, "Unsent draft under org 1");
+        expect(composer).toHaveValue("Unsent draft under org 1");
+
+        rendered.rerender(
+            <AskDevProvider client={client} orgId="org-2">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        // Availability fails closed to a loading state until the new
+        // organization's capabilities resolve (CHAOS-3215 M-capabilities); the
+        // composer only reappears once that settles, and it must come back
+        // empty.
+        expect(await screen.findByRole("textbox", { name: "Ask Dev question" })).toHaveValue("");
+    });
+
+    it("does not let a delayed history response from the previous organization repopulate conversation titles after an org switch (CHAOS-3215 H2)", async () => {
+        const client = makeClient();
+        let resolveOrg1History!: (value: DevConversationList) => void;
+        const org1History = new Promise<DevConversationList>((resolve) => {
+            resolveOrg1History = resolve;
+        });
+        vi.mocked(client.listConversations).mockReturnValueOnce(org1History);
+        navigation.pathname = "/dev";
+        const rendered = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        await waitFor(() => expect(client.listConversations).toHaveBeenCalledTimes(1));
+
+        rendered.rerender(
+            <AskDevProvider client={client} orgId="org-2">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        vi.mocked(client.listConversations).mockResolvedValueOnce({
+            items: [
+                {
+                    conversation_id: "org-2-conv",
+                    direct_scope: "organization",
+                    message_count: 1,
+                    schema_version: "dev_conversation_summary.v1",
+                    state: "active",
+                    title: "Org 2 investigation",
+                    updated_at: "2026-07-29T00:00:00Z",
+                },
+            ],
+            next_cursor: null,
+        });
+
+        // The org-1 request resolves *after* the switch to org-2.
+        resolveOrg1History({
+            items: [
+                {
+                    conversation_id: "org-1-conv",
+                    direct_scope: "organization",
+                    message_count: 1,
+                    schema_version: "dev_conversation_summary.v1",
+                    state: "active",
+                    title: "Org 1 investigation",
+                    updated_at: "2026-07-29T00:00:00Z",
+                },
+            ],
+            next_cursor: null,
+        });
+
+        await waitFor(() => expect(client.listConversations).toHaveBeenCalledTimes(2));
+        expect(await screen.findByText(/Org 2 investigation/i)).toBeVisible();
+        expect(screen.queryByText(/Org 1 investigation/i)).not.toBeInTheDocument();
+    });
+
+    it("refetches capabilities for the newly active organization and fails closed until they resolve (CHAOS-3215 M-capabilities)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        const rendered = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        expect(screen.getByRole("textbox", { name: "Ask Dev question" })).toBeVisible();
+
+        let resolveOrg2!: (value: Awaited<ReturnType<DevApiClient["getCapabilities"]>>) => void;
+        const org2Capabilities = new Promise<Awaited<ReturnType<DevApiClient["getCapabilities"]>>>(
+            (resolve) => {
+                resolveOrg2 = resolve;
+            },
+        );
+        vi.mocked(client.getCapabilities).mockReturnValueOnce(org2Capabilities);
+
+        rendered.rerender(
+            <AskDevProvider client={client} orgId="org-2">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        // Fails closed the instant the org changes: the previous
+        // organization's "ready" composer must not still be shown while the
+        // new organization's capabilities are pending.
+        expect(screen.queryByRole("textbox", { name: "Ask Dev question" })).not.toBeInTheDocument();
+        expect(screen.getByText("Checking Ask Dev availability…")).toBeVisible();
+
+        resolveOrg2({
+            schema_version: "dev_capabilities.v1",
+            ask_dev: true,
+            can_read: true,
+            readiness: "ready",
+        });
+
+        expect(await screen.findByRole("textbox", { name: "Ask Dev question" })).toBeVisible();
+        expect(client.getCapabilities).toHaveBeenCalledTimes(2);
+    });
+
+    it("renders an error-status answer through the failed-run alert treatment instead of as ordinary completed output (CHAOS-3215 M-error-status)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        const errorAnswer = {
+            ...answer,
+            answer_id: "answer-error-1",
+            status: "error",
+            direct_summary: "Ask Dev could not validate the retrieved evidence safely.",
+        } as unknown as DevAnswer;
+        vi.mocked(client.streamMessage).mockImplementationOnce(
+            async (_conversationId, _request, options) => {
+                options?.onEvent?.({
+                    event: "run.started",
+                    run_id: "run-error",
+                    sequence: 0,
+                } as DevStreamEvent);
+                options?.onEvent?.({
+                    event: "answer.completed",
+                    answer: errorAnswer,
+                    run_id: "run-error",
+                    sequence: 1,
+                } as DevStreamEvent);
+                return errorAnswer;
+            },
+        );
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What failed?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        const alert = await screen.findByRole("alert");
+        expect(alert).toHaveTextContent(errorAnswer.direct_summary);
+        expect(screen.queryByText("AI-generated")).not.toBeInTheDocument();
+    });
+
+    it("does not let a superseded run steal focus from a later-opened saved conversation (CHAOS-3215 M-runInProgress)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        vi.mocked(client.streamMessage).mockImplementationOnce(
+            (_conversationId, _request, options) =>
+                new Promise<DevAnswer>(() => {
+                    options?.onEvent?.({
+                        event: "run.started",
+                        run_id: "run-superseded",
+                        sequence: 0,
+                    } as DevStreamEvent);
+                    // Intentionally never resolves: the run stays "running"
+                    // until "New conversation" supersedes it.
+                }),
+        );
+        vi.mocked(client.listConversations).mockResolvedValue({
+            items: [
+                {
+                    conversation_id: "conversation-1",
+                    direct_scope: "organization",
+                    message_count: 1,
+                    schema_version: "dev_conversation_summary.v1",
+                    state: "active",
+                    title: "Delivery status",
+                    updated_at: "2026-07-29T00:00:00Z",
+                },
+            ],
+            next_cursor: null,
+        });
+        vi.mocked(client.getConversation).mockResolvedValue(conversation);
+        vi.mocked(client.getConversationTranscript).mockResolvedValue({
+            conversation_id: "conversation-1",
+            items: [
+                {
+                    answer,
+                    created_at: "2026-07-29T00:00:00Z",
+                    message_id: "message-1",
+                    question: null,
+                    retry_of_run_id: null,
+                    role: "assistant",
+                    run_id: "run-original",
+                    run_state: "completed",
+                    schema_version: "dev_transcript_entry.v1",
+                    scope: null,
+                },
+            ],
+            next_cursor: null,
+            schema_version: "dev_conversation_transcript.v1",
+        });
+        navigation.pathname = "/dev";
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        await user.type(
+            await screen.findByRole("textbox", { name: "Ask Dev question" }),
+            "What remains?",
+        );
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+        await waitFor(() => expect(client.streamMessage).toHaveBeenCalledOnce());
+
+        await user.click(await screen.findByRole("button", { name: "New conversation" }));
+        await user.click(await screen.findByRole("button", { name: /Delivery status/i }));
+
+        expect(await screen.findByText(answer.direct_summary)).toBeVisible();
+        expect(document.getElementById(`ask-dev-answer-${answer.answer_id}`)).not.toHaveFocus();
+    });
+
+    it("does not let a delayed delete-conversation completion from the previous organization clear the new organization's active state (CHAOS-3215 M-delete)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        vi.mocked(client.listConversations).mockResolvedValue({
+            items: [
+                {
+                    conversation_id: "conversation-1",
+                    direct_scope: "organization",
+                    message_count: 1,
+                    schema_version: "dev_conversation_summary.v1",
+                    state: "active",
+                    title: "Delivery status",
+                    updated_at: "2026-07-29T00:00:00Z",
+                },
+            ],
+            next_cursor: null,
+        });
+        let resolveDelete!: () => void;
+        vi.mocked(client.deleteConversation).mockImplementationOnce(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveDelete = resolve;
+                }),
+        );
+        navigation.pathname = "/dev";
+        const rendered = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        await screen.findByRole("button", { name: /Delivery status/i });
+        await user.click(screen.getByRole("button", { name: "Delete" }));
+        await user.click(screen.getByRole("button", { name: "Confirm delete?" }));
+        expect(client.deleteConversation).toHaveBeenCalledOnce();
+
+        rendered.rerender(
+            <AskDevProvider client={client} orgId="org-2">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        // Give org-2 an active, completed answer before the stale org-1
+        // delete resolves.
+        await user.type(
+            await screen.findByRole("textbox", { name: "Ask Dev question" }),
+            "Org 2 question",
+        );
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+        expect(await screen.findByText(answer.direct_summary)).toBeVisible();
+
+        resolveDelete();
+        await waitFor(() => expect(client.deleteConversation).toHaveBeenCalledOnce());
+
+        // The stale org-1 delete completion must not have cleared org-2's
+        // freshly-completed answer.
+        expect(screen.getByText(answer.direct_summary)).toBeVisible();
+    });
+
+    it("aborts the active request when the provider unmounts (CHAOS-3215 M-unmount)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        let capturedSignal: AbortSignal | undefined;
+        vi.mocked(client.streamMessage).mockImplementationOnce(
+            (_conversationId, _request, options) =>
+                new Promise<DevAnswer>(() => {
+                    capturedSignal = options?.signal;
+                    options?.onEvent?.({
+                        event: "run.started",
+                        run_id: "run-unmount",
+                        sequence: 0,
+                    } as DevStreamEvent);
+                    // Intentionally never resolves.
+                }),
+        );
+        const rendered = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What remains?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+        await waitFor(() => expect(capturedSignal).toBeDefined());
+        expect(capturedSignal?.aborted).toBe(false);
+
+        rendered.unmount();
+
+        expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it("moves focus into the panel when a desktop-open window becomes mobile-modal on resize (CHAOS-3215 M5)", async () => {
+        // Held on an object (rather than bare `let`s) so TypeScript's control
+        // flow analysis doesn't narrow these to `never` at the point they are
+        // read below — they are only ever reassigned from inside a nested
+        // closure that TS cannot prove runs before that read.
+        const media: {
+            query: { matches: boolean } | null;
+            changeListener: (() => void) | null;
+        } = { query: null, changeListener: null };
+        // Cast the target to a loosely-typed object so `Object.defineProperty`'s
+        // generic inference doesn't contextually type `value` against the real
+        // `Window["matchMedia"]`/`MediaQueryList` DOM signatures — this stub
+        // intentionally implements only the subset `AskDevWindow` reads.
+        Object.defineProperty(window as unknown as Record<string, unknown>, "matchMedia", {
+            writable: true,
+            configurable: true,
+            value: vi.fn().mockImplementation((query: string) => {
+                const mediaQueryList = {
+                    matches: false,
+                    media: query,
+                    addEventListener: (_event: string, listener: () => void) => {
+                        media.changeListener = listener;
+                    },
+                    removeEventListener: () => {
+                        media.changeListener = null;
+                    },
+                };
+                media.query = mediaQueryList;
+                return mediaQueryList;
+            }),
+        });
+        const user = userEvent.setup();
+        const client = makeClient();
+        render(
+            <div>
+                <button type="button">Somewhere else</button>
+                <AskDevProvider client={client} orgId="org-1">
+                    <main>Dashboard</main>
+                </AskDevProvider>
+            </div>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        expect(screen.queryByRole("dialog", { name: "Ask Dev" })).not.toBeInTheDocument();
+
+        // While the panel is still docked/non-modal on desktop, focus can
+        // legitimately be elsewhere in the app — the desktop panel is
+        // intentionally non-modal.
+        const elsewhere = screen.getByRole("button", { name: "Somewhere else" });
+        elsewhere.focus();
+        expect(elsewhere).toHaveFocus();
+
+        if (media.query) media.query.matches = true;
+        media.changeListener?.();
+
+        const dialog = await screen.findByRole("dialog", { name: "Ask Dev" });
+        await waitFor(() => expect(dialog).toHaveFocus());
+
+        // The close/restore-focus path still works once modal: Escape closes
+        // the panel and returns focus to the launcher.
+        fireEvent.keyDown(dialog, { key: "Escape" });
+        await waitFor(() =>
+            expect(screen.getByRole("button", { name: "Open Ask Dev" })).toHaveFocus(),
         );
     });
 });

--- a/src/components/ask-dev/AskDevProvider.tsx
+++ b/src/components/ask-dev/AskDevProvider.tsx
@@ -81,13 +81,13 @@ type AskDevContextValue = {
     conversations: DevConversationList["items"];
     historyError: string | null;
     historyLoading: boolean;
+    orgId: string;
     panelMode: AskDevPanelMode;
     persistentReturnHref: string;
     proposedContext: AskDevSurfaceContext | null;
     proposedScope: DevScope;
     proposedScopeLabel: string;
     proposedQuestions: readonly { id: string; label: string }[];
-    retentionDays: 0 | 30;
     stream: typeof initialDevConversationStreamState;
     transcript: AskDevTranscriptEntry[];
     cancelRun: () => void;
@@ -105,7 +105,6 @@ type AskDevContextValue = {
     retryLastQuestion: () => Promise<void>;
     returnToPersistentWindow: () => void;
     setPanelMode: (mode: AskDevPanelMode) => void;
-    setRetentionDays: (days: 0 | 30) => void;
     startNewConversation: () => void;
     submitAnswerFeedback: (answerId: string, rating: "helpful" | "not_helpful") => Promise<void>;
     submitQuestion: (question: string) => Promise<void>;
@@ -268,11 +267,36 @@ export function AskDevProvider({
     const [historyLoading, setHistoryLoading] = useState(false);
     const [historyError, setHistoryError] = useState<string | null>(null);
     const [committedScopeLabel, setCommittedScopeLabel] = useState<string | null>(null);
-    const [retentionDays, setRetentionDays] = useState<0 | 30>(30);
     const [stream, setStream] = useState(initialDevConversationStreamState);
     const [availability, setAvailability] = useState<AskDevAvailability>({ state: "loading" });
+    // Once the floating window has been shown at all, an org-switch-triggered
+    // capabilities refetch (which synchronously resets `availability` back to
+    // "loading" below) must not unmount it — only its *content* should fail
+    // closed to a loading state while the new organization's capabilities are
+    // pending (AskDevConversation already renders that). Otherwise the whole
+    // window would flicker closed and reopen on every org switch, which the
+    // H1 fix's "the window itself stays open" invariant explicitly rules out.
+    // It intentionally does NOT reset during the render-time org-switch block
+    // below — resetting it there, alongside `availability`, would collapse
+    // straight back into the H1 flicker it exists to prevent, since the
+    // launcher would vanish for the entire "loading" window of every org
+    // switch. It DOES reset once the new organization's capabilities resolve
+    // to `disabled` (an actual `ask_dev` capability check, not merely "not
+    // ready or loading") — otherwise an org that genuinely never had Ask Dev
+    // available would keep showing the launcher forever because some
+    // *other*, earlier organization in the session once did (CHAOS-3215).
+    const [everAvailable, setEverAvailable] = useState(false);
     const activeRequest = useRef<AbortController | null>(null);
+    const activeHistoryRequest = useRef<AbortController | null>(null);
     const historySelection = useRef(0);
+    // Mirrors the latest `orgId` prop for use inside async callbacks (after an
+    // `await`), so a response that resolves after the organization changed
+    // again can recognize itself as stale even before the cleanup effect below
+    // has run. A plain overwrite during render (not an increment) is safe
+    // under React 18 Strict Mode's dev-only double-render: assigning the same
+    // value twice is a no-op (CHAOS-3215 H2).
+    const orgIdRef = useRef(orgId);
+    orgIdRef.current = orgId;
     const encodedFilter = searchParams.get("f");
     const filters = useMemo(
         () =>
@@ -324,13 +348,85 @@ export function AskDevProvider({
             active = false;
             controller.abort();
         };
-    }, [client]);
+    }, [client, orgId]);
+
+    useEffect(() => {
+        if (availability.state === "ready" || availability.state === "not_ready") {
+            setEverAvailable(true);
+        } else if (availability.state === "disabled") {
+            setEverAvailable(false);
+        }
+    }, [availability.state]);
 
     useEffect(() => {
         if (pathname !== "/dev" && !pathname.startsWith("/superadmin/context-fabric/validation")) {
             setPersistentReturnHref(`${pathname}${searchString ? `?${searchString}` : ""}`);
         }
     }, [pathname, searchString]);
+
+    // A contextual scope proposal is only trustworthy while the user is still on
+    // (or has gone straight to /dev from) the page that registered it. Once the
+    // user visits any other route, permanently clear it — not just hide it —
+    // so it can never resurface later on an unrelated visit to /dev (CHAOS-3215 M1).
+    useEffect(() => {
+        setSurfaceProposal((current) =>
+            current && pathname !== current.sourcePathname && pathname !== "/dev" ? null : current,
+        );
+    }, [pathname]);
+
+    // Conversation state is keyed to the active organization. AskDevProvider is
+    // mounted once in the app shell layout and receives `orgId` as a prop from
+    // the server session — switching orgs triggers a router.refresh() that
+    // updates this prop on the already-mounted provider without unmounting it.
+    //
+    // This reset runs synchronously during render — the "adjusting state while
+    // rendering" pattern (https://react.dev/learn/you-might-not-need-an-effect)
+    // — rather than in a `useEffect`. A passive effect only fires after React
+    // has already committed (and the browser can paint) a render that still
+    // shows the previous organization's transcript/conversation/history, so
+    // for a tenant boundary a post-commit effect is one paint frame too late
+    // (CHAOS-3215 H1). Comparing against a `useState`-tracked previous value
+    // (not a ref) is the documented-safe form of this pattern: React discards
+    // a duplicate `setState` call from Strict Mode's dev-only double render,
+    // so this cannot double-apply.
+    const [previousOrgId, setPreviousOrgId] = useState(orgId);
+    if (orgId !== previousOrgId) {
+        setPreviousOrgId(orgId);
+        // A plain ref bump, not a `setState` call, so it invalidates any
+        // in-flight `openConversation` selection immediately — before the
+        // cleanup effect below (or any promise callback) can run. Harmless if
+        // Strict Mode's dev-only double render bumps it twice: it is only ever
+        // compared for (in)equality, never read as an absolute count.
+        historySelection.current += 1;
+        setConversationId(null);
+        setCommittedScopeLabel(null);
+        setTranscript([]);
+        setStream(initialDevConversationStreamState);
+        setConversations([]);
+        setHistoryError(null);
+        setSurfaceProposal(null);
+        // Fail closed rather than keep showing the previous organization's
+        // availability/remediation copy until the new organization's
+        // capabilities have been (re)fetched by the effect above.
+        setAvailability({ state: "loading" });
+    }
+
+    // Aborting an in-flight request is a real side effect (an
+    // AbortController's listeners can run synchronously), so it stays in an
+    // effect rather than the render-time block above. This effect has no
+    // setup body — only its cleanup — so the same abort runs both when
+    // `orgId` changes and when the provider itself unmounts (e.g. an
+    // entitlement change removes Ask Dev from the tree, where a `[orgId]`
+    // reset effect would otherwise never fire). Also covers the M2 gap:
+    // provider unmount previously left `activeRequest` unaborted.
+    useEffect(() => {
+        return () => {
+            activeRequest.current?.abort();
+            activeRequest.current = null;
+            activeHistoryRequest.current?.abort();
+            activeHistoryRequest.current = null;
+        };
+    }, [orgId]);
 
     const clearProposedContext = useCallback(() => setSurfaceProposal(null), []);
     const setProposedContext = useCallback(
@@ -373,15 +469,33 @@ export function AskDevProvider({
     );
 
     const loadHistory = useCallback(async () => {
+        activeHistoryRequest.current?.abort();
+        const controller = new AbortController();
+        activeHistoryRequest.current = controller;
+        const requestOrgId = orgIdRef.current;
         setHistoryLoading(true);
         setHistoryError(null);
         try {
-            const result = await client.listConversations();
+            const result = await client.listConversations({ signal: controller.signal });
+            // A stale response — from a superseded `loadHistory` call or from
+            // an organization switch that happened while this request was in
+            // flight — must never repopulate the history UI with another
+            // tenant's conversation titles (CHAOS-3215 H2).
+            if (activeHistoryRequest.current !== controller || orgIdRef.current !== requestOrgId) {
+                return;
+            }
             setConversations(result.items);
         } catch (error) {
+            if (controller.signal.aborted) return;
+            if (activeHistoryRequest.current !== controller || orgIdRef.current !== requestOrgId) {
+                return;
+            }
             setHistoryError(safeMessage(error));
         } finally {
-            setHistoryLoading(false);
+            if (activeHistoryRequest.current === controller) {
+                activeHistoryRequest.current = null;
+                setHistoryLoading(false);
+            }
         }
     }, [client]);
 
@@ -412,7 +526,6 @@ export function AskDevProvider({
                 }
                 setConversationId(conversation.conversation_id);
                 setCommittedScopeLabel(conversationLabel(conversation));
-                setRetentionDays(conversation.retention_days);
                 setTranscript(retainedEntries);
                 setStream(initialDevConversationStreamState);
             } catch (error) {
@@ -467,7 +580,12 @@ export function AskDevProvider({
 
     const deleteConversation = useCallback(
         async (targetConversationId: string) => {
+            const requestOrgId = orgIdRef.current;
             await client.deleteConversation(targetConversationId);
+            // A delayed deletion completion from a since-switched-away
+            // organization must not clear or abort whatever the *current*
+            // organization is doing (CHAOS-3215 M-delete).
+            if (orgIdRef.current !== requestOrgId) return;
             setConversations((current) =>
                 current.filter(
                     (conversation) => conversation.conversation_id !== targetConversationId,
@@ -524,15 +642,36 @@ export function AskDevProvider({
             let activeRunId: string | null = null;
             activeRequest.current?.abort();
             activeRequest.current = controller;
+            // Captured once, before any `await`: the org-switch render-time
+            // reset already clears visible state synchronously (CHAOS-3215
+            // H1), but this closure can still be resumed by a microtask after
+            // the org changed again and before the cleanup effect aborts
+            // `controller`. Checking identity against `orgIdRef.current` at
+            // every resumption point closes that residual window.
+            const requestOrgId = orgIdRef.current;
+            const superseded = () =>
+                controller.signal.aborted ||
+                activeRequest.current !== controller ||
+                orgIdRef.current !== requestOrgId;
 
             try {
                 let activeConversationId = conversationId;
                 if (!activeConversationId) {
-                    const created = await client.createConversation({
-                        current_scope: requestScope,
-                        retention_days: retentionDays,
-                        title: normalizedQuestion.slice(0, 80),
-                    });
+                    // Conversation-creation is not itself streamed, but it must still
+                    // honor cancellation: if a reset (startNewConversation) or a history
+                    // selection (openConversation) supersedes this request while it is
+                    // in flight, activeRequest.current will no longer be `controller` by
+                    // the time this resolves. Bail out before applying its result so a
+                    // late response can never overwrite state set by whatever superseded
+                    // it (CHAOS-3215 H2).
+                    const created = await client.createConversation(
+                        {
+                            current_scope: requestScope,
+                            title: normalizedQuestion.slice(0, 80),
+                        },
+                        { signal: controller.signal },
+                    );
+                    if (superseded()) return;
                     activeConversationId = created.conversation_id;
                     setConversationId(activeConversationId);
                     void loadHistory();
@@ -552,8 +691,7 @@ export function AskDevProvider({
                 const answer = await client.streamMessage(activeConversationId, request, {
                     signal: controller.signal,
                     onEvent: (event: DevStreamEvent) => {
-                        if (controller.signal.aborted || activeRequest.current !== controller)
-                            return;
+                        if (superseded()) return;
                         if (event.event === "run.started") {
                             activeRunId = event.run_id;
                             setTranscript((current) =>
@@ -571,7 +709,7 @@ export function AskDevProvider({
                         setStream((current) => reduceDevConversationStream(current, event));
                     },
                 });
-                if (controller.signal.aborted || activeRequest.current !== controller) return;
+                if (superseded()) return;
                 setTranscript((current) => [
                     ...current,
                     {
@@ -584,7 +722,7 @@ export function AskDevProvider({
                     },
                 ]);
             } catch (error) {
-                if (!controller.signal.aborted) {
+                if (!controller.signal.aborted && orgIdRef.current === requestOrgId) {
                     setStream((current) => ({
                         ...current,
                         phase: "failed",
@@ -602,7 +740,6 @@ export function AskDevProvider({
             loadHistory,
             proposedScope,
             proposedScopeLabel,
-            retentionDays,
             stream.phase,
         ],
     );
@@ -638,13 +775,13 @@ export function AskDevProvider({
             conversations,
             historyError,
             historyLoading,
+            orgId,
             panelMode,
             persistentReturnHref,
             proposedContext,
             proposedScope,
             proposedScopeLabel,
             proposedQuestions,
-            retentionDays,
             stream,
             transcript,
             cancelRun,
@@ -662,7 +799,6 @@ export function AskDevProvider({
             retryLastQuestion,
             returnToPersistentWindow: () => setPanelMode("compact"),
             setPanelMode,
-            setRetentionDays,
             startNewConversation,
             submitAnswerFeedback,
             submitQuestion,
@@ -681,6 +817,7 @@ export function AskDevProvider({
             expandEvidence,
             loadHistory,
             openConversation,
+            orgId,
             panelMode,
             persistentReturnHref,
             proposedContext,
@@ -688,7 +825,6 @@ export function AskDevProvider({
             proposedScopeLabel,
             proposedQuestions,
             renameConversation,
-            retentionDays,
             retryLastQuestion,
             startNewConversation,
             stream,
@@ -701,7 +837,7 @@ export function AskDevProvider({
     );
 
     const showPersistentWindow =
-        (availability.state === "ready" || availability.state === "not_ready") &&
+        (availability.state === "ready" || availability.state === "not_ready" || everAvailable) &&
         pathname !== "/dev" &&
         !pathname.startsWith("/superadmin/context-fabric/validation");
 

--- a/src/components/ask-dev/AskDevTrigger.integration.test.tsx
+++ b/src/components/ask-dev/AskDevTrigger.integration.test.tsx
@@ -286,6 +286,7 @@ describe("Ask Dev registered context handoff", () => {
                     },
                 }),
             }),
+            expect.anything(),
         );
         expect(JSON.stringify(vi.mocked(client.createConversation).mock.calls)).not.toContain(
             "Private rendered page prose",
@@ -318,6 +319,40 @@ describe("Ask Dev registered context handoff", () => {
         expect(screen.getByText("Proposed context:")).not.toHaveTextContent("CHAOS-3216");
         expect(client.createConversation).not.toHaveBeenCalled();
         expect(client.streamMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not resurrect a cleared contextual scope when later opening /dev from an unrelated route (CHAOS-3215 M1)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        const rendered = render(
+            <AskDevProvider client={client} contextualEntrypointsEnabled orgId="org-1">
+                <AskDevContextRegistration context={issueContext} />
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        expect(screen.getByText("Proposed context:")).toHaveTextContent("Issue · CHAOS-3216");
+
+        // Navigate away to an unrelated route — the proposal correctly hides here.
+        navigation.pathname = "/metrics";
+        rendered.rerender(
+            <AskDevProvider client={client} contextualEntrypointsEnabled orgId="org-1">
+                <p>Flow metrics</p>
+            </AskDevProvider>,
+        );
+        expect(screen.getByText("Proposed context:")).toHaveTextContent("Flow");
+
+        // Now land on /dev from that unrelated route (not directly from the page
+        // that registered the context). Because the scope was never actually
+        // cleared — only hidden by the derived visibility check — it used to
+        // resurface here even though the user had moved on from that page.
+        navigation.pathname = "/dev";
+        rendered.rerender(
+            <AskDevProvider client={client} contextualEntrypointsEnabled orgId="org-1">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+        expect(screen.getByText("Proposed context:")).not.toHaveTextContent("CHAOS-3216");
     });
 
     it("ignores registered context when contextual entry points are disabled", async () => {
@@ -391,6 +426,7 @@ describe("Ask Dev registered context handoff", () => {
                     surface_context: null,
                 }),
             }),
+            expect.anything(),
         );
         expect(JSON.stringify(vi.mocked(client.createConversation).mock.calls)).not.toContain(
             "private-repository",
@@ -439,6 +475,7 @@ describe("Ask Dev registered context handoff", () => {
                     }),
                 }),
             }),
+            expect.anything(),
         );
     });
 });

--- a/src/components/ask-dev/AskDevWindow.test.tsx
+++ b/src/components/ask-dev/AskDevWindow.test.tsx
@@ -21,4 +21,12 @@ describe("AskDevWindow launcher", () => {
         expect(launcher).not.toHaveTextContent("✦");
         expect(container.querySelector('img[alt=""]')).toBeInTheDocument();
     });
+
+    it("disables the launcher's hover transition under prefers-reduced-motion (CHAOS-3215 L1)", () => {
+        render(<AskDevWindow />);
+
+        const launcher = screen.getByRole("button", { name: "Open Ask Dev" });
+        expect(launcher.className).toContain("motion-reduce:transition-none");
+        expect(launcher.className).toContain("motion-reduce:hover:translate-y-0");
+    });
 });

--- a/src/components/ask-dev/AskDevWindow.tsx
+++ b/src/components/ask-dev/AskDevWindow.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 
 import fcLogo from "@/assets/fc-logo.png";
 import { CTA_LABELS } from "@/lib/design/cta";
@@ -10,18 +10,100 @@ import { CTA_LABELS } from "@/lib/design/cta";
 import { AskDevConversation } from "./AskDevConversation";
 import { useAskDev } from "./AskDevProvider";
 
+/** Matches the Tailwind `max-sm:` breakpoint used below the window's mobile full-screen classes. */
+const MOBILE_FULL_SCREEN_QUERY = "(max-width: 639.98px)";
+
+/** Focusable candidates considered for the mobile Tab/Shift+Tab trap (ConfirmDialog pattern). */
+const FOCUSABLE_SELECTOR =
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+function matchesMobileFullScreen(): boolean {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+    return window.matchMedia(MOBILE_FULL_SCREEN_QUERY).matches;
+}
+
+/** Tracks whether the viewport currently renders the window full-screen (CHAOS-3215 M5). */
+function useIsMobileFullScreen(): boolean {
+    const [isMobile, setIsMobile] = useState(() => matchesMobileFullScreen());
+
+    useEffect(() => {
+        if (typeof window.matchMedia !== "function") return;
+        const query = window.matchMedia(MOBILE_FULL_SCREEN_QUERY);
+        const update = () => setIsMobile(query.matches);
+        update();
+        query.addEventListener("change", update);
+        return () => query.removeEventListener("change", update);
+    }, []);
+
+    return isMobile;
+}
+
 export function AskDevWindow() {
     const { closePanel, panelMode, openPanel, setPanelMode } = useAskDev();
     const launcherRef = useRef<HTMLButtonElement>(null);
     const panelRef = useRef<HTMLElement>(null);
+    const isMobileFullScreen = useIsMobileFullScreen();
 
     useEffect(() => {
         if (panelMode !== "closed") panelRef.current?.focus();
     }, [panelMode]);
 
+    // A desktop→mobile viewport transition can turn an already-open, non-modal
+    // panel into a modal one while focus is still on a background control
+    // (the desktop panel intentionally does not trap focus, so the user could
+    // be anywhere in the app). Re-evaluate whenever `isMobileFullScreen`
+    // changes — not just `panelMode` — and, mirroring the on-open focus
+    // behavior above, move focus into the panel if it is currently outside it
+    // (CHAOS-3215 M5).
+    useEffect(() => {
+        if (panelMode === "closed" || !isMobileFullScreen) return;
+        const container = panelRef.current;
+        if (!container) return;
+        if (!container.contains(document.activeElement)) container.focus();
+    }, [isMobileFullScreen, panelMode]);
+
     const closeAndRestoreFocus = () => {
         closePanel();
         requestAnimationFrame(() => launcherRef.current?.focus());
+    };
+
+    // Focus trap: only while the window renders full-screen on mobile does it
+    // behave as a true modal dialog — the docked desktop panel is
+    // intentionally non-modal (the app behind it stays reachable). Tab from
+    // the last focusable element wraps to the first, and Shift+Tab from the
+    // first wraps to the last, so focus can never escape to obscured
+    // background controls (CHAOS-3215 M5).
+    const handlePanelKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+        if (event.key === "Escape") {
+            event.preventDefault();
+            closeAndRestoreFocus();
+            return;
+        }
+        if (!isMobileFullScreen || event.key !== "Tab") return;
+        const container = panelRef.current;
+        if (!container) return;
+        const focusable = getFocusableElements(container);
+        if (focusable.length === 0) {
+            event.preventDefault();
+            container.focus();
+            return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+        if (event.shiftKey) {
+            if (active === first || active === container) {
+                event.preventDefault();
+                last.focus();
+            }
+        } else if (active === last || active === container) {
+            event.preventDefault();
+            first.focus();
+        }
     };
 
     if (panelMode === "closed") {
@@ -30,7 +112,7 @@ export function AskDevWindow() {
                 ref={launcherRef}
                 type="button"
                 onClick={openPanel}
-                className="fixed bottom-4 right-4 z-50 inline-flex items-center gap-1.5 rounded-(--radius-pill) border border-(--accent-ai)/35 bg-(--surface-raised) px-3 py-2 text-sm font-medium text-(--text-primary) shadow-(--elevation-subtle) transition hover:-translate-y-0.5 hover:border-(--accent-ai)/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/50"
+                className="fixed bottom-4 right-4 z-50 inline-flex items-center gap-1.5 rounded-(--radius-pill) border border-(--accent-ai)/35 bg-(--surface-raised) px-3 py-2 text-sm font-medium text-(--text-primary) shadow-(--elevation-subtle) transition hover:-translate-y-0.5 hover:border-(--accent-ai)/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/50 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
                 aria-label={CTA_LABELS.openAskDev}
             >
                 <Image
@@ -53,17 +135,14 @@ export function AskDevWindow() {
             ref={panelRef}
             tabIndex={-1}
             aria-label="Ask Dev"
+            role={isMobileFullScreen ? "dialog" : undefined}
+            aria-modal={isMobileFullScreen ? "true" : undefined}
             className={`fixed z-50 flex flex-col overflow-hidden border border-(--border) bg-(--surface-raised) shadow-(--elevation-drawer) outline-none max-sm:inset-0 max-sm:h-dvh ${
                 expanded
                     ? "bottom-4 right-4 top-4 w-[min(46rem,calc(100vw-2rem))] rounded-(--radius-lg)"
                     : "bottom-4 right-4 h-[min(44rem,calc(100dvh-2rem))] w-[min(28rem,calc(100vw-2rem))] rounded-(--radius-lg)"
             }`}
-            onKeyDown={(event) => {
-                if (event.key === "Escape") {
-                    event.preventDefault();
-                    closeAndRestoreFocus();
-                }
-            }}
+            onKeyDown={handlePanelKeyDown}
         >
             <header className="flex items-center justify-between gap-3 border-b border-(--border) bg-(--surface)/80 px-4 py-3">
                 <div className="min-w-0">

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -23,6 +23,10 @@ export const CTA_LABELS = {
     expandAskDev: "Expand Ask Dev panel",
     /** Return the expanded Ask Dev window to its compact size. */
     reduceAskDev: "Reduce Ask Dev panel",
+    /** Reveal the Ask Dev conversation history panel below the `lg` breakpoint. */
+    showAskDevHistory: "Show conversations",
+    /** Collapse the Ask Dev conversation history panel below the `lg` breakpoint. */
+    hideAskDevHistory: "Hide conversations",
     /** Record positive feedback on an Ask Dev answer. */
     askDevHelpful: "Helpful",
     /** Record negative feedback on an Ask Dev answer. */
@@ -246,6 +250,8 @@ export const CTA_LABELS = {
     goToValidate: "Validate",
     /** Inline link to the runner setup examples from the empty batch-list state (CHAOS-2714). */
     goToCiJob: "CI job",
+    /** Link from the Ask Dev empty state to the customer doc explaining the Ask Dev / Context Fabric relationship (CHAOS-3215). */
+    viewAskDevDocs: "Learn more",
 } as const;
 
 export type CtaKey = keyof typeof CTA_LABELS;

--- a/tests/live/ask-dev-acceptance.spec.ts
+++ b/tests/live/ask-dev-acceptance.spec.ts
@@ -503,8 +503,13 @@ test("permanent contextual window continues one grounded run in /dev without dup
     const ephemeralPolicy = await updateAskDevPolicy(page, identity, { retention_days: 0 });
     expect(ephemeralPolicy).toMatchObject({ settings: { retention_days: 0 } });
     try {
-        const retention = page.getByLabel("Conversation retention");
-        await retention.selectOption("0");
+        // Retention is an organization-administrator policy (already set to 0
+        // days above via updateAskDevPolicy), not a per-conversation control —
+        // there is no "Conversation retention" selector to interact with
+        // (CHAOS-3215 M7). The conversation created below inherits the org
+        // policy purely from the backend, which the assertions after it
+        // verify (retention_days: 0, expires_at: null, and 404 after the run
+        // completes).
         const ephemeralComposer = page
             .getByRole("region", { name: "Ask Dev workspace" })
             .getByRole("textbox", { name: "Ask Dev question" });


### PR DESCRIPTION
## Summary

Adversarial post-merge verification of #813 (Ask Dev Wave 3 — `/dev` full-page workspace and shared conversational UI core) for CHAOS-3215 found real defects. The original PR branch no longer exists (auto-deleted after merge), so this fixes forward on a new branch.

## What this fixes

- **Cross-tenant conversation-state leak on organization switch.** Conversation, transcript, history, unsent drafts, and capabilities are now reset/refetched correctly on org change — clearing state synchronously (React's render-time "adjusting state" pattern) where the leak window mattered, with async cleanup (aborting in-flight requests) in an effect.
- **Non-cancellable request races.** Conversation creation, history loading, and conversation deletion can no longer let a superseded/stale response — from a previous organization, or from a subsequent reset/selection — overwrite current state.
- **Permanent-launcher visibility bug.** The launcher no longer stays stuck "available" after switching into a genuinely disabled organization.
- **Screen-reader announcement noise.** Streamed answer deltas no longer fire the transcript's `aria-live` region on every token; only coarse phase/terminal-state changes are announced.
- **Mobile accessibility.** History/rename/delete/reopen controls are reachable below the `lg` breakpoint; the full-screen mobile Ask Dev window is a proper `role="dialog"` with a focus trap that also engages on a desktop→mobile resize.
- **Answer-detail id collisions.** DOM ids for evidence/metric detail panels are now unique per answer, so citation/metric focus never lands on the wrong answer.
- **`error`-status answers** now render through the failed-run alert treatment instead of silently rendering as ordinary completed output.
- **Reduced-motion support** for the streaming indicator and window transitions; **deliberate focus movement** to a newly completed answer (without stealing focus from an active composer or an in-progress conversation-rename edit).
- **Removed the non-functional per-conversation retention selector** — retention is organization-administrator policy only (0/30-day), per the governing contract; the selector sent a value the backend always ignored, with no indication to the user.
- **In-product help copy**: accurate per-status explanations for partial/degraded/insufficient-evidence/refused answers (grounded in the existing "a result with limitations, not a silent success" framing), and a "Powered by Context Fabric" link to the customer documentation.

## Verification

- Every fix has a regression test proven to fail on the prior code and pass on the fix (see CHAOS-3215 evidence comment for the cross-tenant-leak proof specifically).
- Full gate green: `tsc --noEmit`, `eslint`, `design-lint` (scoped), `vitest` — 407 files / 3510 tests / 0 failures.
- Three rounds of adversarial Codex review: round 1 found 2 HIGH/9 MEDIUM/3 LOW in round-0's fixes; round 2 fixed all of them; round 3 (scoped, verification-focused) found 1 MEDIUM regression (launcher-visibility flag not reset), fixed and verified with a fail-before/pass-after test. No further findings on the final pass.
- A companion ops-repo docs PR is linked from CHAOS-3215 (runbook, release notes, retention-wording correction).

## Not in this PR

- CHAOS-3286 (OpenAI tool-call adapter rejects dotted `.v1` tool names — 100% of real OpenAI-backed Ask Dev runs currently fail) is an ops-repo backend bug, routed separately, tracked and linked.
- No dedicated Ask Dev Playwright spec exists in the default e2e suite (coverage is Vitest + a live-only acceptance spec) — flagged as a residual gap for a follow-up ticket, not fixed here.

CHAOS-3215