### PR TITLE
fix(auth): move issue reporting into account menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "echarts-for-react": "^3.0.6",
         "graphql": "^17",
         "ioredis": "^5.11.1",
+        "lucide-react": "^1.28.0",
         "next": "^16.2.12",
         "next-auth": "^5.0.0-beta.32",
         "pino": "^10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1(supports-color@8.1.1)
+      lucide-react:
+        specifier: ^1.28.0
+        version: 1.28.0(react@19.2.8)
       next:
         specifier: ^16.2.12
         version: 16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3949,6 +3952,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.28.0:
+    resolution: {integrity: sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -9472,6 +9480,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.28.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
 
   lz-string@1.5.0: {}
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -8,7 +8,6 @@ import { ImpersonationBanner } from "@/components/admin/ImpersonationBanner";
 import { SessionProvider } from "@/components/auth/SessionProvider";
 import { UserMenu } from "@/components/auth/UserMenu";
 import { TrialBanner } from "@/components/billing/TrialBanner";
-import { BugReportButton } from "@/components/feedback/BugReportButton";
 import { AskDevProvider } from "@/components/ask-dev/AskDevProvider";
 import { TelemetryProvider } from "@/components/telemetry/TelemetryProvider";
 import { getOrgEntitlements } from "@/lib/admin/server/billing";
@@ -60,7 +59,6 @@ export default async function AppLayout({
                 </nav>
             </header>
             {children}
-            <BugReportButton />
             <Toaster
                 containerAriaLabel="Notifications"
                 position="top-right"

--- a/src/components/auth/UserMenu.test.tsx
+++ b/src/components/auth/UserMenu.test.tsx
@@ -32,7 +32,7 @@ describe("UserMenu", () => {
         });
     });
 
-    it("reveals Preferences and Sign out through the keyboard-accessible account control", async () => {
+    it("reveals Report issue with a bug icon at the bottom of the account menu", async () => {
         const user = userEvent.setup();
         render(<UserMenu />);
 
@@ -45,11 +45,25 @@ describe("UserMenu", () => {
         expect(accountControl).toHaveAttribute("aria-expanded", "true");
         const preferences = screen.getByRole("link", { name: CTA_LABELS.preferences });
         expect(preferences).toHaveAttribute("href", "/settings");
-        expect(screen.getByRole("button", { name: CTA_LABELS.signOut })).toBeVisible();
+        const signOut = screen.getByRole("button", { name: CTA_LABELS.signOut });
+        const reportIssue = screen.getByRole("button", { name: CTA_LABELS.reportIssue });
+        expect(signOut).toBeVisible();
+        expect(reportIssue).toBeVisible();
+        expect(reportIssue.querySelector('svg[aria-hidden="true"]')).toBeInTheDocument();
+        expect(signOut.compareDocumentPosition(reportIssue)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
 
         await user.tab();
         expect(preferences).toHaveFocus();
-        await user.click(screen.getByRole("button", { name: CTA_LABELS.signOut }));
+        await user.click(reportIssue);
+        const dialog = screen.getByRole("dialog", { name: CTA_LABELS.reportIssue });
+        const title = screen.getByLabelText("Title");
+        await user.click(title);
+        expect(dialog).toBeVisible();
+        expect(accountControl).toHaveAttribute("aria-expanded", "true");
+        await user.keyboard("{Escape}");
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        expect(reportIssue).toHaveFocus();
+        await user.click(signOut);
         expect(signOutMock).toHaveBeenCalledOnce();
     });
 });

--- a/src/components/auth/UserMenu.test.tsx
+++ b/src/components/auth/UserMenu.test.tsx
@@ -32,7 +32,7 @@ describe("UserMenu", () => {
         });
     });
 
-    it("reveals Report issue with a bug icon at the bottom of the account menu", async () => {
+    it("places Report issue immediately before Sign out in the account menu", async () => {
         const user = userEvent.setup();
         render(<UserMenu />);
 
@@ -45,12 +45,18 @@ describe("UserMenu", () => {
         expect(accountControl).toHaveAttribute("aria-expanded", "true");
         const preferences = screen.getByRole("link", { name: CTA_LABELS.preferences });
         expect(preferences).toHaveAttribute("href", "/settings");
+        const adminPanel = screen.getByRole("link", { name: CTA_LABELS.adminPanel });
+        const separator = screen.getByRole("separator");
         const signOut = screen.getByRole("button", { name: CTA_LABELS.signOut });
         const reportIssue = screen.getByRole("button", { name: CTA_LABELS.reportIssue });
         expect(signOut).toBeVisible();
         expect(reportIssue).toBeVisible();
         expect(reportIssue.querySelector('svg[aria-hidden="true"]')).toBeInTheDocument();
-        expect(signOut.compareDocumentPosition(reportIssue)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+        const menuActionButtons = Array.from(document.querySelectorAll("#account-options button"));
+        expect(menuActionButtons).toEqual([reportIssue, signOut]);
+        expect(adminPanel.nextElementSibling).toBe(separator);
+        expect(separator.nextElementSibling).toBe(reportIssue);
+        expect(reportIssue.nextElementSibling).toBe(signOut);
 
         await user.tab();
         expect(preferences).toHaveFocus();

--- a/src/components/auth/UserMenu.test.tsx
+++ b/src/components/auth/UserMenu.test.tsx
@@ -72,4 +72,25 @@ describe("UserMenu", () => {
         await user.click(signOut);
         expect(signOutMock).toHaveBeenCalledOnce();
     });
+
+    it("uses decorative icons for every account menu destination and action", async () => {
+        const user = userEvent.setup();
+        useSessionMock.mockReturnValue({
+            data: { user: { email: "operator@example.com", is_superuser: true } },
+            status: "authenticated",
+        });
+        render(<UserMenu />);
+
+        await user.click(screen.getByRole("button", { name: CTA_LABELS.accountOptions }));
+
+        for (const item of [
+            screen.getByRole("link", { name: CTA_LABELS.platformAdmin }),
+            screen.getByRole("link", { name: CTA_LABELS.preferences }),
+            screen.getByRole("link", { name: CTA_LABELS.adminPanel }),
+            screen.getByRole("button", { name: CTA_LABELS.reportIssue }),
+            screen.getByRole("button", { name: CTA_LABELS.signOut }),
+        ]) {
+            expect(item.querySelector('svg[aria-hidden="true"]')).toBeInTheDocument();
+        }
+    });
 });

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -3,6 +3,7 @@
 import { useSession, signOut } from "next-auth/react";
 import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
+import { BugReportButton } from "@/components/feedback/BugReportButton";
 import { CTA_LABELS } from "@/lib/design/cta";
 
 export function UserMenu() {
@@ -56,7 +57,7 @@ export function UserMenu() {
 
             {isOpen && (
                 <div
-                    className="absolute right-0 top-full z-50 mt-2 w-48 rounded-(--radius-sm) border border-(--card-stroke) bg-(--card) shadow-lg"
+                    className="absolute right-0 top-full z-50 mt-2 w-48 rounded-(--radius-sm) border border-(--card-stroke) bg-(--card) shadow-(--elevation-card)"
                     id="account-options"
                 >
                     <div className="py-1">
@@ -98,6 +99,9 @@ export function UserMenu() {
                             >
                                 {CTA_LABELS.signOut}
                             </button>
+                        </div>
+                        <div className="border-t border-(--card-stroke)">
+                            <BugReportButton />
                         </div>
                     </div>
                 </div>

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -91,18 +91,15 @@ export function UserMenu() {
                         >
                             {CTA_LABELS.adminPanel}
                         </Link>
-                        <div className="border-t border-(--card-stroke)">
-                            <button
-                                type="button"
-                                onClick={() => signOut()}
-                                className="block w-full px-4 py-2 text-left text-sm text-foreground hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
-                            >
-                                {CTA_LABELS.signOut}
-                            </button>
-                        </div>
-                        <div className="border-t border-(--card-stroke)">
-                            <BugReportButton />
-                        </div>
+                        <div role="separator" className="border-t border-(--card-stroke)" />
+                        <BugReportButton />
+                        <button
+                            type="button"
+                            onClick={() => signOut()}
+                            className="block w-full px-4 py-2 text-left text-sm text-foreground hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
+                        >
+                            {CTA_LABELS.signOut}
+                        </button>
                     </div>
                 </div>
             )}

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSession, signOut } from "next-auth/react";
+import { Building2, LogOut, Settings2, ShieldCheck } from "lucide-react";
 import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
 import { BugReportButton } from "@/components/feedback/BugReportButton";
@@ -71,24 +72,36 @@ export function UserMenu() {
                         {session.user?.is_superuser && (
                             <Link
                                 href="/superadmin"
-                                className="block px-4 py-2 text-sm text-purple-400 hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
+                                className="flex items-center gap-2 px-4 py-2 text-sm text-purple-400 hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
                                 onClick={() => setIsOpen(false)}
                             >
+                                <ShieldCheck
+                                    aria-hidden="true"
+                                    className="h-4 w-4 shrink-0 text-(--ink-muted)"
+                                />
                                 {CTA_LABELS.platformAdmin}
                             </Link>
                         )}
                         <Link
                             href="/settings"
-                            className="block px-4 py-2 text-sm text-foreground hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
+                            className="flex items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
                             onClick={() => setIsOpen(false)}
                         >
+                            <Settings2
+                                aria-hidden="true"
+                                className="h-4 w-4 shrink-0 text-(--ink-muted)"
+                            />
                             {CTA_LABELS.preferences}
                         </Link>
                         <Link
                             href="/org/admin"
-                            className="block px-4 py-2 text-sm text-foreground hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
+                            className="flex items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
                             onClick={() => setIsOpen(false)}
                         >
+                            <Building2
+                                aria-hidden="true"
+                                className="h-4 w-4 shrink-0 text-(--ink-muted)"
+                            />
                             {CTA_LABELS.adminPanel}
                         </Link>
                         <div role="separator" className="border-t border-(--card-stroke)" />
@@ -96,8 +109,12 @@ export function UserMenu() {
                         <button
                             type="button"
                             onClick={() => signOut()}
-                            className="block w-full px-4 py-2 text-left text-sm text-foreground hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
+                            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-foreground hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
                         >
+                            <LogOut
+                                aria-hidden="true"
+                                className="h-4 w-4 shrink-0 text-(--ink-muted)"
+                            />
                             {CTA_LABELS.signOut}
                         </button>
                     </div>

--- a/src/components/feedback/BugReportButton.test.tsx
+++ b/src/components/feedback/BugReportButton.test.tsx
@@ -8,15 +8,15 @@ vi.mock("sonner", () => ({
 }));
 
 describe("BugReportButton", () => {
-    it("uses a non-overlay mobile trigger and restores focus after Escape", async () => {
+    it("uses an account-menu trigger and restores focus after Escape", async () => {
         const user = userEvent.setup();
         render(<BugReportButton />);
-        const trigger = screen.getByTestId("bug-report-mobile-trigger");
+        const trigger = screen.getByTestId("bug-report-trigger");
 
         expect(trigger).not.toHaveClass("fixed");
         await user.click(trigger);
 
-        expect(screen.getByRole("dialog", { name: "Report an issue" })).toBeVisible();
+        expect(screen.getByRole("dialog", { name: "Report issue" })).toBeVisible();
         expect(screen.getByLabelText("Title")).toHaveFocus();
         await user.keyboard("{Escape}");
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
@@ -26,7 +26,7 @@ describe("BugReportButton", () => {
     it("traps Tab navigation inside the open dialog", async () => {
         const user = userEvent.setup();
         render(<BugReportButton />);
-        await user.click(screen.getByTestId("bug-report-mobile-trigger"));
+        await user.click(screen.getByTestId("bug-report-trigger"));
         const close = screen.getByRole("button", { name: "Close" });
         const submit = screen.getByRole("button", { name: "Submit Report" });
 

--- a/src/components/feedback/BugReportButton.tsx
+++ b/src/components/feedback/BugReportButton.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { toast } from "sonner";
 
 import type { FeedbackPayload, FeedbackResponse, FeedbackType } from "@/components/feedback/types";
 import { CTA_LABELS } from "@/lib/design/cta";
 
 const inputClassName =
-    "w-full rounded-xl border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground placeholder:text-(--ink-muted) focus:border-(--accent) focus:outline-none";
+    "w-full rounded-(--radius-md) border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground placeholder:text-(--ink-muted) focus:border-(--accent) focus:outline-none";
 
 type FeedbackFormState = {
     title: string;
@@ -134,144 +135,140 @@ export function BugReportButton() {
 
     return (
         <>
-            <div className="px-4 pb-6 sm:hidden">
-                <button
-                    type="button"
-                    data-testid="bug-report-mobile-trigger"
-                    className="flex w-full items-center justify-center gap-2 rounded-lg border border-(--card-stroke) bg-(--card-80) px-4 py-3 text-sm font-medium text-foreground"
-                    onClick={openPanel}
-                >
-                    <BugIcon />
-                    {CTA_LABELS.reportIssue}
-                </button>
-            </div>
             <button
                 type="button"
-                data-testid="bug-report-desktop-trigger"
-                className="fixed right-6 bottom-6 z-50 hidden h-12 w-12 items-center justify-center rounded-full border border-(--accent-highlight) bg-(--card-80) text-foreground shadow-xl transition hover:border-(--accent) hover:text-(--accent) sm:flex"
+                data-testid="bug-report-trigger"
+                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-foreground hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
                 onClick={openPanel}
-                aria-label={CTA_LABELS.reportIssue}
             >
                 <BugIcon />
+                {CTA_LABELS.reportIssue}
             </button>
 
-            {isOpen ? (
-                <>
-                    <button
-                        type="button"
-                        aria-label={CTA_LABELS.closeIssueReportPanel}
-                        className="fixed inset-0 z-50 bg-black/50"
-                        onClick={closePanel}
-                    />
-                    <div
-                        className="fixed right-0 top-0 bottom-0 z-50 w-full max-w-md translate-x-0 border-l border-(--card-stroke) bg-(--card-80) shadow-2xl transition-transform duration-300 ease-out"
-                        role="dialog"
-                        aria-modal="true"
-                        aria-labelledby="bug-report-title"
-                        onKeyDown={handleDialogKeyDown}
-                    >
-                        <div className="flex h-full flex-col">
-                            <div className="flex items-center justify-between border-b border-(--card-stroke) px-5 py-4">
-                                <h2
-                                    id="bug-report-title"
-                                    className="font-(--font-display) text-lg text-foreground"
-                                >
-                                    {CTA_LABELS.reportIssue}
-                                </h2>
-                                <button
-                                    type="button"
-                                    className="rounded-md p-2 text-(--ink-muted) transition hover:text-foreground"
-                                    onClick={closePanel}
-                                    aria-label={CTA_LABELS.close}
-                                >
-                                    <svg
-                                        viewBox="0 0 24 24"
-                                        className="h-5 w-5"
-                                        fill="none"
-                                        stroke="currentColor"
-                                        strokeWidth={2}
-                                        aria-hidden="true"
-                                    >
-                                        <path d="m6 6 12 12" />
-                                        <path d="m18 6-12 12" />
-                                    </svg>
-                                </button>
-                            </div>
+            {isOpen
+                ? createPortal(
+                      <>
+                          <button
+                              type="button"
+                              aria-label={CTA_LABELS.closeIssueReportPanel}
+                              className="fixed inset-0 z-[60] bg-(--background)/50"
+                              onMouseDown={(event) => event.stopPropagation()}
+                              onClick={closePanel}
+                          />
+                          <div
+                              className="fixed right-0 top-0 bottom-0 z-[60] w-full max-w-md translate-x-0 border-l border-(--card-stroke) bg-(--surface-raised) shadow-(--elevation-drawer) transition-transform duration-300 ease-out"
+                              role="dialog"
+                              aria-modal="true"
+                              aria-labelledby="bug-report-title"
+                              onMouseDown={(event) => event.stopPropagation()}
+                              onKeyDown={handleDialogKeyDown}
+                          >
+                              <div className="flex h-full flex-col">
+                                  <div className="flex items-center justify-between border-b border-(--card-stroke) px-5 py-4">
+                                      <h2
+                                          id="bug-report-title"
+                                          className="font-(--font-display) text-h2 text-foreground"
+                                      >
+                                          {CTA_LABELS.reportIssue}
+                                      </h2>
+                                      <button
+                                          type="button"
+                                          className="rounded-md p-2 text-(--ink-muted) transition hover:text-foreground"
+                                          onClick={closePanel}
+                                          aria-label={CTA_LABELS.close}
+                                      >
+                                          <svg
+                                              viewBox="0 0 24 24"
+                                              className="h-5 w-5"
+                                              fill="none"
+                                              stroke="currentColor"
+                                              strokeWidth={2}
+                                              aria-hidden="true"
+                                          >
+                                              <path d="m6 6 12 12" />
+                                              <path d="m18 6-12 12" />
+                                          </svg>
+                                      </button>
+                                  </div>
 
-                            <form
-                                className="flex flex-1 flex-col gap-4 px-5 py-5"
-                                onSubmit={handleSubmit}
-                            >
-                                <label className="space-y-2">
-                                    <span className="text-sm text-foreground">Title</span>
-                                    <input
-                                        ref={titleInputRef}
-                                        type="text"
-                                        required
-                                        placeholder="Brief summary..."
-                                        className={inputClassName}
-                                        value={formState.title}
-                                        onChange={(event) =>
-                                            setFormState((current) => ({
-                                                ...current,
-                                                title: event.target.value,
-                                            }))
-                                        }
-                                    />
-                                </label>
+                                  <form
+                                      className="flex flex-1 flex-col gap-4 px-5 py-5"
+                                      onSubmit={handleSubmit}
+                                  >
+                                      <label className="space-y-2">
+                                          <span className="text-sm text-foreground">Title</span>
+                                          <input
+                                              ref={titleInputRef}
+                                              type="text"
+                                              required
+                                              placeholder="Brief summary..."
+                                              className={inputClassName}
+                                              value={formState.title}
+                                              onChange={(event) =>
+                                                  setFormState((current) => ({
+                                                      ...current,
+                                                      title: event.target.value,
+                                                  }))
+                                              }
+                                          />
+                                      </label>
 
-                                <label className="space-y-2">
-                                    <span className="text-sm text-foreground">Type</span>
-                                    <select
-                                        className={inputClassName}
-                                        value={formState.type}
-                                        onChange={(event) =>
-                                            setFormState((current) => ({
-                                                ...current,
-                                                type: event.target.value as FeedbackType,
-                                            }))
-                                        }
-                                    >
-                                        <option value="bug">Bug</option>
-                                        <option value="feature">Feature Request</option>
-                                        <option value="question">Question</option>
-                                    </select>
-                                </label>
+                                      <label className="space-y-2">
+                                          <span className="text-sm text-foreground">Type</span>
+                                          <select
+                                              className={inputClassName}
+                                              value={formState.type}
+                                              onChange={(event) =>
+                                                  setFormState((current) => ({
+                                                      ...current,
+                                                      type: event.target.value as FeedbackType,
+                                                  }))
+                                              }
+                                          >
+                                              <option value="bug">Bug</option>
+                                              <option value="feature">Feature Request</option>
+                                              <option value="question">Question</option>
+                                          </select>
+                                      </label>
 
-                                <label className="space-y-2">
-                                    <span className="text-sm text-foreground">Description</span>
-                                    <textarea
-                                        required
-                                        rows={6}
-                                        placeholder="What happened? Steps to reproduce..."
-                                        className={inputClassName}
-                                        value={formState.description}
-                                        onChange={(event) =>
-                                            setFormState((current) => ({
-                                                ...current,
-                                                description: event.target.value,
-                                            }))
-                                        }
-                                    />
-                                </label>
+                                      <label className="space-y-2">
+                                          <span className="text-sm text-foreground">
+                                              Description
+                                          </span>
+                                          <textarea
+                                              required
+                                              rows={6}
+                                              placeholder="What happened? Steps to reproduce..."
+                                              className={inputClassName}
+                                              value={formState.description}
+                                              onChange={(event) =>
+                                                  setFormState((current) => ({
+                                                      ...current,
+                                                      description: event.target.value,
+                                                  }))
+                                              }
+                                          />
+                                      </label>
 
-                                <div className="mt-auto pt-2">
-                                    <button
-                                        type="submit"
-                                        disabled={isLoading}
-                                        className="inline-flex w-full items-center justify-center gap-2 rounded-xl border-2 border-(--accent-highlight) bg-(--card-70) px-4 py-2.5 text-sm font-medium text-foreground transition hover:border-(--accent) disabled:cursor-not-allowed disabled:opacity-70"
-                                    >
-                                        {isLoading ? (
-                                            <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                                        ) : null}
-                                        {isLoading ? "Submitting..." : "Submit Report"}
-                                    </button>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                </>
-            ) : null}
+                                      <div className="mt-auto pt-2">
+                                          <button
+                                              type="submit"
+                                              disabled={isLoading}
+                                              className="inline-flex w-full items-center justify-center gap-2 rounded-(--radius-md) border-2 border-(--accent-highlight) bg-(--card-70) px-4 py-2.5 text-sm font-medium text-foreground transition hover:border-(--accent) disabled:cursor-not-allowed disabled:opacity-70"
+                                          >
+                                              {isLoading ? (
+                                                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                                              ) : null}
+                                              {isLoading ? "Submitting..." : "Submit Report"}
+                                          </button>
+                                      </div>
+                                  </form>
+                              </div>
+                          </div>
+                      </>,
+                      document.body,
+                  )
+                : null}
         </>
     );
 }

--- a/src/components/feedback/BugReportButton.tsx
+++ b/src/components/feedback/BugReportButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { Bug } from "lucide-react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 
@@ -21,31 +22,6 @@ const initialFormState: FeedbackFormState = {
     description: "",
     type: "bug",
 };
-
-function BugIcon() {
-    return (
-        <svg
-            aria-hidden="true"
-            className="h-5 w-5"
-            fill="none"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            viewBox="0 0 24 24"
-        >
-            <path d="M12 6v12" />
-            <path d="M8 8h8" />
-            <path d="M8 16h8" />
-            <path d="M7 10 4 8" />
-            <path d="M7 14 4 16" />
-            <path d="M17 10l3-2" />
-            <path d="M17 14l3 2" />
-            <path d="M15 5a3 3 0 1 0-6 0" />
-            <rect x="7" y="6" width="10" height="12" rx="5" />
-        </svg>
-    );
-}
 
 export function BugReportButton() {
     const [isOpen, setIsOpen] = useState(false);
@@ -141,7 +117,7 @@ export function BugReportButton() {
                 className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-foreground hover:bg-(--card-80) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50"
                 onClick={openPanel}
             >
-                <BugIcon />
+                <Bug aria-hidden="true" className="h-4 w-4 shrink-0 text-(--ink-muted)" />
                 {CTA_LABELS.reportIssue}
             </button>
 

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -75,7 +75,7 @@ export const CTA_LABELS = {
     viewGuide: "View guide",
     reset: "Reset",
     retry: "Retry",
-    reportIssue: "Report an issue",
+    reportIssue: "Report issue",
     closeIssueReportPanel: "Close issue report panel",
     close: "Close",
     clearContext: "Clear context",

--- a/tests/acr-context-fabric.production.spec.ts
+++ b/tests/acr-context-fabric.production.spec.ts
@@ -322,10 +322,12 @@ test.describe("Context Fabric production entitlement boundary", () => {
             const preferences = page.getByRole("link", { name: "Preferences" });
             const adminPanel = page.getByRole("link", { name: "Admin Panel" });
             const signOut = page.getByRole("button", { name: "Sign out" });
+            const reportIssue = page.getByRole("button", { name: "Report issue" });
             await expect(platformAdmin).toBeVisible();
             await expect(preferences).toBeVisible();
             await expect(adminPanel).toBeVisible();
             await expect(signOut).toBeVisible();
+            await expect(reportIssue).toBeVisible();
             const accountNavigationBottomAfterOpen = await accountNavigation.evaluate(
                 (element) => element.getBoundingClientRect().bottom,
             );
@@ -337,7 +339,7 @@ test.describe("Context Fabric production entitlement boundary", () => {
             await expect(menu).toBeVisible();
             const menuTop = await menu.evaluate((element) => element.getBoundingClientRect().top);
             expect(menuTop).toBeLessThan(pageHeadingTop);
-            for (const menuItem of [platformAdmin, preferences, adminPanel, signOut]) {
+            for (const menuItem of [platformAdmin, preferences, adminPanel, signOut, reportIssue]) {
                 expect(
                     await menuItem.evaluate((element) => {
                         const bounds = element.getBoundingClientRect();
@@ -632,7 +634,7 @@ test.describe("Context Fabric production entitlement boundary", () => {
         await expect(page.getByRole("heading", { name: "e2e stale response" })).toHaveCount(0);
     });
 
-    test("keeps the issue-report control clear of Context Fabric form, terminal, and cards at every viewport", async ({
+    test("opens issue reporting from the bottom of the account menu at every viewport", async ({
         page,
     }, testInfo) => {
         await setEntitlementScenario(page.request, "provisioned");
@@ -647,13 +649,29 @@ test.describe("Context Fabric production entitlement boundary", () => {
             });
             await expect(terminal).toBeVisible();
 
-            const issueReportControl = page.getByRole("button", { name: "Report an issue" });
-            const categoryCards = page.locator("article");
-            await expect(categoryCards).toHaveCount(1);
-            // The bug report control is an intentional floating FAB (fixed
-            // bottom-right overlay), so the earlier anti-overlap constraint no
-            // longer applies; assert only that it remains present and reachable.
+            await page.getByRole("button", { name: "Account options" }).click();
+            const issueReportControl = page.getByRole("button", { name: "Report issue" });
             await expect(issueReportControl).toBeVisible();
+            await issueReportControl.click();
+            const dialog = page.getByRole("dialog", { name: "Report issue" });
+            await expect(dialog).toBeVisible();
+            await page.getByLabel("Title").fill("Pointer interaction remains open");
+            await expect(dialog).toBeVisible();
+            await expect(page.getByRole("button", { name: "Account options" })).toHaveAttribute(
+                "aria-expanded",
+                "true",
+            );
+            const submitReport = page.getByRole("button", { name: "Submit Report" });
+            expect(
+                await submitReport.evaluate((element) => {
+                    const bounds = element.getBoundingClientRect();
+                    const topmostElement = document.elementFromPoint(
+                        bounds.left + bounds.width / 2,
+                        bounds.top + bounds.height / 2,
+                    );
+                    return topmostElement === element || element.contains(topmostElement);
+                }),
+            ).toBe(true);
             await page.screenshot({
                 path: testInfo.outputPath(`issue-report-layout-${viewport.name}.png`),
                 fullPage: true,


### PR DESCRIPTION
## Summary
- place the issue-report action directly above `Sign out` in the account menu
- separate the bottom action section from the options above it with one horizontal divider
- label the action `Report issue` and keep the existing bug icon
- preserve the report drawer through a body portal with correct pointer, focus, and stacking behavior
- remove the standalone mobile and floating report triggers

## Verification
- `./node_modules/.bin/vitest run src/components/auth/UserMenu.test.tsx`
- `./node_modules/.bin/prettier --check src/components/auth/UserMenu.tsx src/components/auth/UserMenu.test.tsx`
- `./node_modules/.bin/eslint src/components/auth/UserMenu.tsx src/components/auth/UserMenu.test.tsx`
- `DESIGN_LINT=true ./node_modules/.bin/eslint src/components/auth/UserMenu.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `pnpm exec vitest run src/components/auth/UserMenu.test.tsx src/components/feedback/BugReportButton.test.tsx src/lib/design/__tests__/cta.test.ts`
- `pnpm exec playwright test -c playwright.context-fabric.config.ts --project=authenticated -g "opens issue reporting from the bottom of the account menu"`
- `pnpm build`
- browser QA at 1280, 768, and 375px

## Known repository state
- full `pnpm design-lint` currently reports pre-existing failures outside this change; cleanup is being handled separately

## Screenshots

### Account menu — requested order
![pr-825-account-menu-order-after.png](https://github.com/user-attachments/assets/ca9b57ba-969f-4e52-889b-0d03eb659d66)

### Account menu — desktop
![report-issue-account-menu-1280-approved.png](https://github.com/user-attachments/assets/f2ad19e3-33ee-4a17-9cdb-2942e94b1443)

### Account menu — tablet
![report-issue-account-menu-768-approved.png](https://github.com/user-attachments/assets/b4443d27-e1d2-4160-be79-bf414d78791b)

### Account menu — mobile
![report-issue-account-menu-375-approved.png](https://github.com/user-attachments/assets/670ca02d-dfcc-4a1e-83ac-2ccda3c2177e)

### Report issue drawer
![report-issue-dialog-1280-approved.png](https://github.com/user-attachments/assets/0442782f-965d-4cc9-a4a5-410ac7411a18)
