### PR TITLE
fix(ask-dev): CHAOS-3291 answer hierarchy + sanctioned status/outcome copy

### DIFF
--- a/src/components/ask-dev/AskDevAnswer.test.tsx
+++ b/src/components/ask-dev/AskDevAnswer.test.tsx
@@ -4,7 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DevAnswer } from "@/lib/dev/generated";
 
-import { AskDevAnswer } from "./AskDevAnswer";
+import { ANSWER_STATUS_LABELS, AskDevAnswer, SCOPE_OUTCOME_LABELS } from "./AskDevAnswer";
 
 const actions = vi.hoisted(() => ({
     expandEvidence: vi.fn(),
@@ -345,5 +345,41 @@ describe("AskDevAnswer sanctioned copy (CHAOS-3291)", () => {
         expect(screen.getByText("Not accessible")).toBeVisible();
         expect(screen.queryByText(/forbidden/iu)).not.toBeInTheDocument();
         expect(screen.queryByText(/not found/iu)).not.toBeInTheDocument();
+    });
+
+    // Totality guard, independent of any single render: these reference
+    // records exist purely so TypeScript re-enforces exhaustiveness here
+    // too. If AnswerStatus or ScopeResolutionOutcome ever gains a member,
+    // this file fails to compile until it's added below (mirroring the
+    // TOTAL Record in AskDevAnswer.tsx), and the Object.keys comparison
+    // catches any drift between the two lists even if both happened to
+    // compile.
+    it("ANSWER_STATUS_LABELS has exactly one sanctioned entry per AnswerStatus member", () => {
+        const knownStatuses: Record<DevAnswer["status"], true> = {
+            complete: true,
+            degraded: true,
+            error: true,
+            insufficient_evidence: true,
+            partial: true,
+            refused: true,
+        };
+        expect(Object.keys(ANSWER_STATUS_LABELS).sort()).toEqual(
+            Object.keys(knownStatuses).sort(),
+        );
+    });
+
+    it("SCOPE_OUTCOME_LABELS has exactly one sanctioned entry per ScopeResolutionOutcome member", () => {
+        const knownOutcomes: Record<DevAnswer["resolved_scope"]["outcome"], true> = {
+            ambiguous: true,
+            exact: true,
+            filtered: true,
+            forbidden_or_not_found: true,
+            inherited: true,
+            organization_fallback: true,
+            unresolved: true,
+        };
+        expect(Object.keys(SCOPE_OUTCOME_LABELS).sort()).toEqual(
+            Object.keys(knownOutcomes).sort(),
+        );
     });
 });

--- a/src/components/ask-dev/AskDevAnswer.test.tsx
+++ b/src/components/ask-dev/AskDevAnswer.test.tsx
@@ -363,9 +363,7 @@ describe("AskDevAnswer sanctioned copy (CHAOS-3291)", () => {
             partial: true,
             refused: true,
         };
-        expect(Object.keys(ANSWER_STATUS_LABELS).sort()).toEqual(
-            Object.keys(knownStatuses).sort(),
-        );
+        expect(Object.keys(ANSWER_STATUS_LABELS).sort()).toEqual(Object.keys(knownStatuses).sort());
     });
 
     it("SCOPE_OUTCOME_LABELS has exactly one sanctioned entry per ScopeResolutionOutcome member", () => {
@@ -378,8 +376,6 @@ describe("AskDevAnswer sanctioned copy (CHAOS-3291)", () => {
             organization_fallback: true,
             unresolved: true,
         };
-        expect(Object.keys(SCOPE_OUTCOME_LABELS).sort()).toEqual(
-            Object.keys(knownOutcomes).sort(),
-        );
+        expect(Object.keys(SCOPE_OUTCOME_LABELS).sort()).toEqual(Object.keys(knownOutcomes).sort());
     });
 });

--- a/src/components/ask-dev/AskDevAnswer.test.tsx
+++ b/src/components/ask-dev/AskDevAnswer.test.tsx
@@ -295,3 +295,55 @@ describe("AskDevAnswer answer hierarchy (CHAOS-3291)", () => {
         expect(evidenceLabelEl.className).not.toMatch(/text-\(--text-primary\)/u);
     });
 });
