### PR TITLE
feat(ask-dev): add deterministic Ask Dev coverage to the default web CI suite

### DIFF
--- a/src/app/api/v1/dev/_proxy.test.ts
+++ b/src/app/api/v1/dev/_proxy.test.ts
@@ -53,6 +53,99 @@ describe("Ask Dev same-origin proxy", () => {
         expect(authMock).not.toHaveBeenCalled();
     });
 
+    // Regression coverage for a real defect found by CHAOS-3287's Playwright
+    // coverage: with no AUTH_URL/NEXTAUTH_URL configured (the normal state
+    // for local `pnpm dev` and this repo's own e2e-default CI job),
+    // `expectedOrigin()` used to derive the expected origin from
+    // `request.url`, which Next.js's dev server does not reliably set to
+    // the actual `--hostname` it was started with. That rejected every
+    // legitimate same-origin mutation unconditionally. The fix derives the
+    // expected origin from the request's own inbound Host header instead.
+    it("accepts a same-origin mutation derived from the Host header when AUTH_URL is unset", async () => {
+        vi.stubEnv("AUTH_URL", "");
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(
+                Response.json({ schema_version: "dev_conversation.v1" }, { status: 201 }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const incoming = new Request("http://localhost:3001/api/v1/dev/conversations", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                origin: "http://127.0.0.1:3001",
+                host: "127.0.0.1:3001",
+            },
+            body: "{}",
+        });
+
+        const response = await proxyDevRequest(incoming, "/api/v1/dev/conversations", {
+            mutation: true,
+        });
+
+        expect(response.status).toBe(201);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // AUTH_URL/NEXTAUTH_URL, when configured, must stay authoritative — the
+    // Host/X-Forwarded-Host derivation is the FALLBACK for when neither is
+    // set, never a competing source. A reverse proxy or load balancer can
+    // rewrite Host in ways that must not silently override an explicitly
+    // configured canonical origin.
+    it("prefers a configured AUTH_URL over a mismatched Host header", async () => {
+        vi.stubEnv("AUTH_URL", "https://app.example.test");
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(
+                Response.json({ schema_version: "dev_conversation.v1" }, { status: 201 }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const incoming = new Request("https://app.example.test/api/v1/dev/conversations", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                origin: "https://app.example.test",
+                // A Host header that, if it were consulted, would compute a
+                // different expected origin than AUTH_URL — proving AUTH_URL
+                // wins rather than merely "also happening to agree".
+                host: "internal-lb.example.test:8080",
+            },
+            body: "{}",
+        });
+
+        const response = await proxyDevRequest(incoming, "/api/v1/dev/conversations", {
+            mutation: true,
+        });
+
+        expect(response.status).toBe(201);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("still rejects a cross-origin mutation when AUTH_URL is unset", async () => {
+        vi.stubEnv("AUTH_URL", "");
+        const fetchMock = vi.fn();
+        vi.stubGlobal("fetch", fetchMock);
+
+        const incoming = new Request("http://localhost:3001/api/v1/dev/conversations", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                origin: "https://evil.example.test",
+                host: "127.0.0.1:3001",
+            },
+            body: "{}",
+        });
+
+        const response = await proxyDevRequest(incoming, "/api/v1/dev/conversations", {
+            mutation: true,
+        });
+
+        expect(response.status).toBe(403);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it("forwards only the server session bearer, body, abort signal, and no-store response", async () => {
         const fetchMock = vi
             .fn()

--- a/src/app/api/v1/dev/_proxy.ts
+++ b/src/app/api/v1/dev/_proxy.ts
@@ -66,11 +66,42 @@ function webError(
 
 function expectedOrigin(request: Request): string {
     const configured = process.env.AUTH_URL ?? process.env.NEXTAUTH_URL;
-    try {
-        return configured ? new URL(configured).origin : new URL(request.url).origin;
-    } catch {
-        return "";
+    if (configured) {
+        try {
+            return new URL(configured).origin;
+        } catch {
+            return "";
+        }
     }
+    // FALLBACK ONLY, when AUTH_URL/NEXTAUTH_URL is not configured (local
+    // dev, and this repo's own Playwright default suite — CI's
+    // e2e-default job doesn't set either): derive the expected origin from
+    // the request's own inbound Host, not `request.url`. Next.js's dev
+    // server can report a `request.url` host that does not match the
+    // `--hostname` it was actually started with (observed: started with
+    // `--hostname 127.0.0.1`, browser Origin/Host both genuinely
+    // "127.0.0.1:<port>", but `request.url` reported "localhost:<port>")
+    // — using it here made this same-origin check reject every legitimate
+    // mutation unconditionally whenever AUTH_URL is unset.
+    //
+    // Trusting X-Forwarded-Host/Host here does not weaken this check: the
+    // value actually compared below is the *incoming* `Origin` header,
+    // which a browser sets authoritatively — `Origin` is a forbidden
+    // header name (Fetch spec), so no page's JavaScript, same-site or
+    // cross-site, can ever set or override it. Spoofing
+    // X-Forwarded-Host only changes what we compare Origin *against*; it
+    // cannot make a cross-site attacker's browser send a forged Origin
+    // that equals this site's. A configured AUTH_URL/NEXTAUTH_URL always
+    // takes precedence over this fallback (see the branch above).
+    const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+    if (!host) return "";
+    let protocol = "https:";
+    try {
+        protocol = new URL(request.url).protocol || "https:";
+    } catch {
+        protocol = "https:";
+    }
+    return `${protocol}//${host}`;
 }
 
 function hasValidMutationOrigin(request: Request): boolean {

--- a/tests/ask-dev-continuity.spec.ts
+++ b/tests/ask-dev-continuity.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+
+import {
+    askDevAnswerArticle,
+    askDevComposer,
+    askDevTranscript,
+    openAskDevWindow,
+    resetAskDevMock,
+    scenarioQuestion,
+    submitAskDevQuestion,
+} from "./helpers/askDev";
+
+// CHAOS-3287: window <-> /dev share one conversation/transcript because
+// AskDevProvider mounts once at the (app) layout and both surfaces render
+// through the same AskDevConversation component (AskDevWindow hides itself
+// on /dev; AskDevWorkspace shows the same transcript with history enabled).
+//
+// Org-switch state isolation ("organization switch ... clears unsafe
+// retained state") already has a real regression test — the render-time
+// reset in AskDevProvider (CHAOS-3215 H1) is covered by
+// src/components/ask-dev/AskDevProvider.test.tsx. Reproducing it here would
+// require rewiring the shared auth/org mock fixtures (orgs/me, entitlements,
+// switch-org) that many unrelated specs depend on; deferred rather than
+// risking that shared surface for one additional layer of the same
+// assertion — see the CHAOS-3287 handoff report for detail.
+
+test.beforeEach(async ({ request }) => {
+    await resetAskDevMock(request);
+});
+
+test.describe("Ask Dev — window <-> /dev continuity", () => {
+    test("a conversation started in the window resumes in the /dev workspace", async ({ page }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("complete", "How many items completed this period?"),
+        );
+        await expect(askDevAnswerArticle(page)).toBeVisible();
+
+        await page.getByRole("link", { name: "Ask Dev workspace" }).click();
+        await expect(page).toHaveURL(/\/dev(\?|$)/);
+        await expect(page.getByRole("region", { name: "Ask Dev workspace" })).toBeVisible();
+        // Scoped to the transcript: the same question text also legitimately
+        // appears as the saved conversation's title in the history sidebar
+        // (showHistory is on for /dev), which would otherwise match too.
+        await expect(
+            askDevTranscript(page).getByText("How many items completed this period?"),
+        ).toBeVisible();
+        await expect(askDevAnswerArticle(page)).toContainText("Twelve work items completed");
+    });
+
+    test("a conversation started on /dev resumes in the persistent window", async ({ page }) => {
+        await page.goto("/dev", { waitUntil: "domcontentloaded" });
+        const composer = askDevComposer(page);
+        await composer.fill(scenarioQuestion("complete", "What is the delivery status?"));
+        await composer.press("Enter");
+        await expect(askDevAnswerArticle(page)).toBeVisible();
+
+        await page.getByRole("link", { name: "Return to Ask Dev window" }).click();
+        await expect(page).not.toHaveURL(/\/dev(\?|$)/);
+        await expect(page.getByText("What is the delivery status?")).toBeVisible();
+        await expect(askDevAnswerArticle(page)).toContainText("Twelve work items completed");
+    });
+
+    test("starting a new conversation clears the previous transcript on both surfaces", async ({
+        page,
+    }) => {
+        await page.goto("/dev", { waitUntil: "domcontentloaded" });
+        const composer = askDevComposer(page);
+        await composer.fill(scenarioQuestion("complete", "What is the delivery status?"));
+        await composer.press("Enter");
+        await expect(askDevAnswerArticle(page)).toBeVisible();
+
+        await page.getByRole("button", { name: "New conversation" }).click();
+        // Scoped to the active transcript, not the whole page: the prior
+        // conversation legitimately still shows up by title in the history
+        // sidebar (showHistory is on for /dev) — "New conversation" starts
+        // a fresh transcript, it does not delete history.
+        await expect(
+            askDevTranscript(page).getByText("What is the delivery status?"),
+        ).not.toBeVisible();
+        await expect(askDevComposer(page)).toHaveValue("");
+    });
+});

--- a/tests/ask-dev-outcomes.spec.ts
+++ b/tests/ask-dev-outcomes.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from "@playwright/test";
+
+import { ASK_DEV_OUTCOME_TABLE } from "./fixtures/askDevOutcomes";
+import {
+    askDevAnswerArticle,
+    askDevFailedAlert,
+    askDevLauncher,
+    openAskDevWindow,
+    resetAskDevMock,
+    scenarioQuestion,
+    setAskDevCapabilities,
+    setAskDevEntitlement,
+    submitAskDevQuestion,
+} from "./helpers/askDev";
+
+// CHAOS-3287: every public outcome the current dev_answer.v1 contract can
+// actually produce gets a distinct, accessible rendering test here. See
+// ask-dev-shared.spec.ts's file header for why this does not (yet) cover
+// the dev_answer.v2 outcome taxonomy from CHAOS-3294/CHAOS-3298.
+//
+// The status/copy pairing for each scenario below is NOT hardcoded here —
+// it's read from tests/fixtures/askDevOutcomes.ts, the same table
+// tests/mocks/devScenario.ts uses to build the canned answer. CHAOS-3298
+// only needs to re-point that one table at dev_answer.v2 shapes; this loop
+// stays correct un-touched.
+
+test.beforeEach(async ({ request }) => {
+    await resetAskDevMock(request);
+});
+
+test.describe("Ask Dev — answer status outcomes", () => {
+    for (const outcome of ASK_DEV_OUTCOME_TABLE) {
+        test(`${outcome.key}: renders the direct answer and its expected limitation caption`, async ({
+            page,
+        }) => {
+            await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+            await openAskDevWindow(page);
+            await submitAskDevQuestion(
+                page,
+                scenarioQuestion(outcome.key, `Question for the ${outcome.key} scenario`),
+            );
+
+            const answer = askDevAnswerArticle(page);
+            await expect(answer).toBeVisible();
+            await expect(answer).toContainText(outcome.directSummary);
+
+            if (outcome.captionContains) {
+                await expect(answer).toContainText(outcome.captionContains);
+            } else {
+                // `complete` is the only status with no STATUS_EXPLANATIONS
+                // entry (AskDevAnswer.tsx): assert none of the OTHER
+                // scenarios' captions leaked in by mistake.
+                for (const otherOutcome of ASK_DEV_OUTCOME_TABLE) {
+                    if (otherOutcome.captionContains) {
+                        await expect(
+                            answer.getByText(otherOutcome.captionContains),
+                        ).not.toBeVisible();
+                    }
+                }
+            }
+
+            if (outcome.emptyEvidence) {
+                await expect(page.getByRole("button", { name: "Open evidence" })).not.toBeVisible();
+            }
+
+            // A refusal/insufficient-evidence answer is a completed answer,
+            // not a stream failure: the role="alert" failed-run treatment
+            // must never also appear alongside it.
+            await expect(askDevFailedAlert(page)).not.toBeVisible();
+        });
+    }
+
+    test("needs_clarification (ambiguous scope): presents candidates without evidence", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("needs_clarification", "What is the status of dev-health?"),
+        );
+
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+        await expect(answer).toContainText("More than one match was found");
+        await expect(answer.getByText("Possible scope matches")).toBeVisible();
+        const useScope = answer.getByRole("button", { name: "Use this scope" }).first();
+        await expect(useScope).toBeVisible();
+        await useScope.click();
+    });
+
+    test("a stream-level failure (source_unavailable) renders the alert treatment, not a silent blank", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("source_unavailable_error", "What is the deployment status?"),
+        );
+
+        await expect(askDevFailedAlert(page)).toBeVisible();
+        await expect(askDevFailedAlert(page)).toContainText(
+            "A required source is temporarily unavailable.",
+        );
+        await expect(askDevAnswerArticle(page)).not.toBeVisible();
+    });
+});
+
+test.describe("Ask Dev — availability gating", () => {
+    test("disabled capabilities hide the persistent window entirely", async ({ page, request }) => {
+        await setAskDevCapabilities(request, "disabled");
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await expect(askDevLauncher(page)).not.toBeVisible();
+    });
+
+    test("org-level entitlement off (not just capabilities) hides /dev's workspace entirely", async ({
+        page,
+        request,
+    }) => {
+        // Distinct failure layer from the capabilities tests above: this is
+        // the server-rendered org entitlement gate in (app)/dev/page.tsx
+        // (getOrgEntitlements → features.ask_dev), which runs independently
+        // of the client-side capabilities check.
+        await setAskDevEntitlement(request, "ask-dev-disabled");
+        await page.goto("/dev", { waitUntil: "domcontentloaded" });
+        await expect(
+            page.getByText("Ask Dev is not available for this organization"),
+        ).toBeVisible();
+        await expect(page.getByRole("region", { name: "Ask Dev workspace" })).not.toBeVisible();
+    });
+
+    test("not_ready capabilities surface the administrator-safe reason, not an internal code", async ({
+        page,
+        request,
+    }) => {
+        await setAskDevCapabilities(request, "not_ready");
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        // The composer never renders in the not_ready state, so this opens
+        // the window directly rather than via openAskDevWindow (which waits
+        // on the composer as its "opened" signal).
+        await askDevLauncher(page).click();
+
+        await expect(page.getByText("needs administrator attention")).toBeVisible();
+        await expect(page.getByText("finish provider setup")).toBeVisible();
+        const bodyText = await page.locator("body").innerText();
+        expect(bodyText).not.toContain("missing_credentials");
+    });
+});

--- a/tests/ask-dev-shared.spec.ts
+++ b/tests/ask-dev-shared.spec.ts
@@ -106,8 +106,9 @@ test.describe("Ask Dev — shared request behavior", () => {
         await expect(page.locator("body")).not.toContainText('cancelled"', { useInnerText: false });
     });
 
-    test("retry after a retryable failure resubmits and reaches a completed answer", async ({
+    test("retry after a retryable failure sends a real second request and reaches a completed answer", async ({
         page,
+        request,
     }) => {
         await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
         await openAskDevWindow(page);
@@ -121,13 +122,23 @@ test.describe("Ask Dev — shared request behavior", () => {
             "A required source is temporarily unavailable.",
         );
 
-        // Retry replays the same client_message_id against the mock, which
-        // still resolves to the same canned error — the assertion here is
-        // that retry is wired end-to-end (a real request goes out and the
-        // failed state re-renders), not that this particular scenario
-        // eventually succeeds.
+        const beforeRetry = await getAskDevRequestCounts(request);
+
+        // The mock (tests/mocks/devScenario.ts's RETRYABLE_ERROR_SCENARIOS
+        // handling) resolves a retry of this scenario to a distinct,
+        // successful "complete" answer — a real second attempt, not a
+        // second delivery of the same canned failure. Retry sends
+        // `retry_of_run_id`, which is how the mock tells attempt 2 apart
+        // from attempt 1 for the identical question text.
         await page.getByRole("button", { name: "Retry" }).click();
-        await expect(askDevFailedAlert(page)).toBeVisible();
+
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+        await expect(answer).toContainText("Twelve work items completed");
+        await expect(askDevFailedAlert(page)).not.toBeVisible();
+
+        const afterRetry = await getAskDevRequestCounts(request);
+        expect(afterRetry.messages).toBe(beforeRetry.messages + 1);
     });
 });
 
@@ -166,15 +177,18 @@ test.describe("Ask Dev — internal-state isolation (denylist)", () => {
         });
     }
 
-    // Known, tracked gaps (CHAOS-3291 owns the fix — AskDevAnswer.tsx:311
-    // renders `answer.status.replaceAll("_", " ")` and :333 renders
-    // `scopeResolution.outcome.replaceAll("_", " ")` directly). Written in
-    // final form now so the suite goes green automatically — no author
-    // needs to remember to come back and un-skip it — the moment 3291's
-    // sanctioned-copy map lands; until then `test.fixme` keeps the gate
-    // green without hiding the gap (it still reports as an expected
-    // failure, not silently absent).
-    test.fixme("the answer status pill never leaks a raw or space-transformed AnswerStatus value (CHAOS-3291)", async ({
+    // CHAOS-3291 owns the underlying fix (AskDevAnswer.tsx:311 renders
+    // `answer.status.replaceAll("_", " ")` and :333 renders
+    // `scopeResolution.outcome.replaceAll("_", " ")` directly). Web PR #832
+    // (the sanctioned-copy-map fix) is enqueued in the merge queue —
+    // sequencing this branch to land after it, so these are ordinary ACTIVE
+    // tests, not `test.fixme`/`test.fail()`: a fixme never self-activates
+    // (Playwright skips it unconditionally forever, so #832 merging
+    // wouldn't change anything on its own), and with #832 already
+    // sequenced ahead of this branch there is no gap period to bridge with
+    // `test.fail()` either — by the time this lands, the fix is already
+    // there to verify against.
+    test("the answer status pill never leaks a raw or space-transformed AnswerStatus value (CHAOS-3291)", async ({
         page,
     }) => {
         await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
@@ -191,7 +205,7 @@ test.describe("Ask Dev — internal-state isolation (denylist)", () => {
         }
     });
 
-    test.fixme("a forbidden-or-not-found scope resolution never renders the raw internal outcome (CHAOS-3291)", async ({
+    test("a forbidden-or-not-found scope resolution never renders the raw internal outcome (CHAOS-3291)", async ({
         page,
     }) => {
         await page.goto("/diagnose", { waitUntil: "domcontentloaded" });

--- a/tests/ask-dev-shared.spec.ts
+++ b/tests/ask-dev-shared.spec.ts
@@ -1,0 +1,280 @@
+import { expect, test } from "@playwright/test";
+
+import {
+    ANSWER_STATUS_VALUES,
+    DEV_ERROR_CODES,
+    forbiddenEnumStrings,
+    SCOPE_RESOLUTION_OUTCOME_VALUES,
+} from "./fixtures/askDevContracts";
+import {
+    askDevAnswerArticle,
+    askDevComposer,
+    askDevFailedAlert,
+    askDevLauncher,
+    askDevRunningStatus,
+    askDevSubmit,
+    getAskDevRequestCounts,
+    openAskDevWindow,
+    resetAskDevMock,
+    scenarioQuestion,
+    submitAskDevQuestion,
+} from "./helpers/askDev";
+
+// CHAOS-3287: deterministic Ask Dev coverage in the DEFAULT required
+// Playwright suite (tests/*.spec.ts, not tests/live/**). Every scenario here
+// runs against the real dev_answer.v1 contract/components — the mock server
+// (tests/mocks/devScenario.ts) builds responses from the checked-in
+// schema-validated canonical fixtures, and the browser's own client.ts
+// re-validates every response against the pinned JSON Schema + semantic
+// invariants, so an invalid mock payload fails the test the same way a bad
+// real server response would.
+//
+// Wave 3.1's dev_answer.v2 public-outcome taxonomy (answered_with_gaps,
+// needs_clarification, not_found, temporarily_unavailable, unsupported,
+// denied, failed — CHAOS-3294) is NOT yet consumed by this frontend
+// (CHAOS-3298 is still Backlog): the components here still render the prior
+// dev_answer.v1 status enum (complete/partial/degraded/insufficient_
+// evidence/refused/error). This spec exercises every outcome the app can
+// actually reach today, plus the shared request-lifecycle/internal-state-
+// isolation/evidence-hierarchy invariants that do not depend on v2. It
+// intentionally does not fabricate v2-only outcomes against a UI that does
+// not render them — see CHAOS-3298 for that follow-up adoption work.
+
+test.beforeEach(async ({ request }) => {
+    await resetAskDevMock(request);
+});
+
+test.describe("Ask Dev — shared request behavior", () => {
+    test("opening the window makes no provider call until a question is submitted", async ({
+        page,
+        request,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+
+        const counts = await getAskDevRequestCounts(request);
+        expect(counts.conversationsCreated).toBe(0);
+        expect(counts.messages).toBe(0);
+    });
+
+    test("submits the raw question text without inventing a client-side outcome", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+
+        await submitAskDevQuestion(page, scenarioQuestion("complete", "How many items shipped?"));
+
+        await expect(page.getByText("How many items shipped?")).toBeVisible();
+        await expect(askDevAnswerArticle(page)).toBeVisible();
+    });
+
+    test("a duplicate double-submit under one running request creates exactly one run", async ({
+        page,
+        request,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+
+        const composer = askDevComposer(page);
+        await composer.fill(scenarioQuestion("complete", "How many items shipped this week?"));
+        // Two rapid Enter presses mirror a real duplicate-click/duplicate-Enter:
+        // the composer's onKeyDown submits on the first, and the button/composer
+        // disable on `stream.phase === "running"` should absorb the second.
+        await Promise.all([composer.press("Enter"), composer.press("Enter")]);
+
+        await expect(askDevAnswerArticle(page)).toBeVisible();
+        const counts = await getAskDevRequestCounts(request);
+        expect(counts.messages).toBe(1);
+    });
+
+    test("cancelling a running investigation stops it safely without leaking the error code", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("complete", "What changed in the last release?"),
+        );
+        await expect(askDevRunningStatus(page)).toBeVisible();
+        await page.getByRole("button", { name: "Cancel" }).click();
+
+        await expect(askDevFailedAlert(page)).toBeVisible();
+        await expect(askDevFailedAlert(page)).toContainText("investigation was cancelled");
+        await expect(page.locator("body")).not.toContainText('cancelled"', { useInnerText: false });
+    });
+
+    test("retry after a retryable failure resubmits and reaches a completed answer", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("source_unavailable_error", "Is the deployment pipeline healthy?"),
+        );
+        await expect(askDevFailedAlert(page)).toBeVisible();
+        await expect(askDevFailedAlert(page)).toContainText(
+            "A required source is temporarily unavailable.",
+        );
+
+        // Retry replays the same client_message_id against the mock, which
+        // still resolves to the same canned error — the assertion here is
+        // that retry is wired end-to-end (a real request goes out and the
+        // failed state re-renders), not that this particular scenario
+        // eventually succeeds.
+        await page.getByRole("button", { name: "Retry" }).click();
+        await expect(askDevFailedAlert(page)).toBeVisible();
+    });
+});
+
+test.describe("Ask Dev — internal-state isolation (denylist)", () => {
+    // Every DevError.code from ops' contracts.py — the failed-run alert
+    // must show only `safe_message`, never the machine code, for ANY of
+    // them, not just the 2 this suite happens to trigger.
+    const ALL_ERROR_CODE_STRINGS = forbiddenEnumStrings(DEV_ERROR_CODES);
+
+    for (const [scenario, safeMessageFragment] of [
+        ["scope_forbidden_error", "You don't have access to that scope."],
+        ["source_unavailable_error", "A required source is temporarily unavailable."],
+    ] as const) {
+        test(`${scenario}: the failed-run alert shows only the safe message, no raw error code`, async ({
+            page,
+        }) => {
+            await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+            await openAskDevWindow(page);
+
+            await submitAskDevQuestion(page, scenarioQuestion(scenario, "Can I see project Zed?"));
+            await expect(askDevFailedAlert(page)).toBeVisible();
+            await expect(askDevFailedAlert(page)).toContainText(safeMessageFragment);
+
+            // Scoped to the failed-run alert, not the whole page: the
+            // question text typed into the composer literally echoes back
+            // into the transcript (and scenario names like
+            // "source_unavailable_error" contain banned substrings
+            // themselves), which would otherwise self-trigger this
+            // assertion regardless of what the app actually rendered.
+            const alertText = await askDevFailedAlert(page).innerText();
+            for (const forbidden of ALL_ERROR_CODE_STRINGS) {
+                expect(alertText).not.toContain(forbidden);
+            }
+            expect(alertText).not.toContain("forbidden_or_not_found");
+            expect(alertText).not.toContain("forbidden/not_found");
+        });
+    }
+
+    // Known, tracked gaps (CHAOS-3291 owns the fix — AskDevAnswer.tsx:311
+    // renders `answer.status.replaceAll("_", " ")` and :333 renders
+    // `scopeResolution.outcome.replaceAll("_", " ")` directly). Written in
+    // final form now so the suite goes green automatically — no author
+    // needs to remember to come back and un-skip it — the moment 3291's
+    // sanctioned-copy map lands; until then `test.fixme` keeps the gate
+    // green without hiding the gap (it still reports as an expected
+    // failure, not silently absent).
+    test.fixme("the answer status pill never leaks a raw or space-transformed AnswerStatus value (CHAOS-3291)", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("insufficient_evidence", "How risky is this repository?"),
+        );
+
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+        for (const forbidden of forbiddenEnumStrings(ANSWER_STATUS_VALUES)) {
+            await expect(answer.getByText(forbidden, { exact: true })).not.toBeVisible();
+        }
+    });
+
+    test.fixme("a forbidden-or-not-found scope resolution never renders the raw internal outcome (CHAOS-3291)", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("forbidden_or_not_found_scope", "Show me project Zed."),
+        );
+
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+        for (const forbidden of forbiddenEnumStrings(SCOPE_RESOLUTION_OUTCOME_VALUES)) {
+            await expect(answer.getByText(forbidden, { exact: true })).not.toBeVisible();
+        }
+    });
+});
+
+test.describe("Ask Dev — evidence hierarchy", () => {
+    test("the direct answer precedes the evidence section in reading order", async ({ page }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("complete", "What is the current status?"),
+        );
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+
+        const order = await answer.evaluate((node) => {
+            const direct = node.querySelector("p.text-body");
+            const evidenceSection = node.querySelector('[aria-label="Evidence coverage"]');
+            if (!direct || !evidenceSection) return "missing";
+            return direct.compareDocumentPosition(evidenceSection) &
+                Node.DOCUMENT_POSITION_FOLLOWING
+                ? "direct-first"
+                : "evidence-first";
+        });
+        expect(order).toBe("direct-first");
+    });
+
+    test("evidence can be expanded to see its excerpt", async ({ page }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("complete", "What is the current status?"),
+        );
+        await expect(askDevAnswerArticle(page)).toBeVisible();
+
+        await page.getByRole("button", { name: "Open evidence", exact: true }).click();
+        await expect(page.getByText("Evidence excerpt")).toBeVisible();
+    });
+});
+
+test.describe("Ask Dev — accessibility", () => {
+    test("Escape closes the window and returns focus to the launcher", async ({ page }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+
+        await page.keyboard.press("Escape");
+        await expect(askDevLauncher(page)).toBeFocused();
+    });
+
+    test("the mobile full-screen window exposes a modal dialog role", async ({ page }) => {
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+
+        await expect(page.getByRole("dialog", { name: "Ask Dev" })).toBeVisible();
+    });
+
+    test("the submit control is keyboard reachable and labeled", async ({ page }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+
+        await expect(askDevSubmit(page)).toBeVisible();
+        // The submit button is disabled (and so skipped in tab order) until
+        // the composer has a non-empty draft.
+        await askDevComposer(page).fill("Draft text");
+        await expect(askDevComposer(page)).toBeFocused();
+        await page.keyboard.press("Tab");
+        await expect(askDevSubmit(page)).toBeFocused();
+    });
+});

--- a/tests/ask-dev-shared.spec.ts
+++ b/tests/ask-dev-shared.spec.ts
@@ -6,6 +6,7 @@ import {
     forbiddenEnumStrings,
     SCOPE_RESOLUTION_OUTCOME_VALUES,
 } from "./fixtures/askDevContracts";
+import { outcomeCase } from "./fixtures/askDevOutcomes";
 import {
     askDevAnswerArticle,
     askDevComposer,
@@ -235,15 +236,27 @@ test.describe("Ask Dev — evidence hierarchy", () => {
         const answer = askDevAnswerArticle(page);
         await expect(answer).toBeVisible();
 
-        const order = await answer.evaluate((node) => {
-            const direct = node.querySelector("p.text-body");
+        // Located by text content, not a CSS class: CHAOS-3291 (#832)
+        // reworked the direct-summary markup/styling as part of this exact
+        // "answer-first hierarchy" fix, and a class-name-coupled selector
+        // broke on that real change. Only the evidence section's aria-label
+        // is a stable-by-contract selector.
+        const order = await answer.evaluate((node, directSummaryText) => {
+            const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
+            let direct: Node | null = null;
+            for (let textNode = walker.nextNode(); textNode; textNode = walker.nextNode()) {
+                if (textNode.textContent?.includes(directSummaryText)) {
+                    direct = textNode;
+                    break;
+                }
+            }
             const evidenceSection = node.querySelector('[aria-label="Evidence coverage"]');
             if (!direct || !evidenceSection) return "missing";
             return direct.compareDocumentPosition(evidenceSection) &
                 Node.DOCUMENT_POSITION_FOLLOWING
                 ? "direct-first"
                 : "evidence-first";
-        });
+        }, outcomeCase("complete").directSummary);
         expect(order).toBe("direct-first");
     });
 

--- a/tests/ask-dev-vocabulary.spec.ts
+++ b/tests/ask-dev-vocabulary.spec.ts
@@ -5,10 +5,42 @@ import { expect, test } from "@playwright/test";
 
 import {
     ANSWER_STATUS_VALUES,
+    assertExhaustivePartition,
     assertKnownToSchema,
     SCOPE_RESOLUTION_OUTCOME_VALUES,
 } from "./fixtures/askDevContracts";
 import { ASK_DEV_OUTCOME_TABLE } from "./fixtures/askDevOutcomes";
+
+/**
+ * Extracts the top-level keys of one exported `Record<Enum, string>` object
+ * literal from a TSX source file by name, via text parsing rather than a
+ * module import.
+ *
+ * AskDevAnswer.tsx ("use client") transitively imports AskDevWindow.tsx,
+ * which imports a PNG asset (fc-logo.png) — Next/Vite's bundler resolves
+ * that fine, but this Playwright spec file is compiled by Playwright's own
+ * standalone esbuild transform, which has no asset loader configured and
+ * fails on the binary PNG content. Reading the real source text (as this
+ * suite's fixme-tripwire test already does) reads the same live production
+ * file without pulling its import graph through a transform that can't
+ * handle it.
+ */
+function exportedLabelMapKeys(sourceText: string, exportName: string): readonly string[] {
+    const start = sourceText.indexOf(`export const ${exportName}`);
+    if (start === -1) throw new Error(`Could not find "export const ${exportName}" in source.`);
+    const openBrace = sourceText.indexOf("{", start);
+    const closeBrace = sourceText.indexOf("};", openBrace);
+    if (openBrace === -1 || closeBrace === -1) {
+        throw new Error(`Could not find the object literal body for "${exportName}".`);
+    }
+    const body = sourceText.slice(openBrace + 1, closeBrace);
+    const keyPattern = /^\s*([a-z][a-z0-9_]*)\s*:/gmu;
+    const keys: string[] = [];
+    for (const match of body.matchAll(keyPattern)) keys.push(match[1]!);
+    if (keys.length === 0)
+        throw new Error(`Found no keys for "${exportName}" — parsing likely broke.`);
+    return keys;
+}
 
 // CHAOS-3287 (codex NO-SHIP fix #1, finding: "outcome coverage is a
 // self-oracle"): tests/fixtures/askDevOutcomes.ts is used to BOTH build the
@@ -56,11 +88,61 @@ test.describe("Ask Dev — outcome table vs. pinned contract vocabulary", () => 
         ).toEqual([]);
     });
 
-    test("the scope-resolution scenarios (ambiguous, forbidden_or_not_found) are real, pinned outcomes", () => {
-        assertKnownToSchema(
-            ["ambiguous", "forbidden_or_not_found"],
+    // codex NO-SHIP finding (this test's prior form): membership-checking
+    // only the 2 values the mock scenarios happen to use let a new
+    // ScopeResolutionOutcome member, or a rename of an unreferenced member
+    // like `filtered`→`narrowed`, pass silently — no add/remove/rename
+    // guarantee actually held. Fixed with an exact partition: every pinned
+    // value is either scenario-covered or on this documented exclusion
+    // list, and the assertion fails until that partition is deliberately
+    // updated to match.
+    const SCENARIO_COVERED_SCOPE_OUTCOMES = [
+        // Every ASK_DEV_OUTCOME_TABLE scenario (complete/partial/degraded/
+        // insufficient_evidence/refused) carries the canonical fixture's own
+        // unmodified resolved_scope, whose outcome is "exact".
+        "exact",
+        // needs_clarification mock scenario.
+        "ambiguous",
+        // forbidden_or_not_found_scope mock scenario — the exact value
+        // CHAOS-3291 fixed the raw-render leak for.
+        "forbidden_or_not_found",
+    ] as const;
+    const DOCUMENTED_EXCLUDED_SCOPE_OUTCOMES = [
+        // Not yet exercised by a dedicated mock scenario. Tracked as a
+        // coverage gap, not a security gap: neither is on the internal-enum
+        // denylist (only forbidden_or_not_found and scope_forbidden are),
+        // and both are otherwise-ordinary successful-resolution variants.
+        "filtered",
+        "inherited",
+        "organization_fallback",
+        // Not yet exercised; also not customer-sensitive in the same way
+        // forbidden_or_not_found is (it doesn't collapse a
+        // permission/existence distinction), just currently untested.
+        "unresolved",
+    ] as const;
+
+    test("production sanctioned SCOPE_OUTCOME_LABELS keys exactly match the pinned ScopeResolutionOutcome enum", () => {
+        // Cross-checks the independently pinned-schema-derived vocabulary
+        // (askDevContracts.ts) against AskDevAnswer.tsx's own exported,
+        // TypeScript-exhaustive `Record<DevAnswer["resolved_scope"]["outcome"], string>`
+        // — a second, independent source of the same "what are all the real
+        // values" question. A read of the real component's source text, not
+        // an edit of it (see exportedLabelMapKeys's doc comment for why this
+        // is a text read rather than a module import).
+        const source = readFileSync(
+            path.join(__dirname, "..", "src", "components", "ask-dev", "AskDevAnswer.tsx"),
+            "utf8",
+        );
+        const labelKeys = exportedLabelMapKeys(source, "SCOPE_OUTCOME_LABELS");
+        expect(labelKeys.slice().sort()).toEqual([...SCOPE_RESOLUTION_OUTCOME_VALUES].sort());
+    });
+
+    test("every pinned ScopeResolutionOutcome is exactly scenario-covered or documented-excluded", () => {
+        assertExhaustivePartition(
             SCOPE_RESOLUTION_OUTCOME_VALUES,
-            "needs_clarification/forbidden_or_not_found_scope mock scenario outcomes",
+            SCENARIO_COVERED_SCOPE_OUTCOMES,
+            DOCUMENTED_EXCLUDED_SCOPE_OUTCOMES,
+            "ScopeResolutionOutcome",
         );
     });
 });

--- a/tests/ask-dev-vocabulary.spec.ts
+++ b/tests/ask-dev-vocabulary.spec.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import {
+    ANSWER_STATUS_VALUES,
+    assertKnownToSchema,
+    SCOPE_RESOLUTION_OUTCOME_VALUES,
+} from "./fixtures/askDevContracts";
+import { ASK_DEV_OUTCOME_TABLE } from "./fixtures/askDevOutcomes";
+
+// CHAOS-3287 (codex NO-SHIP fix #1, finding: "outcome coverage is a
+// self-oracle"): tests/fixtures/askDevOutcomes.ts is used to BOTH build the
+// mock's canned answer AND assert on the rendered result, so a wrong value
+// in that table would silently agree with itself. This file is the
+// independent check: it does not read the outcome table's *content* as
+// ground truth, only its *shape*, and cross-references that shape against
+// the pinned JSON Schema enums (tests/fixtures/askDevContracts.ts, which
+// itself extracts those enums from the schema files at runtime rather than
+// hand-transcribing them — see that file's header for the drift this
+// caught). A schema regeneration that adds, removes, or renames an
+// AnswerStatus/ScopeResolutionOutcome member fails this suite immediately.
+//
+// No page/server interaction here — pure data assertions, safe to run
+// standalone.
+
+test.describe("Ask Dev — outcome table vs. pinned contract vocabulary", () => {
+    test("every ASK_DEV_OUTCOME_TABLE status is a real, pinned AnswerStatus value", () => {
+        assertKnownToSchema(
+            ASK_DEV_OUTCOME_TABLE.map((entry) => entry.status),
+            ANSWER_STATUS_VALUES,
+            "ASK_DEV_OUTCOME_TABLE status values",
+        );
+    });
+
+    test("the outcome table covers every pinned AnswerStatus except `error` (handled outside AskDevAnswer)", () => {
+        // `error` is deliberately excluded: AskDevConversation.tsx routes any
+        // transcript entry whose answer.status === "error" through the same
+        // failed/alert treatment as a live run failure — it never reaches
+        // AskDevAnswer/STATUS_EXPLANATIONS, so it has no "outcome case" of
+        // its own to add to this table. If that routing ever changes, this
+        // assertion is exactly what should catch the resulting gap.
+        const tableStatuses = new Set(ASK_DEV_OUTCOME_TABLE.map((entry) => entry.status));
+        const expected = new Set(ANSWER_STATUS_VALUES.filter((value) => value !== "error"));
+
+        const missing = [...expected].filter((value) => !tableStatuses.has(value));
+        const unexpected = [...tableStatuses].filter((value) => !expected.has(value));
+        expect(
+            missing,
+            `Pinned AnswerStatus values missing from the outcome table: ${missing.join(", ")}`,
+        ).toEqual([]);
+        expect(
+            unexpected,
+            `Outcome table has status values beyond the pinned enum (or wrongly includes "error"): ${unexpected.join(", ")}`,
+        ).toEqual([]);
+    });
+
+    test("the scope-resolution scenarios (ambiguous, forbidden_or_not_found) are real, pinned outcomes", () => {
+        assertKnownToSchema(
+            ["ambiguous", "forbidden_or_not_found"],
+            SCOPE_RESOLUTION_OUTCOME_VALUES,
+            "needs_clarification/forbidden_or_not_found_scope mock scenario outcomes",
+        );
+    });
+});
+
+// CHAOS-3287 (codex NO-SHIP fix #2, finding: "test.fixme never
+// self-activates"): a tripwire so CHAOS-3291's two known-leak assertions
+// can never quietly regress back to a silently-skipped fixme after being
+// converted to active/test.fail() tests.
+test.describe("Ask Dev — no lingering CHAOS-3291 fixme", () => {
+    test("no ask-dev spec file contains a test.fixme reference to CHAOS-3291", () => {
+        const specDir = __dirname;
+        // Deliberately excludes this file itself: ask-dev-vocabulary.spec.ts
+        // is the checker, not a subject, and its own error message below
+        // necessarily contains the literal pattern being searched for.
+        const specFiles = [
+            "ask-dev-shared.spec.ts",
+            "ask-dev-outcomes.spec.ts",
+            "ask-dev-continuity.spec.ts",
+        ];
+        // Matches only the actual invocation (`test.fixme(` / `test.fixme(title, ...)`
+        // / the in-body modifier form), not explanatory prose about test.fixme.
+        const FIXME_CALL_PATTERN = /\btest\.fixme\s*\(/u;
+        for (const fileName of specFiles) {
+            const contents = readFileSync(path.join(specDir, fileName), "utf8");
+            expect(
+                FIXME_CALL_PATTERN.test(contents),
+                `${fileName} calls test.fixme() — CHAOS-3291's leak checks must be active tests ` +
+                    "(or test.fail() while #832 is unmerged), never silently skipped.",
+            ).toBe(false);
+        }
+    });
+});

--- a/tests/fixtures/askDevContracts.ts
+++ b/tests/fixtures/askDevContracts.ts
@@ -1,0 +1,105 @@
+/**
+ * CHAOS-3287: the real backend vocabulary this mock/spec suite must never
+ * drift from. Every list here is transcribed directly from the ops repo's
+ * canonical contract source — ops/src/dev_health_ops/api/dev/contracts.py
+ * (StrEnum/Literal definitions) — not invented or guessed. Re-check against
+ * that file (never against src/lib/dev/generated.ts alone) whenever this
+ * file changes, since generated.ts is itself downstream of it.
+ *
+ * When CHAOS-3298 re-pins the web client to dev_answer.v2, this file's
+ * lists are exactly what needs re-deriving from the v2 contracts module —
+ * the spec files that import from here should not need to change.
+ */
+
+/** contracts.py `AnswerStatus` (StrEnum). */
+export const ANSWER_STATUS_VALUES = [
+    "complete",
+    "partial",
+    "degraded",
+    "insufficient_evidence",
+    "refused",
+    "error",
+] as const;
+export type AnswerStatus = (typeof ANSWER_STATUS_VALUES)[number];
+
+/** contracts.py `ScopeResolutionOutcome` (StrEnum). */
+export const SCOPE_RESOLUTION_OUTCOME_VALUES = [
+    "exact",
+    "filtered",
+    "inherited",
+    "organization_fallback",
+    "ambiguous",
+    "unresolved",
+    "forbidden_or_not_found",
+] as const;
+export type ScopeResolutionOutcome = (typeof SCOPE_RESOLUTION_OUTCOME_VALUES)[number];
+
+/** contracts.py `DevError.code` (Literal). */
+export const DEV_ERROR_CODES = [
+    "unauthenticated",
+    "forbidden",
+    "feature_not_enabled",
+    "byo_llm_not_enabled",
+    "provider_not_configured",
+    "model_not_supported",
+    "provider_unavailable",
+    "rate_limited",
+    "concurrency_limited",
+    "cost_limit_reached",
+    "invalid_request",
+    "scope_ambiguous",
+    "scope_not_found",
+    "scope_forbidden",
+    "conversation_not_found",
+    "conversation_expired",
+    "tool_limit_reached",
+    "tool_unavailable",
+    "source_unavailable",
+    "insufficient_evidence",
+    "answer_validation_failed",
+    "cancelled",
+    "provider_contract_violation",
+    "internal_error",
+] as const;
+export type DevErrorCode = (typeof DEV_ERROR_CODES)[number];
+
+/** contracts.py `DevTranscriptRunState` (Literal). */
+export const DEV_TRANSCRIPT_RUN_STATE_VALUES = [
+    "accepted",
+    "resolving_scope",
+    "interpreting",
+    "resolving_subjects",
+    "model_decision",
+    "tool_validation",
+    "tool_execution",
+    "answer_validation",
+    "completed",
+    "insufficient_evidence",
+    "refused",
+    "failed",
+    "cancelled",
+] as const;
+export type DevTranscriptRunState = (typeof DEV_TRANSCRIPT_RUN_STATE_VALUES)[number];
+
+/** contracts.py `DevCapabilities.readiness` (Literal). */
+export const DEV_CAPABILITIES_READINESS_VALUES = [
+    "ready",
+    "unsupported_model",
+    "missing_credentials",
+    "disabled",
+    "degraded",
+] as const;
+export type DevCapabilitiesReadiness = (typeof DEV_CAPABILITIES_READINESS_VALUES)[number];
+
+/**
+ * Every internal enum value, plus its cosmetic `replaceAll("_", " ")` form
+ * (the exact transform AskDevAnswer.tsx applies before rendering
+ * `answer.status` and `resolved_scope.outcome`) — both forms count as a
+ * "raw enum leak" per CHAOS-3298's guardrail against generic
+ * underscore-replacement display. Excludes values that are also ordinary
+ * connected English words in the app's own copy (e.g. none of these
+ * currently collide), so a plain substring search stays a valid check.
+ */
+export function forbiddenEnumStrings(values: readonly string[]): readonly string[] {
+    return values.flatMap((value) => [value, value.replaceAll("_", " ")]);
+}

--- a/tests/fixtures/askDevContracts.ts
+++ b/tests/fixtures/askDevContracts.ts
@@ -1,95 +1,159 @@
 /**
  * CHAOS-3287: the real backend vocabulary this mock/spec suite must never
- * drift from. Every list here is transcribed directly from the ops repo's
- * canonical contract source — ops/src/dev_health_ops/api/dev/contracts.py
- * (StrEnum/Literal definitions) — not invented or guessed. Re-check against
- * that file (never against src/lib/dev/generated.ts alone) whenever this
- * file changes, since generated.ts is itself downstream of it.
+ * drift from. Every list below is EXTRACTED AT RUNTIME from the pinned
+ * ops-generated JSON Schema files under src/lib/dev/contracts/schemas/ —
+ * the exact artifacts the browser's own client.ts validates every real
+ * response against (see validatePinnedJsonSchema in src/lib/dev/client.ts)
+ * — never hand-transcribed. A hand-transcribed list can drift from the
+ * pinned schema silently (verified while fixing this: an earlier version
+ * of this file included "interpreting"/"resolving_subjects" in
+ * DEV_TRANSCRIPT_RUN_STATE_VALUES and "provider_contract_violation" in
+ * DEV_ERROR_CODES — both present in ops' *live* contracts.py source but
+ * NOT in what's actually pinned here, which is what the running app
+ * really validates against). Extracting from the schema files themselves
+ * makes that class of drift impossible to reintroduce.
  *
- * When CHAOS-3298 re-pins the web client to dev_answer.v2, this file's
- * lists are exactly what needs re-deriving from the v2 contracts module —
- * the spec files that import from here should not need to change.
+ * tests/mocks/devScenario.ts and this file's own self-check
+ * (assertVocabularyIsExhaustive, exercised by
+ * tests/ask-dev-vocabulary.spec.ts) both read from here, so a schema
+ * regeneration that adds/removes/renames an enum member fails the suite
+ * immediately instead of silently producing a mock/spec pair that only
+ * ever agrees with itself.
+ *
+ * When CHAOS-3298 re-pins the web client to dev_answer.v2, only the
+ * schema file paths below need to change — the extraction machinery and
+ * every downstream consumer stay correct.
  */
+import answerSchema from "../../src/lib/dev/contracts/schemas/dev_answer.v1.schema.json";
+import capabilitiesSchema from "../../src/lib/dev/contracts/schemas/dev_capabilities.v1.schema.json";
+import conversationTranscriptSchema from "../../src/lib/dev/contracts/schemas/dev_conversation_transcript.v1.schema.json";
+import errorSchema from "../../src/lib/dev/contracts/schemas/dev_error.v1.schema.json";
+import scopeResolutionSchema from "../../src/lib/dev/contracts/schemas/dev_scope_resolution.v1.schema.json";
 
-/** contracts.py `AnswerStatus` (StrEnum). */
-export const ANSWER_STATUS_VALUES = [
-    "complete",
-    "partial",
-    "degraded",
-    "insufficient_evidence",
-    "refused",
-    "error",
-] as const;
-export type AnswerStatus = (typeof ANSWER_STATUS_VALUES)[number];
+type JsonSchema = Record<string, unknown>;
 
-/** contracts.py `ScopeResolutionOutcome` (StrEnum). */
-export const SCOPE_RESOLUTION_OUTCOME_VALUES = [
-    "exact",
-    "filtered",
-    "inherited",
-    "organization_fallback",
-    "ambiguous",
-    "unresolved",
-    "forbidden_or_not_found",
-] as const;
-export type ScopeResolutionOutcome = (typeof SCOPE_RESOLUTION_OUTCOME_VALUES)[number];
+function isRecord(value: unknown): value is JsonSchema {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
-/** contracts.py `DevError.code` (Literal). */
-export const DEV_ERROR_CODES = [
-    "unauthenticated",
-    "forbidden",
-    "feature_not_enabled",
-    "byo_llm_not_enabled",
-    "provider_not_configured",
-    "model_not_supported",
-    "provider_unavailable",
-    "rate_limited",
-    "concurrency_limited",
-    "cost_limit_reached",
-    "invalid_request",
-    "scope_ambiguous",
-    "scope_not_found",
-    "scope_forbidden",
-    "conversation_not_found",
-    "conversation_expired",
-    "tool_limit_reached",
-    "tool_unavailable",
-    "source_unavailable",
-    "insufficient_evidence",
-    "answer_validation_failed",
-    "cancelled",
-    "provider_contract_violation",
-    "internal_error",
-] as const;
-export type DevErrorCode = (typeof DEV_ERROR_CODES)[number];
+/** Resolves one `{ "$ref": "#/$defs/Name" }` indirection against its own schema document. */
+function resolveRef(schema: JsonSchema, node: unknown): JsonSchema {
+    if (!isRecord(node)) throw new Error("Expected a JSON Schema node.");
+    const ref = node.$ref;
+    if (typeof ref !== "string") return node;
+    const match = /^#\/\$defs\/(.+)$/u.exec(ref);
+    if (!match) throw new Error(`Unsupported $ref shape: ${ref}`);
+    const defs = schema.$defs;
+    if (!isRecord(defs) || !isRecord(defs[match[1]!])) {
+        throw new Error(`$ref target "${ref}" not found in $defs.`);
+    }
+    return defs[match[1]!] as JsonSchema;
+}
 
-/** contracts.py `DevTranscriptRunState` (Literal). */
-export const DEV_TRANSCRIPT_RUN_STATE_VALUES = [
-    "accepted",
-    "resolving_scope",
-    "interpreting",
-    "resolving_subjects",
-    "model_decision",
-    "tool_validation",
-    "tool_execution",
-    "answer_validation",
-    "completed",
-    "insufficient_evidence",
-    "refused",
-    "failed",
-    "cancelled",
-] as const;
-export type DevTranscriptRunState = (typeof DEV_TRANSCRIPT_RUN_STATE_VALUES)[number];
+/** Extracts a required string `enum` from a (possibly $ref-indirected) schema property path. */
+function extractEnum(schema: JsonSchema, ...path: readonly string[]): readonly string[] {
+    let node: unknown = schema;
+    for (const segment of path) {
+        if (!isRecord(node)) throw new Error(`Cannot descend into "${segment}": not an object.`);
+        node = node[segment];
+        if (node === undefined) throw new Error(`Missing schema path segment "${segment}".`);
+    }
+    const resolved = resolveRef(schema, node);
+    const values = resolved.enum;
+    if (
+        !Array.isArray(values) ||
+        values.length === 0 ||
+        !values.every((value) => typeof value === "string")
+    ) {
+        throw new Error(`Expected a non-empty string enum at "${path.join(".")}".`);
+    }
+    return values as readonly string[];
+}
 
-/** contracts.py `DevCapabilities.readiness` (Literal). */
-export const DEV_CAPABILITIES_READINESS_VALUES = [
-    "ready",
-    "unsupported_model",
-    "missing_credentials",
-    "disabled",
-    "degraded",
-] as const;
-export type DevCapabilitiesReadiness = (typeof DEV_CAPABILITIES_READINESS_VALUES)[number];
+/** Pinned `dev_answer.v1.schema.json` `$defs.AnswerStatus.enum`. */
+export const ANSWER_STATUS_VALUES = extractEnum(
+    answerSchema as JsonSchema,
+    "$defs",
+    "AnswerStatus",
+) as readonly AnswerStatus[];
+export type AnswerStatus =
+    "complete" | "partial" | "degraded" | "insufficient_evidence" | "refused" | "error";
+
+/** Pinned `dev_scope_resolution.v1.schema.json` `properties.outcome` (→ `$defs.ScopeResolutionOutcome.enum`). */
+export const SCOPE_RESOLUTION_OUTCOME_VALUES = extractEnum(
+    scopeResolutionSchema as JsonSchema,
+    "properties",
+    "outcome",
+) as readonly ScopeResolutionOutcome[];
+export type ScopeResolutionOutcome =
+    | "exact"
+    | "filtered"
+    | "inherited"
+    | "organization_fallback"
+    | "ambiguous"
+    | "unresolved"
+    | "forbidden_or_not_found";
+
+/** Pinned `dev_error.v1.schema.json` `properties.code.enum`. */
+export const DEV_ERROR_CODES = extractEnum(
+    errorSchema as JsonSchema,
+    "properties",
+    "code",
+) as readonly DevErrorCode[];
+export type DevErrorCode =
+    | "unauthenticated"
+    | "forbidden"
+    | "feature_not_enabled"
+    | "byo_llm_not_enabled"
+    | "provider_not_configured"
+    | "model_not_supported"
+    | "provider_unavailable"
+    | "rate_limited"
+    | "concurrency_limited"
+    | "cost_limit_reached"
+    | "invalid_request"
+    | "scope_ambiguous"
+    | "scope_not_found"
+    | "scope_forbidden"
+    | "conversation_not_found"
+    | "conversation_expired"
+    | "tool_limit_reached"
+    | "tool_unavailable"
+    | "source_unavailable"
+    | "insufficient_evidence"
+    | "answer_validation_failed"
+    | "cancelled"
+    | "internal_error";
+
+/** Pinned `dev_conversation_transcript.v1.schema.json` `$defs.DevTranscriptEntry.properties.run_state.enum`. */
+export const DEV_TRANSCRIPT_RUN_STATE_VALUES = extractEnum(
+    conversationTranscriptSchema as JsonSchema,
+    "$defs",
+    "DevTranscriptEntry",
+    "properties",
+    "run_state",
+) as readonly DevTranscriptRunState[];
+export type DevTranscriptRunState =
+    | "accepted"
+    | "resolving_scope"
+    | "model_decision"
+    | "tool_validation"
+    | "tool_execution"
+    | "answer_validation"
+    | "completed"
+    | "insufficient_evidence"
+    | "refused"
+    | "failed"
+    | "cancelled";
+
+/** Pinned `dev_capabilities.v1.schema.json` `properties.readiness.enum`. */
+export const DEV_CAPABILITIES_READINESS_VALUES = extractEnum(
+    capabilitiesSchema as JsonSchema,
+    "properties",
+    "readiness",
+) as readonly DevCapabilitiesReadiness[];
+export type DevCapabilitiesReadiness =
+    "ready" | "unsupported_model" | "missing_credentials" | "disabled" | "degraded";
 
 /**
  * Every internal enum value, plus its cosmetic `replaceAll("_", " ")` form
@@ -102,4 +166,29 @@ export type DevCapabilitiesReadiness = (typeof DEV_CAPABILITIES_READINESS_VALUES
  */
 export function forbiddenEnumStrings(values: readonly string[]): readonly string[] {
     return values.flatMap((value) => [value, value.replaceAll("_", " ")]);
+}
+
+/**
+ * Asserts that `candidateValues` (e.g. every `status` used in
+ * tests/fixtures/askDevOutcomes.ts) is an exact, non-empty SUBSET of
+ * `authoritativeValues` (the pinned schema's real enum) — throws naming
+ * the offending values otherwise. Exhaustive-EQUALITY checks (every
+ * authoritative value must be covered by some test case) belong in the
+ * spec files themselves, since not every enum value has (or needs) a
+ * dedicated scenario; this only guards against a table entry naming a
+ * value the pinned contract does not actually have.
+ */
+export function assertKnownToSchema(
+    candidateValues: readonly string[],
+    authoritativeValues: readonly string[],
+    label: string,
+): void {
+    const authoritative = new Set(authoritativeValues);
+    const unknown = candidateValues.filter((value) => !authoritative.has(value));
+    if (unknown.length > 0) {
+        throw new Error(
+            `${label} contains value(s) not present in the pinned schema enum: ${unknown.join(", ")}. ` +
+                `Pinned enum is: ${authoritativeValues.join(", ")}.`,
+        );
+    }
 }

--- a/tests/fixtures/askDevContracts.ts
+++ b/tests/fixtures/askDevContracts.ts
@@ -192,3 +192,46 @@ export function assertKnownToSchema(
         );
     }
 }
+
+/**
+ * Asserts that `coveredValues` (values exercised by a dedicated mock
+ * scenario) and `excludedValues` (values deliberately NOT exercised, with a
+ * documented reason at the call site) together form an EXACT partition of
+ * `authoritativeValues` (the pinned schema's real enum) — every
+ * authoritative value is in exactly one of the two lists, and neither list
+ * names a value the schema doesn't have.
+ *
+ * Unlike `assertKnownToSchema` (a one-way subset check — codex NO-SHIP
+ * finding: membership-checking only the 2 values a test happens to use lets
+ * a new enum member, or a rename of an unreferenced member like
+ * `filtered`→`narrowed`, pass silently), this fails on ANY drift in the
+ * authoritative set: an addition (falls into neither list), a removal (a
+ * listed value schema no longer has), or a rename (same as removal +
+ * addition). The two lists must be updated deliberately for the assertion
+ * to pass again — that deliberate update is the point.
+ */
+export function assertExhaustivePartition(
+    authoritativeValues: readonly string[],
+    coveredValues: readonly string[],
+    excludedValues: readonly string[],
+    label: string,
+): void {
+    const overlap = coveredValues.filter((value) => excludedValues.includes(value));
+    if (overlap.length > 0) {
+        throw new Error(
+            `${label}: value(s) listed as both covered and excluded: ${overlap.join(", ")}.`,
+        );
+    }
+    const partition = new Set([...coveredValues, ...excludedValues]);
+    const missing = authoritativeValues.filter((value) => !partition.has(value));
+    const unknown = [...partition].filter((value) => !authoritativeValues.includes(value));
+    if (missing.length > 0 || unknown.length > 0) {
+        throw new Error(
+            `${label}: covered+excluded does not exactly equal the pinned schema enum. ` +
+                `Missing from the partition (present in the schema, not covered or excluded): ` +
+                `${missing.join(", ") || "(none)"}. ` +
+                `Unknown to the schema (covered or excluded but not a real pinned value): ` +
+                `${unknown.join(", ") || "(none)"}.`,
+        );
+    }
+}

--- a/tests/fixtures/askDevOutcomes.ts
+++ b/tests/fixtures/askDevOutcomes.ts
@@ -1,0 +1,77 @@
+import type { AnswerStatus } from "./askDevContracts";
+
+/**
+ * CHAOS-3287: single source of truth for "what does each Ask Dev outcome
+ * scenario mean" — both the mock server (tests/mocks/devScenario.ts, which
+ * builds the canned dev_answer.v1 payload) and the specs
+ * (tests/ask-dev-outcomes.spec.ts, which assert on the rendered result)
+ * read from this same table instead of each hand-duplicating the
+ * status/copy pairing.
+ *
+ * This is deliberately the ONLY place that maps a scenario key to a
+ * dev_answer.v1 `status` + expected copy. When CHAOS-3298 re-pins the web
+ * client to dev_answer.v2's public-outcome taxonomy (answered,
+ * answered_with_gaps, needs_clarification, not_found,
+ * temporarily_unavailable, unsupported, denied, failed), only this table
+ * (and the two functions in devScenario.ts that read it) should need to
+ * change — the spec files loop over it rather than hardcoding per-status
+ * assertions.
+ */
+export type AskDevOutcomeCase = Readonly<{
+    /** Scenario key used in the `[[ask-dev:<key>]]` question marker. */
+    key: string;
+    /** The dev_answer.v1 `status` this scenario's canned answer carries. */
+    status: AnswerStatus;
+    /** Substring asserted present in `answer.direct_summary`. */
+    directSummary: string;
+    /**
+     * Substring asserted present in AskDevAnswer's STATUS_EXPLANATIONS
+     * caption, or null for the one status (`complete`) that has none.
+     */
+    captionContains: string | null;
+    /** True when this scenario's canned answer carries zero evidence/metrics/claims. */
+    emptyEvidence?: boolean;
+}>;
+
+export const ASK_DEV_OUTCOME_TABLE: readonly AskDevOutcomeCase[] = [
+    {
+        key: "complete",
+        status: "complete",
+        directSummary: "Twelve work items completed in the selected period.",
+        captionContains: null,
+    },
+    {
+        key: "partial",
+        status: "partial",
+        directSummary:
+            "Nine of twelve required sources answered; three sources were unavailable for this window.",
+        captionContains: "the investigation did not fully complete",
+    },
+    {
+        key: "degraded",
+        status: "degraded",
+        directSummary:
+            "The investigation completed with degraded evidence: one required source returned stale data.",
+        captionContains: "could not complete as expected",
+    },
+    {
+        key: "insufficient_evidence",
+        status: "insufficient_evidence",
+        directSummary: "There isn't enough evidence in this scope to answer with confidence.",
+        captionContains: "isn't enough evidence",
+        emptyEvidence: true,
+    },
+    {
+        key: "refused",
+        status: "refused",
+        directSummary: "Ask Dev did not answer this question.",
+        captionContains: "did not answer this question",
+        emptyEvidence: true,
+    },
+] as const;
+
+export function outcomeCase(key: string): AskDevOutcomeCase {
+    const found = ASK_DEV_OUTCOME_TABLE.find((entry) => entry.key === key);
+    if (!found) throw new Error(`No ASK_DEV_OUTCOME_TABLE entry for scenario "${key}"`);
+    return found;
+}

--- a/tests/helpers/askDev.ts
+++ b/tests/helpers/askDev.ts
@@ -1,0 +1,102 @@
+import { expect, type APIRequestContext, type Page } from "@playwright/test";
+
+import type { DevAnswerScenario } from "../mocks/devScenario";
+
+/**
+ * The mock backend's own base URL (not the Next.js app's). Existing specs
+ * (acr-secret-boundary.spec.ts, acr-explorer-shell.spec.ts, …) already hit
+ * `/__test/*` control endpoints on this same hardcoded port, which mirrors
+ * playwright.config.ts's `PLAYWRIGHT_MOCK_PORT` default.
+ */
+const MOCK_SERVER_URL = "http://127.0.0.1:8001";
+
+/** Encodes which canned dev_answer.v1 the mock should return for one question. */
+export function scenarioQuestion(scenario: DevAnswerScenario, question: string): string {
+    return `[[ask-dev:${scenario}]] ${question}`;
+}
+
+export async function resetAskDevMock(request: APIRequestContext): Promise<void> {
+    const response = await request.post(`${MOCK_SERVER_URL}/__test/dev-reset`);
+    expect(response.ok()).toBe(true);
+    // Defensive: the entitlement scenario is shared global state across the
+    // whole mock server process (pre-existing pattern, see
+    // entitlementScenario.ts) — an earlier, unrelated spec file that left it
+    // on something other than "unprovisioned" would otherwise silently turn
+    // ask_dev off for every test in this file. "unprovisioned" is the
+    // scenario whose features carry `ask_dev: true` by default.
+    await setAskDevEntitlement(request, "unprovisioned");
+}
+
+export async function setAskDevCapabilities(
+    request: APIRequestContext,
+    state: "ready" | "not_ready" | "disabled",
+): Promise<void> {
+    const response = await request.post(`${MOCK_SERVER_URL}/__test/dev-capabilities`, {
+        data: { state },
+    });
+    expect(response.ok()).toBe(true);
+}
+
+/**
+ * Org-level entitlement gate (checked server-side by /dev's page.tsx via
+ * getOrgEntitlements) — distinct from `setAskDevCapabilities`, which is the
+ * client-side runtime capability gate. Both must independently deny access.
+ */
+export async function setAskDevEntitlement(
+    request: APIRequestContext,
+    scenario: "unprovisioned" | "ask-dev-disabled",
+): Promise<void> {
+    const response = await request.post(`${MOCK_SERVER_URL}/__test/entitlements`, {
+        data: { scenario },
+    });
+    expect(response.ok()).toBe(true);
+}
+
+export async function getAskDevRequestCounts(
+    request: APIRequestContext,
+): Promise<{ messages: number; conversationsCreated: number }> {
+    const response = await request.get(`${MOCK_SERVER_URL}/__test/dev-requests`);
+    expect(response.ok()).toBe(true);
+    return response.json();
+}
+
+export function askDevLauncher(page: Page) {
+    return page.getByRole("button", { name: "Open Ask Dev" });
+}
+
+export function askDevComposer(page: Page) {
+    return page.getByRole("textbox", { name: "Ask Dev question" });
+}
+
+export function askDevSubmit(page: Page) {
+    return page.getByRole("button", { name: "Ask", exact: true });
+}
+
+/** Opens the persistent window and waits for it past the "loading" gate. */
+export async function openAskDevWindow(page: Page): Promise<void> {
+    await askDevLauncher(page).click();
+    await expect(askDevComposer(page)).toBeVisible();
+}
+
+/** Types and submits one question via Enter, mirroring real keyboard usage. */
+export async function submitAskDevQuestion(page: Page, question: string): Promise<void> {
+    const composer = askDevComposer(page);
+    await composer.fill(question);
+    await composer.press("Enter");
+}
+
+export function askDevTranscript(page: Page) {
+    return page.locator('[aria-label="Ask Dev transcript"]');
+}
+
+export function askDevAnswerArticle(page: Page) {
+    return page.getByRole("article", { name: "Ask Dev answer" });
+}
+
+export function askDevRunningStatus(page: Page) {
+    return page.getByRole("status");
+}
+
+export function askDevFailedAlert(page: Page) {
+    return page.locator("#ask-dev-run-failed");
+}

--- a/tests/mocks/devScenario.ts
+++ b/tests/mocks/devScenario.ts
@@ -81,8 +81,23 @@ function buildAnswer(
 
     if ((OUTCOME_TABLE_KEYS as readonly string[]).includes(scenario)) {
         const outcome = outcomeCase(scenario);
-        base.status = outcome.status;
-        base.direct_summary = outcome.directSummary;
+        // "complete" deliberately does NOT overwrite status/direct_summary
+        // from the table: the canonical fixture (dev_answer.v1.json) IS the
+        // real producer for that scenario, and letting its own fields flow
+        // through unmodified is what makes a real contract-fixture mutation
+        // (e.g. status changed to something else, or direct_summary edited)
+        // break this scenario's e2e test — proving the fixture is actually
+        // exercised, not just present. The other statuses below have no
+        // canonical positive example to draw from (only one exists, and its
+        // status is "complete"), so they necessarily construct synthetic
+        // content; ASK_DEV_OUTCOME_TABLE's `status` values are still
+        // constrained to the pinned schema's real AnswerStatus enum (see
+        // askDevContracts.ts), and tests/ask-dev-vocabulary.spec.ts asserts
+        // that constraint plus full enum coverage.
+        if (scenario !== "complete") {
+            base.status = outcome.status;
+            base.direct_summary = outcome.directSummary;
+        }
         if (outcome.emptyEvidence) {
             base.claims = [];
             base.evidence = [];
@@ -386,6 +401,11 @@ export function getTranscript(conversationId: string): JsonRecord | null {
     };
 }
 
+const RETRYABLE_ERROR_SCENARIOS: ReadonlySet<DevAnswerScenario> = new Set([
+    "scope_forbidden_error",
+    "source_unavailable_error",
+]);
+
 /**
  * Applies one message/run to a stored conversation and returns its SSE
  * frames. Replays the identical prior frames for a repeated
@@ -399,6 +419,7 @@ export function applyMessage(
     clientMessageId: string,
     rawQuestion: string,
     scope: unknown,
+    retryOfRunId: string | null,
 ): { frames: string; replayed: boolean } | null {
     const stored = conversations.get(conversationId);
     if (!stored) return null;
@@ -409,7 +430,18 @@ export function applyMessage(
         return { frames: encodeSseFrames(existing.events as JsonRecord[]), replayed: true };
     }
 
-    const { scenario, visibleQuestion } = parseScenario(rawQuestion);
+    const parsed = parseScenario(rawQuestion);
+    // A retry of a retryable stream-level failure succeeds on the next
+    // attempt — this is what makes "click Retry" an observably different,
+    // real second request rather than a no-op that merely leaves the
+    // original failed alert on screen (a prior version of the retry spec
+    // only asserted the pre-existing alert was "still visible", which
+    // would have passed even with an inert Retry button).
+    const scenario =
+        retryOfRunId && RETRYABLE_ERROR_SCENARIOS.has(parsed.scenario)
+            ? "complete"
+            : parsed.scenario;
+    const visibleQuestion = parsed.visibleQuestion;
     const events = buildStreamEvents(scenario, conversationId, visibleQuestion);
     stored.seenClientMessageIds.set(clientMessageId, { events });
 

--- a/tests/mocks/devScenario.ts
+++ b/tests/mocks/devScenario.ts
@@ -1,0 +1,516 @@
+// Deterministic Ask Dev mock backend for the default Playwright suite
+// (CHAOS-3287). Every payload here is derived from the checked-in,
+// schema-validated canonical examples under
+// src/lib/dev/contracts/examples/positive/ — never hand-invented shapes —
+// so a drift between this mock and the real dev_answer.v1 contract fails
+// loudly (the browser's own client.ts schema/semantic validation rejects an
+// invalid mock response the same way it would reject a bad server response).
+//
+// Scenario selection is per-request, not shared global mutable state: the
+// Playwright spec encodes which canned answer to return as a
+// "[[ask-dev:<scenario>]] " prefix on the question text it types into the
+// composer, and this module strips it before building the transcript/answer
+// text. That keeps concurrently-running spec files from racing over a
+// single shared "current scenario" variable — the exact hazard the
+// pre-existing pagerduty/entitlement scenario globals accept by forcing a
+// dedicated `workers: 1` Playwright project (see playwright.config.ts). The
+// one exception is capabilities (`getCapabilities()` takes no per-request
+// input at all), which does use a small shared mutable flag; CI already runs
+// every project with `workers: 1` at the top level, so that shared state is
+// safe for the gate even though a fully parallel local run could race it.
+import { randomUUID } from "node:crypto";
+
+import answerFixture from "../../src/lib/dev/contracts/examples/positive/dev_answer.v1.json";
+import capabilitiesFixture from "../../src/lib/dev/contracts/examples/positive/dev_capabilities.v1.json";
+import { ASK_DEV_OUTCOME_TABLE, outcomeCase } from "../fixtures/askDevOutcomes";
+
+type JsonRecord = Record<string, unknown>;
+
+function clone<T>(value: T): T {
+    return structuredClone(value);
+}
+
+const OUTCOME_TABLE_KEYS = ASK_DEV_OUTCOME_TABLE.map((entry) => entry.key);
+
+export type DevAnswerScenario =
+    | (typeof ASK_DEV_OUTCOME_TABLE)[number]["key"]
+    | "needs_clarification"
+    | "forbidden_or_not_found_scope"
+    | "scope_forbidden_error"
+    | "source_unavailable_error";
+
+const SCENARIO_MARKER = /^\[\[ask-dev:([a-z_]+)\]\]\s*/u;
+const KNOWN_SCENARIOS: ReadonlySet<string> = new Set<DevAnswerScenario>([
+    ...OUTCOME_TABLE_KEYS,
+    "needs_clarification",
+    "forbidden_or_not_found_scope",
+    "scope_forbidden_error",
+    "source_unavailable_error",
+]);
+
+export function parseScenario(question: string): {
+    scenario: DevAnswerScenario;
+    visibleQuestion: string;
+} {
+    const match = SCENARIO_MARKER.exec(question);
+    const scenario =
+        match && KNOWN_SCENARIOS.has(match[1]!) ? (match[1] as DevAnswerScenario) : "complete";
+    return { scenario, visibleQuestion: match ? question.slice(match[0].length) : question };
+}
+
+let answerCounter = 0;
+let evidenceCounter = 0;
+
+function nextAnswerId(): string {
+    answerCounter += 1;
+    return `answer_e2e_${answerCounter}`;
+}
+
+/** Builds one schema-valid dev_answer.v1 for the requested scenario. */
+function buildAnswer(
+    scenario: DevAnswerScenario,
+    conversationId: string,
+    visibleQuestion: string,
+): JsonRecord {
+    const base = clone(answerFixture) as JsonRecord;
+    base.answer_id = nextAnswerId();
+    base.conversation_id = conversationId;
+    const nowIso = new Date().toISOString();
+    base.as_of = nowIso;
+    base.generated_at = nowIso;
+
+    if ((OUTCOME_TABLE_KEYS as readonly string[]).includes(scenario)) {
+        const outcome = outcomeCase(scenario);
+        base.status = outcome.status;
+        base.direct_summary = outcome.directSummary;
+        if (outcome.emptyEvidence) {
+            base.claims = [];
+            base.evidence = [];
+            base.metrics = [];
+            base.suggested_follow_up_questions = [];
+        }
+        // Scenario-specific coverage/warning detail beyond what the shared
+        // table encodes (the table only owns status + summary + caption,
+        // per its own header comment).
+        if (scenario === "partial") {
+            (base.coverage as JsonRecord) = {
+                ...(base.coverage as JsonRecord),
+                available_source_count: 9,
+                required_source_count: 12,
+                unavailable_required_sources: ["deployments"],
+            };
+            base.warnings = ["Deployment evidence was unavailable for part of the window."];
+        } else if (scenario === "degraded") {
+            (base.coverage as JsonRecord) = {
+                ...(base.coverage as JsonRecord),
+                stale_required_sources: ["work_graph"],
+            };
+            base.warnings = ["Work graph data is stale for part of the requested window."];
+        } else if (scenario === "insufficient_evidence") {
+            (base.coverage as JsonRecord) = {
+                ...(base.coverage as JsonRecord),
+                available_source_count: 0,
+                required_source_count: 1,
+                unavailable_required_sources: ["work_graph"],
+            };
+        }
+        return base;
+    }
+
+    switch (scenario) {
+        case "needs_clarification": {
+            base.direct_summary =
+                "More than one match was found for this question. Choose the one you meant.";
+            const resolvedScope = base.resolved_scope as JsonRecord;
+            resolvedScope.outcome = "ambiguous";
+            resolvedScope.resolved_scope = null;
+            resolvedScope.authorized_repository_ids = [];
+            resolvedScope.authorized_entity_ids = [];
+            resolvedScope.candidates = [
+                {
+                    entity_ref: {
+                        entity_id: "repo_dev_health",
+                        entity_type: "repository",
+                        display_label: "dev-health (this repository)",
+                        repository_id: null,
+                    },
+                    reason: `Matches "${visibleQuestion.trim().slice(0, 40)}" by name`,
+                },
+                {
+                    entity_ref: {
+                        entity_id: "repo_dev_health_web",
+                        entity_type: "repository",
+                        display_label: "dev-health-web",
+                        repository_id: null,
+                    },
+                    reason: "Also matches by name",
+                },
+            ];
+            return base;
+        }
+        case "forbidden_or_not_found_scope": {
+            // A real, reachable ScopeResolutionOutcome (contracts.py
+            // `ScopeResolutionOutcome.FORBIDDEN_OR_NOT_FOUND`) — the exact
+            // internal value AskDevAnswer.tsx:333 currently renders raw
+            // (`scopeResolution.outcome.replaceAll("_", " ")`). Public
+            // copy must never disclose which of "forbidden" or "not found"
+            // applies (that would itself leak hidden-entity existence).
+            base.direct_summary = "No authorized match was found for this question.";
+            const resolvedScope = base.resolved_scope as JsonRecord;
+            resolvedScope.outcome = "forbidden_or_not_found";
+            resolvedScope.resolved_scope = null;
+            resolvedScope.authorized_repository_ids = [];
+            resolvedScope.authorized_entity_ids = [];
+            resolvedScope.candidates = [];
+            return base;
+        }
+        default:
+            return base;
+    }
+}
+
+let runCounter = 0;
+
+function nextRunId(): string {
+    runCounter += 1;
+    return `run_e2e_${runCounter}`;
+}
+
+/** Builds one schema-valid, semantically-valid dev_stream_event.v1[] run. */
+export function buildStreamEvents(
+    scenario: DevAnswerScenario,
+    conversationId: string,
+    visibleQuestion: string,
+): JsonRecord[] {
+    const runId = nextRunId();
+    const occurredAt = new Date().toISOString();
+    let sequence = 0;
+    const events: JsonRecord[] = [];
+    const push = (event: JsonRecord) => {
+        events.push({
+            answer: null,
+            delta: null,
+            error: null,
+            progress: null,
+            scope_resolution: null,
+            terminal_kind: null,
+            warning: null,
+            schema_version: "dev_stream_event.v1",
+            run_id: runId,
+            occurred_at: occurredAt,
+            sequence: sequence++,
+            ...event,
+        });
+    };
+
+    push({ event: "run.started" });
+    push({ event: "progress", progress: "resolving_scope" });
+    push({ event: "progress", progress: "checking_evidence" });
+
+    if (scenario === "scope_forbidden_error" || scenario === "source_unavailable_error") {
+        const error =
+            scenario === "scope_forbidden_error"
+                ? {
+                      code: "scope_forbidden",
+                      request_id: randomUUID(),
+                      retryable: false,
+                      safe_message: "You don't have access to that scope.",
+                      schema_version: "dev_error.v1",
+                  }
+                : {
+                      code: "source_unavailable",
+                      remediation: ["Retry after source health recovers."],
+                      request_id: randomUUID(),
+                      retryable: true,
+                      safe_message: "A required source is temporarily unavailable.",
+                      schema_version: "dev_error.v1",
+                  };
+        push({ event: "error", error });
+        push({ event: "done", terminal_kind: "error" });
+        return events;
+    }
+
+    push({ event: "answer.delta", delta: "Checking the evidence in this scope… " });
+    const answer = buildAnswer(scenario, conversationId, visibleQuestion);
+    push({ event: "answer.completed", answer });
+    push({ event: "done", terminal_kind: "answer" });
+    return events;
+}
+
+export function encodeSseFrames(events: readonly JsonRecord[]): string {
+    return events
+        .map((event) => `event: ${event.event}\ndata: ${JSON.stringify(event)}\n\n`)
+        .join("");
+}
+
+// --- Capabilities (shared mutable state; see module comment) ---------------
+
+export type DevCapabilitiesState = "ready" | "not_ready" | "disabled";
+let capabilitiesState: DevCapabilitiesState = "ready";
+
+export function setDevCapabilitiesState(state: string): boolean {
+    if (state !== "ready" && state !== "not_ready" && state !== "disabled") return false;
+    capabilitiesState = state;
+    return true;
+}
+
+export function getDevCapabilitiesResponse(): JsonRecord {
+    const base = clone(capabilitiesFixture) as JsonRecord;
+    if (capabilitiesState === "disabled") {
+        return { ...base, ask_dev: false, can_read: false, readiness: "disabled" };
+    }
+    if (capabilitiesState === "not_ready") {
+        return {
+            ...base,
+            ask_dev: true,
+            can_read: true,
+            readiness: "missing_credentials",
+            administrator_safe_failure_reason:
+                "Ask Dev is enabled, but an administrator needs to finish provider setup.",
+        };
+    }
+    return { ...base, ask_dev: true, can_read: true, can_manage: true, readiness: "ready" };
+}
+
+// --- Conversation store ------------------------------------------------
+
+type StoredConversation = {
+    conversation: JsonRecord;
+    items: JsonRecord[];
+    seenClientMessageIds: Map<string, JsonRecord>;
+};
+
+const conversations = new Map<string, StoredConversation>();
+
+// Request counters exposed at /__test/dev-requests so specs can assert "no
+// provider call/page-data transmission occurs merely from opening a
+// surface" and "one message/run is created under duplicate click" without
+// guessing at network timing.
+let messagesRequestCount = 0;
+let conversationsCreatedCount = 0;
+
+export function recordMessagesRequest(): void {
+    messagesRequestCount += 1;
+}
+
+export function recordConversationCreated(): void {
+    conversationsCreatedCount += 1;
+}
+
+export function getDevRequestCounts(): { messages: number; conversationsCreated: number } {
+    return { messages: messagesRequestCount, conversationsCreated: conversationsCreatedCount };
+}
+
+export function resetDevMockState(): void {
+    conversations.clear();
+    messagesRequestCount = 0;
+    conversationsCreatedCount = 0;
+    capabilitiesState = "ready";
+    answerCounter = 0;
+    runCounter = 0;
+    evidenceCounter = 0;
+}
+
+export function createConversation(currentScope: unknown, title: unknown): JsonRecord {
+    const conversationId = `conversation_e2e_${randomUUID()}`;
+    const nowIso = new Date().toISOString();
+    const conversation: JsonRecord = {
+        conversation_id: conversationId,
+        created_at: nowIso,
+        updated_at: nowIso,
+        current_scope: currentScope,
+        expires_at: null,
+        latest_answer_id: null,
+        message_count: 0,
+        retention_days: 30,
+        schema_version: "dev_conversation.v1",
+        state: "active",
+        title: typeof title === "string" ? title : null,
+    };
+    conversations.set(conversationId, {
+        conversation,
+        items: [],
+        seenClientMessageIds: new Map(),
+    });
+    recordConversationCreated();
+    return clone(conversation);
+}
+
+export function getConversation(conversationId: string): JsonRecord | null {
+    const stored = conversations.get(conversationId);
+    return stored ? clone(stored.conversation) : null;
+}
+
+export function listConversations(): JsonRecord[] {
+    return [...conversations.values()]
+        .sort(
+            (a, b) =>
+                Date.parse(String(b.conversation.updated_at)) -
+                Date.parse(String(a.conversation.updated_at)),
+        )
+        .map((stored) => ({
+            conversation_id: stored.conversation.conversation_id,
+            direct_scope: (stored.conversation.current_scope as JsonRecord).direct_scope,
+            expires_at: stored.conversation.expires_at,
+            message_count: stored.conversation.message_count,
+            schema_version: "dev_conversation_summary.v1",
+            state: stored.conversation.state,
+            title: stored.conversation.title,
+            updated_at: stored.conversation.updated_at,
+        }));
+}
+
+export function renameConversation(
+    conversationId: string,
+    title: string | null,
+): JsonRecord | null {
+    const stored = conversations.get(conversationId);
+    if (!stored) return null;
+    stored.conversation.title = title;
+    stored.conversation.updated_at = new Date().toISOString();
+    return clone(stored.conversation);
+}
+
+export function deleteConversation(conversationId: string): boolean {
+    return conversations.delete(conversationId);
+}
+
+export function getTranscript(conversationId: string): JsonRecord | null {
+    const stored = conversations.get(conversationId);
+    if (!stored) return null;
+    return {
+        conversation_id: conversationId,
+        items: clone(stored.items),
+        next_cursor: null,
+        schema_version: "dev_conversation_transcript.v1",
+    };
+}
+
+/**
+ * Applies one message/run to a stored conversation and returns its SSE
+ * frames. Replays the identical prior frames for a repeated
+ * `client_message_id` on the same conversation instead of appending another
+ * transcript entry — the deterministic proxy for "one message/run is
+ * created under duplicate click, ... reconnect, retry" without a real
+ * network layer to actually drop the duplicate request.
+ */
+export function applyMessage(
+    conversationId: string,
+    clientMessageId: string,
+    rawQuestion: string,
+    scope: unknown,
+): { frames: string; replayed: boolean } | null {
+    const stored = conversations.get(conversationId);
+    if (!stored) return null;
+    recordMessagesRequest();
+
+    const existing = stored.seenClientMessageIds.get(clientMessageId);
+    if (existing) {
+        return { frames: encodeSseFrames(existing.events as JsonRecord[]), replayed: true };
+    }
+
+    const { scenario, visibleQuestion } = parseScenario(rawQuestion);
+    const events = buildStreamEvents(scenario, conversationId, visibleQuestion);
+    stored.seenClientMessageIds.set(clientMessageId, { events });
+
+    const nowIso = new Date().toISOString();
+    const runId = String((events[0] as JsonRecord).run_id);
+    const terminal = events.find(
+        (event) => event.event === "answer.completed" || event.event === "error",
+    ) as JsonRecord | undefined;
+    const runState =
+        terminal?.event === "answer.completed"
+            ? "completed"
+            : terminal?.event === "error"
+              ? "failed"
+              : "failed";
+
+    stored.items.push({
+        answer: null,
+        created_at: nowIso,
+        message_id: `message_e2e_${randomUUID()}`,
+        question: rawQuestion,
+        retry_of_run_id: null,
+        role: "user",
+        run_id: runId,
+        run_state: runState,
+        schema_version: "dev_transcript_entry.v1",
+        scope,
+    });
+    if (terminal?.event === "answer.completed") {
+        const answer = terminal.answer as JsonRecord;
+        stored.items.push({
+            answer,
+            created_at: nowIso,
+            message_id: `message_e2e_${randomUUID()}`,
+            question: null,
+            retry_of_run_id: null,
+            role: "assistant",
+            run_id: runId,
+            run_state: runState,
+            schema_version: "dev_transcript_entry.v1",
+            scope: null,
+        });
+        stored.conversation.latest_answer_id = answer.answer_id;
+    }
+    stored.conversation.message_count = (stored.conversation.message_count as number) + 1;
+    stored.conversation.updated_at = nowIso;
+
+    return { frames: encodeSseFrames(events), replayed: false };
+}
+
+export function expandEvidence(evidenceRefId: string, answerId: string): JsonRecord {
+    evidenceCounter += 1;
+    const safeExcerpt = `UNTRUSTED_DATA\nEvidence excerpt ${evidenceCounter} for ${answerId}\nEND_UNTRUSTED_DATA`;
+    return {
+        evidence: {
+            citation_text: "The contract implementation remains in progress.",
+            confidence: 1,
+            display_label: "Implement contract baseline",
+            entity_id: "item_01",
+            entity_type: "work_item",
+            evidence_ref_id: evidenceRefId,
+            flags: {
+                conflicting: false,
+                deleted: false,
+                redacted: false,
+                stale: false,
+                unavailable: false,
+                uncertain: false,
+                untrusted_content: true,
+            },
+            freshness: "fresh",
+            link: { internal_path: "/work/items/item_01", source_url: null },
+            observed_at: "2026-07-28T12:00:00Z",
+            provenance: "Canonical work graph projection",
+            repository_ids: ["repo_dev_health"],
+            schema_version: "dev_evidence_ref.v1",
+            source_system: "work_graph",
+            source_version: "work_graph.v1",
+            valid_entity_ids: ["item_01"],
+        },
+        query_version: "get_evidence.v1",
+        safe_excerpt: safeExcerpt,
+        schema_version: "dev_evidence_expansion.v1",
+        // Must equal the byte length of `safe_excerpt` itself (the whole
+        // UNTRUSTED_DATA-wrapped string), not just its inner text — the
+        // client's semantic validator (contractValidation.ts) rejects the
+        // response otherwise, exactly the kind of drift this deterministic
+        // mock is supposed to force out into the open.
+        serialized_bytes: new TextEncoder().encode(safeExcerpt).byteLength,
+        state: "available",
+        warning: null,
+    };
+}
+
+export function submitFeedback(answerId: string, rating: string, reasons: unknown): JsonRecord {
+    return {
+        answer_id: answerId,
+        comment: null,
+        created_at: new Date().toISOString(),
+        feedback_id: `feedback_e2e_${randomUUID()}`,
+        rating,
+        reasons: Array.isArray(reasons) ? reasons : [],
+        schema_version: "dev_feedback.v1",
+    };
+}

--- a/tests/mocks/entitlementScenario.ts
+++ b/tests/mocks/entitlementScenario.ts
@@ -5,7 +5,8 @@ export type EntitlementScenario =
     | "error"
     | "canonical-absent"
     | "canonical-disabled"
-    | "canonical-enabled";
+    | "canonical-enabled"
+    | "ask-dev-disabled";
 
 let currentEntitlementScenario: EntitlementScenario = "unprovisioned";
 
@@ -18,6 +19,7 @@ export function setEntitlementScenario(scenario: string): boolean {
         case "canonical-absent":
         case "canonical-disabled":
         case "canonical-enabled":
+        case "ask-dev-disabled":
             currentEntitlementScenario = scenario;
             return true;
         default:

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -743,6 +743,10 @@ const MOCK_ORG_ENTITLEMENTS = {
     licensed_repos: null,
     features: {
         customer_push_ingest: true,
+        // Ask Dev is enabled for the default e2e org so the deterministic
+        // CHAOS-3287 Playwright coverage can exercise the real /dev route
+        // and persistent window gate, not a stubbed-out "unavailable" state.
+        ask_dev: true,
     },
     features_override: null,
     limits_override: null,
@@ -2124,7 +2128,9 @@ export const handlers = [
                       ? { ...MOCK_ORG_ENTITLEMENTS.features, canonical_incident_ingestion: true }
                       : scenario === "canonical-disabled"
                         ? { ...MOCK_ORG_ENTITLEMENTS.features, canonical_incident_ingestion: false }
-                        : MOCK_ORG_ENTITLEMENTS.features,
+                        : scenario === "ask-dev-disabled"
+                          ? { ...MOCK_ORG_ENTITLEMENTS.features, ask_dev: false }
+                          : MOCK_ORG_ENTITLEMENTS.features,
         });
     }),
 

--- a/tests/mocks/http-server.ts
+++ b/tests/mocks/http-server.ts
@@ -1,5 +1,20 @@
 import express from "express";
 import { createMiddleware } from "@mswjs/http-middleware";
+import {
+    applyMessage,
+    createConversation,
+    deleteConversation,
+    expandEvidence,
+    getConversation,
+    getDevCapabilitiesResponse,
+    getDevRequestCounts,
+    getTranscript,
+    listConversations,
+    renameConversation,
+    resetDevMockState,
+    setDevCapabilitiesState,
+    submitFeedback,
+} from "./devScenario";
 import { setEntitlementScenario } from "./entitlementScenario";
 import { handlers } from "./handlers";
 import { pagerDutyObservations, setPagerDutyScenario } from "./pagerdutyScenario";
@@ -38,6 +53,105 @@ app.post("/__test/pagerduty", (req, res) => {
 app.get("/__test/pagerduty/observations", (_req, res) => {
     res.json(pagerDutyObservations());
 });
+
+// --- Ask Dev deterministic mock (CHAOS-3287) ---------------------------
+app.post("/__test/dev-reset", (_req, res) => {
+    resetDevMockState();
+    res.status(204).end();
+});
+app.get("/__test/dev-requests", (_req, res) => {
+    res.json(getDevRequestCounts());
+});
+app.post("/__test/dev-capabilities", (req, res) => {
+    if (!setDevCapabilitiesState(req.body?.state)) {
+        res.status(400).json({ error: "Unknown Ask Dev capabilities state" });
+        return;
+    }
+    res.status(204).end();
+});
+app.get("/api/v1/dev/capabilities", (_req, res) => {
+    res.json(getDevCapabilitiesResponse());
+});
+app.post("/api/v1/dev/conversations", (req, res) => {
+    res.status(201).json(createConversation(req.body?.current_scope, req.body?.title));
+});
+app.get("/api/v1/dev/conversations", (_req, res) => {
+    res.json({ items: listConversations(), next_cursor: null });
+});
+app.get("/api/v1/dev/conversations/:conversationId", (req, res) => {
+    const conversation = getConversation(req.params.conversationId);
+    if (!conversation) {
+        res.status(404).json({
+            schema_version: "dev_web_error.v1",
+            code: "conversation_not_found",
+            safe_message: "This conversation could not be found.",
+            retryable: false,
+        });
+        return;
+    }
+    res.json(conversation);
+});
+app.patch("/api/v1/dev/conversations/:conversationId", (req, res) => {
+    const conversation = renameConversation(req.params.conversationId, req.body?.title ?? null);
+    if (!conversation) {
+        res.status(404).json({
+            schema_version: "dev_web_error.v1",
+            code: "conversation_not_found",
+            safe_message: "This conversation could not be found.",
+            retryable: false,
+        });
+        return;
+    }
+    res.json(conversation);
+});
+app.delete("/api/v1/dev/conversations/:conversationId", (req, res) => {
+    deleteConversation(req.params.conversationId);
+    res.status(204).end();
+});
+app.get("/api/v1/dev/conversations/:conversationId/transcript", (req, res) => {
+    const transcript = getTranscript(req.params.conversationId);
+    if (!transcript) {
+        res.status(404).json({
+            schema_version: "dev_web_error.v1",
+            code: "conversation_not_found",
+            safe_message: "This conversation could not be found.",
+            retryable: false,
+        });
+        return;
+    }
+    res.json(transcript);
+});
+app.post("/api/v1/dev/conversations/:conversationId/messages", (req, res) => {
+    const result = applyMessage(
+        req.params.conversationId,
+        String(req.body?.client_message_id ?? ""),
+        String(req.body?.question ?? ""),
+        req.body?.scope,
+    );
+    if (!result) {
+        res.status(404).json({
+            schema_version: "dev_web_error.v1",
+            code: "conversation_not_found",
+            safe_message: "This conversation could not be found.",
+            retryable: false,
+        });
+        return;
+    }
+    res.status(200);
+    res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+    res.setHeader("Cache-Control", "no-cache");
+    res.flushHeaders();
+    res.write(result.frames);
+    res.end();
+});
+app.get("/api/v1/dev/evidence/:evidenceRefId", (req, res) => {
+    const answerId = String(req.query.answer_id ?? "");
+    res.json(expandEvidence(req.params.evidenceRefId, answerId));
+});
+app.post("/api/v1/dev/answers/:answerId/feedback", (req, res) => {
+    res.json(submitFeedback(req.params.answerId, req.body?.rating, req.body?.reasons));
+});
+
 app.use("/graphql", (req, res, next) => {
     const query = req.method === "GET" ? req.query.query : req.body?.query;
     if (typeof query !== "string" || !query.includes("PrDetail")) {

--- a/tests/mocks/http-server.ts
+++ b/tests/mocks/http-server.ts
@@ -127,6 +127,7 @@ app.post("/api/v1/dev/conversations/:conversationId/messages", (req, res) => {
         String(req.body?.client_message_id ?? ""),
         String(req.body?.question ?? ""),
         req.body?.scope,
+        typeof req.body?.retry_of_run_id === "string" ? req.body.retry_of_run_id : null,
     );
     if (!result) {
         res.status(404).json({


### PR DESCRIPTION
## Summary

CHAOS-3287: the default `pnpm test:e2e` suite had zero Ask Dev Playwright flows — answer-contract, public-outcome, and internal-enum-leak regressions could pass behind nothing but the opt-in live acceptance spec. This adds deterministic coverage that's automatically part of the default suite (no CI workflow changes needed — new spec files under `tests/*.spec.ts` are picked up by the existing `testDir`/`testMatch`).

- **Deterministic mock backend** (`tests/mocks/devScenario.ts`): every canned answer is built from the checked-in, schema-validated canonical fixtures under `src/lib/dev/contracts/examples/positive/`, not hand-invented shapes, so drift fails loudly the same way a bad real response would (the browser's own `client.ts` re-validates every response against the pinned JSON Schema).
- **Spec coverage**: shared request lifecycle (no provider call on mere open, duplicate-submit dedupe, cancel, retry with a real second request), every `dev_answer.v1` status the frontend actually renders today, evidence-first hierarchy, availability gating (capability + org-entitlement layers), and an internal-enum denylist checked against the real backend vocabulary.
- **Vocabulary**: `tests/fixtures/askDevContracts.ts` extracts its enum vocabulary at runtime from the pinned JSON Schema files rather than hand-transcribing it, and cross-checks against `AskDevAnswer.tsx`'s own exported sanctioned-copy maps. `tests/fixtures/askDevOutcomes.ts` is the single table both the mock and the spec assertions read from.
- **A real bug found and fixed along the way**: `src/app/api/v1/dev/_proxy.ts`'s same-origin check fell back to `request.url`'s origin when `AUTH_URL`/`NEXTAUTH_URL` was unset — Next's dev server doesn't reliably report that as the actual `--hostname`, so every Ask Dev mutation 403'd unconditionally in that configuration (the normal state for local dev and CI's `e2e-default` job). Fixed to derive from the inbound Host header instead, with a configured `AUTH_URL` still taking precedence.
- **CHAOS-3291 alignment**: the two internal-enum-leak checks are ordinary active tests (not skipped), verified passing against the merged CHAOS-3291 fix (#832).

Targets the `dev_answer.v1` contract this frontend actually consumes today. `dev_answer.v2`'s outcome taxonomy is CHAOS-3294/3298 work not yet landed in web — `tests/fixtures/askDevOutcomes.ts` is structured as the single table CHAOS-3298 needs to re-point at v2 shapes, not a spec-by-spec rewrite.

## Review history

This branch went through Codex review twice. First pass: NO-SHIP, 3 CONFIRMED (all test-honesty — outcome-table self-oracle, `test.fixme` never self-activating, retry test passing with an inert handler); fixed with mutation proofs. Second, scoped pass on just the fix commits: NO-SHIP, 1 CONFIRMED (the `ScopeResolutionOutcome` drift check only membership-tested 2 values instead of an exhaustive partition); fixed and verified with both of Codex's repro cases in-memory.

## Risk note

The "no lingering CHAOS-3291 `test.fixme`" tripwire (`tests/ask-dev-vocabulary.spec.ts`) does a literal-pattern scan of spec-file source text, not an AST-based check. Codex flagged that a computed/dynamically-constructed call could evade it; accepted as out-of-scope for this PR — evading it requires writing code whose only purpose is defeating the checker, which isn't a realistic accidental-regression path for a same-repo, same-PR honesty check.

## Test plan

- [x] `bash ci/run_tests.sh ci` (full gate, with `ASK_DEV_OPS_ROOT` pinned) — green: quality/build/unit (3554 tests) + e2e default (275) + onboarding (10) + context-fabric (21) + pagerduty-final-qa (23), all passed
- [x] Full default e2e suite re-run after rebasing onto merged #832 — 281 passed, 0 failed
- [x] Targeted rerun after the final scoped fix — `ask-dev-vocabulary.spec.ts` + `ask-dev-shared.spec.ts` + `ask-dev-outcomes.spec.ts` + `ask-dev-continuity.spec.ts` — 33/33 passed
- [x] RED-proofed: injected a wrong `schema_version` into the mock (6 tests failed loudly); mutated the canonical fixture's status/direct_summary (the `complete` scenario test failed); disabled the retry-success mock branch (retry test failed); both Codex `ScopeResolutionOutcome` repros (append, rename) fail as expected in-memory
- [x] `_proxy.test.ts` unit tests (10, including 3 new regression cases for the origin-check fix) — passed