### PR TITLE
chore(ask-dev): CHAOS-3298 re-pin web contracts to ops main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,13 +90,14 @@ jobs:
             ASK_DEV_OPS_ROOT: dev-health-ops
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-            # This SHA is on the Ask Dev Wave 3 branch. Publish that ops
-            # branch/PR before opening or updating the dependent web PR.
+            # Must stay equal to SOURCE_COMMIT in scripts/ask-dev-contracts.mjs
+            # (scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs reads
+            # that script and asserts the two match). This SHA is ops main.
             - name: Checkout canonical Ask Dev ops contracts
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
               with:
                   repository: full-chaos/dev-health-ops
-                  ref: f8f541c35f971b19e26ce8c14f9b52d0801cc8df
+                  ref: b469dd35caa46c347b120517bb4c779dc129cf91
                   path: dev-health-ops
                   persist-credentials: false
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -269,9 +269,15 @@ digests in `src/lib/dev/contracts/source.json`, and generates
 The repositories land in order: first publish the ops foundation branch and
 open/merge its contract PR, then update the full ops commit pinned in both the
 web sync script and `.github/workflows/tests.yml`, and only then open the
-dependent web PR. The pinned commit must be reachable from an ops branch so the
-web quality job can check it out; web CI compares against that checkout rather
-than trusting its vendored `source.json`.
+dependent web PR. Those two must name the same commit — the quality job checks
+ops out at the workflow's ref and then runs a check that refuses any source
+whose HEAD is not exactly the script's `SOURCE_COMMIT` — so
+`scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs` reads the ref out
+of the sync script and asserts the workflow matches, turning a half-finished
+re-pin into a unit-test failure instead of a CI-only one. The pinned commit
+must be reachable from an ops branch so the web quality job can check it out;
+web CI compares against that checkout rather than trusting its vendored
+`source.json`.
 
 After an approved ops contract change, regenerate from a clean sibling checkout:
 

