### PR TITLE
fix(ask-dev): render project subjects, withhold inconsistent rows, boundary-aware token guard (CHAOS-3377)

### DIFF
--- a/src/components/ask-dev/AskDevAnswer.test.tsx
+++ b/src/components/ask-dev/AskDevAnswer.test.tsx
@@ -250,15 +250,34 @@ describe("AskDevAnswer status explanations (CHAOS-3215)", () => {
             "insufficient_evidence",
             "Insufficient evidence: there isn't enough evidence to answer with confidence. A result with limitations, not a silent success.",
         ],
-        [
-            "refused",
-            "Refused: Ask Dev did not answer this question. A result with limitations, not a silent success.",
-        ],
     ] as const)("shows the sanctioned explanation for a %s answer", (status, expectedText) => {
         const statusAnswer = { ...answer, status } as unknown as DevAnswer;
         render(<AskDevAnswer answer={statusAnswer} />);
 
         expect(screen.getByText(expectedText)).toBeVisible();
+    });
+
+    // CHAOS-3377: a GENUINE refusal (no claim/metric/evidence grounding at
+    // all) still gets the sanctioned "Refused:" caption -- the shared
+    // `answer` fixture above carries real claims/metrics/evidence, so it is
+    // no longer a valid fixture for this case (see the
+    // `refusedDespiteMaterialGrounding` describe block below for what
+    // happens when `status: "refused"` is combined with THAT fixture).
+    it("shows the sanctioned Refused explanation for a genuine refusal with no grounding", () => {
+        const statusAnswer = {
+            ...answer,
+            status: "refused",
+            claims: [],
+            metrics: [],
+            evidence: [],
+        } as unknown as DevAnswer;
+        render(<AskDevAnswer answer={statusAnswer} />);
+
+        expect(
+            screen.getByText(
+                "Refused: Ask Dev did not answer this question. A result with limitations, not a silent success.",
+            ),
+        ).toBeVisible();
     });
 
     it("renders no status explanation for a complete answer", () => {
@@ -500,6 +519,141 @@ describe("AskDevAnswer no-match presentation (CHAOS-3367)", () => {
 
         expect(screen.getByText("Closest matches")).toBeVisible();
         expect(screen.queryByText("Possible scope matches")).not.toBeInTheDocument();
+    });
+});
+
+describe("AskDevAnswer refused-with-grounding presentation (CHAOS-3377)", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    it("never shows a Refused chip or caption over a substantive body", () => {
+        // The live defect: the model self-declared `status=refused` while
+        // `answer` above carries a real claim, metric, and evidence entry.
+        render(<AskDevAnswer answer={{ ...answer, status: "refused" } as DevAnswer} />);
+
+        expect(screen.queryByText("Refused")).not.toBeInTheDocument();
+        expect(screen.queryByText(/Ask Dev did not answer this question/u)).not.toBeInTheDocument();
+        // The body itself is untouched -- this is presentation-only.
+        expect(screen.getByText("The evidence suggests delivery flow improved.")).toBeVisible();
+    });
+
+    it("still shows Refused for a genuine refusal with no grounding (negative control)", () => {
+        const genuineRefusal = {
+            ...answer,
+            status: "refused",
+            claims: [],
+            metrics: [],
+            evidence: [],
+        } as unknown as DevAnswer;
+        render(<AskDevAnswer answer={genuineRefusal} />);
+
+        expect(screen.getByText("Refused")).toBeVisible();
+        expect(screen.getByText(/Ask Dev did not answer this question/u)).toBeVisible();
+    });
+
+    it("catches material grounding carried only by a claim's metric_ref_ids", () => {
+        // A claim can ground itself with a metric reference alone (no
+        // evidence_ref_ids, and no top-level metrics/evidence arrays either)
+        // -- the guard must still catch that shape as "material grounding".
+        const claimMetricOnlyGrounding = {
+            ...answer,
+            status: "refused",
+            metrics: [],
+            evidence: [],
+            claims: [
+                {
+                    ...answer.claims?.[0],
+                    evidence_ref_ids: [],
+                    metric_ref_ids: ["metric-internal-1"],
+                },
+            ],
+        } as unknown as DevAnswer;
+        render(<AskDevAnswer answer={claimMetricOnlyGrounding} />);
+
+        expect(screen.queryByText("Refused")).not.toBeInTheDocument();
+    });
+});
+
+describe("AskDevAnswer CHAOS-3377 acceptance", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    // PRD-prohibited strings for a substantive project-status answer, bound
+    // as literals -- never derived from the module under test.
+    const PROHIBITED_STRINGS = [
+        "actual_completion",
+        "not_ready",
+        "open_blocker",
+        "required_child_incomplete",
+        "required_release_evidence_missing",
+        "ev1_",
+        "}}}{",
+    ];
+
+    it("a substantive project-status answer is never Refused and never leaks internal vocabulary", () => {
+        const projectStatusAnswer = {
+            ...answer,
+            status: "partial",
+            direct_summary:
+                "39 of 69 required items are complete for Falcon Nine. Open items: one or more blocking items are still open; one or more required sub-items are not complete.",
+            resolved_scope: {
+                outcome: "exact",
+                authorized_repository_ids: [],
+                authorized_entity_ids: ["project-falcon-nine"],
+                candidates: [],
+                requested_scope: {
+                    direct_scope: "project",
+                    entity_refs: [
+                        {
+                            display_label: "Falcon Nine",
+                            entity_id: "project-falcon-nine",
+                            entity_type: "project",
+                        },
+                    ],
+                    organization_id: "org-internal-1",
+                    repositories: [],
+                },
+                resolved_scope: {
+                    direct_scope: "project",
+                    entity_refs: [
+                        {
+                            display_label: "Falcon Nine",
+                            entity_id: "project-falcon-nine",
+                            entity_type: "project",
+                        },
+                    ],
+                    organization_id: "org-internal-1",
+                    repositories: [],
+                },
+            },
+        } as unknown as DevAnswer;
+
+        const { container } = render(<AskDevAnswer answer={projectStatusAnswer} />);
+
+        expect(screen.queryByText("Refused")).not.toBeInTheDocument();
+        const rendered = container.textContent ?? "";
+        for (const forbidden of PROHIBITED_STRINGS) {
+            expect(rendered).not.toContain(forbidden);
+        }
+        // Defect 4: a project scope renders its subject, not a repository
+        // count.
+        expect(screen.getByText("Falcon Nine")).toBeVisible();
+        expect(screen.queryByText(/authorized repositories/u)).not.toBeInTheDocument();
+    });
+
+    it("a genuinely refused/no-match result still renders its canonical copy (negative control)", () => {
+        render(<AskDevAnswer answer={{ ...noMatchAnswer, status: "refused" } as DevAnswer} />);
+
+        expect(screen.getByText("No match found")).toBeVisible();
+        expect(screen.queryByText("Refused")).not.toBeInTheDocument();
     });
 });
 

