### PR TITLE
fix(ask-dev): CHAOS-3397 resolve Data Confidence label drift + close drift class

### DIFF
--- a/src/components/ask-dev/AskDevTrigger.integration.test.tsx
+++ b/src/components/ask-dev/AskDevTrigger.integration.test.tsx
@@ -199,7 +199,7 @@ const approvedSurfaceCases = [
             routeId: "data_health" as const,
             entityRefs: [],
         },
-        label: "Data health",
+        label: "Data Confidence",
     },
 ] as const;
 

--- a/src/lib/dev/__tests__/contextualEntryPoints.test.ts
+++ b/src/lib/dev/__tests__/contextualEntryPoints.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { navTitleForPathname } from "@/lib/navigation/areas";
+
 import {
     ASK_DEV_CONTEXTUAL_ENTRYPOINTS,
     askDevContextForPathname,
@@ -9,6 +11,7 @@ import {
     fingerprintAskDevFilter,
     isApprovedAskDevSurfaceContext,
     toDevSurfaceContext,
+    type ApprovedAskDevRouteId,
     type AskDevSurfaceContext,
 } from "../contextualEntryPoints";
 
@@ -154,4 +157,58 @@ describe("Ask Dev contextual entry point registry", () => {
         expect(askDevContextForPathname("/deployments/deploy-1")).toBeNull();
         expect(askDevContextForPathname("/issues/CHAOS-3216")).toBeNull();
     });
+});
+
+describe("entry-point labels stay in sync with the nav single source of truth (CHAOS-3397)", () => {
+    // Route ids that resolve to exactly one pathname and therefore have a
+    // single, unambiguous nav destination (`@/lib/navigation/areas`) they
+    // represent. Any route id added here is asserted to carry the SAME label
+    // as its nav destination unless explicitly listed in
+    // `DELIBERATE_LABEL_DIVERGENCE` below — this is what would have caught
+    // CHAOS-3397 ("Data health" drifting from the "Data Confidence" rename).
+    const ROUTE_PATHS: Readonly<Partial<Record<ApprovedAskDevRouteId, string>>> = {
+        investment: "/investment",
+        cognitive_load: "/cognitive-load",
+        bottlenecks: "/bottleneck",
+        data_health: "/data-health",
+    };
+
+    // Entry points whose Ask Dev copy is deliberately more descriptive than
+    // the terse sidebar label. Documented so any future divergence is a
+    // conscious choice, not an unnoticed drift like CHAOS-3397.
+    const DELIBERATE_LABEL_DIVERGENCE: Readonly<
+        Partial<Record<ApprovedAskDevRouteId, { path: string; reason: string }>>
+    > = {
+        diagnose_overview: {
+            path: "/diagnose",
+            reason: 'Ask Dev copy is "Diagnose overview" vs the terser sidebar "Overview".',
+        },
+        flow_metrics: {
+            path: "/metrics",
+            reason: 'Ask Dev copy is "Flow metrics" vs the terser sidebar "Flow".',
+        },
+    };
+
+    it.each(Object.entries(ROUTE_PATHS))(
+        "%s label matches the nav destination label for its path",
+        (routeId, path) => {
+            const navLabel = navTitleForPathname(path as string);
+            expect(navLabel).not.toBe("");
+            expect(ASK_DEV_CONTEXTUAL_ENTRYPOINTS[routeId as ApprovedAskDevRouteId].label).toBe(
+                navLabel,
+            );
+        },
+    );
+
+    it.each(Object.entries(DELIBERATE_LABEL_DIVERGENCE))(
+        "%s documents why it diverges from its nav destination label",
+        (routeId, { path, reason }) => {
+            expect(reason.length).toBeGreaterThan(0);
+            expect(navTitleForPathname(path)).not.toBe("");
+            // No equality assertion here by design: divergence is intentional.
+            expect(
+                ASK_DEV_CONTEXTUAL_ENTRYPOINTS[routeId as ApprovedAskDevRouteId].label,
+            ).toBeTruthy();
+        },
+    );
 });

