### PR TITLE
fix: format evidence values and hide internal identifiers (CHAOS-3307)

### DIFF
--- a/src/components/charts/SparklineChart.test.tsx
+++ b/src/components/charts/SparklineChart.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatSparklineTooltipDate } from "./SparklineChart";
+import { formatSparklineTooltipDate, formatSparklineTooltipValue } from "./SparklineChart";
 
 describe("formatSparklineTooltipDate", () => {
     it("formats an ISO datetime string as a short date (not the raw ISO)", () => {
@@ -32,5 +32,17 @@ describe("formatSparklineTooltipDate", () => {
         // because integers are not valid dates
         expect(formatSparklineTooltipDate(1)).toBe("1");
         expect(formatSparklineTooltipDate(42)).toBe("42");
+    });
+});
+
+describe("formatSparklineTooltipValue", () => {
+    it("rounds numeric tooltip values instead of exposing floating-point precision", () => {
+        expect(formatSparklineTooltipValue(0.6889888599537036)).toBe("0.7");
+        expect(formatSparklineTooltipValue(11993.3875352)).toBe("11,993.4");
+    });
+
+    it("preserves non-numeric tooltip values", () => {
+        expect(formatSparklineTooltipValue("No data")).toBe("No data");
+        expect(formatSparklineTooltipValue(undefined)).toBe("");
     });
 });

--- a/src/components/charts/SparklineChart.tsx
+++ b/src/components/charts/SparklineChart.tsx
@@ -7,6 +7,7 @@ import { LineChart } from "echarts/charts";
 import { Chart } from "./Chart";
 import { useChartTheme } from "./chartTheme";
 import { echarts } from "@/lib/echartsInit";
+import { formatNumber } from "@/lib/formatters";
 
 echarts.use([LineChart]);
 
@@ -60,6 +61,11 @@ export function formatSparklineTooltipDate(axisValue: string | number): string {
     return str;
 }
 
+export function formatSparklineTooltipValue(value: number | string | undefined): string {
+    if (typeof value === "number") return formatNumber(value);
+    return value ?? "";
+}
+
 export function SparklineChart({
     data,
     categories,
@@ -94,7 +100,7 @@ export function SparklineChart({
                         const first = list[0] as SparklineTooltipParam | undefined;
                         const axisValue = first?.axisValue ?? "";
                         const label = formatSparklineTooltipDate(axisValue);
-                        const value = first?.value !== undefined ? first.value : "";
+                        const value = formatSparklineTooltipValue(first?.value);
                         return `${first?.marker ?? ""}${label}: ${value}`;
                     },
                 },

--- a/src/components/evidence/EvidenceItems.tsx
+++ b/src/components/evidence/EvidenceItems.tsx
@@ -42,9 +42,6 @@ export function EvidenceItems({ items }: EvidenceItemsProps) {
                                     <span className="rounded border border-(--card-stroke) bg-(--card-70) px-1.5 py-0.5 text-[10px] font-bold uppercase text-(--ink-muted)">
                                         {item.type}
                                     </span>
-                                    <span className="truncate font-mono text-xs text-(--ink-muted)">
-                                        {item.id}
-                                    </span>
                                 </div>
                                 <p className="line-clamp-2 text-sm font-medium leading-5 text-foreground group-hover:text-(--accent)">
                                     {item.title}

--- a/src/components/evidence/EvidencePanel.test.tsx
+++ b/src/components/evidence/EvidencePanel.test.tsx
@@ -73,6 +73,74 @@ describe("EvidencePanel", () => {
         expect(screen.getByText("Shorten review queue")).toBeInTheDocument();
     });
 
+    it("formats contributor values and percentages for display", async () => {
+        mockGetExplainData.mockResolvedValue({
+            metric: "throughput",
+            label: "Throughput",
+            value: 11993,
+            unit: "items",
+            delta_pct: 361.38753526545264,
+            summary: "Throughput moved in this window.",
+            contributors: [
+                {
+                    id: "contributor-1",
+                    label: "Repository activity",
+                    value: 11993,
+                    delta_pct: 361.38753526545264,
+                    evidence_link: "/explore",
+                },
+            ],
+            actions: [],
+        });
+
+        render(
+            <EvidencePanel
+                isOpen
+                onCloseAction={() => undefined}
+                title="Throughput"
+                metric="throughput"
+                filters={filters}
+            />,
+        );
+
+        expect(await screen.findByText("11,993 (361%)")).toBeInTheDocument();
+        expect(document.body).not.toHaveTextContent("361.38753526545264");
+    });
+
+    it("does not expose internal evidence identifiers", async () => {
+        const internalId = "a1b2c3d4-e5f6-4789-abcd-0123456789ab";
+        mockGetExplainData.mockResolvedValue({
+            metric: "cycle_time",
+            label: "Cycle Time",
+            value: 4,
+            unit: "days",
+            delta_pct: -12,
+            summary: "Cycle time appears lower in this window.",
+            evidence: [
+                {
+                    id: internalId,
+                    title: "Shorten review queue",
+                    url: "/prs/PR-1",
+                    type: "pr",
+                },
+            ],
+            actions: [],
+        });
+
+        render(
+            <EvidencePanel
+                isOpen
+                onCloseAction={() => undefined}
+                title="Cycle Time"
+                metric="cycle_time"
+                filters={filters}
+            />,
+        );
+
+        expect(await screen.findByText("Shorten review queue")).toBeInTheDocument();
+        expect(document.body).not.toHaveTextContent(internalId);
+    });
+
     it("makes empty evidence explicit as partial data", async () => {
         mockGetExplainData.mockResolvedValue({
             metric: "throughput",

--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -14,6 +14,8 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { buildExploreUrl, withFilterParam } from "@/lib/filters/url";
 import { CTA_LABELS } from "@/lib/design/cta";
 import { getMetricDefinition } from "@/lib/metrics/definitions";
+import { formatNumber, formatPercent as formatDisplayPercent } from "@/lib/formatters";
+import { scrubIdentifiers } from "@/lib/labels/entityLabel";
 import Link from "next/link";
 
 type EvidenceItem = {
@@ -62,7 +64,9 @@ type EvidencePanelResult = Partial<EvidencePanelData> & {
 };
 
 const formatPercent = (value?: number | null) =>
-    typeof value === "number" ? `${Math.round(value)}%` : "not available";
+    typeof value === "number" ? formatDisplayPercent(value) : "not available";
+
+const safeNarrative = (value: string) => scrubIdentifiers(value).text;
 
 const humanizeKey = (value: string) =>
     value
@@ -389,17 +393,23 @@ export function EvidencePanel({
                                     title: d.label,
                                     url: d.evidence_link || "#",
                                     type: "other" as const,
-                                    meta: `${d.value} (${d.delta_pct}%)`,
+                                    meta: `${formatNumber(d.value)} (${formatPercent(d.delta_pct)})`,
                                 }),
                             );
 
                         // Deduplicate by id — drivers and contributors overlap
                         const seen = new Set<string>();
-                        const evidence = rawEvidence.filter((item) => {
-                            if (seen.has(item.id)) return false;
-                            seen.add(item.id);
-                            return true;
-                        });
+                        const evidence = rawEvidence
+                            .filter((item) => {
+                                if (seen.has(item.id)) return false;
+                                seen.add(item.id);
+                                return true;
+                            })
+                            .map((item) => ({
+                                ...item,
+                                title: safeNarrative(item.title),
+                                ...(item.meta ? { meta: safeNarrative(item.meta) } : {}),
+                            }));
 
                         const actions = result.actions || definition?.suggestedActions || [];
 
@@ -411,14 +421,17 @@ export function EvidencePanel({
                             partial: evidence.length === 0,
                         };
 
+                        const summary =
+                            result.summary ||
+                            `${result.label || title} is ${trend} by ${formatPercent(Math.abs(deltaPct))}`;
+                        const whyItMatters = result.why_it_matters || definition?.whyItMatters;
+
                         setData({
                             ...result,
-                            summary:
-                                result.summary ||
-                                `${result.label || title} is ${trend} by ${Math.abs(deltaPct)}%`,
+                            summary: safeNarrative(summary),
                             trend,
                             magnitude,
-                            why_it_matters: result.why_it_matters || definition?.whyItMatters,
+                            why_it_matters: whyItMatters ? safeNarrative(whyItMatters) : undefined,
                             evidence,
                             actions,
                             provenance,

--- a/src/components/home/CockpitClient.test.tsx
+++ b/src/components/home/CockpitClient.test.tsx
@@ -77,6 +77,29 @@ describe("CockpitClient — Key Shifts row", () => {
         expect(screen.getByText("Code Churn")).toBeInTheDocument();
     });
 
+    it("scrubs unresolved identifiers from notable-shift narratives", () => {
+        const internalId = "a1b2c3d4-e5f6-4789-abcd-0123456789ab";
+        render(
+            <CockpitClient
+                home={makeHome({
+                    summary: [
+                        {
+                            id: "summary-1",
+                            text: `Compounding risk appears elevated for ${internalId}.`,
+                            evidence_link: "/api/v1/home?thread=understand",
+                        },
+                    ],
+                })}
+                filters={filters}
+                activeRole="ic"
+            />,
+        );
+
+        expect(document.body).not.toHaveTextContent(internalId);
+        expect(document.body.innerHTML).not.toContain(internalId);
+        expect(screen.getByText(/#a1b2c3d4/)).toBeInTheDocument();
+    });
+
     it("shows no-data-connected when deltas are empty and no sources are connected", () => {
         // makeHome() has freshness.sources: {} → no sources → no-data-connected
         render(<CockpitClient home={makeHome({ deltas: [] })} filters={filters} activeRole="ic" />);

--- a/src/components/home/CockpitClient.tsx
+++ b/src/components/home/CockpitClient.tsx
@@ -10,6 +10,7 @@ import { MetricDelta } from "@/components/shared/MetricDelta";
 import { DataState } from "@/components/ui/DataState";
 import { sortDeltasByRole, getMetricPolarity } from "@/lib/metrics/catalog";
 import { formatMetricValue } from "@/lib/formatters";
+import { scrubIdentifiers } from "@/lib/labels/entityLabel";
 import type { HomeResponse } from "@/lib/types";
 import type { MetricFilter } from "@/lib/filters/types";
 
@@ -178,7 +179,7 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                                 }
                                 className="block w-full text-left rounded-2xl border border-transparent bg-(--card-60) px-4 py-3 transition hover:border-(--card-stroke)"
                             >
-                                {sentence.text}
+                                {scrubIdentifiers(sentence.text).text}
                             </button>
                         ))}
                         {!home?.summary?.length && (
@@ -280,10 +281,10 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                         </div>
                     ) : null}
                     <div className="mt-4 space-y-3 text-sm">
-                        {(home?.constraint.evidence ?? []).map((item, idx) => (
+                        {(home?.constraint.evidence ?? []).map((item) => (
                             <button
                                 type="button"
-                                key={`${item.label}-${idx}`}
+                                key={`${item.label}-${item.link}`}
                                 onClick={() => openPanel(item.label, { apiUrl: item.link })}
                                 className="block w-full text-left rounded-2xl border border-(--card-stroke) bg-(--card-70) px-4 py-3 hover:bg-(--card-60) transition-colors"
                             >
@@ -314,10 +315,10 @@ export function CockpitClient({ home, filters, activeRole }: CockpitClientProps)
                         </Link>
                     </div>
                     <div className="mt-4 space-y-4 text-sm">
-                        {(home?.events ?? []).map((event, idx) => (
+                        {(home?.events ?? []).map((event) => (
                             <button
                                 type="button"
-                                key={`${event.type}-${idx}`}
+                                key={`${event.type}-${event.ts}-${event.text}`}
                                 onClick={() => openPanel(event.type, { apiUrl: event.link })}
                                 className="block w-full text-left rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3 hover:border-(--card-stroke)/80 transition-colors"
                             >


### PR DESCRIPTION
## Summary

- format sparkline tooltip values through the shared number formatter
- format contributor values and percentages before rendering evidence metadata
- remove transport identifiers from evidence cards
- scrub unresolved UUIDs from cockpit and evidence narratives, including rendered markup
- add failing-first regression coverage for each reported leak

Fixes CHAOS-3307

## Validation

- `pnpm test:unit`: 3,536 passed, 8 skipped
- `pnpm typecheck`: passed
- `pnpm build`: passed
- focused ESLint on all changed files: passed
- changed-file Prettier check: passed
- Playwright manual QA: tooltip rendered `0.7`; evidence rendered `11,993 (361%)`; raw UUID and raw percentage were absent; zero console errors
- independent code review: passed with no findings

## Design lint

The full design-lint gate currently reports the same 249 existing errors present on the base branch. This focused bug fix does not add a new design-lint violation; the repository-wide cleanup remains isolated from this PR.

## Visual evidence

### Sparkline tooltip

![Sparkline tooltip showing rounded value](https://github.com/user-attachments/assets/45ec2157-7bc2-438b-b0d9-e4752f81d7d2)

### Evidence panel

![Evidence panel showing formatted values without transport IDs](https://github.com/user-attachments/assets/2fea0b55-398b-47c9-a608-02801034391b)
