### PR TITLE
CHAOS-3436: bump live-e2e Python setup to 3.14

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -108,7 +108,7 @@ jobs:
             - name: Setup Python
               uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
-                  python-version: "3.12"
+                  python-version: "3.14"
                   cache: pip
 
             - name: Install dev-health-ops dependencies


### PR DESCRIPTION
## Problem

`live-e2e.yml` provisions Python 3.12 before installing `dev-health-ops` as an editable dependency (for the schema-export step and to run the live ops API in-workflow). `dev-health-ops`'s `pyproject.toml` now requires `>=3.14` (CHAOS-3419 aligned ops's Python floor across its own CI), so the install step hard-fails:

```
ERROR: Package 'dev-health-ops' requires a different Python: 3.12.13 not in '>=3.14'
##[error]Process completed with exit code 1.
```

This broke on every `dev-health-web` PR run against current ops main — first observed on PR #851 (CHAOS-3412 web-surfacing), which passed a clean `live-e2e` run 4m26s a few hours earlier on PR #850, before the ops Python-floor change landed.

## Fix

Bump `live-e2e.yml`'s `python-version` from `"3.12"` to `"3.14"`, matching what `dev-health-ops`'s own CI now standardizes on everywhere (`python-version: "3.14"` across all its workflows).

## Scope confirmation

Grepped `.github/workflows/` for both `python-version` and `dev-health-ops`:
- `live-e2e.yml` is the **only** web workflow with a `python-version` pin, and the only one that `pip install`s `dev-health-ops`.
- `tests.yml` also references `dev-health-ops` (`ASK_DEV_OPS_ROOT: dev-health-ops`), but only checks it out as a read-only source directory for the Node-based `ask-dev-contracts.mjs` drift check — it never invokes Python against it, so it's unaffected by the version floor.

No other workflow needs a change.

Refs CHAOS-3436, CHAOS-3419.
