### PR TITLE
fix: render authoritative sync coverage windows

### DIFF
--- a/src/components/admin/sync/BackfillOperations.test.tsx
+++ b/src/components/admin/sync/BackfillOperations.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, userEvent } from "@/test/utils";
 import { BackfillOperations } from "./BackfillOperations";
-import { PARTIAL_COVERAGE_SUMMARY } from "@/lib/admin/__tests__/syncCoverageFixtures";
+import {
+    PARTIAL_COVERAGE_SUMMARY,
+    TRUNCATED_COVERAGE_SUMMARY,
+} from "@/lib/admin/__tests__/syncCoverageFixtures";
 
 vi.mock("next/navigation", () => ({
     useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
@@ -49,6 +52,28 @@ describe("BackfillOperations", () => {
         expect(screen.getByRole("dialog")).toBeInTheDocument();
         expect(screen.getByLabelText("From")).toHaveValue("2026-01-02");
         expect(screen.getByLabelText("To")).toHaveValue("2026-01-03");
+    });
+
+    it("opens the wizard with the exact server-owned canonical backfill window", async () => {
+        const user = userEvent.setup();
+        render(
+            <BackfillOperations
+                configId="cfg-1"
+                coverage={TRUNCATED_COVERAGE_SUMMARY}
+                coverageError={undefined}
+                isActive
+                activeBackfillJob={null}
+                testMode
+            />,
+        );
+
+        await user.click(
+            screen.getByRole("button", { name: "Backfill Dec 20, 2025 to Jan 1, 2026" }),
+        );
+
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+        expect(screen.getByLabelText("From")).toHaveValue("2025-12-20");
+        expect(screen.getByLabelText("To")).toHaveValue("2026-01-01");
     });
 
     it("opens an unscoped recovery backfill when coverage cannot load", async () => {

--- a/src/components/admin/sync/BackfillOperations.tsx
+++ b/src/components/admin/sync/BackfillOperations.tsx
@@ -5,7 +5,11 @@ import { SyncCoverageSummaryCard } from "./SyncCoverageSummaryCard";
 import { SyncCoverageTimeline } from "./SyncCoverageTimeline";
 import { BackfillStatus } from "./BackfillStatus";
 import { BackfillWizard } from "./BackfillWizard";
-import type { BackfillJob, SyncCoverageRange, SyncCoverageSummary } from "@/lib/admin/types";
+import type {
+    BackfillJob,
+    SyncCoverageBackfillWindow,
+    SyncCoverageSummary,
+} from "@/lib/admin/types";
 
 interface BackfillOperationsProps {
     configId: string;
@@ -46,7 +50,7 @@ export function BackfillOperations({
     const [isWizardOpen, setIsWizardOpen] = useState(false);
     const [wizardRange, setWizardRange] = useState<WizardRange | null>(null);
 
-    const openWizard = (range?: SyncCoverageRange) => {
+    const openWizard = (range?: SyncCoverageBackfillWindow) => {
         setWizardRange(
             range ? { since: toDateInput(range.since), before: toDateInput(range.before) } : null,
         );
@@ -76,7 +80,7 @@ export function BackfillOperations({
             <SyncCoverageTimeline
                 coverage={coverage}
                 error={coverageError}
-                onBackfillGapAction={openWizard}
+                onBackfillWindowAction={openWizard}
             />
 
             {isWizardOpen && (

--- a/src/components/admin/sync/SyncCoverageSummaryCard.test.tsx
+++ b/src/components/admin/sync/SyncCoverageSummaryCard.test.tsx
@@ -5,6 +5,7 @@ import {
     COMPLETE_COVERAGE_SUMMARY,
     LEGACY_INSUFFICIENT_DATA_SUMMARY,
     PARTIAL_COVERAGE_SUMMARY,
+    TRUNCATED_COVERAGE_SUMMARY,
 } from "@/lib/admin/__tests__/syncCoverageFixtures";
 
 const mockPush = vi.fn();
@@ -102,6 +103,64 @@ describe("SyncCoverageSummaryCard", () => {
         expect(screen.queryByText(/unknown/i)).not.toBeInTheDocument();
     });
 
+    it("shows the server-owned coverage window and explains a truncated response", () => {
+        render(
+            <SyncCoverageSummaryCard
+                configId="cfg-1"
+                coverage={TRUNCATED_COVERAGE_SUMMARY}
+                isActive
+                error={undefined}
+                onBackfillAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("coverage-window")).toHaveTextContent(
+            "Coverage shown: Dec 20, 2025 – Jan 5, 2026",
+        );
+        expect(screen.getByTestId("coverage-truncation-notice")).toHaveTextContent(
+            /limited to this coverage window/i,
+        );
+        expect(screen.queryByText("lookback_limit")).not.toBeInTheDocument();
+    });
+
+    it("derives successful coverage bounds for an older backend response", () => {
+        render(
+            <SyncCoverageSummaryCard
+                configId="cfg-1"
+                coverage={COMPLETE_COVERAGE_SUMMARY}
+                isActive
+                error={undefined}
+                onBackfillAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("coverage-window")).toHaveTextContent(
+            "Coverage shown: Jan 1, 2026 – Jan 2, 2026",
+        );
+        expect(screen.queryByTestId("coverage-truncation-notice")).not.toBeInTheDocument();
+    });
+
+    it("uses safe generic copy for an unrecognized truncation reason", () => {
+        const coverage = {
+            ...TRUNCATED_COVERAGE_SUMMARY,
+            truncation_reason: "internal_database_detail",
+        };
+        render(
+            <SyncCoverageSummaryCard
+                configId="cfg-1"
+                coverage={coverage}
+                isActive
+                error={undefined}
+                onBackfillAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("coverage-truncation-notice")).toHaveTextContent(
+            /limited to this coverage window/i,
+        );
+        expect(screen.queryByText("internal_database_detail")).not.toBeInTheDocument();
+    });
+
     it("shows an explanatory legacy notice for insufficient_data + legacy data_basis", () => {
         render(
             <SyncCoverageSummaryCard
@@ -115,6 +174,9 @@ describe("SyncCoverageSummaryCard", () => {
 
         expect(screen.getByText("Insufficient data")).toBeInTheDocument();
         expect(screen.getByTestId("coverage-legacy-notice")).toBeInTheDocument();
+        expect(screen.getByTestId("coverage-window")).toHaveTextContent(
+            "No successful synced data yet.",
+        );
         expect(screen.getByText("Inactive")).toBeInTheDocument();
         expect(screen.queryByText(/^unknown$/i)).not.toBeInTheDocument();
     });

--- a/src/components/admin/sync/SyncCoverageSummaryCard.tsx
+++ b/src/components/admin/sync/SyncCoverageSummaryCard.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ClientTimestamp } from "@/components/ClientTimestamp";
 import { DataState } from "@/components/ui/DataState";
-import { formatNumber } from "@/lib/formatters";
+import { formatDateUTC, formatNumber } from "@/lib/formatters";
 import { CTA_LABELS } from "@/lib/design/cta";
 import type { SyncCoverageSummary } from "@/lib/admin/types";
 import { CoverageBadge, healthLabel, healthTone } from "./CoverageBadge";
@@ -31,6 +31,13 @@ function StatBlock({ label, value }: { label: string; value: ReactNode }) {
             <dd className="mt-1 text-lg font-medium text-foreground">{value}</dd>
         </div>
     );
+}
+
+function truncationMessage(reason: string | null | undefined): string {
+    if (reason === "lookback_limit") {
+        return "History is limited to this coverage window so coverage can be computed safely. Older activity may not appear in the health summary or timeline.";
+    }
+    return "History is limited to this coverage window. Older activity may not appear in the health summary or timeline.";
 }
 
 export function SyncCoverageSummaryCard({
@@ -86,6 +93,22 @@ export function SyncCoverageSummaryCard({
     }
 
     const { overall, data_basis: dataBasis } = coverage;
+    const coveredRanges = coverage.datasets.flatMap((dataset) => dataset.covered_ranges);
+    const derivedSince = coveredRanges
+        .map((range) => new Date(range.since).getTime())
+        .filter(Number.isFinite)
+        .reduce<number | null>((earliest, value) => Math.min(earliest ?? value, value), null);
+    const derivedThrough = coveredRanges
+        .map((range) => new Date(range.before).getTime())
+        .filter(Number.isFinite)
+        .reduce<number | null>((latest, value) => Math.max(latest ?? value, value), null);
+    const coverageSince =
+        coverage.coverage_since ??
+        (derivedSince === null ? null : new Date(derivedSince).toISOString());
+    const coverageThrough =
+        coverage.coverage_through ??
+        (derivedThrough === null ? null : new Date(derivedThrough).toISOString());
+    const hasCoverageWindow = coverageSince !== null && coverageThrough !== null;
     const isLegacyInsufficientData =
         overall.health === "insufficient_data" && dataBasis === "legacy";
 
@@ -111,6 +134,24 @@ export function SyncCoverageSummaryCard({
                             This configuration has no planner-tracked sync runs yet, so detailed
                             coverage cannot be computed. Coverage will populate once a
                             planner-backed sync completes.
+                        </p>
+                    )}
+                    <p className="text-sm text-(--ink-muted)" data-testid="coverage-window">
+                        {hasCoverageWindow ? (
+                            <>
+                                Coverage shown: {formatDateUTC(coverageSince)} –{" "}
+                                {formatDateUTC(coverageThrough)}
+                            </>
+                        ) : (
+                            "No successful synced data yet."
+                        )}
+                    </p>
+                    {coverage.is_truncated === true && (
+                        <p
+                            className="max-w-2xl rounded-lg border border-(--caution)/40 bg-(--caution)/10 px-3 py-2 text-sm text-foreground"
+                            data-testid="coverage-truncation-notice"
+                        >
+                            {truncationMessage(coverage.truncation_reason)}
                         </p>
                     )}
                 </div>

--- a/src/components/admin/sync/SyncCoverageTimeline.test.tsx
+++ b/src/components/admin/sync/SyncCoverageTimeline.test.tsx
@@ -5,6 +5,7 @@ import {
     COMPLETE_COVERAGE_SUMMARY,
     LEGACY_INSUFFICIENT_DATA_SUMMARY,
     PARTIAL_COVERAGE_SUMMARY,
+    TRUNCATED_COVERAGE_SUMMARY,
 } from "@/lib/admin/__tests__/syncCoverageFixtures";
 import {
     SAMPLE_COVERAGE_CONCURRENT_CONFIG,
@@ -13,7 +14,7 @@ import {
 
 describe("SyncCoverageTimeline", () => {
     it("renders a loading state when coverage has not resolved yet", () => {
-        render(<SyncCoverageTimeline coverage={null} onBackfillGapAction={vi.fn()} />);
+        render(<SyncCoverageTimeline coverage={null} onBackfillWindowAction={vi.fn()} />);
 
         expect(screen.getByTestId("coverage-timeline-loading")).toBeInTheDocument();
     });
@@ -23,7 +24,7 @@ describe("SyncCoverageTimeline", () => {
             <SyncCoverageTimeline
                 coverage={null}
                 error="Coverage endpoint returned 500"
-                onBackfillGapAction={vi.fn()}
+                onBackfillWindowAction={vi.fn()}
             />,
         );
 
@@ -35,7 +36,7 @@ describe("SyncCoverageTimeline", () => {
         render(
             <SyncCoverageTimeline
                 coverage={LEGACY_INSUFFICIENT_DATA_SUMMARY}
-                onBackfillGapAction={vi.fn()}
+                onBackfillWindowAction={vi.fn()}
             />,
         );
 
@@ -47,7 +48,7 @@ describe("SyncCoverageTimeline", () => {
         render(
             <SyncCoverageTimeline
                 coverage={PARTIAL_COVERAGE_SUMMARY}
-                onBackfillGapAction={vi.fn()}
+                onBackfillWindowAction={vi.fn()}
             />,
         );
 
@@ -56,19 +57,19 @@ describe("SyncCoverageTimeline", () => {
         expect(screen.queryByText(/src-repo/)).not.toBeInTheDocument();
     });
 
-    it("invokes onBackfillGapAction with the gap's range when 'Backfill this gap' is clicked", async () => {
-        const onBackfillGapAction = vi.fn();
+    it("preserves the legacy gap action when canonical windows are absent", async () => {
+        const onBackfillWindowAction = vi.fn();
         const user = userEvent.setup();
         render(
             <SyncCoverageTimeline
                 coverage={PARTIAL_COVERAGE_SUMMARY}
-                onBackfillGapAction={onBackfillGapAction}
+                onBackfillWindowAction={onBackfillWindowAction}
             />,
         );
 
         const button = screen.getByRole("button", { name: "Backfill this gap" });
         await user.click(button);
-        expect(onBackfillGapAction).toHaveBeenCalledWith(
+        expect(onBackfillWindowAction).toHaveBeenCalledWith(
             expect.objectContaining({
                 since: "2026-01-02T00:00:00Z",
                 before: "2026-01-03T00:00:00Z",
@@ -76,11 +77,94 @@ describe("SyncCoverageTimeline", () => {
         );
     });
 
+    it("uses only canonical backfill windows when the field is present", async () => {
+        const onBackfillWindowAction = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <SyncCoverageTimeline
+                coverage={TRUNCATED_COVERAGE_SUMMARY}
+                onBackfillWindowAction={onBackfillWindowAction}
+            />,
+        );
+
+        expect(screen.queryByRole("button", { name: "Backfill this gap" })).not.toBeInTheDocument();
+        const action = screen.getByRole("button", {
+            name: "Backfill Dec 20, 2025 to Jan 1, 2026",
+        });
+        await user.click(action);
+        expect(onBackfillWindowAction).toHaveBeenCalledWith({
+            since: "2025-12-20",
+            before: "2026-01-01",
+        });
+    });
+
+    it("does not infer a backfill action from gaps when canonical windows are explicitly empty", () => {
+        render(
+            <SyncCoverageTimeline
+                coverage={{ ...PARTIAL_COVERAGE_SUMMARY, backfill_windows: [] }}
+                onBackfillWindowAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getAllByText("Gap").length).toBeGreaterThan(0);
+        expect(screen.queryByRole("button", { name: /Backfill/ })).not.toBeInTheDocument();
+    });
+
+    it("uses the server coverage bounds as the decorative timeline extent", () => {
+        render(
+            <SyncCoverageTimeline
+                coverage={TRUNCATED_COVERAGE_SUMMARY}
+                onBackfillWindowAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("coverage-covered-band-commits")).toHaveStyle({
+            left: "74.8051948051948%",
+            width: "6.233766233766234%",
+        });
+    });
+
+    it("falls back to the dataset extent when explicit coverage bounds are invalid", () => {
+        render(
+            <SyncCoverageTimeline
+                coverage={{
+                    ...TRUNCATED_COVERAGE_SUMMARY,
+                    coverage_since: "not-a-date",
+                    coverage_through: "also-not-a-date",
+                }}
+                onBackfillWindowAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("coverage-covered-band-commits")).toHaveStyle({
+            left: "0%",
+            width: "50%",
+        });
+    });
+
+    it("expands server coverage bounds to keep actual gap ranges visible", () => {
+        render(
+            <SyncCoverageTimeline
+                coverage={{
+                    ...TRUNCATED_COVERAGE_SUMMARY,
+                    coverage_since: "2026-01-01T00:00:00Z",
+                    coverage_through: "2026-01-02T00:00:00Z",
+                }}
+                onBackfillWindowAction={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("coverage-covered-band-commits")).toHaveStyle({
+            left: "0%",
+            width: "50%",
+        });
+    });
+
     it("filters rendered datasets by the dataset filter", async () => {
         render(
             <SyncCoverageTimeline
                 coverage={COMPLETE_COVERAGE_SUMMARY}
-                onBackfillGapAction={vi.fn()}
+                onBackfillWindowAction={vi.fn()}
             />,
         );
 
@@ -96,7 +180,7 @@ describe("SyncCoverageTimeline", () => {
         render(
             <SyncCoverageTimeline
                 coverage={PARTIAL_COVERAGE_SUMMARY}
-                onBackfillGapAction={vi.fn()}
+                onBackfillWindowAction={vi.fn()}
             />,
         );
 
@@ -114,7 +198,7 @@ describe("SyncCoverageTimeline", () => {
         render(
             <SyncCoverageTimeline
                 coverage={PARTIAL_COVERAGE_SUMMARY}
-                onBackfillGapAction={vi.fn()}
+                onBackfillWindowAction={vi.fn()}
             />,
         );
 
@@ -127,7 +211,7 @@ describe("SyncCoverageTimeline", () => {
         render(
             <SyncCoverageTimeline
                 coverage={SAMPLE_COVERAGE_OVERLAPPING_RETRY}
-                onBackfillGapAction={vi.fn()}
+                onBackfillWindowAction={vi.fn()}
             />,
         );
 
@@ -141,7 +225,7 @@ describe("SyncCoverageTimeline", () => {
         render(
             <SyncCoverageTimeline
                 coverage={SAMPLE_COVERAGE_CONCURRENT_CONFIG}
-                onBackfillGapAction={vi.fn()}
+                onBackfillWindowAction={vi.fn()}
             />,
         );
 

--- a/src/components/admin/sync/SyncCoverageTimeline.tsx
+++ b/src/components/admin/sync/SyncCoverageTimeline.tsx
@@ -5,6 +5,7 @@ import { DataState } from "@/components/ui/DataState";
 import { CTA_LABELS } from "@/lib/design/cta";
 import { formatDateUTC } from "@/lib/formatters";
 import type {
+    SyncCoverageBackfillWindow,
     SyncCoverageDataset,
     SyncCoverageRange,
     SyncCoverageSummary,
@@ -14,8 +15,8 @@ import { CoverageBadge, statusLabel, statusTone, type CoverageTone } from "./Cov
 interface SyncCoverageTimelineProps {
     coverage: SyncCoverageSummary | null;
     error?: string | null;
-    /** Opens the backfill wizard prefilled with this gap's range (CHAOS-2795/2796). */
-    onBackfillGapAction: (range: SyncCoverageRange) => void;
+    /** Opens the backfill wizard with a server-owned or legacy-compatible date window. */
+    onBackfillWindowAction: (range: SyncCoverageBackfillWindow) => void;
 }
 
 type BandKind = "covered" | "gap" | "stale" | "failed";
@@ -79,6 +80,25 @@ function datasetExtent(dataset: SyncCoverageDataset): [number, number] | null {
     return [start, end];
 }
 
+function serverCoverageExtent(coverage: SyncCoverageSummary): [number, number] | null {
+    if (!coverage.coverage_since || !coverage.coverage_through) return null;
+    const start = new Date(coverage.coverage_since).getTime();
+    const end = new Date(coverage.coverage_through).getTime();
+    if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return null;
+    return [start, end];
+}
+
+function timelineExtent(
+    coverage: SyncCoverageSummary,
+    dataset: SyncCoverageDataset,
+): [number, number] | null {
+    const server = serverCoverageExtent(coverage);
+    const data = datasetExtent(dataset);
+    if (!server) return data;
+    if (!data) return server;
+    return [Math.min(server[0], data[0]), Math.max(server[1], data[1])];
+}
+
 function bandStyle(
     range: SyncCoverageRange,
     extent: [number, number],
@@ -102,7 +122,7 @@ function bandStyle(
 export function SyncCoverageTimeline({
     coverage,
     error,
-    onBackfillGapAction,
+    onBackfillWindowAction,
 }: SyncCoverageTimelineProps) {
     const [datasetFilter, setDatasetFilter] = useState<string>("all");
     const [sourceFilter, setSourceFilter] = useState<string>("all");
@@ -151,8 +171,9 @@ export function SyncCoverageTimeline({
                 dataset.failed_ranges.length >
             0,
     );
+    const hasCanonicalBackfill = (coverage.backfill_windows?.length ?? 0) > 0;
 
-    if (!hasAnyRangeData) {
+    if (!hasAnyRangeData && !hasCanonicalBackfill) {
         return (
             <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
                 <DataState
@@ -216,9 +237,43 @@ export function SyncCoverageTimeline({
                 </div>
             </div>
 
+            {coverage.backfill_windows !== undefined && coverage.backfill_windows.length > 0 && (
+                <div
+                    className="space-y-3 rounded-lg border border-(--card-stroke) bg-(--card-70) p-4"
+                    data-testid="coverage-backfill-windows"
+                >
+                    <div>
+                        <h4 className="font-medium text-foreground">Available backfills</h4>
+                        <p className="mt-1 text-sm text-(--ink-muted)">
+                            These config-wide windows are provided by the coverage service.
+                        </p>
+                    </div>
+                    <ul className="space-y-2">
+                        {coverage.backfill_windows.map((window) => (
+                            <li
+                                key={`${window.since}-${window.before}`}
+                                className="flex flex-wrap items-center justify-between gap-3"
+                            >
+                                <span className="text-sm text-foreground">
+                                    {formatDateUTC(window.since)} – {formatDateUTC(window.before)}
+                                </span>
+                                <button
+                                    type="button"
+                                    aria-label={`Backfill ${formatDateUTC(window.since)} to ${formatDateUTC(window.before)}`}
+                                    onClick={() => onBackfillWindowAction(window)}
+                                    className="text-sm font-medium text-(--accent) hover:underline"
+                                >
+                                    {CTA_LABELS.backfillThisWindow}
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+
             <div className="space-y-6">
                 {datasets.map((dataset) => {
-                    const extent = datasetExtent(dataset);
+                    const extent = timelineExtent(coverage, dataset);
                     const activeSourceId = sourceFilter === "all" ? null : sourceFilter;
                     const filterBySource = (ranges: SyncCoverageRange[]) =>
                         ranges.filter((r) => rangeIncludesSource(r, activeSourceId));
@@ -281,6 +336,7 @@ export function SyncCoverageTimeline({
                                                         {kindRanges.map((row) => (
                                                             <div
                                                                 key={rangeKey(kind, row.range)}
+                                                                data-testid={`coverage-${kind}-band-${dataset.dataset_key}`}
                                                                 className={`absolute top-0 h-full rounded-full ${BAND_BAR_CLASS[kind]}`}
                                                                 style={bandStyle(row.range, extent)}
                                                             />
@@ -366,11 +422,14 @@ export function SyncCoverageTimeline({
                                                                   .join(", ")}
                                                     </td>
                                                     <td className="px-2 py-2">
-                                                        {row.kind === "gap" ? (
+                                                        {row.kind === "gap" &&
+                                                        coverage.backfill_windows === undefined ? (
                                                             <button
                                                                 type="button"
                                                                 onClick={() =>
-                                                                    onBackfillGapAction(row.range)
+                                                                    onBackfillWindowAction(
+                                                                        row.range,
+                                                                    )
                                                                 }
                                                                 className="text-(--accent) hover:underline"
                                                             >

--- a/src/data/syncCoverageSample.ts
+++ b/src/data/syncCoverageSample.ts
@@ -69,7 +69,7 @@ export const SAMPLE_COVERAGE_HEALTHY: SyncCoverageSummary = {
     provider: PROVIDER,
     generated_at: GENERATED_AT,
     data_basis: "planner",
-    history_lookback_days: 180,
+    history_lookback_days: 3650,
     truncated_before: TRUNCATED_BEFORE,
     overall: {
         health: "healthy",
@@ -147,7 +147,7 @@ export const SAMPLE_COVERAGE_GAPS: SyncCoverageSummary = {
     provider: PROVIDER,
     generated_at: GENERATED_AT,
     data_basis: "planner",
-    history_lookback_days: 180,
+    history_lookback_days: 3650,
     truncated_before: TRUNCATED_BEFORE,
     overall: {
         health: "gaps",
@@ -270,12 +270,30 @@ export const SAMPLE_COVERAGE_GAPS: SyncCoverageSummary = {
     ],
 };
 
+export const SAMPLE_COVERAGE_TRUNCATED: SyncCoverageSummary = {
+    ...SAMPLE_COVERAGE_GAPS,
+    coverage_since: "2026-06-20T00:00:00.000Z",
+    coverage_through: GENERATED_AT,
+    is_truncated: true,
+    truncation_reason: "lookback_limit",
+    backfill_windows: [
+        {
+            since: "2026-06-24",
+            before: "2026-06-26",
+        },
+        {
+            since: "2026-06-28",
+            before: "2026-07-01",
+        },
+    ],
+};
+
 export const SAMPLE_COVERAGE_FAILED: SyncCoverageSummary = {
     config_id: CONFIG_ID,
     provider: PROVIDER,
     generated_at: GENERATED_AT,
     data_basis: "planner",
-    history_lookback_days: 180,
+    history_lookback_days: 3650,
     truncated_before: TRUNCATED_BEFORE,
     overall: {
         health: "failed",
@@ -336,7 +354,7 @@ export const SAMPLE_COVERAGE_STALE: SyncCoverageSummary = {
     provider: PROVIDER,
     generated_at: GENERATED_AT,
     data_basis: "planner",
-    history_lookback_days: 180,
+    history_lookback_days: 3650,
     truncated_before: TRUNCATED_BEFORE,
     overall: {
         health: "stale",
@@ -392,7 +410,7 @@ export const SAMPLE_COVERAGE_INSUFFICIENT_DATA: SyncCoverageSummary = {
     provider: PROVIDER,
     generated_at: GENERATED_AT,
     data_basis: "legacy",
-    history_lookback_days: 180,
+    history_lookback_days: 3650,
     truncated_before: TRUNCATED_BEFORE,
     overall: {
         health: "insufficient_data",
@@ -412,7 +430,7 @@ export const SAMPLE_COVERAGE_OVERLAPPING_RETRY: SyncCoverageSummary = {
     provider: PROVIDER,
     generated_at: GENERATED_AT,
     data_basis: "planner",
-    history_lookback_days: 180,
+    history_lookback_days: 3650,
     truncated_before: TRUNCATED_BEFORE,
     overall: {
         health: "healthy",
@@ -483,7 +501,7 @@ export const SAMPLE_COVERAGE_CONCURRENT_CONFIG: SyncCoverageSummary = {
     provider: PROVIDER,
     generated_at: GENERATED_AT,
     data_basis: "planner",
-    history_lookback_days: 180,
+    history_lookback_days: 3650,
     truncated_before: TRUNCATED_BEFORE,
     overall: {
         health: "healthy",
@@ -536,6 +554,7 @@ export const SAMPLE_COVERAGE_CONCURRENT_CONFIG: SyncCoverageSummary = {
 export const SYNC_COVERAGE_SAMPLES = {
     healthy: SAMPLE_COVERAGE_HEALTHY,
     gaps: SAMPLE_COVERAGE_GAPS,
+    truncated: SAMPLE_COVERAGE_TRUNCATED,
     failed: SAMPLE_COVERAGE_FAILED,
     stale: SAMPLE_COVERAGE_STALE,
     insufficient_data: SAMPLE_COVERAGE_INSUFFICIENT_DATA,

--- a/src/lib/admin/__tests__/syncCoverageFixtures.ts
+++ b/src/lib/admin/__tests__/syncCoverageFixtures.ts
@@ -33,7 +33,7 @@ const baseSummary = {
     provider: "github",
     generated_at: GENERATED_AT,
     data_basis: "planner",
-    history_lookback_days: 180,
+    history_lookback_days: 3650,
     truncated_before: TRUNCATED_BEFORE,
 } satisfies Pick<
     SyncCoverageSummary,
@@ -130,6 +130,20 @@ export const PARTIAL_COVERAGE_SUMMARY = {
     ],
 } satisfies SyncCoverageSummary;
 
+export const TRUNCATED_COVERAGE_SUMMARY = {
+    ...PARTIAL_COVERAGE_SUMMARY,
+    coverage_since: "2025-12-20T00:00:00Z",
+    coverage_through: GENERATED_AT,
+    is_truncated: true,
+    truncation_reason: "lookback_limit",
+    backfill_windows: [
+        {
+            since: "2025-12-20",
+            before: "2026-01-01",
+        },
+    ],
+} satisfies SyncCoverageSummary;
+
 export const FAILED_COVERAGE_SUMMARY = {
     ...baseSummary,
     overall: {
@@ -205,6 +219,7 @@ export const COVERAGE_SUMMARIES = {
     empty: EMPTY_COVERAGE_SUMMARY,
     complete: COMPLETE_COVERAGE_SUMMARY,
     partial: PARTIAL_COVERAGE_SUMMARY,
+    truncated: TRUNCATED_COVERAGE_SUMMARY,
     failed: FAILED_COVERAGE_SUMMARY,
     legacy: LEGACY_INSUFFICIENT_DATA_SUMMARY,
 } satisfies Record<string, SyncCoverageSummary>;

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -160,6 +160,12 @@ export interface SyncCoverageRange {
     run_ids: string[];
 }
 
+/** Server-owned, config-wide date range accepted by the backfill endpoint. */
+export interface SyncCoverageBackfillWindow {
+    since: string;
+    before: string;
+}
+
 export interface SyncRunJobEnrichment {
     mode: string;
     triggered_by: string;
@@ -208,6 +214,15 @@ export interface SyncCoverageSummary {
     data_basis: SyncCoverageDataBasis;
     history_lookback_days: number;
     truncated_before: string;
+    /** Explicit response window. Optional while Web and Ops deploy independently. */
+    coverage_since?: string;
+    coverage_through?: string;
+    /** True when retained facts exist before the exact response window. */
+    is_truncated?: boolean;
+    /** Stable backend reason code; the UI must map it to user-safe copy. */
+    truncation_reason?: string | null;
+    /** Authoritative config-wide actions. Present empty means no action is available. */
+    backfill_windows?: SyncCoverageBackfillWindow[];
     overall: SyncCoverageOverall;
     datasets: SyncCoverageDataset[];
     sources: SyncCoverageSource[];

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -140,6 +140,8 @@ export const CTA_LABELS = {
     backfill: "Backfill",
     /** Gap-scoped backfill deep-link from the coverage timeline (CHAOS-2793). */
     backfillThisGap: "Backfill this gap",
+    /** Server-owned config-wide backfill window from the coverage timeline. */
+    backfillThisWindow: "Backfill this window",
     allDatasets: "All datasets",
     allSources: "All sources",
     /** Reset the run-detail unit table status filter (CHAOS-2794). */

--- a/tests/admin-sync-observability.spec.ts
+++ b/tests/admin-sync-observability.spec.ts
@@ -159,9 +159,20 @@ test.describe("Journey 1 — coverage-first config detail", () => {
 test.describe("Journey 2 — gap-driven backfill flow", () => {
     test("canonical backfill entry prefills the exact server-owned window", async ({ page }) => {
         await page.goto(`${DETAIL_URL}?coverage_scenario=truncated`);
-        await page.getByRole("button", { name: "Backfill Jun 24, 2026 to Jun 26, 2026" }).click();
+        const backfillButton = page.getByRole("button", {
+            name: "Backfill Jun 24, 2026 to Jun 26, 2026",
+        });
+        const dialog = page.getByRole("dialog");
 
-        await expect(page.getByRole("dialog")).toBeVisible();
+        // On constrained CI runners the server-rendered button can become
+        // actionable just before its client handler hydrates. Retry the complete
+        // click-and-result assertion so a swallowed pre-hydration click is loud
+        // and bounded, matching the repository's navigation journey pattern.
+        await expect(async () => {
+            await backfillButton.click();
+            await expect(dialog).toBeVisible({ timeout: 3000 });
+        }).toPass({ timeout: 30000, intervals: [300, 700, 1500] });
+
         await expect(page.getByLabel("From", { exact: true })).toHaveValue("2026-06-24");
         await expect(page.getByLabel("To", { exact: true })).toHaveValue("2026-06-26");
     });

--- a/tests/admin-sync-observability.spec.ts
+++ b/tests/admin-sync-observability.spec.ts
@@ -135,9 +135,37 @@ test.describe("Journey 1 — coverage-first config detail", () => {
 
         await expect(page.getByText(/unknown/i)).toHaveCount(0);
     });
+
+    test("truncated coverage labels the server-owned window and exposes only canonical backfills", async ({
+        page,
+    }) => {
+        await page.goto(`${DETAIL_URL}?coverage_scenario=truncated`);
+
+        await expect(page.getByTestId("coverage-window")).toContainText(
+            "Coverage shown: Jun 20, 2026 – Jul 2, 2026",
+        );
+        await expect(page.getByTestId("coverage-truncation-notice")).toContainText(
+            "limited to this coverage window",
+        );
+        const timeline = timelineRegion(page);
+        await expect(timeline.getByTestId("coverage-backfill-windows")).toBeVisible();
+        await expect(timeline.getByRole("button", { name: "Backfill this gap" })).toHaveCount(0);
+        await expect(
+            timeline.getByRole("button", { name: "Backfill Jun 24, 2026 to Jun 26, 2026" }),
+        ).toBeVisible();
+    });
 });
 
 test.describe("Journey 2 — gap-driven backfill flow", () => {
+    test("canonical backfill entry prefills the exact server-owned window", async ({ page }) => {
+        await page.goto(`${DETAIL_URL}?coverage_scenario=truncated`);
+        await page.getByRole("button", { name: "Backfill Jun 24, 2026 to Jun 26, 2026" }).click();
+
+        await expect(page.getByRole("dialog")).toBeVisible();
+        await expect(page.getByLabel("From", { exact: true })).toHaveValue("2026-06-24");
+        await expect(page.getByLabel("To", { exact: true })).toHaveValue("2026-06-26");
+    });
+
     test("opens the wizard prefilled from a gap, validates the range, previews an estimate, gates an expensive submit, and completes in test mode", async ({
         page,
     }) => {


### PR DESCRIPTION
## Summary

- show the successful-data coverage range instead of presenting the query lookback as coverage
- render truncation state without leaking backend reason codes
- treat server-provided backfill windows as authoritative, including an explicitly empty list
- preserve legacy gap actions only when the new field is absent
- include server coverage bounds in the timeline extent so older available data is not hidden

## Dependency

- Requires full-chaos/dev-health-ops#1365

## Validation

- focused Vitest coverage/admin tests passed
- full Vitest suite passed: 3,542 tests; the process-group signal file also passed 10/10 outside the restricted sandbox
- TypeScript, Prettier, design ESLint, and design static scans passed
- Next production build passed outside the restricted loopback sandbox
- focused Playwright journeys passed

## Visual evidence

![truncated successful-data coverage](https://github.com/user-attachments/assets/f08e5717-d6cd-41e2-84c4-21ae1c72b996)

![canonical backfill window](https://github.com/user-attachments/assets/992555fb-4cf7-4a2d-8bc4-ac6b71334db3)

Refs CHAOS-3266
Refs #827
Refs #828
