### PR TITLE
ci: remove the integration placeholder from the required test gate (CHAOS-3483)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,21 +146,6 @@ jobs:
                   if-no-files-found: error
                   retention-days: 90
 
-    integration:
-        name: Integration tests
-        needs: [changes]
-        if: needs.changes.outputs.code == 'true'
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
-              with:
-                  node-version: 22
-                  cache: pnpm
-            - run: pnpm install --frozen-lockfile
-            - run: bash ci/run_tests.sh integration
-
     e2e-default:
         name: E2E tests (default, shard ${{ matrix.shard }}/3)
         needs: [changes]
@@ -251,7 +236,7 @@ jobs:
 
     test:
         name: test
-        needs: [changes, format, quality, build, unit, integration, e2e-default, e2e-onboarding]
+        needs: [changes, format, quality, build, unit, e2e-default, e2e-onboarding]
         if: always()
         runs-on: ubuntu-latest
         steps:
@@ -266,7 +251,7 @@ jobs:
             - name: Check general test stages
               if: needs.changes.result == 'success' && needs.changes.outputs.code == 'true'
               run: |
-                  if [[ "${{ needs.format.result }}" != 'success' || "${{ needs.quality.result }}" != 'success' || "${{ needs.build.result }}" != 'success' || "${{ needs.unit.result }}" != 'success' || "${{ needs.integration.result }}" != 'success' ]]; then
+                  if [[ "${{ needs.format.result }}" != 'success' || "${{ needs.quality.result }}" != 'success' || "${{ needs.build.result }}" != 'success' || "${{ needs.unit.result }}" != 'success' ]]; then
                     exit 1
                   fi
             - name: Check E2E test stages

--- a/README.md
+++ b/README.md
@@ -91,25 +91,24 @@ Copy `.env.example` to `.env.local` and configure as needed.
 
 ## Scripts
 
-| Script                     | Description                                                   |
-| -------------------------- | ------------------------------------------------------------- |
-| `npm run dev`              | Start development server                                      |
-| `npm run build`            | Build for production                                          |
-| `npm run start`            | Start production server                                       |
-| `npm run lint`             | Run ESLint                                                    |
-| `npm run typecheck`        | Run TypeScript checks                                         |
-| `npm run test:unit`        | Run unit tests (Vitest)                                       |
-| `npm run test:integration` | Run integration tier placeholder (currently no suite)         |
-| `npm run test:e2e`         | Run e2e tests (Playwright)                                    |
-| `npm run test:e2e:live`    | Run live-backend e2e smoke tests (Playwright)                 |
-| `npm run test:ci`          | Run CI gates (lint, typecheck, build, unit, integration, e2e) |
+| Script                  | Description                                      |
+| ----------------------- | ------------------------------------------------ |
+| `npm run dev`           | Start development server                         |
+| `npm run build`         | Build for production                             |
+| `npm run start`         | Start production server                          |
+| `npm run lint`          | Run ESLint                                       |
+| `npm run typecheck`     | Run TypeScript checks                            |
+| `npm run test:unit`     | Run unit tests (Vitest)                          |
+| `npm run test:e2e`      | Run e2e tests (Playwright)                       |
+| `npm run test:e2e:live` | Run live-backend e2e smoke tests (Playwright)    |
+| `npm run test:ci`       | Run CI gates (lint, typecheck, build, unit, e2e) |
 
 ## Test Tiers (Phase 0 Contract)
 
 Use the runner-agnostic entrypoint:
 
 ```bash
-bash ci/run_tests.sh <unit|integration|e2e|live-e2e|ci>
+bash ci/run_tests.sh <unit|e2e|live-e2e|ci>
 ```
 
 Examples:

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: ci/run_tests.sh <format|quality|build|unit|integration|e2e|e2e-default|e2e-onboarding|e2e-context-fabric|pagerduty-final-qa|live-e2e|design-lint|ci> [current/total]" >&2
+  echo "Usage: ci/run_tests.sh <format|quality|build|unit|e2e|e2e-default|e2e-onboarding|e2e-context-fabric|pagerduty-final-qa|live-e2e|design-lint|ci> [current/total]" >&2
 }
 
 if [[ $# -lt 1 || $# -gt 2 ]]; then
@@ -268,9 +268,6 @@ case "${tier}" in
   unit)
     run_unit
     ;;
-  integration)
-    run_pnpm_script test:integration
-    ;;
   e2e)
     run_e2e
     ;;
