### PR TITLE
ci: cut two runner jobs per PR (PagerDuty matrix out of CI, Context Fabric folded into onboarding)

### DIFF
--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -208,12 +208,6 @@ jobs:
             - name: Run E2E tests
               run: bash ci/run_tests.sh e2e
 
-            - name: Run PagerDuty final QA matrix
-              run: >-
-                  PLAYWRIGHT_REPORT_DIR=test-results/playwright-html/pagerduty-final-qa
-                  PLAYWRIGHT_RESULTS_DIR=test-results/playwright/pagerduty-final-qa
-                  bash ci/run_tests.sh pagerduty-final-qa
-
             - name: Upload Playwright report
               if: always()
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,7 +189,11 @@ jobs:
                   retention-days: 14
 
     e2e-onboarding:
-        name: E2E tests (onboarding)
+        # Context Fabric runs sequentially in this job rather than as its own
+        # runner: GitHub's concurrency limits make every extra parallel job a
+        # queue liability, and the two suites are isolated by run_tests.sh
+        # regardless of which runner hosts them.
+        name: E2E tests (onboarding + Context Fabric)
         needs: [changes]
         if: needs.changes.outputs.e2e == 'true'
         runs-on: ubuntu-latest
@@ -202,42 +206,12 @@ jobs:
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
             - run: bash ci/run_tests.sh e2e-onboarding
-            - name: Upload Playwright report
-              if: always()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-              with:
-                  name: playwright-report-onboarding-${{ github.run_id }}-${{ github.run_attempt }}
-                  path: test-results/playwright-html/
-                  if-no-files-found: warn
-                  retention-days: 14
-            - name: Upload Playwright raw results and JUnit
-              if: always()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-              with:
-                  name: playwright-results-onboarding-${{ github.run_id }}-${{ github.run_attempt }}
-                  path: test-results/playwright/
-                  if-no-files-found: warn
-                  retention-days: 14
-
-    e2e-context-fabric:
-        name: E2E tests (Context Fabric)
-        needs: [changes]
-        if: needs.changes.outputs.e2e == 'true'
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
-              with:
-                  node-version: 22
-                  cache: pnpm
-            - run: pnpm install --frozen-lockfile
             - run: bash ci/run_tests.sh e2e-context-fabric
             - name: Upload Playwright report
               if: always()
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
               with:
-                  name: playwright-report-context-fabric-${{ github.run_id }}-${{ github.run_attempt }}
+                  name: playwright-report-onboarding-context-fabric-${{ github.run_id }}-${{ github.run_attempt }}
                   path: test-results/playwright-html/
                   if-no-files-found: warn
                   retention-days: 14
@@ -245,41 +219,11 @@ jobs:
               if: always()
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
               with:
-                  name: playwright-results-context-fabric-${{ github.run_id }}-${{ github.run_attempt }}
+                  name: playwright-results-onboarding-context-fabric-${{ github.run_id }}-${{ github.run_attempt }}
                   path: test-results/playwright/
                   if-no-files-found: warn
                   retention-days: 14
 
-    pagerduty-final-qa:
-        name: PagerDuty final QA matrix
-        needs: [changes]
-        if: needs.changes.outputs.code == 'true'
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
-              with:
-                  node-version: 22
-                  cache: pnpm
-            - run: pnpm install --frozen-lockfile
-            - run: bash ci/run_tests.sh pagerduty-final-qa
-            - name: Upload Playwright report
-              if: always()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-              with:
-                  name: playwright-report-pagerduty-final-qa-${{ github.run_id }}-${{ github.run_attempt }}
-                  path: test-results/playwright-html/
-                  if-no-files-found: warn
-                  retention-days: 14
-            - name: Upload Playwright raw results and JUnit
-              if: always()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-              with:
-                  name: playwright-results-pagerduty-final-qa-${{ github.run_id }}-${{ github.run_attempt }}
-                  path: test-results/playwright/
-                  if-no-files-found: warn
-                  retention-days: 14
     design-lint:
         name: Design lint advisory
         needs: [changes]
@@ -299,7 +243,7 @@ jobs:
 
     test:
         name: test
-        needs: [changes, format, quality, build, unit, integration, e2e-default, e2e-onboarding, e2e-context-fabric, pagerduty-final-qa]
+        needs: [changes, format, quality, build, unit, integration, e2e-default, e2e-onboarding]
         if: always()
         runs-on: ubuntu-latest
         steps:
@@ -320,18 +264,12 @@ jobs:
             - name: Check E2E test stages
               if: needs.changes.result == 'success' && needs.changes.outputs.e2e == 'true'
               run: |
-                  if [[ "${{ needs.e2e-default.result }}" != 'success' || "${{ needs.e2e-onboarding.result }}" != 'success' || "${{ needs.e2e-context-fabric.result }}" != 'success' ]]; then
+                  if [[ "${{ needs.e2e-default.result }}" != 'success' || "${{ needs.e2e-onboarding.result }}" != 'success' ]]; then
                     exit 1
                   fi
             - name: Check E2E test stages were skipped
               if: needs.changes.result == 'success' && needs.changes.outputs.code == 'true' && needs.changes.outputs.e2e != 'true'
               run: |
