### PR TITLE
chore(ask-dev): re-pin web contracts to ops main 4838e026e

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
               with:
                   repository: full-chaos/dev-health-ops
-                  ref: b469dd35caa46c347b120517bb4c779dc129cf91
+                  ref: 4838e026e08d20bd62090a85218add2761733edd
                   path: dev-health-ops
                   persist-credentials: false
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271

--- a/scripts/ask-dev-contracts.mjs
+++ b/scripts/ask-dev-contracts.mjs
@@ -12,7 +12,7 @@ import { format } from "prettier";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ARTIFACT_ROOT = path.join(ROOT, "src/lib/dev/contracts");
 const GENERATED_PATH = path.join(ROOT, "src/lib/dev/generated.ts");
-const SOURCE_COMMIT = "b469dd35caa46c347b120517bb4c779dc129cf91";
+const SOURCE_COMMIT = "4838e026e08d20bd62090a85218add2761733edd";
 const SOURCE_PREFIX = "contracts/ask-dev/v1/";
 const PRETTIER_OPTIONS = Object.freeze({
     parser: "typescript",

--- a/src/lib/dev/__tests__/contracts.test.ts
+++ b/src/lib/dev/__tests__/contracts.test.ts
@@ -74,7 +74,7 @@ describe("Ask Dev generated contract boundary", () => {
         const source = readJson<SourceManifest>("source.json");
         const manifest = readJson<OpsManifest>("manifest.json");
 
-        expect(source.source_commit).toBe("b469dd35caa46c347b120517bb4c779dc129cf91");
+        expect(source.source_commit).toBe("4838e026e08d20bd62090a85218add2761733edd");
         expect(manifest.schema_version).toBe("ask_dev_contract_manifest.v1");
         expect(manifest.compatibility).toBe("additive-within-v1");
         expect(manifest.contracts.map((contract) => contract.schema_version)).toEqual(

--- a/src/lib/dev/contracts/manifest.json
+++ b/src/lib/dev/contracts/manifest.json
@@ -74,7 +74,7 @@
       },
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
-        "sha256": "635befb43b9080a935d49df136f51508a5b5e1b152809cba67d42de27bc2b60a"
+        "sha256": "d0df8dccbf190a280412e6d4872006459072128d87c7cf8d9e9facc016ab62a3"
       },
       "schema_version": "dev_conversation_transcript.v1"
     },
@@ -150,7 +150,7 @@
       },
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
-        "sha256": "5178e487e3d2b8cbcde7ffea08ea0d3121937db7357c861c3738b2c9120e9039"
+        "sha256": "e156ced39c676bae4e08f5c5e5acc86a4d7120b472ab628ba20f1a605a8ce6fc"
       },
       "schema_version": "dev_answer.v1"
     },
@@ -335,7 +335,7 @@
       },
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
-        "sha256": "eeb3461c25d455140d30e7a779e1480ddd2773fdec29f67b8d053ae4b2cdcc6f"
+        "sha256": "694eeacf026c3c6abe6363625d1188fa59c3b1d194713acd8754babeeaa0dfad"
       },
       "schema_version": "dev_stream_event.v1"
     },

--- a/src/lib/dev/contracts/schemas/dev_answer.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_answer.v1.schema.json
@@ -268,6 +268,17 @@
           "title": "Available Source Count",
           "type": "integer"
         },
+        "degraded_required_sources": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Degraded Required Sources",
+          "type": "array"
+        },
         "required_source_count": {
           "maximum": 100,
           "minimum": 0,

--- a/src/lib/dev/contracts/schemas/dev_conversation_transcript.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_conversation_transcript.v1.schema.json
@@ -390,6 +390,17 @@
           "title": "Available Source Count",
           "type": "integer"
         },
+        "degraded_required_sources": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Degraded Required Sources",
+          "type": "array"
+        },
         "required_source_count": {
           "maximum": 100,
           "minimum": 0,

--- a/src/lib/dev/contracts/schemas/dev_stream_event.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_stream_event.v1.schema.json
@@ -390,6 +390,17 @@
           "title": "Available Source Count",
           "type": "integer"
         },
