### PR TITLE
test(ask-dev): close the default web CI coverage delta (CHAOS-3219 Phase 4)

### DIFF
--- a/docs/audits/ask-dev-web-default-ci-delta.md
+++ b/docs/audits/ask-dev-web-default-ci-delta.md
@@ -1,0 +1,243 @@
+# Ask Dev — default web CI coverage delta (CHAOS-3219 Phase 4 input)
+
+Re-derived 2026-08-06 on `dev-health-web@main` (`c6491d07`) against
+`dev-health-ops@main`. This replaces the lost Phase-0b artifact
+`p0b-webci-delta.md`. It is the authoritative MISSING list for Phase 4
+Lane 4b.
+
+## What this audit compares
+
+**Claim under audit** — Wave 3.1 manifest row `gate.web-default-ci`
+(status `deferred`, `ops/scripts/acceptance/wave31_manifest.py:1638`):
+
+> Default required Playwright CI covers answer-v2 outcomes, subjects,
+> rendering, and window/`/dev` semantic equivalence.
+
+**Against** — CHAOS-3219 required acceptance groups 2 (app-wide window),
+3 (full `/dev` workspace), 4 (cross-surface continuity), 5 (contextual
+interaction), plus the launch thresholds that are web-observable
+(zero internal-enum/reason leakage; zero silent organization widening;
+100% correct typed outcome or deterministic fallback; zero blank/refused
+result when a valid frame exists).
+
+**Scope of this list**: the _default_, mock-backed Playwright tier
+(`playwright.config.ts` → `tests.yml` `e2e-default`). Rows that can only
+be proven on the live compose stack are out of scope here and belong to
+Phase 4 lanes 4a/4c/4d.
+
+## Standing facts established by the audit
+
+1. **Web consumes `dev_answer.v1` only.** `dev_answer.v2` exists in ops
+   (`ops/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json`) but is
+   projected down to v1 before it reaches the wire by the single
+   authorised projector `ops/src/dev_health_ops/api/dev/contracts_v2/compat.py`.
+   `public_outcome` appears zero times in web `src/`. "answer-v2 outcome
+   coverage" in web therefore means **coverage of the projected v1 shapes**,
+   not of a v2 payload. The eight `PublicOutcome` values project as:
+
+    | v2 `public_outcome`       | v1 wire shape | v1 value                                                 |
+    | ------------------------- | ------------- | -------------------------------------------------------- |
+    | `answered`                | `DevAnswer`   | `complete` if coverage satisfied, else `partial`         |
+    | `answered_with_gaps`      | `DevAnswer`   | `partial`                                                |
+    | `needs_clarification`     | `DevAnswer`   | `insufficient_evidence` + scope `ambiguous`/`unresolved` |
+    | `not_found`               | `DevError`    | `scope_not_found` (not retryable)                        |
+    | `temporarily_unavailable` | `DevError`    | `source_unavailable` (retryable)                         |
+    | `unsupported`             | `DevError`    | `feature_not_enabled` (not retryable)                    |
+    | `denied`                  | `DevError`    | `forbidden` (not retryable)                              |
+    | `failed`                  | `DevError`    | `internal_error` (not retryable)                         |
+
+2. **What the default suite actually runs today**: 34 Playwright tests in
+   four files — `ask-dev-outcomes.spec.ts` (10), `ask-dev-shared.spec.ts`
+   (14), `ask-dev-continuity.spec.ts` (3), `ask-dev-vocabulary.spec.ts` (7,
+   pure data/filesystem assertions, no browser). All four land in the
+   `authenticated` project and always execute — sharding is per-file and
+   all three shards are required checks. They are driven by one mock,
+   `tests/mocks/devScenario.ts`, built from
+   `src/lib/dev/contracts/examples/positive/dev_answer.v1.json`.
+
+3. **Vocabulary actually exercised by the default mock**:
+    - `AnswerStatus`: `complete`, `partial`, `degraded`,
+      `insufficient_evidence`, `refused` — 5 of 6 (`error` excluded by
+      documented decision).
+    - `ScopeResolutionOutcome`: `exact`, `ambiguous`,
+      `forbidden_or_not_found` — 3 of 7.
+    - `DevErrorCode`: `scope_forbidden`, `source_unavailable` — **2 of 24**.
+    - `DevCapabilitiesReadiness`: `ready`, `missing_credentials`,
+      `disabled` — 3 of 5.
+
+4. **Surface split**: `ask-dev-outcomes.spec.ts` and
+   `ask-dev-shared.spec.ts` drive the **window only**. Exactly one default
+   test touches `/dev` for an outcome (entitlement-off), plus the three
+   continuity tests. The `/dev` full page has **no answer-state-matrix
+   coverage in the default tier**.
+
+5. **Out-of-band finding — THE LIVE ACCEPTANCE SPEC RUNS IN NO WORKFLOW.**
+   `tests/live/ask-dev-acceptance.spec.ts` is excluded by
+   `playwright.config.ts` (`testIgnore: "live/**"`) _and_ by
+   `playwright.live.config.ts` (`testIgnore: /ask-dev-acceptance\.spec\.ts/`).
+   It executes only via a manual `pnpm test:ask-dev-acceptance`. Any claim
+   resting on it is a claim about a manually-run artifact. This is why
+   CHAOS-3435's two stale selectors survived on main for a full wave.
+
+    **This is a Phase 5 CI-lane input, not a Phase 4 fix.** It is recorded
+    here because it changes how every other row should be read: the live tier
+    cannot be relied on to catch a rendering regression, so anything that
+    must not regress belongs in the default tier or the unit tier. That is
+    why row W11 exists at all, and why the CHAOS-3435 fix shipped with a
+    unit-tier control beside it.
+
+6. **Out-of-band finding — a product defect, not a test gap.**
+   `coverage.degraded_required_sources` exists in both v1 and v2, blocks a
+   `complete` answer identically to `unavailable`/`stale`
+   (`compat.py:308`), and is **never rendered**. `showCoverage`
+   (`src/components/ask-dev/AskDevAnswer.tsx:408-412`) omits it from its
+   predicate and the block body omits it from its output, so an answer
+   degraded-only shows **no coverage block at all** — the user sees a
+   downgraded answer with no explanation. Needs a `src/` fix, ticketed
+   separately, tracked here as W4.
+
+## MISSING (14 rows)
+
+Priority is by customer-visible risk and by which launch threshold the row
+protects. "Closes" names the CHAOS-3219 group or threshold.
+
+| #   | Row                                                                                                                                                                                                                                                                                                                                                                           | Closes                                                                                                            | Why it is missing                                                                                                                                                                                                                                     | Risk     |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| W1  | **No-answer outcome projection matrix** — `not_found`, `unsupported`, `denied`, `failed` each render their canonical copy (`ops/.../no_answer_policy.py:74-82`), and the Retry affordance appears only for the retryable one. (The server's matching `remediation` is NOT rendered by the UI at all — that is CHAOS-3474, so this row asserts only what is renderable today.) | G3, "100% correct typed outcome or deterministic fallback"; "zero blank/refused result when a valid frame exists" | The mock emits 2 of 24 `DevErrorCode`s. Four of the eight v2 outcomes have **no user-visible assertion anywhere in web**.                                                                                                                             | HIGH     |
+| W2  | **Clarification projection fidelity** — the ambiguous scenario must serve the shape the backend actually produces: `status: "insufficient_evidence"` + `resolved_scope.outcome: "ambiguous"`, and the UI must render the clarification pill/caption for it.                                                                                                                   | G3; mocks-mirror-real-vocabulary                                                                                  | `devScenario.ts:136-165` mutates `direct_summary` and `resolved_scope` but leaves `status: "complete"`. The one clarification test today asserts against a payload the backend **cannot emit** — this is a false-coverage row, not merely a thin one. | HIGH     |
+| W3  | **Candidate selection outcome** — "Use this scope" commits the chosen subject, does **not** auto-submit, and the next question is scoped to it.                                                                                                                                                                                                                               | G5 ("no auto-submit"), G2 ("visible committed subjects")                                                          | `ask-dev-outcomes.spec.ts:73` clicks the button and then asserts **nothing**. The click's entire effect is unverified.                                                                                                                                | HIGH     |
+| W4  | **Coverage block truth** — `complete`-vs-`partial` follows coverage, and `degraded_required_sources` is rendered rather than silently dropped.                                                                                                                                                                                                                                | G3 ("source observations… conflicts, freshness")                                                                  | The `showCoverage` predicate and body both ignore `degraded_required_sources`; a degraded-only answer renders no coverage block. Requires a `src/` fix plus its RED-first test.                                                                       | HIGH     |
+| W5  | **Internal-token denylist over prose fields** — poisoned `direct_summary`, `claim.text`, `conflict.summary`, `warnings[]`, `suggested_follow_up_questions[]` are withheld, with the three named negative controls (`factual_completion`, `cannot_ready`, `prev1_state`) proving the guard is word-boundary/shape-based and not over-eager.                                    | "zero internal-enum/reason leakage"                                                                               | Default CI checks only the **failed-run alert** and exact-text status/scope pills. `safeCopy()` guards five prose fields; none is driven with a poisoned payload in the browser tier.                                                                 | HIGH     |
+| W6  | **`/dev` answer-state matrix** — the full outcome table rendered on the `/dev` workspace, not only in the window.                                                                                                                                                                                                                                                             | G3 (complete answer state matrix)                                                                                 | The outcome table runs window-only. `/dev` has exactly one default outcome test, and it is the entitlement-off negative. Half the row's "rendering" claim is unproven.                                                                                | HIGH     |
+| W7  | **Window ↔ `/dev` semantic equivalence beyond `complete`** — the same payload renders equivalent semantics on both surfaces for each status/outcome, not just the happy path.                                                                                                                                                                                                 | G4 ("identical answer-v2 payloads render equivalent semantics")                                                   | All three continuity tests drive the `complete` scenario. Equivalence is proven for 1 of 6 statuses. This is the row's fourth named area.                                                                                                             | HIGH     |
+| W8  | **No user text in URLs or analytics payloads** — question text never reaches the URL, `history.pushState`, or any analytics call.                                                                                                                                                                                                                                             | G4 (explicit)                                                                                                     | No assertion anywhere in web.                                                                                                                                                                                                                         | HIGH     |
+| W9  | **Route exclusions** — no ordinary Ask Dev window on `/superadmin/context-fabric/validation`; the launcher renders on ordinary authenticated routes.                                                                                                                                                                                                                          | G2 (explicit), G6 (admin separation)                                                                              | No default test asserts either half. No spec even asserts the launcher is present on an ordinary page.                                                                                                                                                | HIGH     |
+| W10 | **Proposed vs committed scope, and navigation without mutation** — the proposed row ("Commits when you ask") and the committed label render correctly, and a route change does not silently mutate committed subject/scope.                                                                                                                                                   | G2, G4; "zero silent organization widening"                                                                       | Proven only at the unit tier (`AskDevTrigger.integration.test.tsx`). No browser-tier assertion.                                                                                                                                                       | MED-HIGH |
+| W11 | **Citation ordinals and answer-scoped anchors on the rendered surface** — a cited ref at a non-zero index numbers as `E{index+1}` and opens `ask-dev-evidence-{answer_id}-{index+1}`.                                                                                                                                                                                         | G3 (citation precision)                                                                                           | Unit-tier only. The default browser tier has no citation-anchor assertion, which is precisely why CHAOS-3435's positional assumption survived: the only spec that exercised it runs in no workflow.                                                   | MED      |
+| W12 | **Self-contradiction guards rendered** — the CHAOS-3367 no-match presentation ("No match found", "Closest matches", no Refused chip) and the CHAOS-3377 refused-with-grounding presentation ("Inconsistent result", claims withheld, metrics/evidence retained).                                                                                                              | G3; "zero unresolved-subject fabrication"                                                                         | Both are customer-visible defect classes with unit-tier-only regression cover.                                                                                                                                                                        | MED      |
+| W13 | **Ordered sections and limits** — the full section order (scope → coverage → claims → conflicts → metrics → evidence → limitations → follow-ups) and the truncation/limitation copy for capped answers.                                                                                                                                                                       | G3 ("ordered answer sections", limits)                                                                            | The hierarchy test proves only "direct summary precedes Evidence coverage". No test renders a truncated answer.                                                                                                                                       | MED      |
+| W14 | **Remaining closed-vocabulary states** — scope outcomes `unresolved`, `organization_fallback`, `filtered`, `inherited`, and readiness `unsupported_model`, `degraded`.                                                                                                                                                                                                        | G2/G3; "zero silent organization widening"                                                                        | 4 of 7 scope outcomes and 2 of 5 readiness states are documented-excluded from any rendered assertion. `organization_fallback` and `unresolved` are in `NEVER_ATTESTABLE_TOKENS` and map directly to the widening threshold.                          | MED      |
+
+## Below the line (candidates, not rows)
+
+Real gaps, but either cheaper to cover inside a row above or better owned
+by a live lane. Recorded so they are not silently dropped.
+
+- **At-most-one-canonical-run under route change, expand/minimize, and
+  cancellation races** (G4). Duplicate double-submit _is_ covered
+  (`ask-dev-shared.spec.ts:78`); the other three race shapes are not.
+  Reconnect races need the live stack — split the mockable half into W7 if
+  the lead wants it in the default tier.
+- **Automated a11y (axe) sweep** of both surfaces in both themes (G2, G3).
+  Mock-backed and therefore default-tier-capable, but Phase 4 Lane 4a
+  already owns the accessibility report; assign to avoid duplication.
+- **`/dev` missing from the nav-reachability sweep**
+  (`tests/nav-reachability.spec.ts:5-77`). One-line fix, low risk.
+
+## Verification standard for every row
+
+Each row lands as a spec with a positive control and a negative control:
+the assertion must be observed failing against a deliberately wrong
+payload or a mutated renderer before it counts as coverage. A row whose
+test passes both before and after the defect it names is not coverage and
+is not recorded as such.
+
+Two mutations were run against this changeset, each restored and the
+restore verified by checksum:
+
+- Hardcoding the citation ordinal to 1 in `AskDevAnswer.tsx` killed exactly
+  the new unit test and left the other 35 green.
+- Hiding the coverage block only on the compact (window) surface killed the
+  W7 equivalence clause on all five statuses while **both pre-existing
+  continuity tests stayed green** — the old-pass/new-fail pair showing W7
+  closes a gap they did not cover.
+
+## Status
+
+All 14 rows are implemented in this changeset. Most are test-and-mock work;
+`src/` changed in three places, all of them defect fixes rather than row
+implementation:
+
+- `AskDevAnswer.tsx` — the `showCoverage` predicate and the coverage block
+  (CHAOS-3469, row W4);
+- `contractValidation.ts` — the `fully_covered` mirror (CHAOS-3469, third
+  site, found while reviewing the first fix);
+- `AskDevProvider.tsx` — the surface/answer proposal split (CHAOS-3470,
+  found by row W3 and fixed under an explicit product ruling; a
+  product-behavior change, called out in the PR body).
+
+Findings raised while closing the rows, each filed rather than folded in
+silently:
+
+- **CHAOS-3469** — `degraded_required_sources` never rendered. Fixed here
+  (row W4), RED-first observed. **Three sites, one class**: the field was
+  missing from the `showCoverage` predicate, from the coverage block's
+  output, and — found while reviewing the first fix — from
+  `validateAskDevSemanticInvariants`, which mirrors ops' `fully_covered`
+  and so was accepting a `complete` answer with degraded required sources
+  that ops cannot emit (`compat.py:303-309`). Rather than patch a third
+  time and stop, the closure argument: web reasons about coverage in
+  exactly two files — `AskDevAnswer.tsx` (predicate and render) and
+  `contractValidation.ts` (the ops mirror). `grep` for
+  `available_source_count|required_source_count` outside generated code,
+  pinned contracts and tests returns those two files and nothing else, so
+  all sites are now covered and there is no fourth.
+- **CHAOS-3470** — the clarification "Use this scope" CTA is inert when
+  `ask_dev_contextual_entrypoints` is off. Found by W3, the first
+  assertion ever placed on that button. Not fixed: the two candidate fixes
+  point in opposite directions and it needs a product ruling.
+- **CHAOS-3471** — the canonical no-answer copy lives in Python constants
+  exported into no artifact web pins, so W1's mirror of it cannot detect
+  ops-side drift. The mirror's own comment states this limitation rather
+  than implying a link that does not exist.
+
+Two observations not yet ticketed, pending a ruling:
+
+- **Server `remediation` is never rendered.** The failed-run alert shows
+  `safe_message` plus a client-derived `errorGuidance` covering only the
+  allowance and provider-contract cases. For all five no-answer outcomes
+  the server supplies remediation and the UI drops it, leaving the user a
+  sentence and no next step.
+- **Readiness `degraded` is treated as a hard block.** `AskDevProvider`
+  gates on `readiness !== "ready"`, so a degraded provider that may still
+  answer disables Ask Dev entirely. W14 deliberately asserts only what is
+  correct under either ruling (administrator-safe copy, no raw enum), so
+  the test does not enshrine the current behaviour.
+
+## Process notes from building these rows
+
+Recorded because each cost a real cycle and the next person should not
+repeat it.
+
+- **Assertions must match the guard's own matching semantics.** The first
+  denylist assertion used a substring check, which flags `cannot_ready` as a
+  leak of `not_ready` — exactly the false positive the guard's word-boundary
+  matching exists to avoid. The three negative controls caught it on the
+  first run.
+- **A scope outcome is a shape, not a field.** Stamping an enum onto the
+  happy-path fixture produces payloads the browser client rejects outright
+  (`organization_fallback` needs an organization-shaped `surface_context`
+  too) or, worse, payloads it accepts that production cannot emit
+  (`unresolved` beside a completed answer with claims). Build each scenario
+  from what the projector actually constructs.
+- **Server-owned copy is not yours to invent.** `needs_clarification` and
+  the five no-answer outcomes carry copy the server supplies and the
+  projector passes through. A mock that writes its own sentence tests
+  nothing, and it is the same defect W2 was created to fix.
+- **`git add -A` is unsafe in this repo.** Running the e2e suite regenerates
+  the tracked `public/runtime-config.js` with test-mode values
+  (`NEXT_PUBLIC_DEV_HEALTH_TEST_MODE=true`, production Sentry/telemetry/
+  analytics settings dropped), so a blanket add sweeps a test-mode artifact
+  into the commit. It happened twice on this branch — reverted by hand, then
+  regenerated by the next e2e run and swept in again — and was caught by
+  adversarial review rather than by any gate. Stage explicit paths. The
+  underlying question of whether the file should be tracked at all is
+  CHAOS-3477.
+- **Run ask-dev specs with `--workers=1`.** See below.
+
+## A note on running these locally
+
+The ask-dev specs share mock-server global state (capabilities and the
+entitlement scenario). CI gets away with it by pinning `workers: 1`; a
+local multi-worker run of these four files produces false reds — three,
+reproducibly, in continuity/not_ready/retry. Run them with `--workers=1`.

