### PR TITLE
fix(ask-dev): bump SOURCE_COMMIT pin to ops main (CHAOS-3368 follow-up)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
               with:
                   repository: full-chaos/dev-health-ops
-                  ref: 4838e026e08d20bd62090a85218add2761733edd
+                  ref: c31b9c6de1b4b7dbdfc82d84850e4e09fb71960e
                   path: dev-health-ops
                   persist-credentials: false
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271

--- a/scripts/ask-dev-contracts.mjs
+++ b/scripts/ask-dev-contracts.mjs
@@ -12,7 +12,7 @@ import { format } from "prettier";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ARTIFACT_ROOT = path.join(ROOT, "src/lib/dev/contracts");
 const GENERATED_PATH = path.join(ROOT, "src/lib/dev/generated.ts");
-const SOURCE_COMMIT = "4838e026e08d20bd62090a85218add2761733edd";
+const SOURCE_COMMIT = "c31b9c6de1b4b7dbdfc82d84850e4e09fb71960e";
 const SOURCE_PREFIX = "contracts/ask-dev/v1/";
 const PRETTIER_OPTIONS = Object.freeze({
     parser: "typescript",

--- a/src/lib/dev/__tests__/contracts.test.ts
+++ b/src/lib/dev/__tests__/contracts.test.ts
@@ -74,7 +74,7 @@ describe("Ask Dev generated contract boundary", () => {
         const source = readJson<SourceManifest>("source.json");
         const manifest = readJson<OpsManifest>("manifest.json");
 
-        expect(source.source_commit).toBe("4838e026e08d20bd62090a85218add2761733edd");
+        expect(source.source_commit).toBe("c31b9c6de1b4b7dbdfc82d84850e4e09fb71960e");
         expect(manifest.schema_version).toBe("ask_dev_contract_manifest.v1");
         expect(manifest.compatibility).toBe("additive-within-v1");
         expect(manifest.contracts.map((contract) => contract.schema_version)).toEqual(

--- a/src/lib/dev/contracts/examples/negative/dev_scope.v1.team_scope_entity_ref_is_not_a_team.json
+++ b/src/lib/dev/contracts/examples/negative/dev_scope.v1.team_scope_entity_ref_is_not_a_team.json
@@ -1,0 +1,28 @@
+{
+  "comparison_range": {
+    "end": "2026-06-28T00:00:00Z",
+    "start": "2026-05-29T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  },
+  "direct_scope": "team",
+  "entity_refs": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_type": "project",
+      "repository_id": null
+    }
+  ],
+  "organization_id": "org_fullchaos",
+  "repositories": [],
+  "schema_version": "dev_scope.v1",
+  "surface_context": null,
+  "team_ids": [
+    "team_platform"
+  ],
+  "time_range": {
+    "end": "2026-07-28T00:00:00Z",
+    "start": "2026-06-28T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/src/lib/dev/contracts/examples/negative/dev_scope.v1.team_scope_with_repository_list.json
+++ b/src/lib/dev/contracts/examples/negative/dev_scope.v1.team_scope_with_repository_list.json
@@ -1,0 +1,30 @@
+{
+  "comparison_range": {
+    "end": "2026-06-28T00:00:00Z",
+    "start": "2026-05-29T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  },
+  "direct_scope": "team",
+  "entity_refs": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_type": "team",
+      "repository_id": null
+    }
+  ],
+  "organization_id": "org_fullchaos",
+  "repositories": [
+    "repo_dev_health"
+  ],
+  "schema_version": "dev_scope.v1",
+  "surface_context": null,
+  "team_ids": [
+    "team_platform"
+  ],
+  "time_range": {
+    "end": "2026-07-28T00:00:00Z",
+    "start": "2026-06-28T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/src/lib/dev/contracts/examples/negative/dev_scope.v1.team_scope_without_matching_team_id.json
+++ b/src/lib/dev/contracts/examples/negative/dev_scope.v1.team_scope_without_matching_team_id.json
@@ -1,0 +1,26 @@
+{
+  "comparison_range": {
+    "end": "2026-06-28T00:00:00Z",
+    "start": "2026-05-29T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  },
+  "direct_scope": "team",
+  "entity_refs": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_type": "team",
+      "repository_id": null
+    }
+  ],
+  "organization_id": "org_fullchaos",
+  "repositories": [],
+  "schema_version": "dev_scope.v1",
+  "surface_context": null,
+  "team_ids": [],
+  "time_range": {
+    "end": "2026-07-28T00:00:00Z",
+    "start": "2026-06-28T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/src/lib/dev/contracts/examples/negative/dev_scope_resolution.v1.team_resolution_scope_with_repository_list.json
+++ b/src/lib/dev/contracts/examples/negative/dev_scope_resolution.v1.team_resolution_scope_with_repository_list.json
@@ -1,0 +1,61 @@
+{
+  "authorized_entity_ids": [
+    "team_platform"
+  ],
+  "authorized_repository_ids": [],
+  "candidates": [],
+  "fallbacks": [],
+  "outcome": "exact",
+  "requested_scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "organization",
+    "entity_refs": [],
+    "organization_id": "org_fullchaos",
+    "repositories": [],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "resolved_at": "2026-07-28T12:00:00Z",
+  "resolved_scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "team",
+    "entity_refs": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "repository_id": null
+      }
+    ],
+    "organization_id": "org_fullchaos",
+    "repositories": [
+      "repo_dev_health"
+    ],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [
+      "team_platform"
+    ],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "schema_version": "dev_scope_resolution.v1",
+  "warnings": []
+}

--- a/src/lib/dev/contracts/examples/positive/dev_scope.v1.team_direct_scope.json
+++ b/src/lib/dev/contracts/examples/positive/dev_scope.v1.team_direct_scope.json
@@ -1,0 +1,28 @@
+{
+  "comparison_range": {
+    "end": "2026-06-28T00:00:00Z",
+    "start": "2026-05-29T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  },
+  "direct_scope": "team",
+  "entity_refs": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_type": "team",
+      "repository_id": null
+    }
+  ],
+  "organization_id": "org_fullchaos",
+  "repositories": [],
+  "schema_version": "dev_scope.v1",
+  "surface_context": null,
+  "team_ids": [
+    "team_platform"
+  ],
+  "time_range": {
+    "end": "2026-07-28T00:00:00Z",
+    "start": "2026-06-28T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/src/lib/dev/contracts/examples/positive/dev_scope_resolution.v1.team_direct_scope.json
+++ b/src/lib/dev/contracts/examples/positive/dev_scope_resolution.v1.team_direct_scope.json
@@ -1,0 +1,59 @@
+{
+  "authorized_entity_ids": [
+    "team_platform"
+  ],
+  "authorized_repository_ids": [],
+  "candidates": [],
+  "fallbacks": [],
+  "outcome": "exact",
+  "requested_scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "organization",
+    "entity_refs": [],
+    "organization_id": "org_fullchaos",
+    "repositories": [],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "resolved_at": "2026-07-28T12:00:00Z",
+  "resolved_scope": {
+    "comparison_range": {
+      "end": "2026-06-28T00:00:00Z",
+      "start": "2026-05-29T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    },
+    "direct_scope": "team",
+    "entity_refs": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "repository_id": null
+      }
+    ],
+    "organization_id": "org_fullchaos",
+    "repositories": [],
+    "schema_version": "dev_scope.v1",
+    "surface_context": null,
+    "team_ids": [
+      "team_platform"
+    ],
+    "time_range": {
+      "end": "2026-07-28T00:00:00Z",
+      "start": "2026-06-28T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "schema_version": "dev_scope_resolution.v1",
+  "warnings": []
+}

--- a/src/lib/dev/contracts/manifest.json
+++ b/src/lib/dev/contracts/manifest.json
@@ -13,6 +13,7 @@
         "path": "examples/positive/dev_capabilities.v1.json",
         "sha256": "c50f40db5b17e5542273bd9458260c85ea557ac2c561b1d74b8f2f145bfcd781"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_capabilities.v1.schema.json",
         "sha256": "66f9dd47b340f1ca3b3d545761912e69a0833b1550868a8f45a6ab2836ec2050"
@@ -31,6 +32,7 @@
         "path": "examples/positive/dev_conversation.v1.json",
         "sha256": "47be0516bbcaa870893952b97a0e4c8ab149976dbc7a61c2f3f0a011c8e697ab"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation.v1.schema.json",
         "sha256": "8cc7267de6d08f5a63d1ecef1b4a0b45856a925637ba780f6433856fa7d27bbb"
@@ -49,6 +51,7 @@
         "path": "examples/positive/dev_conversation_summary.v1.json",
         "sha256": "6304c4105dc11299fe840041c76453b0fd1eedecdbafbdb76d9b9f703a3f530b"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation_summary.v1.schema.json",
         "sha256": "53f0fac1fef5801a794ed160b1904fc107c3647d60e52c7462ddeccdb8c6f167"
@@ -72,6 +75,7 @@
         "path": "examples/positive/dev_conversation_transcript.v1.json",
         "sha256": "7aa148b2e030d83df425a53144b2a72c1ce12f6a2fd4bf8ffe798a09239db72d"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
         "sha256": "d0df8dccbf190a280412e6d4872006459072128d87c7cf8d9e9facc016ab62a3"
@@ -105,6 +109,7 @@
         "path": "examples/positive/dev_message_request.v1.json",
         "sha256": "bf3e37433e31bb6df754365523d22bcbcbdde51e5ac187d5c040805d989c2193"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_message_request.v1.schema.json",
         "sha256": "258a495a3ac72ec52164b37164d71b4f01b60d8f1008b046965cd2f002c7b2bc"
@@ -148,6 +153,7 @@
         "path": "examples/positive/dev_answer.v1.json",
         "sha256": "fba7cafc8b232b43e56c8385b2b58439e5a4b0b67cb3eb1da0ffc32f19733c21"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
         "sha256": "e156ced39c676bae4e08f5c5e5acc86a4d7120b472ab628ba20f1a605a8ce6fc"
@@ -166,6 +172,7 @@
         "path": "examples/positive/dev_claim.v1.json",
         "sha256": "d0ecc9782098c5b683e7002d8bf2b62dbf03cd19db5e49a8a6becb738d728b41"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_claim.v1.schema.json",
         "sha256": "4a8505fb87ccae4c4e63c17403410a18f543e54f1e46a79c0b8144d7b60b5481"
@@ -184,6 +191,7 @@
         "path": "examples/positive/dev_metric_ref.v1.json",
         "sha256": "e7ca0ef77b63d9f23812d96033004c1e799baad21f90c8f786b1fa3c6ae6fe1f"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_metric_ref.v1.schema.json",
         "sha256": "8038eef2144551ffd165681dd96a9541d0ae74925708250691f5674acbedde32"
@@ -202,6 +210,7 @@
         "path": "examples/positive/dev_evidence_ref.v1.json",
         "sha256": "736e3ddf1dea4a689d7853b6eeed317980f894aa99477aeb83b85cd5eaa17bb0"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_evidence_ref.v1.schema.json",
         "sha256": "ec835b4334f2f627a14fbb361244b403fd8faed8825b051122e16780918cdf2b"
@@ -220,6 +229,7 @@
         "path": "examples/positive/dev_evidence_expansion.v1.json",
         "sha256": "a685babfe43af765fb48fd9c670c5b9236a5e5bf090f88fcba381fff615ef473"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_evidence_expansion.v1.schema.json",
         "sha256": "615e2e20b938e0e1181dcd5681495352f30d515f7a45f3fb0dd6879d6cdc0628"
@@ -232,12 +242,34 @@
           "case": "repository_scope_without_repository",
           "path": "examples/negative/dev_scope.v1.repository_scope_without_repository.json",
           "sha256": "9231bdb93fd8ca9071b94eddab8efe18117d779a36bd9c98a460645a53a913c7"
+        },
+        {
+          "case": "team_scope_with_repository_list",
+          "path": "examples/negative/dev_scope.v1.team_scope_with_repository_list.json",
+          "sha256": "9be0e272c2f64d88b3045fa75190d56291e306a6f16a12ffc70b11dddc607a71"
+        },
+        {
+          "case": "team_scope_without_matching_team_id",
+          "path": "examples/negative/dev_scope.v1.team_scope_without_matching_team_id.json",
+          "sha256": "6ed6b7870fbbc05695b85b3b537f86427aa9cde17dbaab9b5038729842a3c84c"
+        },
+        {
+          "case": "team_scope_entity_ref_is_not_a_team",
+          "path": "examples/negative/dev_scope.v1.team_scope_entity_ref_is_not_a_team.json",
+          "sha256": "29d0ec2641b0605f52e377ecb19422a01a63f331da161472cf05c39a76032614"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_scope.v1.json",
         "sha256": "dde80325d67210773c48c173a87a10d28175cbfe749de68031ad0aea498b22a8"
       },
+      "positive_variants": [
+        {
+          "case": "team_direct_scope",
+          "path": "examples/positive/dev_scope.v1.team_direct_scope.json",
+          "sha256": "fcfa27343f3c8495cdb53bfedecad7563b88270397eb8510dbfa3a3a44e78689"
+        }
+      ],
       "schema": {
         "path": "schemas/dev_scope.v1.schema.json",
         "sha256": "d968b133e6ebf1fde7851c9a3c7c650dddf6edc5bb3a4dca311c6302add5e1a8"
@@ -250,12 +282,24 @@
           "case": "ambiguous_without_candidates",
           "path": "examples/negative/dev_scope_resolution.v1.ambiguous_without_candidates.json",
           "sha256": "7fed2de44881a812e39df698ac9f70d17ad2687b5152c8deddfa16f0f49627b2"
+        },
+        {
+          "case": "team_resolution_scope_with_repository_list",
+          "path": "examples/negative/dev_scope_resolution.v1.team_resolution_scope_with_repository_list.json",
+          "sha256": "ecac58395a2e44a2172dca0589fade71c71103fe8e91a0452af02242d5a48e27"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_scope_resolution.v1.json",
         "sha256": "c6b8c0117a8d43b2d9cb2307ff84790b09cef16dae6261b0a06bcecce47aa98e"
       },
+      "positive_variants": [
+        {
+          "case": "team_direct_scope",
+          "path": "examples/positive/dev_scope_resolution.v1.team_direct_scope.json",
+          "sha256": "7bba6a7be653b7c2fbc0889b29a3a5828683107a0c6a0fe2da5251b68980efdb"
+        }
+      ],
       "schema": {
         "path": "schemas/dev_scope_resolution.v1.schema.json",
         "sha256": "6f0f9de88d78beb53b5d6e42b9e161cadaf947a2939a3215a810069600227b81"
@@ -274,6 +318,7 @@
         "path": "examples/positive/dev_tool_request.v1.json",
         "sha256": "6813cd3b14a8b89c3f53c636950052733936e92fc396e06a36652d4b02166fff"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_request.v1.schema.json",
         "sha256": "eed1f7ad4d5dac6f12680329eded654e7808fa78280e11280f4e3cf541a0bfe1"
@@ -297,9 +342,10 @@
         "path": "examples/positive/dev_tool_result.v1.json",
         "sha256": "31a956f4659f29f190346a7b873a219ffc85ccd2dfb9d7032937a4eb9c9ed653"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "984a7b92cc1476b929f895c009c4c7c061d7ad594427777329b7271a9b8a4f1f"
+        "sha256": "ec2b36b4b4f20f5203002e0661db826ae78b862a20880d74d3618b059397a5dd"
       },
       "schema_version": "dev_tool_result.v1"
     },
@@ -315,6 +361,7 @@
         "path": "examples/positive/dev_feedback.v1.json",
         "sha256": "f4e15f005ae9314210900993a791b5ab358375997f7dc28b30d4d76487101ba0"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_feedback.v1.schema.json",
         "sha256": "9c792cd80995e4e6eba066d50e495d77e0337621dffaf12fd59ed468af69b545"
@@ -333,6 +380,7 @@
         "path": "examples/positive/dev_stream_event.v1.json",
         "sha256": "0a0f35ac4aa52b623cfce76eca11aca5c6fa186d1e66f3376cdfc5c90d0759b2"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
         "sha256": "694eeacf026c3c6abe6363625d1188fa59c3b1d194713acd8754babeeaa0dfad"
@@ -351,6 +399,7 @@
         "path": "examples/positive/dev_error.v1.json",
         "sha256": "c4536803fbb8259951bca9725d8594801169da9641177f2bd91fd87d124874ee"
       },
+      "positive_variants": [],
       "schema": {
         "path": "schemas/dev_error.v1.schema.json",
         "sha256": "eb78a38684caab42ef2c88c6a33f558330855b86b9b847024560dfeb68581514"
@@ -375,6 +424,13 @@
     {
       "case": "invalid_out_of_order",
       "path": "examples/streams/invalid_out_of_order.json"
+    }
+  ],
+  "vocabulary": [
+    {
+      "case": "internal_prose_denylist",
+      "path": "vocabulary/internal_prose_denylist.v1.json",
+      "sha256": "621ed38192bb17f3c9e9f826a3b3572c29cc8cd58865c77e9ea4ad9296990e7a"
     }
   ]
 }

--- a/src/lib/dev/contracts/schemas/dev_tool_result.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_tool_result.v1.schema.json
@@ -23,6 +23,14 @@
       "additionalProperties": false,
       "description": "Server-computed ``actual-completion`` rule result; the LLM explains, never derives, it.",
       "properties": {
+        "blockers": {
+          "items": {
+            "$ref": "#/$defs/DevRequiredChildFact"
+          },
+          "maxItems": 100,
+          "title": "Blockers",
+          "type": "array"
+        },
         "conflicts": {
           "items": {
             "$ref": "#/$defs/DevStatusConflict"
@@ -1680,6 +1688,45 @@
       "maxItems": 25,
       "title": "Data Health",
       "type": "array"
+    },
+    "declared_project_evidence_ref_ids": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+        "type": "string"
+      },
+      "maxItems": 25,
+      "title": "Declared Project Evidence Ref Ids",
+      "type": "array"
+    },
+    "declared_project_state": {
+      "anyOf": [
+        {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Declared Project State"
+    },
+    "declared_project_target_date": {
+      "anyOf": [
+        {
+          "format": "date",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Declared Project Target Date"
     },
     "deployments": {
       "items": {

--- a/src/lib/dev/contracts/source.json
+++ b/src/lib/dev/contracts/source.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "ask_dev_web_contract_source.v1",
-  "source_commit": "4838e026e08d20bd62090a85218add2761733edd",
+  "source_commit": "c31b9c6de1b4b7dbdfc82d84850e4e09fb71960e",
   "files": [
     {
       "path": "examples/negative/dev_answer.v1.invalid_complete_state.json",
@@ -91,8 +91,24 @@
       "sha256": "9231bdb93fd8ca9071b94eddab8efe18117d779a36bd9c98a460645a53a913c7"
     },
     {
+      "path": "examples/negative/dev_scope.v1.team_scope_entity_ref_is_not_a_team.json",
+      "sha256": "29d0ec2641b0605f52e377ecb19422a01a63f331da161472cf05c39a76032614"
+    },
+    {
+      "path": "examples/negative/dev_scope.v1.team_scope_with_repository_list.json",
+      "sha256": "9be0e272c2f64d88b3045fa75190d56291e306a6f16a12ffc70b11dddc607a71"
+    },
+    {
+      "path": "examples/negative/dev_scope.v1.team_scope_without_matching_team_id.json",
+      "sha256": "6ed6b7870fbbc05695b85b3b537f86427aa9cde17dbaab9b5038729842a3c84c"
+    },
+    {
       "path": "examples/negative/dev_scope_resolution.v1.ambiguous_without_candidates.json",
       "sha256": "7fed2de44881a812e39df698ac9f70d17ad2687b5152c8deddfa16f0f49627b2"
+    },
+    {
+      "path": "examples/negative/dev_scope_resolution.v1.team_resolution_scope_with_repository_list.json",
+      "sha256": "ecac58395a2e44a2172dca0589fade71c71103fe8e91a0452af02242d5a48e27"
     },
     {
       "path": "examples/negative/dev_stream_event.v1.private_reasoning_payload.json",
@@ -163,8 +179,16 @@
       "sha256": "dde80325d67210773c48c173a87a10d28175cbfe749de68031ad0aea498b22a8"
     },
     {
+      "path": "examples/positive/dev_scope.v1.team_direct_scope.json",
+      "sha256": "fcfa27343f3c8495cdb53bfedecad7563b88270397eb8510dbfa3a3a44e78689"
+    },
+    {
       "path": "examples/positive/dev_scope_resolution.v1.json",
       "sha256": "c6b8c0117a8d43b2d9cb2307ff84790b09cef16dae6261b0a06bcecce47aa98e"
+    },
+    {
+      "path": "examples/positive/dev_scope_resolution.v1.team_direct_scope.json",
+      "sha256": "7bba6a7be653b7c2fbc0889b29a3a5828683107a0c6a0fe2da5251b68980efdb"
     },
     {
       "path": "examples/positive/dev_stream_event.v1.json",
@@ -196,7 +220,7 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "b3a78704667c25583b71750e92194d513cc3929bcf194e42d9010f453f23e450"
+      "sha256": "2540bfed0a73c1cce242d5fd3264a3882b5542ab14ba4e423a65df5b8142c647"
     },
     {
       "path": "schemas/dev_answer.v1.schema.json",
@@ -264,7 +288,11 @@
     },
     {
       "path": "schemas/dev_tool_result.v1.schema.json",
-      "sha256": "984a7b92cc1476b929f895c009c4c7c061d7ad594427777329b7271a9b8a4f1f"
+      "sha256": "ec2b36b4b4f20f5203002e0661db826ae78b862a20880d74d3618b059397a5dd"
+    },
+    {
+      "path": "vocabulary/internal_prose_denylist.v1.json",
+      "sha256": "621ed38192bb17f3c9e9f826a3b3572c29cc8cd58865c77e9ea4ad9296990e7a"
     }
   ]
 }

--- a/src/lib/dev/contracts/vocabulary/internal_prose_denylist.v1.json
+++ b/src/lib/dev/contracts/vocabulary/internal_prose_denylist.v1.json
@@ -1,0 +1,28 @@
+{
+  "completion_states": [
+    "not_ready"
+  ],
+  "evidence_handle_pattern": "^ev1_[0-9a-f]{40}$",
+  "extra_tokens": [
+    "actual_completion"
+  ],
+  "reason_codes": [
+    "active_blocking_incident",
+    "assessment_source_limit_reached",
+    "child_requirement_unknown",
+    "ci_requirement_unknown",
+    "declared_status_missing",
+    "open_blocker",
+    "required_child_incomplete",
+    "required_ci_not_passing",
+    "required_ci_skip_state_unknown",
+    "required_ci_work_skipped",
+    "required_deployment_not_succeeded",
+    "required_pull_request_unmerged",
+    "required_release_evidence_missing",
+    "required_review_unresolved",
+    "required_source_not_fresh",
+    "review_changes_requested"
+  ],
+  "schema_version": "ask_dev_internal_prose_denylist.v1"
+}

--- a/src/lib/dev/generated.ts
+++ b/src/lib/dev/generated.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-// Generated from full-chaos/dev-health-ops 4838e026e08d20bd62090a85218add2761733edd. Do not edit.
+// Generated from full-chaos/dev-health-ops c31b9c6de1b4b7dbdfc82d84850e4e09fb71960e. Do not edit.
 export namespace DevAnswerContract {
     export type AnswerId = string;
     export type AsOf = string;
@@ -16260,6 +16260,17 @@ export namespace DevToolRequestContract {
 export type DevToolRequest = DevToolRequestContract.DevToolRequest;
 export namespace DevToolResultContract {
     /**
+     * @maxItems 25
+     */
+    export type EvidenceRefIds = string[];
+    export type FactId = string;
+    export type Status = string;
+    export type Text = string;
+    /**
+     * @maxItems 100
+     */
+    export type Blockers = DevRequiredChildFact[];
+    /**
      * @maxItems 20
      */
     export type Conflicts =
@@ -16504,27 +16515,20 @@ export namespace DevToolResultContract {
     /**
      * @maxItems 25
      */
-    export type EvidenceRefIds = string[];
+    export type EvidenceRefIds1 = string[];
     export type Message = string;
     export type Severity = "warning" | "blocking";
     export type DisplayTruncated = boolean;
     /**
      * @maxItems 25
      */
-    export type EvidenceRefIds1 = string[];
+    export type EvidenceRefIds2 = string[];
     /**
      * @maxItems 25
      */
     export type ReasonCodes = string[];
     export type RequiredChildComplete = number | null;
     export type RequiredChildTotal = number | null;
-    /**
-     * @maxItems 25
-     */
-    export type EvidenceRefIds2 = string[];
-    export type FactId = string;
-    export type Status = string;
-    export type Text = string;
     /**
      * @maxItems 100
      */
@@ -16555,6 +16559,12 @@ export namespace DevToolResultContract {
      * @maxItems 25
      */
     export type DataHealth = DevDataHealth[];
+    /**
+     * @maxItems 25
+     */
+    export type DeclaredProjectEvidenceRefIds = string[];
+    export type DeclaredProjectState = string | null;
+    export type DeclaredProjectTargetDate = string | null;
     export type DisplayLabel1 = string;
     export type EntityId1 = string;
     export type Environment = string | null;
@@ -18982,6 +18992,9 @@ export namespace DevToolResultContract {
         actual_completion?: DevActualCompletion | null;
         ci_checks?: CiChecks;
         data_health?: DataHealth;
+        declared_project_evidence_ref_ids?: DeclaredProjectEvidenceRefIds;
+        declared_project_state?: DeclaredProjectState;
+        declared_project_target_date?: DeclaredProjectTargetDate;
         deployments?: Deployments;
         error?: DevError | null;
         evidence?: Evidence;
@@ -19005,9 +19018,10 @@ export namespace DevToolResultContract {
      * Server-computed ``actual-completion`` rule result; the LLM explains, never derives, it.
      */
     export interface DevActualCompletion {
+        blockers?: Blockers;
         conflicts?: Conflicts;
         display_truncated?: DisplayTruncated;
-        evidence_ref_ids?: EvidenceRefIds1;
+        evidence_ref_ids?: EvidenceRefIds2;
         reason_codes?: ReasonCodes;
         required_child_complete?: RequiredChildComplete;
         required_child_total?: RequiredChildTotal;
@@ -19016,17 +19030,17 @@ export namespace DevToolResultContract {
         rule_version: RuleVersion;
         state: State;
     }
-    export interface DevStatusConflict {
-        code: Code;
-        evidence_ref_ids?: EvidenceRefIds;
-        message: Message;
-        severity: Severity;
-    }
     export interface DevRequiredChildFact {
-        evidence_ref_ids?: EvidenceRefIds2;
+        evidence_ref_ids?: EvidenceRefIds;
         fact_id: FactId;
         status: Status;
         text: Text;
+    }
+    export interface DevStatusConflict {
+        code: Code;
+        evidence_ref_ids?: EvidenceRefIds1;
+        message: Message;
+        severity: Severity;
     }
     export interface DevCIFact {
         conclusion: Conclusion;


### PR DESCRIPTION
## Summary
The `dev_tool_result.v1` contract pin was never bumped after ops #1477 (CHAOS-3368, declared-state/target-date typed fields) merged. Bumps `SOURCE_COMMIT` in `scripts/ask-dev-contracts.mjs` to ops `c31b9c6de` (includes #1477 and #1481/CHAOS-3386) and regenerates every derived artifact via the script's own `generate --source <pinned ops worktree> --allow-write` (schemas, examples, manifest, source.json, generated.ts) — nothing hand-written. Also fixes the two other places that hardcoded the stale ops commit literal: `.github/workflows/tests.yml` Quality job's ops checkout ref, and `src/lib/dev/__tests__/contracts.test.ts` pin assertion.

## Evidence
- `pnpm ask-dev:contracts:check --source <pinned ops worktree>` passes.
- Full gate: quality/build/unit all green.
- e2e default suite has pre-existing failures (ask-dev-continuity/outcomes/shared, filter-propagation, home-flow, nav-reachability, people, admin-settings) reproduced identically against a clean, unmodified web `origin/main` control run — confirmed unrelated to this change.