@@ -298,7 +295,6 @@ case "${tier}" in
     run_quality
     run_pnpm_script build
     run_unit
-    run_pnpm_script test:integration
     run_e2e
     run_pagerduty_final_qa "${PLAYWRIGHT_REPORT_ROOT}/pagerduty-final-qa" "${PLAYWRIGHT_RESULTS_ROOT}/pagerduty-final-qa"
     ;;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "test:e2e:live": "playwright test -c playwright.live.config.ts",
         "test:ask-dev-acceptance": "playwright test -c playwright.ask-dev-acceptance.config.ts",
         "test:unit": "vitest run",
-        "test:integration": "node -e \"console.log('Integration tests are not implemented yet (placeholder).')\"",
         "test:ci": "bash ci/run_tests.sh ci"
     },
     "dependencies": {

--- a/scripts/__tests__/chaos-3017-ci-contract-helpers.mjs
+++ b/scripts/__tests__/chaos-3017-ci-contract-helpers.mjs
@@ -9,7 +9,7 @@ import { expect } from "vitest";
 export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 export const NON_SUCCESS_RESULTS = ["failure", "cancelled", "skipped"];
 export const REQUIRED_STAGE_GROUPS = [
-    ["general", "Check general test stages", ["format", "quality", "build", "unit", "integration"]],
+    ["general", "Check general test stages", ["format", "quality", "build", "unit"]],
     ["E2E", "Check E2E test stages", ["e2e-default", "e2e-onboarding"]],
 ];
 const execFileAsync = promisify(execFile);

--- a/scripts/__tests__/chaos-3017-ci-contract.test.mjs
+++ b/scripts/__tests__/chaos-3017-ci-contract.test.mjs
@@ -36,7 +36,7 @@ describe("CHAOS-3017 CI contracts", () => {
         const aggregator = job(contents(TESTS_WORKFLOW), "test");
 
         expect(aggregator).toMatch(
-            /needs: \[changes, format, quality, build, unit, integration, e2e-default, e2e-onboarding\]/,
+            /needs: \[changes, format, quality, build, unit, e2e-default, e2e-onboarding\]/,
         );
         expect(aggregator).toMatch(/^        if: always\(\)$/mu);
         expect(aggregator).not.toContain("toJson(needs)");

--- a/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
+++ b/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
@@ -69,15 +69,6 @@ const GENERAL_TIERS = [
         packageScripts: {},
         tier: "unit",
     },
-    {
-        commands: ["test:integration"],
-        jobId: "integration",
-        packageScripts: {
-            "test:integration":
-                "node -e \"console.log('Integration tests are not implemented yet (placeholder).')\"",
-        },
-        tier: "integration",
-    },
 ];
 const E2E_STAGES = ["e2e-default", "e2e-onboarding"];
 // Context Fabric's tier runs inside the e2e-onboarding job (one runner,

--- a/scripts/__tests__/chaos-3483-required-stage-substance.test.mjs
+++ b/scripts/__tests__/chaos-3483-required-stage-substance.test.mjs
@@ -1,0 +1,155 @@
+// CHAOS-3483: no stage inside the REQUIRED `test` gate may pass while doing
+// nothing.
+//
+// The `integration` stage did exactly that from the day the tiered test
+// contract landed (2026-02-19) until this file did. `test:integration` was
+// `node -e "console.log('Integration tests are not implemented yet
+// (placeholder).')"`, wired into the `integration` job, wired into the `test`
+// aggregator's `needs`, and `test` is the required status check on this
+// repository. It was honestly named -- and that is exactly why it survived:
+// in the gate's output a placeholder that exits 0 and a real suite that exits
+// 0 are the same green tick, so nobody was ever prompted to implement or
+// remove it. The stage is gone now, and this test is what keeps it gone.
+//
+// It does not hard-code "integration". It walks the aggregator's real `needs`
+// list, executes each stage's `ci/run_tests.sh` invocation through the
+// recording harness (which shims pnpm/npx, so nothing real runs), and asserts
+// every command that reaches a package script resolves to something that
+// actually invokes a test runner. A future stage wired to `echo TODO` fails
+// here, whatever it is called.
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+    ROOT,
+    contents,
+    job,
+    recordHarnessPackageCommands,
+} from "./chaos-3017-ci-contract-helpers.mjs";
+
+const TESTS_WORKFLOW = path.join(ROOT, ".github/workflows/tests.yml");
+const PACKAGE_JSON = path.join(ROOT, "package.json");
+
+// Shapes that print or shrug rather than test. `node -e` is here because it is
+// what the removed placeholder used; `echo`/`true`/`:` because they are what a
+// hurried replacement would use next.
+const INERT_COMMAND = /^\s*(echo\b|:\s*$|true\s*$|node\s+-e\b|printf\b)/u;
+const INERT_WORDS = /placeholder|not implemented|no-op|todo/iu;
+
+/**
+ * @param {string} body a package.json script body
+ * @returns {string[]} the reasons this body does no testing work, if any
+ */
+export function inertReasons(body) {
+    const reasons = [];
+    if (INERT_COMMAND.test(body)) {
+        reasons.push(`runs an inert command: ${body}`);
+    }
+    if (INERT_WORDS.test(body)) {
+        reasons.push(`declares itself unimplemented: ${body}`);
+    }
+    return reasons;
+}
+
+function aggregatorStages() {
+    const aggregator = job(contents(TESTS_WORKFLOW), "test");
+    const match = aggregator.match(/^\s+needs: \[([^\]]+)\]$/mu);
+    expect(match, "the test aggregator declares no needs").not.toBeNull();
+    const stages = match[1].split(",").map((value) => value.trim());
+    // `changes` is the selector, not a stage that runs work.
+    return stages.filter((stage) => stage !== "changes");
+}
+
+function harnessInvocations(stageJob) {
+    const invocations = [];
+    for (const line of stageJob.split(/\r?\n/u)) {
+        const match = line.match(/- run: bash ci\/run_tests\.sh (.+)$/u);
+        if (match) {
+            invocations.push(
+                match[1]
+                    // The shard matrix expands at run time; one shard is enough
+                    // to reach the package script the tier executes.
+                    .replace(/\$\{\{\s*matrix\.shard\s*\}\}/gu, "1")
+                    .trim()
+                    .split(/\s+/u),
+            );
+        }
+    }
+    return invocations;
+}
+
+describe("CHAOS-3483 required stages do substantive work", () => {
+    const workflow = contents(TESTS_WORKFLOW);
+    const scripts = JSON.parse(fs.readFileSync(PACKAGE_JSON, "utf8")).scripts;
+    const stages = aggregatorStages();
+
+    it("finds stages to judge", () => {
+        // A gate given nothing to judge must not report success -- if this
+        // parse ever returns an empty list, every assertion below would pass
+        // vacuously and this file would read as coverage while checking
+        // nothing.
+        expect(stages.length).toBeGreaterThan(0);
+    });
+
+    it("no longer carries the integration placeholder", () => {
+        expect(stages).not.toContain("integration");
+        expect(scripts).not.toHaveProperty("test:integration");
+        expect(contents(path.join(ROOT, "ci/run_tests.sh"))).not.toContain("test:integration");
+    });
+
+    it.each(aggregatorStages())("stage %s executes a real suite", (stage) => {
+        const stageJob = job(workflow, stage);
+        const invocations = harnessInvocations(stageJob);
+        expect(invocations.length, `${stage} never invokes ci/run_tests.sh`).toBeGreaterThan(0);
+
+        for (const args of invocations) {
+            const { commands, result } = recordHarnessPackageCommands(args);
+            expect(result.error, `${stage}: ${args.join(" ")}`).toBeUndefined();
+            expect(
+                commands.filter(Boolean).length,
+                `${stage} tier ${args.join(" ")} issued no commands at all`,
+            ).toBeGreaterThan(0);
+
+            for (const command of commands) {
+                const name = command.split(" ", 1)[0];
+                const body = scripts[name];
+                // A command that is not a package script name is a direct
+                // runner invocation (`exec vitest ...`, `audit ...`) -- the
+                // program IS the work, so judge the command text itself.
+                const reasons = inertReasons(body ?? command);
+                expect(
+                    reasons,
+                    `${stage} tier ${args.join(" ")} runs '${command}', which does no testing work`,
+                ).toEqual([]);
+            }
+        }
+    });
+});
+
+describe("CHAOS-3483 the inertness predicate itself", () => {
+    // The check above is only as good as this predicate, and a predicate that
+    // rejects nothing would let every stage pass. These are the old
+    // placeholder's exact body and the shapes a replacement would take,
+    // against the real script bodies this repository actually ships.
+    it.each([
+        "node -e \"console.log('Integration tests are not implemented yet (placeholder).')\"",
+        "echo 'TODO: integration tests'",
+        "true",
+        ":",
+        "node scripts/thing.mjs # placeholder until CHAOS-9999",
+    ])("rejects %s", (body) => {
+        expect(inertReasons(body)).not.toEqual([]);
+    });
+
+    it.each([
+        "vitest run",
+        "playwright test --project=authenticated",
+        "next build",
+        "tsc --noEmit",
+        "node scripts/check-format-changed.mjs",
+    ])("accepts %s", (body) => {
+        expect(inertReasons(body)).toEqual([]);
+    });
+});