--- a/src/components/ask-dev/AskDevAnswer.test.tsx
+++ b/src/components/ask-dev/AskDevAnswer.test.tsx
@@ -219,6 +219,78 @@ describe("AskDevAnswer citations", () => {
         );
         expect(document.getElementById("ask-dev-evidence-answer-1-1")).not.toHaveFocus();
     });
+
+    // CHAOS-3435. `answer.evidence` carries no ordering contract: it is
+    // first-seen assembly order across tool results, and the upstream evidence
+    // search ranks by relevance/source precedence/freshness independently of
+    // what the model cites. A cited ref therefore lands at an arbitrary index,
+    // and the citation ordinal + detail-panel anchor must both follow that
+    // index. This is the unit-tier control for the live acceptance spec's
+    // id-derived assertions.
+    it("numbers a citation by the cited ref's index in answer.evidence, not by assuming it is first", async () => {
+        const user = userEvent.setup();
+        const citedEvidence = answer.evidence![0]!;
+        const decoyEvidence = Array.from({ length: 23 }, (_, index) => ({
+            ...citedEvidence,
+            display_label: `Pull request ${500 + index}`,
+            entity_id: String(500 + index),
+            evidence_ref_id: `evidence-decoy-${index + 1}`,
+        }));
+        // Cited ref sits at index 23 -> ordinal 24, exactly the live shape.
+        const rankedAnswer = {
+            ...answer,
+            evidence: [...decoyEvidence, citedEvidence],
+        } as unknown as DevAnswer;
+
+        render(<AskDevAnswer answer={rankedAnswer} />);
+
+        expect(
+            screen.queryByRole("button", { name: "Open evidence citation 1 for claim" }),
+        ).not.toBeInTheDocument();
+
+        await user.click(
+            screen.getByRole("button", { name: "Open evidence citation 24 for claim" }),
+        );
+
+        expect(actions.expandEvidence).toHaveBeenCalledWith("evidence-internal-1", "answer-1");
+        await waitFor(() =>
+            expect(document.getElementById("ask-dev-evidence-answer-1-24")).toHaveFocus(),
+        );
+        expect(document.getElementById("ask-dev-evidence-answer-1-1")).not.toHaveFocus();
+    });
+
+    // The metric half of the same contract. The evidence control above left
+    // metrics unguarded: a renderer hardcoded to metric citation 1 passes
+    // whenever the cited metric happens to be first, which it is in every
+    // other fixture here (codex adversarial review, MEDIUM). The live
+    // acceptance spec derives the metric ordinal too, but it runs in no
+    // workflow, so this is the control that can actually gate.
+    it("numbers a metric citation by the cited ref's index in answer.metrics, not by assuming it is first", async () => {
+        const user = userEvent.setup();
+        const citedMetric = answer.metrics![0]!;
+        const decoyMetrics = Array.from({ length: 4 }, (_, index) => ({
+            ...citedMetric,
+            label: `Decoy metric ${index + 1}`,
+            metric_id: `decoy_${index + 1}`,
+            metric_ref_id: `metric-decoy-${index + 1}`,
+        }));
+        // Cited ref sits at index 4 -> ordinal 5.
+        const rankedAnswer = {
+            ...answer,
+            metrics: [...decoyMetrics, citedMetric],
+        } as unknown as DevAnswer;
+
+        render(<AskDevAnswer answer={rankedAnswer} />);
+
+        expect(
+            screen.queryByRole("button", { name: "Open metric citation 1 for claim" }),
+        ).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: "Open metric citation 5 for claim" }));
+
+        expect(document.getElementById("ask-dev-metric-answer-1-5")).toHaveFocus();
+        expect(document.getElementById("ask-dev-metric-answer-1-1")).not.toHaveFocus();
+    });
 });
 
 describe("AskDevAnswer status explanations (CHAOS-3215)", () => {
@@ -869,6 +941,35 @@ describe("AskDevAnswer coverage suppression (CHAOS-3367)", () => {
         );
 
         expect(screen.getByText("1 required sources unavailable")).toBeVisible();
+    });
+
+    // CHAOS-3219 W4. `degraded_required_sources` is a real DevCoverage field
+    // in both v1 and v2, and it blocks a `complete` answer exactly as
+    // `unavailable`/`stale` do (ops contracts_v2/compat.py). It was absent
+    // from both the `showCoverage` predicate and the rendered block, so a
+    // degraded-only answer showed no coverage section at all — a downgraded
+    // answer with nothing on screen to explain the downgrade.
+    it("reports degraded required sources, and keeps the coverage block for a degraded-only answer", () => {
+        render(
+            <AskDevAnswer
+                answer={
+                    {
+                        ...answer,
+                        status: "degraded",
+                        coverage: {
+                            available_source_count: 0,
+                            required_source_count: 0,
+                            degraded_required_sources: ["work_graph", "deployments"],
+                            stale_required_sources: [],
+                            unavailable_required_sources: [],
+                        },
+                    } as unknown as DevAnswer
+                }
+            />,
+        );
+
+        expect(screen.getByLabelText("Evidence coverage")).toBeVisible();
+        expect(screen.getByText("2 required sources degraded")).toBeVisible();
     });
 });
 

--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -404,11 +404,19 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     // only source-specific explanation with it. A contradictory legacy row is also
     // suppressed — its counts describe a source plan that provably did not run for
     // the subject its own summary says was not found.