+
+describe("AskDevAnswer sanctioned copy (CHAOS-3291)", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    beforeEach(() => {
+        Object.values(actions).forEach((action) => action.mockReset());
+    });
+
+    // The status pill previously rendered answer.status verbatim
+    // (`insufficient_evidence`, underscores and all). It must go through
+    // the sanctioned copy map instead.
+    it("renders sanctioned copy for the status pill, never the raw enum value", () => {
+        const statusAnswer = {
+            ...answer,
+            status: "insufficient_evidence",
+        } as unknown as DevAnswer;
+        render(<AskDevAnswer answer={statusAnswer} />);
+
+        expect(screen.getByText("Insufficient evidence")).toBeVisible();
+        expect(screen.queryByText("insufficient_evidence")).not.toBeInTheDocument();
+        expect(screen.queryByText(/insufficient_evidence/u)).not.toBeInTheDocument();
+    });
+
+    // The reported leak: scope outcome "forbidden_or_not_found" rendered
+    // verbatim as "forbidden or not found". The backend deliberately
+    // collapses forbidden vs. not-found into one outcome (so scope
+    // resolution can't be used to enumerate what exists); the sanctioned
+    // copy must preserve that, never re-split or expose the raw member.
+    it("renders sanctioned copy for a forbidden_or_not_found scope outcome, never the raw enum value", () => {
+        const forbiddenAnswer = {
+            ...answer,
+            resolved_scope: {
+                authorized_repository_ids: [],
+                candidates: [],
+                outcome: "forbidden_or_not_found",
+                resolved_at: "2026-07-29T00:00:00Z",
+                schema_version: "dev_scope_resolution.v1",
+                warnings: [],
+            },
+        } as unknown as DevAnswer;
+        render(<AskDevAnswer answer={forbiddenAnswer} />);
+
+        expect(screen.getByText("Not accessible")).toBeVisible();
+        expect(screen.queryByText(/forbidden/iu)).not.toBeInTheDocument();
+        expect(screen.queryByText(/not found/iu)).not.toBeInTheDocument();
+    });
+});

--- a/src/components/ask-dev/AskDevAnswer.test.tsx
+++ b/src/components/ask-dev/AskDevAnswer.test.tsx
@@ -258,3 +258,40 @@ describe("AskDevAnswer status explanations (CHAOS-3215)", () => {
         expect(screen.queryByText(/not a silent success/u)).not.toBeInTheDocument();
     });
 });
+
+describe("AskDevAnswer answer hierarchy (CHAOS-3291)", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    beforeEach(() => {
+        Object.values(actions).forEach((action) => action.mockReset());
+    });
+
+    // Regression guard for the reported inversion: the direct answer must
+    // carry the primary (display-font, heading-scale) typography, while an
+    // Evidence entry's label must NOT carry that same primary treatment —
+    // it is supporting material, not the headline. Planting the old classes
+    // back on either element is exactly the defect this issue fixed.
+    it("gives the direct answer primary typographic weight and keeps evidence entries secondary", () => {
+        const thinAnswer = {
+            ...answer,
+            claims: [],
+            direct_summary: "Status: partial.",
+            metrics: [],
+            status: "partial",
+        } as unknown as DevAnswer;
+        render(<AskDevAnswer answer={thinAnswer} />);
+
+        const summaryEl = screen.getByText("Status: partial.");
+        expect(summaryEl.className).toMatch(/text-h3/u);
+
+        const evidenceLabelEl = screen.getByText("Pull request 451");
+        expect(evidenceLabelEl.className).not.toMatch(/text-h3/u);
+        expect(evidenceLabelEl.className).not.toMatch(/font-medium/u);
+        expect(evidenceLabelEl.className).not.toMatch(/text-\(--text-primary\)/u);
+    });
+});

