### PR TITLE
fix(ask-dev): CHAOS-3367 render a no-match as a no-match, never a refusal

### DIFF
--- a/src/components/ask-dev/AskDevAnswer.test.tsx
+++ b/src/components/ask-dev/AskDevAnswer.test.tsx
@@ -342,9 +342,15 @@ describe("AskDevAnswer sanctioned copy (CHAOS-3291)", () => {
         } as unknown as DevAnswer;
         render(<AskDevAnswer answer={forbiddenAnswer} />);
 
-        expect(screen.getByText("Not accessible")).toBeVisible();
+        // CHAOS-3367 changed this label from "Not accessible" to the TRD §7.1
+        // public class for the same outcome. It still collapses forbidden and
+        // not-found into one statement, which is what this test guards; what
+        // changed is that "Not accessible" additionally asserted an access
+        // denial the backend cannot actually distinguish, and PRD §12 forbids
+        // an authorization-shaped statement unless access was really denied.
+        expect(screen.getByText("No authorized match found")).toBeVisible();
         expect(screen.queryByText(/forbidden/iu)).not.toBeInTheDocument();
-        expect(screen.queryByText(/not found/iu)).not.toBeInTheDocument();
+        expect(screen.queryByText(/not accessible/iu)).not.toBeInTheDocument();
     });
 
     // Totality guard, independent of any single render: these reference
@@ -377,5 +383,224 @@ describe("AskDevAnswer sanctioned copy (CHAOS-3291)", () => {
             unresolved: true,
         };
         expect(Object.keys(SCOPE_OUTCOME_LABELS).sort()).toEqual(Object.keys(knownOutcomes).sort());
+    });
+});
+
+// --- CHAOS-3367: the Wave 3.1 PRD §12 prohibitions, as string-level negative
+// --- controls against the exact payload a live screenshot showed rendering.
+
+const noMatchAnswer = {
+    ...answer,
+    claims: [],
+    conflicts: [],
+    coverage: { available_source_count: 0, required_source_count: 0 },
+    direct_summary:
+        "I couldn't find an authorized project named 'Falcon' in the selected " +
+        "organization. I did not substitute organization-wide data. Here are the " +
+        "closest matches, if any.",
+    evidence: [],
+    metrics: [],
+    resolved_scope: {
+        authorized_repository_ids: [],
+        candidates: [],
+        outcome: "forbidden_or_not_found",
+        resolved_at: "2026-07-29T00:00:00Z",
+        schema_version: "dev_scope_resolution.v1",
+        warnings: [],
+    },
+    status: "insufficient_evidence",
+    warnings: [],
+} as unknown as DevAnswer;
+
+describe("AskDevAnswer no-match presentation (CHAOS-3367)", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    it("never shows a Refused chip for a no-match result", () => {
+        // The live screenshot: the model marked its own answer `refused` after
+        // a not-found resolution. Keyed off the resolution outcome rather than
+        // the status, so a replayed row written before the server fix still
+        // renders honestly.
+        render(<AskDevAnswer answer={{ ...noMatchAnswer, status: "refused" } as DevAnswer} />);
+
+        expect(screen.getByText("No match found")).toBeVisible();
+        expect(screen.queryByText("Refused")).not.toBeInTheDocument();
+        expect(screen.queryByText(/Ask Dev did not answer this question/u)).not.toBeInTheDocument();
+    });
+
+    it("never shows an Exact match scope outcome beside a no-match summary", () => {
+        render(<AskDevAnswer answer={noMatchAnswer} />);
+
+        expect(screen.getByText("No authorized match found")).toBeVisible();
+        expect(screen.queryByText("Exact match")).not.toBeInTheDocument();
+    });
+
+    it("hides the sources line entirely when no source plan ran", () => {
+        render(<AskDevAnswer answer={noMatchAnswer} />);
+
+        // The live defect read "Coverage: 1 of 1 sources" for a subject that
+        // was never resolved. "0 of 0 sources" is no better: it still reads as
+        // a measurement that happened.
+        expect(screen.queryByText(/sources/u)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText("Evidence coverage")).not.toBeInTheDocument();
+    });
+
+    it("renders the PRD's own no-match sentence unaltered", () => {
+        render(<AskDevAnswer answer={noMatchAnswer} />);
+
+        expect(
+            screen.getByText(/I couldn't find an authorized project named 'Falcon'/u),
+        ).toBeVisible();
+        expect(screen.getByText(/I did not substitute organization-wide data\./u)).toBeVisible();
+    });
+
+    it("calls a no-match candidate list closest matches, not possible scope matches", () => {
+        // CHAOS-3366 fills this list; the contract slot and its copy exist now
+        // so that work is additive.
+        render(
+            <AskDevAnswer
+                answer={
+                    {
+                        ...noMatchAnswer,
+                        resolved_scope: {
+                            ...noMatchAnswer.resolved_scope,
+                            candidates: [
+                                {
+                                    entity_ref: {
+                                        display_label: "Falcon Nine",
+                                        entity_id: "project-falcon-nine",
+                                        entity_type: "project",
+                                    },
+                                    reason: "Closest authorized name match.",
+                                },
+                            ],
+                        },
+                    } as unknown as DevAnswer
+                }
+            />,
+        );
+
+        expect(screen.getByText("Closest matches")).toBeVisible();
+        expect(screen.queryByText("Possible scope matches")).not.toBeInTheDocument();
+    });
+});
+
+describe("AskDevAnswer internal-token guard (CHAOS-3367)", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    // ops fails these terminals closed at the server boundary. This is the
+    // last layer before a human reads it, and it is the only one that covers
+    // a row persisted before that server check existed.
+    it.each([
+        [
+            "direct_summary",
+            {
+                direct_summary:
+                    "Scope resolution for the requested entity returned " +
+                    "forbidden_or_not_found. No authorized entity matched.",
+            },
+        ],
+        [
+            "a warning",
+            { warnings: ["The request was rejected with scope_forbidden for this repository."] },
+        ],
+        [
+            "a claim",
+            {
+                claims: [
+                    {
+                        claim_id: "claim-leak-1",
+                        confidence: 0.5,
+                        evidence_ref_ids: [],
+                        flags: {},
+                        kind: "inferred",
+                        metric_ref_ids: [],
+                        text: "The scope came back forbidden_or_not_found for this project.",
+                    },
+                ],
+            },
+        ],
+        [
+            "a conflict",
+            {
+                conflicts: [
+                    { evidence_ref_ids: [], summary: "Two sources disagree: scope_forbidden." },
+                ],
+            },
+        ],
+    ])("never renders an internal token that arrived in %s", (_field, overrides) => {
+        render(<AskDevAnswer answer={{ ...noMatchAnswer, ...overrides } as DevAnswer} />);
+
+        for (const token of ["forbidden_or_not_found", "scope_forbidden"]) {
+            expect(document.body.textContent).not.toContain(token);
+        }
+        expect(screen.getByText("This part of the answer could not be shown.")).toBeVisible();
+    });
+
+    it("leaves ordinary prose untouched", () => {
+        // The guard must not fire on English that happens to contain the enum
+        // members' individual words -- otherwise it silently eats real answers.
+        const prose =
+            "The exact match was filtered because the source was unavailable, so " +
+            "nothing was found.";
+        render(<AskDevAnswer answer={{ ...noMatchAnswer, direct_summary: prose } as DevAnswer} />);
+
+        expect(screen.getByText(prose)).toBeVisible();
+    });
+});
+
+describe("AskDevAnswer token-guard provenance (CHAOS-3367)", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    // Codex adversarial review round 1: a substring scan with no provenance
+    // blanks a healthy answer whose authorized entity is genuinely named like
+    // an enum member. The exemption is earned by the answer carrying that
+    // name as an authorized label, not by a hard-coded exception.
+    const attestedAnswer = {
+        ...answer,
+        claims: [],
+        conflicts: [],
+        direct_summary: "The authorized project not_found has validated status data.",
+        evidence: [{ ...answer.evidence[0], display_label: "not_found" }],
+        metrics: [],
+        warnings: [],
+    } as unknown as DevAnswer;
+
+    it("keeps copy naming an authorized entity that looks like an enum member", () => {
+        render(<AskDevAnswer answer={attestedAnswer} />);
+
+        expect(
+            screen.getByText("The authorized project not_found has validated status data."),
+        ).toBeVisible();
+    });
+
+    it("still blanks a real leak in the same answer", () => {
+        render(
+            <AskDevAnswer
+                answer={
+                    {
+                        ...attestedAnswer,
+                        direct_summary: "The project not_found returned forbidden_or_not_found.",
+                    } as DevAnswer
+                }
+            />,
+        );
+
+        expect(document.body.textContent).not.toContain("forbidden_or_not_found");
+        expect(screen.getByText("This part of the answer could not be shown.")).toBeVisible();
     });
 });