--- a/src/components/ask-dev/AskDevAnswer.test.tsx
+++ b/src/components/ask-dev/AskDevAnswer.test.tsx
@@ -530,15 +530,26 @@ describe("AskDevAnswer refused-with-grounding presentation (CHAOS-3377)", () => 
         };
     });
 
-    it("never shows a Refused chip or caption over a substantive body", () => {
+    it("never shows a Refused chip, and withholds the rejected-shaped body instead of inventing Answered around it", () => {
         // The live defect: the model self-declared `status=refused` while
         // `answer` above carries a real claim, metric, and evidence entry.
+        // CHAOS-3377 HIGH (round 2): an earlier revision relabeled this
+        // "Answered" while STILL rendering the model's original prose --
+        // the ops contract never does that (it discards rejected narrative,
+        // never shows it under an invented label). The chip must read
+        // neutrally AND the original summary/claims must be withheld.
         render(<AskDevAnswer answer={{ ...answer, status: "refused" } as DevAnswer} />);
 
         expect(screen.queryByText("Refused")).not.toBeInTheDocument();
+        expect(screen.queryByText("Answered")).not.toBeInTheDocument();
         expect(screen.queryByText(/Ask Dev did not answer this question/u)).not.toBeInTheDocument();
-        // The body itself is untouched -- this is presentation-only.
-        expect(screen.getByText("The evidence suggests delivery flow improved.")).toBeVisible();
+        expect(screen.getByText("Inconsistent result")).toBeVisible();
+        // The rejected-shaped body/claims are withheld, never rendered.
+        expect(
+            screen.queryByText("The evidence suggests delivery flow improved."),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByText("Cycle time appears to have improved.")).not.toBeInTheDocument();
+        expect(screen.getByText("This part of the answer could not be shown.")).toBeVisible();
     });
 
     it("still shows Refused for a genuine refusal with no grounding (negative control)", () => {

--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -15,6 +15,7 @@ import {
     findInternalToken,
     NEVER_ATTESTABLE_TOKENS,
     safeCopy,
+    WITHHELD_COPY,
 } from "@/lib/dev/internalTokens";
 import { formatMetricValue, formatNumber, formatPercent, formatTimestamp } from "@/lib/formatters";
 
@@ -165,13 +166,36 @@ export function refusedDespiteMaterialGrounding(answer: DevAnswer): boolean {
     );
 }
 
-/** The status pill copy for `refusedDespiteMaterialGrounding` -- mirrors
- * `NO_MATCH_STATUS_LABEL`'s rationale: neither the raw status nor a
- * boilerplate "Refused" caption is accurate, so a neutral, honest label
- * takes their place instead of asserting a specific status the client
- * cannot itself verify from a legacy row.
+/**
+ * The status pill copy for `refusedDespiteMaterialGrounding`.
+ *
+ * CHAOS-3377 HIGH (codex adversarial web review, round 2): an earlier
+ * revision relabeled this contradiction "Answered" while STILL rendering
+ * the model's original (rejected-shaped) `direct_summary`/`claims`
+ * underneath -- the ops contract never does that (a refused-with-grounding
+ * candidate is either repaired or has its narrative DISCARDED and replaced
+ * with server-owned content; see `answer_validator.py` /
+ * `Orchestrator._server_grounded_answer`). Labelling this "Answered" while
+ * showing the rejected prose invents a coherent answer the server never
+ * produced. This is now a genuinely neutral, non-committal label -- content
+ * is withheld alongside it (see `refusedWithGrounding` below in the
+ * component body), never invented around.
+ *
+ * The authoritative fix for a NEW run's persisted row is server-side
+ * (`no_match_terminal._normalize_refused_with_grounding`, run on every
+ * replay/transcript read); this remains only as defense-in-depth for a row
+ * that somehow reaches the client without having gone through that
+ * normalization.
  */
-export const REFUSED_WITH_GROUNDING_STATUS_LABEL = "Answered";
+export const REFUSED_WITH_GROUNDING_STATUS_LABEL = "Inconsistent result";
+
+/** The caption shown in place of `STATUS_EXPLANATIONS` when
+ * `refusedWithGrounding` is true -- explains the withholding, not the
+ * (rejected) content underneath it. */
+export const REFUSED_WITH_GROUNDING_EXPLANATION =
+    "Inconsistent result: this answer's recorded status and its own content " +
+    "disagree. The original narrative has been withheld; any structured " +
+    "metrics or evidence below are unaffected.";
 
 /**
  * Every string in this answer with a server-authorized provenance, joined for
@@ -366,8 +390,11 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         : refusedWithGrounding
           ? REFUSED_WITH_GROUNDING_STATUS_LABEL
           : ANSWER_STATUS_LABELS[answer.status];
-    const statusExplanation =
-        noMatch || refusedWithGrounding ? undefined : STATUS_EXPLANATIONS[answer.status];
+    const statusExplanation = noMatch
+        ? undefined
+        : refusedWithGrounding
+          ? REFUSED_WITH_GROUNDING_EXPLANATION
+          : STATUS_EXPLANATIONS[answer.status];
     // The coverage row is meaningless when no source plan ran -- "0 of 0
     // sources" reads as a measurement, and the live defect's "1 of 1 sources"
     // read as a completed source plan for a subject that was never resolved.
@@ -560,7 +587,9 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                     <p className="text-sm leading-6 text-(--text-secondary)">{statusExplanation}</p>
                 ) : null}
                 <p className="font-(--font-display) text-h3 text-(--text-primary)">
-                    {safeCopy(answer.direct_summary, INTERNAL_TOKEN_DENYLIST, attested)}
+                    {refusedWithGrounding
+                        ? WITHHELD_COPY
+                        : safeCopy(answer.direct_summary, INTERNAL_TOKEN_DENYLIST, attested)}
                 </p>
             </div>
 
@@ -659,7 +688,13 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                 </section>
             ) : null}
 
-            {answer.claims?.length ? (
+            {/*
+             * CHAOS-3377 HIGH: claims are model-authored prose, exactly
+             * like direct_summary above -- a refused-with-grounding row's
+             * claims are withheld the same way, never rendered alongside a
+             * relabeled-but-invented status.
+             */}
+            {!refusedWithGrounding && answer.claims?.length ? (
                 <section
                     className="space-y-3 border-t border-(--border) pt-4"
                     aria-labelledby={findingsHeadingId}

--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -137,6 +137,43 @@ export function isNoMatchAnswer(answer: DevAnswer): boolean {
 }
 
 /**
+ * Whether this answer is labelled Refused despite carrying material
+ * grounding -- CHAOS-3377 defect 1's client-side backstop.
+ *
+ * Ops now server-renders an honest, never-Refused status for a NEW run
+ * whose tool results include a completion assessment
+ * (`status_answer_render.deterministic_answer_status`), and validates that
+ * a self-declared `refused` status cannot coexist with real grounding for
+ * every other path (`answer_validator.py`'s "refused_with_material_
+ * grounding" check). Neither of those can reach a row persisted, or
+ * replayed, before this fix existed -- the client has to notice the
+ * contradiction itself, exactly as `contradictsCommittedScope` already does
+ * for the CHAOS-3367 scope-outcome case this mirrors. "Material grounding"
+ * uses the same signal ops's own floor/ceiling checks do: a real claim,
+ * metric, or evidence entry -- not just a non-empty array of any shape.
+ */
+export function refusedDespiteMaterialGrounding(answer: DevAnswer): boolean {
+    if (answer.status !== "refused") return false;
+    return (
+        (answer.metrics?.length ?? 0) > 0 ||
+        (answer.evidence?.length ?? 0) > 0 ||
+        (answer.claims ?? []).some(
+            (claim) =>
+                (claim.evidence_ref_ids?.length ?? 0) > 0 ||
+                (claim.metric_ref_ids?.length ?? 0) > 0,
+        )
+    );
+}
+
+/** The status pill copy for `refusedDespiteMaterialGrounding` -- mirrors
+ * `NO_MATCH_STATUS_LABEL`'s rationale: neither the raw status nor a
+ * boilerplate "Refused" caption is accurate, so a neutral, honest label
+ * takes their place instead of asserting a specific status the client
+ * cannot itself verify from a legacy row.
+ */
+export const REFUSED_WITH_GROUNDING_STATUS_LABEL = "Answered";
+
+/**
  * Every string in this answer with a server-authorized provenance, joined for
  * the token guard. Read off the answer's OWN scope, candidates, evidence and
  * metrics — never a catalog lookup: an entity that is not already part of this
@@ -181,6 +218,32 @@ function validityScopeLabel(scope: DevScope | null | undefined): string | null {
                   .length ?? 0);
     const label = scope.direct_scope.replaceAll("_", " ");
     return count > 0 ? `${count} ${label}${count === 1 ? "" : "s"}` : label;
+}
+
+/**
+ * The scope-outcome row's secondary line (CHAOS-3377 defect 4).
+ *
+ * Previously always rendered "{authorized_repository_ids.length} authorized
+ * repositories", regardless of the resolved scope's own kind -- correct for
+ * a REPOSITORY-scoped answer, but for a PROJECT (or any other non-repository)
+ * scope the repository count is at best incidental and at worst reads as
+ * "0 authorized repositories" for a subject that has real, substantive
+ * content and simply carries no repository dimension on the wire (see
+ * ops's `ScopeResolutionService`/`DevScope.repositories`, which is only
+ * ever populated for a REPOSITORY commit). Reuses `validityScopeLabel` --
+ * the same "name the subject, not a count" logic `claim.validity_scope`
+ * already renders -- so a project scope shows its subject ("Falcon Nine")
+ * instead. Falls back to the repository count whenever the scope itself is
+ * missing or genuinely repository-scoped, which is unchanged behavior.
+ */
+function scopeCoverageLabel(scopeResolution: NonNullable<DevAnswer["resolved_scope"]>): string {
+    const scope = scopeResolution.resolved_scope ?? scopeResolution.requested_scope;
+    if (scope && scope.direct_scope !== "repository") {
+        const subjectLabel = validityScopeLabel(scope);
+        if (subjectLabel) return subjectLabel;
+    }
+    const count = scopeResolution.authorized_repository_ids?.length ?? 0;
+    return `${count} authorized repositories`;
 }
 
 function EvidenceRow({
@@ -286,13 +349,25 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     // status. The server's own summary carries the explanation, so a second
     // boilerplate caption above it would only repeat it less accurately.
     const noMatch = isNoMatchAnswer(answer);
+    // CHAOS-3377 defect 1. A refusal that carries real claim/metric/evidence
+    // grounding is the same class of self-contradiction as a no-match whose
+    // scope outcome says "exact" -- a result with content is not a refusal
+    // (PRD §12). Checked only when `noMatch` didn't already claim this row
+    // (the two are mutually exclusive in practice, but `noMatch` is the more
+    // specific, better-understood diagnosis when both could apply).
+    const refusedWithGrounding = !noMatch && refusedDespiteMaterialGrounding(answer);
     // A contradictory legacy row's scope outcome is not trustworthy — showing
     // "Exact match" beside a not-found summary is the §12 juxtaposition
     // itself. The row is kept (the repository count beside it is still real)
     // but the outcome value is withheld rather than asserted.
     const scopeOutcomeTrusted = !contradictsCommittedScope(answer);
-    const statusLabel = noMatch ? NO_MATCH_STATUS_LABEL : ANSWER_STATUS_LABELS[answer.status];
-    const statusExplanation = noMatch ? undefined : STATUS_EXPLANATIONS[answer.status];
+    const statusLabel = noMatch
+        ? NO_MATCH_STATUS_LABEL
+        : refusedWithGrounding
+          ? REFUSED_WITH_GROUNDING_STATUS_LABEL
+          : ANSWER_STATUS_LABELS[answer.status];
+    const statusExplanation =
+        noMatch || refusedWithGrounding ? undefined : STATUS_EXPLANATIONS[answer.status];
     // The coverage row is meaningless when no source plan ran -- "0 of 0
     // sources" reads as a measurement, and the live defect's "1 of 1 sources"
     // read as a completed source plan for a subject that was never resolved.
@@ -504,8 +579,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                             </strong>
                         </span>
                         <span className="text-(--text-muted)">
-                            {scopeResolution.authorized_repository_ids?.length ?? 0} authorized
-                            repositories
+                            {scopeCoverageLabel(scopeResolution)}
                         </span>
                     </div>
                     {scopeResolution.candidates?.length ? (

--- a/src/lib/__tests__/internalTokens.test.ts
+++ b/src/lib/__tests__/internalTokens.test.ts
@@ -1,0 +1,132 @@
+/**
+ * CHAOS-3377 (codex adversarial web review, round 2): two MEDIUM findings
+ * against the `STATUS_ASSESSMENT_TOKENS` denylist widening.
+ *
+ * 1. No effective drift/mutation guard. The original acceptance test fed
+ *    already-TRANSLATED prose and asserted the raw tokens were absent from
+ *    it -- true regardless of whether the denylist contains those tokens at
+ *    all, so deleting the entire `STATUS_ASSESSMENT_TOKENS` array would
+ *    leave that test green. This file's `EXPECTED_STATUS_TOKENS` is a
+ *    hand-written LITERAL list, mirroring the same rule
+ *    `AskDevAnswer.test.tsx`'s own `PRD_PROHIBITED_TOKENS` states for
+ *    itself ("a control that imports its own expected string from the code
+ *    it is checking cannot fail when that code is wrong") -- it must never
+ *    import from `internalTokens.ts`. Every literal is INJECTED into a
+ *    guarded field and the guard is asserted to actually catch it: removing
+ *    any one token from the real denylist turns exactly that test red,
+ *    because the literal a token would need to still be caught by lives
+ *    here, independent of the array under test.
+ *
+ * 2. Substring collisions over-redacted legitimate text: `findInternalToken`
+ *    used to do a bare case-insensitive `includes()` and replace the WHOLE
+ *    field. `factual_completion.ts`, `cannot_ready`, and `prev1_state` all
+ *    contain a denylisted token as a substring while being ordinary,
+ *    legitimate identifiers. Fixed with word-boundary matching (plus a
+ *    dedicated shape check for the `ev1_` evidence-handle prefix, which a
+ *    plain `\bev1_\b` boundary can't correctly express -- a real handle
+ *    continues with 40 more word characters immediately after the prefix).
+ *
+ * Source of truth for `EXPECTED_STATUS_TOKENS`: ops
+ * `status_change_service.STATUS_REASON_CODES` (+ the `not_ready` completion
+ * state and the `actual_completion` rule id), also published as the checked
+ * -in artifact `contracts/ask-dev/v1/vocabulary/internal_prose_denylist.v1.json`.
+ * KNOWN GAP (tracked, not silently accepted): this list is a manual snapshot
+ * of that artifact, not yet pulled automatically the way
+ * `scripts/ask-dev-contracts.mjs` pulls the JSON-schema artifacts from a
+ * pinned ops commit -- ops CHAOS-3377 has not merged yet, so there is no
+ * commit to pin to. Extending that script's existing pinned-source mechanism
+ * to also sync `vocabulary/internal_prose_denylist.v1.json` (dropping this
+ * hand-copied list in favor of a generated one) is the correct follow-up
+ * once ops merges; until then, this file's list must be updated by hand
+ * alongside any ops change to `STATUS_REASON_CODES`, and IS covered by the
+ * effectiveness test below even though it cannot detect that specific
+ * cross-repo drift on its own.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { INTERNAL_TOKEN_DENYLIST } from "@/components/ask-dev/AskDevAnswer";
+import { findInternalToken, safeCopy, WITHHELD_COPY } from "@/lib/dev/internalTokens";
+
+const EXPECTED_STATUS_TOKENS = [
+    "actual_completion",
+    "not_ready",
+    "child_requirement_unknown",
+    "declared_status_missing",
+    "required_source_not_fresh",
+    "assessment_source_limit_reached",
+    "required_release_evidence_missing",
+    "required_child_incomplete",
+    "open_blocker",
+    "required_pull_request_unmerged",
+    "required_review_unresolved",
+    "review_changes_requested",
+    "ci_requirement_unknown",
+    "required_ci_skip_state_unknown",
+    "required_ci_work_skipped",
+    "required_ci_not_passing",
+    "required_deployment_not_succeeded",
+    "active_blocking_incident",
+] as const;
+
+describe("STATUS_ASSESSMENT_TOKENS coverage (CHAOS-3377 MEDIUM 1)", () => {
+    it.each(EXPECTED_STATUS_TOKENS)(
+        "the real denylist contains the literal token '%s'",
+        (token) => {
+            expect(INTERNAL_TOKEN_DENYLIST.has(token)).toBe(true);
+        },
+    );
+
+    it.each(EXPECTED_STATUS_TOKENS)(
+        "injecting '%s' into a guarded field is actually caught",
+        (token) => {
+            const text = `The assessment reported ${token} for this subject.`;
+            expect(findInternalToken(text, INTERNAL_TOKEN_DENYLIST)).toBe(token);
+            expect(safeCopy(text, INTERNAL_TOKEN_DENYLIST)).toBe(WITHHELD_COPY);
+        },
+    );
+
+    it("catches a real evidence-handle shape (ev1_ + 40 hex chars)", () => {
+        const handle = `ev1_${"a".repeat(40)}`;
+        const text = `See ${handle} for detail.`;
+        expect(findInternalToken(text, INTERNAL_TOKEN_DENYLIST)).toBe("ev1_");
+        expect(safeCopy(text, INTERNAL_TOKEN_DENYLIST)).toBe(WITHHELD_COPY);
+    });
+
+    it("a token embedded at the very start or end of the field is still caught", () => {
+        const [token] = EXPECTED_STATUS_TOKENS;
+        expect(findInternalToken(`${token} is the reason.`, INTERNAL_TOKEN_DENYLIST)).toBe(token);
+        expect(findInternalToken(`The reason is ${token}`, INTERNAL_TOKEN_DENYLIST)).toBe(token);
+    });
+});
+
+describe("findInternalToken substring-collision negative controls (CHAOS-3377 MEDIUM 2)", () => {
+    // Reviewer repros: each identifier CONTAINS a denylisted token as a
+    // literal substring while being ordinary, legitimate text with no
+    // internal-vocabulary leak in it at all.
+    it.each([
+        ["A file named factual_completion.ts was changed.", "actual_completion"],
+        ["The check is cannot_ready until Friday.", "not_ready"],
+        ["The variable prev1_state tracks the previous render.", "ev1_"],
+    ])("'%s' is not flagged despite containing '%s' as a substring", (text) => {
+        expect(findInternalToken(text, INTERNAL_TOKEN_DENYLIST)).toBeNull();
+        expect(safeCopy(text, INTERNAL_TOKEN_DENYLIST)).toBe(text);
+    });
+
+    it("a longer identifier containing 'ev1_' followed by fewer than 40 hex chars is not flagged", () => {
+        const text = `Reference ev1_${"a".repeat(10)} is not a real handle.`;
+        expect(findInternalToken(text, INTERNAL_TOKEN_DENYLIST)).toBeNull();
+    });
+
+    it("a longer identifier containing 'ev1_' followed by non-hex characters is not flagged", () => {
+        const text = `Config key ev1_${"z".repeat(40)} is unrelated.`;
+        expect(findInternalToken(text, INTERNAL_TOKEN_DENYLIST)).toBeNull();
+    });
+
+    it("still catches a genuine leak in the SAME sentence as a substring collision", () => {
+        // A sentence that contains BOTH an innocuous substring collision and
+        // a genuine standalone leak must still fail on the real leak.
+        const text = "factual_completion.ts references open_blocker directly.";
+        expect(findInternalToken(text, INTERNAL_TOKEN_DENYLIST)).toBe("open_blocker");
+    });
+});

--- a/src/lib/dev/internalTokens.ts
+++ b/src/lib/dev/internalTokens.ts
@@ -58,9 +58,10 @@ const DEV_ERROR_CODE_TOKENS: readonly string[] = [
  * vocabulary -- the completion `state` Literal plus every reason code
  * `status_change_service._assess` can emit (ops
  * `status_change_service.STATUS_REASON_CODES` / `status_completion_copy.py`
- * is the source of truth this list mirrors; kept in sync by
- * `AskDevAnswer.test.tsx`'s totality test against the PRD's literal
- * prohibited strings, the same way `DEV_ERROR_CODE_TOKENS` above is pinned).
+ * is the source of truth this list mirrors, also published as the checked-in
+ * artifact `contracts/ask-dev/v1/vocabulary/internal_prose_denylist.v1.json`;
+ * kept in sync by `src/lib/__tests__/internalTokens.test.ts`'s literal-
+ * mutation test, the same way `DEV_ERROR_CODE_TOKENS` above is pinned).
  *
  * Ops now server-renders this vocabulary through a closed translation table
  * before it ever reaches `dev_answer.v1` (`status_answer_render.py`), so a
@@ -70,9 +71,13 @@ const DEV_ERROR_CODE_TOKENS: readonly string[] = [
  * rationale for the CHAOS-3367 scope-resolution vocabulary.
  *
  * `"ev1_"` is not a StrEnum member but an evidence-handle PREFIX
- * (`ev1_<40 hex>`, ops `contracts_v2/base.py`); included directly since the
- * substring-based scan below matches a prefix exactly the same way it
- * matches a whole token.
+ * (`ev1_<40 hex>`, ops `contracts_v2/base.py`). Kept in this array so
+ * `INTERNAL_TOKEN_DENYLIST.has("ev1_")` still reads true, but
+ * `findInternalToken` below does NOT substring-match it here -- a plain
+ * substring/prefix check false-positives on ordinary identifiers that merely
+ * contain "ev1_" (codex adversarial review round 2 MEDIUM, e.g.
+ * `prev1_state`); it is matched by its full wire shape instead, via
+ * `EVIDENCE_HANDLE_PATTERN`.
  */
 const STATUS_ASSESSMENT_TOKENS: readonly string[] = [
     "actual_completion",
@@ -125,12 +130,51 @@ export function buildInternalTokenDenylist(
     );
 }
 
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+//: Compiled once per token (the denylist is a small, fixed vocabulary), not
+//: rebuilt on every `findInternalToken` call.
+const WORD_BOUNDARY_PATTERN_CACHE = new Map<string, RegExp>();
+
+function wordBoundaryPattern(token: string): RegExp {
+    let pattern = WORD_BOUNDARY_PATTERN_CACHE.get(token);
+    if (!pattern) {
+        pattern = new RegExp(`\\b${escapeRegExp(token)}\\b`, "iu");
+        WORD_BOUNDARY_PATTERN_CACHE.set(token, pattern);
+    }
+    return pattern;
+}
+
+/**
+ * An Ask Dev evidence handle's exact wire shape -- `ev1_` followed by 40
+ * lowercase hex characters (ops `contracts_v2/base.py`'s own
+ * `ev1_[0-9a-f]{40}` pattern). Matched by SHAPE, not as a bare "ev1_"
+ * substring or prefix (codex adversarial review round 2 MEDIUM: a plain
+ * substring/prefix check false-positived on ordinary identifiers that merely
+ * contain "ev1_", e.g. a variable named `prev1_state`). A real evidence
+ * handle's word-boundary word-character run continues for exactly 40 hex
+ * digits past the prefix, which `prev1_state`-shaped identifiers cannot
+ * produce.
+ */
+const EVIDENCE_HANDLE_PATTERN = /\bev1_[0-9a-f]{40}\b/giu;
+
 /**
  * The first denylisted token found in `value`, or `null`.
  *
- * Case-insensitive and substring-based: the reported live defect rendered
- * `forbidden_or_not_found` in the middle of a sentence, so an equality check
- * against the whole field would not have seen it.
+ * Word-boundary matched (``\b<token>\b``, case-insensitive), not a bare
+ * substring check: the reported live defect rendered `forbidden_or_not_found`
+ * in the middle of a sentence, so an equality check against the whole field
+ * would not have seen it, but a bare substring check over-matches ordinary
+ * identifiers that merely CONTAIN a token -- `factual_completion.ts` contains
+ * `actual_completion`, `cannot_ready` contains `not_ready` (codex adversarial
+ * review round 2 MEDIUM, both reproduced and now covered by negative-control
+ * tests). Word boundaries eliminate both false positives without an
+ * exclusion list, the same way the existing underscore-only filter already
+ * eliminates `exact`/`denied`/`failed` as false positives. The evidence-
+ * handle token (`ev1_`) is matched separately, by its full wire shape, for
+ * the same reason -- see `EVIDENCE_HANDLE_PATTERN`.
  *
  * `attested` is the provenance escape hatch, mirroring ops
  * `no_match_terminal.internal_token_leak`. Some denylisted tokens are also
@@ -147,10 +191,18 @@ export function findInternalToken(
     attested = "",
 ): string | null {
     if (!value) return null;
-    const lowered = value.toLowerCase();
     const attestedText = attested.toLowerCase();
+
+    EVIDENCE_HANDLE_PATTERN.lastIndex = 0;
+    const handleMatch = EVIDENCE_HANDLE_PATTERN.exec(value);
+    if (handleMatch) {
+        const handle = handleMatch[0].toLowerCase();
+        if (!attestedText.includes(handle)) return "ev1_";
+    }
+
     for (const token of denylist) {
-        if (!lowered.includes(token)) continue;
+        if (token === "ev1_") continue; // matched above, by shape, not substring
+        if (!wordBoundaryPattern(token).test(value)) continue;
         if (NEVER_ATTESTABLE_TOKENS.has(token) || !attestedText.includes(token)) return token;
     }
     return null;

--- a/src/lib/dev/internalTokens.ts
+++ b/src/lib/dev/internalTokens.ts
@@ -54,6 +54,49 @@ const DEV_ERROR_CODE_TOKENS: readonly string[] = [
 ];
 
 /**
+ * CHAOS-3377 defect 2: the `dev_status_snapshot`/`ActualCompletion` internal
+ * vocabulary -- the completion `state` Literal plus every reason code
+ * `status_change_service._assess` can emit (ops
+ * `status_change_service.STATUS_REASON_CODES` / `status_completion_copy.py`
+ * is the source of truth this list mirrors; kept in sync by
+ * `AskDevAnswer.test.tsx`'s totality test against the PRD's literal
+ * prohibited strings, the same way `DEV_ERROR_CODE_TOKENS` above is pinned).
+ *
+ * Ops now server-renders this vocabulary through a closed translation table
+ * before it ever reaches `dev_answer.v1` (`status_answer_render.py`), so a
+ * NEW run cannot leak these. This list is the client-side backstop for an
+ * already-persisted or replayed row written before that fix existed --
+ * mirrors `no_match_terminal.py`'s own read-time `redact_persisted_answer`
+ * rationale for the CHAOS-3367 scope-resolution vocabulary.
+ *
+ * `"ev1_"` is not a StrEnum member but an evidence-handle PREFIX
+ * (`ev1_<40 hex>`, ops `contracts_v2/base.py`); included directly since the
+ * substring-based scan below matches a prefix exactly the same way it
+ * matches a whole token.
+ */
+const STATUS_ASSESSMENT_TOKENS: readonly string[] = [
+    "actual_completion",
+    "not_ready",
+    "child_requirement_unknown",
+    "declared_status_missing",
+    "required_source_not_fresh",
+    "assessment_source_limit_reached",
+    "required_release_evidence_missing",
+    "required_child_incomplete",
+    "open_blocker",
+    "required_pull_request_unmerged",
+    "required_review_unresolved",
+    "review_changes_requested",
+    "ci_requirement_unknown",
+    "required_ci_skip_state_unknown",
+    "required_ci_work_skipped",
+    "required_ci_not_passing",
+    "required_deployment_not_succeeded",
+    "active_blocking_incident",
+    "ev1_",
+];
+
+/**
  * Tokens no provenance may ever exempt, mirroring ops
  * `no_match_terminal.NEVER_ATTESTABLE_TOKENS`.
  *
@@ -76,7 +119,9 @@ export function buildInternalTokenDenylist(
     ...vocabularies: readonly (readonly string[])[]
 ): ReadonlySet<string> {
     return new Set(
-        [...vocabularies, DEV_ERROR_CODE_TOKENS].flat().filter((token) => token.includes("_")),
+        [...vocabularies, DEV_ERROR_CODE_TOKENS, STATUS_ASSESSMENT_TOKENS]
+            .flat()
+            .filter((token) => token.includes("_")),
     );
 }
 


### PR DESCRIPTION
## Summary

Web half of CHAOS-3377 (companion to the ops PR "server-render the §10 status verdict deterministically at every terminal"):

- **Project scopes render their subject**, not a repository count ("Falcon Nine", never "Exact match / 0 authorized repositories").
- **Inconsistent rows are withheld, not relabeled**: a replayed row whose wire status says refused but which carries material grounding renders an explicit "Inconsistent result" state with summary/claims withheld — the client never invents "Answered" around rejected model prose (ops-side replay normalization is authoritative; this is defense-in-depth).
- **Boundary-aware internal-token guard**: `findInternalToken` uses word-boundary matching, evidence handles match only their full `ev1_[0-9a-f]{40}` shape — `factual_completion.ts` / `cannot_ready` / `prev1_state` no longer trigger whole-field redaction (negative controls pinned).
- **STATUS_ASSESSMENT_TOKENS widened** to the status reason-code vocabulary, with a real mutation guard: every token injected into each guarded field and asserted caught — removing any one token turns exactly that test red. Ops now publishes `internal_prose_denylist.v1.json` for future generator sync (follow-up tracked in the test docstring; pinning requires the ops PR to merge first).

Merge order: ops PR first.

## Testing

- Full repo vitest: 410 files, 3650 passed, 8 skipped, 0 failed. tsc / eslint / prettier clean.
- Codex adversarial review round; each finding fail→pass verified against pre-fix code.