### PR DESCRIPTION
CHAOS-3483.

## The defect

The `integration` stage of the required `test` gate ran:

```
node -e "console.log('Integration tests are not implemented yet (placeholder).')"
```

and exited 0. It was a hard dependency of the `test` aggregator, and `test` is one of the two required status checks on this repository (ruleset `11469284`, contexts `Build Static Assets` and `test`). So a job that did nothing has been satisfying a required gate since the tiered test contract landed on 2026-02-19 (`ab033eca`), and became a hard dependency of the aggregator in `66c00bd0`.

It was honestly named — and that is exactly why it survived. In the gate's output, a placeholder that exits 0 and a real suite that exits 0 are the same green tick, so nobody was ever prompted to implement or remove it. This is the web-side instance of CHAOS-3219's own criterion: *"no required job may exit success after skipping substantive work."*

## The fix: removed, not implemented

Per CHAOS-3483's recommended default. There is no dormant integration suite to switch on — `vitest.config.ts` defines only the `unit` and `components` projects, and there is no `tests/integration/`. The two real tiers, vitest and Playwright, already cover what the gate needs. An honest six-stage gate beats a seven-stage one whose seventh stage is a print statement.

Removed: the `integration` job; its entry in the aggregator's `needs` and in the "Check general test stages" condition; `test:integration` from `package.json`; the `integration` case and the `ci`-tier call in `ci/run_tests.sh`; the tier from the README table and usage line.