+        "degraded_required_sources": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Degraded Required Sources",
+          "type": "array"
+        },
         "required_source_count": {
           "maximum": 100,
           "minimum": 0,

--- a/src/lib/dev/contracts/source.json
+++ b/src/lib/dev/contracts/source.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "ask_dev_web_contract_source.v1",
-  "source_commit": "b469dd35caa46c347b120517bb4c779dc129cf91",
+  "source_commit": "4838e026e08d20bd62090a85218add2761733edd",
   "files": [
     {
       "path": "examples/negative/dev_answer.v1.invalid_complete_state.json",
@@ -196,11 +196,11 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "b10c1f190dd0a9ea1b6f7f0071fbe0cea68b10c88d7019c0a1c30cd796b8eeff"
+      "sha256": "b3a78704667c25583b71750e92194d513cc3929bcf194e42d9010f453f23e450"
     },
     {
       "path": "schemas/dev_answer.v1.schema.json",
-      "sha256": "5178e487e3d2b8cbcde7ffea08ea0d3121937db7357c861c3738b2c9120e9039"
+      "sha256": "e156ced39c676bae4e08f5c5e5acc86a4d7120b472ab628ba20f1a605a8ce6fc"
     },
     {
       "path": "schemas/dev_capabilities.v1.schema.json",
@@ -220,7 +220,7 @@
     },
     {
       "path": "schemas/dev_conversation_transcript.v1.schema.json",
-      "sha256": "635befb43b9080a935d49df136f51508a5b5e1b152809cba67d42de27bc2b60a"
+      "sha256": "d0df8dccbf190a280412e6d4872006459072128d87c7cf8d9e9facc016ab62a3"
     },
     {
       "path": "schemas/dev_error.v1.schema.json",
@@ -256,7 +256,7 @@
     },
     {
       "path": "schemas/dev_stream_event.v1.schema.json",
-      "sha256": "eeb3461c25d455140d30e7a779e1480ddd2773fdec29f67b8d053ae4b2cdcc6f"
+      "sha256": "694eeacf026c3c6abe6363625d1188fa59c3b1d194713acd8754babeeaa0dfad"
     },
     {
       "path": "schemas/dev_tool_request.v1.schema.json",

--- a/src/lib/dev/generated.ts
+++ b/src/lib/dev/generated.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-// Generated from full-chaos/dev-health-ops b469dd35caa46c347b120517bb4c779dc129cf91. Do not edit.
+// Generated from full-chaos/dev-health-ops 4838e026e08d20bd62090a85218add2761733edd. Do not edit.
 export namespace DevAnswerContract {
     export type AnswerId = string;
     export type AsOf = string;
@@ -1136,6 +1136,10 @@ export namespace DevAnswerContract {
     export type ConversationId = string;
     export type AsOf1 = string;
     export type AvailableSourceCount = number;
+    /**
+     * @maxItems 25
+     */
+    export type DegradedRequiredSources = string[];
     export type RequiredSourceCount = number;
     /**
      * @maxItems 25
@@ -2509,6 +2513,7 @@ export namespace DevAnswerContract {
     export interface DevCoverage {
         as_of: AsOf1;
         available_source_count: AvailableSourceCount;
+        degraded_required_sources?: DegradedRequiredSources;
         required_source_count: RequiredSourceCount;
         stale_required_sources?: StaleRequiredSources;
         unavailable_required_sources?: UnavailableRequiredSources;
@@ -4953,6 +4958,10 @@ export namespace DevConversationTranscriptContract {
     export type ConversationId1 = string;
     export type AsOf1 = string;
     export type AvailableSourceCount = number;
+    /**
+     * @maxItems 25
+     */
+    export type DegradedRequiredSources = string[];
     export type RequiredSourceCount = number;
     /**
      * @maxItems 25
@@ -6377,6 +6386,7 @@ export namespace DevConversationTranscriptContract {
     export interface DevCoverage {
         as_of: AsOf1;
         available_source_count: AvailableSourceCount;
+        degraded_required_sources?: DegradedRequiredSources;
         required_source_count: RequiredSourceCount;
         stale_required_sources?: StaleRequiredSources;
         unavailable_required_sources?: UnavailableRequiredSources;
@@ -13781,6 +13791,10 @@ export namespace DevStreamEventContract {
     export type ConversationId = string;
     export type AsOf1 = string;
     export type AvailableSourceCount = number;
+    /**
+     * @maxItems 25
+     */
+    export type DegradedRequiredSources = string[];
     export type RequiredSourceCount = number;
     /**
      * @maxItems 25
@@ -15232,6 +15246,7 @@ export namespace DevStreamEventContract {
     export interface DevCoverage {
         as_of: AsOf1;
         available_source_count: AvailableSourceCount;
+        degraded_required_sources?: DegradedRequiredSources;
         required_source_count: RequiredSourceCount;
         stale_required_sources?: StaleRequiredSources;
         unavailable_required_sources?: UnavailableRequiredSources;


### PR DESCRIPTION
Mechanical pin bump. Re-mints the checked-in Ask Dev artifacts from
`full-chaos/dev-health-ops` `4838e026e08d20bd62090a85218add2761733edd`
(previous pin: `b469dd35caa46c347b120517bb4c779dc129cf91`).

## What drifted

**Ask Dev contracts — YES.** Regenerated with
`pnpm ask-dev:contracts:generate --source <clean ops worktree at the new SHA>`.
Nothing under `src/lib/dev/contracts/` or `src/lib/dev/generated.ts` was
hand-edited.

The delta across the two pins is a single additive optional field,
`dev_coverage.degraded_required_sources` (array of source ids, `maxItems: 25`),
in `dev_answer.v1`, `dev_conversation_transcript.v1` and `dev_stream_event.v1`,
plus the three `manifest.json` digests that cover them. Compatibility stays
`additive-within-v1`, so no client code has to change — the generated
`DevCoverage` interfaces just gain an optional property.

**GraphQL schema — NO.** `python -m dev_health_ops.api.graphql.export_schema`
run from ops `main` is byte-identical to `src/lib/graphql/schema.graphql`, so
that file is untouched.

## Pin references updated in lockstep

`scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs` asserts the script
and the workflow agree, so all three move together:

- `scripts/ask-dev-contracts.mjs` — `SOURCE_COMMIT`
- `.github/workflows/tests.yml` — the `dev-health-ops` checkout `ref`
- `src/lib/dev/__tests__/contracts.test.ts` — the hard-coded expectation

## Gates

Deterministic gates, all green:

| Gate | Result |
| --- | --- |
| `pnpm codegen:check` | pass |
| `pnpm ask-dev:contracts:check --source <new pin>` | pass — "Ask Dev contracts are current." |
| `pnpm lint` | pass |
| `pnpm typecheck` (`tsc --noEmit`) | pass |
| `pnpm exec vitest run` | pass — 409 files, 3585 passed / 8 skipped |
| `pnpm format` (prettier write) | no change from this branch |

`prettier --check .` flags `src/app/site.webmanifest`, which is already
unformatted on `main` and is not touched here. CI's format lane is
`format:check:changed`, so it is unaffected.

**E2E: inconclusive on the machine that ran it, not a clean pass.** The default
Playwright suite touches these schemas via `tests/fixtures/askDevContracts.ts`,
so it was run — but the host was heavily loaded (load average 47-62) and the
suite is non-deterministic under that contention:

- full suite on this branch: 286 tests, 24 failed
- re-run of the 17 failing spec files on **the same commit**: 22 failed — and
  the two runs disagree on **32** tests (17 that failed then passed, 15 that
  passed then failed). Only 7 failures were stable across both.
- the same 17 spec files on **unmodified `origin/main`**: 13 failed / 90 passed

So `main` fails at a comparable rate with none of this change applied, and two
runs of identical code do not agree with each other. The failures are spread
across surfaces this change cannot reach (`chord-chart`, `home-flow`,
`people`, `filter-propagation`, `admin-customer-push`) and present as
`ECONNRESET` / slow-GraphQL timeouts. There is no evidence of a regression from
this change, but this run does not positively prove its absence — CI on a
quiet runner is the real signal.