### PR TITLE
CHAOS-3412: surface budget-blocked and exhausted sync units

### DIFF
--- a/src/components/admin/sync/SyncRunDetail.test.tsx
+++ b/src/components/admin/sync/SyncRunDetail.test.tsx
@@ -7,6 +7,7 @@ import {
     SAMPLE_SYNC_RUN_UNIT_SUMMARY_WITH_BUDGET_UNITS,
     SAMPLE_BUDGET_BLOCKED_UNIT,
     SAMPLE_BUDGET_EXHAUSTED_UNIT,
+    SAMPLE_DEFERRALS_EXHAUSTED_UNIT,
 } from "@/data/syncRunDetailSample";
 import { getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
 
@@ -273,6 +274,47 @@ describe("SyncRunDetailLive", () => {
 
         expect(screen.queryByText("Budget exhausted")).not.toBeInTheDocument();
         expect(screen.getByText(/Category: budget_deferred/)).toBeInTheDocument();
+    });
+
+    it("renders a distinct 'Deferrals exhausted' treatment and the actionable error text for error_category=deferral_exhausted", () => {
+        // Third terminal category (CHAOS-3412, ops-exhaustion lane): the
+        // aggregate deferral cap — a unit that oscillated between budget and
+        // rate-limit episodes without ever running. Exact persisted string is
+        // "deferral_exhausted" (owned by the ops-exhaustion lane) — do not
+        // invent variants.
+        render(
+            <SyncRunDetailLive
+                initialRun={{
+                    ...SAMPLE_SYNC_RUN,
+                    total_units: SAMPLE_SYNC_RUN_UNIT_SUMMARY.unit_count + 1,
+                }}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { ...SAMPLE_SYNC_RUN_UNIT_SUMMARY.by_status, failed: 2 },
+                    failed_unit_count: 2,
+                    failed_unit_ids: [
+                        ...SAMPLE_SYNC_RUN_UNIT_SUMMARY.failed_unit_ids,
+                        SAMPLE_DEFERRALS_EXHAUSTED_UNIT.id,
+                    ],
+                    unit_count: SAMPLE_SYNC_RUN_UNIT_SUMMARY.unit_count + 1,
+                    units: [...SAMPLE_SYNC_RUN_UNIT_SUMMARY.units, SAMPLE_DEFERRALS_EXHAUSTED_UNIT],
+                }}
+                testMode
+            />,
+        );
+
+        // Badge (attention panel + unit table) — same exhausted-style treatment
+        // as budget_deferral_exhausted, distinct label.
+        expect(screen.getAllByText("Deferrals exhausted").length).toBe(2);
+        // The actionable error text (naming the last episode kind and both
+        // counters) surfaces prominently, same path as any failed unit.
+        expect(
+            screen.getAllByText(/Deferral cap exceeded after oscillating between budget and/)
+                .length,
+        ).toBeGreaterThan(0);
+        // Not mistaken for the other two categories' treatments.
+        expect(screen.queryByText("Blocked: budget")).not.toBeInTheDocument();
+        expect(screen.queryByText("Budget exhausted")).not.toBeInTheDocument();
     });
 
     it("renders a row per unit in the unit table", () => {

--- a/src/components/admin/sync/SyncRunDetail.test.tsx
+++ b/src/components/admin/sync/SyncRunDetail.test.tsx
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, userEvent, within } from "@/test/utils";
 import { SyncRunDetailLive } from "./SyncRunDetailLive";
-import { SAMPLE_SYNC_RUN, SAMPLE_SYNC_RUN_UNIT_SUMMARY } from "@/data/syncRunDetailSample";
+import {
+    SAMPLE_SYNC_RUN,
+    SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+    SAMPLE_SYNC_RUN_UNIT_SUMMARY_WITH_BUDGET_UNITS,
+    SAMPLE_BUDGET_BLOCKED_UNIT,
+    SAMPLE_BUDGET_EXHAUSTED_UNIT,
+} from "@/data/syncRunDetailSample";
 import { getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
 
 // The detail component imports the admin server actions for live polling. The
@@ -123,6 +129,150 @@ describe("SyncRunDetailLive", () => {
         expect(screen.getAllByText("Secondary rate limit hit; backing off").length).toBeGreaterThan(
             0,
         );
+    });
+
+    it("renders a distinct 'Blocked: budget' treatment with deferral count, next attempt, and the rollup chip", () => {
+        render(
+            <SyncRunDetailLive
+                initialRun={{
+                    ...SAMPLE_SYNC_RUN,
+                    total_units: SAMPLE_SYNC_RUN_UNIT_SUMMARY_WITH_BUDGET_UNITS.unit_count,
+                }}
+                initialSummary={SAMPLE_SYNC_RUN_UNIT_SUMMARY_WITH_BUDGET_UNITS}
+                testMode
+            />,
+        );
+
+        // Badge (attention panel + unit table) replaces the generic "retrying" look.
+        expect(screen.getAllByText("Blocked: budget").length).toBe(2);
+        // Deferral count + next attempt render from the persisted fields.
+        expect(screen.getByText(/6 deferrals/)).toBeInTheDocument();
+        expect(screen.getByText(/Next attempt/)).toBeInTheDocument();
+        // Summary rollup chip.
+        expect(screen.getByText(/Budget blocked: 1/)).toBeInTheDocument();
+        // The badge replaces the generic category line for this unit — it is
+        // not ALSO rendered as raw "Category: budget_deferred" text.
+        expect(screen.queryByText(/Category: budget_deferred/)).not.toBeInTheDocument();
+    });
+
+    it("surfaces the actionable error text for a budget_deferral_exhausted unit", () => {
+        render(
+            <SyncRunDetailLive
+                initialRun={{
+                    ...SAMPLE_SYNC_RUN,
+                    total_units: SAMPLE_SYNC_RUN_UNIT_SUMMARY_WITH_BUDGET_UNITS.unit_count,
+                }}
+                initialSummary={SAMPLE_SYNC_RUN_UNIT_SUMMARY_WITH_BUDGET_UNITS}
+                testMode
+            />,
+        );
+
+        expect(screen.getAllByText("Budget exhausted").length).toBe(2);
+        expect(
+            screen.getAllByText(/Budget deferral cap exceeded for REST_CORE bucket/).length,
+        ).toBeGreaterThan(0);
+    });
+
+    it("renders the blocked-budget badge without the deferral count or rollup chip when the backend field is absent", () => {
+        const { budget_deferrals: _omit, ...unitWithoutCount } = SAMPLE_BUDGET_BLOCKED_UNIT;
+        render(
+            <SyncRunDetailLive
+                initialRun={SAMPLE_SYNC_RUN}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { ...SAMPLE_SYNC_RUN_UNIT_SUMMARY.by_status, retrying: 2 },
+                    unit_count: 5,
+                    units: [...SAMPLE_SYNC_RUN_UNIT_SUMMARY.units, unitWithoutCount],
+                }}
+                testMode
+            />,
+        );
+
+        expect(screen.getAllByText("Blocked: budget").length).toBe(2);
+        expect(screen.queryByText(/deferral/)).not.toBeInTheDocument();
+        expect(screen.getByText(/Next attempt/)).toBeInTheDocument();
+        // budget_blocked_unit_count wasn't set on this summary — chip omitted.
+        expect(screen.queryByText(/Budget blocked:/)).not.toBeInTheDocument();
+    });
+
+    it("keeps the persisted next-attempt timestamp visible for a budget-blocked unit, not just the label", () => {
+        // Negative control on codex's "the blocked branch hides retry-at info"
+        // claim: the label alone proves nothing — assert the actual formatted
+        // clock time renders alongside it (TZ-agnostic: matches the hh:mm AM/PM
+        // shape formatTimestamp produces, not a hardcoded date/offset).
+        render(
+            <SyncRunDetailLive
+                initialRun={{
+                    ...SAMPLE_SYNC_RUN,
+                    total_units: SAMPLE_SYNC_RUN_UNIT_SUMMARY_WITH_BUDGET_UNITS.unit_count,
+                }}
+                initialSummary={SAMPLE_SYNC_RUN_UNIT_SUMMARY_WITH_BUDGET_UNITS}
+                testMode
+            />,
+        );
+
+        const nextAttemptSpan = screen.getByText(/Next attempt/).closest("span");
+        expect(nextAttemptSpan).not.toBeNull();
+        expect(nextAttemptSpan?.textContent).toMatch(/Next attempt.*\d{1,2}:\d{2}\s*[AP]M/);
+    });
+
+    it("does NOT apply the budget-blocked treatment to a retrying unit with a different error_category", () => {
+        // Guards key on status AND the exact persisted error_category string —
+        // a retrying unit that merely carries some other category (e.g. a
+        // stale/unrelated one) must render the pre-existing generic look.
+        const nonBudgetRetryingUnit = {
+            ...SAMPLE_BUDGET_BLOCKED_UNIT,
+            id: "sample-unit-worker-lost",
+            error_category: "worker_lost",
+            error: "Worker lost heartbeat mid-run",
+        };
+        render(
+            <SyncRunDetailLive
+                initialRun={SAMPLE_SYNC_RUN}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { ...SAMPLE_SYNC_RUN_UNIT_SUMMARY.by_status, retrying: 2 },
+                    unit_count: 5,
+                    units: [...SAMPLE_SYNC_RUN_UNIT_SUMMARY.units, nonBudgetRetryingUnit],
+                }}
+                testMode
+            />,
+        );
+
+        expect(screen.queryByText("Blocked: budget")).not.toBeInTheDocument();
+        expect(screen.getByText(/Category: worker_lost/)).toBeInTheDocument();
+    });
+
+    it("does NOT apply the budget-exhausted treatment to a failed unit whose category is the non-terminal budget_deferred", () => {
+        // The exhausted badge must key strictly on the terminal category that
+        // only the terminalize path stamps — a failed unit that (incorrectly,
+        // hypothetically) still carries the non-terminal "budget_deferred"
+        // category must never read as exhausted.
+        const failedButNotExhausted = {
+            ...SAMPLE_BUDGET_EXHAUSTED_UNIT,
+            id: "sample-unit-not-exhausted",
+            error_category: "budget_deferred",
+        };
+        render(
+            <SyncRunDetailLive
+                initialRun={SAMPLE_SYNC_RUN}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { ...SAMPLE_SYNC_RUN_UNIT_SUMMARY.by_status, failed: 2 },
+                    failed_unit_count: 2,
+                    failed_unit_ids: [
+                        ...SAMPLE_SYNC_RUN_UNIT_SUMMARY.failed_unit_ids,
+                        failedButNotExhausted.id,
+                    ],
+                    unit_count: 5,
+                    units: [...SAMPLE_SYNC_RUN_UNIT_SUMMARY.units, failedButNotExhausted],
+                }}
+                testMode
+            />,
+        );
+
+        expect(screen.queryByText("Budget exhausted")).not.toBeInTheDocument();
+        expect(screen.getByText(/Category: budget_deferred/)).toBeInTheDocument();
     });
 
     it("renders a row per unit in the unit table", () => {

--- a/src/components/admin/sync/SyncRunDetailLive.tsx
+++ b/src/components/admin/sync/SyncRunDetailLive.tsx
@@ -58,6 +58,42 @@ function unitBadgeStatus(status: string): SyncStatus {
     }
 }
 
+/**
+ * A `retrying` unit currently blocked on the sync budget guard (CHAOS-3412):
+ * still within its deferral caps, waiting for the next scheduled attempt.
+ * Distinct from a generic retry so operators don't read it as silent nothing.
+ */
+function isBudgetBlockedUnit(unit: SyncRunUnit): boolean {
+    return unit.status === "retrying" && unit.error_category === "budget_deferred";
+}
+
+/**
+ * A `failed` unit that exhausted its budget-deferral caps (CHAOS-3412) —
+ * terminal, with an actionable `error` naming the bucket, cap, and remedies.
+ */
+function isBudgetExhaustedUnit(unit: SyncRunUnit): boolean {
+    return unit.status === "failed" && unit.error_category === "budget_deferral_exhausted";
+}
+
+/**
+ * Distinct badge treatment for budget-guard states, styled with the same
+ * theme-aware token idiom used elsewhere for warning/negative tones
+ * (ByoLlmErrorStates.tsx) — soft opacity border, never a bright literal one.
+ */
+function BudgetGuardBadge({ tone, label }: { tone: "blocked" | "exhausted"; label: string }) {
+    const toneClasses =
+        tone === "blocked"
+            ? "border-(--accent-3)/40 bg-(--accent-3)/10 text-(--accent-3)"
+            : "border-(--accent-negative)/40 bg-(--accent-negative)/10 text-(--accent-negative)";
+    return (
+        <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold ${toneClasses}`}
+        >
+            {label}
+        </span>
+    );
+}
+
 function statusCount(summary: SyncRunUnitSummary | null, status: string): number | null {
     if (!summary) return null;
     return summary.by_status[status] ?? 0;
@@ -617,15 +653,24 @@ export function SyncRunDetailLive({
                                 <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
                                     Needs attention
                                 </h3>
-                                {summary.next_retry_at && (
-                                    <span className="text-xs text-(--ink-muted)">
-                                        Next retry{" "}
-                                        <ClientTimestamp
-                                            value={summary.next_retry_at}
-                                            fallback="—"
-                                        />
-                                    </span>
-                                )}
+                                <div className="flex flex-wrap items-center gap-3">
+                                    {typeof summary.budget_blocked_unit_count === "number" &&
+                                        summary.budget_blocked_unit_count > 0 && (
+                                            <span className="text-xs text-(--ink-muted)">
+                                                Budget blocked:{" "}
+                                                {formatNumber(summary.budget_blocked_unit_count)}
+                                            </span>
+                                        )}
+                                    {summary.next_retry_at && (
+                                        <span className="text-xs text-(--ink-muted)">
+                                            Next retry{" "}
+                                            <ClientTimestamp
+                                                value={summary.next_retry_at}
+                                                fallback="—"
+                                            />
+                                        </span>
+                                    )}
+                                </div>
                             </div>
                             <ul className="space-y-3">
                                 {attentionUnits.map((unit) => (
@@ -637,24 +682,64 @@ export function SyncRunDetailLive({
                                             <span className="font-medium text-foreground">
                                                 {sourceLabel(unit.source_id)} · {unit.dataset_key}
                                             </span>
-                                            <SyncStatusBadge
-                                                status={unitBadgeStatus(unit.status)}
-                                                label={unit.status}
-                                            />
+                                            {isBudgetBlockedUnit(unit) ? (
+                                                <BudgetGuardBadge
+                                                    tone="blocked"
+                                                    label="Blocked: budget"
+                                                />
+                                            ) : isBudgetExhaustedUnit(unit) ? (
+                                                <BudgetGuardBadge
+                                                    tone="exhausted"
+                                                    label="Budget exhausted"
+                                                />
+                                            ) : (
+                                                <SyncStatusBadge
+                                                    status={unitBadgeStatus(unit.status)}
+                                                    label={unit.status}
+                                                />
+                                            )}
                                         </div>
                                         <div className="mt-1 text-xs text-(--ink-muted)">
-                                            {unit.error_category && (
-                                                <span>Category: {unit.error_category}</span>
-                                            )}
-                                            {unit.error_category && unit.available_at && " · "}
-                                            {unit.available_at && (
-                                                <span>
-                                                    Retry at{" "}
-                                                    <ClientTimestamp
-                                                        value={unit.available_at}
-                                                        fallback="—"
-                                                    />
-                                                </span>
+                                            {isBudgetBlockedUnit(unit) ? (
+                                                <>
+                                                    {typeof unit.budget_deferrals === "number" && (
+                                                        <span>
+                                                            {formatNumber(unit.budget_deferrals)}{" "}
+                                                            deferral
+                                                            {unit.budget_deferrals === 1 ? "" : "s"}
+                                                        </span>
+                                                    )}
+                                                    {typeof unit.budget_deferrals === "number" &&
+                                                        unit.available_at &&
+                                                        " · "}
+                                                    {unit.available_at && (
+                                                        <span>
+                                                            Next attempt{" "}
+                                                            <ClientTimestamp
+                                                                value={unit.available_at}
+                                                                fallback="—"
+                                                            />
+                                                        </span>
+                                                    )}
+                                                </>
+                                            ) : (
+                                                <>
+                                                    {unit.error_category && (
+                                                        <span>Category: {unit.error_category}</span>
+                                                    )}
+                                                    {unit.error_category &&
+                                                        unit.available_at &&
+                                                        " · "}
+                                                    {unit.available_at && (
+                                                        <span>
+                                                            Retry at{" "}
+                                                            <ClientTimestamp
+                                                                value={unit.available_at}
+                                                                fallback="—"
+                                                            />
+                                                        </span>
+                                                    )}
+                                                </>
                                             )}
                                         </div>
                                         {unit.error && (
@@ -801,10 +886,22 @@ export function SyncRunDetailLive({
                                                 {unit.cost_class}
                                             </td>
                                             <td className="px-4 py-3">
-                                                <SyncStatusBadge
-                                                    status={unitBadgeStatus(unit.status)}
-                                                    label={unit.status}
-                                                />
+                                                {isBudgetBlockedUnit(unit) ? (
+                                                    <BudgetGuardBadge
+                                                        tone="blocked"
+                                                        label="Blocked: budget"
+                                                    />
+                                                ) : isBudgetExhaustedUnit(unit) ? (
+                                                    <BudgetGuardBadge
+                                                        tone="exhausted"
+                                                        label="Budget exhausted"
+                                                    />
+                                                ) : (
+                                                    <SyncStatusBadge
+                                                        status={unitBadgeStatus(unit.status)}
+                                                        label={unit.status}
+                                                    />
+                                                )}
                                             </td>
                                             <td className="px-4 py-3 text-sm text-(--ink-muted)">
                                                 {formatNumber(unit.attempts)}

--- a/src/components/admin/sync/SyncRunDetailLive.tsx
+++ b/src/components/admin/sync/SyncRunDetailLive.tsx
@@ -76,6 +76,16 @@ function isBudgetExhaustedUnit(unit: SyncRunUnit): boolean {
 }
 
 /**
+ * A `failed` unit that hit the aggregate deferral cap (CHAOS-3412) — it
+ * oscillated between budget and rate-limit deferral episodes without ever
+ * running. Terminal, with an actionable `error` naming the last episode kind
+ * and both counters.
+ */
+function isDeferralsExhaustedUnit(unit: SyncRunUnit): boolean {
+    return unit.status === "failed" && unit.error_category === "deferral_exhausted";
+}
+
+/**
  * Distinct badge treatment for budget-guard states, styled with the same
  * theme-aware token idiom used elsewhere for warning/negative tones
  * (ByoLlmErrorStates.tsx) — soft opacity border, never a bright literal one.
@@ -692,6 +702,11 @@ export function SyncRunDetailLive({
                                                     tone="exhausted"
                                                     label="Budget exhausted"
                                                 />
+                                            ) : isDeferralsExhaustedUnit(unit) ? (
+                                                <BudgetGuardBadge
+                                                    tone="exhausted"
+                                                    label="Deferrals exhausted"
+                                                />
                                             ) : (
                                                 <SyncStatusBadge
                                                     status={unitBadgeStatus(unit.status)}
@@ -895,6 +910,11 @@ export function SyncRunDetailLive({
                                                     <BudgetGuardBadge
                                                         tone="exhausted"
                                                         label="Budget exhausted"
+                                                    />
+                                                ) : isDeferralsExhaustedUnit(unit) ? (
+                                                    <BudgetGuardBadge
+                                                        tone="exhausted"
+                                                        label="Deferrals exhausted"
                                                     />
                                                 ) : (
                                                     <SyncStatusBadge

--- a/src/data/syncRunDetailSample.ts
+++ b/src/data/syncRunDetailSample.ts
@@ -161,3 +161,107 @@ export const SAMPLE_SYNC_RUN_UNIT_SUMMARY: SyncRunUnitSummary = {
     next_retry_at: NEXT_RETRY_AT,
     units: SAMPLE_UNITS,
 };
+
+// ── Budget-guard sample units (CHAOS-3412) ────────────────────────────────
+//
+// Separate from SAMPLE_UNITS/SAMPLE_SYNC_RUN_UNIT_SUMMARY above (which many
+// existing tests assert exact counts/percentages against) — exported for
+// tests that build their own run+summary fixture, mirroring the pattern
+// already used by "renders every returned unit without a client-side table
+// cap" in SyncRunDetail.test.tsx. Exact persisted vocabulary per the
+// CHAOS-3412 design record: error_category values "budget_deferred" (still
+// retrying, within caps) and "budget_deferral_exhausted" (terminal, actionable
+// error naming the bucket/cap/remedies) — do not invent variants.
+const BUDGET_FIRST_DEFERRED_AT = "2026-06-26T09:00:00.000Z";
+const BUDGET_NEXT_ATTEMPT_AT = "2026-06-26T12:00:00.000Z";
+const BUDGET_EXHAUSTED_FIRST_DEFERRED_AT = "2026-06-26T06:00:00.000Z";
+
+/** Still retrying, blocked on the sync budget guard but within its caps. */
+export const SAMPLE_BUDGET_BLOCKED_UNIT: SyncRunUnit = {
+    id: "sample-unit-budget11",
+    org_id: SAMPLE_ORG_ID,
+    sync_run_id: SAMPLE_RUN_ID,
+    integration_id: SAMPLE_INTEGRATION_ID,
+    source_id: "sample-source-1",
+    source_name: "platform-api",
+    source_full_name: "fullchaos/platform-api",
+    provider: "github",
+    dataset_key: "tests",
+    cost_class: "heavy",
+    mode: "incremental",
+    since_at: "2026-03-28T00:00:00.000Z",
+    before_at: "2026-06-26T11:00:00.000Z",
+    status: "retrying",
+    attempts: 0,
+    available_at: BUDGET_NEXT_ATTEMPT_AT,
+    rate_limit_deferrals: 0,
+    budget_deferrals: 6,
+    budget_first_deferred_at: BUDGET_FIRST_DEFERRED_AT,
+    duration_seconds: null,
+    error: "Deferred by sync budget guard: REST_CORE estimate 360 exceeds bucket cap",
+    error_category: "budget_deferred",
+    last_heartbeat_at: null,
+    result: null,
+    created_at: STARTED_AT,
+    updated_at: COMPLETED_AT,
+};
+
+/** Terminal: exhausted its budget-deferral caps. */
+export const SAMPLE_BUDGET_EXHAUSTED_UNIT: SyncRunUnit = {
+    id: "sample-unit-budget22",
+    org_id: SAMPLE_ORG_ID,
+    sync_run_id: SAMPLE_RUN_ID,
+    integration_id: SAMPLE_INTEGRATION_ID,
+    source_id: "sample-source-2",
+    source_name: "billing-service",
+    source_full_name: "fullchaos/billing-service",
+    provider: "github",
+    dataset_key: "commit-stats",
+    cost_class: "heavy",
+    mode: "incremental",
+    since_at: "2026-03-28T00:00:00.000Z",
+    before_at: "2026-06-26T11:00:00.000Z",
+    status: "failed",
+    attempts: 0,
+    available_at: null,
+    rate_limit_deferrals: 0,
+    budget_deferrals: 10,
+    budget_first_deferred_at: BUDGET_EXHAUSTED_FIRST_DEFERRED_AT,
+    duration_seconds: null,
+    error:
+        "Budget deferral cap exceeded for REST_CORE bucket (estimate 360 > cap 200) after " +
+        "10 deferrals over 6h; scope a backfill window or raise SYNC_BUDGET_BUCKET_LIMITS[REST_CORE]",
+    error_category: "budget_deferral_exhausted",
+    last_heartbeat_at: null,
+    result: null,
+    created_at: STARTED_AT,
+    updated_at: COMPLETED_AT,
+};
+
+/**
+ * SAMPLE_SYNC_RUN_UNIT_SUMMARY + the two budget-guard sample units, for tests
+ * exercising the "Blocked: budget" / "Budget exhausted" treatments and the
+ * budget_blocked_unit_count rollup. Independent of the base summary above so
+ * existing count/percentage assertions never shift.
+ */
+export const SAMPLE_SYNC_RUN_UNIT_SUMMARY_WITH_BUDGET_UNITS: SyncRunUnitSummary = {
+    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+    by_status: { success: 2, failed: 2, retrying: 2 },
+    by_source: {
+        "sample-source-1": { success: 2, retrying: 1 },
+        "sample-source-2": { failed: 2, retrying: 1 },
+    },
+    by_dataset: {
+        git: { success: 1 },
+        prs: { success: 1, failed: 1 },
+        cicd: { retrying: 1 },
+        tests: { retrying: 1 },
+        "commit-stats": { failed: 1 },
+    },
+    by_cost_class: { standard: 2, expensive: 2, heavy: 2 },
+    failed_unit_ids: ["sample-unit-ee55ff66", "sample-unit-budget22"],
+    failed_unit_count: 2,
+    budget_blocked_unit_count: 1,
+    unit_count: 6,
+    units: [...SAMPLE_UNITS, SAMPLE_BUDGET_BLOCKED_UNIT, SAMPLE_BUDGET_EXHAUSTED_UNIT],
+};

--- a/src/data/syncRunDetailSample.ts
+++ b/src/data/syncRunDetailSample.ts
@@ -238,6 +238,39 @@ export const SAMPLE_BUDGET_EXHAUSTED_UNIT: SyncRunUnit = {
     updated_at: COMPLETED_AT,
 };
 
+/** Terminal: hit the aggregate deferral cap (budget + rate-limit episodes combined). */
+export const SAMPLE_DEFERRALS_EXHAUSTED_UNIT: SyncRunUnit = {
+    id: "sample-unit-budget33",
+    org_id: SAMPLE_ORG_ID,
+    sync_run_id: SAMPLE_RUN_ID,
+    integration_id: SAMPLE_INTEGRATION_ID,
+    source_id: "sample-source-2",
+    source_name: "billing-service",
+    source_full_name: "fullchaos/billing-service",
+    provider: "github",
+    dataset_key: "files",
+    cost_class: "heavy",
+    mode: "incremental",
+    since_at: "2026-03-28T00:00:00.000Z",
+    before_at: "2026-06-26T11:00:00.000Z",
+    status: "failed",
+    attempts: 0,
+    available_at: null,
+    rate_limit_deferrals: 5,
+    budget_deferrals: 7,
+    budget_first_deferred_at: BUDGET_EXHAUSTED_FIRST_DEFERRED_AT,
+    duration_seconds: null,
+    error:
+        "Deferral cap exceeded after oscillating between budget and rate-limit episodes " +
+        "(last episode: rate_limit; 7 budget deferrals, 5 rate-limit deferrals); scope a " +
+        "backfill window or raise the relevant bucket/rate-limit cap",
+    error_category: "deferral_exhausted",
+    last_heartbeat_at: null,
+    result: null,
+    created_at: STARTED_AT,
+    updated_at: COMPLETED_AT,
+};
+
 /**
  * SAMPLE_SYNC_RUN_UNIT_SUMMARY + the two budget-guard sample units, for tests
  * exercising the "Blocked: budget" / "Budget exhausted" treatments and the

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -321,9 +321,26 @@ export interface SyncRunUnit {
     /** Earliest retry timestamp for a retrying unit, else null. */
     available_at: string | null;
     rate_limit_deferrals: number;
+    /**
+     * Count of times this unit was deferred by the sync budget guard
+     * (`error_category: "budget_deferred"`). Optional: backend field is
+     * in-flight (CHAOS-3412) and may be absent until that PR merges.
+     */
+    budget_deferrals?: number;
+    /**
+     * Timestamp of the first budget deferral for this unit, else null.
+     * Optional: backend field is in-flight (CHAOS-3412).
+     */
+    budget_first_deferred_at?: string | null;
     duration_seconds: number | null;
     error: string | null;
-    /** Extracted failure category (e.g. rate_limit), or null. */
+    /**
+     * Extracted failure category (e.g. rate_limit), or null. Budget-guard
+     * values: "budget_deferred" (retrying, still within caps) and
+     * "budget_deferral_exhausted" (terminal failure — the `error` text
+     * names the bucket, cap, and remedies). Persisted strings — render
+     * verbatim, never invent variants.
+     */
     error_category: string | null;
     last_heartbeat_at: string | null;
     result: Record<string, unknown> | null;
@@ -347,6 +364,12 @@ export interface SyncRunUnitSummary {
     slowest_unit_ids: string[];
     failed_unit_ids: string[];
     failed_unit_count: number;
+    /**
+     * Count of units currently blocked on the sync budget guard (`retrying`
+     * with `error_category: "budget_deferred"`). Optional: backend field is
+     * in-flight (CHAOS-3412) and may be absent until that PR merges.
+     */
+    budget_blocked_unit_count?: number;
     unit_count: number;
     partial_failure_summary: Record<string, unknown> | null;
     /** Earliest available_at among retrying units, else null. */

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -336,10 +336,13 @@ export interface SyncRunUnit {
     error: string | null;
     /**
      * Extracted failure category (e.g. rate_limit), or null. Budget-guard
-     * values: "budget_deferred" (retrying, still within caps) and
-     * "budget_deferral_exhausted" (terminal failure — the `error` text
-     * names the bucket, cap, and remedies). Persisted strings — render
-     * verbatim, never invent variants.
+     * values: "budget_deferred" (retrying, still within caps),
+     * "budget_deferral_exhausted" (terminal — the `error` text names the
+     * bucket, cap, and remedies), and "deferral_exhausted" (terminal —
+     * aggregate cap: the unit oscillated between budget and rate-limit
+     * deferral episodes without ever running; `error` names the last
+     * episode kind and both counters). Persisted strings — render verbatim,
+     * never invent variants.
      */
     error_category: string | null;
     last_heartbeat_at: string | null;


### PR DESCRIPTION
## Problem

Budget-deferred sync units (`status: retrying`, `error_category: "budget_deferred"`) rendered as generic retrying — operators saw silent nothing while a unit sat blocked, indefinitely in the worst case (CHAOS-3412). This PR adds visibility for that state and for the two terminal failure states the backend now emits when a unit exhausts its deferral caps.

## What changed

Three derived, render-only UI treatments in `SyncRunDetailLive.tsx` (unit table + "Needs attention" panel), keyed strictly on `status` + the exact persisted `error_category` string — no UX-time recomputation, everything renders from already-persisted fields:

1. **`budget_deferred`** (still `retrying`, within caps) — distinct "Blocked: budget" badge + deferral count (`budget_deferrals`) + next-attempt time (`available_at`), instead of the generic retrying look.
2. **`budget_deferral_exhausted`** (terminal `failed`) — "Budget exhausted" badge; the actionable `error` text (bucket, cap, remedies) surfaces through the existing failed-unit red-text path.
3. **`deferral_exhausted`** (terminal `failed`, aggregate cap — a unit that oscillated between budget and rate-limit deferral episodes without ever running) — "Deferrals exhausted" badge, same exhausted-style treatment; actionable `error` text (last episode kind + both counters) surfaces the same way.

Also: a `budget_blocked_unit_count` rollup chip next to the existing "Next retry" indicator in the run summary.

### Deployable in either order

`budget_deferrals`, `budget_first_deferred_at` (unit) and `budget_blocked_unit_count` (summary) are added as **optional** fields on `SyncRunUnit`/`SyncRunUnitSummary`. The `budget_deferred` category treatment already works against today's merged backend; the counts/rollup render when present and omit gracefully when absent — this shipped independently of the backend PR and stays correct now that it's merged.

### Codex round

One medium finding addressed: verified (via new negative-control tests, not a code change — the guards already keyed correctly) that a `retrying` unit with an unrelated `error_category` never gets the budget-blocked treatment, and a `failed` unit stamped with the non-terminal `budget_deferred` category never reads as exhausted — the exhausted badge requires the exact terminal string, stamped only by the terminalize path. Also pinned that the blocked-budget branch keeps the actual next-attempt timestamp visible (not just the label), refuting the initial concern that it was hidden.

## Test coverage

Extended `SyncRunDetail.test.tsx` + `syncRunDetailSample.ts` with dedicated fixture units per category, mirroring the real backend vocabulary exactly (`budget_deferred`, `budget_deferral_exhausted`, `deferral_exhausted` — no invented variants). New tests cover: each badge's positive rendering (count/timestamp/error text), graceful omission when optional fields are absent, and negative controls proving the guards don't cross-fire on adjacent status/category combinations.

## Gate evidence

- Full `ci`-tier gate (format, quality [audit/codegen/ask-dev-contracts/lint/typecheck], build, unit, e2e default/onboarding/context-fabric, pagerduty-final-qa): **green**, with the one documented known-flake (context-fabric "closes mobile navigation with Escape") reproduced once and cleared clean on an isolated rerun — no other failures.
- Delta gate for the `deferral_exhausted` addendum: e2e-default came back noisy across repeated runs. Ran a controlled bisection — the *same unchanged* commit produced a *different* failure set on repeated full-suite runs, proving suite-level flakiness independent of this change (not a regression). Filed as CHAOS-3434 for separate follow-up.
- Deterministic gates on every commit in this PR: tsc, prettier, eslint all clean; targeted vitest **43/43 passing**.

Refs CHAOS-3412, CHAOS-3434.