No orphaned required check: `integration` never had its own required context — it was only a dependency inside the `test` aggregator, whose job name is the required context and still runs. PRs will not block.

## The guard, so it cannot come back

`scripts/__tests__/chaos-3483-required-stage-substance.test.mjs` does not hard-code "integration". It walks the aggregator's **real** `needs` list, runs each stage's `ci/run_tests.sh` invocation through the existing recording harness (which shims pnpm/npx, so nothing real executes), resolves every command it issues to its `package.json` script, and rejects bodies that only print or shrug. A future stage wired to `echo TODO` fails here, whatever it is called.

It also carries an explicit anti-vacuity assertion — if the `needs` parse ever returns an empty list, every assertion below it would pass vacuously, so that case fails loudly instead.

**Proven RED, not merely present.** Reinstating the placeholder job, script and `run_tests.sh` case makes the guard fail and name the inert command: 2 failed / 17 passed. With them removed: 18 passed.

## Also updated

The three CHAOS-3017 CI contract tests that pinned the stage list, so the aggregator's `needs`, its rendered bash condition, and its per-tier execution contract all still match the workflow.

## What was run

No `src/` changes, so no e2e impact; the web full gate was not needed for this scope.

- `prettier` (write) on every changed file
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- the full `scripts/__tests__/` vitest tier — 3 files, 53 tests, passing

One unrelated flake observed and re-run clean: `run-owned-process.test.mjs` timed out at 15s while a Docker acceptance stack was saturating the machine, then passed 10/10 on its own.