--- a/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
+++ b/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
@@ -16,6 +16,23 @@ import {
 
 const TESTS_WORKFLOW = path.join(ROOT, ".github/workflows/tests.yml");
 const PACKAGE_JSON = path.join(ROOT, "package.json");
+const ASK_DEV_CONTRACTS_SCRIPT = path.join(ROOT, "scripts/ask-dev-contracts.mjs");
+
+/**
+ * The ops commit the Ask Dev contracts are pinned to, read from the sync
+ * script that owns it rather than transcribed here. The quality job checks
+ * out ops at this ref and then runs `ask-dev:contracts:check`, which refuses
+ * any source whose HEAD is not exactly SOURCE_COMMIT — so a re-pin that
+ * moved one and not the other would fail in CI only. Deriving it means the
+ * workflow and the script cannot disagree in the first place.
+ */
+function pinnedOpsCommit() {
+    const match = /^const SOURCE_COMMIT = "([0-9a-f]{40})";$/mu.exec(
+        contents(ASK_DEV_CONTRACTS_SCRIPT),
+    );
+    if (!match) throw new Error("Could not read SOURCE_COMMIT from scripts/ask-dev-contracts.mjs.");
+    return match[1];
+}
 const GENERAL_TIERS = [
     {
         commands: ["format:check:changed"],
@@ -142,7 +159,7 @@ describe("CHAOS-3017 executable CI boundaries", () => {
                     "        env:\n            ASK_DEV_OPS_ROOT: dev-health-ops",
                 );
                 expect(workflowJob).toContain("repository: full-chaos/dev-health-ops");
-                expect(workflowJob).toContain("ref: f8f541c35f971b19e26ce8c14f9b52d0801cc8df");
+                expect(workflowJob).toContain(`ref: ${pinnedOpsCommit()}`);
                 expect(workflowJob).toContain("path: dev-health-ops");
             }
             for (const [name, implementation] of Object.entries(packageScripts)) {

--- a/scripts/ask-dev-contracts.mjs
+++ b/scripts/ask-dev-contracts.mjs
@@ -12,7 +12,7 @@ import { format } from "prettier";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ARTIFACT_ROOT = path.join(ROOT, "src/lib/dev/contracts");
 const GENERATED_PATH = path.join(ROOT, "src/lib/dev/generated.ts");
-const SOURCE_COMMIT = "f8f541c35f971b19e26ce8c14f9b52d0801cc8df";
+const SOURCE_COMMIT = "b469dd35caa46c347b120517bb4c779dc129cf91";
 const SOURCE_PREFIX = "contracts/ask-dev/v1/";
 const PRETTIER_OPTIONS = Object.freeze({
     parser: "typescript",

--- a/src/components/ask-dev/AskDevConversation.test.tsx
+++ b/src/components/ask-dev/AskDevConversation.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
-import { AskDevConversation } from "./AskDevConversation";
+import type { DevProgressState } from "@/lib/dev/client";
+
+import { AskDevConversation, PROGRESS_LABELS } from "./AskDevConversation";
 
 vi.mock("next/navigation", () => ({
     usePathname: () => "/cockpit",
@@ -67,5 +69,32 @@ describe("AskDevConversation empty state (CHAOS-3215)", () => {
         expect(link).toHaveAttribute("href", "/docs/use/ai-workflows/");
         expect(link).toHaveAttribute("target", "_blank");
         expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+});
+
+describe("Ask Dev progress copy", () => {
+    // Mirrors the totality guard in AskDevAnswer.test.tsx. PROGRESS_LABELS is
+    // typed TOTAL over DevProgressState, so a re-pin that adds a phase already
+    // fails to compile; this reference record makes that pressure visible in
+    // the test file too, and the Object.keys comparison catches drift between
+    // the two lists even when both happen to compile.
+    it("PROGRESS_LABELS has exactly one sanctioned entry per pinned progress phase", () => {
+        const knownPhases: Record<DevProgressState, true> = {
+            checking_data_freshness: true,
+            checking_dependencies: true,
+            checking_evidence: true,
+            checking_status: true,
+            preparing_answer: true,
+            querying_metrics: true,
+            resolving_scope: true,
+        };
+        expect(Object.keys(PROGRESS_LABELS).sort()).toEqual(Object.keys(knownPhases).sort());
+    });
+
+    it("names every phase without leaking the raw enum value", () => {
+        for (const [phase, label] of Object.entries(PROGRESS_LABELS)) {
+            expect(label, phase).not.toContain(phase);
+            expect(label, phase).not.toContain(phase.replaceAll("_", " "));
+        }
     });
 });

--- a/src/components/ask-dev/AskDevConversation.test.tsx
+++ b/src/components/ask-dev/AskDevConversation.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DevProgressState } from "@/lib/dev/client";
 
@@ -9,6 +9,38 @@ vi.mock("next/navigation", () => ({
     usePathname: () => "/cockpit",
     useRouter: () => ({ replace: vi.fn() }),
     useSearchParams: () => new URLSearchParams(),
+}));
+
+// The error-guidance tests need to drive `stream` per case, so the mock reads
+// it from here instead of closing over a literal. Reset in beforeEach.
+type MockStream = {
+    phase: "idle" | "running" | "completed" | "failed";
+    delta: string;
+    warnings: string[];
+    error: { code: string; safe_message: string; retryable: boolean } | null;
+    progress: null;
+};
+const IDLE_STREAM: Readonly<MockStream> = Object.freeze({
+    phase: "idle",
+    delta: "",
+    warnings: [],
+    error: null,
+    progress: null,
+});
+const askDevState = vi.hoisted(() => ({
+    stream: {
+        phase: "idle",
+        delta: "",
+        warnings: [],
+        error: null,
+        progress: null,
+    } as {
+        phase: "idle" | "running" | "completed" | "failed";
+        delta: string;
+        warnings: string[];
+        error: { code: string; safe_message: string; retryable: boolean } | null;
+        progress: null;
+    },
 }));
 
 vi.mock("./AskDevProvider", () => ({
@@ -42,7 +74,7 @@ vi.mock("./AskDevProvider", () => ({
         renameConversation: vi.fn(),
         retryLastQuestion: vi.fn(),
         startNewConversation: vi.fn(),
-        stream: { phase: "idle" as const, delta: "", warnings: [], error: null, progress: null },
+        stream: askDevState.stream,
         submitQuestion: vi.fn(),
         transcript: [],
     }),
@@ -96,5 +128,65 @@ describe("Ask Dev progress copy", () => {
             expect(label, phase).not.toContain(phase);
             expect(label, phase).not.toContain(phase.replaceAll("_", " "));
         }
+    });
+});
+
+describe("Ask Dev error guidance", () => {
+    beforeAll(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    beforeEach(() => {
+        askDevState.stream = { ...IDLE_STREAM };
+    });
+
+    function renderWithError(code: string) {
+        askDevState.stream = {
+            ...IDLE_STREAM,
+            phase: "failed",
+            error: { code, safe_message: "Ask Dev stopped.", retryable: true },
+        };
+        return render(<AskDevConversation />);
+    }
+
+    // CHAOS-3339. The guidance names the provider as the faulting side and
+    // says a retry is worth trying — the opposite of the allowance guidance,
+    // which exists to tell you a retry cannot help.
+    it("explains a provider contract violation as a provider-side fault", () => {
+        renderWithError("provider_contract_violation");
+
+        expect(
+            screen.getByText(/provider returned a response that violated its contract/iu),
+        ).toBeVisible();
+        expect(screen.getByText(/retrying may help/iu)).toBeVisible();
+    });
+
+    it("keeps the retry affordance for a provider contract violation", () => {
+        renderWithError("provider_contract_violation");
+
+        expect(screen.getByRole("button", { name: /retry/iu })).toBeVisible();
+    });
+
+    // The pre-existing behaviour this must not disturb: an exhausted
+    // allowance replaces the retry button rather than sitting beside it.
+    it("replaces the retry affordance for an exhausted allowance", () => {
+        renderWithError("cost_limit_reached");
+
+        expect(screen.getByText(/Retrying immediately will not help/iu)).toBeVisible();
+        expect(screen.queryByRole("button", { name: /retry/iu })).not.toBeInTheDocument();
+    });
+
+    it("shows no tailored guidance for an unrelated error code", () => {
+        renderWithError("internal_error");
+
+        expect(screen.queryByText(/violated its contract/iu)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Retrying immediately will not help/iu)).not.toBeInTheDocument();
+    });
+
+    it("never renders the raw error code", () => {
+        renderWithError("provider_contract_violation");
+
+        expect(screen.queryByText(/provider_contract_violation/u)).not.toBeInTheDocument();
+        expect(screen.queryByText(/provider contract violation/iu)).not.toBeInTheDocument();
     });
 });

--- a/src/components/ask-dev/AskDevConversation.tsx
+++ b/src/components/ask-dev/AskDevConversation.tsx
@@ -37,6 +37,20 @@ function platformAllowanceGuidance(
 }
 
 /**
+ * CHAOS-3339. Kept separate from `platformAllowanceGuidance` because the two
+ * pull opposite ways on the retry affordance: an exhausted allowance means
+ * retrying cannot help (so that guidance replaces the retry button), while a
+ * provider contract violation is transient and worth retrying. Provisional
+ * copy — product may refine the wording.
+ */
+function providerContractGuidance(
+    error: ReturnType<typeof useAskDev>["stream"]["error"],
+): string | null {
+    if (error?.code !== "provider_contract_violation") return null;
+    return "The AI provider returned a response that violated its contract. This is a provider-side fault — retrying may help.";
+}
+
+/**
  * Sanctioned copy for every pinned progress phase, TOTAL over
  * `DevProgressState`.
  *
@@ -108,6 +122,9 @@ export function AskDevConversation({
     const searchParams = useSearchParams();
     const filters = useMemo(() => decodeFilter(searchParams.get("f")), [searchParams]);
     const allowanceGuidance = platformAllowanceGuidance(stream.error);
+    // Only the allowance case replaces the retry button; see
+    // providerContractGuidance for why the two are not one function.
+    const errorGuidance = allowanceGuidance ?? providerContractGuidance(stream.error);
     // "Powered by Context Fabric" is the sanctioned relationship framing
     // (CHAOS-3215): Ask Dev is the customer interaction layer, Context
     // Fabric Validation is a separate platform-administrator diagnostic
@@ -686,9 +703,9 @@ export function AskDevConversation({
                                         {stream.error?.safe_message ??
                                             "Ask Dev could not complete that request."}
                                     </p>
-                                    {allowanceGuidance ? (
+                                    {errorGuidance ? (
                                         <p className="mt-2 text-xs leading-5 text-(--text-secondary)">
-                                            {allowanceGuidance}
+                                            {errorGuidance}
                                         </p>
                                     ) : null}
                                     {stream.error?.retryable && !allowanceGuidance ? (

--- a/src/components/ask-dev/AskDevConversation.tsx
+++ b/src/components/ask-dev/AskDevConversation.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 
+import type { DevProgressState } from "@/lib/dev/client";
 import { CTA_LABELS } from "@/lib/design/cta";
 import { decodeFilter, encodeFilterParam } from "@/lib/filters/encode";
 import { formatDateUTC } from "@/lib/formatters";
@@ -35,7 +36,19 @@ function platformAllowanceGuidance(
     return `Retrying before ${resetLabel} will not help. New platform-backed runs resume at that reset.`;
 }
 
-const PROGRESS_LABELS: Record<string, string> = {
+/**
+ * Sanctioned copy for every pinned progress phase, TOTAL over
+ * `DevProgressState`.
+ *
+ * The `?? "Investigating"` fallback below is not a compatibility path: every
+ * stream event is validated against the pinned schema in client.ts
+ * (`assertStreamEvent`) before it reaches this state, so a phase the pin does
+ * not know is rejected at the boundary and never renders. Totality here is
+ * what keeps the fallback genuinely unreachable — while this was
+ * `Record<string, string>`, a re-pin could add a phase that quietly rendered
+ * as the generic label instead of failing anything.
+ */
+export const PROGRESS_LABELS: Record<DevProgressState, string> = {
     resolving_scope: "Resolving the committed scope",
     checking_status: "Checking current status",
     querying_metrics: "Querying registered metrics",

--- a/src/lib/dev/__tests__/contracts.test.ts
+++ b/src/lib/dev/__tests__/contracts.test.ts
@@ -13,7 +13,12 @@ import {
     BYO_LLM_FEATURE,
     devCapabilitiesFromEntitlements,
 } from "../entitlements";
-import { validateAskDevSemanticInvariants, validateAskDevStream } from "../contractValidation";
+import {
+    SCOPE_OUTCOMES_REQUIRING_RESOLVED_SCOPE,
+    SCOPE_OUTCOMES_WITHOUT_RESOLVED_SCOPE,
+    validateAskDevSemanticInvariants,
+    validateAskDevStream,
+} from "../contractValidation";
 
 type ManifestCase = Readonly<{ case: string; path: string; sha256: string }>;
 type ManifestContract = Readonly<{
@@ -69,7 +74,7 @@ describe("Ask Dev generated contract boundary", () => {
         const source = readJson<SourceManifest>("source.json");
         const manifest = readJson<OpsManifest>("manifest.json");
 
-        expect(source.source_commit).toBe("f8f541c35f971b19e26ce8c14f9b52d0801cc8df");
+        expect(source.source_commit).toBe("b469dd35caa46c347b120517bb4c779dc129cf91");
         expect(manifest.schema_version).toBe("ask_dev_contract_manifest.v1");
         expect(manifest.compatibility).toBe("additive-within-v1");
         expect(manifest.contracts.map((contract) => contract.schema_version)).toEqual(
@@ -105,6 +110,122 @@ describe("Ask Dev generated contract boundary", () => {
             .readdirSync(path.join(CONTRACT_ROOT, "examples/negative"))
             .map((name) => `examples/negative/${name}`);
         expect([...checkedNegativePaths].sort()).toEqual(copiedNegativePaths.sort());
+    });
+
+    // The pinned manifest only carries a dangling-evidence negative for
+    // `status_facts`. The ops rule (DevToolResult.validate_evidence_closure)
+    // covers six fact arrays plus three slots hanging off `actual_completion`,
+    // so each of those cells is planted separately rather than inferred from the
+    // one fixture ops happens to ship — a single combined case would die on the
+    // first cell and leave the rest unproven.
+    const DANGLING_CITATION = { evidence_ref_ids: ["ev_not_in_evidence_array"] } as const;
+    const CITING_SLOTS: readonly (readonly [string, Record<string, unknown>])[] = [
+        ["status_facts", { status_facts: [DANGLING_CITATION] }],
+        ["graph_edges", { graph_edges: [DANGLING_CITATION] }],
+        ["pull_requests", { pull_requests: [DANGLING_CITATION] }],
+        ["ci_checks", { ci_checks: [DANGLING_CITATION] }],
+        ["deployments", { deployments: [DANGLING_CITATION] }],
+        ["incidents", { incidents: [DANGLING_CITATION] }],
+        ["actual_completion", { actual_completion: { ...DANGLING_CITATION } }],
+        [
+            "actual_completion.required_children",
+            { actual_completion: { required_children: [DANGLING_CITATION] } },
+        ],
+        ["actual_completion.conflicts", { actual_completion: { conflicts: [DANGLING_CITATION] } }],
+    ];
+
+    it("accepts the unmodified tool-result golden", () => {
+        expect(
+            validateAskDevSemanticInvariants(readJson("examples/positive/dev_tool_result.v1.json")),
+        ).toBe(true);
+    });
+
+    it.each(CITING_SLOTS)("rejects a dangling evidence reference from %s", (_slot, plant) => {
+        const golden = readJson<Record<string, unknown>>(
+            "examples/positive/dev_tool_result.v1.json",
+        );
+        expect(validateAskDevSemanticInvariants({ ...golden, ...plant })).toBe(false);
+    });
+
+    // CHAOS-3298's re-pin admitted `team` to DirectScope/EntityType (ops
+    // CHAOS-3301). Ops ships no team-scope golden in either contract tree, so
+    // the base below is derived from the canonical repository-scope golden
+    // rather than emitted by a fixture producer. It was checked against the
+    // real producer before being written down: ops' own DevScope model
+    // accepts this exact object, and its `validate_direct_scope` rejects
+    // every mutation listed below.
+    const TEAM_ENTITY_REF = {
+        display_label: "Platform team",
+        entity_id: "team_platform",
+        entity_type: "team",
+        repository_id: null,
+    } as const;
+    function teamScopeGolden(): Record<string, unknown> {
+        return {
+            ...readJson<Record<string, unknown>>("examples/positive/dev_scope.v1.json"),
+            direct_scope: "team",
+            entity_refs: [TEAM_ENTITY_REF],
+            // A team direct scope carries no repository list of its own and
+            // asserts no page surface context — both are ops invariants, not
+            // conveniences of this fixture.
+            repositories: [],
+            team_ids: ["team_platform"],
+            surface_context: null,
+        };
+    }
+    const REJECTED_TEAM_SCOPES: readonly (readonly [string, Record<string, unknown>])[] = [
+        ["team_ids empty", { team_ids: [] }],
+        ["team_ids names another team", { team_ids: ["team_other"] }],
+        ["team_ids carries an extra team", { team_ids: ["team_platform", "team_other"] }],
+        ["repositories non-empty", { repositories: ["repo_dev_health"] }],
+        [
+            "entity_type is not team",
+            { entity_refs: [{ ...TEAM_ENTITY_REF, entity_type: "project" }] },
+        ],
+        ["two entity_refs", { entity_refs: [TEAM_ENTITY_REF, TEAM_ENTITY_REF] }],
+        [
+            "surface context asserts a team entity",
+            {
+                surface_context: {
+                    entity_refs: [TEAM_ENTITY_REF],
+                    filter_fingerprint: "filters_01",
+                    route_id: "diagnose_overview",
+                },
+            },
+        ],
+    ];
+
+    it("accepts a well-formed team direct scope", () => {
+        expect(validateAskDevSemanticInvariants(teamScopeGolden())).toBe(true);
+    });
+
+    it.each(REJECTED_TEAM_SCOPES)("rejects a team direct scope whose %s", (_case, mutation) => {
+        expect(validateAskDevSemanticInvariants({ ...teamScopeGolden(), ...mutation })).toBe(false);
+    });
+
+    // The resolved/unresolved split is a hand-kept subset of a pinned enum,
+    // and it fails OPEN: an outcome that ops treats as resolved but that is
+    // missing from both sets here would let web accept a resolution ops
+    // rejects. Read the enum out of the schema rather than restating it, so a
+    // re-pin that adds a member lands in neither set and fails this.
+    it("partitions every pinned ScopeResolutionOutcome into resolved or unresolved", () => {
+        const schema = readJson<Record<string, Record<string, { enum?: string[] }>>>(
+            "schemas/dev_scope_resolution.v1.schema.json",
+        );
+        const pinned = schema.$defs?.ScopeResolutionOutcome?.enum;
+        // A silently-absent enum would make every assertion below vacuous.
+        expect(Array.isArray(pinned) && pinned.length > 0).toBe(true);
+
+        const overlap = [...SCOPE_OUTCOMES_REQUIRING_RESOLVED_SCOPE].filter((value) =>
+            SCOPE_OUTCOMES_WITHOUT_RESOLVED_SCOPE.has(value),
+        );
+        expect(overlap, "an outcome cannot be both resolved and unresolved").toEqual([]);
+
+        const partition = [
+            ...SCOPE_OUTCOMES_REQUIRING_RESOLVED_SCOPE,
+            ...SCOPE_OUTCOMES_WITHOUT_RESOLVED_SCOPE,
+        ].sort();
+        expect(partition).toEqual([...pinned!].sort());
     });
 
     it("validates every manifest stream sequence and exactly one terminal", () => {

--- a/src/lib/dev/client.ts
+++ b/src/lib/dev/client.ts
@@ -66,10 +66,19 @@ export type DevFeedbackInput = Readonly<{
     comment?: string | null;
 }>;
 
+/**
+ * The pinned `dev_stream_event.v1` progress phase. Held as the generated
+ * union rather than `string` so a re-pin that adds a phase puts compile-time
+ * pressure on everything that maps one to display copy. `assertStreamEvent`
+ * already rejects any phase outside the pinned enum, so widening this to
+ * `string` bought no real tolerance — it only hid that pressure.
+ */
+export type DevProgressState = NonNullable<DevStreamEvent["progress"]>;
+
 export type DevConversationStreamState = Readonly<{
     phase: "idle" | "running" | "completed" | "failed";
     runId: string | null;
-    progress: string | null;
+    progress: DevProgressState | null;
     delta: string;
     answer: DevAnswer | null;
     error: DevWebError | null;

--- a/src/lib/dev/contractValidation.ts
+++ b/src/lib/dev/contractValidation.ts
@@ -86,6 +86,7 @@ function validateScope(scope: JsonRecord): boolean {
         work_unit: "work_unit",
         issue: "issue",
         pull_request: "pull_request",
+        team: "team",
     };
     if (
         typeof directScope === "string" &&
@@ -93,6 +94,17 @@ function validateScope(scope: JsonRecord): boolean {
         (entityRefs.length !== 1 || entityRefs[0]?.entity_type !== expectedEntityType[directScope])
     ) {
         return false;
+    }
+    if (directScope === "team") {
+        // CHAOS-3301: a team *subject* and the pre-existing team_ids *filter*
+        // stay structurally separate. team_ids must name exactly the one
+        // committed team, and a team scope carries no repository list of its
+        // own — team-to-repository attribution is re-derived server-side, so
+        // a foreign `repositories` list here would otherwise be consumed by
+        // the status source seam rather than rejected.
+        const teamIdList = teamIds as unknown[];
+        if (teamIdList.length !== 1 || teamIdList[0] !== entityRefs[0]?.entity_id) return false;
+        if ((repositories as unknown[]).length > 0) return false;
     }
     if (!validateSurfaceContext(scope, entityRefs)) return false;
 
@@ -107,11 +119,32 @@ function validateScope(scope: JsonRecord): boolean {
     return true;
 }
 
+/**
+ * Outcomes that ops requires a `resolved_scope` for, mirroring
+ * `DevScopeResolution.validate_outcome`. This one is exported because it
+ * fails OPEN on drift: a new "resolved" outcome missing from this set makes
+ * web accept a resolution ops would reject, silently. The pinned enum's
+ * remaining members are the unresolved side of the partition, and
+ * `contracts.test.ts` holds the two against the schema.
+ */
+export const SCOPE_OUTCOMES_REQUIRING_RESOLVED_SCOPE: ReadonlySet<string> = new Set([
+    "exact",
+    "filtered",
+    "inherited",
+    "organization_fallback",
+]);
+
+export const SCOPE_OUTCOMES_WITHOUT_RESOLVED_SCOPE: ReadonlySet<string> = new Set([
+    "ambiguous",
+    "unresolved",
+    "forbidden_or_not_found",
+]);
+
 function validateScopeResolution(resolution: JsonRecord): boolean {
     const outcome = resolution.outcome;
     const candidates = asRecords(resolution.candidates);
     const resolvedScope = resolution.resolved_scope;
-    const resolvedOutcomes = new Set(["exact", "filtered", "inherited", "organization_fallback"]);
+    const resolvedOutcomes = SCOPE_OUTCOMES_REQUIRING_RESOLVED_SCOPE;
     if (typeof outcome === "string" && resolvedOutcomes.has(outcome) && !isRecord(resolvedScope)) {
         return false;
     }
@@ -174,6 +207,29 @@ function validateAnswer(answer: JsonRecord): boolean {
         );
     }
     return true;
+}
+
+function validateToolResult(result: JsonRecord): boolean {
+    if (result.status === "error" ? !isRecord(result.error) : result.error != null) return false;
+
+    const knownEvidence = new Set(asRecords(result.evidence).map((item) => item.evidence_ref_id));
+    const citing = [
+        ...asRecords(result.status_facts),
+        ...asRecords(result.graph_edges),
+        ...asRecords(result.pull_requests),
+        ...asRecords(result.ci_checks),
+        ...asRecords(result.deployments),
+        ...asRecords(result.incidents),
+    ];
+    const completion = result.actual_completion;
+    if (isRecord(completion)) {
+        citing.push(
+            completion,
+            ...asRecords(completion.required_children),
+            ...asRecords(completion.conflicts),
+        );
+    }
+    return citing.every((fact) => referencesOnlyKnown(fact.evidence_ref_ids ?? [], knownEvidence));
 }
 
 function validateStreamEvent(event: JsonRecord): boolean {
@@ -269,7 +325,7 @@ function validateOneSemanticObject(value: JsonRecord): boolean {
                     ).byteLength
             );
         case "dev_tool_result.v1":
-            return value.status === "error" ? isRecord(value.error) : value.error == null;
+            return validateToolResult(value);
         case "dev_stream_event.v1":
             return validateStreamEvent(value);
         case "dev_transcript_entry.v1":

--- a/src/lib/dev/contracts/examples/negative/dev_answer.v1.invalid_complete_state.json
+++ b/src/lib/dev/contracts/examples/negative/dev_answer.v1.invalid_complete_state.json
@@ -268,7 +268,7 @@
     "metric_definition_version": "ask_dev_metrics.v1",
     "prompt_version": "ask_dev_prompt.v1",
     "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v1"
+    "tool_contract_version": "ask_dev_tools.v2"
   },
   "warnings": []
 }

--- a/src/lib/dev/contracts/examples/negative/dev_answer.v1.oversized_evidence.json
+++ b/src/lib/dev/contracts/examples/negative/dev_answer.v1.oversized_evidence.json
@@ -1091,7 +1091,7 @@
     "metric_definition_version": "ask_dev_metrics.v1",
     "prompt_version": "ask_dev_prompt.v1",
     "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v1"
+    "tool_contract_version": "ask_dev_tools.v2"
   },
   "warnings": []
 }

--- a/src/lib/dev/contracts/examples/negative/dev_answer.v1.unknown_evidence_id.json
+++ b/src/lib/dev/contracts/examples/negative/dev_answer.v1.unknown_evidence_id.json
@@ -266,7 +266,7 @@
     "metric_definition_version": "ask_dev_metrics.v1",
     "prompt_version": "ask_dev_prompt.v1",
     "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v1"
+    "tool_contract_version": "ask_dev_tools.v2"
   },
   "warnings": []
 }

--- a/src/lib/dev/contracts/examples/negative/dev_answer.v1.unknown_metric_id.json
+++ b/src/lib/dev/contracts/examples/negative/dev_answer.v1.unknown_metric_id.json
@@ -266,7 +266,7 @@
     "metric_definition_version": "ask_dev_metrics.v1",
     "prompt_version": "ask_dev_prompt.v1",
     "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v1"
+    "tool_contract_version": "ask_dev_tools.v2"
   },
   "warnings": []
 }

--- a/src/lib/dev/contracts/examples/negative/dev_conversation_transcript.v1.answer_from_another_conversation.json
+++ b/src/lib/dev/contracts/examples/negative/dev_conversation_transcript.v1.answer_from_another_conversation.json
@@ -315,7 +315,7 @@
           "metric_definition_version": "ask_dev_metrics.v1",
           "prompt_version": "ask_dev_prompt.v1",
           "query_version": "ask_dev_queries.v1",
-          "tool_contract_version": "ask_dev_tools.v1"
+          "tool_contract_version": "ask_dev_tools.v2"
         },
         "warnings": []
       },

--- a/src/lib/dev/contracts/examples/negative/dev_conversation_transcript.v1.assistant_contains_user_question.json
+++ b/src/lib/dev/contracts/examples/negative/dev_conversation_transcript.v1.assistant_contains_user_question.json
@@ -315,7 +315,7 @@
           "metric_definition_version": "ask_dev_metrics.v1",
           "prompt_version": "ask_dev_prompt.v1",
           "query_version": "ask_dev_queries.v1",
-          "tool_contract_version": "ask_dev_tools.v1"
+          "tool_contract_version": "ask_dev_tools.v2"
         },
         "warnings": []
       },

--- a/src/lib/dev/contracts/examples/negative/dev_tool_result.v1.oversized_result.json
+++ b/src/lib/dev/contracts/examples/negative/dev_tool_result.v1.oversized_result.json
@@ -1,5 +1,8 @@
 {
+  "actual_completion": null,
+  "ci_checks": [],
   "data_health": [],
+  "deployments": [],
   "error": null,
   "evidence": [
     {
@@ -37,6 +40,7 @@
     }
   ],
   "graph_edges": [],
+  "incidents": [],
   "metric_definitions": [
     {
       "definition_version": "items_completed.v1",
@@ -128,6 +132,7 @@
       "value": 12
     }
   ],
+  "pull_requests": [],
   "run_id": "run_01",
   "schema_version": "dev_tool_result.v1",
   "scope_resolution": {
@@ -211,6 +216,7 @@
     "warnings": []
   },
   "serialized_bytes": 65537,
+  "source_health": [],
   "status": "success",
   "status_facts": [],
   "tool_call_id": "tool_call_01",

--- a/src/lib/dev/contracts/examples/negative/dev_tool_result.v1.status_fact_evidence_not_in_array.json
+++ b/src/lib/dev/contracts/examples/negative/dev_tool_result.v1.status_fact_evidence_not_in_array.json
@@ -1,72 +1,9 @@
 {
-  "answer_id": "answer_01",
-  "as_of": "2026-07-28T12:00:00Z",
-  "claims": [
-    {
-      "claim_id": "claim_01",
-      "confidence": 1.0,
-      "evidence_ref_ids": [
-        "ev_01"
-      ],
-      "flags": {
-        "conflicting": false,
-        "stale": false,
-        "uncertain": false,
-        "untrusted_source": false
-      },
-      "kind": "observed",
-      "metric_ref_ids": [
-        "metric_01"
-      ],
-      "recommendation_rule_version": null,
-      "schema_version": "dev_claim.v1",
-      "text": "Twelve work items completed in the selected period.",
-      "validity_scope": {
-        "comparison_range": {
-          "end": "2026-06-28T00:00:00Z",
-          "start": "2026-05-29T00:00:00Z",
-          "timezone": "America/Los_Angeles"
-        },
-        "direct_scope": "repository",
-        "entity_refs": [],
-        "organization_id": "org_fullchaos",
-        "repositories": [
-          "repo_dev_health"
-        ],
-        "schema_version": "dev_scope.v1",
-        "surface_context": {
-          "entity_refs": [
-            {
-              "display_label": "Selected repository",
-              "entity_id": "repo_dev_health",
-              "entity_type": "repository",
-              "repository_id": null
-            }
-          ],
-          "filter_fingerprint": "filters_01",
-          "route_id": "diagnose_overview"
-        },
-        "team_ids": [
-          "team_platform"
-        ],
-        "time_range": {
-          "end": "2026-07-28T00:00:00Z",
-          "start": "2026-06-28T00:00:00Z",
-          "timezone": "America/Los_Angeles"
-        }
-      }
-    }
-  ],
-  "conflicts": [],
-  "conversation_id": "conversation_01",
-  "coverage": {
-    "as_of": "2026-07-28T12:00:00Z",
-    "available_source_count": 1,
-    "required_source_count": 1,
-    "stale_required_sources": [],
-    "unavailable_required_sources": []
-  },
-  "direct_summary": "Twelve work items completed in the selected period.",
+  "actual_completion": null,
+  "ci_checks": [],
+  "data_health": [],
+  "deployments": [],
+  "error": null,
   "evidence": [
     {
       "citation_text": "The contract implementation remains in progress.",
@@ -102,7 +39,30 @@
       ]
     }
   ],
-  "generated_at": "2026-07-28T12:00:00Z",
+  "graph_edges": [],
+  "incidents": [],
+  "metric_definitions": [
+    {
+      "definition_version": "items_completed.v1",
+      "description": "Completed work items in the selected window.",
+      "freshness_policy": "work_item_metrics_daily.daily.v1",
+      "label": "Items completed",
+      "metric_id": "items_completed",
+      "supported_dimensions": [
+        "repository"
+      ],
+      "supported_scopes": [
+        "organization",
+        "project",
+        "work_unit"
+      ],
+      "supported_time_grains": [
+        "window",
+        "day"
+      ],
+      "unit": "items"
+    }
+  ],
   "metrics": [
     {
       "aggregation": "count",
@@ -172,12 +132,10 @@
       "value": 12
     }
   ],
-  "model": {
-    "model_fingerprint": "model_certified_01",
-    "provider_family": "openai_compatible",
-    "provider_source": "platform"
-  },
-  "resolved_scope": {
+  "pull_requests": [],
+  "run_id": "run_01",
+  "schema_version": "dev_tool_result.v1",
+  "scope_resolution": {
     "authorized_entity_ids": [],
     "authorized_repository_ids": [
       "repo_dev_health"
@@ -229,7 +187,9 @@
       "direct_scope": "repository",
       "entity_refs": [],
       "organization_id": "org_fullchaos",
-      "repositories": [],
+      "repositories": [
+        "repo_dev_health"
+      ],
       "schema_version": "dev_scope.v1",
       "surface_context": {
         "entity_refs": [
@@ -255,16 +215,19 @@
     "schema_version": "dev_scope_resolution.v1",
     "warnings": []
   },
-  "schema_version": "dev_answer.v1",
-  "status": "complete",
-  "suggested_follow_up_questions": [
-    "What changed from the previous period?"
+  "serialized_bytes": 4096,
+  "source_health": [],
+  "status": "success",
+  "status_facts": [
+    {
+      "evidence_ref_ids": [
+        "ev_not_in_evidence_array"
+      ],
+      "fact_id": "issue:item_02",
+      "text": "Child issue: open"
+    }
   ],
-  "versions": {
-    "metric_definition_version": "ask_dev_metrics.v1",
-    "prompt_version": "ask_dev_prompt.v1",
-    "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v2"
-  },
+  "tool_call_id": "tool_call_01",
+  "tool_id": "query_metric.v1",
   "warnings": []
 }

--- a/src/lib/dev/contracts/examples/positive/dev_answer.v1.json
+++ b/src/lib/dev/contracts/examples/positive/dev_answer.v1.json
@@ -266,7 +266,7 @@
     "metric_definition_version": "ask_dev_metrics.v1",
     "prompt_version": "ask_dev_prompt.v1",
     "query_version": "ask_dev_queries.v1",
-    "tool_contract_version": "ask_dev_tools.v1"
+    "tool_contract_version": "ask_dev_tools.v2"
   },
   "warnings": []
 }

--- a/src/lib/dev/contracts/examples/positive/dev_conversation_transcript.v1.json
+++ b/src/lib/dev/contracts/examples/positive/dev_conversation_transcript.v1.json
@@ -315,7 +315,7 @@
           "metric_definition_version": "ask_dev_metrics.v1",
           "prompt_version": "ask_dev_prompt.v1",
           "query_version": "ask_dev_queries.v1",
-          "tool_contract_version": "ask_dev_tools.v1"
+          "tool_contract_version": "ask_dev_tools.v2"
         },
         "warnings": []
       },

--- a/src/lib/dev/contracts/examples/positive/dev_tool_result.v1.json
+++ b/src/lib/dev/contracts/examples/positive/dev_tool_result.v1.json
@@ -1,5 +1,8 @@
 {
+  "actual_completion": null,
+  "ci_checks": [],
   "data_health": [],
+  "deployments": [],
   "error": null,
   "evidence": [
     {
@@ -37,6 +40,7 @@
     }
   ],
   "graph_edges": [],
+  "incidents": [],
   "metric_definitions": [
     {
       "definition_version": "items_completed.v1",
@@ -128,6 +132,7 @@
       "value": 12
     }
   ],
+  "pull_requests": [],
   "run_id": "run_01",
   "schema_version": "dev_tool_result.v1",
   "scope_resolution": {
@@ -211,6 +216,7 @@
     "warnings": []
   },
   "serialized_bytes": 4096,
+  "source_health": [],
   "status": "success",
   "status_facts": [],
   "tool_call_id": "tool_call_01",

--- a/src/lib/dev/contracts/manifest.json
+++ b/src/lib/dev/contracts/manifest.json
@@ -33,7 +33,7 @@
       },
       "schema": {
         "path": "schemas/dev_conversation.v1.schema.json",
-        "sha256": "763452f78629179c07604927650d39e3e3c82247823b1854e352f61fbafa8872"
+        "sha256": "8cc7267de6d08f5a63d1ecef1b4a0b45856a925637ba780f6433856fa7d27bbb"
       },
       "schema_version": "dev_conversation.v1"
     },
@@ -51,7 +51,7 @@
       },
       "schema": {
         "path": "schemas/dev_conversation_summary.v1.schema.json",
-        "sha256": "3c9983bdc802a85fa4b5f766fd3e6de109142bba97fb6e207b45173f07a06d7f"
+        "sha256": "53f0fac1fef5801a794ed160b1904fc107c3647d60e52c7462ddeccdb8c6f167"
       },
       "schema_version": "dev_conversation_summary.v1"
     },
@@ -60,21 +60,21 @@
         {
           "case": "assistant_contains_user_question",
           "path": "examples/negative/dev_conversation_transcript.v1.assistant_contains_user_question.json",
-          "sha256": "ce14c52a308aa86a2cc9bec8aed7350b86952e443de8de34bcbb8f1f12d29684"
+          "sha256": "d9b3310c03cec9e22176952cae7254b8b90d795912ea501f14c84e01de99cd63"
         },
         {
           "case": "answer_from_another_conversation",
           "path": "examples/negative/dev_conversation_transcript.v1.answer_from_another_conversation.json",
-          "sha256": "b4a879ae52086bae0af69bdca0eae3d04fdf682d4df1112b52217e8ea84696a7"
+          "sha256": "ed0ce846ce393c1dbac33315faef6b85d0b9bfa24cbd7bcf5f2623bcc2e708e3"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_conversation_transcript.v1.json",
-        "sha256": "73b9a33b083b34fd450cd200e44a611d70816baafc9f7b2710f3767a11b6b877"
+        "sha256": "7aa148b2e030d83df425a53144b2a72c1ce12f6a2fd4bf8ffe798a09239db72d"
       },
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
-        "sha256": "1f8bb8b787ebacfb6373053cab676c2e3f15c5c20b59971b178d2895c545e21f"
+        "sha256": "635befb43b9080a935d49df136f51508a5b5e1b152809cba67d42de27bc2b60a"
       },
       "schema_version": "dev_conversation_transcript.v1"
     },
@@ -107,7 +107,7 @@
       },
       "schema": {
         "path": "schemas/dev_message_request.v1.schema.json",
-        "sha256": "ef00198a78046e649a750a465e230df7e5b02c27ed8d6ad5dae6f2268a6fc897"
+        "sha256": "258a495a3ac72ec52164b37164d71b4f01b60d8f1008b046965cd2f002c7b2bc"
       },
       "schema_version": "dev_message_request.v1"
     },
