### PR TITLE
feat(marketing): add Context Fabric product page

### DIFF
--- a/src/app/marketing/context-fabric/page.tsx
+++ b/src/app/marketing/context-fabric/page.tsx
@@ -249,8 +249,9 @@ export default function ContextFabricMarketingPage() {
                         </p>
                         <h3 className="mt-4 font-(--font-display) text-3xl">Ask Dev</h3>
                         <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
-                            Dev is embedded in the Dev Health application and answers questions about
-                            project, team, and organizational health across the connected ecosystem.
+                            Dev is embedded in the Dev Health application and answers questions
+                            about project, team, and organizational health across the connected
+                            ecosystem.
                         </p>
                         <ul className="mt-7 space-y-3">
                             {ASK_DEV_QUESTIONS.map((question) => (
@@ -308,8 +309,8 @@ export default function ContextFabricMarketingPage() {
                             An answer should show its work.
                         </h2>
                         <p className="mt-5 text-sm leading-relaxed text-(--ink-muted)">
-                            Context Fabric does not quietly turn incomplete data into certainty. What
-                            it can answer depends on the sources, permissions, freshness, and
+                            Context Fabric does not quietly turn incomplete data into certainty.
+                            What it can answer depends on the sources, permissions, freshness, and
                             capabilities available to the organization.
                         </p>
                     </div>

--- a/src/app/marketing/context-fabric/page.tsx
+++ b/src/app/marketing/context-fabric/page.tsx
@@ -1,0 +1,361 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CTA_LABELS } from "@/lib/design/cta";
+
+export const metadata: Metadata = {
+    title: "Context Fabric — Full Chaos Dev Health",
+    description:
+        "Connect planning, code, delivery, reliability, and source-health evidence so people and agents can understand the real state of engineering work.",
+    openGraph: {
+        title: "Context Fabric — See the whole engineering picture",
+        description:
+            "Understand project, team, and organizational health from connected evidence instead of one status field.",
+        type: "website",
+        siteName: "Full Chaos Dev Health",
+        images: [
+            {
+                url: "/opengraph-image.png",
+                width: 1200,
+                height: 630,
+                alt: "Full Chaos Dev Health Context Fabric",
+            },
+        ],
+    },
+};
+
+const CONNECTED_SIGNALS = [
+    "Planning and tracking",
+    "Code and review",
+    "CI and delivery",
+    "Incidents and reliability",
+] as const;
+
+const ACTUAL_STATE = [
+    "Pull request merged",
+    "CI passed",
+    "Deployment succeeded",
+    "Feature flag enabled",
+    "Available to users",
+] as const;
+
+const ASK_DEV_QUESTIONS = [
+    "Is this project actually done?",
+    "What is blocking delivery?",
+    "Which teams need attention?",
+    "What changed in this team’s DORA metrics over the last 90 days?",
+] as const;
+
+const AGENT_QUESTIONS = [
+    "What decisions already govern this work?",
+    "Which related changes or failures matter?",
+    "What evidence should be verified before editing?",
+    "Which risks and required checks are already known?",
+] as const;
+
+function CheckIcon() {
+    return (
+        <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+        >
+            <path d="m5 12 4 4L19 6" />
+        </svg>
+    );
+}
+
+export default function ContextFabricMarketingPage() {
+    return (
+        <>
+            <section className="mx-auto grid max-w-7xl gap-12 px-6 pb-20 pt-16 sm:pt-24 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.8fr)] lg:items-center">
+                <div>
+                    <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
+                        Context Fabric
+                    </p>
+                    <h1 className="mt-6 max-w-4xl font-(--font-display) text-4xl leading-tight sm:text-5xl lg:text-6xl">
+                        Know what is actually happening—not just what the tracker says.
+                    </h1>
+                    <p className="mt-6 max-w-2xl text-lg leading-relaxed text-(--ink-muted)">
+                        Context Fabric connects the work, code, delivery, reliability, and
+                        source-health evidence already flowing through Dev Health. People and agents
+                        get a shared, evidence-backed view of the real state of a project, team, or
+                        organization.
+                    </p>
+                    <div className="mt-10 flex flex-wrap gap-4">
+                        <Link
+                            href="/auth/signup"
+                            className="rounded-full bg-(--accent) px-8 py-3 text-sm font-medium text-white transition hover:opacity-90"
+                        >
+                            {CTA_LABELS.getStarted}
+                        </Link>
+                        <a
+                            href="https://github.com/full-chaos/dev-health-ops/blob/main/docs/use/ai-workflows/index.md#use-ask-dev-for-a-human-investigation"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                        >
+                            {CTA_LABELS.viewGuide}
+                        </a>
+                    </div>
+                </div>
+
+                <div
+                    className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-5 shadow-2xl shadow-black/10 sm:p-7"
+                    aria-label="Context Fabric connects engineering evidence to Ask Dev and compatible agents"
+                >
+                    <div className="grid grid-cols-2 gap-3">
+                        {CONNECTED_SIGNALS.map((signal) => (
+                            <div
+                                key={signal}
+                                className="rounded-2xl border border-(--card-stroke) bg-(--card) px-4 py-3 text-sm text-(--ink-muted)"
+                            >
+                                {signal}
+                            </div>
+                        ))}
+                    </div>
+
+                    <div className="mx-auto my-5 h-8 w-px bg-(--card-stroke)" aria-hidden="true" />
+
+                    <div className="rounded-3xl border border-(--accent)/40 bg-(--accent)/10 p-6 text-center">
+                        <p className="font-(--font-display) text-2xl">Context Fabric</p>
+                        <p className="mt-2 text-xs uppercase tracking-[0.14em] text-(--ink-muted)">
+                            State → Pressure → Cause → Evidence → Action
+                        </p>
+                    </div>
+
+                    <div className="mx-auto my-5 h-8 w-px bg-(--card-stroke)" aria-hidden="true" />
+
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card) p-4 text-center">
+                            <p className="font-(--font-display) text-lg">Ask Dev</p>
+                            <p className="mt-1 text-xs text-(--ink-muted)">For people</p>
+                        </div>
+                        <div className="rounded-2xl border border-(--card-stroke) bg-(--card) p-4 text-center">
+                            <p className="font-(--font-display) text-lg">MCP</p>
+                            <p className="mt-1 text-xs text-(--ink-muted)">
+                                For developers and agents
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="mx-auto max-w-3xl text-center">
+                    <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                        The problem
+                    </p>
+                    <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
+                        Project status is a relationship, not a field
+                    </h2>
+                    <p className="mt-5 text-base leading-relaxed text-(--ink-muted)">
+                        A tracking system records what someone declared. The rest of the engineering
+                        ecosystem records what actually happened. Context Fabric connects those
+                        signals instead of treating one tracker—or one teammate’s memory—as the only
+                        source of truth.
+                    </p>
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-6 sm:p-10">
+                    <div className="max-w-3xl">
+                        <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
+                            Real-world example
+                        </p>
+                        <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
+                            The ticket says “In Progress.” What is the actual state?
+                        </h2>
+                    </div>
+
+                    <div className="mt-10 grid gap-5 lg:grid-cols-[0.8fr_1fr_1.1fr]">
+                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
+                            <p className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
+                                Tracking system
+                            </p>
+                            <p className="mt-5 font-(--font-display) text-3xl">In Progress</p>
+                            <p className="mt-2 text-sm text-(--ink-muted)">
+                                Last updated four days ago
+                            </p>
+                        </div>
+
+                        <div className="space-y-3 rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
+                            <p className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
+                                Observed evidence
+                            </p>
+                            {ACTUAL_STATE.map((signal) => (
+                                <div key={signal} className="flex items-center gap-3 text-sm">
+                                    <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-(--accent)/10 text-(--accent)">
+                                        <CheckIcon />
+                                    </span>
+                                    <span>{signal}</span>
+                                </div>
+                            ))}
+                        </div>
+
+                        <div className="rounded-3xl border border-(--accent)/40 bg-(--accent)/10 p-6">
+                            <p className="text-xs uppercase tracking-[0.16em] text-(--accent)">
+                                Context Fabric
+                            </p>
+                            <p className="mt-5 font-(--font-display) text-2xl">
+                                Implemented, deployed, and available
+                            </p>
+                            <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
+                                The delivery evidence shows the feature is live. The tracking record
+                                is stale, and any remaining rollout or follow-up work is reported
+                                separately.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="mx-auto max-w-3xl text-center">
+                    <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                        Better conversations
+                    </p>
+                    <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
+                        Come to the discussion prepared
+                    </h2>
+                    <p className="mt-5 text-base leading-relaxed text-(--ink-muted)">
+                        Context Fabric is not meant to replace talking with your teammates. It helps
+                        teams, leaders, developers, and agents arrive with the relevant evidence
+                        already connected—like the A+ student who actually did the reading.
+                    </p>
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="mx-auto max-w-3xl text-center">
+                    <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                        Two experiences
+                    </p>
+                    <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
+                        Context for people and agents
+                    </h2>
+                </div>
+
+                <div className="mt-10 grid gap-5 lg:grid-cols-2">
+                    <article className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-7 sm:p-9">
+                        <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
+                            For teams and leaders
+                        </p>
+                        <h3 className="mt-4 font-(--font-display) text-3xl">Ask Dev</h3>
+                        <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
+                            Dev is embedded in the Dev Health application and answers questions about
+                            project, team, and organizational health across the connected ecosystem.
+                        </p>
+                        <ul className="mt-7 space-y-3">
+                            {ASK_DEV_QUESTIONS.map((question) => (
+                                <li key={question} className="flex gap-3 text-sm">
+                                    <span className="mt-2 size-1.5 shrink-0 rounded-full bg-(--accent)" />
+                                    <span>{question}</span>
+                                </li>
+                            ))}
+                        </ul>
+                        <Link
+                            href="/auth/signup"
+                            className="mt-8 inline-flex rounded-full bg-(--accent) px-6 py-2.5 text-sm font-medium text-white transition hover:opacity-90"
+                        >
+                            {CTA_LABELS.getStarted}
+                        </Link>
+                    </article>
+
+                    <article className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-7 sm:p-9">
+                        <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
+                            For developers and agents
+                        </p>
+                        <h3 className="mt-4 font-(--font-display) text-3xl">MCP for agents</h3>
+                        <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
+                            Compatible coding, review, documentation, and automation agents can
+                            receive scoped context and supporting evidence before they begin work
+                            instead of starting cold.
+                        </p>
+                        <ul className="mt-7 space-y-3">
+                            {AGENT_QUESTIONS.map((question) => (
+                                <li key={question} className="flex gap-3 text-sm">
+                                    <span className="mt-2 size-1.5 shrink-0 rounded-full bg-(--accent)" />
+                                    <span>{question}</span>
+                                </li>
+                            ))}
+                        </ul>
+                        <a
+                            href="https://github.com/full-chaos/dev-health-acr/blob/main/docs/mcp-sidecar.md"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-8 inline-flex rounded-full border border-(--card-stroke) bg-(--card-70) px-6 py-2.5 text-sm font-medium transition hover:border-foreground/30"
+                        >
+                            {CTA_LABELS.viewGuide}
+                        </a>
+                    </article>
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="grid gap-8 rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-7 sm:p-10 lg:grid-cols-[0.8fr_1.2fr] lg:items-center">
+                    <div>
+                        <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
+                            Evidence before confidence
+                        </p>
+                        <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
+                            An answer should show its work.
+                        </h2>
+                        <p className="mt-5 text-sm leading-relaxed text-(--ink-muted)">
+                            Context Fabric does not quietly turn incomplete data into certainty. What
+                            it can answer depends on the sources, permissions, freshness, and
+                            capabilities available to the organization.
+                        </p>
+                    </div>
+                    <ul className="grid gap-3 sm:grid-cols-2">
+                        {[
+                            "Observed facts stay separate from inferences and recommendations.",
+                            "Missing, stale, or unavailable sources are disclosed—not represented as zero.",
+                            "Evidence is authorized again when it is opened.",
+                            "Conflicting systems remain visible instead of being silently overwritten.",
+                        ].map((point) => (
+                            <li
+                                key={point}
+                                className="rounded-2xl border border-(--card-stroke) bg-(--card) p-5 text-sm leading-relaxed text-(--ink-muted)"
+                            >
+                                {point}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
+                    <h2 className="font-(--font-display) text-3xl sm:text-4xl">
+                        See the whole picture before deciding what happens next.
+                    </h2>
+                    <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-(--ink-muted)">
+                        Use Ask Dev when a person needs an evidence-backed answer. Use the ACR MCP
+                        path when an agent needs context before it works.
+                    </p>
+                    <div className="mt-8 flex flex-wrap justify-center gap-4">
+                        <Link
+                            href="/auth/signup"
+                            className="rounded-full bg-(--accent) px-8 py-3 text-sm font-medium text-white transition hover:opacity-90"
+                        >
+                            {CTA_LABELS.getStarted}
+                        </Link>
+                        <Link
+                            href="/marketing"
+                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                        >
+                            {CTA_LABELS.solutions}
+                        </Link>
+                    </div>
+                </div>
+            </section>
+        </>
+    );
+}

--- a/src/app/marketing/page.tsx
+++ b/src/app/marketing/page.tsx
@@ -82,9 +82,9 @@ export default function MarketingHubPage() {
                             Context Fabric
                         </h2>
                         <p className="mt-4 max-w-2xl text-sm leading-relaxed text-(--ink-muted)">
-                            Connect planning, code, delivery, reliability, and source-health evidence
-                            so people and agents can understand what is actually happening—not just
-                            what one tracker says.
+                            Connect planning, code, delivery, reliability, and source-health
+                            evidence so people and agents can understand what is actually
+                            happening—not just what one tracker says.
                         </p>
                         <p className="mt-6 inline-flex items-center gap-1 text-sm font-medium text-(--accent)">
                             {CTA_LABELS.viewAskDevDocs}

--- a/src/app/marketing/page.tsx
+++ b/src/app/marketing/page.tsx
@@ -5,7 +5,7 @@ import { CTA_LABELS } from "@/lib/design/cta";
 export const metadata: Metadata = {
     title: "Solutions — Full Chaos Dev Health",
     description:
-        "Pick the buyer narrative that maps to your role. Each page links to the product surfaces that answer your operating questions.",
+        "Explore Context Fabric and buyer-aligned Dev Health solutions for engineering leaders, platform teams, managers, and architecture.",
 };
 
 type Buyer = {
@@ -53,7 +53,6 @@ const BUYERS: ReadonlyArray<Buyer> = [
 export default function MarketingHubPage() {
     return (
         <>
-            {/* Hero */}
             <section className="mx-auto max-w-7xl px-6 pb-16 pt-16 sm:pt-24">
                 <div className="mx-auto max-w-3xl text-center">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
@@ -64,13 +63,52 @@ export default function MarketingHubPage() {
                         <span className="text-(--accent)">framed by your role</span>
                     </h1>
                     <p className="mx-auto mt-6 max-w-2xl text-lg text-(--ink-muted)">
-                        Same platform, four buyer narratives. Each page maps the operating questions
-                        you actually ask to the product surfaces that answer them.
+                        Start with Context Fabric, then explore the operating questions and product
+                        surfaces that matter most to your role.
                     </p>
                 </div>
             </section>
 
-            {/* Buyer cards */}
+            <section className="mx-auto max-w-7xl px-6 pb-12">
+                <Link
+                    href="/marketing/context-fabric"
+                    className="group grid gap-8 rounded-[2rem] border border-(--accent)/35 bg-(--accent)/10 p-8 transition hover:-translate-y-1 hover:border-(--accent)/60 sm:p-10 lg:grid-cols-[1fr_0.8fr] lg:items-center"
+                >
+                    <div>
+                        <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
+                            Product capability
+                        </p>
+                        <h2 className="mt-4 font-(--font-display) text-3xl transition-colors group-hover:text-(--accent) sm:text-4xl">
+                            Context Fabric
+                        </h2>
+                        <p className="mt-4 max-w-2xl text-sm leading-relaxed text-(--ink-muted)">
+                            Connect planning, code, delivery, reliability, and source-health evidence
+                            so people and agents can understand what is actually happening—not just
+                            what one tracker says.
+                        </p>
+                        <p className="mt-6 inline-flex items-center gap-1 text-sm font-medium text-(--accent)">
+                            {CTA_LABELS.viewAskDevDocs}
+                            <span aria-hidden="true">→</span>
+                        </p>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                        {[
+                            "Project status",
+                            "Team health",
+                            "Delivery blockers",
+                            "Evidence and context",
+                        ].map((label) => (
+                            <span
+                                key={label}
+                                className="rounded-2xl border border-(--card-stroke) bg-(--card-80) px-4 py-4 text-center text-sm"
+                            >
+                                {label}
+                            </span>
+                        ))}
+                    </div>
+                </Link>
+            </section>
+
             <section className="mx-auto max-w-7xl px-6 pb-24">
                 <div className="grid gap-5 sm:grid-cols-2">
                     {BUYERS.map((buyer) => (
@@ -82,7 +120,7 @@ export default function MarketingHubPage() {
                             <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
                                 {buyer.eyebrow}
                             </p>
-                            <h2 className="mt-4 font-(--font-display) text-2xl group-hover:text-(--accent) transition-colors">
+                            <h2 className="mt-4 font-(--font-display) text-2xl transition-colors group-hover:text-(--accent)">
                                 {buyer.title}
                             </h2>
                             <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
@@ -100,7 +138,6 @@ export default function MarketingHubPage() {
                 </div>
             </section>
 
-            {/* No surveillance pillar (compact form, links to full buyer pages) */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
                 <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
                     <p className="text-xs uppercase tracking-[0.15em] text-(--ink-muted)">
@@ -119,7 +156,6 @@ export default function MarketingHubPage() {
                 </div>
             </section>
 
-            {/* CTA */}
             <section className="mx-auto max-w-7xl px-6 pb-24">
                 <div className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
                     <h2 className="font-(--font-display) text-3xl sm:text-4xl">

--- a/src/app/site.webmanifest
+++ b/src/app/site.webmanifest
@@ -1,1 +1,11 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+    "name": "",
+    "short_name": "",
+    "icons": [
+        { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
+        { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
+    ],
+    "theme_color": "#ffffff",
+    "background_color": "#ffffff",
+    "display": "standalone"
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,6 +20,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
             changeFrequency: "monthly",
             priority: 0.9,
         },
+        // Product capability
+        {
+            url: `${BASE_URL}/marketing/context-fabric`,
+            lastModified: now,
+            changeFrequency: "monthly",
+            priority: 0.9,
+        },
         // Buyer landings — one per role
         {
             url: `${BASE_URL}/marketing/vp-engineering`,

--- a/src/components/marketing/MarketingShell.tsx
+++ b/src/components/marketing/MarketingShell.tsx
@@ -22,6 +22,7 @@ const FOOTER_LINKS: Record<
     ReadonlyArray<{ label: string; href: string; external?: boolean }>
 > = {
     Product: [
+        { label: "Context Fabric", href: "/marketing/context-fabric" },
         { label: "Features", href: "/#features" },
         { label: "Pricing", href: "/marketing/pricing" },
         { label: "How it works", href: "/#how-it-works" },

--- a/tests/marketing-context-fabric.spec.ts
+++ b/tests/marketing-context-fabric.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Context Fabric marketing page", () => {
+    test("renders the product story and both supported experiences", async ({ page }) => {
+        await page.goto("/marketing/context-fabric");
+
+        await expect(
+            page.getByRole("heading", {
+                name: /know what is actually happening—not just what the tracker says/i,
+            }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole("heading", {
+                name: /the ticket says “in progress.” what is the actual state/i,
+            }),
+        ).toBeVisible();
+        await expect(page.getByText("Implemented, deployed, and available")).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Ask Dev" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "MCP for agents" })).toBeVisible();
+    });
+
+    test("exposes the page from the marketing hub and footer", async ({ page }) => {
+        await page.goto("/marketing");
+
+        const hubLink = page.getByRole("link", { name: /context fabric/i }).first();
+        await expect(hubLink).toHaveAttribute("href", "/marketing/context-fabric");
+
+        const footerLink = page.locator("footer").getByRole("link", { name: "Context Fabric" });
+        await expect(footerLink).toHaveAttribute("href", "/marketing/context-fabric");
+    });
+
+    test("keeps public calls to action on supported destinations", async ({ page }) => {
+        await page.goto("/marketing/context-fabric");
+
+        await expect(page.getByRole("link", { name: "Get started" }).first()).toHaveAttribute(
+            "href",
+            "/auth/signup",
+        );
+        await expect(page.getByRole("link", { name: "View guide" }).last()).toHaveAttribute(
+            "href",
+            "https://github.com/full-chaos/dev-health-acr/blob/main/docs/mcp-sidecar.md",
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Moves the Context Fabric marketing page into the repository that owns the existing public marketing site.

- adds `/marketing/context-fabric` under the canonical `src/app/marketing/` route group;
- tells the outcome-led product story without exposing service topology or raw Mermaid diagrams;
- uses the concrete stale-tracker / merged / deployed / feature-enabled example;
- presents **Ask Dev** for people and **MCP for agents** as the two primary experiences;
- keeps scope, freshness, missing sources, conflicts, and evidence visible as product trust boundaries;
- adds Context Fabric to the marketing hub, shared footer, and sitemap;
- adds Playwright coverage for the page, discoverability, and public CTA destinations.

## Repository boundary

- `dev-health-web`: public product marketing and rendered marketing experience;
- `dev-health-ops`: user guidance and contributor/technical architecture;
- `dev-health-acr`: canonical MCP setup and agent-runtime details.

This supersedes `full-chaos/dev-health-ops#1472`; the ops documentation PR remains separate.

## Route

`/marketing/context-fabric`

The route inherits the existing public marketing shell and `/marketing` proxy allowlist.

## Validation

- source governance is satisfied by `tests/marketing-context-fabric.spec.ts`;
- CI should run formatting, lint, typecheck, unit, design-lint, and Playwright gates;
- visual evidence is still required before this draft is marked ready for review, following `docs/agent-visual-testing.md`.

## Visual evidence checklist

- desktop hero and product visual;
- stale-tracker example;
- Ask Dev / MCP cards;
- mobile layout;
- light and dark theme review where supported.