--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -83,30 +83,33 @@ function EvidenceRow({
         <div
             id={anchorId}
             tabIndex={-1}
-            className="scroll-mt-6 space-y-2 border-l-2 border-(--border) pl-3 outline-none focus-visible:border-(--accent)"
+            className="scroll-mt-6 space-y-1.5 border-l-2 border-(--border) pl-3 outline-none focus-visible:border-(--accent)"
         >
             <div className="flex flex-wrap items-start justify-between gap-2">
-                <div className="flex min-w-0 flex-col gap-1">
-                    <span className="font-medium text-(--text-primary)">
+                <div className="flex min-w-0 flex-col gap-0.5">
+                    <span className="text-sm text-(--text-secondary)">
                         {evidence.display_label}
                     </span>
                     <span className="text-xs text-(--text-muted)">
                         {evidence.provenance} · {formatTimestamp(evidence.observed_at)}
                     </span>
                 </div>
+                {/*
+                 * Quiet by default (text-muted, no fill) — this is a
+                 * secondary, on-demand affordance, not a primary CTA; it
+                 * only picks up accent color on hover/focus (CHAOS-3291).
+                 */}
                 <button
                     type="button"
                     onClick={() => void openExpansion()}
                     disabled={loading}
-                    className="rounded-(--radius-sm) px-2 py-1 text-xs font-medium text-(--accent) hover:bg-(--accent)/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
+                    className="rounded-(--radius-sm) px-2 py-1 text-xs font-medium text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
                 >
                     {loading ? "Opening…" : CTA_LABELS.openEvidence}
                 </button>
             </div>
             {evidence.citation_text ? (
-                <p className="text-sm leading-6 text-(--text-secondary)">
-                    {evidence.citation_text}
-                </p>
+                <p className="text-xs leading-5 text-(--text-muted)">{evidence.citation_text}</p>
             ) : null}
             {expansion ? (
                 <div className="rounded-(--radius-md) bg-(--background)/60 p-3 text-sm leading-6 text-(--text-secondary)">
@@ -315,11 +318,29 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                 </span>
             </div>
 
-            {statusExplanation ? (
-                <p className="text-xs text-(--text-muted)">{statusExplanation}</p>
-            ) : null}
-
-            <p className="text-body leading-7 text-(--text-primary)">{answer.direct_summary}</p>
+            {/*
+             * The direct answer is the primary content (TRD §16: scope →
+             * question → answer → evidence/metrics → follow-up; CHAOS-3291).
+             * Previously the status caption rendered as an isolated text-xs
+             * line and direct_summary as plain text-body — same visual
+             * weight as the supporting chrome below it, so a thin answer
+             * (e.g. "Status: partial.") read as smaller and less important
+             * than the Evidence block. Keeping the caption tightly coupled
+             * to the summary (one block, no separating chrome) and giving
+             * the summary the same display-font treatment used for section
+             * headings elsewhere makes it read as one coherent answer
+             * rather than badge + boilerplate + terse line.
+             */}
+            <div className="space-y-1.5">
+                {statusExplanation ? (
+                    <p className="text-sm leading-6 text-(--text-secondary)">
+                        {statusExplanation}
+                    </p>
+                ) : null}
+                <p className="font-(--font-display) text-h3 text-(--text-primary)">
+                    {answer.direct_summary}
+                </p>
+            </div>
 
             {scopeResolution ? (
                 <section
@@ -573,7 +594,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                     <h3 id={evidenceHeadingId} className="text-label-caps text-(--text-muted)">
                         Evidence
                     </h3>
-                    <div className="space-y-4">
+                    <div className="space-y-3">
                         {answer.evidence.map((evidence) => (
                             <EvidenceRow
                                 key={evidence.evidence_ref_id}

--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -35,6 +35,35 @@ function safeExcerpt(value: string | null | undefined): string | null {
 // *full* evidence coverage (available_source_count === required_source_count)
 // — not only when required evidence was unavailable. That specific claim
 // belongs to `insufficient_evidence`, where it is accurate.
+// Sanctioned copy for the status pill. A TOTAL map (no Partial, no raw
+// enum fallback) so an unmapped AnswerStatus is a type error at build time,
+// never a raw internal value reaching the badge at runtime (CHAOS-3291,
+// design system A8 "no internal/impl leakage").
+const ANSWER_STATUS_LABELS: Record<DevAnswer["status"], string> = {
+    complete: "Complete",
+    degraded: "Degraded",
+    error: "Error",
+    insufficient_evidence: "Insufficient evidence",
+    partial: "Partial",
+    refused: "Refused",
+};
+
+// Sanctioned copy for the scope-resolution outcome row. Also TOTAL: the raw
+// `forbidden_or_not_found` member previously rendered verbatim as "forbidden
+// or not found" — customer-facing copy must not leak that internal
+// distinction (the backend deliberately collapses forbidden vs. not-found
+// into one outcome so scope resolution can't be used to enumerate what
+// exists; the label must preserve that, not re-split it).
+const SCOPE_OUTCOME_LABELS: Record<DevAnswer["resolved_scope"]["outcome"], string> = {
+    ambiguous: "Ambiguous",
+    exact: "Exact match",
+    filtered: "Filtered",
+    forbidden_or_not_found: "Not accessible",
+    inherited: "Inherited",
+    organization_fallback: "Organization-wide",
+    unresolved: "Unresolved",
+};
+
 const STATUS_EXPLANATIONS: Partial<Record<DevAnswer["status"], string>> = {
     partial:
         "Partial: the investigation did not fully complete. A result with limitations, not a silent success.",
@@ -311,7 +340,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                     AI-generated
                 </span>
                 <span className="rounded-(--radius-pill) border border-(--border) px-2.5 py-1 text-label-caps text-(--text-muted)">
-                    {answer.status.replaceAll("_", " ")}
+                    {ANSWER_STATUS_LABELS[answer.status]}
                 </span>
                 <span className="text-xs text-(--text-muted)">
                     As of {formatTimestamp(answer.as_of)}
@@ -351,7 +380,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                         <span className="text-(--text-muted)">
                             Scope outcome:{" "}
                             <strong className="font-medium text-(--text-secondary)">
-                                {scopeResolution.outcome.replaceAll("_", " ")}
+                                {SCOPE_OUTCOME_LABELS[scopeResolution.outcome]}
                             </strong>
                         </span>
                         <span className="text-(--text-muted)">

--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -366,9 +366,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
              */}
             <div className="space-y-1.5">
                 {statusExplanation ? (
-                    <p className="text-sm leading-6 text-(--text-secondary)">
-                        {statusExplanation}
-                    </p>
+                    <p className="text-sm leading-6 text-(--text-secondary)">{statusExplanation}</p>
                 ) : null}
                 <p className="font-(--font-display) text-h3 text-(--text-primary)">
                     {answer.direct_summary}

--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -39,7 +39,11 @@ function safeExcerpt(value: string | null | undefined): string | null {
 // enum fallback) so an unmapped AnswerStatus is a type error at build time,
 // never a raw internal value reaching the badge at runtime (CHAOS-3291,
 // design system A8 "no internal/impl leakage").
-const ANSWER_STATUS_LABELS: Record<DevAnswer["status"], string> = {
+// Exported (rather than module-private) so the totality test in
+// AskDevAnswer.test.tsx can assert Object.keys(...) coverage against the
+// real generated union directly, instead of duplicating a second copy of
+// the member list in the test file that could itself drift.
+export const ANSWER_STATUS_LABELS: Record<DevAnswer["status"], string> = {
     complete: "Complete",
     degraded: "Degraded",
     error: "Error",
@@ -54,7 +58,7 @@ const ANSWER_STATUS_LABELS: Record<DevAnswer["status"], string> = {
 // distinction (the backend deliberately collapses forbidden vs. not-found
 // into one outcome so scope resolution can't be used to enumerate what
 // exists; the label must preserve that, not re-split it).
-const SCOPE_OUTCOME_LABELS: Record<DevAnswer["resolved_scope"]["outcome"], string> = {
+export const SCOPE_OUTCOME_LABELS: Record<DevAnswer["resolved_scope"]["outcome"], string> = {
     ambiguous: "Ambiguous",
     exact: "Exact match",
     filtered: "Filtered",


### PR DESCRIPTION
## Summary
- Direct answer now leads visually: status caption + `direct_summary` render as one primary block (display font, h3 scale); evidence rows demoted to secondary weight with muted actions (accent on hover/focus only).
- Raw internal enum passthroughs removed: `ANSWER_STATUS_LABELS` and `SCOPE_OUTCOME_LABELS` are TOTAL `Record`s over the generated types (a new enum member is a type error until mapped). `forbidden_or_not_found` renders "Not accessible" — never the mechanical de-underscore.

## TEST-EVIDENCE
- vitest: 69/69 in `src/components/ask-dev/` (+4 new: hierarchy regression, 2 sanctioned-copy leak guards, 2 runtime totality guards). Mutation-verified: reverting the component alone fails exactly the new tests; runtime-deleting one map entry fails exactly the totality test.
- Full web gate green on this branch: quality/lint/typecheck, vitest 3556/0, e2e default 250/0, onboarding 10/0, context-fabric 21/0 (one unrelated mobile-nav focus flake passed clean on stage rerun).
- Codex adversarial review: SHIP, no material findings (all render paths through total maps; persisted-error path emits neither raw value).
- Before/after screenshots in both themes verified (no bright borders, tokens only).

## RISK-NOTES
- Copy changes are user-visible: status pills and scope-outcome rows now show sanctioned copy instead of de-underscored enum text.
- `forbidden_or_not_found` deliberately stays combined ("Not accessible") so scope resolution can't be used to enumerate what exists.
- Interacts with CHAOS-3288/3289/3290 content changes — layout holds for thin answers now; revisit emphasis once those land. Playwright denylist specs asserting no-raw-enums land with CHAOS-3287.