@@ -116,12 +116,12 @@
         {
           "case": "unknown_evidence_id",
           "path": "examples/negative/dev_answer.v1.unknown_evidence_id.json",
-          "sha256": "3546f034242e02c9a5d9afd19b81426cfacf2a2d9d48d420a13b2d90cca36bec"
+          "sha256": "0c77e93e77d2029f0403e26c5a571191712fe032c584bffebb274613369c2247"
         },
         {
           "case": "unknown_metric_id",
           "path": "examples/negative/dev_answer.v1.unknown_metric_id.json",
-          "sha256": "77450a616cd71501238f3b2944b3276441d8916461fc80bec312d9630ca1a354"
+          "sha256": "5edba7a3cb9853d81b12672acdd7c2465d4cde3ecc95f5c12ce37ca2edcd55d7"
         },
         {
           "case": "missing_required_metadata",
@@ -131,26 +131,26 @@
         {
           "case": "invalid_scope",
           "path": "examples/negative/dev_answer.v1.invalid_scope.json",
-          "sha256": "ff06c0937444d79e83c32460c52569e0e8804cd774f1cfa7557877d7eec72ecb"
+          "sha256": "d61351bdacd0355b1a9f2e5b0e9dff4042da171e6b1e49ebd5fd2da0f1c3faae"
         },
         {
           "case": "oversized_evidence",
           "path": "examples/negative/dev_answer.v1.oversized_evidence.json",
-          "sha256": "08a7fadfe436b9f7645503d1df3acf3706d9bd4d70cb8486594bf576faca64ca"
+          "sha256": "9ff9a4caedd30b7dc15c345a9641da4a70e5a1c84e3bac1576772985a7bdce6d"
         },
         {
           "case": "invalid_complete_state",
           "path": "examples/negative/dev_answer.v1.invalid_complete_state.json",
-          "sha256": "5dd35c270b26c18ee75e28bbdc46e4e5a9417e6aa92dc64461032883b98b5153"
+          "sha256": "304e8da54dbdb878bbbe44101e89fca1c8f8c44a84cf61c5e51e8dda3f25d359"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_answer.v1.json",
-        "sha256": "1ee3230951ae3590fd921c18042b40a98be45452ecacd9d5d6caa90f32927e55"
+        "sha256": "fba7cafc8b232b43e56c8385b2b58439e5a4b0b67cb3eb1da0ffc32f19733c21"
       },
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
-        "sha256": "eb16f4820efce0d76fc9d9dbaff84719b91b41fe2f3d5016c324bcdb8141269d"
+        "sha256": "5178e487e3d2b8cbcde7ffea08ea0d3121937db7357c861c3738b2c9120e9039"
       },
       "schema_version": "dev_answer.v1"
     },
