### PR TITLE
feat(marketing): expand Context Fabric landing and use cases

### DIFF
--- a/src/app/marketing/context-fabric/page.tsx
+++ b/src/app/marketing/context-fabric/page.tsx
@@ -5,11 +5,11 @@ import { CTA_LABELS } from "@/lib/design/cta";
 export const metadata: Metadata = {
     title: "Context Fabric — Full Chaos Dev Health",
     description:
-        "Connect planning, code, delivery, reliability, and source-health evidence so people and agents can understand the real state of engineering work.",
+        "Give people and agents evidence-backed context about the work, systems, relationships, decisions, and conditions across an engineering organization.",
     openGraph: {
-        title: "Context Fabric — See the whole engineering picture",
+        title: "Context Fabric — Give people and agents the context behind the work",
         description:
-            "Understand project, team, and organizational health from connected evidence instead of one status field.",
+            "Connect engineering evidence so people and agents can understand who, what, why, and how before they decide or act.",
         type: "website",
         siteName: "Full Chaos Dev Health",
         images: [
@@ -24,49 +24,81 @@ export const metadata: Metadata = {
 };
 
 const CONNECTED_SIGNALS = [
-    "Planning and tracking",
-    "Code and review",
-    "CI and delivery",
-    "Incidents and reliability",
+    "Work and priorities",
+    "Code and delivery",
+    "Teams and ownership",
+    "Reliability and operations",
 ] as const;
 
-const ACTUAL_STATE = [
-    "Pull request merged",
-    "CI passed",
-    "Deployment succeeded",
-    "Feature flag enabled",
-    "Available to users",
+const CONTEXT_DIMENSIONS = [
+    {
+        title: "Who",
+        eyebrow: "Connected scope",
+        description:
+            "The teams, owners, reviewers, repositories, services, projects, and stakeholders that are related, responsible, or affected.",
+    },
+    {
+        title: "What",
+        eyebrow: "Observed state",
+        description:
+            "The work, changes, delivery state, incidents, metrics, investment mix, and source coverage that describe current reality.",
+    },
+    {
+        title: "Why",
+        eyebrow: "Relationships and causes",
+        description:
+            "The decisions, dependencies, prior attempts, failures, constraints, and sustained pressures behind the current state.",
+    },
+    {
+        title: "How",
+        eyebrow: "Ways of working",
+        description:
+            "The architecture, workflows, required checks, evidence paths, operating boundaries, and next actions that shape the work.",
+    },
+] as const;
+
+const USE_CASE_TEASERS = [
+    "Project and portfolio readiness",
+    "Project health",
+    "Team health and sustained pressure",
+    "Workload and review demand",
+    "Investment balance",
+    "Operational deficiencies",
+    "Observed change and source trust",
+    "Agent planning and investigation",
 ] as const;
 
 const ASK_DEV_QUESTIONS = [
-    "Is this project actually done?",
-    "What is blocking delivery?",
-    "Which teams need attention?",
-    "What changed in this team’s DORA metrics over the last 90 days?",
+    "What needs attention across this portfolio?",
+    "Which teams show sustained pressure, and why?",
+    "Where is engineering investment going?",
+    "What operational deficiencies should we investigate first?",
 ] as const;
 
 const AGENT_QUESTIONS = [
-    "What decisions already govern this work?",
-    "Which related changes or failures matter?",
-    "What evidence should be verified before editing?",
-    "Which risks and required checks are already known?",
+    "Who owns or is affected by this change?",
+    "What decisions and dependencies already govern it?",
+    "Which related code, reviews, incidents, or failures matter?",
+    "What constraints, evidence, risks, and checks should shape the plan?",
 ] as const;
 
-function CheckIcon() {
+const TRUST_POINTS = [
+    "Observed facts stay separate from inferences and recommendations.",
+    "Missing, stale, or unavailable sources are disclosed—not represented as zero.",
+    "Conflicting systems remain visible instead of being silently overwritten.",
+    "Every answer stays bounded by authorized scope, relationships, and evidence.",
+] as const;
+
+function QuestionList({ questions }: Readonly<{ questions: readonly string[] }>) {
     return (
-        <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-        >
-            <path d="m5 12 4 4L19 6" />
-        </svg>
+        <ul className="mt-7 space-y-3">
+            {questions.map((question) => (
+                <li key={question} className="flex gap-3 text-sm">
+                    <span className="mt-2 size-1.5 shrink-0 rounded-full bg-(--accent)" />
+                    <span>{question}</span>
+                </li>
+            ))}
+        </ul>
     );
 }
 
@@ -79,35 +111,33 @@ export default function ContextFabricMarketingPage() {
                         Context Fabric
                     </p>
                     <h1 className="mt-6 max-w-4xl font-(--font-display) text-4xl leading-tight sm:text-5xl lg:text-6xl">
-                        Know what is actually happening—not just what the tracker says.
+                        Give people and agents the context behind the work.
                     </h1>
                     <p className="mt-6 max-w-2xl text-lg leading-relaxed text-(--ink-muted)">
-                        Context Fabric connects the work, code, delivery, reliability, and
-                        source-health evidence already flowing through Dev Health. People and agents
-                        get a shared, evidence-backed view of the real state of a project, team, or
-                        organization.
+                        Context Fabric turns the engineering evidence already flowing through Dev
+                        Health into shared operating context: who owns and is affected by the work,
+                        what is actually happening, why it matters, how systems and decisions relate,
+                        and what evidence should guide the next action.
                     </p>
                     <div className="mt-10 flex flex-wrap gap-4">
                         <Link
-                            href="/auth/signup"
+                            href="/marketing/context-fabric/use-cases"
                             className="rounded-full bg-(--accent) px-8 py-3 text-sm font-medium text-white transition hover:opacity-90"
+                        >
+                            Explore use cases
+                        </Link>
+                        <Link
+                            href="/auth/signup"
+                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
                             {CTA_LABELS.getStarted}
                         </Link>
-                        <a
-                            href="https://github.com/full-chaos/dev-health-ops/blob/main/docs/use/ai-workflows/index.md#use-ask-dev-for-a-human-investigation"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
-                        >
-                            {CTA_LABELS.viewGuide}
-                        </a>
                     </div>
                 </div>
 
                 <div
                     className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-5 shadow-2xl shadow-black/10 sm:p-7"
-                    aria-label="Context Fabric connects engineering evidence to Ask Dev and compatible agents"
+                    aria-label="Context Fabric connects the engineering ecosystem to Ask Dev and ACR MCP consumers"
                 >
                     <div className="grid grid-cols-2 gap-3">
                         {CONNECTED_SIGNALS.map((signal) => (
@@ -119,25 +149,21 @@ export default function ContextFabricMarketingPage() {
                             </div>
                         ))}
                     </div>
-
                     <div className="mx-auto my-5 h-8 w-px bg-(--card-stroke)" aria-hidden="true" />
-
                     <div className="rounded-3xl border border-(--accent)/40 bg-(--accent)/10 p-6 text-center">
                         <p className="font-(--font-display) text-2xl">Context Fabric</p>
                         <p className="mt-2 text-xs uppercase tracking-[0.14em] text-(--ink-muted)">
                             State → Pressure → Cause → Evidence → Action
                         </p>
                     </div>
-
                     <div className="mx-auto my-5 h-8 w-px bg-(--card-stroke)" aria-hidden="true" />
-
                     <div className="grid grid-cols-2 gap-3">
                         <div className="rounded-2xl border border-(--card-stroke) bg-(--card) p-4 text-center">
                             <p className="font-(--font-display) text-lg">Ask Dev</p>
                             <p className="mt-1 text-xs text-(--ink-muted)">For people</p>
                         </div>
                         <div className="rounded-2xl border border-(--card-stroke) bg-(--card) p-4 text-center">
-                            <p className="font-(--font-display) text-lg">MCP</p>
+                            <p className="font-(--font-display) text-lg">ACR / MCP</p>
                             <p className="mt-1 text-xs text-(--ink-muted)">
                                 For developers and agents
                             </p>
@@ -149,86 +175,71 @@ export default function ContextFabricMarketingPage() {
             <section className="mx-auto max-w-7xl px-6 pb-24">
                 <div className="mx-auto max-w-3xl text-center">
                     <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-                        The problem
+                        Connected understanding
                     </p>
                     <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
-                        Project status is a relationship, not a field
+                        Understand the engineering ecosystem around the work
                     </h2>
                     <p className="mt-5 text-base leading-relaxed text-(--ink-muted)">
-                        A tracking system records what someone declared. The rest of the engineering
-                        ecosystem records what actually happened. Context Fabric connects those
-                        signals instead of treating one tracker—or one teammate’s memory—as the only
-                        source of truth.
+                        Planning systems, repositories, reviews, delivery pipelines, incidents,
+                        architecture, ownership, investment, dependencies, and source health each
+                        describe a different part of engineering reality. Context Fabric connects
+                        those authorized signals without flattening them into one status field or
+                        opaque score.
                     </p>
+                </div>
+                <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+                    {CONTEXT_DIMENSIONS.map((dimension) => (
+                        <article
+                            key={dimension.title}
+                            className="rounded-3xl border border-(--card-stroke) bg-(--card-80) p-6"
+                        >
+                            <p className="text-xs uppercase tracking-[0.16em] text-(--accent)">
+                                {dimension.eyebrow}
+                            </p>
+                            <h3 className="mt-4 font-(--font-display) text-3xl">
+                                {dimension.title}
+                            </h3>
+                            <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
+                                {dimension.description}
+                            </p>
+                        </article>
+                    ))}
                 </div>
             </section>
 
             <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-6 sm:p-10">
-                    <div className="max-w-3xl">
+                <div className="grid gap-10 rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-7 sm:p-10 lg:grid-cols-[0.85fr_1.15fr] lg:items-center">
+                    <div>
                         <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
-                            Real-world example
+                            Beyond one status field
                         </p>
                         <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
-                            The ticket says “In Progress.” What is the actual state?
+                            A shared context layer for everyday engineering decisions
                         </h2>
+                        <p className="mt-5 text-sm leading-relaxed text-(--ink-muted)">
+                            Project status is one familiar example, not the product boundary. The
+                            same fabric supports questions about teams, portfolios, investment,
+                            reliability, operational gaps, source trust, and the context an agent
+                            needs before it changes anything.
+                        </p>
+                        <Link
+                            href="/marketing/context-fabric/use-cases"
+                            className="mt-7 inline-flex rounded-full bg-(--accent) px-6 py-2.5 text-sm font-medium text-white transition hover:opacity-90"
+                        >
+                            See Context Fabric in action
+                        </Link>
                     </div>
-
-                    <div className="mt-10 grid gap-5 lg:grid-cols-[0.8fr_1fr_1.1fr]">
-                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
-                            <p className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
-                                Tracking system
-                            </p>
-                            <p className="mt-5 font-(--font-display) text-3xl">In Progress</p>
-                            <p className="mt-2 text-sm text-(--ink-muted)">
-                                Last updated four days ago
-                            </p>
-                        </div>
-
-                        <div className="space-y-3 rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
-                            <p className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
-                                Observed evidence
-                            </p>
-                            {ACTUAL_STATE.map((signal) => (
-                                <div key={signal} className="flex items-center gap-3 text-sm">
-                                    <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-(--accent)/10 text-(--accent)">
-                                        <CheckIcon />
-                                    </span>
-                                    <span>{signal}</span>
-                                </div>
-                            ))}
-                        </div>
-
-                        <div className="rounded-3xl border border-(--accent)/40 bg-(--accent)/10 p-6">
-                            <p className="text-xs uppercase tracking-[0.16em] text-(--accent)">
-                                Context Fabric
-                            </p>
-                            <p className="mt-5 font-(--font-display) text-2xl">
-                                Implemented, deployed, and available
-                            </p>
-                            <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
-                                The delivery evidence shows the feature is live. The tracking record
-                                is stale, and any remaining rollout or follow-up work is reported
-                                separately.
-                            </p>
-                        </div>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        {USE_CASE_TEASERS.map((useCase) => (
+                            <div
+                                key={useCase}
+                                className="rounded-2xl border border-(--card-stroke) bg-(--card) p-5 text-sm"
+                            >
+                                {useCase}
+                            </div>
+                        ))}
                     </div>
-                </div>
-            </section>
-
-            <section className="mx-auto max-w-7xl px-6 pb-24">
-                <div className="mx-auto max-w-3xl text-center">
-                    <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
-                        Better conversations
-                    </p>
-                    <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
-                        Come to the discussion prepared
-                    </h2>
-                    <p className="mt-5 text-base leading-relaxed text-(--ink-muted)">
-                        Context Fabric is not meant to replace talking with your teammates. It helps
-                        teams, leaders, developers, and agents arrive with the relevant evidence
-                        already connected—like the A+ student who actually did the reading.
-                    </p>
                 </div>
             </section>
 
@@ -238,10 +249,9 @@ export default function ContextFabricMarketingPage() {
                         Two experiences
                     </p>
                     <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
-                        Context for people and agents
+                        One fabric, built for people and agents
                     </h2>
                 </div>
-
                 <div className="mt-10 grid gap-5 lg:grid-cols-2">
                     <article className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-7 sm:p-9">
                         <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
@@ -249,51 +259,38 @@ export default function ContextFabricMarketingPage() {
                         </p>
                         <h3 className="mt-4 font-(--font-display) text-3xl">Ask Dev</h3>
                         <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
-                            Dev is embedded in the Dev Health application and answers questions
-                            about project, team, and organizational health across the connected
-                            ecosystem.
+                            Ask Dev is the people-facing conversational layer in Dev Health. It
+                            brings project, team, portfolio, delivery, reliability, investment,
+                            operational, and data-trust evidence into one investigation.
                         </p>
-                        <ul className="mt-7 space-y-3">
-                            {ASK_DEV_QUESTIONS.map((question) => (
-                                <li key={question} className="flex gap-3 text-sm">
-                                    <span className="mt-2 size-1.5 shrink-0 rounded-full bg-(--accent)" />
-                                    <span>{question}</span>
-                                </li>
-                            ))}
-                        </ul>
-                        <Link
-                            href="/auth/signup"
-                            className="mt-8 inline-flex rounded-full bg-(--accent) px-6 py-2.5 text-sm font-medium text-white transition hover:opacity-90"
+                        <QuestionList questions={ASK_DEV_QUESTIONS} />
+                        <a
+                            href="https://github.com/full-chaos/dev-health-ops/blob/main/docs/use/ai-workflows/index.md#use-ask-dev-for-a-human-investigation"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-8 inline-flex rounded-full border border-(--card-stroke) bg-(--card-70) px-6 py-2.5 text-sm font-medium transition hover:border-foreground/30"
                         >
-                            {CTA_LABELS.getStarted}
-                        </Link>
+                            Read the Ask Dev guide
+                        </a>
                     </article>
-
                     <article className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-7 sm:p-9">
                         <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
                             For developers and agents
                         </p>
-                        <h3 className="mt-4 font-(--font-display) text-3xl">MCP for agents</h3>
+                        <h3 className="mt-4 font-(--font-display) text-3xl">ACR and MCP</h3>
                         <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
-                            Compatible coding, review, documentation, and automation agents can
-                            receive scoped context and supporting evidence before they begin work
-                            instead of starting cold.
+                            Compatible coding, review, documentation, CI, research, and automation
+                            agents can receive scoped context and supporting evidence before they
+                            begin work instead of starting cold or rediscovering the ecosystem.
                         </p>
-                        <ul className="mt-7 space-y-3">
-                            {AGENT_QUESTIONS.map((question) => (
-                                <li key={question} className="flex gap-3 text-sm">
-                                    <span className="mt-2 size-1.5 shrink-0 rounded-full bg-(--accent)" />
-                                    <span>{question}</span>
-                                </li>
-                            ))}
-                        </ul>
+                        <QuestionList questions={AGENT_QUESTIONS} />
                         <a
                             href="https://github.com/full-chaos/dev-health-acr/blob/main/docs/mcp-sidecar.md"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="mt-8 inline-flex rounded-full border border-(--card-stroke) bg-(--card-70) px-6 py-2.5 text-sm font-medium transition hover:border-foreground/30"
                         >
-                            {CTA_LABELS.viewGuide}
+                            Configure the ACR MCP sidecar
                         </a>
                     </article>
                 </div>
@@ -306,21 +303,16 @@ export default function ContextFabricMarketingPage() {
                             Evidence before confidence
                         </p>
                         <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
-                            An answer should show its work.
+                            Context should explain what it knows—and what it does not.
                         </h2>
                         <p className="mt-5 text-sm leading-relaxed text-(--ink-muted)">
-                            Context Fabric does not quietly turn incomplete data into certainty.
-                            What it can answer depends on the sources, permissions, freshness, and
-                            capabilities available to the organization.
+                            Context Fabric keeps scope, freshness, coverage, relationships,
+                            conflicts, unavailable sources, and supporting evidence visible instead
+                            of turning incomplete data into certainty.
                         </p>
                     </div>
                     <ul className="grid gap-3 sm:grid-cols-2">
-                        {[
-                            "Observed facts stay separate from inferences and recommendations.",
-                            "Missing, stale, or unavailable sources are disclosed—not represented as zero.",
-                            "Evidence is authorized again when it is opened.",
-                            "Conflicting systems remain visible instead of being silently overwritten.",
-                        ].map((point) => (
+                        {TRUST_POINTS.map((point) => (
                             <li
                                 key={point}
                                 className="rounded-2xl border border-(--card-stroke) bg-(--card) p-5 text-sm leading-relaxed text-(--ink-muted)"
@@ -335,24 +327,24 @@ export default function ContextFabricMarketingPage() {
             <section className="mx-auto max-w-7xl px-6 pb-24">
                 <div className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
                     <h2 className="font-(--font-display) text-3xl sm:text-4xl">
-                        See the whole picture before deciding what happens next.
+                        Understand the whole context before deciding what happens next.
                     </h2>
                     <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-(--ink-muted)">
-                        Use Ask Dev when a person needs an evidence-backed answer. Use the ACR MCP
-                        path when an agent needs context before it works.
+                        Use Ask Dev when a person needs an evidence-backed investigation. Use ACR
+                        and MCP when an agent needs scoped context before it works.
                     </p>
                     <div className="mt-8 flex flex-wrap justify-center gap-4">
                         <Link
-                            href="/auth/signup"
+                            href="/marketing/context-fabric/use-cases"
                             className="rounded-full bg-(--accent) px-8 py-3 text-sm font-medium text-white transition hover:opacity-90"
                         >
-                            {CTA_LABELS.getStarted}
+                            Explore use cases
                         </Link>
                         <Link
-                            href="/marketing"
+                            href="/auth/signup"
                             className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
-                            {CTA_LABELS.solutions}
+                            {CTA_LABELS.getStarted}
                         </Link>
                     </div>
                 </div>

--- a/src/app/marketing/context-fabric/page.tsx
+++ b/src/app/marketing/context-fabric/page.tsx
@@ -105,7 +105,7 @@ function QuestionList({ questions }: Readonly<{ questions: readonly string[] }>)
 export default function ContextFabricMarketingPage() {
     return (
         <>
-            <section className="mx-auto grid max-w-7xl gap-12 px-6 pb-20 pt-16 sm:pt-24 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.8fr)] lg:items-center">
+            <section className="mx-auto grid max-w-7xl gap-12 px-6 pb-20 pt-16 sm:pt-24 lg:grid-cols-[minmax(0,1fr)_minmax(22.5rem,0.8fr)] lg:items-center">
                 <div>
                     <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
                         Context Fabric
@@ -116,15 +116,15 @@ export default function ContextFabricMarketingPage() {
                     <p className="mt-6 max-w-2xl text-lg leading-relaxed text-(--ink-muted)">
                         Context Fabric turns the engineering evidence already flowing through Dev
                         Health into shared operating context: who owns and is affected by the work,
-                        what is actually happening, why it matters, how systems and decisions relate,
-                        and what evidence should guide the next action.
+                        what is actually happening, why it matters, how systems and decisions
+                        relate, and what evidence should guide the next action.
                     </p>
                     <div className="mt-10 flex flex-wrap gap-4">
                         <Link
                             href="/marketing/context-fabric/use-cases"
                             className="rounded-full bg-(--accent) px-8 py-3 text-sm font-medium text-white transition hover:opacity-90"
                         >
-                            Explore use cases
+                            {CTA_LABELS.exploreContextFabricUseCases}
                         </Link>
                         <Link
                             href="/auth/signup"
@@ -137,6 +137,7 @@ export default function ContextFabricMarketingPage() {
 
                 <div
                     className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-5 shadow-2xl shadow-black/10 sm:p-7"
+                    role="img"
                     aria-label="Context Fabric connects the engineering ecosystem to Ask Dev and ACR MCP consumers"
                 >
                     <div className="grid grid-cols-2 gap-3">
@@ -227,7 +228,7 @@ export default function ContextFabricMarketingPage() {
                             href="/marketing/context-fabric/use-cases"
                             className="mt-7 inline-flex rounded-full bg-(--accent) px-6 py-2.5 text-sm font-medium text-white transition hover:opacity-90"
                         >
-                            See Context Fabric in action
+                            {CTA_LABELS.seeContextFabricInAction}
                         </Link>
                     </div>
                     <div className="grid gap-3 sm:grid-cols-2">
@@ -270,7 +271,7 @@ export default function ContextFabricMarketingPage() {
                             rel="noopener noreferrer"
                             className="mt-8 inline-flex rounded-full border border-(--card-stroke) bg-(--card-70) px-6 py-2.5 text-sm font-medium transition hover:border-foreground/30"
                         >
-                            Read the Ask Dev guide
+                            {CTA_LABELS.readAskDevGuide}
                         </a>
                     </article>
                     <article className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-7 sm:p-9">
@@ -290,7 +291,7 @@ export default function ContextFabricMarketingPage() {
                             rel="noopener noreferrer"
                             className="mt-8 inline-flex rounded-full border border-(--card-stroke) bg-(--card-70) px-6 py-2.5 text-sm font-medium transition hover:border-foreground/30"
                         >
-                            Configure the ACR MCP sidecar
+                            {CTA_LABELS.configureAcrMcpSidecar}
                         </a>
                     </article>
                 </div>
@@ -338,7 +339,7 @@ export default function ContextFabricMarketingPage() {
                             href="/marketing/context-fabric/use-cases"
                             className="rounded-full bg-(--accent) px-8 py-3 text-sm font-medium text-white transition hover:opacity-90"
                         >
-                            Explore use cases
+                            {CTA_LABELS.exploreContextFabricUseCases}
                         </Link>
                         <Link
                             href="/auth/signup"

--- a/src/app/marketing/context-fabric/use-cases/page.tsx
+++ b/src/app/marketing/context-fabric/use-cases/page.tsx
@@ -1,0 +1,390 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CTA_LABELS } from "@/lib/design/cta";
+
+export const metadata: Metadata = {
+    title: "Context Fabric use cases — Full Chaos Dev Health",
+    description:
+        "See how Context Fabric helps people and agents understand project status, health, workload, investment, operational deficiencies, source trust, and the context behind engineering work.",
+    openGraph: {
+        title: "Context Fabric use cases — Evidence-backed engineering context",
+        description:
+            "Explore practical Context Fabric use cases for teams, leaders, developers, and agents.",
+        type: "website",
+        siteName: "Full Chaos Dev Health",
+        images: [
+            {
+                url: "/opengraph-image.png",
+                width: 1200,
+                height: 630,
+                alt: "Full Chaos Dev Health Context Fabric use cases",
+            },
+        ],
+    },
+};
+
+const ACTUAL_STATE = [
+    "Pull request merged",
+    "CI passed",
+    "Deployment succeeded",
+    "Feature flag enabled",
+    "Available to users",
+] as const;
+
+const PEOPLE_USE_CASES = [
+    {
+        eyebrow: "Project and portfolio readiness",
+        title: "Know what is complete, blocked, ready, or still uncertain",
+        question: "What is the status of these projects, and which need attention?",
+        description:
+            "Connect declared state with required work, reviews, CI, releases, incidents, dependencies, and source freshness. See remaining work and blockers without averaging unknown projects into a misleading portfolio percentage.",
+        signals: ["Actual completion", "Remaining work", "Blockers", "Readiness", "Coverage"],
+    },
+    {
+        eyebrow: "Project health",
+        title: "Understand the conditions affecting safe delivery",
+        question: "What does project health look like, and what is driving it?",
+        description:
+            "Bring together delivery flow, execution state, reliability, code and ownership risk, review pressure, investment mix, dependencies, and data trust as an inspectable profile—not one unexplained score.",
+        signals: ["Delivery flow", "Reliability", "Code risk", "Dependencies", "Data trust"],
+    },
+    {
+        eyebrow: "Team health",
+        title: "Find teams that may need attention without ranking people",
+        question: "Which teams show sustained pressure, and why?",
+        description:
+            "Look for supported patterns across flow, WIP, review demand, reliability, ownership concentration, investment, and source coverage. A single bad week or one metric is not enough to label a team.",
+        signals: ["Flow", "Review demand", "Reliability", "Ownership", "Sustained pressure"],
+    },
+    {
+        eyebrow: "Workload pressure",
+        title: "Separate visible pressure from unsupported workload claims",
+        question: "Which teams appear overburdened?",
+        description:
+            "Compare active work, WIP, review demand, ownership breadth, team size, and historical or cohort baselines. When a defensible denominator is missing, report higher observed pressure rather than pretending burden is known.",
+        signals: ["WIP", "Review load", "Ownership breadth", "Denominators", "Baselines"],
+    },
+    {
+        eyebrow: "Investment balance",
+        title: "See where engineering effort is going—and what remains unclassified",
+        question: "Which teams are light on feature work, and what are they working on instead?",
+        description:
+            "Read new-value work beside KTLO, security, infrastructure, and unclassified work with enough coverage and a valid comparison period. Maintenance and platform work remain visible rather than being treated as less valuable.",
+        signals: ["New value", "KTLO", "Security", "Infrastructure", "Coverage"],
+    },
+    {
+        eyebrow: "Operational deficiencies",
+        title: "Prioritize evidence-backed gaps across the delivery system",
+        question: "What operational deficiencies should we investigate first?",
+        description:
+            "Surface versioned, evidence-linked gaps in data coverage, planning relationships, delivery flow, review and CI, reliability, ownership and code risk, capacity pressure, and investment balance.",
+        signals: ["Data coverage", "Delivery flow", "CI controls", "Reliability", "Code risk"],
+    },
+    {
+        eyebrow: "Change and source trust",
+        title: "Understand what improved, worsened, or cannot yet be concluded",
+        question: "What changed over the last 90 days, and which sources can we trust?",
+        description:
+            "Compare canonical metrics and operating conditions while keeping stale, missing, unavailable, unconfigured, and not-applicable sources distinct. Missing evidence never silently becomes zero or healthy.",
+        signals: ["Observed change", "Freshness", "Coverage", "Conflicts", "Uncertainty"],
+    },
+] as const;
+
+const AGENT_USE_CASES = [
+    {
+        title: "Plan a change without starting cold",
+        description:
+            "Give an agent the authorized repository, task, branch or commit, related work, ownership, prior decisions, known risks, and required checks before it proposes an implementation.",
+        questions: [
+            "Who owns or is affected by this change?",
+            "Which decisions and dependencies already govern it?",
+        ],
+    },
+    {
+        title: "Review code with the surrounding evidence",
+        description:
+            "Connect the change to related files, open work, earlier reviews, CI results, hotspots, incidents, and documented constraints so a review is informed by more than the diff alone.",
+        questions: [
+            "Which related changes or failures matter?",
+            "What evidence should be verified before approval?",
+        ],
+    },
+    {
+        title: "Investigate a failure across systems",
+        description:
+            "Trace relevant delivery, incident, code, ownership, and prior-attempt evidence without allowing unrelated organization-wide records to masquerade as causes.",
+        questions: [
+            "What changed before the failure?",
+            "Which evidence supports the suspected relationship?",
+        ],
+    },
+    {
+        title: "Carry context into docs, CI, and automation",
+        description:
+            "Let documentation and automation agents understand current contracts, source health, release constraints, and existing decisions before they update instructions or workflows.",
+        questions: [
+            "What constraints must this workflow preserve?",
+            "Which checks and evidence paths are already required?",
+        ],
+    },
+] as const;
+
+function CheckIcon() {
+    return (
+        <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+        >
+            <path d="m5 12 4 4L19 6" />
+        </svg>
+    );
+}
+
+export default function ContextFabricUseCasesPage() {
+    return (
+        <>
+            <section className="mx-auto max-w-7xl px-6 pb-20 pt-16 sm:pt-24">
+                <div className="mx-auto max-w-4xl text-center">
+                    <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
+                        Context Fabric use cases
+                    </p>
+                    <h1 className="mt-6 font-(--font-display) text-4xl leading-tight sm:text-5xl lg:text-6xl">
+                        Understand the whole context behind an engineering decision.
+                    </h1>
+                    <p className="mx-auto mt-6 max-w-3xl text-lg leading-relaxed text-(--ink-muted)">
+                        Context Fabric connects authorized evidence across work, code, delivery,
+                        reliability, ownership, investment, dependencies, and source health. These
+                        are representative questions people and agents can investigate without
+                        treating one tool, metric, or memory as the whole story.
+                    </p>
+                    <div className="mt-10 flex flex-wrap justify-center gap-4">
+                        <Link
+                            href="/marketing/context-fabric"
+                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                        >
+                            Context Fabric overview
+                        </Link>
+                        <Link
+                            href="/auth/signup"
+                            className="rounded-full bg-(--accent) px-8 py-3 text-sm font-medium text-white transition hover:opacity-90"
+                        >
+                            {CTA_LABELS.getStarted}
+                        </Link>
+                    </div>
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-6 sm:p-10">
+                    <div className="max-w-3xl">
+                        <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
+                            A familiar day-to-day example
+                        </p>
+                        <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
+                            The ticket says “In Progress.” What is the actual state?
+                        </h2>
+                        <p className="mt-5 text-sm leading-relaxed text-(--ink-muted)">
+                            A tracking system records what someone declared. The rest of the
+                            engineering ecosystem records what actually happened. Project status is
+                            one place where connected context immediately changes the answer.
+                        </p>
+                    </div>
+
+                    <div className="mt-10 grid gap-5 lg:grid-cols-[0.8fr_1fr_1.1fr]">
+                        <div className="rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
+                            <p className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
+                                Tracking system
+                            </p>
+                            <p className="mt-5 font-(--font-display) text-3xl">In Progress</p>
+                            <p className="mt-2 text-sm text-(--ink-muted)">
+                                Last updated four days ago
+                            </p>
+                        </div>
+
+                        <div className="space-y-3 rounded-3xl border border-(--card-stroke) bg-(--card) p-6">
+                            <p className="text-xs uppercase tracking-[0.16em] text-(--ink-muted)">
+                                Observed evidence
+                            </p>
+                            {ACTUAL_STATE.map((signal) => (
+                                <div key={signal} className="flex items-center gap-3 text-sm">
+                                    <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-(--accent)/10 text-(--accent)">
+                                        <CheckIcon />
+                                    </span>
+                                    <span>{signal}</span>
+                                </div>
+                            ))}
+                        </div>
+
+                        <div className="rounded-3xl border border-(--accent)/40 bg-(--accent)/10 p-6">
+                            <p className="text-xs uppercase tracking-[0.16em] text-(--accent)">
+                                Context Fabric
+                            </p>
+                            <p className="mt-5 font-(--font-display) text-2xl">
+                                Implemented, deployed, and available
+                            </p>
+                            <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
+                                The delivery evidence shows the feature is live. The tracking record
+                                is stale, and any remaining rollout or follow-up work is reported
+                                separately.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="mx-auto max-w-3xl text-center">
+                    <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                        For teams and leaders
+                    </p>
+                    <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
+                        Ask operating questions across the ecosystem
+                    </h2>
+                    <p className="mt-5 text-base leading-relaxed text-(--ink-muted)">
+                        Ask Dev is the people-facing path into Context Fabric. It can bring the
+                        relevant authorized sources into one bounded investigation while keeping
+                        evidence, coverage, and uncertainty visible.
+                    </p>
+                </div>
+
+                <div className="mt-12 grid gap-5 lg:grid-cols-2">
+                    {PEOPLE_USE_CASES.map((useCase) => (
+                        <article
+                            key={useCase.title}
+                            className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-7 sm:p-8"
+                        >
+                            <p className="text-xs uppercase tracking-[0.16em] text-(--accent)">
+                                {useCase.eyebrow}
+                            </p>
+                            <h3 className="mt-4 font-(--font-display) text-2xl">
+                                {useCase.title}
+                            </h3>
+                            <p className="mt-5 rounded-2xl border border-(--card-stroke) bg-(--card) p-4 text-sm font-medium">
+                                “{useCase.question}”
+                            </p>
+                            <p className="mt-5 text-sm leading-relaxed text-(--ink-muted)">
+                                {useCase.description}
+                            </p>
+                            <div className="mt-6 flex flex-wrap gap-2">
+                                {useCase.signals.map((signal) => (
+                                    <span
+                                        key={signal}
+                                        className="rounded-full border border-(--card-stroke) bg-(--card) px-3 py-1.5 text-xs text-(--ink-muted)"
+                                    >
+                                        {signal}
+                                    </span>
+                                ))}
+                            </div>
+                        </article>
+                    ))}
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="mx-auto max-w-3xl text-center">
+                    <p className="text-xs uppercase tracking-[0.2em] text-(--ink-muted)">
+                        For developers and agents
+                    </p>
+                    <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
+                        Bring the surrounding context to the agent before it works
+                    </h2>
+                    <p className="mt-5 text-base leading-relaxed text-(--ink-muted)">
+                        Through ACR and MCP, compatible coding, review, documentation, CI, research,
+                        and automation agents can retrieve bounded context and expand supporting
+                        evidence instead of reconstructing the ecosystem from scratch.
+                    </p>
+                </div>
+
+                <div className="mt-12 grid gap-5 sm:grid-cols-2">
+                    {AGENT_USE_CASES.map((useCase) => (
+                        <article
+                            key={useCase.title}
+                            className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-7 sm:p-8"
+                        >
+                            <h3 className="font-(--font-display) text-2xl">{useCase.title}</h3>
+                            <p className="mt-4 text-sm leading-relaxed text-(--ink-muted)">
+                                {useCase.description}
+                            </p>
+                            <ul className="mt-6 space-y-3">
+                                {useCase.questions.map((question) => (
+                                    <li key={question} className="flex gap-3 text-sm">
+                                        <span className="mt-2 size-1.5 shrink-0 rounded-full bg-(--accent)" />
+                                        <span>{question}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </article>
+                    ))}
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="grid gap-8 rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-7 sm:p-10 lg:grid-cols-[0.85fr_1.15fr] lg:items-center">
+                    <div>
+                        <p className="text-xs uppercase tracking-[0.2em] text-(--accent)">
+                            Evidence-backed by design
+                        </p>
+                        <h2 className="mt-4 font-(--font-display) text-3xl sm:text-4xl">
+                            Useful context preserves its limits.
+                        </h2>
+                        <p className="mt-5 text-sm leading-relaxed text-(--ink-muted)">
+                            Context Fabric does not turn a missing denominator into a workload claim,
+                            one bad week into a team judgment, semantic similarity into a
+                            relationship, or incomplete source coverage into certainty.
+                        </p>
+                    </div>
+                    <ul className="grid gap-3 sm:grid-cols-2">
+                        {[
+                            "Named subjects stay bound to exact authorized relationships.",
+                            "Observed facts, inferred pressure, and recommendations remain distinct.",
+                            "Missing, stale, unavailable, and not-applicable sources remain distinct.",
+                            "No person-level productivity, health, commitment, or workload ranking.",
+                        ].map((point) => (
+                            <li
+                                key={point}
+                                className="rounded-2xl border border-(--card-stroke) bg-(--card) p-5 text-sm leading-relaxed text-(--ink-muted)"
+                            >
+                                {point}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 pb-24">
+                <div className="rounded-[2rem] border border-(--card-stroke) bg-(--card-80) p-8 text-center sm:p-12">
+                    <h2 className="font-(--font-display) text-3xl sm:text-4xl">
+                        Give the next conversation—or the next agent—the whole relevant context.
+                    </h2>
+                    <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-(--ink-muted)">
+                        Start with Ask Dev for people, or connect a compatible agent through the ACR
+                        MCP sidecar.
+                    </p>
+                    <div className="mt-8 flex flex-wrap justify-center gap-4">
+                        <Link
+                            href="/auth/signup"
+                            className="rounded-full bg-(--accent) px-8 py-3 text-sm font-medium text-white transition hover:opacity-90"
+                        >
+                            {CTA_LABELS.getStarted}
+                        </Link>
+                        <a
+                            href="https://github.com/full-chaos/dev-health-acr/blob/main/docs/mcp-sidecar.md"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
+                        >
+                            Configure ACR and MCP
+                        </a>
+                    </div>
+                </div>
+            </section>
+        </>
+    );
+}

--- a/src/app/marketing/context-fabric/use-cases/page.tsx
+++ b/src/app/marketing/context-fabric/use-cases/page.tsx
@@ -169,7 +169,7 @@ export default function ContextFabricUseCasesPage() {
                             href="/marketing/context-fabric"
                             className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
-                            Context Fabric overview
+                            {CTA_LABELS.openContextFabricOverview}
                         </Link>
                         <Link
                             href="/auth/signup"
@@ -263,9 +263,7 @@ export default function ContextFabricUseCasesPage() {
                             <p className="text-xs uppercase tracking-[0.16em] text-(--accent)">
                                 {useCase.eyebrow}
                             </p>
-                            <h3 className="mt-4 font-(--font-display) text-2xl">
-                                {useCase.title}
-                            </h3>
+                            <h3 className="mt-4 font-(--font-display) text-2xl">{useCase.title}</h3>
                             <p className="mt-5 rounded-2xl border border-(--card-stroke) bg-(--card) p-4 text-sm font-medium">
                                 “{useCase.question}”
                             </p>
@@ -335,8 +333,8 @@ export default function ContextFabricUseCasesPage() {
                             Useful context preserves its limits.
                         </h2>
                         <p className="mt-5 text-sm leading-relaxed text-(--ink-muted)">
-                            Context Fabric does not turn a missing denominator into a workload claim,
-                            one bad week into a team judgment, semantic similarity into a
+                            Context Fabric does not turn a missing denominator into a workload
+                            claim, one bad week into a team judgment, semantic similarity into a
                             relationship, or incomplete source coverage into certainty.
                         </p>
                     </div>
@@ -380,7 +378,7 @@ export default function ContextFabricUseCasesPage() {
                             rel="noopener noreferrer"
                             className="rounded-full border border-(--card-stroke) bg-(--card-70) px-8 py-3 text-sm font-medium transition hover:border-foreground/30"
                         >
-                            Configure ACR and MCP
+                            {CTA_LABELS.configureAcrAndMcp}
                         </a>
                     </div>
                 </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -27,6 +27,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
             changeFrequency: "monthly",
             priority: 0.9,
         },
+        {
+            url: `${BASE_URL}/marketing/context-fabric/use-cases`,
+            lastModified: now,
+            changeFrequency: "monthly",
+            priority: 0.8,
+        },
         // Buyer landings — one per role
         {
             url: `${BASE_URL}/marketing/vp-engineering`,

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -319,6 +319,12 @@ export const CTA_LABELS = {
     saveOverride: "Save Override",
     manageEntitlements: "Manage Entitlements",
     clearThemeScope: "Clear theme scope",
+    exploreContextFabricUseCases: "Explore use cases",
+    openContextFabricOverview: "Context Fabric overview",
+    seeContextFabricInAction: "See Context Fabric in action",
+    readAskDevGuide: "Read the Ask Dev guide",
+    configureAcrMcpSidecar: "Configure the ACR MCP sidecar",
+    configureAcrAndMcp: "Configure ACR and MCP",
 } as const;
 
 export type CtaKey = keyof typeof CTA_LABELS;

--- a/tests/marketing-context-fabric.spec.ts
+++ b/tests/marketing-context-fabric.spec.ts
@@ -1,12 +1,41 @@
 import { expect, test } from "@playwright/test";
 
-test.describe("Context Fabric marketing page", () => {
-    test("renders the product story and both supported experiences", async ({ page }) => {
+test.describe("Context Fabric marketing pages", () => {
+    test("renders the ecosystem-wide product story and both supported experiences", async ({
+        page,
+    }) => {
         await page.goto("/marketing/context-fabric");
 
         await expect(
             page.getByRole("heading", {
-                name: /know what is actually happening—not just what the tracker says/i,
+                name: /give people and agents the context behind the work/i,
+            }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole("heading", {
+                name: /understand the engineering ecosystem around the work/i,
+            }),
+        ).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Who" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "What" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Why" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "How" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Ask Dev" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "ACR and MCP" })).toBeVisible();
+        await expect(page.getByRole("link", { name: "Explore use cases" }).first()).toHaveAttribute(
+            "href",
+            "/marketing/context-fabric/use-cases",
+        );
+    });
+
+    test("keeps project status as one use case and covers broader people and agent questions", async ({
+        page,
+    }) => {
+        await page.goto("/marketing/context-fabric/use-cases");
+
+        await expect(
+            page.getByRole("heading", {
+                name: /understand the whole context behind an engineering decision/i,
             }),
         ).toBeVisible();
         await expect(
@@ -15,11 +44,29 @@ test.describe("Context Fabric marketing page", () => {
             }),
         ).toBeVisible();
         await expect(page.getByText("Implemented, deployed, and available")).toBeVisible();
-        await expect(page.getByRole("heading", { name: "Ask Dev" })).toBeVisible();
-        await expect(page.getByRole("heading", { name: "MCP for agents" })).toBeVisible();
+        await expect(
+            page.getByRole("heading", {
+                name: /know what is complete, blocked, ready, or still uncertain/i,
+            }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole("heading", {
+                name: /find teams that may need attention without ranking people/i,
+            }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole("heading", {
+                name: /prioritize evidence-backed gaps across the delivery system/i,
+            }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole("heading", {
+                name: /bring the surrounding context to the agent before it works/i,
+            }),
+        ).toBeVisible();
     });
 
-    test("exposes the page from the marketing hub and footer", async ({ page }) => {
+    test("exposes the landing page from the marketing hub and footer", async ({ page }) => {
         await page.goto("/marketing");
 
         const hubLink = page.getByRole("link", { name: /context fabric/i }).first();
@@ -30,15 +77,19 @@ test.describe("Context Fabric marketing page", () => {
     });
 
     test("keeps public calls to action on supported destinations", async ({ page }) => {
-        await page.goto("/marketing/context-fabric");
+        await page.goto("/marketing/context-fabric/use-cases");
 
         await expect(page.getByRole("link", { name: "Get started" }).first()).toHaveAttribute(
             "href",
             "/auth/signup",
         );
-        await expect(page.getByRole("link", { name: "View guide" }).last()).toHaveAttribute(
+        await expect(page.getByRole("link", { name: "Configure ACR and MCP" })).toHaveAttribute(
             "href",
             "https://github.com/full-chaos/dev-health-acr/blob/main/docs/mcp-sidecar.md",
+        );
+        await expect(page.getByRole("link", { name: "Context Fabric overview" })).toHaveAttribute(
+            "href",
+            "/marketing/context-fabric",
         );
     });
 });

--- a/tests/marketing-context-fabric.spec.ts
+++ b/tests/marketing-context-fabric.spec.ts
@@ -16,10 +16,16 @@ test.describe("Context Fabric marketing pages", () => {
                 name: /understand the engineering ecosystem around the work/i,
             }),
         ).toBeVisible();
-        await expect(page.getByRole("heading", { name: "Who" })).toBeVisible();
-        await expect(page.getByRole("heading", { name: "What" })).toBeVisible();
-        await expect(page.getByRole("heading", { name: "Why" })).toBeVisible();
-        await expect(page.getByRole("heading", { name: "How" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Who", exact: true })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "What", exact: true })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Why", exact: true })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "How", exact: true })).toBeVisible();
+        await expect(
+            page.getByRole("img", {
+                name: "Context Fabric connects the engineering ecosystem to Ask Dev and ACR MCP consumers",
+                exact: true,
+            }),
+        ).toBeVisible();
         await expect(page.getByRole("heading", { name: "Ask Dev" })).toBeVisible();
         await expect(page.getByRole("heading", { name: "ACR and MCP" })).toBeVisible();
         await expect(page.getByRole("link", { name: "Explore use cases" }).first()).toHaveAttribute(


### PR DESCRIPTION
## Summary

Expands the Context Fabric marketing surface from a project-status narrative into the broader product story, while preserving project status as a concrete day-to-day example.

## Route structure

- `/marketing/context-fabric` — product landing for the shared Context Fabric capability
- `/marketing/context-fabric/use-cases` — representative people and agent use cases

## Landing page

- positions Context Fabric as shared operating context for people and agents;
- explains the **who, what, why, and how** behind engineering work;
- keeps the diagnosis loop **State → Pressure → Cause → Evidence → Action**;
- connects work/priorities, code/delivery, teams/ownership, and reliability/operations;
- presents **Ask Dev** as the people-facing path and **ACR/MCP** as the developer/agent path;
- links directly into the new use-case collection.

## Use cases

Preserves the stale tracker example:

- ticket says `In Progress`;
- PR merged, CI passed, deployment succeeded, flag enabled, and feature available;
- Context Fabric reports the implemented/deployed/available state while disclosing the stale tracker and remaining follow-up separately.

Adds representative use cases for:

- project and portfolio completion/readiness;
- project health;
- team health and sustained pressure;
- workload/review pressure with denominator and baseline limits;
- investment balance and classification coverage;
- operational deficiencies;
- observed change, freshness, source coverage, conflicts, and uncertainty;
- agent planning, review, failure investigation, documentation, CI, and automation context.

## Guardrails retained in marketing copy

- no person-level productivity or health ranking;
- no workload/burden claim without defensible denominators and baselines;
- no missing/stale/unavailable source represented as zero or healthy;
- no unrelated evidence or semantic similarity presented as a verified relationship;
- observed facts, inferred pressure, and recommendations remain distinct.

## Integration and validation

- adds the use-case route to the public sitemap;
- updates Playwright coverage for both routes, hub/footer discoverability, route relationships, the preserved project example, broader use-case coverage, and public CTA destinations;
- visual review is still required for desktop and mobile before merge.
