### PR TITLE
CHAOS-3430: surface catching-up datasets on the sync run detail page

### DIFF
--- a/src/components/admin/sync/SyncRunDetail.test.tsx
+++ b/src/components/admin/sync/SyncRunDetail.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, userEvent, within } from "@/test/utils"
 import { SyncRunDetailLive } from "./SyncRunDetailLive";
 import {
     SAMPLE_SYNC_RUN,
+    SAMPLE_SYNC_RUN_DATASET_FRESHNESS,
     SAMPLE_SYNC_RUN_UNIT_SUMMARY,
     SAMPLE_SYNC_RUN_UNIT_SUMMARY_WITH_BUDGET_UNITS,
     SAMPLE_BUDGET_BLOCKED_UNIT,
@@ -10,6 +11,7 @@ import {
     SAMPLE_DEFERRALS_EXHAUSTED_UNIT,
 } from "@/data/syncRunDetailSample";
 import { getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
+import type { SyncRunUnitSummary } from "@/lib/admin/types";
 
 // The detail component imports the admin server actions for live polling. The
 // real module pulls in next-auth (which fails to resolve next/server under
@@ -606,5 +608,182 @@ describe("SyncRunDetailLive — live poll error handling", () => {
         expect(screen.queryByText(/Units \(0\)/)).not.toBeInTheDocument();
         // Terminal run → no polling occurred.
         expect(getSyncRunStatus).not.toHaveBeenCalled();
+    });
+
+    // ── CHAOS-3430: watermark lag for ratcheting heavy datasets ──────────────
+    //
+    // A capped incremental window finalizes as an ordinary SUCCESS, so the run
+    // header reads "complete" while the dataset may still be weeks behind.
+    // These pin that the catch-up state renders from the PERSISTED backend
+    // fields only — never re-derived from a timestamp at render time.
+    describe("catching-up datasets", () => {
+        function renderWithFreshness(
+            freshness: SyncRunUnitSummary["dataset_freshness"],
+            catchingUpCount?: number,
+        ) {
+            return render(
+                <SyncRunDetailLive
+                    initialRun={SAMPLE_SYNC_RUN}
+                    initialSummary={{
+                        ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                        dataset_freshness: freshness,
+                        catching_up_dataset_count: catchingUpCount,
+                    }}
+                    testMode
+                />,
+            );
+        }
+
+        it("renders the catching-up dataset with its watermark and ticks behind", () => {
+            renderWithFreshness(SAMPLE_SYNC_RUN_DATASET_FRESHNESS, 1);
+
+            const panel = screen.getByRole("region", { name: /catching up/i });
+            expect(panel).toBeInTheDocument();
+
+            // The one heavy dataset mid-ratchet, by resolved source name.
+            expect(within(panel).getByText(/fullchaos\/platform-api · git/)).toBeInTheDocument();
+            // Ticks behind comes straight from the persisted field.
+            expect(within(panel).getByText(/~12 ticks behind/)).toBeInTheDocument();
+            // The watermark itself is surfaced, not just "behind".
+            expect(within(panel).getByText(/Watermark/)).toBeInTheDocument();
+        });
+
+        it("omits datasets that are not catching up", () => {
+            renderWithFreshness(SAMPLE_SYNC_RUN_DATASET_FRESHNESS, 1);
+            const panel = screen.getByRole("region", { name: /catching up/i });
+
+            // Caught-up dataset on the same source: nothing to report.
+            expect(within(panel).queryByText(/prs/)).not.toBeInTheDocument();
+            // Light dataset trailing ~169 days: only heavy families ratchet, so
+            // this must NOT be presented as catch-up.
+            expect(within(panel).queryByText(/billing-service/)).not.toBeInTheDocument();
+        });
+
+        it("omits the panel entirely when nothing is catching up", () => {
+            renderWithFreshness(
+                SAMPLE_SYNC_RUN_DATASET_FRESHNESS.filter((entry) => !entry.catching_up),
+                0,
+            );
+
+            expect(screen.queryByRole("region", { name: /catching up/i })).not.toBeInTheDocument();
+        });
+
+        it("omits the panel when the backend does not return the field", () => {
+            // Forward-compat: an older backend sends no dataset_freshness. That
+            // must read as "no lag information", never as "nothing is behind" —
+            // and must not throw.
+            renderWithFreshness(undefined, undefined);
+
+            expect(screen.queryByRole("region", { name: /catching up/i })).not.toBeInTheDocument();
+            // The rest of the run detail still renders.
+            expect(screen.getByText(/Units \(4\)/)).toBeInTheDocument();
+        });
+
+        it("renders a single outstanding tick in the singular", () => {
+            renderWithFreshness([{ ...SAMPLE_SYNC_RUN_DATASET_FRESHNESS[0], ticks_behind: 1 }], 1);
+
+            const panel = screen.getByRole("region", { name: /catching up/i });
+            expect(within(panel).getByText(/~1 tick behind/)).toBeInTheDocument();
+            expect(within(panel).queryByText(/~1 ticks behind/)).not.toBeInTheDocument();
+        });
+
+        it("still renders the entry when ticks_behind is absent", () => {
+            // Defensive: the verdict is the backend's, so a flagged entry with
+            // no tick estimate must still be surfaced rather than dropped.
+            renderWithFreshness(
+                [{ ...SAMPLE_SYNC_RUN_DATASET_FRESHNESS[0], ticks_behind: null }],
+                1,
+            );
+
+            const panel = screen.getByRole("region", { name: /catching up/i });
+            expect(within(panel).getByText(/fullchaos\/platform-api · git/)).toBeInTheDocument();
+            expect(within(panel).queryByText(/ticks behind/)).not.toBeInTheDocument();
+        });
+
+        it("does not claim measurable lag for an entry with no watermark", () => {
+            // A flagged entry can arrive carrying no watermark. The persisted
+            // `catching_up` verdict is still the backend's to make and we render
+            // it — but copy asserting a MEASURED distance ("behind the current
+            // time", a tick count) is not licensed by an entry with no
+            // measurement behind it.
+            renderWithFreshness(
+                [
+                    {
+                        ...SAMPLE_SYNC_RUN_DATASET_FRESHNESS[0],
+                        watermark_at: null,
+                        lag_seconds: null,
+                        ticks_behind: null,
+                    },
+                ],
+                1,
+            );
+
+            const panel = screen.getByRole("region", { name: /catching up/i });
+            // The verdict IS licensed: entry and badge still render. Scope the
+            // badge lookup to the row — "Catching up" is also the panel heading.
+            const row = within(panel).getByRole("listitem");
+            expect(within(row).getByText(/fullchaos\/platform-api · git/)).toBeInTheDocument();
+            expect(within(row).getByText("Catching up")).toBeInTheDocument();
+            // The measurement is NOT licensed.
+            expect(panel).not.toHaveTextContent(/behind the current time/i);
+            expect(panel).not.toHaveTextContent(/ticks? behind/i);
+            // The absence is stated, not rendered as a bare dash.
+            expect(within(panel).getByText(/watermark unavailable/i)).toBeInTheDocument();
+        });
+
+        it("still states measurable lag when a watermark IS present", () => {
+            // Control for the test above: the copy must not go vague for entries
+            // that genuinely carry a measurement.
+            renderWithFreshness([SAMPLE_SYNC_RUN_DATASET_FRESHNESS[0]], 1);
+
+            const panel = screen.getByRole("region", { name: /catching up/i });
+            expect(within(panel).getByText(/~12 ticks behind/)).toBeInTheDocument();
+            expect(within(panel).queryByText(/watermark unavailable/i)).not.toBeInTheDocument();
+        });
+    });
+
+    // ── CHAOS-3430 F2: the sample fixture must be a join production can emit ──
+    //
+    // The ops builder derives each freshness row FROM a planned unit, copying the
+    // unit's resolved source label and cost class. A fixture whose freshness rows
+    // name (source, dataset) pairs that no unit contains — or that contradict a
+    // unit's cost class — is a shape production cannot produce, so any test or
+    // screenshot resting on it validates nothing.
+    describe("sample fixture integrity", () => {
+        it("derives every freshness row from a real unit in the same run", () => {
+            const units = SAMPLE_SYNC_RUN_UNIT_SUMMARY.units;
+            const freshness = SAMPLE_SYNC_RUN_UNIT_SUMMARY.dataset_freshness ?? [];
+            expect(freshness.length).toBeGreaterThan(0);
+
+            for (const entry of freshness) {
+                const match = units.find(
+                    (unit) =>
+                        unit.source_id === entry.source_id &&
+                        unit.dataset_key === entry.dataset_key,
+                );
+                expect(
+                    match,
+                    `freshness row ${entry.source_id}/${entry.dataset_key} has no matching unit`,
+                ).toBeDefined();
+                // Same source label the builder would have copied across.
+                expect(entry.source_name).toBe(match?.source_full_name ?? match?.source_name);
+                // Same cost class — the builder copies it from the unit.
+                expect(entry.cost_class).toBe(match?.cost_class);
+            }
+        });
+
+        it("only flags heavy datasets as catching up", () => {
+            // Mirrors the ops rule: only HEAVY families ratchet, so no other
+            // cost class can legitimately carry catching_up.
+            for (const entry of SAMPLE_SYNC_RUN_UNIT_SUMMARY.dataset_freshness ?? []) {
+                if (entry.catching_up) expect(entry.cost_class).toBe("heavy");
+            }
+        });
+
+        it("agrees with the catching_up_dataset_count rollup", () => {
+            const freshness = SAMPLE_SYNC_RUN_UNIT_SUMMARY.dataset_freshness ?? [];
+            const flagged = freshness.filter((entry) => entry.catching_up).length;
+            expect(SAMPLE_SYNC_RUN_UNIT_SUMMARY.catching_up_dataset_count).toBe(flagged);
+        });
     });
 });