@@ -168,7 +168,7 @@
       },
       "schema": {
         "path": "schemas/dev_claim.v1.schema.json",
-        "sha256": "f47efaec1dfde2d409b1053bfd04b29a5e8f5f112e7895501115ead41862b0fb"
+        "sha256": "4a8505fb87ccae4c4e63c17403410a18f543e54f1e46a79c0b8144d7b60b5481"
       },
       "schema_version": "dev_claim.v1"
     },
@@ -186,7 +186,7 @@
       },
       "schema": {
         "path": "schemas/dev_metric_ref.v1.schema.json",
-        "sha256": "bac5613b1a2bf598138469db99fbb65a20f60d466e9b1228728b14cfd34aa2cf"
+        "sha256": "8038eef2144551ffd165681dd96a9541d0ae74925708250691f5674acbedde32"
       },
       "schema_version": "dev_metric_ref.v1"
     },
@@ -240,7 +240,7 @@
       },
       "schema": {
         "path": "schemas/dev_scope.v1.schema.json",
-        "sha256": "97d5d98bbe7a8e4790ccf0bd67d5c0296f5f2d81cdcaa3235042b493bbb7bcdd"
+        "sha256": "d968b133e6ebf1fde7851c9a3c7c650dddf6edc5bb3a4dca311c6302add5e1a8"
       },
       "schema_version": "dev_scope.v1"
     },
@@ -258,7 +258,7 @@
       },
       "schema": {
         "path": "schemas/dev_scope_resolution.v1.schema.json",
-        "sha256": "707fe458b01f5dbe407833a7145497918e0052f66d01236bfec62bf8dd609c94"
+        "sha256": "6f0f9de88d78beb53b5d6e42b9e161cadaf947a2939a3215a810069600227b81"
       },
       "schema_version": "dev_scope_resolution.v1"
     },
@@ -276,7 +276,7 @@
       },
       "schema": {
         "path": "schemas/dev_tool_request.v1.schema.json",
-        "sha256": "e28410490c2b34bbf729d537e0d022c4cdc8a2dcf53013381c6105832bdb4582"
+        "sha256": "eed1f7ad4d5dac6f12680329eded654e7808fa78280e11280f4e3cf541a0bfe1"
       },
       "schema_version": "dev_tool_request.v1"
     },
@@ -285,16 +285,21 @@
         {
           "case": "oversized_result",
           "path": "examples/negative/dev_tool_result.v1.oversized_result.json",
-          "sha256": "94e8ce815d630657daceb37bb3f7ab8647c350d234429cd0ac699702604e2602"
+          "sha256": "a40d6bbd0794c3ba8b2c6fbcd62fc158a4eb65c66e60a16b3d1a75d0416be3a4"
+        },
+        {
+          "case": "status_fact_evidence_not_in_array",
+          "path": "examples/negative/dev_tool_result.v1.status_fact_evidence_not_in_array.json",
+          "sha256": "26afbb73e6e8865f5884ba5af09a86effd6b5b5b63bf9ad4390b4ea8261a72ce"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_tool_result.v1.json",
-        "sha256": "5998122f3d515432423cba1e67e5785983e11f743fa18e0a9bbbd9358ef21549"
+        "sha256": "31a956f4659f29f190346a7b873a219ffc85ccd2dfb9d7032937a4eb9c9ed653"
       },
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "4a50d7e3853ddb25c6eb0b2141d6156000547aed28244f9659e4ee18b4a9b13e"
+        "sha256": "984a7b92cc1476b929f895c009c4c7c061d7ad594427777329b7271a9b8a4f1f"
       },
       "schema_version": "dev_tool_result.v1"
     },
@@ -330,7 +335,7 @@
       },
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
-        "sha256": "1cd0ad8794e65be66b741fe0b5cc4d3d347785f23a1c8c6cfaf127c51dfcf37e"
+        "sha256": "eeb3461c25d455140d30e7a779e1480ddd2773fdec29f67b8d053ae4b2cdcc6f"
       },
       "schema_version": "dev_stream_event.v1"
     },
@@ -348,7 +353,7 @@
       },
       "schema": {
         "path": "schemas/dev_error.v1.schema.json",
-        "sha256": "e68386046905c634c118564dd3d74447fc55387c57d84a6a79ce903f0a4c3907"
+        "sha256": "eb78a38684caab42ef2c88c6a33f558330855b86b9b847024560dfeb68581514"
       },
       "schema_version": "dev_error.v1"
     }

--- a/src/lib/dev/contracts/schemas/dev_answer.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_answer.v1.schema.json
@@ -1020,7 +1020,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -1031,7 +1032,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_claim.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_claim.v1.schema.json
@@ -252,7 +252,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -263,7 +264,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_conversation.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_conversation.v1.schema.json
@@ -216,7 +216,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -227,7 +228,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_conversation_summary.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_conversation_summary.v1.schema.json
@@ -7,7 +7,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_conversation_transcript.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_conversation_transcript.v1.schema.json
@@ -1211,6 +1211,8 @@
           "enum": [
             "accepted",
             "resolving_scope",
+            "interpreting",
+            "resolving_subjects",
             "model_decision",
             "tool_validation",
             "tool_execution",
@@ -1259,7 +1261,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -1270,7 +1273,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_error.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_error.v1.schema.json
@@ -27,6 +27,7 @@
         "insufficient_evidence",
         "answer_validation_failed",
         "cancelled",
+        "provider_contract_violation",
         "internal_error"
       ],
       "title": "Code",

--- a/src/lib/dev/contracts/schemas/dev_message_request.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_message_request.v1.schema.json
@@ -216,7 +216,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -227,7 +228,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_metric_ref.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_metric_ref.v1.schema.json
@@ -236,7 +236,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -247,7 +248,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_scope.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_scope.v1.schema.json
@@ -133,7 +133,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -144,7 +145,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_scope_resolution.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_scope_resolution.v1.schema.json
@@ -251,7 +251,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -262,7 +263,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_stream_event.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_stream_event.v1.schema.json
@@ -532,6 +532,7 @@
             "insufficient_evidence",
             "answer_validation_failed",
             "cancelled",
+            "provider_contract_violation",
             "internal_error"
           ],
           "title": "Code",
@@ -1230,7 +1231,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -1241,7 +1243,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_tool_request.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_tool_request.v1.schema.json
@@ -216,7 +216,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -227,7 +228,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"

--- a/src/lib/dev/contracts/schemas/dev_tool_result.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_tool_result.v1.schema.json
@@ -19,6 +19,185 @@
       "title": "AskDevSurfaceRouteID",
       "type": "string"
     },
+    "DevActualCompletion": {
+      "additionalProperties": false,
+      "description": "Server-computed ``actual-completion`` rule result; the LLM explains, never derives, it.",
+      "properties": {
+        "conflicts": {
+          "items": {
+            "$ref": "#/$defs/DevStatusConflict"
+          },
+          "maxItems": 20,
+          "title": "Conflicts",
+          "type": "array"
+        },
+        "display_truncated": {
+          "default": false,
+          "title": "Display Truncated",
+          "type": "boolean"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "reason_codes": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Reason Codes",
+          "type": "array"
+        },
+        "required_child_complete": {
+          "anyOf": [
+            {
+              "maximum": 100000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Required Child Complete"
+        },
+        "required_child_total": {
+          "anyOf": [
+            {
+              "maximum": 100000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Required Child Total"
+        },
+        "required_children": {
+          "items": {
+            "$ref": "#/$defs/DevRequiredChildFact"
+          },
+          "maxItems": 100,
+          "title": "Required Children",
+          "type": "array"
+        },
+        "rule_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Rule Id",
+          "type": "string"
+        },
+        "rule_version": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Rule Version",
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "ready",
+            "not_ready",
+            "indeterminate"
+          ],
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "required": [
+        "state",
+        "rule_id",
+        "rule_version"
+      ],
+      "title": "DevActualCompletion",
+      "type": "object"
+    },
+    "DevCIFact": {
+      "additionalProperties": false,
+      "properties": {
+        "conclusion": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Conclusion",
+          "type": "string"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "required": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Required"
+        },
+        "skipped_required_work": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Skipped Required Work"
+        }
+      },
+      "required": [
+        "entity_id",
+        "display_label",
+        "conclusion",
+        "observed_at"
+      ],
+      "title": "DevCIFact",
+      "type": "object"
+    },
     "DevCitationLink": {
       "additionalProperties": false,
       "properties": {
@@ -108,6 +287,75 @@
         "coverage"
       ],
       "title": "DevDataHealth",
+      "type": "object"
+    },
+    "DevDeploymentFact": {
+      "additionalProperties": false,
+      "properties": {
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "environment": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Environment"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "required": {
+          "title": "Required",
+          "type": "boolean"
+        },
+        "status": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_id",
+        "display_label",
+        "status",
+        "required",
+        "observed_at"
+      ],
+      "title": "DevDeploymentFact",
       "type": "object"
     },
     "DevDisambiguationCandidate": {
@@ -215,6 +463,7 @@
             "insufficient_evidence",
             "answer_validation_failed",
             "cancelled",
+            "provider_contract_violation",
             "internal_error"
           ],
           "title": "Code",
@@ -457,6 +706,12 @@
     "DevGraphEdge": {
       "additionalProperties": false,
       "properties": {
+        "confidence": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Confidence",
+          "type": "number"
+        },
         "evidence_ref_ids": {
           "items": {
             "maxLength": 128,
@@ -467,6 +722,17 @@
           "maxItems": 25,
           "title": "Evidence Ref Ids",
           "type": "array"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "provenance": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Provenance",
+          "type": "string"
         },
         "relationship": {
           "maxLength": 128,
@@ -493,9 +759,71 @@
       "required": [
         "source_entity_id",
         "relationship",
-        "target_entity_id"
+        "target_entity_id",
+        "provenance",
+        "confidence",
+        "observed_at"
       ],
       "title": "DevGraphEdge",
+      "type": "object"
+    },
+    "DevIncidentFact": {
+      "additionalProperties": false,
+      "properties": {
+        "active": {
+          "title": "Active",
+          "type": "boolean"
+        },
+        "blocking": {
+          "title": "Blocking",
+          "type": "boolean"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "status": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_id",
+        "display_label",
+        "status",
+        "active",
+        "blocking",
+        "observed_at"
+      ],
+      "title": "DevIncidentFact",
       "type": "object"
     },
     "DevMetricDefinition": {
@@ -760,6 +1088,130 @@
       "title": "DevMetricRef",
       "type": "object"
     },
+    "DevPullRequestFact": {
+      "additionalProperties": false,
+      "properties": {
+        "changes_requested": {
+          "maximum": 1000,
+          "minimum": 0,
+          "title": "Changes Requested",
+          "type": "integer"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "merged": {
+          "title": "Merged",
+          "type": "boolean"
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "required": {
+          "title": "Required",
+          "type": "boolean"
+        },
+        "review_state": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Review State"
+        },
+        "state": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "State",
+          "type": "string"
+        }
+      },
+      "required": [
+        "entity_id",
+        "display_label",
+        "state",
+        "changes_requested",
+        "merged",
+        "required",
+        "observed_at"
+      ],
+      "title": "DevPullRequestFact",
+      "type": "object"
+    },
+    "DevRequiredChildFact": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "fact_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Fact Id",
+          "type": "string"
+        },
+        "status": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Status",
+          "type": "string"
+        },
+        "text": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fact_id",
+        "text",
+        "status"
+      ],
+      "title": "DevRequiredChildFact",
+      "type": "object"
+    },
     "DevScope": {
       "additionalProperties": false,
       "properties": {
@@ -933,6 +1385,92 @@
       "title": "DevScopeResolution",
       "type": "object"
     },
+    "DevSourceHealth": {
+      "additionalProperties": false,
+      "properties": {
+        "freshness": {
+          "$ref": "#/$defs/FreshnessState"
+        },
+        "ref_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Ref Id",
+          "type": "string"
+        },
+        "source_system": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Source System",
+          "type": "string"
+        },
+        "watermark": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Watermark"
+        }
+      },
+      "required": [
+        "ref_id",
+        "source_system",
+        "freshness"
+      ],
+      "title": "DevSourceHealth",
+      "type": "object"
+    },
+    "DevStatusConflict": {
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Code",
+          "type": "string"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "message": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Message",
+          "type": "string"
+        },
+        "severity": {
+          "enum": [
+            "warning",
+            "blocking"
+          ],
+          "title": "Severity",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message",
+        "severity"
+      ],
+      "title": "DevStatusConflict",
+      "type": "object"
+    },
     "DevStatusFact": {
       "additionalProperties": false,
       "properties": {
@@ -1041,7 +1579,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "DirectScope",
       "type": "string"
@@ -1052,7 +1591,8 @@
         "project",
         "work_unit",
         "issue",
-        "pull_request"
+        "pull_request",
+        "team"
       ],
       "title": "EntityType",
       "type": "string"
@@ -1114,12 +1654,39 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
+    "actual_completion": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DevActualCompletion"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "ci_checks": {
+      "items": {
+        "$ref": "#/$defs/DevCIFact"
+      },
+      "maxItems": 100,
+      "title": "Ci Checks",
+      "type": "array"
+    },
     "data_health": {
       "items": {
         "$ref": "#/$defs/DevDataHealth"
       },
       "maxItems": 25,
       "title": "Data Health",
+      "type": "array"
+    },
+    "deployments": {
+      "items": {
+        "$ref": "#/$defs/DevDeploymentFact"
+      },
+      "maxItems": 100,
+      "title": "Deployments",
       "type": "array"
     },
     "error": {
@@ -1149,6 +1716,14 @@
       "title": "Graph Edges",
       "type": "array"
     },