--- a/src/lib/dev/__tests__/contextualEntryPoints.test.ts
+++ b/src/lib/dev/__tests__/contextualEntryPoints.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { navTitleForPathname } from "@/lib/navigation/areas";
 
 import {
+    ASK_DEV_APPROVED_ROUTE_IDS,
     ASK_DEV_CONTEXTUAL_ENTRYPOINTS,
     askDevContextForPathname,
     askDevDirectScope,
@@ -160,36 +161,81 @@ describe("Ask Dev contextual entry point registry", () => {
 });
 
 describe("entry-point labels stay in sync with the nav single source of truth (CHAOS-3397)", () => {
-    // Route ids that resolve to exactly one pathname and therefore have a
-    // single, unambiguous nav destination (`@/lib/navigation/areas`) they
-    // represent. Any route id added here is asserted to carry the SAME label
-    // as its nav destination unless explicitly listed in
-    // `DELIBERATE_LABEL_DIVERGENCE` below — this is what would have caught
+    // Every approved route id must land in EXACTLY ONE of the three buckets
+    // below. This is what makes the guard exhaustive: a new route id (or one
+    // silently dropped from a bucket) fails the classification test, so it
+    // can never sit uncovered the way `data_health` did before CHAOS-3397.
+
+    // Bucket 1 — route ids with a single, unambiguous nav destination whose
+    // label is expected to match verbatim. This is what would have caught
     // CHAOS-3397 ("Data health" drifting from the "Data Confidence" rename).
-    const ROUTE_PATHS: Readonly<Partial<Record<ApprovedAskDevRouteId, string>>> = {
+    const SYNCHRONIZED: Readonly<Partial<Record<ApprovedAskDevRouteId, string>>> = {
         investment: "/investment",
+        work_graph: "/diagnose/work-graph",
+        complexity: "/complexity",
         cognitive_load: "/cognitive-load",
         bottlenecks: "/bottleneck",
         data_health: "/data-health",
     };
 
-    // Entry points whose Ask Dev copy is deliberately more descriptive than
-    // the terse sidebar label. Documented so any future divergence is a
-    // conscious choice, not an unnoticed drift like CHAOS-3397.
+    // Bucket 2 — route ids with a nav destination whose Ask Dev copy is
+    // deliberately MORE descriptive than the terse sidebar label. The exact
+    // pair of labels is pinned (not just "non-empty") so redefining either
+    // string, or moving a future accidental drift into this map, fails the
+    // suite instead of being silently accepted.
     const DELIBERATE_LABEL_DIVERGENCE: Readonly<
-        Partial<Record<ApprovedAskDevRouteId, { path: string; reason: string }>>
+        Partial<
+            Record<
+                ApprovedAskDevRouteId,
+                {
+                    path: string;
+                    expectedEntryPointLabel: string;
+                    expectedNavLabel: string;
+                    reason: string;
+                }
+            >
+        >
     > = {
         diagnose_overview: {
             path: "/diagnose",
+            expectedEntryPointLabel: "Diagnose overview",
+            expectedNavLabel: "Overview",
             reason: 'Ask Dev copy is "Diagnose overview" vs the terser sidebar "Overview".',
         },
         flow_metrics: {
             path: "/metrics",
+            expectedEntryPointLabel: "Flow metrics",
+            expectedNavLabel: "Flow",
             reason: 'Ask Dev copy is "Flow metrics" vs the terser sidebar "Flow".',
         },
     };
 
-    it.each(Object.entries(ROUTE_PATHS))(
+    // Bucket 3 — route ids for entity-detail pages (e.g. `/issues/:id`) that
+    // have no single corresponding nav destination: their label names the
+    // ENTITY TYPE, not a page. Nothing to compare against `areas.ts` for
+    // these; they exist purely so the classification below is exhaustive.
+    const NON_NAV_BACKED: ReadonlySet<ApprovedAskDevRouteId> = new Set([
+        "repository_detail",
+        "project_detail",
+        "work_unit_detail",
+        "issue_detail",
+        "pull_request_detail",
+    ]);
+
+    it("classifies every approved route id into exactly one bucket", () => {
+        const classified = [
+            ...Object.keys(SYNCHRONIZED),
+            ...Object.keys(DELIBERATE_LABEL_DIVERGENCE),
+            ...NON_NAV_BACKED,
+        ];
+        // No route id double-counted across buckets.
+        expect(new Set(classified).size).toBe(classified.length);
+        // The buckets' union is exactly the approved route id set — nothing
+        // missing, nothing extra.
+        expect(new Set(classified)).toEqual(new Set(ASK_DEV_APPROVED_ROUTE_IDS));
+    });
+
+    it.each(Object.entries(SYNCHRONIZED))(
         "%s label matches the nav destination label for its path",
         (routeId, path) => {
             const navLabel = navTitleForPathname(path as string);
@@ -201,14 +247,16 @@ describe("entry-point labels stay in sync with the nav single source of truth (C
     );
 
     it.each(Object.entries(DELIBERATE_LABEL_DIVERGENCE))(
-        "%s documents why it diverges from its nav destination label",
-        (routeId, { path, reason }) => {
+        "%s pins its intentional divergence from the nav destination label",
+        (routeId, { path, expectedEntryPointLabel, expectedNavLabel, reason }) => {
             expect(reason.length).toBeGreaterThan(0);
-            expect(navTitleForPathname(path)).not.toBe("");
-            // No equality assertion here by design: divergence is intentional.
-            expect(
-                ASK_DEV_CONTEXTUAL_ENTRYPOINTS[routeId as ApprovedAskDevRouteId].label,
-            ).toBeTruthy();
+            expect(navTitleForPathname(path)).toBe(expectedNavLabel);
+            expect(ASK_DEV_CONTEXTUAL_ENTRYPOINTS[routeId as ApprovedAskDevRouteId].label).toBe(
+                expectedEntryPointLabel,
+            );
+            // The whole point of this bucket: the two labels must actually
+            // differ, or the entry belongs in SYNCHRONIZED instead.
+            expect(expectedEntryPointLabel).not.toBe(expectedNavLabel);
         },
     );
 });

--- a/src/lib/dev/contextualEntryPoints.ts
+++ b/src/lib/dev/contextualEntryPoints.ts
@@ -1,3 +1,5 @@
+import { navTitleForPathname } from "@/lib/navigation/areas";
+
 import type { DevScope, DevScopeContract } from "./generated";
 
 type DevEntityRef = DevScopeContract.DevEntityRef;
@@ -21,6 +23,13 @@ export const ASK_DEV_APPROVED_ROUTE_IDS = [
 
 export type ApprovedAskDevRouteId = (typeof ASK_DEV_APPROVED_ROUTE_IDS)[number];
 export type ApprovedAskDevEntityType = DevEntityRef["entity_type"];
+
+/**
+ * Canonical route for the Data Confidence admin destination. Shared between
+ * the pathname match below and the entry-point label derivation so the two
+ * can never point at different pages.
+ */
+const DATA_HEALTH_PATH = "/data-health";
 
 export const ASK_DEV_SUGGESTED_QUESTION_IDS = [
     "delivery_status",
@@ -128,7 +137,11 @@ export const ASK_DEV_CONTEXTUAL_ENTRYPOINTS = {
         suggestedQuestionIds: ["delivery_status", "remaining_work", "data_trust"],
     },
     data_health: {
-        label: "Data health",
+        // Derived, not hardcoded: `/lib/navigation/areas.ts` is the single
+        // source of truth for destination labels (sidebar, breadcrumbs, page
+        // title). Hardcoding a second copy here is exactly what drifted out
+        // of sync with the "Data Confidence" rename (CHAOS-3397).
+        label: navTitleForPathname(DATA_HEALTH_PATH),
         allowEmptyEntityRefs: true,
         allowedEntityTypes: ["repository"],
         suggestedQuestionIds: ["data_trust", "observed_change"],
@@ -297,7 +310,7 @@ export function askDevContextForPathname(
     pathname: string,
     filterFingerprint?: string,
 ): AskDevSurfaceContext | null {
-    const routeId = pathname.startsWith("/data-health")
+    const routeId = pathname.startsWith(DATA_HEALTH_PATH)
         ? "data_health"
         : APPROVED_EMPTY_CONTEXT_PATHS[pathname];
     if (!routeId) return null;

--- a/tests/live/ask-dev-acceptance.spec.ts
+++ b/tests/live/ask-dev-acceptance.spec.ts
@@ -170,7 +170,7 @@ test("permanent contextual window continues one grounded run in /dev without dup
 
     const permanentWindow = page.getByRole("region", { name: "Ask Dev" });
     await expect(permanentWindow).toBeVisible();
-    await expect(permanentWindow.getByText(/Proposed context:/u)).toContainText("Data health");
+    await expect(permanentWindow.getByText(/Proposed context:/u)).toContainText("Data Confidence");
     const composer = permanentWindow.getByRole("textbox", { name: "Ask Dev question" });
     await expect(composer).toHaveValue("");
     expect(


### PR DESCRIPTION
## Defect

The Ask Dev acceptance oracle fails on main: the contextual entry point for `/data-health` renders "Proposed context: Data health", but the destination it represents is labeled "Data Confidence" everywhere else in the product (sidebar, breadcrumbs, page title). Two independently hardcoded copies of the same page's name had drifted apart:

- `src/lib/dev/contextualEntryPoints.ts:131` — `data_health.label: "Data health"`
- `src/lib/navigation/areas.ts:707` — nav destination `label: "Data Confidence"`

## Rename-intent evidence

"Data Confidence" is the deliberate, established product name:
- `areas.ts` has carried `"Data Confidence"` since PR #726 (Jun 3), including an inline comment that predates the bug: `// \`/data-health\` (Data Confidence) is an Admin destination outside \`/org/admin\`.`
- `"Data health"` was a brand-new, independently-typed string introduced during Ask Dev Wave 3 (PR #813, Jul 29) — ~2 months later. It was never a rename of the nav label; it was a second, unsynchronized copy.

So the fix target is `contextualEntryPoints.ts`, not `areas.ts`.

## Fix

`contextualEntryPoints.ts`'s `data_health.label` now **derives** from `navTitleForPathname("/data-health")` — the same nav-derived function that already powers breadcrumbs and page titles — instead of a second hardcoded string. A shared `DATA_HEALTH_PATH` constant ties the pathname match and the label derivation to one literal so they cannot diverge again.

## Guard (class closure)

Added an exhaustive regression suite in `contextualEntryPoints.test.ts` that partitions every approved route id into exactly one of three buckets:
- **SYNCHRONIZED** — route ids with a single, unambiguous nav destination whose label must match verbatim (`investment`, `work_graph`, `complexity`, `cognitive_load`, `bottlenecks`, `data_health`).
- **DELIBERATE_LABEL_DIVERGENCE** — route ids whose Ask Dev copy is intentionally more descriptive than the terse sidebar label (`diagnose_overview`, `flow_metrics`), with the exact expected label pair pinned and asserted unequal.
- **NON_NAV_BACKED** — entity-detail route ids with no corresponding nav destination (`repository_detail`, `project_detail`, `work_unit_detail`, `issue_detail`, `pull_request_detail`).

A test asserts the three buckets partition `ASK_DEV_APPROVED_ROUTE_IDS` exactly (no overlap, no gap), so a future route id can't sit uncovered by any bucket the way `data_health` effectively was before this PR.

RED confirmed before each fix (label revert, dropped bucket entry, tampered pinned value all reproduced the intended failure); GREEN after.

## Codex review round

A first review pass on the guard suite flagged two MEDIUMs (production derivation itself was clean):
1. The original two-table guard was non-exhaustive (`Partial` records with no completeness check) — `work_graph` and `complexity` were nav-backed but covered by neither table. Replaced with the exhaustive three-bucket partition above.
2. The divergence-exception test only checked non-empty strings, so a future accidental drift moved into that map would silently pass. Each exception now pins `expectedEntryPointLabel` + `expectedNavLabel` and asserts both exact values plus their inequality.

## Sites touched

- `src/lib/dev/contextualEntryPoints.ts` — label now derived
- `src/lib/dev/__tests__/contextualEntryPoints.test.ts` — new exhaustive guard suite
- `src/components/ask-dev/AskDevTrigger.integration.test.tsx` — stale `"Data health"` assertion updated (default-CI)
- `tests/live/ask-dev-acceptance.spec.ts` — stale `"Data health"` assertion updated (live suite, out of default CI, fixed anyway)

Repo-wide grep of `src/` and `tests/` (ops contract fixtures excluded, out of scope) confirms no other `"Data health"` site remains, and all existing `"Data Confidence"` sites already carried the intended label.

## Gates

- unit (`pnpm exec vitest run`): full suite green aside from one unrelated pre-existing flaky file (`rate-limit.test.ts`, confirmed flaky in isolation, untouched by this change); both touched files 40/40 in isolation.
- lint / typecheck: clean.
- quality tier: audit + codegen:check pass; `ask-dev:contracts:check` hits a pre-existing environmental ops-checkout pin mismatch unrelated to this change.
- targeted e2e: no default-suite spec exercises this label; skipped per scope (mocks untouched).