+    // `degraded_required_sources` belongs in this predicate for the same
+    // reason the other two lists do: it is a required source in a state that
+    // independently blocks a `complete` answer (ops contracts_v2/compat.py
+    // treats degraded exactly as unavailable and stale). Omitting it meant a
+    // degraded-only answer rendered no coverage block at all — a visibly
+    // downgraded answer with nothing on screen explaining the downgrade
+    // (CHAOS-3219 W4).
     const coverage = answer.coverage;
     const showCoverage =
         !noMatch &&
         ((coverage?.required_source_count ?? 0) > 0 ||
             (coverage?.unavailable_required_sources?.length ?? 0) > 0 ||
+            (coverage?.degraded_required_sources?.length ?? 0) > 0 ||
             (coverage?.stale_required_sources?.length ?? 0) > 0);
     const attested = useMemo(() => attestedText(answer), [answer]);
     const evidenceById = useMemo(
@@ -678,6 +686,12 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                         <span className="text-(--caution)">
                             {answer.coverage.unavailable_required_sources.length} required sources
                             unavailable
+                        </span>
+                    ) : null}
+                    {answer.coverage?.degraded_required_sources?.length ? (
+                        <span className="text-(--caution)">
+                            {answer.coverage.degraded_required_sources.length} required sources
+                            degraded
                         </span>
                     ) : null}
                     {answer.coverage?.stale_required_sources?.length ? (

--- a/src/components/ask-dev/AskDevProvider.test.tsx
+++ b/src/components/ask-dev/AskDevProvider.test.tsx
@@ -13,7 +13,7 @@ import type {
 } from "@/lib/dev/generated";
 
 import { AskDevContextRegistration } from "./AskDevContextRegistration";
-import { AskDevProvider } from "./AskDevProvider";
+import { AskDevProvider, useAskDev } from "./AskDevProvider";
 import { AskDevWorkspace } from "./AskDevWorkspace";
 
 const navigation = vi.hoisted(() => ({ pathname: "/dashboard", query: "", replace: vi.fn() }));
@@ -1584,6 +1584,137 @@ describe("AskDevProvider permanent window", () => {
         fireEvent.keyDown(dialog, { key: "Escape" });
         await waitFor(() =>
             expect(screen.getByRole("button", { name: "Open Ask Dev" })).toHaveFocus(),
+        );
+    });
+});
+
+// CHAOS-3470. `ask_dev_contextual_entrypoints` gates SURFACE entry points —
+// the launchers and typed context a route offers. A clarification candidate
+// is not one: it arrives inside an answer the organization was fully
+// entitled to receive, so committing one is answer semantics, not an entry
+// point. Before this fix `selectProposedEntity` went through the same
+// flag-gated path as surface proposals, so for an org with `ask_dev` on and
+// contextual entry points off the "Use this scope" button rendered and did
+// nothing at all — no state change, no error — leaving a clarification turn
+// with no in-product resolution.
+describe("AskDev candidate selection vs contextual-entrypoint gating (CHAOS-3470)", () => {
+    beforeAll(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    beforeEach(() => {
+        navigation.pathname = "/dashboard";
+        navigation.query = "";
+        navigation.replace.mockClear();
+    });
+
+    function SetSurfaceContext() {
+        const { setProposedContext } = useAskDev();
+        return (
+            <button
+                type="button"
+                onClick={() =>
+                    setProposedContext({
+                        routeId: "data_health",
+                        entityRefs: [
+                            {
+                                entity_type: "repository",
+                                entity_id: "repo-1",
+                                display_label: "dev-health-web",
+                            },
+                        ],
+                    })
+                }
+            >
+                Register surface context
+            </button>
+        );
+    }
+
+    function SelectCandidate() {
+        const { selectProposedEntity } = useAskDev();
+        return (
+            <button
+                type="button"
+                onClick={() =>
+                    selectProposedEntity({
+                        entity_type: "repository",
+                        entity_id: "repo-1",
+                        display_label: "dev-health-web",
+                    })
+                }
+            >
+                Use this scope
+            </button>
+        );
+    }
+
+    it("commits an answer's candidate even when contextual entry points are disabled", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        navigation.pathname = "/data-health";
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <SelectCandidate />
+                <main>Data Health</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.click(screen.getByRole("button", { name: "Use this scope" }));
+
+        await waitFor(() =>
+            expect(screen.getByText("Proposed context:")).toHaveTextContent("dev-health-web"),
+        );
+    });
+
+    it("still ignores a SURFACE proposal when contextual entry points are disabled", async () => {
+        // The other half of the ruling: ungating candidate selection must not
+        // ungate entry points. Same flag state, same target entity — only the
+        // origin differs, and only the answer-driven origin is exempt.
+        //
+        // This calls the provider's `setProposedContext` DIRECTLY rather than
+        // going through AskDevContextRegistration. That component carries its
+        // own `contextualEntrypointsEnabled` early return
+        // (AskDevContextRegistration.tsx:53), so a registration-based test
+        // passes on the component's guard and stays green even if the
+        // provider's guard is deleted — it would prove the wrong layer
+        // (codex adversarial review round 3, MEDIUM). Probing the provider is
+        // the only way to assert the split this change actually made.
+        const user = userEvent.setup();
+        const client = makeClient();
+        navigation.pathname = "/data-health";
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <SetSurfaceContext />
+                <main>Data Health</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.click(screen.getByRole("button", { name: "Register surface context" }));
+
+        expect(screen.getByText("Proposed context:")).not.toHaveTextContent("dev-health-web");
+    });
+
+    it("accepts the same SURFACE proposal once contextual entry points are enabled", async () => {
+        // Positive control for the guard above: without this, the negative
+        // test could pass because the probe never worked at all.
+        const user = userEvent.setup();
+        const client = makeClient();
+        navigation.pathname = "/data-health";
+        render(
+            <AskDevProvider client={client} orgId="org-1" contextualEntrypointsEnabled>
+                <SetSurfaceContext />
+                <main>Data Health</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.click(screen.getByRole("button", { name: "Register surface context" }));
+
+        await waitFor(() =>
+            expect(screen.getByText("Proposed context:")).toHaveTextContent("dev-health-web"),
         );
     });
 });

--- a/src/components/ask-dev/AskDevProvider.tsx
+++ b/src/components/ask-dev/AskDevProvider.tsx
@@ -443,9 +443,16 @@ export function AskDevProvider({
     }, [orgId]);
 
     const clearProposedContext = useCallback(() => setSurfaceProposal(null), []);
-    const setProposedContext = useCallback(
+
+    /**
+     * Applies an approved proposal. The approval check
+     * (`isApprovedAskDevSurfaceContext`) is unconditional and stays here —
+     * only the ENTITLEMENT check differs by origin, and it lives in the two
+     * callers below.
+     */
+    const applyProposedContext = useCallback(
         (context: AskDevSurfaceContext) => {
-            if (!contextualEntrypointsEnabled || !isApprovedAskDevSurfaceContext(context)) return;
+            if (!isApprovedAskDevSurfaceContext(context)) return;
             const surfaceContext = toDevSurfaceContext(context);
             const directScope = askDevDirectScope(context);
             setSurfaceProposal({
@@ -459,7 +466,20 @@ export function AskDevProvider({
                 sourcePathname: pathname,
             });
         },
-        [contextualEntrypointsEnabled, pathname, routeScope],
+        [pathname, routeScope],
+    );
+
+    /**
+     * A SURFACE proposal: typed context a route offers before the user has
+     * asked anything. This is what `ask_dev_contextual_entrypoints` governs,
+     * so it stays gated.
+     */
+    const setProposedContext = useCallback(
+        (context: AskDevSurfaceContext) => {
+            if (!contextualEntrypointsEnabled) return;
+            applyProposedContext(context);
+        },
+        [applyProposedContext, contextualEntrypointsEnabled],
     );
 
     const selectProposedEntity = useCallback(
@@ -477,9 +497,19 @@ export function AskDevProvider({
                             ? "pull_request_detail"
                             : null;
             if (!routeId) return;
-            setProposedContext({ routeId, entityRefs: [entity] });
+            // CHAOS-3470: NOT gated on `contextualEntrypointsEnabled`. This
+            // entity came from a clarification answer the organization was
+            // entitled to receive, so committing it is answer semantics, not
+            // a surface entry point. Routing it through the gated
+            // `setProposedContext` made the "Use this scope" button inert for
+            // any org with `ask_dev` on and contextual entry points off — the
+            // button still rendered (AskDevAnswer has no feature check) and
+            // silently did nothing, leaving a clarification turn with no
+            // in-product resolution. Entry-point gating is unaffected: only
+            // this origin is exempt.
+            applyProposedContext({ routeId, entityRefs: [entity] });
         },
-        [setProposedContext],
+        [applyProposedContext],
     );
 
     const loadHistory = useCallback(async () => {

--- a/src/lib/dev/__tests__/contracts.test.ts
+++ b/src/lib/dev/__tests__/contracts.test.ts
@@ -277,4 +277,33 @@ describe("Ask Dev generated contract boundary", () => {
             }),
         ).toMatchObject({ ask_dev: false, byo_llm: true, agent_context_runtime: true });
     });
+
+    // CHAOS-3219 W4 follow-up. `fully_covered` in ops' projector
+    // (contracts_v2/compat.py:303-309) requires ALL THREE required-source
+    // lists to be empty before an answered outcome may become `complete`:
+    // unavailable, stale AND degraded. Web's semantic mirror checked only
+    // the first two, so it accepted a `complete` answer with degraded
+    // required sources — a payload ops cannot emit. Same omission as the
+    // rendering defect this row fixed, in a second place; there is no
+    // pinned negative example for it because ops did not ship one, so the
+    // case is asserted directly.
+    it("rejects a complete answer that still carries degraded required sources", () => {
+        const positive = readJson<Record<string, unknown>>("examples/positive/dev_answer.v1.json");
+        expect(validateAskDevSemanticInvariants(positive)).toBe(true);
+
+        const degradedWhileComplete = {
+            ...positive,
+            coverage: {
+                ...(positive.coverage as Record<string, unknown>),
+                degraded_required_sources: ["work_graph"],
+            },
+        };
+        expect(validateAskDevSemanticInvariants(degradedWhileComplete)).toBe(false);
+
+        // The same coverage is legitimate on a non-complete status, so the
+        // rule must key on the status and not simply reject the field.
+        expect(
+            validateAskDevSemanticInvariants({ ...degradedWhileComplete, status: "degraded" }),
+        ).toBe(true);
+    });
 });

--- a/src/lib/dev/contractValidation.ts
+++ b/src/lib/dev/contractValidation.ts
@@ -216,6 +216,23 @@ function validateAnswer(answer: JsonRecord): boolean {
         return false;
     }
 
+    // Mirrors `fully_covered` in ops' v2->v1 projector
+    // (contracts_v2/compat.py): an answered outcome becomes `complete` only
+    // when the counts agree AND all three required-source lists are empty.
+    // `degraded_required_sources` was missing here, so web accepted a
+    // `complete` answer ops cannot emit — the same omission as the coverage
+    // block that never rendered the field (CHAOS-3469), in a second place.
+    // There is no pinned negative example for it; ops did not ship one.
+    //
+    // The new clause treats an ABSENT list as satisfied, deliberately: all
+    // three lists are optional in `DevCoverage` (only the two counts and
+    // `as_of` are required), and absent means empty, which is exactly when
+    // `complete` is legal. Note the asymmetry this exposes — the two older
+    // clauses demand `Array.isArray(...)` and so reject a schema-valid
+    // `complete` answer that simply omits an optional list. Ops always
+    // serialises them, so nothing hits it today; left as-is rather than
+    // loosened here, because relaxing an existing acceptance rule is a
+    // contract decision and not part of this row.
     const coverage = answer.coverage;
     if (answer.status === "complete" && isRecord(coverage)) {
         return (
@@ -223,7 +240,10 @@ function validateAnswer(answer: JsonRecord): boolean {
             Array.isArray(coverage.unavailable_required_sources) &&
             coverage.unavailable_required_sources.length === 0 &&
             Array.isArray(coverage.stale_required_sources) &&
-            coverage.stale_required_sources.length === 0
+            coverage.stale_required_sources.length === 0 &&
+            (coverage.degraded_required_sources === undefined ||
+                (Array.isArray(coverage.degraded_required_sources) &&
+                    coverage.degraded_required_sources.length === 0))
         );
     }
     return true;

--- a/tests/ask-dev-continuity.spec.ts
+++ b/tests/ask-dev-continuity.spec.ts
@@ -1,14 +1,30 @@
 import { expect, test } from "@playwright/test";
 
+import { ASK_DEV_OUTCOME_TABLE } from "./fixtures/askDevOutcomes";
+import { CLARIFICATION_CANDIDATE_REFS } from "./mocks/devScenario";
 import {
     askDevAnswerArticle,
     askDevComposer,
     askDevTranscript,
+    getAskDevRequestCounts,
     openAskDevWindow,
     resetAskDevMock,
     scenarioQuestion,
     submitAskDevQuestion,
 } from "./helpers/askDev";
+
+/**
+ * Collapses whitespace and drops the rendered "As of <timestamp>" line so two
+ * renderings of the SAME answer compare equal. The timestamp is formatted
+ * from the payload and is identical across surfaces, but stripping it keeps
+ * the comparison from becoming a clock test if that ever changes.
+ */
+function normalizeAnswerText(text: string): string {
+    return text
+        .replace(/As of [^\n]*/gu, "As of <timestamp>")
+        .replace(/\s+/gu, " ")
+        .trim();
+}
 
 // CHAOS-3287: window <-> /dev share one conversation/transcript because
 // AskDevProvider mounts once at the (app) layout and both surfaces render
@@ -61,6 +77,188 @@ test.describe("Ask Dev — window <-> /dev continuity", () => {
         await expect(page).not.toHaveURL(/\/dev(\?|$)/);
         await expect(page.getByText("What is the delivery status?")).toBeVisible();
         await expect(askDevAnswerArticle(page)).toContainText("Twelve work items completed");
+    });
+
+    // CHAOS-3219 W6 + W7.
+    //
+    // W6: the outcome state matrix ran window-only. `/dev` had exactly one
+    // default-tier outcome test and it was the entitlement-off negative, so
+    // half of this row's "rendering" claim covered nothing.
+    //
+    // W7: continuity was proven for the `complete` scenario alone — 1 of 6
+    // statuses — while group 4 requires that identical payloads render
+    // equivalent semantics across both surfaces. A surface that dropped the
+    // limitation caption, or showed a different status for the same answer,
+    // passed every test that existed.
+    //
+    // Comparing normalized article text rather than a chosen field list is
+    // deliberate: a projection would only ever compare what its author
+    // thought to name, and the failure this guards against is a surface
+    // silently omitting something nobody listed.
+    for (const outcome of ASK_DEV_OUTCOME_TABLE) {
+        test(`${outcome.key}: renders on /dev and resumes in the window with equivalent semantics`, async ({
+            page,
+            request,
+        }) => {
+            await page.goto("/dev", { waitUntil: "domcontentloaded" });
+            const composer = askDevComposer(page);
+            await composer.fill(
+                scenarioQuestion(outcome.key, `A ${outcome.key} question for the workspace`),
+            );
+            await composer.press("Enter");
+
+            const workspaceAnswer = askDevAnswerArticle(page);
+            await expect(workspaceAnswer).toBeVisible();
+            await expect(workspaceAnswer).toContainText(outcome.directSummary);
+            if (outcome.captionContains) {
+                await expect(workspaceAnswer).toContainText(outcome.captionContains);
+            }
+            const workspaceText = normalizeAnswerText(await workspaceAnswer.innerText());
+            const workspaceAnswerId = await workspaceAnswer.getAttribute("id");
+            const countsBefore = await getAskDevRequestCounts(request);
+
+            await page.getByRole("link", { name: "Return to Ask Dev window" }).click();
+            await expect(page).not.toHaveURL(/\/dev(\?|$)/);
+
+            const windowAnswer = askDevAnswerArticle(page);
+            await expect(windowAnswer).toBeVisible();
+            await expect(windowAnswer).toContainText(outcome.directSummary);
+            if (outcome.captionContains) {
+                await expect(windowAnswer).toContainText(outcome.captionContains);
+            }
+            expect(
+                normalizeAnswerText(await windowAnswer.innerText()),
+                `The ${outcome.key} answer must read the same on both surfaces.`,
+            ).toBe(workspaceText);
+
+            // Matching text is not proof of one run. A surface transition
+            // that started a SECOND conversation and rendered the same canned
+            // answer satisfies every assertion above (codex adversarial
+            // review round 2, HIGH), while the product contract requires at
+            // most one canonical run across surfaces. Identity and the
+            // request counters settle it.
+            expect(
+                await windowAnswer.getAttribute("id"),
+                "The window rendered a different answer, not the same one resumed.",
+            ).toBe(workspaceAnswerId);
+            const countsAfter = await getAskDevRequestCounts(request);
+            expect(countsAfter.messages, "Returning to the window re-ran the question.").toBe(
+                countsBefore.messages,
+            );
+            expect(
+                countsAfter.conversationsCreated,
+                "Returning to the window started a second conversation.",
+            ).toBe(countsBefore.conversationsCreated);
+        });
+    }
+
+    // CHAOS-3219 W7, clarification arm. The equivalence loop above iterates
+    // ASK_DEV_OUTCOME_TABLE, which does not contain `needs_clarification` —
+    // so the one answer shape whose whole purpose is to ask the user for
+    // something was covered on the window only, and a window/`/dev`
+    // divergence in candidate rendering stayed invisible (codex adversarial
+    // review round 2, MEDIUM). Candidates and the scope row are compared,
+    // not just the answer text: the candidate list IS the content here.
+    test("needs_clarification: candidates and scope render equivalently on both surfaces", async ({
+        page,
+        request,
+    }) => {
+        await page.goto("/dev", { waitUntil: "domcontentloaded" });
+        const composer = askDevComposer(page);
+        await composer.fill(
+            scenarioQuestion("needs_clarification", "What is the status of dev-health?"),
+        );
+        await composer.press("Enter");
+
+        const workspaceAnswer = askDevAnswerArticle(page);
+        await expect(workspaceAnswer).toBeVisible();
+        await expect(workspaceAnswer).toContainText("Possible scope matches");
+        for (const candidate of CLARIFICATION_CANDIDATE_REFS) {
+            await expect(workspaceAnswer).toContainText(candidate.display_label);
+        }
+        const workspaceText = normalizeAnswerText(await workspaceAnswer.innerText());
+        const workspaceAnswerId = await workspaceAnswer.getAttribute("id");
+        const countsBefore = await getAskDevRequestCounts(request);
+
+        await page.getByRole("link", { name: "Return to Ask Dev window" }).click();
+        await expect(page).not.toHaveURL(/\/dev(\?|$)/);
+
+        const windowAnswer = askDevAnswerArticle(page);
+        await expect(windowAnswer).toBeVisible();
+        await expect(windowAnswer).toContainText("Possible scope matches");
+        for (const candidate of CLARIFICATION_CANDIDATE_REFS) {
+            await expect(windowAnswer).toContainText(candidate.display_label);
+        }
+        expect(
+            normalizeAnswerText(await windowAnswer.innerText()),
+            "The clarification answer must read the same on both surfaces.",
+        ).toBe(workspaceText);
+        expect(await windowAnswer.getAttribute("id")).toBe(workspaceAnswerId);
+        const countsAfter = await getAskDevRequestCounts(request);
+        expect(countsAfter.messages).toBe(countsBefore.messages);
+        expect(countsAfter.conversationsCreated).toBe(countsBefore.conversationsCreated);
+    });
+
+    // CHAOS-3219 W10. Group 2 requires page navigation without silent
+    // subject/scope mutation, and the launch thresholds require zero silent
+    // organization widening. Proven only at the unit tier until now: no
+    // browser-tier test navigated at all after committing a scope.
+    test("navigating between ordinary routes does not mutate the committed scope, the transcript, or the run", async ({
+        page,
+        request,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("complete", "How many items completed this period?"),
+        );
+        await expect(askDevAnswerArticle(page)).toBeVisible();
+
+        const committedRow = page.getByText(/^Committed scope:/u).first();
+        const committedBefore = (await committedRow.innerText()).trim();
+        const answerIdBefore = await askDevAnswerArticle(page).getAttribute("id");
+        const countsBefore = await getAskDevRequestCounts(request);
+        expect(
+            committedBefore,
+            "The scope must be committed before this test can prove it stays put.",
+        ).not.toContain("Commits when you ask");
+
+        // Client-side navigation, not page.goto: the requirement is about
+        // moving around the app with the window open. A hard reload remounts
+        // the provider and is a different claim (conversation restoration),
+        // covered by the resume tests above.
+        await page
+            .getByRole("complementary")
+            .getByRole("link", { name: "Plan", exact: true })
+            .click();
+        await expect(page).toHaveURL(/\/plan(?:[?#]|$)/u);
+
+        await expect(askDevAnswerArticle(page)).toContainText("Twelve work items completed");
+        await expect(
+            askDevTranscript(page).getByText("How many items completed this period?"),
+        ).toBeVisible();
+        expect(
+            (
+                await page
+                    .getByText(/^Committed scope:/u)
+                    .first()
+                    .innerText()
+            ).trim(),
+            "Navigating to another route silently re-scoped the conversation.",
+        ).toBe(committedBefore);
+
+        // Same answer carried across, not a re-run that happened to produce
+        // identical canned text (codex adversarial review round 2, HIGH).
+        expect(
+            await askDevAnswerArticle(page).getAttribute("id"),
+            "Navigation replaced the answer instead of carrying it across.",
+        ).toBe(answerIdBefore);
+        const countsAfter = await getAskDevRequestCounts(request);
+        expect(countsAfter.messages, "Navigation re-ran the question.").toBe(countsBefore.messages);
+        expect(countsAfter.conversationsCreated, "Navigation started a second conversation.").toBe(
+            countsBefore.conversationsCreated,
+        );
     });
 
     test("starting a new conversation clears the previous transcript on both surfaces", async ({

--- a/tests/ask-dev-outcomes.spec.ts
+++ b/tests/ask-dev-outcomes.spec.ts
@@ -5,6 +5,7 @@ import {
     askDevAnswerArticle,
     askDevFailedAlert,
     askDevLauncher,
+    getAskDevRequestCounts,
     openAskDevWindow,
     resetAskDevMock,
     scenarioQuestion,
@@ -12,6 +13,12 @@ import {
     setAskDevEntitlement,
     submitAskDevQuestion,
 } from "./helpers/askDev";
+import {
+    CLARIFICATION_CANDIDATE_REFS,
+    CLARIFICATION_COPY,
+    NO_ANSWER_OUTCOMES,
+    NOT_READY_READINESS_VALUES,
+} from "./mocks/devScenario";
 
 // CHAOS-3287: every public outcome the current dev_answer.v1 contract can
 // actually produce gets a distinct, accessible rendering test here. See
@@ -70,7 +77,14 @@ test.describe("Ask Dev — answer status outcomes", () => {
         });
     }
 
-    test("needs_clarification (ambiguous scope): presents candidates without evidence", async ({
+    // CHAOS-3219 W2. `needs_clarification` is one of the v2 contract's
+    // EMPTY_CONTENT_OUTCOMES and projects to v1 as `insufficient_evidence`
+    // with an `ambiguous` scope row and no content (ops
+    // contracts_v2/compat.py). Before this test the mock served the
+    // canonical fixture's `status: "complete"` here, so the suite asserted a
+    // payload production cannot emit — coverage that could not fail for the
+    // reason it claimed to exist.
+    test("needs_clarification (ambiguous scope): renders the clarification status the backend actually projects, with candidates and no content", async ({
         page,
     }) => {
         await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
@@ -82,12 +96,217 @@ test.describe("Ask Dev — answer status outcomes", () => {
 
         const answer = askDevAnswerArticle(page);
         await expect(answer).toBeVisible();
-        await expect(answer).toContainText("More than one match was found");
+        await expect(answer).toContainText(CLARIFICATION_COPY.ambiguous);
+
+        // The projected status, not the fixture's. `Complete` beside a
+        // request for clarification is the exact contradiction W2 closes.
+        await expect(answer.getByText("Insufficient evidence", { exact: true })).toBeVisible();
+        await expect(answer.getByText("Complete", { exact: true })).not.toBeVisible();
+        await expect(answer).toContainText("isn't enough evidence");
+
+        // Ambiguity is NOT a no-match: several authorized entities did
+        // match. Rendering "Closest matches" here would assert the opposite
+        // (AskDevAnswer.tsx's `noMatch` branch) and is the misclassification
+        // this pair of assertions pins.
         await expect(answer.getByText("Possible scope matches")).toBeVisible();
-        const useScope = answer.getByRole("button", { name: "Use this scope" }).first();
-        await expect(useScope).toBeVisible();
-        await useScope.click();
+        await expect(answer.getByText("Closest matches")).not.toBeVisible();
+        for (const candidate of CLARIFICATION_CANDIDATE_REFS) {
+            await expect(answer).toContainText(candidate.display_label);
+        }
+        await expect(answer).toContainText(
+            "Choose or remove the proposed context before asking the next question.",
+        );
+
+        // No source plan ran for a subject that was never committed, so the
+        // answer carries no claims, metrics or evidence to expand.
+        await expect(page.getByRole("button", { name: "Open evidence" })).not.toBeVisible();
+        await expect(askDevFailedAlert(page)).not.toBeVisible();
     });
+
+    // CHAOS-3219 W3. The prior revision clicked this button and asserted
+    // nothing, so the entire effect of candidate selection — the whole point
+    // of a clarification turn — was unverified.
+    test("needs_clarification: choosing a candidate commits it as proposed context and does not auto-submit", async ({
+        page,
+        request,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("needs_clarification", "What is the status of dev-health?"),
+        );
+
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+        const countsBefore = await getAskDevRequestCounts(request);
+        const proposedRow = page.getByText(/^Proposed context:/u).first();
+        const committedRow = page.getByText(/^Committed scope:/u).first();
+        const committedBefore = (await committedRow.innerText()).trim();
+
+        const chosen = CLARIFICATION_CANDIDATE_REFS[0];
+        await answer
+            .getByRole("listitem")
+            .filter({ hasText: chosen.display_label })
+            .getByRole("button", { name: "Use this scope" })
+            .click();
+
+        // The choice becomes visible PROPOSED context — and only proposed.
+        // Committing is the user's next act, so the committed row must not
+        // move underneath them (CHAOS-3219 group 2: proposed and committed
+        // subjects are both visible, and scope never mutates silently).
+        await expect(proposedRow).toContainText(chosen.display_label);
+        expect(
+            (await committedRow.innerText()).trim(),
+            "Selecting a candidate proposes a scope; it must not silently re-commit one.",
+        ).toBe(committedBefore);
+
+        // Group 5 is explicit that an approved action never auto-submits:
+        // selecting a candidate must not execute a run by itself.
+        const countsAfterSelect = await getAskDevRequestCounts(request);
+        expect(
+            countsAfterSelect.messages,
+            "Selecting a clarification candidate must not execute a run.",
+        ).toBe(countsBefore.messages);
+        expect(
+            countsAfterSelect.conversationsCreated,
+            "Selecting a clarification candidate must not create a conversation.",
+        ).toBe(countsBefore.conversationsCreated);
+
+        // The user still drives the next turn, and it is one run — and that
+        // run must actually CARRY the chosen subject. Displayed state is not
+        // proof of what went on the wire: a defect that renders the chosen
+        // candidate while submitting the old or an organization-wide scope
+        // passes every assertion above (codex adversarial review, HIGH).
+        await submitAskDevQuestion(page, "And how is delivery trending?");
+        await expect(askDevAnswerArticle(page).nth(1)).toBeVisible();
+        const countsAfterAsk = await getAskDevRequestCounts(request);
+        expect(countsAfterAsk.messages).toBe(countsBefore.messages + 1);
+        expect(countsAfterAsk.conversationsCreated).toBe(countsBefore.conversationsCreated);
+
+        const submitted = countsAfterAsk.lastMessageScope as {
+            direct_scope?: string;
+            repositories?: string[];
+            entity_refs?: { entity_id?: string }[];
+        } | null;
+        expect(submitted, "The message request carried no scope at all.").not.toBeNull();
+        const submittedIds = [
+            ...(submitted?.repositories ?? []),
+            ...(submitted?.entity_refs ?? []).map((ref) => ref.entity_id),
+        ];
+        expect(submittedIds, "The chosen candidate was displayed but not submitted.").toContain(
+            chosen.entity_id,
+        );
+        expect(
+            submitted?.direct_scope,
+            "Choosing a specific repository must not widen the submitted scope to the organization.",
+        ).not.toBe("organization");
+    });
+
+    // CHAOS-3219 W4. The coverage block is the only place the UI explains
+    // WHY an answer was downgraded. Each required-source failure state must
+    // reach the screen, and a satisfied answer must claim no failure it does
+    // not have.
+    const COVERAGE_MATRIX = [
+        {
+            scenario: "complete",
+            question: "How much work completed?",
+            expected: "Coverage: 1 of 1 sources",
+            absent: [
+                "required sources unavailable",
+                "required sources degraded",
+                "required sources stale",
+            ],
+        },
+        {
+            scenario: "partial",
+            question: "How much work completed?",
+            expected: "1 required sources unavailable",
+            absent: ["required sources degraded", "required sources stale"],
+        },
+        {
+            scenario: "degraded",
+            question: "How much work completed?",
+            expected: "1 required sources stale",
+            absent: ["required sources unavailable", "required sources degraded"],
+        },
+        {
+            scenario: "degraded_sources_only",
+            question: "How much work completed?",
+            expected: "1 required sources degraded",
+            absent: ["required sources unavailable", "required sources stale"],
+        },
+    ] as const;
+
+    for (const row of COVERAGE_MATRIX) {
+        test(`${row.scenario}: the coverage block names the required-source states this answer actually has`, async ({
+            page,
+        }) => {
+            await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+            await openAskDevWindow(page);
+            await submitAskDevQuestion(page, scenarioQuestion(row.scenario, row.question));
+
+            const answer = askDevAnswerArticle(page);
+            await expect(answer).toBeVisible();
+            const coverage = answer.getByLabel("Evidence coverage");
+            await expect(coverage).toBeVisible();
+            await expect(coverage).toContainText(row.expected);
+            for (const absent of row.absent) {
+                await expect(coverage).not.toContainText(absent);
+            }
+        });
+    }
+
+    // CHAOS-3219 W1. Five of the eight dev_answer.v2 public outcomes never
+    // become an answer at all: the projector turns each into a DevError
+    // carrying server-owned canonical copy (ops
+    // contracts_v2/compat.py:484-494). Those sentences are therefore the
+    // ENTIRE user-visible artifact of those outcomes, and until now the
+    // default suite emitted 2 of 24 DevErrorCodes and asserted none of them.
+    for (const outcome of NO_ANSWER_OUTCOMES) {
+        test(`${outcome.outcome}: renders the canonical no-answer copy and the correct retry affordance`, async ({
+            page,
+        }) => {
+            await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+            await openAskDevWindow(page);
+            await submitAskDevQuestion(
+                page,
+                scenarioQuestion(outcome.scenario, `A question that ends in ${outcome.outcome}`),
+            );
+
+            const alert = askDevFailedAlert(page);
+            await expect(alert).toBeVisible();
+            await expect(alert).toContainText(outcome.safeMessage);
+
+            // A no-answer outcome is not an answer: the answer article must
+            // not also render (a "blank answer" is its own launch-threshold
+            // failure).
+            await expect(askDevAnswerArticle(page)).not.toBeVisible();
+
+            // Only the retryable outcome offers a retry. Offering it on a
+            // terminal outcome invites a pointless second run; withholding
+            // it on the retryable one strands a recoverable failure.
+            const retry = alert.getByRole("button", { name: "Retry" });
+            if (outcome.retryable) {
+                await expect(retry).toBeVisible();
+            } else {
+                await expect(retry).not.toBeVisible();
+            }
+
+            // The copy is outcome-specific, not one fixed apology reused for
+            // everything — a renderer that printed a constant would satisfy
+            // the assertion above and fail this one.
+            for (const other of NO_ANSWER_OUTCOMES) {
+                if (other.outcome === outcome.outcome) continue;
+                await expect(alert).not.toContainText(other.safeMessage);
+            }
+
+            // The raw code behind the outcome never reaches the alert.
+            const alertText = await alert.innerText();
+            expect(alertText).not.toContain(outcome.code);
+            expect(alertText).not.toContain(outcome.code.replaceAll("_", " "));
+        });
+    }
 
     test("a stream-level failure (source_unavailable) renders the alert treatment, not a silent blank", async ({
         page,
@@ -129,6 +348,28 @@ test.describe("Ask Dev — availability gating", () => {
         ).toBeVisible();
         await expect(page.getByRole("region", { name: "Ask Dev workspace" })).not.toBeVisible();
     });
+
+    // CHAOS-3219 W14. Only 3 of the 5 pinned DevCapabilitiesReadiness values
+    // were ever served by the mock. `unsupported_model` and `degraded` are
+    // real enum members an administrator can land on, and neither had any
+    // assertion that its copy stays administrator-safe.
+    for (const readiness of NOT_READY_READINESS_VALUES) {
+        test(`readiness ${readiness}: surfaces an administrator-safe explanation, never the raw enum`, async ({
+            page,
+            request,
+        }) => {
+            await setAskDevCapabilities(request, readiness);
+            await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+            await askDevLauncher(page).click();
+
+            await expect(page.getByText("needs administrator attention")).toBeVisible();
+            const bodyText = await page.locator("body").innerText();
+            expect(bodyText, `The raw ${readiness} enum reached the page.`).not.toContain(
+                readiness,
+            );
+            expect(bodyText).not.toContain(readiness.replaceAll("_", " "));
+        });
+    }
 
     test("not_ready capabilities surface the administrator-safe reason, not an internal code", async ({
         page,

--- a/tests/ask-dev-shared.spec.ts
+++ b/tests/ask-dev-shared.spec.ts
@@ -229,6 +229,441 @@ test.describe("Ask Dev — internal-state isolation (denylist)", () => {
     });
 });
 
+// CHAOS-3219 W5. `safeCopy` guards five separate prose fields
+// (direct_summary, claim text, conflict summary, warnings, follow-ups), and
+// the launch thresholds require zero internal-enum/reason leakage. The
+// default suite checked only the failed-run alert and the status/scope
+// pills, so no browser-tier test ever drove a poisoned payload through the
+// guarded fields at all.
+test.describe("Ask Dev — internal-token guard over answer prose", () => {
+    const WITHHELD_COPY = "This part of the answer could not be shown.";
+    const POISONED_TOKENS = [
+        "insufficient_evidence",
+        "internal_error",
+        "feature_not_enabled",
+        "source_unavailable",
+        "not_ready",
+    ];
+    const CLEAN_STRINGS = [
+        "Coverage was computed from factual_completion.ts inputs.",
+        "Should the cannot_ready helper be reviewed?",
+        "Completion is computed by the prev1_state accessor.",
+    ];
+
+    test("withholds every prose field carrying an internal token, and leaves look-alike text alone", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("leaky_prose", "What is the current status?"),
+        );
+
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+        const answerText = await answer.innerText();
+
+        // Not one of the five poisoned fields reaches the screen carrying
+        // its token. Each field carries a DIFFERENT token, so a guard wired
+        // to only one of them fails here rather than passing on the others.
+        //
+        // Matched at word boundaries, the same way the guard itself matches
+        // (lib/dev/internalTokens.ts). A bare substring check would be
+        // wrong in both directions: it reports a leak for the deliberate
+        // `cannot_ready` control, which merely CONTAINS `not_ready`, and it
+        // is the over-matching behaviour the guard exists to avoid. The
+        // space-transformed form catches a renderer that prints
+        // `token.replaceAll("_", " ")`; it stays lowercase so the sanctioned
+        // capitalised labels ("Insufficient evidence") are not mistaken for
+        // a leak.
+        for (const token of POISONED_TOKENS) {
+            expect(answerText, `"${token}" leaked into the rendered answer.`).not.toMatch(
+                new RegExp(`\\b${token}\\b`, "u"),
+            );
+            expect(answerText, `"${token}" leaked in space-transformed form.`).not.toMatch(
+                new RegExp(`\\b${token.replaceAll("_", " ")}\\b`, "u"),
+            );
+        }
+
+        // Withholding is visible, not silent, AND it happened in EVERY
+        // guarded region. Two weaker shapes were rejected on the way here:
+        // scanning one aggregate string cannot tell "withheld" from "the
+        // region was never rendered", and asserting a region merely exists
+        // proves nothing about its guarded child (codex adversarial review
+        // rounds 1 and 2). Each poisoned field is therefore located through
+        // its own containing region.
+        const WITHHELD_REGIONS = [
+            { name: "claim text", locator: answer.getByLabel("What the evidence suggests") },
+            { name: "conflict summary", locator: answer.getByLabel("Conflicting evidence") },
+            { name: "warnings", locator: answer.getByLabel("Answer limitations") },
+            { name: "follow-ups", locator: answer.getByLabel("Suggested follow-up questions") },
+        ];
+        for (const region of WITHHELD_REGIONS) {
+            await expect(
+                region.locator,
+                `The ${region.name} region did not render at all.`,
+            ).toBeVisible();
+            await expect(
+                region.locator,
+                `The poisoned ${region.name} was not withheld.`,
+            ).toContainText(WITHHELD_COPY);
+        }
+
+        // Exactly five, not "at least four". Five fields were poisoned, and
+        // the four regions above account for four of them — so this pins the
+        // fifth, the direct summary, without needing a brittle selector for
+        // it. A leaking direct summary yields four and fails here even though
+        // every region assertion above still passes.
+        expect(
+            await answer.getByText(WITHHELD_COPY).count(),
+            "Each of the five poisoned prose fields must be withheld exactly once.",
+        ).toBe(5);
+
+        // The negative controls. These are the guard's three documented
+        // false-positive shapes; `factual_completion` contains
+        // `actual_completion`, `cannot_ready` contains `not_ready`, and
+        // `prev1_state` contains the `ev1_` handle prefix. A guard widened
+        // from word-boundary/shape matching to bare substring matching
+        // still passes every assertion above and fails these.
+        for (const clean of CLEAN_STRINGS) {
+            expect(answerText, `"${clean}" is not a leak and must not be withheld.`).toContain(
+                clean,
+            );
+        }
+    });
+});
+
+// CHAOS-3219 W8. Group 4 states it plainly: no user text is placed in URLs
+// or analytics payloads. Nothing in web asserted it. A question is the most
+// sensitive string Ask Dev handles — it lands in browser history, in
+// referrer headers, and in any third-party beacon that reads either.
+test.describe("Ask Dev — question text containment", () => {
+    test("a question never reaches the URL, history, or any outbound request but the Ask Dev message", async ({
+        page,
+    }) => {
+        // Distinctive enough that a substring match cannot collide with
+        // ordinary page copy, and URL-encodes recognisably.
+        const SECRET_QUESTION = "Zephyrine quarterly burndown for Falcon Nine?";
+        const ENCODED = encodeURIComponent(SECRET_QUESTION);
+        // Percent-encoding is not the only way a question reaches a URL:
+        // form encoding writes spaces as "+", and a partially-encoded value
+        // matches neither the raw nor the fully-encoded form (codex
+        // adversarial review round 2, MEDIUM). Decoding the candidate and
+        // normalising "+" catches all three with one predicate.
+        const containsQuestion = (value: string | null | undefined): boolean => {
+            if (!value) return false;
+            let decoded = value;
+            try {
+                decoded = decodeURIComponent(value.replaceAll("+", " "));
+            } catch {
+                // A malformed escape sequence cannot be decoded; the raw
+                // comparison below still applies.
+            }
+            return [value, decoded].some(
+                (candidate) =>
+                    candidate.includes(SECRET_QUESTION) ||
+                    candidate.includes(ENCODED) ||
+                    candidate.includes(ENCODED.replaceAll("%20", "+")),
+            );
+        };
+
+        const leaks: string[] = [];
+        // Positive control for the detector itself. Everything else in this
+        // test is an absence assertion, which a listener that never fired —
+        // or that could not read post bodies — would satisfy perfectly. This
+        // records the one carrier the question IS known to travel in, so a
+        // blind detector fails loudly instead of reporting a clean run.
+        const observedAskDevBodies: string[] = [];
+        page.on("request", (request) => {
+            const url = request.url();
+            const path = new URL(url).pathname;
+            if (path.startsWith("/api/v1/dev/")) {
+                const askDevBody = request.postData();
+                if (askDevBody) observedAskDevBodies.push(askDevBody);
+            }
+            // A URL is never an acceptable carrier, for ANY endpoint: it
+            // reaches browser history, referrer headers, and server logs.
+            if (containsQuestion(url)) {
+                leaks.push(`URL: ${url}`);
+            }
+            // Request BODIES are a different question. The Ask Dev API is
+            // where the question is supposed to go, and it goes to more than
+            // one endpoint there: `/messages` carries the question itself,
+            // and `POST /conversations` carries a question-derived title
+            // (which is what the history sidebar lists). Both are the
+            // product working. Group 4's prohibition is on URLs and
+            // analytics payloads, so the body check covers every request
+            // that is NOT the Ask Dev API — telemetry, error reporting, and
+            // any third-party beacon included.
+            if (path.startsWith("/api/v1/dev/")) return;
+            if (containsQuestion(request.postData())) {
+                leaks.push(`${request.method()} ${path} body`);
+            }
+        });
+
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(page, SECRET_QUESTION);
+        await expect(askDevAnswerArticle(page)).toBeVisible();
+
+        // Surviving a surface change is part of the claim: carry the
+        // conversation to /dev and back, which is where a naive
+        // "resume by query param" implementation would put it.
+        await page.getByRole("link", { name: "Ask Dev workspace" }).click();
+        await expect(page).toHaveURL(/\/dev(\?|$)/u);
+        await page.getByRole("link", { name: "Return to Ask Dev window" }).click();
+        await expect(page).not.toHaveURL(/\/dev(\?|$)/u);
+
+        expect(
+            observedAskDevBodies.some((body) => body.includes(SECRET_QUESTION)),
+            "The request detector never observed the question in the Ask Dev body it is known to travel in — the absence assertions below would be vacuous.",
+        ).toBe(true);
+        expect(leaks, "Question text escaped into a URL or an unrelated request.").toEqual([]);
+        expect(containsQuestion(page.url()), "The question reached the address bar.").toBe(false);
+
+        // Browser history, not just the current address bar: a pushState
+        // that embedded the question would still be readable by anything
+        // that reads location, and would survive a back navigation.
+        const historyCandidates = await page.evaluate(() => [
+            JSON.stringify(window.history.state ?? null),
+            document.location.href,
+        ]);
+        for (const candidate of historyCandidates) {
+            expect(
+                containsQuestion(candidate),
+                "Question text was written into history state or the location.",
+            ).toBe(false);
+        }
+    });
+});
+
+// CHAOS-3219 W9. Group 2 requires app-shell entry on ordinary routes and an
+// explicit exclusion on the platform-admin validation surface (group 6 keeps
+// that surface separate from Ask Dev entirely). Neither half was asserted —
+// no spec even checked that the launcher renders on an ordinary page.
+test.describe("Ask Dev — route exclusions", () => {
+    test("the launcher renders on an ordinary authenticated route", async ({ page }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await expect(askDevLauncher(page)).toBeVisible();
+    });
+
+    test("the ordinary window never renders on /superadmin/context-fabric/validation", async ({
+        page,
+    }) => {
+        // Proven against the same session that just saw the launcher, so a
+        // failure here is the route exclusion and not a lost session or a
+        // capability gate (which would hide the launcher everywhere and make
+        // this assertion pass for the wrong reason).
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await expect(askDevLauncher(page)).toBeVisible();
+
+        await page.goto("/superadmin/context-fabric/validation", {
+            waitUntil: "domcontentloaded",
+        });
+        // Prove we actually LANDED on the validation surface before asserting
+        // absence. A redirect to the dashboard, an auth failure, or a route
+        // error would satisfy all three negative assertions below without the
+        // exclusion existing at all (codex adversarial review, MEDIUM).
+        await expect(page).toHaveURL(/\/superadmin\/context-fabric\/validation(?:[?#]|$)/u);
+        await expect(page.getByRole("heading", { name: /context fabric/iu }).first()).toBeVisible();
+
+        await expect(askDevLauncher(page)).not.toBeVisible();
+        await expect(page.getByRole("dialog", { name: "Ask Dev" })).not.toBeVisible();
+        await expect(askDevComposer(page)).not.toBeVisible();
+    });
+});
+
+// CHAOS-3219 W11. Citation ordinals and per-answer detail anchors had
+// unit-tier coverage only. The one spec that exercised them on a rendered
+// surface (tests/live/ask-dev-acceptance.spec.ts) runs in no workflow, which
+// is how CHAOS-3435's positional assumption survived on main for a wave.
+test.describe("Ask Dev — citation anchors", () => {
+    test("a claim citation opens the detail panel scoped to its own answer id", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(page, scenarioQuestion("complete", "What completed?"));
+
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+
+        // The anchor id is derived from the answer's own id, never from the
+        // citation ordinal alone (CHAOS-3215 M6): position-only ids collide
+        // across every answer in a transcript.
+        const answerId = await answer.getAttribute("id");
+        expect(answerId, "The answer article must carry its answer-scoped id.").toMatch(
+            /^ask-dev-answer-/u,
+        );
+        const scopeSuffix = answerId!.replace(/^ask-dev-answer-/u, "");
+
+        await answer.getByRole("button", { name: "Open evidence citation 1 for claim" }).click();
+        await expect(page.locator(`[id="ask-dev-evidence-${scopeSuffix}-1"]`)).toBeVisible();
+
+        await answer.getByRole("button", { name: "Open metric citation 1 for claim" }).click();
+        await expect(
+            page.locator(`[id="ask-dev-metric-${scopeSuffix}-1"] details`),
+        ).toHaveAttribute("open", "");
+
+        // The pre-CHAOS-3215 unscoped ids must not exist at all — a renderer
+        // that emitted both would satisfy every assertion above.
+        await expect(page.locator('[id="ask-dev-evidence-1"]')).toHaveCount(0);
+        await expect(page.locator('[id="ask-dev-metric-1"]')).toHaveCount(0);
+    });
+});
+
+// CHAOS-3219 W12. Two customer-visible defect classes whose regression cover
+// was unit-tier only, both about the UI refusing to present a payload that
+// contradicts itself.
+test.describe("Ask Dev — self-contradiction presentation", () => {
+    test("a no-match answer is presented as a no-match, never as a refusal (CHAOS-3367)", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("forbidden_or_not_found_scope", "How is project Zed doing?"),
+        );
+
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+        await expect(answer.getByText("No match found", { exact: true })).toBeVisible();
+        // §12 prohibits labelling a no-match as a refusal, and "Exact match"
+        // beside a not-found statement is the contradiction the client-side
+        // guard exists to catch.
+        await expect(answer.getByText("Refused", { exact: true })).not.toBeVisible();
+        await expect(answer.getByText("Exact match", { exact: true })).not.toBeVisible();
+        // No source plan ran for a subject that was never resolved, so the
+        // coverage block must be suppressed rather than reporting zeros.
+        await expect(answer.getByLabel("Evidence coverage")).toHaveCount(0);
+    });
+
+    test("a refused answer carrying material grounding withholds its narrative (CHAOS-3377)", async ({
+        page,
+    }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(
+            page,
+            scenarioQuestion("refused_with_grounding", "How is delivery trending?"),
+        );
+
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+        await expect(answer.getByText("Inconsistent result", { exact: true })).toBeVisible();
+        // Relabelling this "Answered" while still showing the rejected prose
+        // would invent an answer the server never produced.
+        await expect(answer.getByText("Answered", { exact: true })).not.toBeVisible();
+        await expect(answer).toContainText("This part of the answer could not be shown.");
+        await expect(answer).not.toContainText("Delivery improved by twelve items this period.");
+        // Structured grounding is unaffected by the withholding.
+        await expect(
+            answer.getByRole("button", { name: "Open evidence", exact: true }),
+        ).toBeVisible();
+    });
+});
+
+// CHAOS-3219 W14 (scope half). Four of the seven pinned
+// ScopeResolutionOutcome values were "documented excluded" from any rendered
+// assertion — a recorded gap, not coverage.
+test.describe("Ask Dev — scope outcome vocabulary on screen", () => {
+    const SCOPE_OUTCOMES = [
+        { scenario: "scope_unresolved", raw: "unresolved", label: "Unresolved" },
+        {
+            scenario: "scope_organization_fallback",
+            raw: "organization_fallback",
+            label: "Organization-wide",
+        },
+        { scenario: "scope_filtered", raw: "filtered", label: "Filtered" },
+        { scenario: "scope_inherited", raw: "inherited", label: "Inherited" },
+    ] as const;
+
+    for (const outcome of SCOPE_OUTCOMES) {
+        test(`${outcome.raw}: renders its sanctioned label and never the raw enum`, async ({
+            page,
+        }) => {
+            await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+            await openAskDevWindow(page);
+            await submitAskDevQuestion(
+                page,
+                scenarioQuestion(outcome.scenario, "What is the current status?"),
+            );
+
+            const answer = askDevAnswerArticle(page);
+            await expect(answer).toBeVisible();
+            const scope = answer.getByLabel("Resolved answer scope");
+            await expect(scope).toContainText(outcome.label);
+            // An organization-wide resolution must also READ as
+            // organization-wide. The secondary line is where a widening that
+            // kept repository-scoped authorization data would surface as
+            // "1 authorized repositories" beside an Organization-wide
+            // outcome (codex adversarial review round 3).
+            if (outcome.raw === "organization_fallback") {
+                await expect(scope).toContainText("Organization");
+                await expect(scope).not.toContainText("authorized repositories");
+            }
+            const scopeText = await scope.innerText();
+            expect(scopeText, `The raw ${outcome.raw} outcome reached the screen.`).not.toMatch(
+                new RegExp(`\\b${outcome.raw}\\b`, "u"),
+            );
+            expect(scopeText).not.toMatch(
+                new RegExp(`\\b${outcome.raw.replaceAll("_", " ")}\\b`, "u"),
+            );
+        });
+    }
+});
+
+// CHAOS-3219 W13. The existing hierarchy test compares exactly two things —
+// the direct summary and the coverage block. TRD §16 fixes the whole reading
+// order, and no default-tier payload had ever carried every section at once,
+// so the order of the remaining six was asserted nowhere.
+test.describe("Ask Dev — ordered answer sections", () => {
+    test("every section renders in the contract's reading order", async ({ page }) => {
+        await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+        await openAskDevWindow(page);
+        await submitAskDevQuestion(page, scenarioQuestion("full_sections", "What is the status?"));
+
+        const answer = askDevAnswerArticle(page);
+        await expect(answer).toBeVisible();
+
+        const EXPECTED_ORDER = [
+            "Resolved answer scope",
+            "Evidence coverage",
+            "What the evidence suggests",
+            "Conflicting evidence",
+            "Metrics",
+            "Evidence",
+            "Answer limitations",
+            "Suggested follow-up questions",
+        ];
+
+        // Read the accessible names of the answer's sections in DOM order.
+        // Every expected section must be present AND in this relative order:
+        // asserting presence alone would pass with the evidence block above
+        // the answer, which is the hierarchy defect CHAOS-3291 fixed.
+        const rendered = await answer.evaluate((node) =>
+            [...node.querySelectorAll("section")].map((section) => {
+                const label = section.getAttribute("aria-label");
+                if (label) return label;
+                const labelledBy = section.getAttribute("aria-labelledby");
+                const heading = labelledBy ? document.getElementById(labelledBy) : null;
+                return heading?.textContent?.trim() ?? "";
+            }),
+        );
+
+        for (const expected of EXPECTED_ORDER) {
+            expect(rendered, `The "${expected}" section did not render.`).toContain(expected);
+        }
+        const positions = EXPECTED_ORDER.map((name) => rendered.indexOf(name));
+        expect(
+            positions,
+            `Sections rendered out of contract order: ${rendered.join(" -> ")}`,
+        ).toEqual([...positions].sort((a, b) => a - b));
+    });
+});
+
 test.describe("Ask Dev — evidence hierarchy", () => {
     test("the direct answer precedes the evidence section in reading order", async ({ page }) => {
         await page.goto("/diagnose", { waitUntil: "domcontentloaded" });

--- a/tests/helpers/askDev.ts
+++ b/tests/helpers/askDev.ts
@@ -1,6 +1,6 @@
 import { expect, type APIRequestContext, type Page } from "@playwright/test";
 
-import type { DevAnswerScenario } from "../mocks/devScenario";
+import type { DevAnswerScenario, DevCapabilitiesState } from "../mocks/devScenario";
 
 /**
  * The mock backend's own base URL (not the Next.js app's). Existing specs
@@ -29,7 +29,7 @@ export async function resetAskDevMock(request: APIRequestContext): Promise<void>
 
 export async function setAskDevCapabilities(
     request: APIRequestContext,
-    state: "ready" | "not_ready" | "disabled",
+    state: DevCapabilitiesState,
 ): Promise<void> {
     const response = await request.post(`${MOCK_SERVER_URL}/__test/dev-capabilities`, {
         data: { state },
@@ -54,7 +54,7 @@ export async function setAskDevEntitlement(
 
 export async function getAskDevRequestCounts(
     request: APIRequestContext,
-): Promise<{ messages: number; conversationsCreated: number }> {
+): Promise<{ messages: number; conversationsCreated: number; lastMessageScope: unknown }> {
     const response = await request.get(`${MOCK_SERVER_URL}/__test/dev-requests`);
     expect(response.ok()).toBe(true);
     return response.json();

--- a/tests/live/ask-dev-acceptance.spec.ts
+++ b/tests/live/ask-dev-acceptance.spec.ts
@@ -351,6 +351,42 @@ test("permanent contextual window continues one grounded run in /dev without dup
         `The claim must cite seeded ${EXPECTED_EVIDENCE_FRAGMENT} evidence.`,
     ).toBeDefined();
     expect(claims[0]!.evidence_ref_ids).toEqual([repositoryEvidence!.evidence_ref_id]);
+
+    // Citation ordinals and detail-panel anchors are DERIVED from the payload,
+    // never assumed (CHAOS-3435). `answer.evidence` carries no ordering
+    // contract -- it is first-seen assembly order across tool results, and the
+    // upstream evidence search deliberately ranks by relevance/source
+    // precedence/freshness, so a cited ref legitimately lands at any index.
+    // The UI numbers a citation by the cited ref's index in `answer.evidence`
+    // (E{index+1}) and scopes the detail-panel id per answer
+    // (`ask-dev-evidence-${answer_id}-${index+1}`, CHAOS-3215 M6).
+    const answerId = answer.answer_id;
+    expect(
+        typeof answerId,
+        "answer.answer_id scopes every citation anchor id (CHAOS-3215 M6).",
+    ).toBe("string");
+    expect(answerId as string).not.toBe("");
+
+    const citedEvidenceRefId = (claims[0]!.evidence_ref_ids as string[])[0]!;
+    const citedEvidenceIndex = evidence.findIndex(
+        (item) => item.evidence_ref_id === citedEvidenceRefId,
+    );
+    expect(
+        citedEvidenceIndex,
+        "The claim's cited evidence ref must resolve inside answer.evidence.",
+    ).toBeGreaterThanOrEqual(0);
+    const evidenceOrdinal = citedEvidenceIndex + 1;
+
+    const citedMetricRefId = (claims[0]!.metric_ref_ids as string[])[0]!;
+    const citedMetricIndex = metrics.findIndex(
+        (metric) => metric.metric_ref_id === citedMetricRefId,
+    );
+    expect(
+        citedMetricIndex,
+        "The claim's cited metric ref must resolve inside answer.metrics.",
+    ).toBeGreaterThanOrEqual(0);
+    const metricOrdinal = citedMetricIndex + 1;
+
     const done = events.find((event) => event.name === "done")!.data;
     expect(done).toMatchObject({ run_id: runId, terminal_kind: "answer" });
 
@@ -362,14 +398,28 @@ test("permanent contextual window continues one grounded run in /dev without dup
             response.request().method() === "GET",
     );
     await permanentAnswer
-        .getByRole("button", { name: "Open evidence citation 1 for claim" })
+        .getByRole("button", {
+            name: `Open evidence citation ${evidenceOrdinal} for claim`,
+            exact: true,
+        })
         .click();
     expect((await expansionResponsePromise).ok(), "Authorized evidence expansion failed.").toBe(
         true,
     );
-    await expect(page.locator("#ask-dev-evidence-1")).toContainText(/available/u);
-    await permanentAnswer.getByRole("button", { name: "Open metric citation 1 for claim" }).click();
-    await expect(page.locator("#ask-dev-metric-1 details")).toHaveAttribute("open", "");
+    // Attribute selector, not `#id`: answer ids are opaque and need not be
+    // valid bare CSS identifiers.
+    await expect(
+        page.locator(`[id="ask-dev-evidence-${answerId as string}-${evidenceOrdinal}"]`),
+    ).toContainText(/available/u);
+    await permanentAnswer
+        .getByRole("button", {
+            name: `Open metric citation ${metricOrdinal} for claim`,
+            exact: true,
+        })
+        .click();
+    await expect(
+        page.locator(`[id="ask-dev-metric-${answerId as string}-${metricOrdinal}"] details`),
+    ).toHaveAttribute("open", "");
     await page.screenshot({
         path: testInfo.outputPath("ask-dev-permanent-window-grounded-answer.png"),
         fullPage: true,

--- a/tests/mocks/devScenario.test.ts
+++ b/tests/mocks/devScenario.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    buildStreamEvents,
+    CLARIFICATION_COPY,
+    NO_ANSWER_OUTCOMES,
+    type DevAnswerScenario,
+} from "./devScenario";
+
+/**
+ * Fixture-fidelity oracle for the Ask Dev mock (CHAOS-3219).
+ *
+ * The browser specs assert what the UI RENDERS. That cannot tell whether the
+ * payload underneath is one production could actually produce — and a mock
+ * that emits an impossible shape makes every test built on it worthless
+ * while still passing. Two rounds of adversarial review found exactly that:
+ * a clarification answer carrying `status: "complete"`, an `unresolved`
+ * outcome beside a completed answer, and an organization-wide resolution
+ * that still named one authorized repository.
+ *
+ * Comments claiming "this matches the projector" are not checkable. These
+ * assertions are. Each one is keyed to the ops code path that produces the
+ * shape, so a fixture edit that drifts from the projector fails here rather
+ * than silently weakening the suite that depends on it.
+ */
+type JsonRecord = Record<string, unknown>;
+
+function answerFor(scenario: DevAnswerScenario): JsonRecord {
+    const events = buildStreamEvents(scenario, "conversation_test", "A question");
+    const completed = events.find((event) => event.event === "answer.completed");
+    expect(completed, `${scenario} produced no answer.completed event`).toBeDefined();
+    return completed!.answer as JsonRecord;
+}
+
+function errorFor(scenario: DevAnswerScenario): JsonRecord {
+    const events = buildStreamEvents(scenario, "conversation_test", "A question");
+    const failed = events.find((event) => event.event === "error");
+    expect(failed, `${scenario} produced no error event`).toBeDefined();
+    return failed!.error as JsonRecord;
+}
+
+describe("Ask Dev mock fidelity — clarification projection", () => {
+    // ops contracts_v2/compat.py `_project_needs_clarification`: status is
+    // hard-coded INSUFFICIENT_EVIDENCE and claims/metrics/evidence/conflicts
+    // are hard-coded empty. `needs_clarification` is one of
+    // EMPTY_CONTENT_OUTCOMES; only `answered`/`answered_with_gaps` may carry
+    // content.
+    it("needs_clarification projects to insufficient_evidence with an ambiguous scope and no content", () => {
+        const answer = answerFor("needs_clarification");
+        expect(answer.status).toBe("insufficient_evidence");
+        expect(answer.direct_summary).toBe(CLARIFICATION_COPY.ambiguous);
+        expect(answer.claims).toEqual([]);
+        expect(answer.metrics).toEqual([]);
+        expect(answer.evidence).toEqual([]);
+
+        const resolution = answer.resolved_scope as JsonRecord;
+        expect(resolution.outcome).toBe("ambiguous");
+        expect(resolution.resolved_scope).toBeNull();
+        // AMBIGUOUS requires candidates (DevScopeResolution.validate_outcome_payload).
+        expect((resolution.candidates as unknown[]).length).toBeGreaterThan(0);
+    });
+
+    // The no-candidates branch (compat.py:427) is the ONLY producer of an
+    // `unresolved` scope row, and it carries the uninterpretable copy.
+    it("scope_unresolved is the no-candidates clarification shape, not a completed answer", () => {
+        const answer = answerFor("scope_unresolved");
+        expect(answer.status).toBe("insufficient_evidence");
+        expect(answer.direct_summary).toBe(CLARIFICATION_COPY.uninterpretable);
+        expect(answer.claims).toEqual([]);
+        expect(answer.metrics).toEqual([]);
+        expect(answer.evidence).toEqual([]);
+
+        const resolution = answer.resolved_scope as JsonRecord;
+        expect(resolution.outcome).toBe("unresolved");
+        expect(resolution.resolved_scope).toBeNull();
+        expect(resolution.candidates).toEqual([]);
+        // requested_scope comes from the same `_build_resolved_scope` call as
+        // resolved (compat.py:404, :431), which with no subject is an
+        // organization scope — not the caller's repository scope.
+        const requested = resolution.requested_scope as JsonRecord;
+        expect(requested.direct_scope).toBe("organization");
+        expect(requested.repositories).toEqual([]);
+        expect(requested.entity_refs).toEqual([]);
+    });
+});
+
+describe("Ask Dev mock fidelity — organization fallback", () => {
+    // `_build_resolved_scope` builds the no-subject scope from scratch with
+    // exactly seven fields; `authorized_repository_ids` and
+    // `authorized_entity_ids` are then derived FROM that scope
+    // (compat.py:325-326). Every assertion here failed at some point during
+    // review against a fixture that merely stamped the enum on.
+    it("widens the whole resolution, not just the outcome enum", () => {
+        const answer = answerFor("scope_organization_fallback");
+        const resolution = answer.resolved_scope as JsonRecord;
+        expect(resolution.outcome).toBe("organization_fallback");
+
+        for (const key of ["resolved_scope", "requested_scope"] as const) {
+            const scope = resolution[key] as JsonRecord;
+            expect(scope.direct_scope, `${key}.direct_scope`).toBe("organization");
+            expect(scope.repositories, `${key}.repositories`).toEqual([]);
+            expect(scope.entity_refs, `${key}.entity_refs`).toEqual([]);
+            expect(scope.team_ids, `${key}.team_ids`).toEqual([]);
+            expect(scope.comparison_range, `${key}.comparison_range`).toBeNull();
+            expect(scope.surface_context, `${key}.surface_context`).toBeNull();
+        }
+
+        // The rendered UI cannot catch these: `scopeCoverageLabel` returns
+        // "Organization" for ANY non-repository scope and never reads the
+        // authorization lists, so a browser assertion on the scope row is
+        // vacuous here (codex adversarial review round 4). Assert the payload.
+        expect(resolution.authorized_repository_ids).toEqual([]);
+        expect(resolution.authorized_entity_ids).toEqual([]);
+
+        // Claim validity has to widen with the scope too, or the answer
+        // asserts organization-wide reach with repository-scoped grounding.
+        for (const claim of answer.claims as JsonRecord[]) {
+            expect((claim.validity_scope as JsonRecord).direct_scope).toBe("organization");
+        }
+    });
+});
+
+describe("Ask Dev mock fidelity — no-answer outcomes", () => {
+    // These five never become a DevAnswer at all: the projector turns each
+    // into a DevError whose code/retryable come from `_ERROR_OUTCOME_CODES`
+    // and whose text comes from the server-owned canonical tables.
+    for (const outcome of NO_ANSWER_OUTCOMES) {
+        it(`${outcome.outcome} projects to a ${outcome.code} DevError, never an answer`, () => {
+            const events = buildStreamEvents(outcome.scenario, "conversation_test", "A question");
+            expect(events.some((event) => event.event === "answer.completed")).toBe(false);
+
+            const error = errorFor(outcome.scenario);
+            expect(error.code).toBe(outcome.code);
+            expect(error.retryable).toBe(outcome.retryable);
+            expect(error.safe_message).toBe(outcome.safeMessage);
+            expect(error.remediation).toEqual([...outcome.remediation]);
+        });
+    }
+});

--- a/tests/mocks/devScenario.ts
+++ b/tests/mocks/devScenario.ts
@@ -32,20 +32,114 @@ function clone<T>(value: T): T {
 
 const OUTCOME_TABLE_KEYS = ASK_DEV_OUTCOME_TABLE.map((entry) => entry.key);
 
+/**
+ * The five `dev_answer.v2` no-answer outcomes as they reach a v1 client.
+ *
+ * `PublicOutcome` values in `NO_ANSWER_OUTCOMES` never become a `DevAnswer`:
+ * the projector turns each into a `DevError` whose code and `retryable` flag
+ * come from `_ERROR_OUTCOME_CODES` and whose text comes from the server-owned
+ * `CANONICAL_NO_ANSWER_COPY` / `CANONICAL_NO_ANSWER_REMEDIATION` tables
+ * (ops contracts_v2/compat.py:209-214, :484-494; validators.py). Producer
+ * text is replaced wholesale, never trimmed or re-emitted, so these sentences
+ * are the entire user-visible artifact of four of the eight outcomes.
+ *
+ * What the specs built on this table DO prove: the UI renders the server's
+ * `safe_message` verbatim (none of these sentences exists anywhere in web
+ * `src/`, so a client-side substitution fails the assertion), each outcome
+ * renders its own distinct copy rather than one reused apology, and the
+ * retry affordance follows `retryable`.
+ *
+ * What they DO NOT prove: that this table still matches ops. These strings
+ * are a HAND-PINNED MIRROR — the canonical tables are Python constants in
+ * `validators.py` and are not exported into any artifact web pins, so
+ * nothing here detects ops-side drift. Compared to the ops source by script
+ * on 2026-08-06 — all five entries match on both copy and remediation, and
+ * the mirrored key set equals the ops key set — but that check has no
+ * automated successor. Closing the gap needs the copy published as a pinned
+ * contract vocabulary artifact (as `internal_prose_denylist.v1.json` already
+ * is); tracked in CHAOS-3471.
+ */
+export const NO_ANSWER_OUTCOMES = [
+    {
+        outcome: "not_found",
+        scenario: "no_answer_not_found",
+        code: "scope_not_found",
+        retryable: false,
+        safeMessage: "No matching subject was found for this question.",
+        remediation: ["Check the name and try again."],
+    },
+    {
+        outcome: "temporarily_unavailable",
+        scenario: "no_answer_temporarily_unavailable",
+        code: "source_unavailable",
+        retryable: true,
+        safeMessage: "This answer is temporarily unavailable. Please try again shortly.",
+        remediation: ["Try the question again in a few minutes."],
+    },
+    {
+        outcome: "unsupported",
+        scenario: "no_answer_unsupported",
+        code: "feature_not_enabled",
+        retryable: false,
+        safeMessage: "This question is not supported yet.",
+        remediation: ["Try a status, health, or metric question instead."],
+    },
+    {
+        outcome: "denied",
+        scenario: "no_answer_denied",
+        code: "forbidden",
+        retryable: false,
+        safeMessage: "You do not have access to ask about this.",
+        remediation: ["Ask an administrator for access to this area."],
+    },
+    {
+        outcome: "failed",
+        scenario: "no_answer_failed",
+        code: "internal_error",
+        retryable: false,
+        safeMessage: "Something went wrong while preparing this answer.",
+        remediation: ["Try the question again."],
+    },
+] as const;
+
+type NoAnswerScenario = (typeof NO_ANSWER_OUTCOMES)[number]["scenario"];
+
+const NO_ANSWER_BY_SCENARIO = new Map<string, (typeof NO_ANSWER_OUTCOMES)[number]>(
+    NO_ANSWER_OUTCOMES.map((entry) => [entry.scenario, entry]),
+);
+
 export type DevAnswerScenario =
     | (typeof ASK_DEV_OUTCOME_TABLE)[number]["key"]
     | "needs_clarification"
+    | "degraded_sources_only"
+    | "leaky_prose"
+    | "full_sections"
+    | "refused_with_grounding"
+    | "scope_unresolved"
+    | "scope_organization_fallback"
+    | "scope_filtered"
+    | "scope_inherited"
     | "forbidden_or_not_found_scope"
     | "scope_forbidden_error"
-    | "source_unavailable_error";
+    | "source_unavailable_error"
+    | NoAnswerScenario;
 
 const SCENARIO_MARKER = /^\[\[ask-dev:([a-z_]+)\]\]\s*/u;
 const KNOWN_SCENARIOS: ReadonlySet<string> = new Set<DevAnswerScenario>([
     ...OUTCOME_TABLE_KEYS,
     "needs_clarification",
+    "degraded_sources_only",
+    "leaky_prose",
+    "full_sections",
+    "refused_with_grounding",
+    "scope_unresolved",
+    "scope_organization_fallback",
+    "scope_filtered",
+    "scope_inherited",
     "forbidden_or_not_found_scope",
     "scope_forbidden_error",
     "source_unavailable_error",
+    ...NO_ANSWER_OUTCOMES.map((entry) => entry.scenario),
 ]);
 
 export function parseScenario(question: string): {
@@ -56,6 +150,114 @@ export function parseScenario(question: string): {
     const scenario =
         match && KNOWN_SCENARIOS.has(match[1]!) ? (match[1] as DevAnswerScenario) : "complete";
     return { scenario, visibleQuestion: match ? question.slice(match[0].length) : question };
+}
+
+/**
+ * Server-owned clarification copy, mirroring ops
+ * `preflight_outcomes.CLARIFICATION_COPY`.
+ *
+ * `needs_clarification` is the one outcome whose `frame.direct_answer` is NOT
+ * producer-authored: the preflight supplies these exact sentences, and the
+ * v2->v1 projector passes them through unchanged. An earlier draft of the
+ * clarification scenario invented its own wording, which meant the browser
+ * test asserted a sentence production never sends (codex adversarial review,
+ * HIGH) — the same defect class row W2 was created to fix.
+ *
+ * Hand-pinned, with the same limitation as `NO_ANSWER_OUTCOMES`: these are
+ * Python constants exported into no artifact web pins, so this mirror cannot
+ * detect ops-side drift. Compared to the ops source by script on 2026-08-06
+ * (both keys byte-identical); tracked in CHAOS-3471 with the no-answer
+ * tables.
+ */
+export const CLARIFICATION_COPY = {
+    // Mirrors the FULL ops key set, not only the keys these scenarios use.
+    // A partial mirror beside a "matches ops" comment overstates parity and
+    // leaves a canonical branch unmirrored (codex adversarial review round 2,
+    // MEDIUM). `not_found_close_matches` belongs to the CHAOS-3366 no-match
+    // path and is not exercised by any scenario here; it is mirrored so the
+    // key sets are equal and drift in it is visible to a reader.
+    not_found_close_matches:
+        "I could not find an authorized entity of that kind with that name. " +
+        "Here are the closest matches -- please ask again naming one of them.",
+    ambiguous:
+        "More than one authorized entity matches the name in this question. " +
+        "Please ask again naming exactly which one you mean.",
+    uninterpretable:
+        "This question could not be interpreted confidently. Please rephrase " +
+        "it, naming the project, repository, or team you are asking about.",
+} as const;
+
+/**
+ * The candidate entity refs the `needs_clarification` scenario offers.
+ *
+ * Exported so a spec asserting what "Use this scope" committed reads the
+ * same labels the mock served instead of restating them — a restated label
+ * lets the mock drift while the assertion still passes.
+ */
+export const CLARIFICATION_CANDIDATE_REFS = [
+    {
+        entity_id: "repo_dev_health",
+        entity_type: "repository",
+        display_label: "dev-health (this repository)",
+        repository_id: null,
+    },
+    {
+        entity_id: "repo_dev_health_web",
+        entity_type: "repository",
+        display_label: "dev-health-web",
+        repository_id: null,
+    },
+] as const;
+
+/**
+ * Rewrites a repository-shaped scope from the canonical fixture into the
+ * organization-shaped scope ops builds when there is no committed subject
+ * (`_build_resolved_scope` returns a DirectScope.ORGANIZATION DevScope for a
+ * frame with `subject_ref is None`).
+ *
+ * The surface_context refs must be cleared too: `validateScope` requires a
+ * repository direct_scope while repository refs are attached, so a scope that
+ * changed only `direct_scope` is rejected outright as an invalid stream
+ * event (codex adversarial review round 2, HIGH).
+ */
+function toOrganizationScope(scope: JsonRecord): JsonRecord {
+    const organizationScope = clone(scope);
+    organizationScope.direct_scope = "organization";
+    organizationScope.repositories = [];
+    organizationScope.entity_refs = [];
+    // `team_ids` is empty too: the no-subject branch builds the DevScope from
+    // scratch with empty repositories, entity_refs AND team_ids — it does not
+    // carry the requested scope's team filter forward.
+    organizationScope.team_ids = [];
+    // `_build_resolved_scope` constructs the no-subject scope from scratch
+    // with only schema_version, organization_id, direct_scope, repositories,
+    // entity_refs, team_ids and time_range. `comparison_range` and
+    // `surface_context` are never passed, so they take their None defaults —
+    // carrying the repository fixture's values forward produced a payload
+    // that is schema-valid but that production cannot emit (codex
+    // adversarial review round 4).
+    organizationScope.comparison_range = null;
+    organizationScope.surface_context = null;
+    return organizationScope;
+}
+
+/**
+ * Recomputes a resolution's authorization lists FROM its committed scope, the
+ * way the projector does (`authorized_repository_ids=list(resolved.repositories)`,
+ * `authorized_entity_ids=[ref.entity_id for ref in resolved.entity_refs]`,
+ * compat.py:325-326).
+ *
+ * Derived rather than hardcoded so it cannot drift from the scope beside it.
+ * Leaving the repository-scoped lists in place while widening the scope
+ * produced a resolution that claimed organization-wide reach while still
+ * naming one authorized repository — a contradiction a widening test must be
+ * able to tell apart from the real thing (codex adversarial review round 3).
+ */
+function syncAuthorizedIds(resolution: JsonRecord, committedScope: JsonRecord): void {
+    resolution.authorized_repository_ids = clone(committedScope.repositories ?? []);
+    resolution.authorized_entity_ids = ((committedScope.entity_refs ?? []) as JsonRecord[]).map(
+        (ref) => ref.entity_id,
+    );
 }
 
 let answerCounter = 0;
@@ -134,8 +336,44 @@ function buildAnswer(
 
     switch (scenario) {
         case "needs_clarification": {
-            base.direct_summary =
-                "More than one match was found for this question. Choose the one you meant.";
+            // CHAOS-3219 W2. This scenario previously left the canonical
+            // fixture's `status: "complete"` in place while rewriting the
+            // scope row -- a payload production cannot emit, so the e2e
+            // assertions on it were proving nothing about the real product.
+            //
+            // The authoritative shape comes from the v2->v1 projector
+            // (ops contracts_v2/compat.py `_project_needs_clarification`).
+            // What the projector GUARANTEES: `status` is
+            // `insufficient_evidence`, `claims`/`metrics`/`evidence`/
+            // `conflicts` are all hard-coded empty, and the scope row
+            // carries `ambiguous` when the frame has clarification
+            // candidates (`unresolved` when it does not — see the
+            // `scope_unresolved` scenario). `answered`/`answered_with_gaps`
+            // are the only outcomes that may carry content.
+            //
+            // What is this scenario's own CHOICE, not a projector guarantee:
+            // the zeroed coverage and the empty warnings/follow-ups. Those
+            // three pass through from the frame (`coverage=_as_v1(...)`,
+            // `warnings=list(frame.limitations)`,
+            // `suggested_follow_up_questions=list(frame.safe_follow_up_
+            // questions)`), so a clarification answer MAY legitimately carry
+            // them. Zeroed coverage is chosen here because no source plan
+            // runs for a subject that was never committed; it is one valid
+            // instance of the shape, not the only one.
+            base.status = "insufficient_evidence";
+            base.direct_summary = CLARIFICATION_COPY.ambiguous;
+            base.claims = [];
+            base.evidence = [];
+            base.metrics = [];
+            base.warnings = [];
+            base.suggested_follow_up_questions = [];
+            (base.coverage as JsonRecord) = {
+                ...(base.coverage as JsonRecord),
+                available_source_count: 0,
+                required_source_count: 0,
+                unavailable_required_sources: [],
+                stale_required_sources: [],
+            };
             const resolvedScope = base.resolved_scope as JsonRecord;
             resolvedScope.outcome = "ambiguous";
             resolvedScope.resolved_scope = null;
@@ -143,24 +381,215 @@ function buildAnswer(
             resolvedScope.authorized_entity_ids = [];
             resolvedScope.candidates = [
                 {
-                    entity_ref: {
-                        entity_id: "repo_dev_health",
-                        entity_type: "repository",
-                        display_label: "dev-health (this repository)",
-                        repository_id: null,
-                    },
+                    entity_ref: clone(CLARIFICATION_CANDIDATE_REFS[0]) as JsonRecord,
                     reason: `Matches "${visibleQuestion.trim().slice(0, 40)}" by name`,
                 },
                 {
-                    entity_ref: {
-                        entity_id: "repo_dev_health_web",
-                        entity_type: "repository",
-                        display_label: "dev-health-web",
-                        repository_id: null,
-                    },
+                    entity_ref: clone(CLARIFICATION_CANDIDATE_REFS[1]) as JsonRecord,
                     reason: "Also matches by name",
                 },
             ];
+            return base;
+        }
+        case "full_sections": {
+            // CHAOS-3219 W13. The canonical fixture carries no conflicts and
+            // no warnings, so no default-tier test had ever rendered an
+            // answer with every section present — and the one ordering test
+            // that exists compares just two of them. TRD §16 fixes the
+            // reading order (scope -> coverage -> findings -> conflicts ->
+            // metrics -> evidence -> limitations -> follow-ups) and that is
+            // the evidence-first hierarchy CHAOS-3291 was about.
+            const evidence = base.evidence as JsonRecord[];
+            const secondEvidence = clone(evidence[0]!) as JsonRecord;
+            secondEvidence.evidence_ref_id = "ev_02";
+            secondEvidence.display_label = "Pull request 452";
+            secondEvidence.entity_id = "452";
+            base.evidence = [evidence[0]!, secondEvidence];
+            base.conflicts = [
+                {
+                    summary: "Two sources disagree about the merge date.",
+                    evidence_ref_ids: ["ev_01", "ev_02"],
+                },
+            ];
+            base.warnings = ["Deployment evidence covers only part of the window."];
+            return base;
+        }
+        case "refused_with_grounding": {
+            // CHAOS-3219 W12. CHAOS-3377's client-side backstop: a row
+            // labelled `refused` that nonetheless carries material grounding
+            // is a self-contradiction, so the narrative is WITHHELD and the
+            // pill reads "Inconsistent result" — never relabelled "Answered"
+            // over the rejected prose. Structured metrics and evidence are
+            // unaffected and must still render. Regression-covered at the
+            // unit tier only until now.
+            base.status = "refused";
+            base.direct_summary = "Delivery improved by twelve items this period.";
+            return base;
+        }
+        case "scope_unresolved":
+        case "scope_organization_fallback":
+        case "scope_filtered":
+        case "scope_inherited": {
+            // CHAOS-3219 W14. Four of the seven pinned ScopeResolutionOutcome
+            // values had no rendered-surface assertion at all — they were
+            // enumerated as "documented excluded" in the vocabulary spec,
+            // which records the gap rather than closing it. Two of them
+            // (`organization_fallback`, `unresolved`) are also
+            // NEVER_ATTESTABLE_TOKENS and sit directly on the "zero silent
+            // organization widening" launch threshold.
+            //
+            // Each outcome is built to the shape the contract actually
+            // requires rather than by stamping the enum onto the happy-path
+            // fixture: `unresolved` sits on the no-resolved-scope side of the
+            // partition, and `organization_fallback` must carry an
+            // organization-scoped commit (client `validateScopeResolution`
+            // mirrors ops `DevScopeResolution.validate_outcome`). Building
+            // them any other way produces a payload the browser client
+            // rejects outright — which is how the first draft of this
+            // scenario was caught.
+            const outcome = scenario.slice("scope_".length);
+            const resolvedScope = base.resolved_scope as JsonRecord;
+            resolvedScope.outcome = outcome;
+            resolvedScope.candidates = [];
+            if (outcome === "unresolved") {
+                // `unresolved` is NOT reachable beside a completed answer.
+                // The only producer is `_project_needs_clarification` taking
+                // its no-candidates branch (compat.py:427) — the question
+                // could not be interpreted, so nothing ran. That path emits
+                // `insufficient_evidence` with empty content and the
+                // server-owned "uninterpretable" clarification sentence. An
+                // earlier draft stamped the enum onto the happy-path fixture
+                // and so asserted an answer shape ops cannot produce; that
+                // is the same defect row W2 exists to fix (codex adversarial
+                // review, HIGH).
+                base.status = "insufficient_evidence";
+                base.direct_summary = CLARIFICATION_COPY.uninterpretable;
+                base.claims = [];
+                base.metrics = [];
+                base.evidence = [];
+                base.conflicts = [];
+                base.warnings = [];
+                base.suggested_follow_up_questions = [];
+                (base.coverage as JsonRecord) = {
+                    ...(base.coverage as JsonRecord),
+                    available_source_count: 0,
+                    required_source_count: 0,
+                    unavailable_required_sources: [],
+                    stale_required_sources: [],
+                };
+                // `requested_scope` must be organization-shaped too. The
+                // projector sets BOTH requested and resolved from the same
+                // `_build_resolved_scope(...)` result (compat.py:404, :431),
+                // and with no subject that result is an organization scope.
+                // Leaving the happy-path repository requested_scope produced
+                // a contradictory pairing — an unresolved subject beside a
+                // committed repository request — which is precisely the
+                // silent-widening shape these rows exist to detect (codex
+                // adversarial review round 2, HIGH).
+                resolvedScope.requested_scope = toOrganizationScope(
+                    resolvedScope.requested_scope as JsonRecord,
+                );
+                resolvedScope.resolved_scope = null;
+                resolvedScope.authorized_repository_ids = [];
+                resolvedScope.authorized_entity_ids = [];
+            } else if (outcome === "organization_fallback") {
+                // An organization commit is more than a changed enum: the
+                // scope's own surface_context must agree with it. With a
+                // repository entity ref still attached, `validateScope`
+                // requires direct_scope "repository", so the payload is
+                // rejected as an invalid stream event. Clearing the refs
+                // moves it onto the organization-route branch, which
+                // `diagnose_overview` (the fixture's route) satisfies.
+                const organizationScope = toOrganizationScope(
+                    resolvedScope.resolved_scope as JsonRecord,
+                );
+                resolvedScope.resolved_scope = organizationScope;
+                resolvedScope.requested_scope = clone(organizationScope);
+                syncAuthorizedIds(resolvedScope, organizationScope);
+                // The ANSWER CONTENT has to widen with the scope. Leaving
+                // repository-scoped claim validity beside an organization
+                // commit is the contradictory pairing a widening test must
+                // be able to tell apart from the real thing (codex round 2,
+                // HIGH).
+                for (const claim of base.claims as JsonRecord[]) {
+                    claim.validity_scope = clone(organizationScope);
+                }
+            }
+            return base;
+        }
+        case "leaky_prose": {
+            // CHAOS-3219 W5. `safeCopy` guards five separate prose fields,
+            // but the default suite only ever checked the failed-run alert
+            // and the status/scope pills, so no test drove a poisoned
+            // payload through direct_summary, claim text, conflict summary,
+            // warnings or follow-ups.
+            //
+            // Each poisoned field carries a DIFFERENT denylisted token, so a
+            // guard applied to only one field cannot satisfy the whole
+            // scenario. None of the tokens is in NEVER_ATTESTABLE_TOKENS --
+            // those would additionally flip the answer into the no-match
+            // presentation and change what is being measured.
+            //
+            // The clean fields carry the guard's three documented false-
+            // positive shapes and must survive verbatim: word-boundary
+            // matching is what separates `factual_completion` from
+            // `actual_completion` and `cannot_ready` from `not_ready`, and
+            // shape matching is what separates `prev1_state` from a real
+            // `ev1_<40 hex>` handle. Without these, a guard that widened to
+            // bare substring matching would still pass every assertion above.
+            const evidence = base.evidence as JsonRecord[];
+            const secondEvidence = clone(evidence[0]!) as JsonRecord;
+            secondEvidence.evidence_ref_id = "ev_02";
+            secondEvidence.display_label = "Pull request 452";
+            secondEvidence.entity_id = "452";
+            base.evidence = [evidence[0]!, secondEvidence];
+
+            const claims = base.claims as JsonRecord[];
+            const poisonedClaim = clone(claims[0]!) as JsonRecord;
+            poisonedClaim.claim_id = "claim_poisoned";
+            poisonedClaim.text = "Delivery slowed because internal_error was reported upstream.";
+            const cleanClaim = clone(claims[0]!) as JsonRecord;
+            cleanClaim.claim_id = "claim_clean";
+            cleanClaim.text = "Completion is computed by the prev1_state accessor.";
+            base.claims = [poisonedClaim, cleanClaim];
+
+            base.direct_summary =
+                "The scope resolved to insufficient_evidence before the metrics were read.";
+            base.conflicts = [
+                {
+                    summary: "Two sources disagree because feature_not_enabled was returned.",
+                    evidence_ref_ids: ["ev_01", "ev_02"],
+                },
+            ];
+            base.warnings = [
+                "Provider health degraded after source_unavailable was raised.",
+                "Coverage was computed from factual_completion.ts inputs.",
+            ];
+            base.suggested_follow_up_questions = [
+                "Should the not_ready pipeline be retried?",
+                "Should the cannot_ready helper be reviewed?",
+            ];
+            return base;
+        }
+        case "degraded_sources_only": {
+            // CHAOS-3219 W4. `degraded_required_sources` is the third
+            // required-source failure state in DevCoverage, and it blocks a
+            // `complete` answer on its own. No scenario carried it, so the
+            // suite never rendered an answer whose ONLY coverage problem was
+            // degradation — the shape that used to display no coverage block
+            // at all.
+            base.status = "degraded";
+            base.direct_summary =
+                "Delivery flow improved, but one required source answered in a degraded state.";
+            (base.coverage as JsonRecord) = {
+                ...(base.coverage as JsonRecord),
+                available_source_count: 11,
+                required_source_count: 12,
+                degraded_required_sources: ["work_graph"],
+                stale_required_sources: [],
+                unavailable_required_sources: [],
+            };
+            base.warnings = ["Work graph answered in a degraded state for part of the window."];
             return base;
         }
         case "forbidden_or_not_found_scope": {
@@ -246,6 +675,23 @@ export function buildStreamEvents(
     push({ event: "progress", progress: "resolving_scope" });
     push({ event: "progress", progress: "checking_evidence" });
 
+    const noAnswer = NO_ANSWER_BY_SCENARIO.get(scenario);
+    if (noAnswer) {
+        push({
+            event: "error",
+            error: {
+                code: noAnswer.code,
+                remediation: [...noAnswer.remediation],
+                request_id: randomUUID(),
+                retryable: noAnswer.retryable,
+                safe_message: noAnswer.safeMessage,
+                schema_version: "dev_error.v1",
+            },
+        });
+        push({ event: "done", terminal_kind: "error" });
+        return events;
+    }
+
     if (scenario === "scope_forbidden_error" || scenario === "source_unavailable_error") {
         const error =
             scenario === "scope_forbidden_error"
@@ -284,12 +730,31 @@ export function encodeSseFrames(events: readonly JsonRecord[]): string {
 
 // --- Capabilities (shared mutable state; see module comment) ---------------
 
-export type DevCapabilitiesState = "ready" | "not_ready" | "disabled";
+// `not_ready` is retained as an alias for `missing_credentials` so the
+// pre-existing specs and helper calls keep working; the other members are the
+// real dev_capabilities.v1 `readiness` enum, four of whose five values had no
+// default-CI coverage (CHAOS-3219 W14).
+export const NOT_READY_READINESS_VALUES = [
+    "missing_credentials",
+    "unsupported_model",
+    "degraded",
+] as const;
+
+export type DevCapabilitiesState =
+    "ready" | "not_ready" | "disabled" | (typeof NOT_READY_READINESS_VALUES)[number];
+
+const CAPABILITIES_STATES: ReadonlySet<string> = new Set<DevCapabilitiesState>([
+    "ready",
+    "not_ready",
+    "disabled",
+    ...NOT_READY_READINESS_VALUES,
+]);
+
 let capabilitiesState: DevCapabilitiesState = "ready";
 
 export function setDevCapabilitiesState(state: string): boolean {
-    if (state !== "ready" && state !== "not_ready" && state !== "disabled") return false;
-    capabilitiesState = state;
+    if (!CAPABILITIES_STATES.has(state)) return false;
+    capabilitiesState = state as DevCapabilitiesState;
     return true;
 }
 
@@ -298,12 +763,13 @@ export function getDevCapabilitiesResponse(): JsonRecord {
     if (capabilitiesState === "disabled") {
         return { ...base, ask_dev: false, can_read: false, readiness: "disabled" };
     }
-    if (capabilitiesState === "not_ready") {
+    if (capabilitiesState !== "ready") {
         return {
             ...base,
             ask_dev: true,
             can_read: true,
-            readiness: "missing_credentials",
+            readiness:
+                capabilitiesState === "not_ready" ? "missing_credentials" : capabilitiesState,
             administrator_safe_failure_reason:
                 "Ask Dev is enabled, but an administrator needs to finish provider setup.",
         };
@@ -327,6 +793,12 @@ const conversations = new Map<string, StoredConversation>();
 // guessing at network timing.
 let messagesRequestCount = 0;
 let conversationsCreatedCount = 0;
+// The scope actually SUBMITTED with the most recent message. Displayed state
+// is not proof that the next request carries the scope the user chose: a
+// defect that renders the chosen candidate while still sending the old (or an
+// organization-wide) scope would satisfy every display assertion (codex
+// adversarial review, HIGH). Recorded here so a spec can assert on the wire.
+let lastMessageScope: unknown = null;
 
 export function recordMessagesRequest(): void {
     messagesRequestCount += 1;
@@ -336,14 +808,23 @@ export function recordConversationCreated(): void {
     conversationsCreatedCount += 1;
 }
 
-export function getDevRequestCounts(): { messages: number; conversationsCreated: number } {
-    return { messages: messagesRequestCount, conversationsCreated: conversationsCreatedCount };
+export function getDevRequestCounts(): {
+    messages: number;
+    conversationsCreated: number;
+    lastMessageScope: unknown;
+} {
+    return {
+        messages: messagesRequestCount,
+        conversationsCreated: conversationsCreatedCount,
+        lastMessageScope,
+    };
 }
 
 export function resetDevMockState(): void {
     conversations.clear();
     messagesRequestCount = 0;
     conversationsCreatedCount = 0;
+    lastMessageScope = null;
     capabilitiesState = "ready";
     answerCounter = 0;
     runCounter = 0;
@@ -448,6 +929,7 @@ export function applyMessage(
     const stored = conversations.get(conversationId);
     if (!stored) return null;
     recordMessagesRequest();
+    lastMessageScope = scope;
 
     const existing = stored.seenClientMessageIds.get(clientMessageId);
     if (existing) {

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -747,6 +747,16 @@ const MOCK_ORG_ENTITLEMENTS = {
         // CHAOS-3287 Playwright coverage can exercise the real /dev route
         // and persistent window gate, not a stubbed-out "unavailable" state.
         ask_dev: true,
+        // CHAOS-3219 W3. An Ask-Dev-enabled organization is provisioned with
+        // BOTH overrides -- the acceptance seeder
+        // (ops prepare_ask_dev_acceptance.py) turns on `ask_dev` and
+        // `ask_dev_contextual_entrypoints` together. Leaving this one unset
+        // left the default e2e org in a shape the seeded product does not
+        // have, which silently disabled every proposed-context code path
+        // (AskDevProvider.setProposedContext returns early without it) --
+        // including clarification candidate selection, whose CTA renders
+        // regardless.
+        ask_dev_contextual_entrypoints: true,
     },
     features_override: null,
     limits_override: null,


### PR DESCRIPTION
# CHAOS-3219 Phase 4 (web): close the default web CI Ask Dev coverage delta

Closes the Wave 3.1 manifest's deferred `gate.web-default-ci` row, fixes
CHAOS-3435, and fixes two defects found while doing it.

## ⚠️ Product-behavior change in this PR — reviewer please confirm

**CHAOS-3470: candidate selection is no longer gated on
`ask_dev_contextual_entrypoints`.**

An organization with `ask_dev` enabled and `ask_dev_contextual_entrypoints`
disabled previously got a clarification answer whose "Use this scope" button
rendered and did **nothing** — no state change, no error, no feedback. The
candidate block in `AskDevAnswer.tsx` has no feature check, but
`selectProposedEntity` routed through the flag-gated `setProposedContext`,
which returned early. The answer tells the user "Choose or remove the
proposed context before asking the next question" and choosing was inert, so
a clarification turn had no in-product resolution.

Ruling (team-lead): the flag gates **surface entry points** — launchers and
typed context a route offers before the user has asked anything. A
clarification candidate is not one; it arrives inside an answer the
organization was entitled to receive, so committing it is answer semantics.

`AskDevProvider` now splits the path: `applyProposedContext` holds the
unconditional approval check and the state write; `setProposedContext` (the
surface path) keeps the entitlement guard in front of it;
`selectProposedEntity` calls `applyProposedContext` directly. Entry-point
gating is unchanged, and a test asserts that explicitly.

**This does not widen the trust boundary.** The approval check was never
inside the flag guard, and authorization is enforced server-side against the
session's `org_id` — every catalog lookup in `ScopeResolutionService.resolve`
is org-scoped (`scope_service.py:632-633`, `:798`). The candidate refs come
from the org's own answer. The flag gates a UX surface, never authorization.
If it had been carrying a security meaning, this change would be wrong.

Veto this and the alternative is gating the CTA, which needs server-side copy
changes and still leaves the clarification loop broken for a legal
configuration.

## What this closes

Wave 3.1 manifest row `gate.web-default-ci` claimed default Playwright CI
covers "answer-v2 outcomes, subjects, rendering, and window//dev semantic
equivalence". The audit re-deriving that claim is committed as
`docs/audits/ask-dev-web-default-ci-delta.md` (the original Phase-0b artifact
was lost). Its central correction:

**Web consumes `dev_answer.v1` only.** `dev_answer.v2` lives in ops and is
projected down before it reaches the wire; `public_outcome` appears zero
times in web `src/`. So "answer-v2 outcome coverage" means coverage of the
projected shapes — three of eight `PublicOutcome` values arrive as a
`DevAnswer`, five as a `DevError`. The default mock emitted **2 of 24
`DevErrorCode`s**, so four of the eight outcomes had no user-visible
assertion anywhere in web.

All 14 rows of the MISSING list are implemented. Two notable ones were
**false coverage rather than absent coverage**: the clarification scenario
served `status: "complete"`, a payload production cannot emit, and the
candidate CTA was clicked with nothing asserted afterwards.

## Defects found and fixed here

- **CHAOS-3469** — `degraded_required_sources` was never rendered, so an
  answer degraded only in that dimension showed no coverage block at all.
  Three sites, one class: the `showCoverage` predicate, the block body, and
  `validateAskDevSemanticInvariants` (which mirrors ops' `fully_covered` and
  was accepting a `complete` answer ops cannot emit). Closed with a closure
  argument rather than a fourth patch — web reasons about coverage in exactly
  two files.
- **CHAOS-3470** — above.

## Defects found and filed, not fixed here

- **CHAOS-3471** — the canonical no-answer and clarification copy live in
  Python constants exported into no artifact web pins, so web's mirrors
  cannot detect ops drift.
- **CHAOS-3474** — `DevError.remediation` is never rendered; no-answer
  outcomes tell the user what failed but not what to do.
- **CHAOS-3477** — `public/runtime-config.js` is tracked but generated;
  running the e2e suite makes any blanket `git add` commit test-mode public
  config.
- **CHAOS-3478** — candidate selection has no client-side binding to the
  answer's candidate list (pre-existing; server-side reauthorization is the
  enforcement boundary).

## Verification

Every row has a positive and a negative control. Four mutations were run,
each restored with the restore verified by checksum:

- hardcoding the evidence citation ordinal → killed exactly the new unit
  test, other 35 green;
- hardcoding the metric citation ordinal → same, for the metric arm;
- hiding the coverage block on the compact surface only → killed the
  cross-surface equivalence clause on all five statuses **while both
  pre-existing continuity tests stayed green**;
- removing the provider's surface-entry guard → killed the new
  entitlement-split test (and demonstrably did **not** kill the earlier
  version of that test, which is why it was replaced).

Four adversarial review rounds; every medium-and-above finding was validated
with evidence before being fixed, and one was partially refuted on its stated
mechanism while its substance was accepted.

Gate: tsc clean, `eslint src` clean, vitest 3694 passing, full Playwright
default suite green.

## Note for reviewers running this locally

The ask-dev specs share mock-server global state; CI pins `workers: 1`. Run
them with `--workers=1` or you will see false reds in
continuity/not_ready/retry.
