### PR TITLE
fix(admin): remove navigation subtitles

### DIFF
--- a/src/components/admin/AdminSidebar.test.tsx
+++ b/src/components/admin/AdminSidebar.test.tsx
@@ -41,13 +41,13 @@ describe("AdminSidebar", () => {
         render(<AdminSidebar />);
 
         expect(screen.getByText("Admin")).toBeInTheDocument();
-        expect(screen.queryByText("System configuration and management.")).not.toBeInTheDocument();
+        expect(screen.getByText("System configuration and management.")).toBeInTheDocument();
         expect(screen.queryByText("Full Chaos Dev Health Ops")).not.toBeInTheDocument();
         expect(screen.getByTestId("org-switcher")).toBeInTheDocument();
         expect(
             screen.queryByRole("link", { name: /product telemetryusage/i }),
         ).not.toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /dashboardoverview/i })).toHaveAttribute(
+        expect(screen.getByRole("link", { name: /^Dashboard$/ })).toHaveAttribute(
             "aria-current",
             "page",
         );
@@ -75,10 +75,8 @@ describe("AdminSidebar", () => {
         render(<AdminSidebar isSuperuser={true} />);
 
         expect(screen.getAllByText("Platform Admin")).toHaveLength(2);
-        expect(screen.getByRole("link", { name: /platform adminglobal/i })).toBeInTheDocument();
-        expect(
-            screen.queryByRole("link", { name: /organizationworkspace settings/i }),
-        ).not.toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Platform Admin$/ })).toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: /^Organization$/ })).not.toBeInTheDocument();
     });
 
     it("handles feature flags by including enabled admin links only", () => {
@@ -93,14 +91,10 @@ describe("AdminSidebar", () => {
             />,
         );
 
-        expect(screen.getByRole("link", { name: /audit logsaccess history/i })).toBeInTheDocument();
-        expect(
-            screen.getByRole("link", { name: /data retentionretention policy/i }),
-        ).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /ai setupmodel provider/i })).toBeInTheDocument();
-        expect(
-            screen.queryByRole("link", { name: /ip allowlistnetwork access/i }),
-        ).not.toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Audit Logs$/ })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^Data Retention$/ })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /^AI Setup$/ })).toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: /^IP Allowlist$/ })).not.toBeInTheDocument();
     });
 
     it.each([
@@ -111,7 +105,7 @@ describe("AdminSidebar", () => {
     ] as const)("keeps AI Setup independent for %o", (features, visible) => {
         render(<AdminSidebar features={features} />);
 
-        const link = screen.queryByRole("link", { name: /ai setupmodel provider/i });
+        const link = screen.queryByRole("link", { name: /^AI Setup$/ });
         if (visible) {
             expect(link).toHaveAttribute("href", "/org/admin/ai");
         } else {
@@ -144,11 +138,11 @@ describe("AdminSidebar", () => {
     });
 
     it.each([
-        ["/org/admin/users/new", /usersorg members/i],
-        ["/org/admin/integrations/github", /providersconnected sources/i],
-        ["/org/admin/teams/team-1/edit", /teamsteam ownership/i],
-        ["/org/admin/ai/ask-dev", /ai setupmodel provider/i],
-        ["/org/admin/ai/byo-llm", /ai setupmodel provider/i],
+        ["/org/admin/users/new", /^Users$/],
+        ["/org/admin/integrations/github", /^Providers$/],
+        ["/org/admin/teams/team-1/edit", /^Teams$/],
+        ["/org/admin/ai/ask-dev", /^AI Setup$/],
+        ["/org/admin/ai/byo-llm", /^AI Setup$/],
     ])("keeps the parent nav item active for descendant route %s", (route, linkName) => {
         pathname = route;
 

--- a/src/components/admin/AdminSidebar.test.tsx
+++ b/src/components/admin/AdminSidebar.test.tsx
@@ -41,6 +41,7 @@ describe("AdminSidebar", () => {
         render(<AdminSidebar />);
 
         expect(screen.getByText("Admin")).toBeInTheDocument();
+        expect(screen.queryByText("System configuration and management.")).not.toBeInTheDocument();
         expect(screen.queryByText("Full Chaos Dev Health Ops")).not.toBeInTheDocument();
         expect(screen.getByTestId("org-switcher")).toBeInTheDocument();
         expect(

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -151,9 +151,6 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                                 Platform Admin
                             </span>
                         )}
-                        <p className="mt-2 text-xs text-(--ink-muted)">
-                            System configuration and management.
-                        </p>
                     </div>
 
                     <OrgSwitcher />

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -9,7 +9,6 @@ type NavItem = {
     id: string;
     label: string;
     href: string;
-    description: string;
     featureKeys?: readonly string[];
 };
 
@@ -18,70 +17,59 @@ const navItems: NavItem[] = [
         id: "dashboard",
         label: "Dashboard",
         href: "/org/admin",
-        description: "Overview",
     },
     {
         id: "users",
         label: "Users",
         href: "/org/admin/users",
-        description: "Org members",
     },
     {
         id: "organization",
         label: "Organization",
         href: "/org/admin/settings",
-        description: "Workspace settings",
     },
     {
         id: "integrations",
         label: "Providers",
         href: "/org/admin/integrations",
-        description: "Connected sources",
     },
     {
         id: "sync",
         label: "Sync Status",
         href: "/org/admin/sync",
-        description: "Sync activity",
     },
     {
         id: "teams",
         label: "Teams",
         href: "/org/admin/teams",
-        description: "Team ownership",
     },
     {
         id: "identities",
         label: "Identities",
         href: "/org/admin/identities",
-        description: "Identity mapping",
     },
     {
         id: "audit",
         label: "Audit Logs",
         href: "/org/admin/audit-logs",
-        description: "Access history",
         featureKeys: ["audit_log"],
     },
     {
         id: "ip-allowlist",
         label: "IP Allowlist",
         href: "/org/admin/ip-allowlist",
-        description: "Network access",
         featureKeys: ["ip_allowlist"],
     },
     {
         id: "retention",
         label: "Data Retention",
         href: "/org/admin/retention",
-        description: "Retention policy",
         featureKeys: ["custom_retention"],
     },
     {
         id: "ai-setup",
         label: "AI Setup",
         href: "/org/admin/ai",
-        description: "Model provider",
         featureKeys: ["ask_dev", "byo_llm"],
     },
 ];
@@ -151,6 +139,9 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                                 Platform Admin
                             </span>
                         )}
+                        <p className="mt-2 text-xs text-(--ink-muted)">
+                            System configuration and management.
+                        </p>
                     </div>
 
                     <OrgSwitcher />
@@ -163,20 +154,13 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                                     href={item.href}
                                     prefetch={false}
                                     aria-current={isActive ? "page" : undefined}
-                                    className={`group flex items-center justify-between rounded-2xl border px-3 py-2 transition ${
+                                    className={`group flex items-center rounded-2xl border px-3 py-2 transition ${
                                         isActive
                                             ? "border-(--accent) bg-(--accent)/15 text-foreground"
                                             : "border-transparent bg-(--card-70) text-(--ink-muted) hover:border-(--card-stroke) hover:text-foreground"
                                     }`}
                                 >
                                     <span className="font-medium">{item.label}</span>
-                                    <span
-                                        className={`text-label-caps uppercase ${
-                                            isActive ? "text-(--accent)" : "text-(--ink-muted)"
-                                        }`}
-                                    >
-                                        {item.description}
-                                    </span>
                                 </Link>
                             );
                         })}
@@ -184,10 +168,9 @@ export function AdminSidebar({ isSuperuser, features }: AdminSidebarProps) {
                             <Link
                                 href="/superadmin"
                                 prefetch={false}
-                                className="group flex items-center justify-between rounded-2xl border border-purple-500/20 bg-purple-500/10 px-3 py-2 text-purple-400 hover:bg-purple-500/20 transition"
+                                className="group flex items-center rounded-2xl border border-purple-500/20 bg-purple-500/10 px-3 py-2 text-purple-400 hover:bg-purple-500/20 transition"
                             >
                                 <span className="font-medium">Platform Admin</span>
-                                <span className="text-label-caps uppercase">Global</span>
                             </Link>
                         )}
                     </nav>

--- a/tests/admin-settings.spec.ts
+++ b/tests/admin-settings.spec.ts
@@ -25,6 +25,7 @@ async function waitForSettledToast(page: Page, message: RegExp) {
 test("settings page renders all sections", async ({ page }) => {
     await page.goto("/org/admin/settings");
 
+    await expect(page.getByText("System configuration and management.")).toHaveCount(0);
     await expect(page.getByRole("heading", { name: "Organization", exact: true })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Billing" })).toBeVisible();
@@ -54,6 +55,10 @@ test("settings notifications settle below Account without obscuring responsive a
             await page.keyboard.press("Enter");
             await expect(navigationControl).toHaveAttribute("aria-expanded", "true");
             await expect(navigationControl).toHaveAccessibleName("Hide admin navigation");
+            await page.screenshot({
+                path: testInfo.outputPath("admin-navigation-open-mobile.png"),
+                fullPage: true,
+            });
             await page.keyboard.press("Escape");
             await expect(navigationControl).toBeFocused();
             await expect(navigationControl).toHaveAttribute("aria-expanded", "false");

--- a/tests/admin-settings.spec.ts
+++ b/tests/admin-settings.spec.ts
@@ -25,7 +25,23 @@ async function waitForSettledToast(page: Page, message: RegExp) {
 test("settings page renders all sections", async ({ page }) => {
     await page.goto("/org/admin/settings");
 
-    await expect(page.getByText("System configuration and management.")).toHaveCount(0);
+    await expect(page.getByText("System configuration and management.")).toBeVisible();
+    for (const description of [
+        "Overview",
+        "Org members",
+        "Workspace settings",
+        "Connected sources",
+        "Sync activity",
+        "Team ownership",
+        "Identity mapping",
+        "Access history",
+        "Network access",
+        "Retention policy",
+        "Model provider",
+        "Global",
+    ]) {
+        await expect(page.getByText(description, { exact: true })).toHaveCount(0);
+    }
     await expect(page.getByRole("heading", { name: "Organization", exact: true })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Billing" })).toBeVisible();
@@ -44,6 +60,7 @@ test("settings notifications settle below Account without obscuring responsive a
     for (const viewport of viewports) {
         await page.setViewportSize(viewport);
         await page.goto("/org/admin/settings");
+        await page.addStyleTag({ content: "nextjs-portal { display: none !important; }" });
 
         const pageTitle = page.getByRole("heading", { name: "Organization", exact: true });
         await expect(pageTitle).toBeInViewport();


### PR DESCRIPTION
## Summary

- remove descriptive subtitles from admin navigation so each destination renders as a label only
- preserve the Admin header description, `System configuration and management.`
- preserve feature gating, responsive behavior, and the mobile return link
- add unit and authenticated browser coverage for label-only navigation

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run --project components src/components/admin/AdminSidebar.test.tsx`
- `pnpm exec eslint src/components/admin/AdminSidebar.tsx src/components/admin/AdminSidebar.test.tsx tests/admin-settings.spec.ts`
- `DESIGN_LINT=true pnpm exec eslint src/components/admin/AdminSidebar.tsx src/components/admin/AdminSidebar.test.tsx tests/admin-settings.spec.ts`
- authenticated Playwright admin-settings coverage
- independent desktop/mobile visual QA: PASS, no blockers

Full-repository `pnpm design-lint` remains blocked by pre-existing violations outside the changed files.

## Screenshots

### Desktop

![Admin navigation labels only on desktop](https://github.com/user-attachments/assets/a22117da-e311-4989-ae4a-e6ad38b4384d)

### Mobile navigation open

![Admin navigation labels only on mobile](https://github.com/user-attachments/assets/d91301f7-7726-4dca-9feb-7bfd5baf6f5d)