-                  if [[ "${{ needs.e2e-default.result }}" != 'skipped' || "${{ needs.e2e-onboarding.result }}" != 'skipped' || "${{ needs.e2e-context-fabric.result }}" != 'skipped' ]]; then
-                    exit 1
-                  fi
-            - name: Check PagerDuty final QA matrix
-              if: needs.changes.result == 'success' && needs.changes.outputs.code == 'true'
-              run: |
-                  if [[ "${{ needs.pagerduty-final-qa.result }}" != 'success' ]]; then
+                  if [[ "${{ needs.e2e-default.result }}" != 'skipped' || "${{ needs.e2e-onboarding.result }}" != 'skipped' ]]; then
                     exit 1
                   fi

--- a/scripts/__tests__/chaos-3017-ci-contract-helpers.mjs
+++ b/scripts/__tests__/chaos-3017-ci-contract-helpers.mjs
@@ -10,8 +10,7 @@ export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "
 export const NON_SUCCESS_RESULTS = ["failure", "cancelled", "skipped"];
 export const REQUIRED_STAGE_GROUPS = [
     ["general", "Check general test stages", ["format", "quality", "build", "unit", "integration"]],
-    ["E2E", "Check E2E test stages", ["e2e-default", "e2e-onboarding", "e2e-context-fabric"]],
-    ["PagerDuty", "Check PagerDuty final QA matrix", ["pagerduty-final-qa"]],
+    ["E2E", "Check E2E test stages", ["e2e-default", "e2e-onboarding"]],
 ];
 const execFileAsync = promisify(execFile);
 const PLAYWRIGHT_CLI = path.join(ROOT, "node_modules/@playwright/test/cli.js");