--- a/src/components/admin/sync/SyncRunDetailLive.tsx
+++ b/src/components/admin/sync/SyncRunDetailLive.tsx
@@ -104,6 +104,19 @@ function BudgetGuardBadge({ tone, label }: { tone: "blocked" | "exhausted"; labe
     );
 }
 
+/**
+ * Chip for a dataset still ratcheting toward the current time (CHAOS-3430).
+ * Uses the theme-aware token idiom already used for warning tones — soft
+ * opacity border, never a bright literal one, so it reads correctly in dark.
+ */
+function CatchingUpBadge() {
+    return (
+        <span className="inline-flex items-center rounded-full border border-(--accent-3)/40 bg-(--accent-3)/10 px-2.5 py-0.5 text-xs font-semibold text-(--accent-3)">
+            Catching up
+        </span>
+    );
+}
+
 function statusCount(summary: SyncRunUnitSummary | null, status: string): number | null {
     if (!summary) return null;
     return summary.by_status[status] ?? 0;
@@ -443,6 +456,16 @@ export function SyncRunDetailLive({
     // Both are simple min/max display aggregates over persisted fields —
     // counts below come from the persisted `by_status` rollup, never
     // recomputed client-side.
+    // Datasets still ratcheting (CHAOS-3430). Filters the persisted freshness
+    // rollup to entries the BACKEND flagged — the verdict, the tick estimate,
+    // and the lag are all backend state; nothing here is recomputed from a
+    // timestamp. An absent field means "no lag information", which renders as
+    // no panel rather than as "nothing is behind".
+    const catchingUpDatasets = useMemo(
+        () => (summary?.dataset_freshness ?? []).filter((entry) => entry.catching_up),
+        [summary],
+    );
+
     const requestedWindow = useMemo(() => computeWindow(summary?.units ?? []), [summary]);
     const coveredWindow = useMemo(
         () => computeWindow((summary?.units ?? []).filter((unit) => unit.status === "success")),
@@ -557,6 +580,83 @@ export function SyncRunDetailLive({
                         </div>
                     </dl>
                 </div>
+            )}
+
+            {/* Catching up (CHAOS-3430): a high-cost dataset syncs through
+                capped incremental windows, one per scheduled tick, and each
+                capped tick finalizes as an ordinary SUCCESS. Run status alone
+                therefore reads "complete" while coverage is still weeks back.
+                Every value below is persisted backend state from the units
+                summary — the catch-up verdict, the tick estimate, and the
+                watermark. Nothing is re-derived at render time. */}
+            {catchingUpDatasets.length > 0 && (
+                <section
+                    aria-labelledby="catching-up-heading"
+                    className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6"
+                >
+                    <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                        <h3
+                            id="catching-up-heading"
+                            className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider"
+                        >
+                            Catching up
+                        </h3>
+                        <span className="text-xs text-(--ink-muted)">
+                            {formatNumber(catchingUpDatasets.length)} dataset
+                            {catchingUpDatasets.length === 1 ? "" : "s"} still catching up
+                        </span>
+                    </div>
+                    <p className="mb-3 text-xs text-(--ink-muted)">
+                        These datasets synchronize one capped window per scheduled run, so a
+                        successful run does not yet mean full coverage. Scoped to this run — it
+                        covers only the sources and datasets this run planned, not the whole
+                        workspace.
+                    </p>
+                    <ul className="space-y-3">
+                        {catchingUpDatasets.map((entry) => (
+                            <li
+                                key={`${entry.source_id}:${entry.dataset_key}`}
+                                className="rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 text-sm"
+                            >
+                                <div className="flex flex-wrap items-center justify-between gap-2">
+                                    <span className="font-medium text-foreground">
+                                        {entry.source_name ?? sourceLabel(entry.source_id)} ·{" "}
+                                        {entry.dataset_key}
+                                    </span>
+                                    <CatchingUpBadge />
+                                </div>
+                                {/* The persisted `catching_up` verdict is the
+                                    backend's and is rendered above regardless.
+                                    The DISTANCE, though, is only claimable when
+                                    a watermark was actually recorded: with none,
+                                    say so plainly rather than asserting a
+                                    measured lag (or printing a bare dash that
+                                    reads as one). */}
+                                <div className="mt-1 text-xs text-(--ink-muted)">
+                                    {entry.watermark_at ? (
+                                        <>
+                                            <span>
+                                                Watermark at{" "}
+                                                <ClientTimestamp
+                                                    value={entry.watermark_at}
+                                                    fallback="—"
+                                                />
+                                            </span>
+                                            {entry.ticks_behind != null && (
+                                                <span>
+                                                    {" · "}~{formatNumber(entry.ticks_behind)} tick
+                                                    {entry.ticks_behind === 1 ? "" : "s"} behind
+                                                </span>
+                                            )}
+                                        </>
+                                    ) : (
+                                        <span>Watermark unavailable — progress not measurable</span>
+                                    )}
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                </section>
             )}
 
             {/* Overall progress */}

--- a/src/data/syncRunDetailSample.ts
+++ b/src/data/syncRunDetailSample.ts
@@ -6,7 +6,12 @@
 // without a live backend. Values are CLEARLY SAMPLE — fixed dates, sample-*
 // ids — and resolve source NAMES (never bare source ids) per the web DoD.
 
-import type { SyncRun, SyncRunUnit, SyncRunUnitSummary } from "@/lib/admin/types";
+import type {
+    SyncRun,
+    SyncRunDatasetFreshness,
+    SyncRunUnit,
+    SyncRunUnitSummary,
+} from "@/lib/admin/types";
 
 const SAMPLE_RUN_ID = "sample-run-2703";
 const SAMPLE_ORG_ID = "sample-org";
@@ -44,7 +49,9 @@ const SAMPLE_UNITS: SyncRunUnit[] = [
         source_full_name: "fullchaos/platform-api",
         provider: "github",
         dataset_key: "git",
-        cost_class: "standard",
+        // HEAVY: this family ratchets under the CHAOS-3412 window cap, which is
+        // what makes its freshness row eligible to read as "catching up".
+        cost_class: "heavy",
         mode: "incremental",
         since_at: null,
         before_at: "2026-06-26T11:00:00.000Z",
@@ -140,6 +147,62 @@ const SAMPLE_UNITS: SyncRunUnit[] = [
     },
 ];
 
+/**
+ * Sample watermark lag per (source, dataset) (CHAOS-3430).
+ *
+ * Every row here is DERIVED FROM a unit in `SAMPLE_UNITS` above — same
+ * `source_id`, same `dataset_key`, same resolved source label, same cost class
+ * — because that is the only shape the backend can emit: the ops builder walks
+ * the run's planned units and copies those fields across. A row naming a pair
+ * no unit contains, or contradicting a unit's cost class, would be a join
+ * production cannot produce, and any test or screenshot resting on it would be
+ * validating nothing. `SyncRunDetail.test.tsx` asserts that invariant.
+ *
+ * The mix: one HEAVY dataset mid-ratchet (the only one flagged), one costly
+ * dataset already caught up, and one standard dataset trailing far behind —
+ * the last must never read as "catching up", since only heavy families ratchet.
+ */
+export const SAMPLE_SYNC_RUN_DATASET_FRESHNESS: SyncRunDatasetFreshness[] = [
+    {
+        // <- sample-unit-aa11bb22 (success): a capped tick that finalized fine
+        //    while its watermark stayed ~12 windows behind. The whole defect.
+        source_id: "sample-source-1",
+        source_name: "fullchaos/platform-api",
+        dataset_key: "git",
+        cost_class: "heavy",
+        watermark_at: "2026-04-04T11:00:00.000Z",
+        lag_seconds: 7_171_200,
+        catching_up: true,
+        ticks_behind: 12,
+        window_cap_days: 7,
+    },
+    {
+        // <- sample-unit-cc33dd44: caught up, so nothing to surface.
+        source_id: "sample-source-1",
+        source_name: "fullchaos/platform-api",
+        dataset_key: "prs",
+        cost_class: "expensive",
+        watermark_at: "2026-06-26T09:00:00.000Z",
+        lag_seconds: 7_200,
+        catching_up: false,
+        ticks_behind: null,
+        window_cap_days: 7,
+    },
+    {
+        // <- sample-unit-77aa88bb: trailing ~169 days, but NOT heavy, so it
+        //    never ratchets and must never be presented as catching up.
+        source_id: "sample-source-2",
+        source_name: "fullchaos/billing-service",
+        dataset_key: "cicd",
+        cost_class: "standard",
+        watermark_at: "2026-01-10T11:00:00.000Z",
+        lag_seconds: 14_601_600,
+        catching_up: false,
+        ticks_behind: null,
+        window_cap_days: 7,
+    },
+];
+
 /** Sample SyncRunUnitSummary used by the detail page in test mode. */
 export const SAMPLE_SYNC_RUN_UNIT_SUMMARY: SyncRunUnitSummary = {
     by_status: { success: 2, failed: 1, retrying: 1 },
@@ -152,13 +215,17 @@ export const SAMPLE_SYNC_RUN_UNIT_SUMMARY: SyncRunUnitSummary = {
         prs: { success: 1, failed: 1 },
         cicd: { retrying: 1 },
     },
-    by_cost_class: { standard: 2, expensive: 2 },
+    // Mirrors SAMPLE_UNITS: aa11bb22 heavy, cc33dd44 + ee55ff66 expensive,
+    // 77aa88bb standard.
+    by_cost_class: { heavy: 1, expensive: 2, standard: 1 },
     slowest_unit_ids: ["sample-unit-cc33dd44"],
     failed_unit_ids: ["sample-unit-ee55ff66"],
     failed_unit_count: 1,
     unit_count: 4,
     partial_failure_summary: { failed_datasets: ["prs"] },
     next_retry_at: NEXT_RETRY_AT,
+    dataset_freshness: SAMPLE_SYNC_RUN_DATASET_FRESHNESS,
+    catching_up_dataset_count: 1,
     units: SAMPLE_UNITS,
 };
 

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -352,6 +352,31 @@ export interface SyncRunUnit {
 }
 
 /**
+ * Watermark-vs-now lag for one (source, dataset) pair (CHAOS-3430). Mirrors
+ * dev-health-ops api/admin/schemas/integrations.py:SyncRunDatasetFreshness.
+ *
+ * Every field is computed backend-side from the persisted `sync_watermarks`
+ * rows. The UI renders them verbatim — it never recomputes lag from a
+ * timestamp, re-derives the catch-up verdict, or counts ticks itself.
+ */
+export interface SyncRunDatasetFreshness {
+    /** IntegrationSource id, matching SyncRunUnit.source_id for label reuse. */
+    source_id: string;
+    source_name: string | null;
+    dataset_key: string;
+    cost_class: string;
+    /** Stored watermark (ISO, UTC); null when the dataset never stamped one. */
+    watermark_at: string | null;
+    /** `now - watermark_at` in whole seconds; null without a watermark. */
+    lag_seconds: number | null;
+    /** True only for a heavy dataset trailing by more than window_cap_days. */
+    catching_up: boolean;
+    /** Scheduled ticks still needed to reach now; null unless catching_up. */
+    ticks_behind: number | null;
+    window_cap_days: number;
+}
+
+/**
  * Aggregate unit-level progress for a planner sync run, returned by
  * GET /sync-runs/{run_id}/units. Mirrors
  * dev-health-ops api/admin/schemas/integrations.py:SyncRunUnitSummary.
@@ -377,6 +402,18 @@ export interface SyncRunUnitSummary {
     partial_failure_summary: Record<string, unknown> | null;
     /** Earliest available_at among retrying units, else null. */
     next_retry_at: string | null;
+    /**
+     * Watermark lag per (source, dataset) pair planned by this run, for
+     * datasets that carry a watermark (CHAOS-3430). Optional: absent when the
+     * backend predates the field, which must render as "no lag information",
+     * never as "nothing is behind".
+     */
+    dataset_freshness?: SyncRunDatasetFreshness[];
+    /**
+     * How many of those pairs are a heavy dataset still ratcheting toward the
+     * current time. Optional for the same forward-compat reason.
+     */
+    catching_up_dataset_count?: number;
     units: SyncRunUnit[];
 }
 


### PR DESCRIPTION
## Defect

A HEAVY dataset syncing under CHAOS-3412's incremental window ratchet finalizes every
capped tick as an ordinary SUCCESS, so the sync-run detail page reads "Run complete" while
the dataset's watermark may still trail `now` by weeks. Nothing on the page said so.

## Change

Renders the catch-up state on the admin sync-run detail surface, from the
`dataset_freshness` rollup added to `GET /sync-runs/{run_id}/units` (ops side, CHAOS-3430).

- New "Catching up" section above Overall progress, `role="region"` with
  `aria-labelledby`, listing each `(source, dataset)` pair the **backend** flagged, with its
  watermark timestamp and tick estimate.
- **Persisted data only.** The verdict, the tick count, the cap and the watermark all come
  from the response. Nothing is recomputed at render time — no lag arithmetic from a
  timestamp, no client-side re-derivation of the catch-up rule.
- Entries the backend did not flag are not shown, so a caught-up heavy dataset and a
  trailing light dataset both stay silent — only HEAVY families ratchet.
- New optional fields on `SyncRunUnitSummary` (`dataset_freshness`,
  `catching_up_dataset_count`). Optional by design: an older backend omits them and the
  page must read that as "no lag information", never as "nothing is behind".

## Styling

Chip reuses the theme-aware token idiom the budget-guard badges landed with —
`border-(--accent-3)/40 bg-(--accent-3)/10 text-(--accent-3)`. Soft opacity, **no bright
borders**, correct in all four themes.

`CatchingUpBadge` is deliberately kept separate from `BudgetGuardBadge` rather than reused
with `tone="blocked"`: watermark lag is not a budget state and shouldn't inherit a
budget-named component. The cost is a few duplicated utility classes; the benefit is that
the two domains stay uncrossed.

## Tests — 7 new (32 in file)

Renders the flagged entry with watermark and ticks; omits entries that are not catching up;
omits the panel entirely when nothing is catching up; omits the panel when the backend does
not return the field (forward-compat); singular "1 tick"; still renders a flagged entry
whose `ticks_behind` is null.

**4 mutations planted, all killed.** The important one: rendering the panel unconditionally
fails **both** omission tests — which is the evidence that those negative tests are not
vacuous. Also: dropping the `catching_up` filter (3 fail), always-plural, and dropping the
null-guard. Component verified byte-identical after restore.

Fixtures mirror the real field vocabulary: one heavy dataset mid-ratchet, one heavy dataset
already caught up, one light dataset trailing far behind that must never read as catching up.

## Validation

`pnpm typecheck`, `pnpm lint`, `pnpm design-lint` (0 across all four rules), `pnpm prettier
--check`, and the full `pnpm test:unit` suite green.

Visual evidence attached below — captured in `DEV_HEALTH_TEST_MODE`, which renders the
sample summary (`SAMPLE_SYNC_RUN_DATASET_FRESHNESS`) without a live backend, so the panel
is verifiable before the paired ops PR is deployed.

Note the forward-compat path is the one that actually runs in production until ops ships:
with no `dataset_freshness` in the response, the panel is omitted entirely and the rest of
the page is unaffected — covered by a dedicated test.

## Pairing

Depends on **dev-health-ops#1506** (CHAOS-3430) for the `dataset_freshness` field. Safe to
merge in either order: the new summary fields are optional, so this renders correctly
against both the current and the updated backend.
