### PR TITLE
fix(ask-dev): CHAOS-3410 wire ambient route context into suggested questions

### DIFF
--- a/src/components/ask-dev/AskDevProvider.test.tsx
+++ b/src/components/ask-dev/AskDevProvider.test.tsx
@@ -155,6 +155,35 @@ describe("AskDevProvider permanent window", () => {
         expect(client.streamMessage).not.toHaveBeenCalled();
     });
 
+    it("shows the route's suggested questions when the plain launcher opens on an approved ambient route without an explicit contextual-entry click (CHAOS-3410)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        navigation.pathname = "/data-health";
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Data Health</main>
+            </AskDevProvider>,
+        );
+
+        // No entity-scoped "Ask Dev about this" trigger exists on this route
+        // (it is an organization-wide admin page, not tied to one entity) --
+        // the only way in is the permanent floating launcher.
+        expect(screen.queryByRole("button", { name: "Ask Dev about this" })).not.toBeInTheDocument();
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+
+        const permanentWindow = screen.getByRole("region", { name: "Ask Dev" });
+        // The scope banner already resolves this page's implicit context (this
+        // assertion passes today) -- the suggested-question buttons driven by
+        // that same implicit context do not, which is the bug this test pins.
+        expect(permanentWindow).toHaveTextContent("Data Confidence");
+        expect(
+            screen.getByRole("button", {
+                name: "What changed in this scope during the selected time range?",
+            }),
+        ).toBeVisible();
+        expect(client.createConversation).not.toHaveBeenCalled();
+    });
+
     it("preserves one conversation and run across expand, minimize, navigation, and the /dev workspace", async () => {
         const user = userEvent.setup();
         const client = makeClient();

--- a/src/components/ask-dev/AskDevProvider.test.tsx
+++ b/src/components/ask-dev/AskDevProvider.test.tsx
@@ -12,6 +12,7 @@ import type {
     DevStreamEvent,
 } from "@/lib/dev/generated";
 
+import { AskDevContextRegistration } from "./AskDevContextRegistration";
 import { AskDevProvider } from "./AskDevProvider";
 import { AskDevWorkspace } from "./AskDevWorkspace";
 
@@ -182,6 +183,109 @@ describe("AskDevProvider permanent window", () => {
             }),
         ).toBeVisible();
         expect(client.createConversation).not.toHaveBeenCalled();
+    });
+
+    it("shows the ambient route's suggested questions on a real descendant path (CHAOS-3410 codex round)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        navigation.pathname = "/data-health/connectors";
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Connectors</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+
+        expect(
+            screen.getByRole("button", {
+                name: "What changed in this scope during the selected time range?",
+            }),
+        ).toBeVisible();
+        expect(
+            screen.getByRole("button", {
+                name: "How complete and fresh is the evidence for this scope?",
+            }),
+        ).toBeVisible();
+    });
+
+    it("does not show suggested questions on a sibling route that merely shares the /data-health prefix (CHAOS-3410 codex round)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        navigation.pathname = "/data-health-legacy";
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Legacy</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+
+        expect(screen.getByText("Proposed context:")).toHaveTextContent("Organization");
+        expect(
+            screen.queryByRole("button", {
+                name: "What changed in this scope during the selected time range?",
+            }),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByLabelText("Suggested questions")).not.toBeInTheDocument();
+    });
+
+    it("does not show suggested questions on an unrelated, non-approved route (CHAOS-3410 codex round)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        navigation.pathname = "/dashboard";
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+
+        expect(screen.getByText("Proposed context:")).toHaveTextContent("Organization");
+        expect(screen.queryByLabelText("Suggested questions")).not.toBeInTheDocument();
+    });
+
+    it("lets an explicit contextual-entry proposal on an ambient route override that route's ambient suggested questions (CHAOS-3410 codex round)", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        navigation.pathname = "/data-health";
+        render(
+            <AskDevProvider client={client} orgId="org-1" contextualEntrypointsEnabled>
+                <AskDevContextRegistration
+                    context={{
+                        routeId: "data_health",
+                        entityRefs: [
+                            {
+                                entity_type: "repository",
+                                entity_id: "repo-1",
+                                display_label: "dev-health-web",
+                            },
+                        ],
+                        suggestedQuestionIds: ["data_trust"],
+                    }}
+                />
+                <main>Data Health</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+
+        const permanentWindow = screen.getByRole("region", { name: "Ask Dev" });
+        expect(permanentWindow).toHaveTextContent("Data Confidence · dev-health-web");
+        expect(
+            screen.getByRole("button", {
+                name: "How complete and fresh is the evidence for this scope?",
+            }),
+        ).toBeVisible();
+        // The ambient route's other default question must not also appear --
+        // the explicit proposal replaces the ambient list, it does not merge
+        // with it.
+        expect(
+            screen.queryByRole("button", {
+                name: "What changed in this scope during the selected time range?",
+            }),
+        ).not.toBeInTheDocument();
     });
 
     it("preserves one conversation and run across expand, minimize, navigation, and the /dev workspace", async () => {

--- a/src/components/ask-dev/AskDevProvider.test.tsx
+++ b/src/components/ask-dev/AskDevProvider.test.tsx
@@ -169,7 +169,9 @@ describe("AskDevProvider permanent window", () => {
         // No entity-scoped "Ask Dev about this" trigger exists on this route
         // (it is an organization-wide admin page, not tied to one entity) --
         // the only way in is the permanent floating launcher.
-        expect(screen.queryByRole("button", { name: "Ask Dev about this" })).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Ask Dev about this" }),
+        ).not.toBeInTheDocument();
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
 
         const permanentWindow = screen.getByRole("region", { name: "Ask Dev" });

--- a/src/components/ask-dev/AskDevProvider.tsx
+++ b/src/components/ask-dev/AskDevProvider.tsx
@@ -126,17 +126,18 @@ function availabilityFromCapabilities(capabilities: DevCapabilities): AskDevAvai
     return { state: "ready", capabilities };
 }
 
-function createScope(orgId: string, pathname: string, filters: MetricFilter): DevScope {
+function createScope(
+    orgId: string,
+    pathname: string,
+    filters: MetricFilter,
+    implicitContext: AskDevSurfaceContext | null,
+): DevScope {
     const end = filters.time.end_date ? new Date(filters.time.end_date) : new Date();
     const start = filters.time.start_date ? new Date(filters.time.start_date) : new Date(end);
     if (!filters.time.start_date) start.setUTCDate(start.getUTCDate() - filters.time.range_days);
     const comparisonEnd = new Date(start);
     const comparisonStart = new Date(comparisonEnd);
     comparisonStart.setUTCDate(comparisonStart.getUTCDate() - filters.time.compare_days);
-    const implicitContext = askDevContextForPathname(
-        pathname,
-        fingerprintAskDevFilter(encodeFilter(filters)),
-    );
     const filtersApplyToScope = pathname === "/dev" || implicitContext !== null;
     const repositoryIds = (
         filtersApplyToScope
@@ -305,9 +306,22 @@ export function AskDevProvider({
                 : filterFromQueryParams(Object.fromEntries(new URLSearchParams(searchString))),
         [encodedFilter, searchString],
     );
+    // Approved ambient routes (data_health, diagnose_overview, flow_metrics,
+    // investment, cognitive_load, bottlenecks) get an implicit scope context
+    // with no user action required -- it already silently drives `routeScope`
+    // below (the "Proposed context:" banner). Suggested questions must follow
+    // the same implicit context, not just an explicit `setProposedContext`
+    // call from a per-entity "Ask Dev about this" trigger: many ambient
+    // routes (e.g. /data-health) have no such trigger at all, so the only way
+    // in is the permanent floating launcher, and it must not open to a
+    // contextually-blank composer with zero suggested questions (CHAOS-3410).
+    const ambientContext = useMemo(
+        () => askDevContextForPathname(pathname, fingerprintAskDevFilter(encodeFilter(filters))),
+        [pathname, filters],
+    );
     const routeScope = useMemo(
-        () => createScope(orgId, pathname, filters),
-        [filters, orgId, pathname],
+        () => createScope(orgId, pathname, filters, ambientContext),
+        [ambientContext, filters, orgId, pathname],
     );
     const [surfaceProposal, setSurfaceProposal] = useState<{
         context: AskDevSurfaceContext;
@@ -326,10 +340,10 @@ export function AskDevProvider({
         (routeScope.surface_context || pathname === "/dev"
             ? (navTitleForPathname(pathname) ?? "Current page")
             : "Organization");
-    const proposedQuestions = useMemo(
-        () => (proposedContext ? askDevSuggestedQuestions(proposedContext) : []),
-        [proposedContext],
-    );
+    const proposedQuestions = useMemo(() => {
+        const context = proposedContext ?? ambientContext;
+        return context ? askDevSuggestedQuestions(context) : [];
+    }, [ambientContext, proposedContext]);
 
     useEffect(() => {
         const controller = new AbortController();

--- a/src/lib/dev/__tests__/contextualEntryPoints.test.ts
+++ b/src/lib/dev/__tests__/contextualEntryPoints.test.ts
@@ -154,9 +154,34 @@ describe("Ask Dev contextual entry point registry", () => {
             entityRefs: [],
             filterFingerprint: "filter-v1-deadbeef",
         });
+        expect(askDevContextForPathname("/data-health")?.routeId).toBe("data_health");
         expect(askDevContextForPathname("/data-health/connectors")?.routeId).toBe("data_health");
         expect(askDevContextForPathname("/deployments/deploy-1")).toBeNull();
         expect(askDevContextForPathname("/issues/CHAOS-3216")).toBeNull();
+    });
+
+    // `/data-health` was matched with a bare `pathname.startsWith("/data-health")`,
+    // which also matches an unrelated sibling route that merely shares the
+    // prefix -- there is no `/`-delimited boundary check. Every OTHER ambient
+    // route (diagnose_overview, flow_metrics, investment, cognitive_load,
+    // bottlenecks) is looked up by exact key in a plain
+    // `Record<string, RouteId>`, which cannot suffer this collision --
+    // `record["/diagnose-legacy"]` is simply `undefined`. `/data-health` is
+    // the only prefix-style matcher in this module, so it is the only one
+    // that needed tightening (CHAOS-3410 codex round).
+    it("does not treat an unrelated sibling route that merely shares the /data-health prefix as the data_health entry point", () => {
+        expect(askDevContextForPathname("/data-health-legacy")).toBeNull();
+        expect(askDevContextForPathname("/data-health-legacy/connectors")).toBeNull();
+        // A same-prefix route with no separator at all must not match either.
+        expect(askDevContextForPathname("/data-healthy")).toBeNull();
+    });
+
+    it("does not let a sibling route sharing another ambient route's prefix match by accident", () => {
+        expect(askDevContextForPathname("/diagnose-legacy")).toBeNull();
+        expect(askDevContextForPathname("/metrics-v2")).toBeNull();
+        expect(askDevContextForPathname("/investment-portfolio")).toBeNull();
+        expect(askDevContextForPathname("/cognitive-load-v2")).toBeNull();
+        expect(askDevContextForPathname("/bottleneck-analysis")).toBeNull();
     });
 });
 

--- a/src/lib/dev/contextualEntryPoints.ts
+++ b/src/lib/dev/contextualEntryPoints.ts
@@ -305,12 +305,24 @@ const APPROVED_EMPTY_CONTEXT_PATHS: Readonly<
     "/bottleneck": "bottlenecks",
 };
 
+/**
+ * True for `/data-health` itself and any of its descendants
+ * (`/data-health/connectors`, `/data-health/identity`, ...). A bare
+ * `startsWith(DATA_HEALTH_PATH)` also matches an unrelated sibling route that
+ * merely shares the prefix (e.g. a hypothetical `/data-health-legacy`) --
+ * this requires the boundary to be the path itself or a `/`-delimited
+ * descendant (CHAOS-3410 codex round).
+ */
+function isDataHealthPathname(pathname: string): boolean {
+    return pathname === DATA_HEALTH_PATH || pathname.startsWith(`${DATA_HEALTH_PATH}/`);
+}
+
 /** Resolve only approved pages where an organization-level context is valid. */
 export function askDevContextForPathname(
     pathname: string,
     filterFingerprint?: string,
 ): AskDevSurfaceContext | null {
-    const routeId = pathname.startsWith(DATA_HEALTH_PATH)
+    const routeId = isDataHealthPathname(pathname)
         ? "data_health"
         : APPROVED_EMPTY_CONTEXT_PATHS[pathname];
     if (!routeId) return null;


### PR DESCRIPTION
## Defect

The permanent Ask Dev window's suggested-question buttons have shown **zero** buttons on approved ambient routes (e.g. `/data-health`) since PR #820 (Jul 30) — the P0 exit acceptance oracle (CHAOS-3410) caught this once PR #847's CHAOS-3397 label fix let the test reach the assertion; before that, the test failed one assertion earlier (the label drift) every run, masking this gap the whole time.

## Root cause

`proposedQuestions` in `AskDevProvider.tsx` was only ever populated by an explicit `setProposedContext()` call, fired from a per-entity "Ask Dev about this" trigger (`AskDevContextRegistration`). Approved *ambient* routes (`data_health`, `diagnose_overview`, `flow_metrics`, `investment`, `cognitive_load`, `bottlenecks`) get an implicit scope context via `askDevContextForPathname` with zero user action — it already silently drives the "Proposed context:" scope banner — but that implicit context was never consulted for suggested questions.

`/data-health` has no entity-scoped trigger at all (it's an org-wide admin page), so PR #820's switch to the plain floating launcher there made this the *only* entry point on that route, and it always rendered an empty suggested-questions list.

## Fix

- Refactored `createScope` to take a precomputed `implicitContext` instead of recomputing it internally, and fall `proposedQuestions` back onto that same ambient context when there's no explicit `surfaceProposal`. An explicit per-entity proposal still wins when present.
- **Codex round**: the ambient fallback made a pre-existing over-broad matcher user-visible — `askDevContextForPathname` classified *every* pathname starting with `/data-health` as the `data_health` entry point (e.g. a hypothetical `/data-health-legacy`). Audited the other five ambient routes for the same shape (all are exact-key `Record` lookups, immune to prefix collision) and tightened `data_health` to match itself or a `/`-delimited descendant only.

## Tests

RED-first throughout:
- Unit test pinning the exact acceptance-oracle symptom: plain launcher on `/data-health` renders zero suggested-question buttons pre-fix, the expected button post-fix.
- Unit test pinning the matcher bug: `askDevContextForPathname("/data-health-legacy")` returned a `data_health` context pre-fix, `null` post-fix. Parallel test confirms the other five ambient routes' sibling-prefix paths were never vulnerable.
- Provider-level tests, all directions: real descendant → questions render; prefix-collision path → none; unrelated non-approved route → none; explicit contextual-entry proposal on an ambient route → overrides the ambient list rather than merging with it.

Full `ask-dev`/`dev` unit suite: 63 files / 479 tests pass. `tsc --noEmit` and `eslint` clean on all touched files.

CHAOS-3410