--- a/scripts/__tests__/chaos-3017-ci-contract.test.mjs
+++ b/scripts/__tests__/chaos-3017-ci-contract.test.mjs
@@ -36,7 +36,7 @@ describe("CHAOS-3017 CI contracts", () => {
         const aggregator = job(contents(TESTS_WORKFLOW), "test");
 
         expect(aggregator).toMatch(
-            /needs: \[changes, format, quality, build, unit, integration, e2e-default, e2e-onboarding, e2e-context-fabric, pagerduty-final-qa\]/,
+            /needs: \[changes, format, quality, build, unit, integration, e2e-default, e2e-onboarding\]/,
         );
         expect(aggregator).toMatch(/^        if: always\(\)$/mu);
         expect(aggregator).not.toContain("toJson(needs)");
@@ -84,10 +84,12 @@ describe("CHAOS-3017 CI contracts", () => {
         expect(defaultE2e).toMatch(
             /^            - run: bash ci\/run_tests\.sh e2e-default \$\{\{ matrix\.shard \}\}\/3$/mu,
         );
+        // Context Fabric shares the onboarding runner (GitHub concurrency
+        // limits); both suites must still run, in one job.
         expect(job(workflow, "e2e-onboarding")).toMatch(
             /^            - run: bash ci\/run_tests\.sh e2e-onboarding$/mu,
         );
-        expect(job(workflow, "e2e-context-fabric")).toMatch(
+        expect(job(workflow, "e2e-onboarding")).toMatch(
             /^            - run: bash ci\/run_tests\.sh e2e-context-fabric$/mu,
         );
     });
@@ -141,12 +143,10 @@ describe("CHAOS-3017 CI contracts", () => {
             ...workflow.matchAll(/^\s+name: (playwright-(?:report|results)-[^\n]+)$/gm),
         ].map(([, name]) => name);
 
-        expect(names).toHaveLength(8);
+        expect(names).toHaveLength(4);
         expect(new Set(names).size).toBe(names.length);
         expect(names.join("\n")).toContain("default-${{ matrix.shard }}");
-        expect(names.join("\n")).toContain("onboarding");
-        expect(names.join("\n")).toContain("context-fabric");
-        expect(names.join("\n")).toContain("pagerduty-final-qa");
+        expect(names.join("\n")).toContain("onboarding-context-fabric");
     });
 
     it("runs static E2E only for tags and manual dispatch", () => {

--- a/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
+++ b/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
@@ -79,11 +79,10 @@ const GENERAL_TIERS = [
         tier: "integration",
     },
 ];
-const E2E_STAGES = ["e2e-default", "e2e-onboarding", "e2e-context-fabric"];
-const DEDICATED_E2E = [
-    ["e2e-onboarding", "e2e-onboarding"],
-    ["e2e-context-fabric", "e2e-context-fabric"],
-];
+const E2E_STAGES = ["e2e-default", "e2e-onboarding"];
+// Context Fabric's tier runs inside the e2e-onboarding job (one runner,
+// two sequential suites — GitHub concurrency limits).
+const DEDICATED_E2E = [["e2e-onboarding", "e2e-onboarding"]];
 const E2E_HARNESS_CASES = [
     ...["1/3", "2/3", "3/3"].map((shard) => ({
         args: ["e2e-default", shard],
@@ -102,12 +101,6 @@ const E2E_HARNESS_CASES = [
         expectedCommand: "test:e2e:context-fabric",
         failScript: "test:e2e:context-fabric",
         name: "Context Fabric",
-    },
-    {
-        args: ["pagerduty-final-qa"],
-        expectedCommand: "test:e2e:pagerduty-final-qa",
-        failScript: "test:e2e:pagerduty-final-qa",
-        name: "PagerDuty final QA",
     },
 ];
 
@@ -217,11 +210,10 @@ describe("CHAOS-3017 executable CI boundaries", () => {
             );
         }
 
-        const pagerDutyJob = job(workflow, "pagerduty-final-qa");
-        expect(pagerDutyJob).toMatch(/^        if: needs\.changes\.outputs\.code == 'true'$/mu);
-        expect(runStep(pagerDutyJob, "bash ci/run_tests.sh pagerduty-final-qa")).toBe(
-            "            - run: bash ci/run_tests.sh pagerduty-final-qa",
-        );
+        // Context Fabric runs as a second step of the onboarding job.
+        expect(
+            runStep(job(workflow, "e2e-onboarding"), "bash ci/run_tests.sh e2e-context-fabric"),
+        ).toBe("            - run: bash ci/run_tests.sh e2e-context-fabric");
     });
 
     it.each(E2E_HARNESS_CASES)(

--- a/scripts/__tests__/playwright-config.test.mjs
+++ b/scripts/__tests__/playwright-config.test.mjs
@@ -62,22 +62,15 @@ describe("default Playwright web servers", () => {
         );
     });
 
-    it("runs the complete dedicated PagerDuty matrix separately in CI", () => {
+    it("keeps the PagerDuty matrix as a manual tier, out of CI (concurrency budget)", () => {
+        // The signoff evidence pack stays runnable by hand…
         expect(ciRunner).toContain("run_pagerduty_final_qa()");
         expect(ciRunner).toContain(
             "run_isolated_e2e_suite pagerduty-final-qa test:e2e:pagerduty-final-qa",
         );
         expect(ciRunner).toMatch(/pagerduty-final-qa\)\n    run_pagerduty_final_qa/);
-        expect(testsWorkflow).toMatch(
-            /pagerduty-final-qa:\n        name: PagerDuty final QA matrix/,
-        );
-        expect(testsWorkflow).toContain("bash ci/run_tests.sh pagerduty-final-qa");
-        expect(ciRunner).toContain(
-            'run_pagerduty_final_qa "${PLAYWRIGHT_REPORT_ROOT}/pagerduty-final-qa" "${PLAYWRIGHT_RESULTS_ROOT}/pagerduty-final-qa"',
-        );
-        expect(staticBuildWorkflow).toContain("bash ci/run_tests.sh pagerduty-final-qa");
-        expect(staticBuildWorkflow).toContain(
-            "PLAYWRIGHT_RESULTS_DIR=test-results/playwright/pagerduty-final-qa",
-        );
+        // …but no workflow spends a runner on it per PR.
+        expect(testsWorkflow).not.toContain("pagerduty-final-qa");
+        expect(staticBuildWorkflow).not.toContain("pagerduty-final-qa");
     });
 });


### PR DESCRIPTION
GitHub's new concurrency limits make every parallel job queue budget. Two cuts, net 13 -> 11 jobs on a full code+e2e PR:

1. **PagerDuty final QA matrix — removed from CI entirely** (tests.yml job + aggregator step, build-static.yml step). It was the signoff evidence pack for the PagerDuty setup epics (CHAOS-3020/3021/3061) — serial specs capturing screenshots/evidence — not regression coverage; the provider wizard's regression lives in admin-integrations.spec.ts. The `pagerduty-final-qa` tier in ci/run_tests.sh and the four spec files stay for manual signoff runs.
2. **Context Fabric e2e — folded into the onboarding runner** as a second sequential step (renamed "E2E tests (onboarding + Context Fabric)"). Suite isolation is provided by run_tests.sh regardless of which runner hosts it.

The `test` aggregator (the required status check) keeps its name and fail-closed shape; its needs list and E2E checks now reference the two remaining e2e jobs. CI-contract tests updated to pin the new shape, including asserting pagerduty-final-qa appears in NEITHER workflow.

Test plan: scripts/__tests__ suite 122 passed (includes the chaos-3017 CI-contract and playwright-config pins, all updated); YAML parses; prettier clean.

Note: "PagerDuty final QA matrix" and "E2E tests (Context Fabric)" disappear as check names — if either is listed in branch protection required checks (the aggregator `test` should be the only required one), remove them there or PRs will wait on a check that never reports.