### PR TITLE
fix(web): CHAOS-3339 provider_contract_violation copy + CHAOS-3341 deflake acr-contract-artifacts fixture/clock races

### DIFF
--- a/scripts/__tests__/acr-contract-artifacts.test.mjs
+++ b/scripts/__tests__/acr-contract-artifacts.test.mjs
@@ -11,6 +11,7 @@ import {
     currentArtifacts,
     writeArtifacts,
 } from "../acr-contract-artifacts.mjs";
+import { isNotLockState } from "./acr-fixture-copy.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const SCRIPT = path.join(ROOT, "scripts/sync-acr-contracts.mjs");
@@ -65,8 +66,7 @@ function createTemporaryProject() {
     const artifactRoot = path.join(root, "src/lib/acr/contracts");
     const script = path.join(root, "scripts/sync-acr-contracts.mjs");
     fs.mkdirSync(path.dirname(artifactRoot), { recursive: true });
-    fs.cpSync(ARTIFACT_ROOT, artifactRoot, { recursive: true });
-    fs.rmSync(path.join(artifactRoot, ".acr-contract-sync.lock"), { force: true });
+    fs.cpSync(ARTIFACT_ROOT, artifactRoot, { recursive: true, filter: isNotLockState });
     fs.mkdirSync(path.dirname(script), { recursive: true });
     fs.copyFileSync(SCRIPT, script);
     fs.copyFileSync(
@@ -204,17 +204,23 @@ describe("ACR contract artifact filesystem boundaries", () => {
         expect(fs.readFileSync(lockPath, "utf8")).toBe("replacement\n");
     });
 
+    // The bound is injected, not mocked (CHAOS-3341). This used to script the
+    // process-wide clock with `vi.spyOn(Date, "now").mockReturnValueOnce(0)`,
+    // where any other reader between the spy and acquireArtifactLock's first
+    // reading consumes the once-value and pushes the deadline permanently out
+    // of reach — and since the wait loop is synchronous, the resulting hang
+    // cannot be cut short by a test timeout. A real 50ms bound against the
+    // real clock cannot be stolen, still crosses the deadline through the
+    // genuine wait-and-recheck loop, and leaves no global to restore.
     it("bounds a live-owner wait without leaking a failed contender lock file", () => {
         const project = createTemporaryProject();
         const release = acquireArtifactLock(project.artifactRoot);
-        const now = vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValue(30_000);
 
         try {
-            expect(() => acquireArtifactLock(project.artifactRoot)).toThrow(
+            expect(() => acquireArtifactLock(project.artifactRoot, { timeoutMillis: 50 })).toThrow(
                 "artifact generation lock timed out",
             );
         } finally {
-            now.mockRestore();
             release();
         }
 
@@ -224,6 +230,38 @@ describe("ACR contract artifact filesystem boundaries", () => {
                 (entry) => entry.startsWith(".acr-contract-sync.lock.") && entry.endsWith(".tmp"),
             );
         expect(leftovers).toEqual([]);
+    });
+
+    // CHAOS-3341 regression guard, and the deterministic form of the flake
+    // that motivated it. The committed artifact root is a live lock directory
+    // during a unit run — sync-acr-contracts.test.mjs shells the real sync
+    // script at it from a parallel worker — so an isolated fixture must never
+    // inherit whatever lock state is in flight when it is copied. Planting the
+    // exact contender temp file that used to be copied in makes that failure
+    // reproducible on demand: without the copy filter the fixture below
+    // contains it, and the leftover assertion in the timeout test above then
+    // fails on a file no test ever wrote.
+    //
+    // The plant goes into the real artifact root, so cleanup is armed BEFORE
+    // the write: a write that fails partway (ENOSPC, EIO) still leaves the
+    // file, and an uncleaned lock-family file in a tracked directory dirties
+    // the checkout — which the new copy filter would then hide from every
+    // later fixture assertion.
+    it("keeps a planted contender lock out of an isolated fixture copy", () => {
+        const planted = path.join(ARTIFACT_ROOT, `.acr-contract-sync.lock.${randomUUID()}.tmp`);
+
+        try {
+            fs.writeFileSync(planted, "contender\n", { mode: 0o600 });
+            const project = createTemporaryProject();
+
+            expect(
+                fs
+                    .readdirSync(project.artifactRoot)
+                    .filter((entry) => entry.startsWith(".acr-contract-sync.lock")),
+            ).toEqual([]);
+        } finally {
+            fs.rmSync(planted, { force: true });
+        }
     });
 
     it("recovers a lock only after proving its owner process is dead", () => {

--- a/scripts/__tests__/acr-fixture-copy.mjs
+++ b/scripts/__tests__/acr-fixture-copy.mjs
@@ -1,0 +1,24 @@
+import path from "node:path";
+
+/**
+ * `fs.cpSync` filter that keeps an isolated fixture free of another process's
+ * in-flight lock state (CHAOS-3341).
+ *
+ * The committed `src/lib/acr/contracts` is a live lock directory during a unit
+ * run: `sync-acr-contracts.test.mjs` shells out to the real
+ * `scripts/sync-acr-contracts.mjs` against it, and that script takes its lease
+ * by writing `.acr-contract-sync.lock.<uuid>.tmp` into the same directory and
+ * hard-linking it onto `.acr-contract-sync.lock`. Vitest runs the two script
+ * test files in parallel workers, so a fixture copy taken during that window
+ * captured a contender temp file that no test in the copying file ever
+ * created — and `acr-contract-artifacts.test.mjs` then failed asserting the
+ * lock family had left nothing behind. Deleting `.acr-contract-sync.lock`
+ * after the copy, the previous defence, sees neither the `.tmp` nor the
+ * `.recovery` members of that family.
+ *
+ * Filtering during the copy rather than cleaning up after it also avoids
+ * duplicating a half-written lock file into the fixture.
+ */
+export function isNotLockState(source) {
+    return !path.basename(source).startsWith(".acr-contract-sync.lock");
+}

--- a/scripts/__tests__/sync-acr-contracts.test.mjs
+++ b/scripts/__tests__/sync-acr-contracts.test.mjs
@@ -5,6 +5,8 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { isNotLockState } from "./acr-fixture-copy.mjs";
+
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const SCRIPT = path.join(ROOT, "scripts/sync-acr-contracts.mjs");
 const SOURCE = process.env.ACR_ROOT;
@@ -47,8 +49,7 @@ function createTemporaryProject() {
     const artifactRoot = path.join(root, "src/lib/acr/contracts");
     const script = path.join(root, "scripts/sync-acr-contracts.mjs");
 
-    fs.cpSync(ARTIFACT_ROOT, artifactRoot, { recursive: true });
-    fs.rmSync(path.join(artifactRoot, ".acr-contract-sync.lock"), { force: true });
+    fs.cpSync(ARTIFACT_ROOT, artifactRoot, { recursive: true, filter: isNotLockState });
     fs.mkdirSync(path.dirname(script), { recursive: true });
     fs.copyFileSync(SCRIPT, script);
     fs.copyFileSync(

--- a/scripts/acr-contract-filesystem.mjs
+++ b/scripts/acr-contract-filesystem.mjs
@@ -423,11 +423,22 @@ function recoverDeadLock(lockPath, recoveryPath, root) {
     }
 }
 
-export function acquireArtifactLock(artifactRoot) {
+/**
+ * `timeoutMillis` exists so a caller can bound its own wait against the REAL
+ * clock (CHAOS-3341). The test that proves this wait is bounded used to script
+ * `Date.now` with `vi.spyOn(Date, "now").mockReturnValueOnce(0)` instead —
+ * scripting a process-wide global, where anything else reading the clock
+ * between the spy and the first read below silently consumes the once-value.
+ * Losing it puts `deadline` a full timeout beyond every later reading, so this
+ * loop never terminates; and because the loop is synchronous, no test timeout
+ * can interrupt it — the whole file hangs. Injecting the bound removes the
+ * global mutation rather than re-scoping it.
+ */
+export function acquireArtifactLock(artifactRoot, { timeoutMillis = LOCK_TIMEOUT_MILLIS } = {}) {
     const { root } = artifactRootDirectories(artifactRoot);
     const lockPath = path.join(root, ".acr-contract-sync.lock");
     const recoveryPath = `${lockPath}.recovery`;
-    const deadline = Date.now() + LOCK_TIMEOUT_MILLIS;
+    const deadline = Date.now() + timeoutMillis;
     while (true) {
         if (recoveryInProgress(recoveryPath, root)) {
             if (Date.now() >= deadline) throw new Error("artifact generation lock timed out");

--- a/src/components/ask-dev/AskDevConversation.test.tsx
+++ b/src/components/ask-dev/AskDevConversation.test.tsx
@@ -140,30 +140,42 @@ describe("Ask Dev error guidance", () => {
         askDevState.stream = { ...IDLE_STREAM };
     });
 
-    function renderWithError(code: string) {
+    function renderWithError(code: string, retryable = true) {
         askDevState.stream = {
             ...IDLE_STREAM,
             phase: "failed",
-            error: { code, safe_message: "Ask Dev stopped.", retryable: true },
+            error: { code, safe_message: "Ask Dev stopped.", retryable },
         };
         return render(<AskDevConversation />);
     }
 
-    // CHAOS-3339. The guidance names the provider as the faulting side and
-    // says a retry is worth trying — the opposite of the allowance guidance,
-    // which exists to tell you a retry cannot help.
-    it("explains a provider contract violation as a provider-side fault", () => {
-        renderWithError("provider_contract_violation");
+    // CHAOS-3339. `retryable: false` is what ops emits today: the sole raise
+    // site (openai_compatible.py) omits `retryable`, taking
+    // AgentProviderError's `retryable=False` default, and the orchestrator
+    // passes that straight through. An earlier revision of this copy claimed
+    // "retrying may help" regardless; this asserts against that by name.
+    it("explains a provider contract violation as a provider-side fault a retry cannot fix", () => {
+        renderWithError("provider_contract_violation", false);
 
         expect(
             screen.getByText(/provider returned a response that violated its contract/iu),
         ).toBeVisible();
-        expect(screen.getByText(/retrying may help/iu)).toBeVisible();
+        expect(screen.getByText(/provider-side fault/iu)).toBeVisible();
+        expect(screen.getByText(/Retrying will not help/iu)).toBeVisible();
+        expect(screen.queryByText(/retrying may help/iu)).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: /retry/iu })).not.toBeInTheDocument();
     });
 
-    it("keeps the retry affordance for a provider contract violation", () => {
-        renderWithError("provider_contract_violation");
+    // The version-skew case, and the reason the retry sentence is read off
+    // `error.retryable` instead of hard-coded: web pins ops' contracts and
+    // re-pins later, so an ops that decides this fault is recoverable must not
+    // meet a web build that insists otherwise and hides the only retry button.
+    // The fault attribution still holds — only the retry advice moves.
+    it("drops the retry advice, not the fault attribution, when ops calls the violation retryable", () => {
+        renderWithError("provider_contract_violation", true);
 
+        expect(screen.getByText(/provider-side fault/iu)).toBeVisible();
+        expect(screen.queryByText(/Retrying will not help/iu)).not.toBeInTheDocument();
         expect(screen.getByRole("button", { name: /retry/iu })).toBeVisible();
     });
 
@@ -176,11 +188,16 @@ describe("Ask Dev error guidance", () => {
         expect(screen.queryByRole("button", { name: /retry/iu })).not.toBeInTheDocument();
     });
 
-    it("shows no tailored guidance for an unrelated error code", () => {
+    // Also the guard on the allowance override: it is the one arm allowed to
+    // suppress the retry button against a retryable error, so an override
+    // predicate that widened past the allowance codes would silently strip the
+    // affordance from every failure. This is the case that fails if it does.
+    it("shows no tailored guidance for an unrelated error code, and keeps its retry button", () => {
         renderWithError("internal_error");
 
         expect(screen.queryByText(/violated its contract/iu)).not.toBeInTheDocument();
         expect(screen.queryByText(/Retrying immediately will not help/iu)).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /retry/iu })).toBeVisible();
     });
 
     it("never renders the raw error code", () => {

--- a/src/components/ask-dev/AskDevConversation.tsx
+++ b/src/components/ask-dev/AskDevConversation.tsx
@@ -38,16 +38,38 @@ function platformAllowanceGuidance(
 
 /**
  * CHAOS-3339. Kept separate from `platformAllowanceGuidance` because the two
- * pull opposite ways on the retry affordance: an exhausted allowance means
- * retrying cannot help (so that guidance replaces the retry button), while a
- * provider contract violation is transient and worth retrying. Provisional
- * copy — product may refine the wording.
+ * treat `retryable` oppositely — see the call site.
+ *
+ * Naming the provider as the faulting side is safe to state unconditionally.
+ * The retry sentence is not: it is READ OFF `error.retryable` rather than
+ * assumed, so this copy cannot contradict the retry button beside it, which is
+ * gated on the same field. That matters because web pins ops' contracts and
+ * re-pins later, so the two deploy independently: hard-coding "retrying cannot
+ * help" here would start lying the moment ops decided this fault was
+ * recoverable, and would take the only retry affordance with it.
+ *
+ * Today ops emits it non-retryable, which is why the futile wording is the one
+ * users will actually see. The sole raise site (the
+ * `_SequentialToolContractViolation` handler in
+ * `llm/agent/openai_compatible.py`) constructs `AgentProviderError` without a
+ * `retryable` argument, taking the class default `retryable: bool = False`
+ * (`llm/agent/errors.py`), and `DevOrchestrator._provider_error`
+ * (`api/dev/orchestrator.py`) projects it straight through as
+ * `retryable=exc.retryable`. Ops treats it as a standing capability defect
+ * elsewhere too: its remediation asks an operator to confirm the endpoint
+ * honours `parallel_tool_calls=false` (`api/dev/contracts.py`), and readiness
+ * maps the code to the `unsupported_model` role state
+ * (`llm/agent/readiness.py`). An earlier revision of this copy said "retrying
+ * may help", which contradicted all of that.
  */
 function providerContractGuidance(
     error: ReturnType<typeof useAskDev>["stream"]["error"],
 ): string | null {
     if (error?.code !== "provider_contract_violation") return null;
-    return "The AI provider returned a response that violated its contract. This is a provider-side fault — retrying may help.";
+    const fault =
+        "The AI provider returned a response that violated its contract. This is a provider-side fault, not a problem with your question.";
+    if (error.retryable) return fault;
+    return `${fault} Retrying will not help until an administrator corrects the configured model or endpoint.`;
 }
 
 /**
@@ -121,9 +143,14 @@ export function AskDevConversation({
     const router = useRouter();
     const searchParams = useSearchParams();
     const filters = useMemo(() => decodeFilter(searchParams.get("f")), [searchParams]);
+    // Only the allowance case overrides the server's `retryable` and replaces
+    // the retry button: an exhausted monthly platform allowance is a
+    // product-side fact that ops' per-error `retryable` does not model (it
+    // reports the provider call itself as retryable). Provider-contract
+    // guidance instead derives its retry sentence from `error.retryable`, so
+    // it never needs to override the button to stay consistent with it — see
+    // providerContractGuidance.
     const allowanceGuidance = platformAllowanceGuidance(stream.error);
-    // Only the allowance case replaces the retry button; see
-    // providerContractGuidance for why the two are not one function.
     const errorGuidance = allowanceGuidance ?? providerContractGuidance(stream.error);
     // "Powered by Context Fabric" is the sanctioned relationship framing
     // (CHAOS-3215): Ask Dev is the customer interaction layer, Context


### PR DESCRIPTION
## CHAOS-3339 — the shipped copy was untruthful, not missing

Tailored `provider_contract_violation` copy already landed on main (#834). It said:

> This is a provider-side fault — retrying may help.

Ops says the opposite. The sole raise site, the `_SequentialToolContractViolation` handler in `llm/agent/openai_compatible.py`, constructs `AgentProviderError` **without** a `retryable` argument, so the class default `retryable: bool = False` (`llm/agent/errors.py`) applies, and `DevOrchestrator._provider_error` (`api/dev/orchestrator.py`) projects it straight through as `retryable=exc.retryable`. Ops treats it as a standing capability defect everywhere else too: its remediation asks an operator to confirm the endpoint honours `parallel_tool_calls=false` (`api/dev/contracts.py`), and readiness maps the code to the `unsupported_model` role state (`llm/agent/readiness.py`).

The fault attribution is now stated unconditionally, but the **retry sentence is read off `error.retryable`** rather than hard-coded. Web pins ops' contracts and re-pins later, so the two deploy independently — a hard-coded "retrying cannot help" would start lying the moment ops decided this fault was recoverable, and would take the only retry affordance with it. Both the sentence and the button now derive from the same field, so they cannot contradict each other. Only the allowance guidance still overrides `retryable`, which is deliberate: a monthly platform allowance is a product-side fact ops' per-error `retryable` does not model.

## CHAOS-3341 — two races; the one that was failing was not the clock

**Observed** (2/16 full unit runs; 0/20 running the file alone): the committed `src/lib/acr/contracts` is a *live lock directory* during a unit run. `sync-acr-contracts.test.mjs` shells the real sync script at the real artifact root, and taking the lease writes `.acr-contract-sync.lock.<uuid>.tmp` there before hard-linking it onto `.acr-contract-sync.lock`. Vitest runs the two script test files in parallel workers, so `createTemporaryProject`'s `cpSync` of that directory could copy a contender temp file into its isolated fixture; the fixture setup deleted only `.acr-contract-sync.lock`, never the `.tmp`. "bounds a live-owner wait without leaking a failed contender lock file" then failed on a file no test in that file had written. Directly confirmed by polling the real artifact root while the sibling file ran — `.acr-contract-sync.lock` and two `.tmp` members appeared. Fixed by filtering the whole lock family out during the copy, in both fixture builders, plus a new test that plants that exact temp file so the failure is reproducible on demand.

**Latent** (the originally reported cause, real but not what was failing): the same test scripted the process-wide clock with `vi.spyOn(Date, "now").mockReturnValueOnce(0)`. Anything else reading the clock between the spy and `acquireArtifactLock`'s first reading consumes the once-value, putting the deadline a full timeout beyond every later reading — and since the wait loop is synchronous, the resulting hang cannot be cut short by a test timeout. `acquireArtifactLock` now takes an injectable `timeoutMillis` (default unchanged at 30s) and the test bounds its contender against the real clock, so there is no global to steal from or restore.

## Verification

Ran and passing:

- Scoped `vitest run` on all touched test files — 25 passed / 6 skipped (`ACR_ROOT` unset skips the source-clone cases).
- `pnpm lint`, `pnpm typecheck`, `prettier --check` on touched files.
- Flake reproduced on unmodified main before the fix: **2/16** full unit runs, **0/20** running the file alone — the isolation gap is itself evidence for the cross-file mechanism.
- Each new guard was mutation-checked by reverting its fix and confirming the guard, and only that guard, fails: drop the `cpSync` filter → planted-lock test fails; ignore `error.retryable` in the copy → version-skew test fails; revert to "retrying may help" → non-retryable test fails; gate the retry button on `retryable` alone → both suppression tests fail.
- One Codex adversarial review round; both findings fixed (the `retryable` override, and arming the planted-lock cleanup before the write rather than after).

Not completed, machine under memory/CPU pressure with processes being killed:

- **The post-fix deflake loop is not a valid measurement.** 25 scoped runs after the final edits produced timeouts across unrelated files (CI-harness `format`/`quality` jobs, E2E shard config, process guardian) at 5–20s where they normally take under a second. The target assertion did not fail in any of those 25 runs, but load that severe makes the run worthless as evidence either way. The brief asked for 0 failures in ≥20 clean runs; that has **not** been demonstrated.
- Full `pnpm exec vitest run` was green 14/16 before the fix (the 2 failures being this flake) but was not re-run to completion after the final Codex-driven edits.
- No Codex re-review after those edits.
- e2e not run: no e2e spec or mock scenario reads this copy or these scripts (`grep` over `tests/` finds the strings only in the component and its unit test).

CI arbitrates.

SCREENSHOT-WAIVER: copy-only string change inside the existing Ask Dev failure alert; no layout, component, or style change, and the surface is only reachable from a provider-side contract failure the mock backend cannot produce.