### PR TITLE
fix(deps): resolve high-severity prod audit advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri: 3.1.4
+  fast-uri: '>=3.1.5 <4'
   sharp: 0.35.3
   postcss: '>=8.5.18'
-  minimatch@10>brace-expansion: '>=5.0.8'
+  minimatch@10>brace-expansion: '>=5.0.9'
 
 importers:
 
@@ -2465,8 +2465,8 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3110,8 +3110,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -7668,7 +7668,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7835,7 +7835,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8653,7 +8653,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -9888,7 +9888,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,9 @@ allowBuilds:
     unrs-resolver: true
 
 overrides:
-    fast-uri: 3.1.4
+    # fast-uri: held inside major 3 (ajv 8 declares ^3.0.1; 4.x is a breaking major).
+    # Floor raised past the host-confusion advisory GHSA-7p8r-x3mc-p8w7 (fixed in 3.1.5).
+    fast-uri: ">=3.1.5 <4"
     sharp: 0.35.3
     # Security floors for advisories reachable only transitively (CHAOS-3096 audit gate).
     # postcss: next pins 8.4.31 exactly, so GHSA-6g55-p6wh-862q / GHSA-r28c-9q8g-f849
@@ -17,4 +19,5 @@ overrides:
     # minimatch; 10.68.0 is the newest release in the declared ^10 range (GHSA-mh99-v99m-4gvg).
     # Scoped to minimatch@10 deliberately: an unscoped floor also hits minimatch@3, whose
     # v1 brace-expansion API differs, breaking ESLint with "expand is not a function".
-    minimatch@10>brace-expansion: ">=5.0.8"
+    # Floor raised to 5.0.9 for GHSA-rgw5-rvv9-x895 (unbounded intermediate arrays).
+    minimatch@10>brace-expansion: ">=5.0.9"


### PR DESCRIPTION
`pnpm audit --audit-level=high --prod` fails on `main`, blocking the audit gate. This clears it with the narrowest possible change.

## Advisories → fix

Both advisories are **transitive only** — neither package is a direct dependency, so there is no direct bump that clears them. Overrides in this repo live in `pnpm-workspace.yaml`, not `package.json`.

| # | Package | Advisory | Vulnerable | Patched | Reached via | Fix |
|---|---------|----------|-----------|---------|-------------|-----|
| 1 | `fast-uri` 3.1.4 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — host confusion via backslash authority introducer (high) | `>=3.0.0 <3.1.5` | `3.1.5` | 14 paths, all `@sentry/nextjs > @sentry/webpack-plugin > @sentry/bundler-plugins > webpack > schema-utils > ajv > fast-uri` (also via `ajv-formats` / `ajv-keywords` → `ajv`) | override `fast-uri: 3.1.4` → `">=3.1.5 <4"` |
| 2 | `brace-expansion` 5.0.8 | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation (high) | `>=4.0.0 <5.0.9` | `5.0.9` | `@sentry/nextjs > @sentry/bundler-plugin-core > glob > minimatch > brace-expansion` and `@sentry/nextjs > @sentry/webpack-plugin > @sentry/bundler-plugins > glob > minimatch > brace-expansion` | override `minimatch@10>brace-expansion: ">=5.0.8"` → `">=5.0.9"` |

No criticals. Nothing ignored or allowlisted.

## Why these exact edits

- **`fast-uri` was pinned to exactly `3.1.4`** by an existing override (added in #800). That pin — not a stale lockfile — was what held the vulnerable version in place; `pnpm update` was a no-op until it was raised. The new range stays **inside major 3** deliberately: `ajv@8.20.0` declares `^3.0.1`, and `fast-uri` 4.x is a breaking major, so bumping across it was not on the table.
- **`brace-expansion` stays scoped to `minimatch@10`**, per the reason already documented in-repo: an unscoped floor also hits `minimatch@3`, whose v1 `brace-expansion` API differs and breaks ESLint with `expand is not a function`.
- **No `package.json` change.** Both patched versions already satisfy the declared consumer ranges (`ajv` wants `^3.0.1`; `minimatch@10` wants `^5.0.5`).

## Diff surface

Two files. The lockfile moves **exactly two packages** — no unrelated churn, no importer or settings drift:

- `fast-uri` 3.1.4 → 3.1.5
- `brace-expansion` 5.0.8 → 5.0.9

`brace-expansion@1.1.16` is deliberately left alone — it is confined to the dev-only ESLint path and is not in the `--prod` tree.

## Verification

- `pnpm audit --audit-level=high --prod` → **`No known vulnerabilities found`, exit 0** (same command exits 1 on a fresh `origin/main` worktree, confirming the reproduction).
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm exec vitest run` ✅ — 409 files, 3585 passed, 8 skipped
- `prettier --write` clean on touched files

**Codex adversarial review: SHIP / approve, no material findings.** It independently confirmed the PROD graph resolves `fast-uri` only to 3.1.5 and `brace-expansion` only to 5.0.9 (no override masking a still-vulnerable path), that `brace-expansion` 1.1.x remains only on the dev-only ESLint path, and that `fast-uri` 3.1.5 satisfies ajv 8.20.0's `^3.0.1` with its only behavior change being stricter rejection of malformed authority inputs — it compiled all 23 runtime ACR schemas successfully against 3.1.5. It also noted frozen-lockfile build paths prevent the open `>=3.1.5 <4` range from silently pulling a future 3.x.

### E2E: inconclusive locally — CI arbitrates

Honest status: the local Playwright run was **252 passed / 32 failed / 2 skipped**, and I am **not** claiming those 32 are pre-existing.

The failure signature is infrastructure, not assertions: 52 × `ECONNRESET` / `Error: aborted`, 17 × `Test timeout of 30000ms exceeded`, 5 × `page.goto` timeouts, scattered across unrelated specs. The host was running at **load average ~110 on 16 cores** (~7× oversubscribed). An `origin/main` baseline run on the same machine did substantially *worse* — 167 failed / 117 passed in 25.4m vs. this branch's 6.7m — and specs that passed here in 2.4s were failing at 36s minutes later on unchanged code. Attempts to isolate the residual specs were cut short by machine pressure.

Neither changed package sits on the Next.js request path: `fast-uri` is ajv's URI parser for schema `$ref`s, and `brace-expansion` is `glob`'s dependency inside the Sentry **build** plugin. Combined with a fully green unit suite and the Codex schema-compilation check, there is no plausible mechanism by which these two patch bumps produce browser-navigation timeouts — but local e2e cannot settle it under this load, so **CI is the arbiter**.

TEST-WAIVER: lockfile/override-only security bump; no `src/` change, so no test change applies.
SCREENSHOT-WAIVER: no rendered-UI change — dependency resolution only.