--- a/src/components/ask-dev/AskDevAnswer.test.tsx
+++ b/src/components/ask-dev/AskDevAnswer.test.tsx
@@ -2,9 +2,18 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { DevAnswer } from "@/lib/dev/generated";
+import type { DevAnswer, DevError } from "@/lib/dev/generated";
 
-import { ANSWER_STATUS_LABELS, AskDevAnswer, SCOPE_OUTCOME_LABELS } from "./AskDevAnswer";
+import { findInternalToken } from "@/lib/dev/internalTokens";
+
+import {
+    ANSWER_STATUS_LABELS,
+    AskDevAnswer,
+    INTERNAL_TOKEN_DENYLIST,
+    SCOPE_OUTCOME_LABELS,
+} from "./AskDevAnswer";
+
+type DevErrorCode = NonNullable<DevError>["code"];
 
 const actions = vi.hoisted(() => ({
     expandEvidence: vi.fn(),
@@ -449,7 +458,12 @@ describe("AskDevAnswer no-match presentation (CHAOS-3367)", () => {
         expect(screen.queryByLabelText("Evidence coverage")).not.toBeInTheDocument();
     });
 
-    it("renders the PRD's own no-match sentence unaltered", () => {
+    // NOT a RED control, and labelled as one: the pre-change component
+    // rendered direct_summary verbatim too, so this stays green with the
+    // component reverted. It is a compatibility check — the new token guard
+    // must not mangle the server's own sentence — and it earns its place for
+    // that, not as evidence the fix works.
+    it("passes the PRD's own no-match sentence through the token guard unaltered", () => {
         render(<AskDevAnswer answer={noMatchAnswer} />);
 
         expect(
@@ -574,8 +588,8 @@ describe("AskDevAnswer token-guard provenance (CHAOS-3367)", () => {
         ...answer,
         claims: [],
         conflicts: [],
-        direct_summary: "The authorized project not_found has validated status data.",
-        evidence: [{ ...answer.evidence[0], display_label: "not_found" }],
+        direct_summary: "The insufficient_evidence branch was merged last week.",
+        evidence: [{ ...answer.evidence![0], display_label: "insufficient_evidence" }],
         metrics: [],
         warnings: [],
     } as unknown as DevAnswer;
@@ -584,7 +598,7 @@ describe("AskDevAnswer token-guard provenance (CHAOS-3367)", () => {
         render(<AskDevAnswer answer={attestedAnswer} />);
 
         expect(
-            screen.getByText("The authorized project not_found has validated status data."),
+            screen.getByText("The insufficient_evidence branch was merged last week."),
         ).toBeVisible();
     });
 
@@ -602,5 +616,143 @@ describe("AskDevAnswer token-guard provenance (CHAOS-3367)", () => {
 
         expect(document.body.textContent).not.toContain("forbidden_or_not_found");
         expect(screen.getByText("This part of the answer could not be shown.")).toBeVisible();
+    });
+});
+
+describe("AskDevAnswer legacy contradictory payload (CHAOS-3367)", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    // The reported screenshot's actual shape, and the one the first revision
+    // of this fix missed: `resolved_scope.outcome` is "exact", so keying the
+    // no-match presentation off that field alone left every §12 violation on
+    // screen. The row is already persisted and still schema-valid, so no
+    // server-side change can reach it — the client has to notice that the
+    // summary and the scope row cannot both be true.
+    const legacyAnswer = {
+        ...answer,
+        claims: [],
+        conflicts: [],
+        coverage: { available_source_count: 1, required_source_count: 1 },
+        direct_summary:
+            "Scope resolution for the requested entity returned forbidden_or_not_found. " +
+            "No authorized entity matched the requested name under the current authorization.",
+        evidence: [],
+        metrics: [],
+        resolved_scope: {
+            authorized_repository_ids: [],
+            candidates: [],
+            outcome: "exact",
+            resolved_at: "2026-07-29T00:00:00Z",
+            schema_version: "dev_scope_resolution.v1",
+            warnings: [],
+        },
+        status: "refused",
+        warnings: [],
+    } as unknown as DevAnswer;
+
+    it("shows none of the four prohibited elements for the live legacy payload", () => {
+        render(<AskDevAnswer answer={legacyAnswer} />);
+
+        const body = document.body.textContent ?? "";
+        expect(body).not.toContain("forbidden_or_not_found");
+        expect(screen.queryByText("Refused")).not.toBeInTheDocument();
+        expect(screen.queryByText("Exact match")).not.toBeInTheDocument();
+        expect(screen.queryByText(/sources/u)).not.toBeInTheDocument();
+        expect(screen.getByText("No match found")).toBeVisible();
+    });
+
+    it("does not reclassify an ordinary answer that merely mentions a source", () => {
+        // The classifier keys off scope-resolution tokens only, so a normal
+        // committed-scope answer keeps its own presentation.
+        render(<AskDevAnswer answer={answer} />);
+
+        expect(screen.queryByText("No match found")).not.toBeInTheDocument();
+        expect(screen.getByText(/1 of 1/u)).toBeVisible();
+    });
+});
+
+describe("AskDevAnswer coverage suppression (CHAOS-3367)", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    it("keeps the coverage block when zero were required but sources are unavailable", () => {
+        // The contract permits required_source_count: 0 beside a non-empty
+        // unavailable list. Hiding the whole block on the count alone would
+        // take the only source-specific explanation with it.
+        render(
+            <AskDevAnswer
+                answer={
+                    {
+                        ...answer,
+                        coverage: {
+                            available_source_count: 0,
+                            required_source_count: 0,
+                            unavailable_required_sources: ["github"],
+                        },
+                    } as unknown as DevAnswer
+                }
+            />,
+        );
+
+        expect(screen.getByText("1 required sources unavailable")).toBeVisible();
+    });
+});
+
+describe("internal-token guard vocabulary (CHAOS-3367)", () => {
+    it("never lets provenance exempt a scope-resolution token", () => {
+        // Codex round 2: an evidence label named `scope_forbidden` would
+        // otherwise exempt a genuinely leaked `scope_forbidden` elsewhere in
+        // the same answer.
+        expect(
+            findInternalToken(
+                "Resolution returned scope_forbidden.",
+                INTERNAL_TOKEN_DENYLIST,
+                "scope_forbidden",
+            ),
+        ).toBe("scope_forbidden");
+    });
+
+    it("pins the DevError code vocabulary against the generated union", () => {
+        // The hand-written half of the denylist. Anything here that stops
+        // being a real code, or any underscore-bearing code missing from it,
+        // fails at build time rather than becoming a silent gap.
+        const codes: Record<NonNullable<DevErrorCode>, true> = {
+            answer_validation_failed: true,
+            byo_llm_not_enabled: true,
+            cancelled: true,
+            concurrency_limited: true,
+            conversation_expired: true,
+            conversation_not_found: true,
+            cost_limit_reached: true,
+            feature_not_enabled: true,
+            forbidden: true,
+            insufficient_evidence: true,
+            internal_error: true,
+            invalid_request: true,
+            model_not_supported: true,
+            provider_contract_violation: true,
+            provider_not_configured: true,
+            provider_unavailable: true,
+            rate_limited: true,
+            scope_ambiguous: true,
+            scope_forbidden: true,
+            scope_not_found: true,
+            source_unavailable: true,
+            tool_limit_reached: true,
+            tool_unavailable: true,
+            unauthenticated: true,
+        };
+        for (const code of Object.keys(codes).filter((value) => value.includes("_"))) {
+            expect(INTERNAL_TOKEN_DENYLIST.has(code)).toBe(true);
+        }
     });
 });

--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -10,6 +10,7 @@ import type {
     DevEvidenceRef,
     DevScope,
 } from "@/lib/dev/generated";
+import { buildInternalTokenDenylist, safeCopy } from "@/lib/dev/internalTokens";
 import { formatMetricValue, formatNumber, formatPercent, formatTimestamp } from "@/lib/formatters";
 
 import { useAskDev } from "./AskDevProvider";
@@ -58,15 +59,65 @@ export const ANSWER_STATUS_LABELS: Record<DevAnswer["status"], string> = {
 // distinction (the backend deliberately collapses forbidden vs. not-found
 // into one outcome so scope resolution can't be used to enumerate what
 // exists; the label must preserve that, not re-split it).
+//
+// `forbidden_or_not_found` reads "No authorized match found" rather than the
+// earlier "Not accessible" (CHAOS-3367). Both collapse the forbidden/not-found
+// distinction, which is what that comment above is about; "Not accessible" is
+// additionally authorization-shaped, and Wave 3.1 PRD §12 forbids an
+// authorization-shaped statement unless access was actually denied — which
+// this outcome, by construction, cannot tell us. The wording is the TRD §7.1
+// public class for the same internal outcome. It lives here rather than being
+// mirrored on the ops side: no ops code path renders it, and a constant only
+// its own test reads is a coverage claim with nothing behind it.
 export const SCOPE_OUTCOME_LABELS: Record<DevAnswer["resolved_scope"]["outcome"], string> = {
     ambiguous: "Ambiguous",
     exact: "Exact match",
     filtered: "Filtered",
-    forbidden_or_not_found: "Not accessible",
+    forbidden_or_not_found: "No authorized match found",
     inherited: "Inherited",
     organization_fallback: "Organization-wide",
     unresolved: "Unresolved",
 };
+
+// The status pill copy a no-match answer gets instead of its raw
+// `AnswerStatus`. §12 prohibits labelling a no-match result as a refusal, and
+// the server now terminates these as `insufficient_evidence` — but "Insufficient
+// evidence" is also wrong here: there is no evidence problem, the named subject
+// simply is not in the authorized catalog. Keyed off the resolution outcome
+// rather than the status so it stays correct whichever status a replayed older
+// row carries.
+export const NO_MATCH_STATUS_LABEL = "No match found";
+
+// The internal-token denylist, derived from the two TOTAL label maps above so
+// it cannot fall behind the generated unions. See lib/dev/internalTokens.ts.
+export const INTERNAL_TOKEN_DENYLIST = buildInternalTokenDenylist(
+    Object.keys(ANSWER_STATUS_LABELS),
+    Object.keys(SCOPE_OUTCOME_LABELS),
+);
+
+export function isNoMatchAnswer(answer: DevAnswer): boolean {
+    return answer.resolved_scope?.outcome === "forbidden_or_not_found";
+}
+
+/**
+ * Every string in this answer with a server-authorized provenance, joined for
+ * the token guard. Read off the answer's OWN scope, candidates, evidence and
+ * metrics — never a catalog lookup: an entity that is not already part of this
+ * answer has no business exempting a token in it. Mirrors ops
+ * `no_match_terminal.attested_strings`.
+ */
+export function attestedText(answer: DevAnswer): string {
+    const scope = answer.resolved_scope;
+    return [
+        ...(scope?.requested_scope?.entity_refs ?? []).map((ref) => ref.display_label),
+        ...(scope?.requested_scope?.repositories ?? []),
+        ...(scope?.resolved_scope?.entity_refs ?? []).map((ref) => ref.display_label),
+        ...(scope?.resolved_scope?.repositories ?? []),
+        ...(scope?.candidates ?? []).map((candidate) => candidate.entity_ref.display_label),
+        ...(answer.evidence ?? []).map((item) => item.display_label),
+        ...(answer.metrics ?? []).map((metric) => metric.label),
+    ].join(" ");
+}
 
 const STATUS_EXPLANATIONS: Partial<Record<DevAnswer["status"], string>> = {
     partial:
@@ -192,7 +243,19 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     );
     const [openMetricIds, setOpenMetricIds] = useState<ReadonlySet<string>>(() => new Set());
     const scopeResolution = answer.resolved_scope;
-    const statusExplanation = STATUS_EXPLANATIONS[answer.status];
+    // CHAOS-3367. A no-match gets its own presentation rather than the generic
+    // status treatment: no "Refused" chip, no status caption claiming Ask Dev
+    // declined to answer, and the sanctioned outcome label in place of the raw
+    // status. The server's own summary carries the explanation, so a second
+    // boilerplate caption above it would only repeat it less accurately.
+    const noMatch = isNoMatchAnswer(answer);
+    const statusLabel = noMatch ? NO_MATCH_STATUS_LABEL : ANSWER_STATUS_LABELS[answer.status];
+    const statusExplanation = noMatch ? undefined : STATUS_EXPLANATIONS[answer.status];
+    // The coverage row is meaningless when no source plan ran -- "0 of 0
+    // sources" reads as a measurement, and the live defect's "1 of 1 sources"
+    // read as a completed source plan for a subject that was never resolved.
+    const showCoverage = (answer.coverage?.required_source_count ?? 0) > 0;
+    const attested = useMemo(() => attestedText(answer), [answer]);
     const evidenceById = useMemo(
         () =>
             new Map(
@@ -344,7 +407,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                     AI-generated
                 </span>
                 <span className="rounded-(--radius-pill) border border-(--border) px-2.5 py-1 text-label-caps text-(--text-muted)">
-                    {ANSWER_STATUS_LABELS[answer.status]}
+                    {statusLabel}
                 </span>
                 <span className="text-xs text-(--text-muted)">
                     As of {formatTimestamp(answer.as_of)}
@@ -369,7 +432,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                     <p className="text-sm leading-6 text-(--text-secondary)">{statusExplanation}</p>
                 ) : null}
                 <p className="font-(--font-display) text-h3 text-(--text-primary)">
-                    {answer.direct_summary}
+                    {safeCopy(answer.direct_summary, INTERNAL_TOKEN_DENYLIST, attested)}
                 </p>
             </div>
 
@@ -392,8 +455,18 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                     </div>
                     {scopeResolution.candidates?.length ? (
                         <div className="mt-3">
+                            {/*
+                             * Two different situations share this list.
+                             * Ambiguity means several authorized entities DID
+                             * match and one must be picked; a no-match means
+                             * none did and these are only the nearest names
+                             * (CHAOS-3366 fills them; empty today). Calling
+                             * the second "possible scope matches" would assert
+                             * the subject exists, which is the substitution
+                             * §12 prohibits.
+                             */}
                             <p className="text-label-caps text-(--caution)">
-                                Possible scope matches
+                                {noMatch ? "Closest matches" : "Possible scope matches"}
                             </p>
                             <ul className="mt-2 space-y-1 text-sm text-(--text-secondary)">
                                 {scopeResolution.candidates.map((candidate) => (
@@ -418,41 +491,44 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                                 ))}
                             </ul>
                             <p className="mt-2 text-xs text-(--text-muted)">
-                                Choose or remove the proposed context before asking the next
-                                question.
+                                {noMatch
+                                    ? "None of these is the subject you named. Pick one to ask about it instead."
+                                    : "Choose or remove the proposed context before asking the next question."}
                             </p>
                         </div>
                     ) : null}
                 </section>
             ) : null}
 
-            <section
-                aria-label="Evidence coverage"
-                className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-(--text-muted)"
-            >
-                <span>
-                    Coverage:{" "}
-                    {formatNumber(answer.coverage?.available_source_count ?? 0, {
-                        maximumFractionDigits: 0,
-                    })}{" "}
-                    of{" "}
-                    {formatNumber(answer.coverage?.required_source_count ?? 0, {
-                        maximumFractionDigits: 0,
-                    })}{" "}
-                    sources
-                </span>
-                {answer.coverage?.unavailable_required_sources?.length ? (
-                    <span className="text-(--caution)">
-                        {answer.coverage.unavailable_required_sources.length} required sources
-                        unavailable
+            {showCoverage ? (
+                <section
+                    aria-label="Evidence coverage"
+                    className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-(--text-muted)"
+                >
+                    <span>
+                        Coverage:{" "}
+                        {formatNumber(answer.coverage?.available_source_count ?? 0, {
+                            maximumFractionDigits: 0,
+                        })}{" "}
+                        of{" "}
+                        {formatNumber(answer.coverage?.required_source_count ?? 0, {
+                            maximumFractionDigits: 0,
+                        })}{" "}
+                        sources
                     </span>
-                ) : null}
-                {answer.coverage?.stale_required_sources?.length ? (
-                    <span className="text-(--caution)">
-                        {answer.coverage.stale_required_sources.length} required sources stale
-                    </span>
-                ) : null}
-            </section>
+                    {answer.coverage?.unavailable_required_sources?.length ? (
+                        <span className="text-(--caution)">
+                            {answer.coverage.unavailable_required_sources.length} required sources
+                            unavailable
+                        </span>
+                    ) : null}
+                    {answer.coverage?.stale_required_sources?.length ? (
+                        <span className="text-(--caution)">
+                            {answer.coverage.stale_required_sources.length} required sources stale
+                        </span>
+                    ) : null}
+                </section>
+            ) : null}
 
             {answer.claims?.length ? (
                 <section
@@ -468,7 +544,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                                 <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-(--accent)" />
                                 <div className="min-w-0">
                                     <p>
-                                        {claim.text}
+                                        {safeCopy(claim.text, INTERNAL_TOKEN_DENYLIST, attested)}
                                         {renderInlineCitations(
                                             claim.evidence_ref_ids,
                                             claim.metric_ref_ids,
@@ -522,7 +598,9 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                     <p className="text-label-caps text-(--caution)">Conflicting evidence</p>
                     <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-(--text-secondary)">
                         {answer.conflicts.map((conflict) => (
-                            <li key={conflict.summary}>{conflict.summary}</li>
+                            <li key={conflict.summary}>
+                                {safeCopy(conflict.summary, INTERNAL_TOKEN_DENYLIST, attested)}
+                            </li>
                         ))}
                     </ul>
                 </section>
@@ -651,7 +729,9 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                     <p className="text-label-caps text-(--caution)">Limitations</p>
                     <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-(--text-secondary)">
                         {answer.warnings.map((warning) => (
-                            <li key={warning}>{warning}</li>
+                            <li key={warning}>
+                                {safeCopy(warning, INTERNAL_TOKEN_DENYLIST, attested)}
+                            </li>
                         ))}
                     </ul>
                 </section>

--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -10,7 +10,12 @@ import type {
     DevEvidenceRef,
     DevScope,
 } from "@/lib/dev/generated";
-import { buildInternalTokenDenylist, safeCopy } from "@/lib/dev/internalTokens";
+import {
+    buildInternalTokenDenylist,
+    findInternalToken,
+    NEVER_ATTESTABLE_TOKENS,
+    safeCopy,
+} from "@/lib/dev/internalTokens";
 import { formatMetricValue, formatNumber, formatPercent, formatTimestamp } from "@/lib/formatters";
 
 import { useAskDev } from "./AskDevProvider";
@@ -95,8 +100,40 @@ export const INTERNAL_TOKEN_DENYLIST = buildInternalTokenDenylist(
     Object.keys(SCOPE_OUTCOME_LABELS),
 );
 
+/**
+ * Whether this answer's own copy contradicts the scope row it carries.
+ *
+ * The reported live payload is the reason this exists, and keying only off
+ * `resolved_scope.outcome` missed it: that row carries `outcome: "exact"`
+ * while its summary says a named subject was not found, so it is an ordinary
+ * committed-scope answer as far as the outcome field is concerned. It is
+ * already persisted and still schema-valid, so the server-side fix cannot
+ * reach it — the client has to notice the contradiction itself.
+ *
+ * The signal is a scope-resolution token in the answer's own prose. Those
+ * tokens are `NEVER_ATTESTABLE_TOKENS`, so no entity label can produce a
+ * false positive here, and prose that narrates the resolver's verdict while
+ * the scope row claims a commit cannot both be true. When they disagree the
+ * scope row is the one that loses: it is the field that would otherwise put
+ * "Exact match" beside a not-found statement.
+ */
+export function contradictsCommittedScope(answer: DevAnswer): boolean {
+    const prose = [
+        answer.direct_summary,
+        ...(answer.warnings ?? []),
+        ...(answer.claims ?? []).map((claim) => claim.text),
+    ];
+    return prose.some((text) => {
+        const token = findInternalToken(text, INTERNAL_TOKEN_DENYLIST);
+        return token !== null && NEVER_ATTESTABLE_TOKENS.has(token);
+    });
+}
+
 export function isNoMatchAnswer(answer: DevAnswer): boolean {
-    return answer.resolved_scope?.outcome === "forbidden_or_not_found";
+    return (
+        answer.resolved_scope?.outcome === "forbidden_or_not_found" ||
+        contradictsCommittedScope(answer)
+    );
 }
 
 /**
@@ -249,12 +286,28 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     // status. The server's own summary carries the explanation, so a second
     // boilerplate caption above it would only repeat it less accurately.
     const noMatch = isNoMatchAnswer(answer);
+    // A contradictory legacy row's scope outcome is not trustworthy — showing
+    // "Exact match" beside a not-found summary is the §12 juxtaposition
+    // itself. The row is kept (the repository count beside it is still real)
+    // but the outcome value is withheld rather than asserted.
+    const scopeOutcomeTrusted = !contradictsCommittedScope(answer);
     const statusLabel = noMatch ? NO_MATCH_STATUS_LABEL : ANSWER_STATUS_LABELS[answer.status];
     const statusExplanation = noMatch ? undefined : STATUS_EXPLANATIONS[answer.status];
     // The coverage row is meaningless when no source plan ran -- "0 of 0
     // sources" reads as a measurement, and the live defect's "1 of 1 sources"
     // read as a completed source plan for a subject that was never resolved.
-    const showCoverage = (answer.coverage?.required_source_count ?? 0) > 0;
+    // Hidden only when there is genuinely nothing to report. `required_source_count: 0`
+    // alone is not enough: the contract permits zero required sources alongside a
+    // non-empty unavailable/stale list, and removing the whole block would take the
+    // only source-specific explanation with it. A contradictory legacy row is also
+    // suppressed — its counts describe a source plan that provably did not run for
+    // the subject its own summary says was not found.
+    const coverage = answer.coverage;
+    const showCoverage =
+        !noMatch &&
+        ((coverage?.required_source_count ?? 0) > 0 ||
+            (coverage?.unavailable_required_sources?.length ?? 0) > 0 ||
+            (coverage?.stale_required_sources?.length ?? 0) > 0);
     const attested = useMemo(() => attestedText(answer), [answer]);
     const evidenceById = useMemo(
         () =>
@@ -445,7 +498,9 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                         <span className="text-(--text-muted)">
                             Scope outcome:{" "}
                             <strong className="font-medium text-(--text-secondary)">
-                                {SCOPE_OUTCOME_LABELS[scopeResolution.outcome]}
+                                {scopeOutcomeTrusted
+                                    ? SCOPE_OUTCOME_LABELS[scopeResolution.outcome]
+                                    : SCOPE_OUTCOME_LABELS.forbidden_or_not_found}
                             </strong>
                         </span>
                         <span className="text-(--text-muted)">
@@ -751,7 +806,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                                 onClick={() => void submitQuestion(question)}
                                 className="rounded-(--radius-pill) border border-(--border) px-3 py-1.5 text-left text-xs text-(--text-secondary) hover:border-(--accent)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
                             >
-                                {question}
+                                {safeCopy(question, INTERNAL_TOKEN_DENYLIST, attested)}
                             </button>
                         ))}
                     </div>

--- a/src/components/ask-dev/AskDevConversation.tsx
+++ b/src/components/ask-dev/AskDevConversation.tsx
@@ -7,10 +7,11 @@ import type { DevProgressState } from "@/lib/dev/client";
 import { CTA_LABELS } from "@/lib/design/cta";
 import { decodeFilter, encodeFilterParam } from "@/lib/filters/encode";
 import { formatDateUTC } from "@/lib/formatters";
+import { safeCopy } from "@/lib/dev/internalTokens";
 import { runtimeConfig } from "@/lib/runtimeConfig";
 import { DataState } from "@/components/ui/DataState";
 
-import { AskDevAnswer } from "./AskDevAnswer";
+import { AskDevAnswer, attestedText, INTERNAL_TOKEN_DENYLIST } from "./AskDevAnswer";
 import { useAskDev } from "./AskDevProvider";
 
 function platformAllowanceGuidance(
@@ -662,8 +663,18 @@ export function AskDevConversation({
                                                 The investigation stopped safely.
                                             </p>
                                             <p className="mt-1 text-sm text-(--text-secondary)">
-                                                {entry.answer.direct_summary ||
-                                                    "Ask Dev could not complete that request."}
+                                                {/*
+                                                 * This branch bypasses AskDevAnswer entirely, so
+                                                 * it needs its own copy guard: an older persisted
+                                                 * error answer whose summary narrates an internal
+                                                 * token would otherwise leak it here while the
+                                                 * ordinary answer path is protected (CHAOS-3367).
+                                                 */}
+                                                {safeCopy(
+                                                    entry.answer.direct_summary,
+                                                    INTERNAL_TOKEN_DENYLIST,
+                                                    attestedText(entry.answer),
+                                                ) || "Ask Dev could not complete that request."}
                                             </p>
                                         </div>
                                     ) : (

--- a/src/lib/dev/contractValidation.ts
+++ b/src/lib/dev/contractValidation.ts
@@ -140,6 +140,18 @@ export const SCOPE_OUTCOMES_WITHOUT_RESOLVED_SCOPE: ReadonlySet<string> = new Se
     "forbidden_or_not_found",
 ]);
 
+/**
+ * Outcomes a resolution may carry `candidates` for, mirroring ops
+ * `contracts.CANDIDATE_BEARING_OUTCOMES` (CHAOS-3367). This one fails CLOSED
+ * on drift — a new candidate-bearing outcome missing from this set makes web
+ * reject a payload ops would accept, which surfaces as a visible validation
+ * failure rather than as silently-accepted contradictory data.
+ */
+export const CANDIDATE_BEARING_SCOPE_OUTCOMES: ReadonlySet<string> = new Set([
+    "ambiguous",
+    "forbidden_or_not_found",
+]);
+
 function validateScopeResolution(resolution: JsonRecord): boolean {
     const outcome = resolution.outcome;
     const candidates = asRecords(resolution.candidates);
@@ -148,7 +160,15 @@ function validateScopeResolution(resolution: JsonRecord): boolean {
     if (typeof outcome === "string" && resolvedOutcomes.has(outcome) && !isRecord(resolvedScope)) {
         return false;
     }
-    if (outcome === "ambiguous" ? candidates.length === 0 : candidates.length > 0) return false;
+    // Mirrors ops `DevScopeResolution.CANDIDATE_BEARING_OUTCOMES`. `ambiguous`
+    // REQUIRES candidates; `forbidden_or_not_found` MAY carry them — the PRD's
+    // no-match sentence ends "Here are the closest matches, if any", and the
+    // closest-match list lives here rather than in a second, parallel field
+    // (CHAOS-3367; CHAOS-3366 fills it). Every other outcome still forbids
+    // them: an `exact` commit with candidates beside it is a contradiction.
+    if (outcome === "ambiguous" && candidates.length === 0) return false;
+    if (!CANDIDATE_BEARING_SCOPE_OUTCOMES.has(String(outcome)) && candidates.length > 0)
+        return false;
     return !(
         outcome === "organization_fallback" &&
         (!isRecord(resolvedScope) || resolvedScope.direct_scope !== "organization")

--- a/src/lib/dev/internalTokens.ts
+++ b/src/lib/dev/internalTokens.ts
@@ -1,0 +1,111 @@
+/**
+ * The render-time half of the CHAOS-3367 copy contract.
+ *
+ * ops/src/dev_health_ops/api/dev/no_match_terminal.py fails a terminal closed
+ * when a user-visible string carries an internal vocabulary token. This is the
+ * same rule at the last layer before a human reads it: the server owns most of
+ * that copy, but `direct_summary`, `claims[].text`, `warnings[]` and
+ * `conflicts[].summary` are model-authored, and a client that renders whatever
+ * arrives has no defence if a producer regresses or an older run is replayed
+ * from persistence (rows written before the server-side check existed are not
+ * rewritten by it).
+ *
+ * The token list is DERIVED, not hand-written. `ANSWER_STATUS_LABELS` and
+ * `SCOPE_OUTCOME_LABELS` in AskDevAnswer.tsx are TOTAL `Record`s over the
+ * generated unions -- a member added to either fails to compile until it is
+ * added there -- so taking `Object.keys()` of them gives a runtime list that
+ * cannot silently fall behind the wire contract.
+ *
+ * Only underscore-bearing members are kept, matching the server: `exact`,
+ * `denied` and `failed` are ordinary English that safe prose may contain,
+ * while `forbidden_or_not_found` and `scope_forbidden` cannot occur in written
+ * English at all. That is what keeps the check free of false positives without
+ * an exclusion list.
+ */
+
+/**
+ * Internal token vocabularies that have no total `Record` in the component
+ * layer to derive from. Kept minimal and pinned by a test against the schema's
+ * own `dev_error.v1` code enum, so drift is a test failure rather than a
+ * silent gap.
+ */
+const DEV_ERROR_CODE_TOKENS: readonly string[] = [
+    "answer_validation_failed",
+    "byo_llm_not_enabled",
+    "concurrency_limited",
+    "conversation_expired",
+    "conversation_not_found",
+    "cost_limit_reached",
+    "feature_not_enabled",
+    "insufficient_evidence",
+    "internal_error",
+    "invalid_request",
+    "model_not_supported",
+    "provider_contract_violation",
+    "provider_not_configured",
+    "provider_unavailable",
+    "rate_limited",
+    "scope_ambiguous",
+    "scope_forbidden",
+    "scope_not_found",
+    "source_unavailable",
+    "tool_limit_reached",
+    "tool_unavailable",
+];
+
+export function buildInternalTokenDenylist(
+    ...vocabularies: readonly (readonly string[])[]
+): ReadonlySet<string> {
+    return new Set(
+        [...vocabularies, DEV_ERROR_CODE_TOKENS].flat().filter((token) => token.includes("_")),
+    );
+}
+
+/**
+ * The first denylisted token found in `value`, or `null`.
+ *
+ * Case-insensitive and substring-based: the reported live defect rendered
+ * `forbidden_or_not_found` in the middle of a sentence, so an equality check
+ * against the whole field would not have seen it.
+ *
+ * `attested` is the provenance escape hatch, mirroring ops
+ * `no_match_terminal.internal_token_leak`. Some denylisted tokens are also
+ * plausible real names — an authorized repository can genuinely be called
+ * `not_found`, and a claim can genuinely mention `app/not_found.tsx`. Without
+ * it, this guard would blank a healthy answer's own content. A token is
+ * suppressed only when nothing this answer already carries as an authorized
+ * label contains it; the exemption is per token, so a sentence mixing an
+ * attested name with a real leak still fails on the leak.
+ */
+export function findInternalToken(
+    value: string | null | undefined,
+    denylist: ReadonlySet<string>,
+    attested = "",
+): string | null {
+    if (!value) return null;
+    const lowered = value.toLowerCase();
+    const attestedText = attested.toLowerCase();
+    for (const token of denylist) {
+        if (lowered.includes(token) && !attestedText.includes(token)) return token;
+    }
+    return null;
+}
+
+/**
+ * Copy substituted for a string that carries an internal token.
+ *
+ * A neutral replacement rather than a redaction of the token alone: a sentence
+ * built around a leaked enum does not become true when the enum is removed
+ * from it ("Scope resolution returned ." is not an improvement), and it must
+ * not read as a claim the server never made.
+ */
+export const WITHHELD_COPY = "This part of the answer could not be shown.";
+
+export function safeCopy(
+    value: string | null | undefined,
+    denylist: ReadonlySet<string>,
+    attested = "",
+): string {
+    if (!value) return "";
+    return findInternalToken(value, denylist, attested) === null ? value : WITHHELD_COPY;
+}

--- a/src/lib/dev/internalTokens.ts
+++ b/src/lib/dev/internalTokens.ts
@@ -53,6 +53,25 @@ const DEV_ERROR_CODE_TOKENS: readonly string[] = [
     "tool_unavailable",
 ];
 
+/**
+ * Tokens no provenance may ever exempt, mirroring ops
+ * `no_match_terminal.NEVER_ATTESTABLE_TOKENS`.
+ *
+ * Left unbounded, `attested` was itself a hole: an evidence label named
+ * `scope_forbidden` would exempt a genuinely leaked `scope_forbidden` anywhere
+ * else in the same answer. These tokens describe Ask Dev's own scope-resolution
+ * decision — an entity cannot plausibly be named after one, and they are
+ * exactly what PRD §12 prohibits by name — so the escape hatch does not apply
+ * to them at all.
+ */
+export const NEVER_ATTESTABLE_TOKENS: ReadonlySet<string> = new Set([
+    "forbidden_or_not_found",
+    "organization_fallback",
+    "scope_ambiguous",
+    "scope_forbidden",
+    "scope_not_found",
+]);
+
 export function buildInternalTokenDenylist(
     ...vocabularies: readonly (readonly string[])[]
 ): ReadonlySet<string> {
@@ -86,7 +105,8 @@ export function findInternalToken(
     const lowered = value.toLowerCase();
     const attestedText = attested.toLowerCase();
     for (const token of denylist) {
-        if (lowered.includes(token) && !attestedText.includes(token)) return token;
+        if (!lowered.includes(token)) continue;
+        if (NEVER_ATTESTABLE_TOKENS.has(token) || !attestedText.includes(token)) return token;
     }
     return null;
 }

--- a/tests/mocks/devScenario.ts
+++ b/tests/mocks/devScenario.ts
@@ -170,7 +170,31 @@ function buildAnswer(
             // (`scopeResolution.outcome.replaceAll("_", " ")`). Public
             // copy must never disclose which of "forbidden" or "not found"
             // applies (that would itself leak hidden-entity existence).
-            base.direct_summary = "No authorized match was found for this question.";
+            // CHAOS-3367: mirrors what ops
+            // (no_match_terminal.named_subject_not_found_answer) actually
+            // emits now, not an approximation of it -- the PRD's verbatim
+            // sentence, insufficient_evidence rather than refused, no
+            // warnings, and a zero coverage block because no source plan ran
+            // for a subject that was never resolved. A mock that kept the old
+            // shape would let the e2e suite assert a payload production no
+            // longer produces.
+            base.status = "insufficient_evidence";
+            base.direct_summary =
+                "I couldn't find an authorized project named 'Zed' in the selected " +
+                "organization. I did not substitute organization-wide data. Here are " +
+                "the closest matches, if any.";
+            base.claims = [];
+            base.evidence = [];
+            base.metrics = [];
+            base.warnings = [];
+            base.suggested_follow_up_questions = [];
+            (base.coverage as JsonRecord) = {
+                ...(base.coverage as JsonRecord),
+                available_source_count: 0,
+                required_source_count: 0,
+                unavailable_required_sources: [],
+                stale_required_sources: [],
+            };
             const resolvedScope = base.resolved_scope as JsonRecord;
             resolvedScope.outcome = "forbidden_or_not_found";
             resolvedScope.resolved_scope = null;


### PR DESCRIPTION
Companion to **full-chaos/dev-health-ops#1449**. That PR fixes the payload; this fixes the presentation, which has to hold independently because the server-side change cannot reach rows that are already persisted.

**No pin bump needed.** The ops change produced no contract-artifact diff (both exporters re-run), so this PR does not depend on the ops merge for a regenerated `schema.graphql` or `generated.ts`. It does mirror one ops *runtime* rule (candidates on a no-match resolution) in `contractValidation.ts`.

## What broke

A live screenshot showed four Wave 3.1 PRD §12 prohibitions on screen at once for a named subject that resolved to not-found: a **Refused** chip; a body reading "Scope resolution … returned `forbidden_or_not_found` …"; **Scope outcome: Exact match**; **Coverage: 1 of 1 sources**.

## What this does

**A no-match answer gets its own presentation**, keyed off the resolution outcome rather than the status so it stays correct whichever status a replayed row carries: a "No match found" chip instead of "Refused", no status caption claiming Ask Dev declined to answer, and "Closest matches" rather than "Possible scope matches" over the candidate list — the second phrasing asserts the subject exists, which is the substitution §12 prohibits.

**It also catches the legacy contradictory shape**, which is what the screenshot actually is. That row carries `outcome: "exact"` beside a summary saying a named subject was not found, so keying off the outcome field alone left every violation on screen. The classifier now also fires when the answer's own prose carries a scope-resolution token — those tokens are never attestable, so no entity label can produce a false positive — and when the summary and the scope row disagree, the scope row loses. It is the field that would otherwise put "Exact match" next to a not-found statement.

**`forbidden_or_not_found` now reads "No authorized match found"** instead of "Not accessible". Both collapse the forbidden/not-found distinction the backend deliberately hides (which is what the existing comment on that map is about); "Not accessible" additionally asserted an access denial this outcome cannot establish, and §12 forbids an authorization-shaped statement unless access was really denied. The wording is the TRD §7.1 public class. It lives only here — no ops constant mirrors it, because no ops code path renders it and a constant only its own test reads is a coverage claim with nothing behind it.

**The coverage row is hidden when there is genuinely nothing to report.** "0 of 0 sources" reads as a measurement that happened. Suppression requires the required count *and* the unavailable and stale lists to all be empty — the contract permits zero required beside a non-empty unavailable list, and hiding the block on the count alone would take the only source-specific explanation with it.

**Model-authored prose passes through a token guard.** `direct_summary`, claim text, warnings, conflict summaries and suggested follow-ups, plus the `status: "error"` branch in `AskDevConversation` that bypasses `AskDevAnswer` entirely. The denylist is derived from the two TOTAL label `Record`s, so it cannot fall behind the generated unions, and the hand-written `DevError` half is pinned by a test against the generated union. It has a provenance escape hatch — a token is suppressed only when nothing this answer already carries as an authorized label contains it — so an authorized repository whose name looks like an enum member keeps its own copy, while scope-resolution tokens are never exemptable regardless.

**The e2e mock now mirrors what ops actually emits** (PRD sentence, `insufficient_evidence`, zero coverage) rather than an approximation of it.

## RED-first evidence

Nine controls were run against unmodified `origin/main` before the fix:

```
× renders sanctioned copy for a forbidden_or_not_found scope outcome…
× never shows a Refused chip for a no-match result
× never shows an Exact match scope outcome beside a no-match summary
× hides the sources line entirely when no source plan ran
× calls a no-match candidate list closest matches, not possible scope matches
× never renders an internal token that arrived in direct_summary
    expected 'AI-generatedInsufficient evidenceAs o…' not to contain 'forbidden_or_not_found'
× never renders an internal token that arrived in a warning / a claim / a conflict
Tests  9 failed | 14 passed (23)
```

Three further controls added in the second commit were verified RED against the first.

One test is explicitly **not** a control and is labelled as such: "passes the PRD's own no-match sentence through the token guard unaltered" stays green with the component reverted. It is a compatibility check — the guard must not mangle the server's own sentence — and it earns its place for that, not as evidence the fix works.

## Codex adversarial review

One round, 1 HIGH + 4 MEDIUM + 1 LOW, all addressed in `0c6a7cbd`:

- **HIGH** the live legacy payload still rendered Refused / Exact match / 1 of 1 → the contradiction classifier above. This was the review's most valuable finding: the first revision fixed everything except the exact row from the report.
- **MEDIUM** attestation was neither occurrence- nor field-bound, so an evidence label named `scope_forbidden` would exempt a real leak → scope-resolution tokens are never exemptable (mirrored in ops).
- **MEDIUM** `status: "error"` answers and suggested follow-ups bypassed the guard → both now pass through it.
- **MEDIUM** coverage suppression was too broad → now requires the detail arrays empty too.
- **LOW** two claimed controls were not controls → one relabelled, one fixed to use a token that is actually in the denylist (it had used `not_found`, which web's denylist does not contain, so it never exercised the escape hatch at all).
- **Declined:** the review also proposed denying tool identifiers (`resolve_scope.v1`). Tried, and it broke a healthy run on the ops side — server copy names tool ids on purpose ("Provider health was measured through `data_health.v1`") and the acceptance oracle asserts it. Reasoning recorded in ops#1449.

The review also read the three Ask Dev Playwright specs and predicts no failures from the mock change; none of them asserts the no-match presentation.

## Verification

Run on this machine:

- `vitest run` — **3603 passed, 8 skipped, 409 files**
- `tsc --noEmit` — clean
- `eslint` on every changed file — clean
- `prettier --check` — clean on changed files (the one warning, `src/app/site.webmanifest`, is pre-existing and untouched here)

**Not run, honestly:** the **Playwright e2e suite was not run** — the machine is under load and the team lead's instruction for this lane was scoped unit tests and typecheck/lint only. `tests/mocks/devScenario.ts` changed, so the Ask Dev e2e specs will first execute in CI. I reviewed them by hand and expect them to pass (the assertions in `ask-dev-outcomes`, `ask-dev-shared` and `ask-dev-vocabulary` are outcome-agnostic or target the `ambiguous` scenario, whose copy is unchanged), and the codex review reached the same conclusion from source — but that is a prediction, not a measurement.