+    "incidents": {
+      "items": {
+        "$ref": "#/$defs/DevIncidentFact"
+      },
+      "maxItems": 100,
+      "title": "Incidents",
+      "type": "array"
+    },
     "metric_definitions": {
       "items": {
         "$ref": "#/$defs/DevMetricDefinition"
@@ -1163,6 +1738,14 @@
       },
       "maxItems": 12,
       "title": "Metrics",
+      "type": "array"
+    },
+    "pull_requests": {
+      "items": {
+        "$ref": "#/$defs/DevPullRequestFact"
+      },
+      "maxItems": 100,
+      "title": "Pull Requests",
       "type": "array"
     },
     "run_id": {
@@ -1193,6 +1776,14 @@
       "minimum": 0,
       "title": "Serialized Bytes",
       "type": "integer"
+    },
+    "source_health": {
+      "items": {
+        "$ref": "#/$defs/DevSourceHealth"
+      },
+      "maxItems": 25,
+      "title": "Source Health",
+      "type": "array"
     },
     "status": {
       "enum": [

--- a/src/lib/dev/contracts/source.json
+++ b/src/lib/dev/contracts/source.json
@@ -1,14 +1,14 @@
 {
   "schema_version": "ask_dev_web_contract_source.v1",
-  "source_commit": "f8f541c35f971b19e26ce8c14f9b52d0801cc8df",
+  "source_commit": "b469dd35caa46c347b120517bb4c779dc129cf91",
   "files": [
     {
       "path": "examples/negative/dev_answer.v1.invalid_complete_state.json",
-      "sha256": "5dd35c270b26c18ee75e28bbdc46e4e5a9417e6aa92dc64461032883b98b5153"
+      "sha256": "304e8da54dbdb878bbbe44101e89fca1c8f8c44a84cf61c5e51e8dda3f25d359"
     },
     {
       "path": "examples/negative/dev_answer.v1.invalid_scope.json",
-      "sha256": "ff06c0937444d79e83c32460c52569e0e8804cd774f1cfa7557877d7eec72ecb"
+      "sha256": "d61351bdacd0355b1a9f2e5b0e9dff4042da171e6b1e49ebd5fd2da0f1c3faae"
     },
     {
       "path": "examples/negative/dev_answer.v1.missing_required_metadata.json",
@@ -16,15 +16,15 @@
     },
     {
       "path": "examples/negative/dev_answer.v1.oversized_evidence.json",
-      "sha256": "08a7fadfe436b9f7645503d1df3acf3706d9bd4d70cb8486594bf576faca64ca"
+      "sha256": "9ff9a4caedd30b7dc15c345a9641da4a70e5a1c84e3bac1576772985a7bdce6d"
     },
     {
       "path": "examples/negative/dev_answer.v1.unknown_evidence_id.json",
-      "sha256": "3546f034242e02c9a5d9afd19b81426cfacf2a2d9d48d420a13b2d90cca36bec"
+      "sha256": "0c77e93e77d2029f0403e26c5a571191712fe032c584bffebb274613369c2247"
     },
     {
       "path": "examples/negative/dev_answer.v1.unknown_metric_id.json",
-      "sha256": "77450a616cd71501238f3b2944b3276441d8916461fc80bec312d9630ca1a354"
+      "sha256": "5edba7a3cb9853d81b12672acdd7c2465d4cde3ecc95f5c12ce37ca2edcd55d7"
     },
     {
       "path": "examples/negative/dev_capabilities.v1.unknown_gate.json",
@@ -44,11 +44,11 @@
     },
     {
       "path": "examples/negative/dev_conversation_transcript.v1.answer_from_another_conversation.json",
-      "sha256": "b4a879ae52086bae0af69bdca0eae3d04fdf682d4df1112b52217e8ea84696a7"
+      "sha256": "ed0ce846ce393c1dbac33315faef6b85d0b9bfa24cbd7bcf5f2623bcc2e708e3"
     },
     {
       "path": "examples/negative/dev_conversation_transcript.v1.assistant_contains_user_question.json",
-      "sha256": "ce14c52a308aa86a2cc9bec8aed7350b86952e443de8de34bcbb8f1f12d29684"
+      "sha256": "d9b3310c03cec9e22176952cae7254b8b90d795912ea501f14c84e01de99cd63"
     },
     {
       "path": "examples/negative/dev_error.v1.provider_exception_text.json",
@@ -104,11 +104,15 @@
     },
     {
       "path": "examples/negative/dev_tool_result.v1.oversized_result.json",
-      "sha256": "94e8ce815d630657daceb37bb3f7ab8647c350d234429cd0ac699702604e2602"
+      "sha256": "a40d6bbd0794c3ba8b2c6fbcd62fc158a4eb65c66e60a16b3d1a75d0416be3a4"
+    },
+    {
+      "path": "examples/negative/dev_tool_result.v1.status_fact_evidence_not_in_array.json",
+      "sha256": "26afbb73e6e8865f5884ba5af09a86effd6b5b5b63bf9ad4390b4ea8261a72ce"
     },
     {
       "path": "examples/positive/dev_answer.v1.json",
-      "sha256": "1ee3230951ae3590fd921c18042b40a98be45452ecacd9d5d6caa90f32927e55"
+      "sha256": "fba7cafc8b232b43e56c8385b2b58439e5a4b0b67cb3eb1da0ffc32f19733c21"
     },
     {
       "path": "examples/positive/dev_capabilities.v1.json",
@@ -128,7 +132,7 @@
     },
     {
       "path": "examples/positive/dev_conversation_transcript.v1.json",
-      "sha256": "73b9a33b083b34fd450cd200e44a611d70816baafc9f7b2710f3767a11b6b877"
+      "sha256": "7aa148b2e030d83df425a53144b2a72c1ce12f6a2fd4bf8ffe798a09239db72d"
     },
     {
       "path": "examples/positive/dev_error.v1.json",
@@ -172,7 +176,7 @@
     },
     {
       "path": "examples/positive/dev_tool_result.v1.json",
-      "sha256": "5998122f3d515432423cba1e67e5785983e11f743fa18e0a9bbbd9358ef21549"
+      "sha256": "31a956f4659f29f190346a7b873a219ffc85ccd2dfb9d7032937a4eb9c9ed653"
     },
     {
       "path": "examples/streams/invalid_duplicate_terminal.json",
@@ -192,11 +196,11 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "2274b580514ca74ca62523f10f7a2462240bad19d6b53ccdcd8593ac8c78f151"
+      "sha256": "b10c1f190dd0a9ea1b6f7f0071fbe0cea68b10c88d7019c0a1c30cd796b8eeff"
     },
     {
       "path": "schemas/dev_answer.v1.schema.json",
-      "sha256": "eb16f4820efce0d76fc9d9dbaff84719b91b41fe2f3d5016c324bcdb8141269d"
+      "sha256": "5178e487e3d2b8cbcde7ffea08ea0d3121937db7357c861c3738b2c9120e9039"
     },
     {
       "path": "schemas/dev_capabilities.v1.schema.json",
@@ -204,23 +208,23 @@
     },
     {
       "path": "schemas/dev_claim.v1.schema.json",
-      "sha256": "f47efaec1dfde2d409b1053bfd04b29a5e8f5f112e7895501115ead41862b0fb"
+      "sha256": "4a8505fb87ccae4c4e63c17403410a18f543e54f1e46a79c0b8144d7b60b5481"
     },
     {
       "path": "schemas/dev_conversation.v1.schema.json",
-      "sha256": "763452f78629179c07604927650d39e3e3c82247823b1854e352f61fbafa8872"
+      "sha256": "8cc7267de6d08f5a63d1ecef1b4a0b45856a925637ba780f6433856fa7d27bbb"
     },
     {
       "path": "schemas/dev_conversation_summary.v1.schema.json",
-      "sha256": "3c9983bdc802a85fa4b5f766fd3e6de109142bba97fb6e207b45173f07a06d7f"
+      "sha256": "53f0fac1fef5801a794ed160b1904fc107c3647d60e52c7462ddeccdb8c6f167"
     },
     {
       "path": "schemas/dev_conversation_transcript.v1.schema.json",
-      "sha256": "1f8bb8b787ebacfb6373053cab676c2e3f15c5c20b59971b178d2895c545e21f"
+      "sha256": "635befb43b9080a935d49df136f51508a5b5e1b152809cba67d42de27bc2b60a"
     },
     {
       "path": "schemas/dev_error.v1.schema.json",
-      "sha256": "e68386046905c634c118564dd3d74447fc55387c57d84a6a79ce903f0a4c3907"
+      "sha256": "eb78a38684caab42ef2c88c6a33f558330855b86b9b847024560dfeb68581514"
     },
     {
       "path": "schemas/dev_evidence_expansion.v1.schema.json",
@@ -236,31 +240,31 @@
     },
     {
       "path": "schemas/dev_message_request.v1.schema.json",
-      "sha256": "ef00198a78046e649a750a465e230df7e5b02c27ed8d6ad5dae6f2268a6fc897"
+      "sha256": "258a495a3ac72ec52164b37164d71b4f01b60d8f1008b046965cd2f002c7b2bc"
     },
     {
       "path": "schemas/dev_metric_ref.v1.schema.json",
-      "sha256": "bac5613b1a2bf598138469db99fbb65a20f60d466e9b1228728b14cfd34aa2cf"
+      "sha256": "8038eef2144551ffd165681dd96a9541d0ae74925708250691f5674acbedde32"
     },
     {
       "path": "schemas/dev_scope.v1.schema.json",
-      "sha256": "97d5d98bbe7a8e4790ccf0bd67d5c0296f5f2d81cdcaa3235042b493bbb7bcdd"
+      "sha256": "d968b133e6ebf1fde7851c9a3c7c650dddf6edc5bb3a4dca311c6302add5e1a8"
     },
     {
       "path": "schemas/dev_scope_resolution.v1.schema.json",
-      "sha256": "707fe458b01f5dbe407833a7145497918e0052f66d01236bfec62bf8dd609c94"
+      "sha256": "6f0f9de88d78beb53b5d6e42b9e161cadaf947a2939a3215a810069600227b81"
     },
     {
       "path": "schemas/dev_stream_event.v1.schema.json",
-      "sha256": "1cd0ad8794e65be66b741fe0b5cc4d3d347785f23a1c8c6cfaf127c51dfcf37e"
+      "sha256": "eeb3461c25d455140d30e7a779e1480ddd2773fdec29f67b8d053ae4b2cdcc6f"
     },
     {
       "path": "schemas/dev_tool_request.v1.schema.json",
-      "sha256": "e28410490c2b34bbf729d537e0d022c4cdc8a2dcf53013381c6105832bdb4582"
+      "sha256": "eed1f7ad4d5dac6f12680329eded654e7808fa78280e11280f4e3cf541a0bfe1"
     },
     {
       "path": "schemas/dev_tool_result.v1.schema.json",
-      "sha256": "4a50d7e3853ddb25c6eb0b2141d6156000547aed28244f9659e4ee18b4a9b13e"
+      "sha256": "984a7b92cc1476b929f895c009c4c7c061d7ad594427777329b7271a9b8a4f1f"
     }
   ]
 }

--- a/src/lib/dev/generated.ts
+++ b/src/lib/dev/generated.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-// Generated from full-chaos/dev-health-ops f8f541c35f971b19e26ce8c14f9b52d0801cc8df. Do not edit.
+// Generated from full-chaos/dev-health-ops b469dd35caa46c347b120517bb4c779dc129cf91. Do not edit.
 export namespace DevAnswerContract {
     export type AnswerId = string;
     export type AsOf = string;
@@ -51,7 +51,7 @@ export namespace DevAnswerContract {
     export type Start = string;
     export type Timezone = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 20
      */
@@ -282,7 +282,8 @@ export namespace DevAnswerContract {
           ];
     export type DisplayLabel = string;
     export type EntityId = string;
-    export type EntityType = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type EntityType =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type OrganizationId = string;
     /**
@@ -2909,7 +2910,7 @@ export namespace DevClaimContract {
     export type Start = string;
     export type Timezone = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 20
      */
@@ -3140,7 +3141,8 @@ export namespace DevClaimContract {
           ];
     export type DisplayLabel = string;
     export type EntityId = string;
-    export type EntityType = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type EntityType =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type OrganizationId = string;
     /**
@@ -3794,7 +3796,7 @@ export type DevClaim = DevClaimContract.DevClaim;
 export namespace DevConversationSummaryContract {
     export type ConversationId = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type ExpiresAt = string | null;
     export type MessageCount = number;
     export type SchemaVersion = "dev_conversation_summary.v1";
@@ -3866,7 +3868,7 @@ export namespace DevConversationTranscriptContract {
     export type Start = string;
     export type Timezone = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 20
      */
@@ -4097,7 +4099,8 @@ export namespace DevConversationTranscriptContract {
           ];
     export type DisplayLabel = string;
     export type EntityId = string;
-    export type EntityType = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type EntityType =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type OrganizationId = string;
     /**
@@ -6260,6 +6263,8 @@ export namespace DevConversationTranscriptContract {
     export type RunState =
         | "accepted"
         | "resolving_scope"
+        | "interpreting"
+        | "resolving_subjects"
         | "model_decision"
         | "tool_validation"
         | "tool_execution"
@@ -6470,7 +6475,7 @@ export namespace DevConversationContract {
     export type Start = string;
     export type Timezone = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 20
      */
@@ -6701,7 +6706,8 @@ export namespace DevConversationContract {
           ];
     export type DisplayLabel = string;
     export type EntityId = string;
-    export type EntityType = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type EntityType =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type OrganizationId = string;
     /**
@@ -7379,6 +7385,7 @@ export namespace DevErrorContract {
         | "insufficient_evidence"
         | "answer_validation_failed"
         | "cancelled"
+        | "provider_contract_violation"
         | "internal_error";
     export type LimitResetAt = string | null;
     /**
@@ -8482,7 +8489,7 @@ export namespace DevMessageRequestContract {
     export type Start = string;
     export type Timezone = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 20
      */
@@ -8713,7 +8720,8 @@ export namespace DevMessageRequestContract {
           ];
     export type DisplayLabel = string;
     export type EntityId = string;
-    export type EntityType = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type EntityType =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type OrganizationId = string;
     /**
@@ -9414,7 +9422,7 @@ export namespace DevMetricRefContract {
     export type MetricRefId = string;
     export type QueryVersion = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 20
      */
@@ -9645,7 +9653,8 @@ export namespace DevMetricRefContract {
           ];
     export type DisplayLabel = string;
     export type EntityId = string;
-    export type EntityType = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type EntityType =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type OrganizationId = string;
     /**
@@ -10673,7 +10682,8 @@ export namespace DevScopeResolutionContract {
           ];
     export type DisplayLabel = string;
     export type EntityId = string;
-    export type EntityType = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type EntityType =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type Reason = string;
     export type RepositoryId1 = string | null;
@@ -10708,7 +10718,7 @@ export namespace DevScopeResolutionContract {
     export type Start = string;
     export type Timezone = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 20
      */
@@ -11770,7 +11780,7 @@ export namespace DevScopeContract {
     export type Start = string;
     export type Timezone = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 20
      */
@@ -12001,7 +12011,8 @@ export namespace DevScopeContract {
           ];
     export type DisplayLabel = string;
     export type EntityId = string;
-    export type EntityType = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type EntityType =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type OrganizationId = string;
     /**
@@ -12685,7 +12696,7 @@ export namespace DevStreamEventContract {
     export type Start = string;
     export type Timezone = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 20
      */
@@ -12916,7 +12927,8 @@ export namespace DevStreamEventContract {
           ];
     export type DisplayLabel = string;
     export type EntityId = string;
-    export type EntityType = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type EntityType =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type OrganizationId = string;
     /**
@@ -15094,6 +15106,7 @@ export namespace DevStreamEventContract {
         | "insufficient_evidence"
         | "answer_validation_failed"
         | "cancelled"
+        | "provider_contract_violation"
         | "internal_error";
     export type LimitResetAt = string | null;
     /**
@@ -15342,7 +15355,7 @@ export namespace DevToolRequestContract {
     export type Start = string;
     export type Timezone = string;
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 20
      */
@@ -15573,7 +15586,8 @@ export namespace DevToolRequestContract {
           ];
     export type DisplayLabel = string;
     export type EntityId = string;
-    export type EntityType = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type EntityType =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type OrganizationId = string;
     /**
@@ -16230,6 +16244,293 @@ export namespace DevToolRequestContract {
 }
 export type DevToolRequest = DevToolRequestContract.DevToolRequest;
 export namespace DevToolResultContract {
+    /**
+     * @maxItems 20
+     */
+    export type Conflicts =
+        | []
+        | [DevStatusConflict]
+        | [DevStatusConflict, DevStatusConflict]
+        | [DevStatusConflict, DevStatusConflict, DevStatusConflict]
+        | [DevStatusConflict, DevStatusConflict, DevStatusConflict, DevStatusConflict]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ]
+        | [
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+              DevStatusConflict,
+          ];
+    export type Code = string;
+    /**
+     * @maxItems 25
+     */
+    export type EvidenceRefIds = string[];
+    export type Message = string;
+    export type Severity = "warning" | "blocking";
+    export type DisplayTruncated = boolean;
+    /**
+     * @maxItems 25
+     */
+    export type EvidenceRefIds1 = string[];
+    /**
+     * @maxItems 25
+     */
+    export type ReasonCodes = string[];
+    export type RequiredChildComplete = number | null;
+    export type RequiredChildTotal = number | null;
+    /**
+     * @maxItems 25
+     */
+    export type EvidenceRefIds2 = string[];
+    export type FactId = string;
+    export type Status = string;
+    export type Text = string;
+    /**
+     * @maxItems 100
+     */
+    export type RequiredChildren = DevRequiredChildFact[];
+    export type RuleId = string;
+    export type RuleVersion = string;
+    export type State = "ready" | "not_ready" | "indeterminate";
+    export type Conclusion = string;
+    export type DisplayLabel = string;
+    export type EntityId = string;
+    /**
+     * @maxItems 25
+     */
+    export type EvidenceRefIds3 = string[];
+    export type ObservedAt = string;
+    export type Required = boolean | null;
+    export type SkippedRequiredWork = boolean | null;
+    /**
+     * @maxItems 100
+     */
+    export type CiChecks = DevCIFact[];
     export type Coverage = number;
     export type FreshnessState = "fresh" | "stale" | "unavailable" | "unknown";
     export type LastSuccessfulAt = string | null;
@@ -16239,7 +16540,21 @@ export namespace DevToolResultContract {
      * @maxItems 25
      */
     export type DataHealth = DevDataHealth[];
-    export type Code =
+    export type DisplayLabel1 = string;
+    export type EntityId1 = string;
+    export type Environment = string | null;
+    /**
+     * @maxItems 25
+     */
+    export type EvidenceRefIds4 = string[];
+    export type ObservedAt1 = string;
+    export type Required1 = boolean;
+    export type Status1 = string;
+    /**
+     * @maxItems 100
+     */
+    export type Deployments = DevDeploymentFact[];
+    export type Code1 =
         | "unauthenticated"
         | "forbidden"
         | "feature_not_enabled"
@@ -16262,6 +16577,7 @@ export namespace DevToolResultContract {
         | "insufficient_evidence"
         | "answer_validation_failed"
         | "cancelled"
+        | "provider_contract_violation"
         | "internal_error";
     export type LimitResetAt = string | null;
     /**
@@ -16280,8 +16596,8 @@ export namespace DevToolResultContract {
     export type SchemaVersion = "dev_error.v1";
     export type CitationText = string | null;
     export type Confidence = number;
-    export type DisplayLabel = string;
-    export type EntityId = string;
+    export type DisplayLabel2 = string;
+    export type EntityId2 = string;
     export type EntityType = string;
     export type EvidenceRefId = string;
     export type Conflicting = boolean;
@@ -16293,7 +16609,7 @@ export namespace DevToolResultContract {
     export type UntrustedContent = boolean;
     export type InternalPath = string | null;
     export type SourceUrl = string | null;
-    export type ObservedAt = string;
+    export type ObservedAt2 = string;
     export type Provenance = string;
     /**
      * @maxItems 20
@@ -16658,10 +16974,13 @@ export namespace DevToolResultContract {
      * @maxItems 25
      */
     export type Evidence = DevEvidenceRef[];
+    export type Confidence1 = number;
     /**
      * @maxItems 25
      */
-    export type EvidenceRefIds = string[];
+    export type EvidenceRefIds5 = string[];
+    export type ObservedAt3 = string;
+    export type Provenance1 = string;
     export type Relationship = string;
     export type SourceEntityId = string;
     export type TargetEntityId = string;
@@ -16669,6 +16988,20 @@ export namespace DevToolResultContract {
      * @maxItems 100
      */
     export type GraphEdges = DevGraphEdge[];
+    export type Active = boolean;
+    export type Blocking = boolean;
+    export type DisplayLabel3 = string;
+    export type EntityId3 = string;
+    /**
+     * @maxItems 25
+     */
+    export type EvidenceRefIds6 = string[];
+    export type ObservedAt4 = string;
+    export type Status2 = string;
+    /**
+     * @maxItems 100
+     */
+    export type Incidents = DevIncidentFact[];
     /**
      * @maxItems 12
      */
@@ -16836,7 +17169,7 @@ export namespace DevToolResultContract {
               DirectScope,
           ];
     export type DirectScope =
-        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request";
+        "organization" | "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     /**
      * @maxItems 12
      */
@@ -16989,7 +17322,7 @@ export namespace DevToolResultContract {
     /**
      * @maxItems 25
      */
-    export type EvidenceRefIds1 = string[];
+    export type EvidenceRefIds7 = string[];
     export type Label1 = string;
     export type MetricRefId = string;
     export type QueryVersion = string;
@@ -17221,9 +17554,10 @@ export namespace DevToolResultContract {
               DevEntityRef,
               DevEntityRef,
           ];
-    export type DisplayLabel1 = string;
-    export type EntityId1 = string;
-    export type EntityType1 = "repository" | "project" | "work_unit" | "issue" | "pull_request";
+    export type DisplayLabel4 = string;
+    export type EntityId4 = string;
+    export type EntityType1 =
+        "repository" | "project" | "work_unit" | "issue" | "pull_request" | "team";
     export type RepositoryId = string | null;
     export type OrganizationId = string;
     /**
@@ -17836,6 +18170,22 @@ export namespace DevToolResultContract {
     export type SourceVersion1 = string;
     export type Unit1 = string;
     export type Value1 = number | null;
+    export type ChangesRequested = number;
+    export type DisplayLabel5 = string;
+    export type EntityId5 = string;
+    /**
+     * @maxItems 25
+     */
+    export type EvidenceRefIds8 = string[];
+    export type Merged = boolean;
+    export type ObservedAt5 = string;
+    export type Required2 = boolean;
+    export type ReviewState = string | null;
+    export type State1 = string;
+    /**
+     * @maxItems 100
+     */
+    export type PullRequests = DevPullRequestFact[];
     export type RunId = string;
     export type SchemaVersion4 = "dev_tool_result.v1";
     /**
@@ -18404,14 +18754,21 @@ export namespace DevToolResultContract {
               string,
           ];
     export type SerializedBytes = number;
-    export type Status = "success" | "partial" | "unavailable" | "error";
+    export type RefId = string;
+    export type SourceSystem2 = string;
+    export type Watermark = string | null;
+    /**
+     * @maxItems 25
+     */
+    export type SourceHealth = DevSourceHealth[];
+    export type Status3 = "success" | "partial" | "unavailable" | "error";
     /**
      * @minItems 1
      * @maxItems 25
      */
-    export type EvidenceRefIds2 = [string, ...string[]];
-    export type FactId = string;
-    export type Text = string;
+    export type EvidenceRefIds9 = [string, ...string[]];
+    export type FactId1 = string;
+    export type Text1 = string;
     /**
      * @maxItems 100
      */
@@ -18607,21 +18964,63 @@ export namespace DevToolResultContract {
           ];
 
     export interface DevToolResult {
+        actual_completion?: DevActualCompletion | null;
+        ci_checks?: CiChecks;
         data_health?: DataHealth;
+        deployments?: Deployments;
         error?: DevError | null;
         evidence?: Evidence;
         graph_edges?: GraphEdges;
+        incidents?: Incidents;
         metric_definitions?: MetricDefinitions;
         metrics?: Metrics;
+        pull_requests?: PullRequests;
         run_id: RunId;
         schema_version: SchemaVersion4;
         scope_resolution?: DevScopeResolution | null;
         serialized_bytes: SerializedBytes;
-        status: Status;
+        source_health?: SourceHealth;
+        status: Status3;
         status_facts?: StatusFacts;
         tool_call_id: ToolCallId;
         tool_id: ToolID;
         warnings?: Warnings1;
+    }
+    /**
+     * Server-computed ``actual-completion`` rule result; the LLM explains, never derives, it.
+     */
+    export interface DevActualCompletion {
+        conflicts?: Conflicts;
+        display_truncated?: DisplayTruncated;
+        evidence_ref_ids?: EvidenceRefIds1;
+        reason_codes?: ReasonCodes;
+        required_child_complete?: RequiredChildComplete;
+        required_child_total?: RequiredChildTotal;
+        required_children?: RequiredChildren;
+        rule_id: RuleId;
+        rule_version: RuleVersion;
+        state: State;
+    }
+    export interface DevStatusConflict {
+        code: Code;
+        evidence_ref_ids?: EvidenceRefIds;
+        message: Message;
+        severity: Severity;
+    }
+    export interface DevRequiredChildFact {
+        evidence_ref_ids?: EvidenceRefIds2;
+        fact_id: FactId;
+        status: Status;
+        text: Text;
+    }
+    export interface DevCIFact {
+        conclusion: Conclusion;
+        display_label: DisplayLabel;
+        entity_id: EntityId;
+        evidence_ref_ids?: EvidenceRefIds3;
+        observed_at: ObservedAt;
+        required?: Required;
+        skipped_required_work?: SkippedRequiredWork;
     }
     export interface DevDataHealth {
         coverage: Coverage;
@@ -18630,8 +19029,17 @@ export namespace DevToolResultContract {
         source_system: SourceSystem;
         warning?: Warning;
     }
+    export interface DevDeploymentFact {
+        display_label: DisplayLabel1;
+        entity_id: EntityId1;
+        environment?: Environment;
+        evidence_ref_ids?: EvidenceRefIds4;
+        observed_at: ObservedAt1;
+        required: Required1;
+        status: Status1;
+    }
     export interface DevError {
-        code: Code;
+        code: Code1;
         limit_reset_at?: LimitResetAt;
         remediation?: Remediation;
         request_id: RequestId;
@@ -18642,14 +19050,14 @@ export namespace DevToolResultContract {
     export interface DevEvidenceRef {
         citation_text?: CitationText;
         confidence: Confidence;
-        display_label: DisplayLabel;
-        entity_id: EntityId;
+        display_label: DisplayLabel2;
+        entity_id: EntityId2;
         entity_type: EntityType;
         evidence_ref_id: EvidenceRefId;
         flags: DevEvidenceFlags;
         freshness: FreshnessState;
         link?: DevCitationLink | null;
-        observed_at: ObservedAt;
+        observed_at: ObservedAt2;
         provenance: Provenance;
         repository_ids?: RepositoryIds;
         schema_version: SchemaVersion1;
@@ -18671,10 +19079,22 @@ export namespace DevToolResultContract {
         source_url?: SourceUrl;
     }
     export interface DevGraphEdge {
-        evidence_ref_ids?: EvidenceRefIds;
+        confidence: Confidence1;
+        evidence_ref_ids?: EvidenceRefIds5;
+        observed_at: ObservedAt3;
+        provenance: Provenance1;
         relationship: Relationship;
         source_entity_id: SourceEntityId;
         target_entity_id: TargetEntityId;
+    }
+    export interface DevIncidentFact {
+        active: Active;
+        blocking: Blocking;
+        display_label: DisplayLabel3;
+        entity_id: EntityId3;
+        evidence_ref_ids?: EvidenceRefIds6;
+        observed_at: ObservedAt4;
+        status: Status2;
     }
     export interface DevMetricDefinition {
         definition_version: DefinitionVersion;
@@ -18696,7 +19116,7 @@ export namespace DevToolResultContract {
         definition_version: DefinitionVersion1;
         dimensions?: Dimensions;
         display_precision: DisplayPrecision;
-        evidence_ref_ids?: EvidenceRefIds1;
+        evidence_ref_ids?: EvidenceRefIds7;
         freshness: FreshnessState;
         label: Label1;
         metric_id: MetricID;
@@ -18726,8 +19146,8 @@ export namespace DevToolResultContract {
         time_range: DevTimeRange;
     }
     export interface DevEntityRef {
-        display_label: DisplayLabel1;
-        entity_id: EntityId1;
+        display_label: DisplayLabel4;
+        entity_id: EntityId4;
         entity_type: EntityType1;
         repository_id?: RepositoryId;
     }
@@ -18739,6 +19159,17 @@ export namespace DevToolResultContract {
     export interface DevMetricPoint {
         timestamp: Timestamp;
         value: Value;
+    }
+    export interface DevPullRequestFact {
+        changes_requested: ChangesRequested;
+        display_label: DisplayLabel5;
+        entity_id: EntityId5;
+        evidence_ref_ids?: EvidenceRefIds8;
+        merged: Merged;
+        observed_at: ObservedAt5;
+        required: Required2;
+        review_state?: ReviewState;
+        state: State1;
     }
     export interface DevScopeResolution {
         authorized_entity_ids?: AuthorizedEntityIds;
@@ -18757,10 +19188,16 @@ export namespace DevToolResultContract {
         reason: Reason;
         repository_id?: RepositoryId1;
     }
+    export interface DevSourceHealth {
+        freshness: FreshnessState;
+        ref_id: RefId;
+        source_system: SourceSystem2;
+        watermark?: Watermark;
+    }
     export interface DevStatusFact {
-        evidence_ref_ids: EvidenceRefIds2;
-        fact_id: FactId;
-        text: Text;
+        evidence_ref_ids: EvidenceRefIds9;
+        fact_id: FactId1;
+        text: Text1;
     }
 }
 export type DevToolResult = DevToolResultContract.DevToolResult;

--- a/src/lib/graphql/__generated__/types.ts
+++ b/src/lib/graphql/__generated__/types.ts
@@ -776,8 +776,11 @@ export type DateRangeInput = {
 export type DevActualCompletion = {
   __typename?: 'DevActualCompletion';
   conflicts: Array<DevStatusConflict>;
+  displayTruncated: Scalars['Boolean']['output'];
   evidenceRefIds: Array<Scalars['ID']['output']>;
   reasonCodes: Array<Scalars['String']['output']>;
+  requiredChildComplete?: Maybe<Scalars['Int']['output']>;
+  requiredChildTotal?: Maybe<Scalars['Int']['output']>;
   requiredChildren: Array<DevStatusFact>;
   ruleId: Scalars['String']['output'];
   ruleVersion: Scalars['String']['output'];

--- a/src/lib/graphql/schema.graphql
+++ b/src/lib/graphql/schema.graphql
@@ -710,6 +710,9 @@ type DevActualCompletion {
   ruleVersion: String!
   reasonCodes: [String!]!
   requiredChildren: [DevStatusFact!]!
+  requiredChildTotal: Int
+  requiredChildComplete: Int
+  displayTruncated: Boolean!
   conflicts: [DevStatusConflict!]!
   sourceRefIds: [ID!]!
   evidenceRefIds: [ID!]!

--- a/tests/ask-dev-outcomes.spec.ts
+++ b/tests/ask-dev-outcomes.spec.ts
@@ -20,9 +20,9 @@ import {
 //
 // The status/copy pairing for each scenario below is NOT hardcoded here —
 // it's read from tests/fixtures/askDevOutcomes.ts, the same table
-// tests/mocks/devScenario.ts uses to build the canned answer. CHAOS-3298
-// only needs to re-point that one table at dev_answer.v2 shapes; this loop
-// stays correct un-touched.
+// tests/mocks/devScenario.ts uses to build the canned answer. Whoever
+// eventually points that one table at dev_answer.v2 shapes leaves this loop
+// correct un-touched.
 
 test.beforeEach(async ({ request }) => {
     await resetAskDevMock(request);

--- a/tests/ask-dev-shared.spec.ts
+++ b/tests/ask-dev-shared.spec.ts
@@ -32,14 +32,19 @@ import {
 //
 // Wave 3.1's dev_answer.v2 public-outcome taxonomy (answered_with_gaps,
 // needs_clarification, not_found, temporarily_unavailable, unsupported,
-// denied, failed — CHAOS-3294) is NOT yet consumed by this frontend
-// (CHAOS-3298 is still Backlog): the components here still render the prior
-// dev_answer.v1 status enum (complete/partial/degraded/insufficient_
-// evidence/refused/error). This spec exercises every outcome the app can
-// actually reach today, plus the shared request-lifecycle/internal-state-
-// isolation/evidence-hierarchy invariants that do not depend on v2. It
-// intentionally does not fabricate v2-only outcomes against a UI that does
-// not render them — see CHAOS-3298 for that follow-up adoption work.
+// denied, failed — CHAOS-3294) is NOT consumed by this frontend, and
+// CHAOS-3298's contract re-pin did not change that: ops' v2 frame stays
+// server-internal and is projected back down to a v1 answer before it
+// reaches the wire (api/dev/router.py's v2-to-v1 projector), so
+// dev_answer.v1 is still the whole transport contract. The components here
+// render the v1 status enum (complete/partial/degraded/insufficient_
+// evidence/refused/error) because that is what the server actually sends.
+// This spec exercises every outcome the app can reach today, plus the
+// shared request-lifecycle/internal-state-isolation/evidence-hierarchy
+// invariants that do not depend on v2. It intentionally does not fabricate
+// v2-only outcomes against a UI that does not render them and a server that
+// does not emit them — that adoption unblocks when the backend serves v2 on
+// the wire, not when web re-pins.
 
 test.beforeEach(async ({ request }) => {
     await resetAskDevMock(request);

--- a/tests/ask-dev-vocabulary.spec.ts
+++ b/tests/ask-dev-vocabulary.spec.ts
@@ -3,11 +3,14 @@ import path from "node:path";
 
 import { expect, test } from "@playwright/test";
 
+import * as askDevContracts from "./fixtures/askDevContracts";
 import {
     ANSWER_STATUS_VALUES,
     assertExhaustivePartition,
     assertKnownToSchema,
+    assertVocabularyIsExhaustive,
     SCOPE_RESOLUTION_OUTCOME_VALUES,
+    VOCABULARY_COUNT,
 } from "./fixtures/askDevContracts";
 import { ASK_DEV_OUTCOME_TABLE } from "./fixtures/askDevOutcomes";
 
@@ -56,6 +59,35 @@ function exportedLabelMapKeys(sourceText: string, exportName: string): readonly 
 //
 // No page/server interaction here — pure data assertions, safe to run
 // standalone.
+
+test.describe("Ask Dev — declared unions vs. pinned contract vocabulary", () => {
+    // askDevContracts.ts casts each schema-extracted array to its declared
+    // union without TypeScript checking the cast. CHAOS-3298's re-pin added
+    // "provider_contract_violation" to DevErrorCode and
+    // "interpreting"/"resolving_subjects" to DevTranscriptRunState; before
+    // this check existed, the casts absorbed all three silently.
+    test("every declared union names exactly what the pinned schema enum contains", () => {
+        expect(() => assertVocabularyIsExhaustive()).not.toThrow();
+    });
+
+    // Guards the table `assertVocabularyIsExhaustive` walks: a new vocabulary
+    // exported from askDevContracts.ts but left out of VOCABULARIES would
+    // otherwise be checked by nothing at all. The expected count is read off
+    // the module's real exports rather than a second hand-kept list here —
+    // a list maintained beside the one it checks would agree with itself.
+    test("every exported vocabulary is enrolled in the exhaustiveness table", () => {
+        const exportedVocabularies = Object.entries(askDevContracts).filter(
+            ([, value]) =>
+                Array.isArray(value) &&
+                value.length > 0 &&
+                value.every((member) => typeof member === "string"),
+        );
+        expect(
+            exportedVocabularies.map(([name]) => name).sort(),
+            "askDevContracts.ts exports a string-array vocabulary that VOCABULARIES does not enroll",
+        ).toHaveLength(VOCABULARY_COUNT);
+    });
+});
 
 test.describe("Ask Dev — outcome table vs. pinned contract vocabulary", () => {
     test("every ASK_DEV_OUTCOME_TABLE status is a real, pinned AnswerStatus value", () => {

--- a/tests/fixtures/askDevContracts.ts
+++ b/tests/fixtures/askDevContracts.ts
@@ -9,9 +9,12 @@
  * of this file included "interpreting"/"resolving_subjects" in
  * DEV_TRANSCRIPT_RUN_STATE_VALUES and "provider_contract_violation" in
  * DEV_ERROR_CODES — both present in ops' *live* contracts.py source but
- * NOT in what's actually pinned here, which is what the running app
- * really validates against). Extracting from the schema files themselves
- * makes that class of drift impossible to reintroduce.
+ * NOT in what was pinned at the time, which is what the running app
+ * really validates against; CHAOS-3298's re-pin then brought all three
+ * into the pinned schemas, and `assertVocabularyIsExhaustive` below is
+ * what forced them back into the declared unions rather than leaving the
+ * casts quietly lying). Extracting from the schema files themselves makes
+ * that class of drift impossible to reintroduce.
  *
  * tests/mocks/devScenario.ts and this file's own self-check
  * (assertVocabularyIsExhaustive, exercised by
@@ -70,14 +73,42 @@ function extractEnum(schema: JsonSchema, ...path: readonly string[]): readonly s
     return values as readonly string[];
 }
 
+/**
+ * Each vocabulary below declares its members twice on purpose: a `const`
+ * tuple (the compile-time union every consumer types against) and a
+ * runtime extraction from the pinned schema. The `as readonly T[]` cast on
+ * the extraction is unchecked by TypeScript, so on its own it would let the
+ * declared union drift silently away from what is really pinned — exactly
+ * the drift the header describes. `assertVocabularyIsExhaustive` closes
+ * that by comparing the two sets, and the spec suite runs it.
+ */
+const DECLARED_ANSWER_STATUS = [
+    "complete",
+    "partial",
+    "degraded",
+    "insufficient_evidence",
+    "refused",
+    "error",
+] as const;
+export type AnswerStatus = (typeof DECLARED_ANSWER_STATUS)[number];
+
 /** Pinned `dev_answer.v1.schema.json` `$defs.AnswerStatus.enum`. */
 export const ANSWER_STATUS_VALUES = extractEnum(
     answerSchema as JsonSchema,
     "$defs",
     "AnswerStatus",
 ) as readonly AnswerStatus[];
-export type AnswerStatus =
-    "complete" | "partial" | "degraded" | "insufficient_evidence" | "refused" | "error";
+
+const DECLARED_SCOPE_RESOLUTION_OUTCOME = [
+    "exact",
+    "filtered",
+    "inherited",
+    "organization_fallback",
+    "ambiguous",
+    "unresolved",
+    "forbidden_or_not_found",
+] as const;
+export type ScopeResolutionOutcome = (typeof DECLARED_SCOPE_RESOLUTION_OUTCOME)[number];
 
 /** Pinned `dev_scope_resolution.v1.schema.json` `properties.outcome` (→ `$defs.ScopeResolutionOutcome.enum`). */
 export const SCOPE_RESOLUTION_OUTCOME_VALUES = extractEnum(
@@ -85,14 +116,36 @@ export const SCOPE_RESOLUTION_OUTCOME_VALUES = extractEnum(
     "properties",
     "outcome",
 ) as readonly ScopeResolutionOutcome[];
-export type ScopeResolutionOutcome =
-    | "exact"
-    | "filtered"
-    | "inherited"
-    | "organization_fallback"
-    | "ambiguous"
-    | "unresolved"
-    | "forbidden_or_not_found";
+
+const DECLARED_DEV_ERROR_CODE = [
+    "unauthenticated",
+    "forbidden",
+    "feature_not_enabled",
+    "byo_llm_not_enabled",
+    "provider_not_configured",
+    "model_not_supported",
+    "provider_unavailable",
+    "rate_limited",
+    "concurrency_limited",
+    "cost_limit_reached",
+    "invalid_request",
+    "scope_ambiguous",
+    "scope_not_found",
+    "scope_forbidden",
+    "conversation_not_found",
+    "conversation_expired",
+    "tool_limit_reached",
+    "tool_unavailable",
+    "source_unavailable",
+    "insufficient_evidence",
+    "answer_validation_failed",
+    "cancelled",
+    // Reached the pinned contract with CHAOS-3298's re-pin; ops added it
+    // when it started enforcing sequential tool decisions.
+    "provider_contract_violation",
+    "internal_error",
+] as const;
+export type DevErrorCode = (typeof DECLARED_DEV_ERROR_CODE)[number];
 
 /** Pinned `dev_error.v1.schema.json` `properties.code.enum`. */
 export const DEV_ERROR_CODES = extractEnum(
@@ -100,30 +153,27 @@ export const DEV_ERROR_CODES = extractEnum(
     "properties",
     "code",
 ) as readonly DevErrorCode[];
-export type DevErrorCode =
-    | "unauthenticated"
-    | "forbidden"
-    | "feature_not_enabled"
-    | "byo_llm_not_enabled"
-    | "provider_not_configured"
-    | "model_not_supported"
-    | "provider_unavailable"
-    | "rate_limited"
-    | "concurrency_limited"
-    | "cost_limit_reached"
-    | "invalid_request"
-    | "scope_ambiguous"
-    | "scope_not_found"
-    | "scope_forbidden"
-    | "conversation_not_found"
-    | "conversation_expired"
-    | "tool_limit_reached"
-    | "tool_unavailable"
-    | "source_unavailable"
-    | "insufficient_evidence"
-    | "answer_validation_failed"
-    | "cancelled"
-    | "internal_error";
+
+const DECLARED_DEV_TRANSCRIPT_RUN_STATE = [
+    "accepted",
+    "resolving_scope",
+    // Reached the pinned contract with CHAOS-3298's re-pin; ops added both
+    // for CHAOS-3292's server-owned intent interpretation and named-subject
+    // preflight. Neither is rendered — see AskDevProvider's `runState`,
+    // which is stored and never read.
+    "interpreting",
+    "resolving_subjects",
+    "model_decision",
+    "tool_validation",
+    "tool_execution",
+    "answer_validation",
+    "completed",
+    "insufficient_evidence",
+    "refused",
+    "failed",
+    "cancelled",
+] as const;
+export type DevTranscriptRunState = (typeof DECLARED_DEV_TRANSCRIPT_RUN_STATE)[number];
 
 /** Pinned `dev_conversation_transcript.v1.schema.json` `$defs.DevTranscriptEntry.properties.run_state.enum`. */
 export const DEV_TRANSCRIPT_RUN_STATE_VALUES = extractEnum(
@@ -133,18 +183,15 @@ export const DEV_TRANSCRIPT_RUN_STATE_VALUES = extractEnum(
     "properties",
     "run_state",
 ) as readonly DevTranscriptRunState[];
-export type DevTranscriptRunState =
-    | "accepted"
-    | "resolving_scope"
-    | "model_decision"
-    | "tool_validation"
-    | "tool_execution"
-    | "answer_validation"
-    | "completed"
-    | "insufficient_evidence"
-    | "refused"
-    | "failed"
-    | "cancelled";
+
+const DECLARED_DEV_CAPABILITIES_READINESS = [
+    "ready",
+    "unsupported_model",
+    "missing_credentials",
+    "disabled",
+    "degraded",
+] as const;
+export type DevCapabilitiesReadiness = (typeof DECLARED_DEV_CAPABILITIES_READINESS)[number];
 
 /** Pinned `dev_capabilities.v1.schema.json` `properties.readiness.enum`. */
 export const DEV_CAPABILITIES_READINESS_VALUES = extractEnum(
@@ -152,8 +199,51 @@ export const DEV_CAPABILITIES_READINESS_VALUES = extractEnum(
     "properties",
     "readiness",
 ) as readonly DevCapabilitiesReadiness[];
-export type DevCapabilitiesReadiness =
-    "ready" | "unsupported_model" | "missing_credentials" | "disabled" | "degraded";
+
+/**
+ * Every vocabulary this file publishes, paired with the union declared
+ * alongside it. `assertVocabularyIsExhaustive` walks this table, so adding
+ * a vocabulary above without adding it here is itself caught (the spec
+ * asserts the table's size against the exported `*_VALUES` count).
+ */
+const VOCABULARIES = [
+    ["AnswerStatus", ANSWER_STATUS_VALUES, DECLARED_ANSWER_STATUS],
+    ["ScopeResolutionOutcome", SCOPE_RESOLUTION_OUTCOME_VALUES, DECLARED_SCOPE_RESOLUTION_OUTCOME],
+    ["DevErrorCode", DEV_ERROR_CODES, DECLARED_DEV_ERROR_CODE],
+    ["DevTranscriptRunState", DEV_TRANSCRIPT_RUN_STATE_VALUES, DECLARED_DEV_TRANSCRIPT_RUN_STATE],
+    [
+        "DevCapabilitiesReadiness",
+        DEV_CAPABILITIES_READINESS_VALUES,
+        DECLARED_DEV_CAPABILITIES_READINESS,
+    ],
+] as const satisfies readonly (readonly [string, readonly string[], readonly string[]])[];
+
+export const VOCABULARY_COUNT = VOCABULARIES.length;
+
+/**
+ * Asserts that every declared union in this file names exactly the members
+ * the pinned schema really has. The `as readonly T[]` casts on the
+ * extractions are unchecked, so without this a re-pin that adds a member
+ * leaves the union silently short — consumers keep compiling, mocks keep
+ * omitting the new value, and the "extracted from the schema, never
+ * hand-transcribed" guarantee holds only for the runtime array while the
+ * type it is cast to still lies.
+ */
+export function assertVocabularyIsExhaustive(): void {
+    for (const [label, pinned, declared] of VOCABULARIES) {
+        const declaredSet = new Set<string>(declared);
+        const pinnedSet = new Set<string>(pinned);
+        const missing = [...pinnedSet].filter((value) => !declaredSet.has(value));
+        const extra = [...declaredSet].filter((value) => !pinnedSet.has(value));
+        if (missing.length > 0 || extra.length > 0) {
+            throw new Error(
+                `${label}: the declared union and the pinned schema enum disagree. ` +
+                    `Pinned but not declared: ${missing.join(", ") || "(none)"}. ` +
+                    `Declared but not pinned: ${extra.join(", ") || "(none)"}.`,
+            );
+        }
+    }
+}
 
 /**
  * Every internal enum value, plus its cosmetic `replaceAll("_", " ")` form


### PR DESCRIPTION
Re-pins the web repo's Ask Dev contract artifacts and GraphQL schema to ops
`b469dd35caa46c347b120517bb4c779dc129cf91`, and closes the client-side drift the
newer pin exposed.

## Scope: this is a pin refresh, not the v2 adoption

CHAOS-3298 has two halves. This PR is the first one only.

The v2 answer frame is **not on the wire**. Ops keeps it server-internal and
projects it back down to a v1 answer before responding (`api/dev/router.py`'s
v2-to-v1 projector), and the exported GraphQL schema carries no frame types at
all — no `DevAnswerFrame`, no `evidence_classification`, no
`deficiency_category_statuses`, no subject sets or narrative mode. `dev_answer.v1`
remains the entire transport contract.

So the ticket's "consume `dev_answer.v2` types and the eight-outcome taxonomy"
half is blocked on **s5 serving v2**, not on anything web-side. No v2 rendering
was invented here, and the pin was deliberately **not** widened to
`contracts/ask-dev/v2/` — pinning a 23.5k-line contract tree the server never
sends would be dead weight and a false "adopted" signal.

The GraphQL delta is three fields on `DevActualCompletion`: `requiredChildTotal`,
`requiredChildComplete`, `displayTruncated` (the s2 completion denominators).

## Six drift defects the re-pin surfaced, and closed

Every one was latent before this PR — the re-pin is what made them visible.

1. **The evidence-closure rule was never implemented in web.** ops' new
   `dev_tool_result.v1.status_fact_evidence_not_in_array` negative fixture
   *failed on arrival*: web's semantic validator had no equivalent of
   `DevToolResult.validate_evidence_closure`. Now mirrored across all six fact
   arrays plus `actual_completion` and its `required_children` and `conflicts`.

2. **`team` joined `DirectScope`/`EntityType`** (ops CHAOS-3301) with no client
   arm, so its invariants went unenforced: a team scope must have `team_ids`
   naming exactly the committed team, and must carry no repository list.

3. **Three new enum members would have been swallowed by an unchecked cast.**
   `provider_contract_violation` joined `DevErrorCode`; `interpreting` and
   `resolving_subjects` joined `DevTranscriptRunState`. `askDevContracts.ts`
   casts its schema extraction to hand-written unions with an unchecked `as`,
   so the runtime array grew while the declared type silently did not.
   `assertVocabularyIsExhaustive` — a function the file's own header already
   claimed existed — now holds the two against each other, with an enrollment
   guard derived from the module's real exports rather than a second hand-list.

4. **The ops commit was pinned in three places, not one.** The sync script, the
   quality job's checkout ref, and a hardcoded literal in the CI-contract test.
   The test now *reads* the ref out of the sync script, so a half-finished
   re-pin fails a unit test instead of only CI.

5. **`PROGRESS_LABELS` had lost its type pressure.** `DevConversationStreamState`
   widened the progress phase to `string`, erasing the generated union, so the
   label map was `Record<string, string>` with a generic runtime fallback —
   total today, but a re-pin could have added a phase that silently rendered as
   "Investigating". Both now carry the union (`DevProgressState`) with a
   totality guard.

6. **The scope-resolution outcome split fails open.** It matched ops exactly,
   but an outcome ops treats as resolved that went missing here would make web
   accept a resolution ops rejects — silently. Both halves are now held against
   the pinned enum as an exact partition, with a vacuity check so an absent enum
   fails loudly rather than passing trivially.

`payloadByEvent` was re-audited too and matches `StreamEventType` exactly. It is
deliberately left unguarded: drift there fails *closed* (the event is rejected),
so it is loud rather than silent, and a guard would add machinery without
closing a real hole.

## Related tickets

- **CHAOS-3338** — ops ships no team-scope golden in either contract tree despite
  `team` being a first-class `DirectScope`. The test base here was derived from
  the repository-scope golden and verified against the real ops `DevScope`
  producer (accepts the base, rejects all six mutations) rather than
  hand-authored, but a producer-emitted golden belongs in ops.
- **CHAOS-3339** — included in this PR: `provider_contract_violation` was falling
  through to the generic error card. It now has tailored copy, kept as its own
  function because it pulls the opposite way on the retry affordance from the
  allowance guidance. Copy is provisional; product may refine it.

## TEST-EVIDENCE

Full `ci/run_tests.sh ci` with `ASK_DEV_OPS_ROOT` pinned to a clean detached ops
worktree at the pinned commit, run on the committed SHA: format, audit,
`codegen:check`, `ask-dev:contracts:check`, lint, typecheck, build, vitest
409 files, e2e default + onboarding + context-fabric + pagerduty-final-qa.

Every new guard was observed failing before being trusted, each with a
digest-verified restore:

- narrowing the evidence closure to `status_facts` kills all eight added cells;
- dropping either team rule kills exactly its own cells;
- dropping a member from a declared union is caught by name;
- reverting the workflow ref alone fails the CI-contract test;
- an outcome in neither partition half, and one in both, each fail;
- dropping a progress phase fails `tsc`; a raw or underscore-transformed label
  fails the leak check;
- removing the 3339 copy, suppressing its retry button, or letting it leak the
  raw enum each break their own assertion.

The schema and generated types are regenerated only — never hand-edited — so
the live-e2e exact-diff against ops `export_schema` holds.

## RISK-NOTES

- **A follow-up pin bump is already known.** The in-flight ops PR for CHAOS-3334
  adds a coverage disclosure bucket to the wire contract; this pin takes a small
  mechanical bump once that merges. Sequenced by the orchestrator.
- The v2-adoption remainder stays open and is tracked against s5.
- **`scripts/__tests__/acr-contract-artifacts.test.mjs` is flaky on `main`,
  independently of this PR.** It went red on two local gate runs here, so rather
  than re-rolling to green it was isolated: the full unit suite was run on a
  clean detached worktree at `origin/main` with none of these changes present
  and that file byte-identical, and it failed **2 of 7 runs** — in two
  *different* tests within the file ("bounds a live-owner wait without leaking a
  failed contender lock file" and "rejects a symlinked Git source root").
  The mechanism is visible in the test: it stubs the global clock with
  `vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValue(30_000)`, so
  anything else calling `Date.now()` between the spy setup and the lock acquire
  consumes the once-value and changes the elapsed-time computation, leaving the
  contender's `.tmp` lock behind. Load makes that interleaving probable — it is
  a latent race, not randomness. Roughly a 1-in-4 rate per full unit run, so it
  will surface on unrelated branches' CI. Filed as **CHAOS-3341** and
  deliberately untouched here — this PR's scope stays shut.
