### PR TITLE
CHAOS-3526: emit scope.resolved on Ask Dev mock error-scenario streams

### DIFF
--- a/tests/mocks/devScenario.test.ts
+++ b/tests/mocks/devScenario.test.ts
@@ -137,3 +137,113 @@ describe("Ask Dev mock fidelity — no-answer outcomes", () => {
         });
     }
 });
+
+describe("Ask Dev mock fidelity — scope.resolved on error terminals (CHAOS-3526)", () => {
+    // CHAOS-3497 (ops `streaming.stream_orchestrator`): a `scope.resolved`
+    // frame is emitted for EVERY terminal whose run got as far as completing
+    // scope resolution -- not only the answering ones -- immediately before
+    // the terminal frame. Before this fix the mock never emitted it on an
+    // error path at all, so the default e2e suite exercised a stream shape
+    // production no longer produces.
+    //
+    // Which outcome each scenario carries is pinned against the ops
+    // acceptance corpus's own `resolution-profiles/deterministic-v1.json`
+    // (`expected_public_outcome` -> `expected_scope_resolution_outcome`),
+    // the real producer's own recorded mapping, not an invented one:
+    //   not_found              -> unresolved
+    //   temporarily_unavailable -> exact
+    //   unsupported            -> null (no scope.resolved at all)
+    //   denied                 -> null (no scope.resolved at all)
+    //   failed                 -> exact
+    // `unsupported`/`denied` are refused before any catalog round trip (a
+    // preflight bound, or a provider-level refusal) -- the run never
+    // resolves scope at all, so publishing a resolution for either would be
+    // inventing one the run never reached (`streaming.py`'s own negative
+    // control: "a run that never resolved scope emits no scope frame").
+    const SCOPE_RESOLUTION_BY_OUTCOME: Record<
+        (typeof NO_ANSWER_OUTCOMES)[number]["outcome"],
+        string | null
+    > = {
+        not_found: "unresolved",
+        temporarily_unavailable: "exact",
+        unsupported: null,
+        denied: null,
+        failed: "exact",
+    };
+
+    function eventsFor(scenario: DevAnswerScenario) {
+        return buildStreamEvents(scenario, "conversation_test", "A question");
+    }
+
+    for (const outcome of NO_ANSWER_OUTCOMES) {
+        const expected = SCOPE_RESOLUTION_BY_OUTCOME[outcome.outcome];
+        if (expected === null) {
+            it(`${outcome.outcome} emits no scope.resolved event (scope was never resolved)`, () => {
+                const events = eventsFor(outcome.scenario);
+                expect(events.some((event) => event.event === "scope.resolved")).toBe(false);
+            });
+            continue;
+        }
+        it(`${outcome.outcome} emits scope.resolved (${expected}) immediately before the error frame`, () => {
+            const events = eventsFor(outcome.scenario);
+            const kinds = events.map((event) => event.event);
+            const scopeIndex = kinds.indexOf("scope.resolved");
+            const errorIndex = kinds.indexOf("error");
+
+            expect(scopeIndex, "no scope.resolved event was emitted").toBeGreaterThanOrEqual(0);
+            expect(errorIndex).toBe(scopeIndex + 1);
+            expect(kinds.slice(-2)).toEqual(["error", "done"]);
+            expect(events.map((event) => event.sequence)).toEqual(events.map((_, index) => index));
+
+            const resolution = events[scopeIndex]!.scope_resolution as JsonRecord;
+            expect(resolution.schema_version).toBe("dev_scope_resolution.v1");
+            expect(resolution.outcome).toBe(expected);
+            if (expected === "unresolved") {
+                expect(resolution.resolved_scope).toBeNull();
+                expect(resolution.candidates).toEqual([]);
+            } else {
+                expect(resolution.resolved_scope).not.toBeNull();
+            }
+        });
+    }
+
+    // `scope_forbidden_error` / `source_unavailable_error` are hand-built
+    // (not part of `NO_ANSWER_OUTCOMES`), mirroring the top-level
+    // `orchestrator.run()` resolve-outcome branch and the stream-level
+    // source-unavailable shape respectively. `scope_forbidden` carries
+    // `forbidden_or_not_found` -- the same "genuinely unhealthy" outcome
+    // CHAOS-3497 uses elsewhere, never a healthy `exact` beside a "you don't
+    // have access" error (the exact juxtaposition CHAOS-3497 removed from
+    // ops). `source_unavailable` mirrors `temporarily_unavailable`: the
+    // scope resolved fine and a downstream source failed, so `exact` is
+    // honest here.
+    it("scope_forbidden_error emits scope.resolved (forbidden_or_not_found) immediately before the error frame", () => {
+        const events = eventsFor("scope_forbidden_error");
+        const kinds = events.map((event) => event.event);
+        const scopeIndex = kinds.indexOf("scope.resolved");
+
+        expect(scopeIndex).toBeGreaterThanOrEqual(0);
+        expect(kinds[scopeIndex + 1]).toBe("error");
+        expect(kinds.slice(-2)).toEqual(["error", "done"]);
+        expect(events.map((event) => event.sequence)).toEqual(events.map((_, index) => index));
+
+        const resolution = events[scopeIndex]!.scope_resolution as JsonRecord;
+        expect(resolution.outcome).toBe("forbidden_or_not_found");
+        expect(resolution.resolved_scope).toBeNull();
+    });
+
+    it("source_unavailable_error emits scope.resolved (exact) immediately before the error frame", () => {
+        const events = eventsFor("source_unavailable_error");
+        const kinds = events.map((event) => event.event);
+        const scopeIndex = kinds.indexOf("scope.resolved");
+
+        expect(scopeIndex).toBeGreaterThanOrEqual(0);
+        expect(kinds[scopeIndex + 1]).toBe("error");
+        expect(kinds.slice(-2)).toEqual(["error", "done"]);
+        expect(events.map((event) => event.sequence)).toEqual(events.map((_, index) => index));
+
+        const resolution = events[scopeIndex]!.scope_resolution as JsonRecord;
+        expect(resolution.outcome).toBe("exact");
+        expect(resolution.resolved_scope).not.toBeNull();
+    });
+});

--- a/tests/mocks/devScenario.ts
+++ b/tests/mocks/devScenario.ts
@@ -67,6 +67,9 @@ export const NO_ANSWER_OUTCOMES = [
         retryable: false,
         safeMessage: "No matching subject was found for this question.",
         remediation: ["Check the name and try again."],
+        // See `SCOPE_RESOLUTION_OUTCOME_BY_NO_ANSWER` below for what this
+        // field means and where it comes from.
+        scopeResolutionOutcome: "unresolved",
     },
     {
         outcome: "temporarily_unavailable",
@@ -75,6 +78,7 @@ export const NO_ANSWER_OUTCOMES = [
         retryable: true,
         safeMessage: "This answer is temporarily unavailable. Please try again shortly.",
         remediation: ["Try the question again in a few minutes."],
+        scopeResolutionOutcome: "exact",
     },
     {
         outcome: "unsupported",
@@ -83,6 +87,7 @@ export const NO_ANSWER_OUTCOMES = [
         retryable: false,
         safeMessage: "This question is not supported yet.",
         remediation: ["Try a status, health, or metric question instead."],
+        scopeResolutionOutcome: null,
     },
     {
         outcome: "denied",
@@ -91,6 +96,7 @@ export const NO_ANSWER_OUTCOMES = [
         retryable: false,
         safeMessage: "You do not have access to ask about this.",
         remediation: ["Ask an administrator for access to this area."],
+        scopeResolutionOutcome: null,
     },
     {
         outcome: "failed",
@@ -99,8 +105,38 @@ export const NO_ANSWER_OUTCOMES = [
         retryable: false,
         safeMessage: "Something went wrong while preparing this answer.",
         remediation: ["Try the question again."],
+        scopeResolutionOutcome: "exact",
     },
 ] as const;
+
+/**
+ * What `scope.resolved` outcome (if any) each `NO_ANSWER_OUTCOMES` entry's
+ * stream carries, immediately before its `error` frame (CHAOS-3526).
+ *
+ * As of CHAOS-3497, ops emits `scope.resolved` on every terminal whose run
+ * completed scope resolution -- including a no-answer error terminal --
+ * built from `OrchestratorResult.scope_resolution`
+ * (`streaming.stream_orchestrator`). Which outcome each of these five
+ * carries is pinned against the real producer, not invented: the ops
+ * acceptance corpus's own `resolution-profiles/deterministic-v1.json` maps
+ * every corpus case's `expected_public_outcome` to an
+ * `expected_scope_resolution_outcome`, and every case sharing one of these
+ * five public outcomes agrees on a single value --
+ *   not_found               -> unresolved
+ *   temporarily_unavailable -> exact
+ *   unsupported             -> null
+ *   denied                  -> null
+ *   failed                  -> exact
+ * `null` means no `scope.resolved` event at all, not a placeholder
+ * resolution: `unsupported` (an oversized/unsupported request rejected by
+ * `subject_preflight`'s bound) and `denied` (a provider-level refusal) are
+ * both rejected before any catalog round trip ever runs, so
+ * `OrchestratorResult.scope_resolution` is `None` and streaming's own
+ * negative control applies ("a run that never resolved scope emits no
+ * scope frame") -- inventing a resolution here would assert something the
+ * run never reached, the same overclaiming CHAOS-3497 exists to prevent in
+ * the other direction.
+ */
 
 type NoAnswerScenario = (typeof NO_ANSWER_OUTCOMES)[number]["scenario"];
 
@@ -644,6 +680,36 @@ function nextRunId(): string {
     return `run_e2e_${runCounter}`;
 }
 
+/**
+ * A schema-valid `dev_scope_resolution.v1` for an error terminal's
+ * `scope.resolved` frame (CHAOS-3526), derived from the checked-in
+ * canonical `exact` fixture rather than hand-authored.
+ *
+ * `"exact"` returns the fixture's own resolution unchanged -- it is already
+ * a real, schema-valid `exact` commit. The two unhealthy outcomes clear
+ * `resolved_scope`/the authorization lists/`candidates` the same way the
+ * `forbidden_or_not_found_scope` and `scope_unresolved` answer scenarios
+ * above do, so this cannot describe a shape those scenarios' own pinned
+ * tests would reject: `unresolved` and `forbidden_or_not_found` both sit on
+ * DevScopeResolution's un-resolved side (`resolved_scope` is `None`), and
+ * neither carries the fixture's repository-scoped authorization.
+ * `forbidden_or_not_found` MAY carry `candidates` (CHAOS-3367) but is never
+ * required to; none are offered here since the mock has no closest-match
+ * catalog to draw them from.
+ */
+function buildScopeResolution(
+    outcome: "exact" | "unresolved" | "forbidden_or_not_found",
+): JsonRecord {
+    const resolution = clone((answerFixture as JsonRecord).resolved_scope) as JsonRecord;
+    if (outcome === "exact") return resolution;
+    resolution.outcome = outcome;
+    resolution.resolved_scope = null;
+    resolution.authorized_repository_ids = [];
+    resolution.authorized_entity_ids = [];
+    resolution.candidates = [];
+    return resolution;
+}
+
 /** Builds one schema-valid, semantically-valid dev_stream_event.v1[] run. */
 export function buildStreamEvents(
     scenario: DevAnswerScenario,
@@ -677,6 +743,16 @@ export function buildStreamEvents(
 
     const noAnswer = NO_ANSWER_BY_SCENARIO.get(scenario);
     if (noAnswer) {
+        // CHAOS-3526: `scope.resolved` immediately before the terminal, and
+        // only when this run's outcome family actually reached scope
+        // resolution -- see the block comment above `NO_ANSWER_OUTCOMES`
+        // for the per-outcome sourcing.
+        if (noAnswer.scopeResolutionOutcome !== null) {
+            push({
+                event: "scope.resolved",
+                scope_resolution: buildScopeResolution(noAnswer.scopeResolutionOutcome),
+            });
+        }
         push({
             event: "error",
             error: {
@@ -693,6 +769,26 @@ export function buildStreamEvents(
     }
 
     if (scenario === "scope_forbidden_error" || scenario === "source_unavailable_error") {
+        // CHAOS-3526: both scenarios reach an error only after scope
+        // resolution completed, so both carry `scope.resolved` immediately
+        // before it. `scope_forbidden_error` mirrors ops
+        // `orchestrator.run()`'s top-level resolve-outcome branch (a
+        // resolution outcome outside `{ambiguous, unresolved,
+        // forbidden_or_not_found}` still forbidden by an authorization
+        // check downstream of scope resolution) with the "genuinely
+        // unhealthy" `forbidden_or_not_found` outcome CHAOS-3497 uses for
+        // this family elsewhere -- never a healthy `exact` beside a "you
+        // don't have access" error, which is the exact juxtaposition
+        // CHAOS-3497 removed from ops. `source_unavailable_error` mirrors
+        // the `temporarily_unavailable` no-answer outcome: the scope
+        // resolved fine and a downstream source failed, so `exact` is
+        // honest here.
+        const scopeResolutionOutcome =
+            scenario === "scope_forbidden_error" ? "forbidden_or_not_found" : "exact";
+        push({
+            event: "scope.resolved",
+            scope_resolution: buildScopeResolution(scopeResolutionOutcome),
+        });
         const error =
             scenario === "scope_forbidden_error"
                 ? {


### PR DESCRIPTION
Fixes CHAOS-3526.

## Problem

`web/tests/mocks/devScenario.ts`'s `buildStreamEvents()` never emitted a `scope.resolved` frame on an error terminal (the five `NO_ANSWER_OUTCOMES` scenarios, plus `scope_forbidden_error`/`source_unavailable_error`). As of CHAOS-3497 (ops), the real backend emits `scope.resolved` on every terminal whose run completed scope resolution — including error terminals — immediately before the terminal frame. The mocked error streams were the one shape the real server no longer produces, so the default e2e suite exercised a stale wire shape.

## Fix

Derived the real event vocabulary and per-scenario outcome from the real producer, not invented:

- **Ordering/structure**: ops `streaming.stream_orchestrator` (origin/main `fe69de46c`, CHAOS-3497) emits `scope.resolved` built from `OrchestratorResult.scope_resolution` immediately before the terminal frame, only when a resolution exists (a run that never resolved scope emits none).
- **Per-scenario outcome**: pinned against the ops acceptance corpus's own `resolution-profiles/deterministic-v1.json` (`expected_public_outcome` → `expected_scope_resolution_outcome`), the real producer's own recorded mapping:
  - `not_found` → `unresolved`
  - `temporarily_unavailable` → `exact`
  - `unsupported` → **no `scope.resolved` event at all** (refused before any catalog round trip, so the run never resolved scope — inventing one would assert something that never happened)
  - `denied` → same, no event
  - `failed` → `exact`
  - `scope_forbidden_error` (hand-built, outside `NO_ANSWER_OUTCOMES`) → `forbidden_or_not_found`, the "genuinely unhealthy" outcome — never a healthy `exact` beside a "you don't have access" error, which is the exact juxtaposition CHAOS-3497 removed from ops
  - `source_unavailable_error` → `exact`, mirroring `temporarily_unavailable`

`buildScopeResolution()` derives the payload from the checked-in canonical `exact` fixture rather than hand-authoring JSON.

## Testing

RED-first: `tests/mocks/devScenario.test.ts` asserts `scope.resolved` precedes the error frame with contiguous sequencing for the five scenarios that should carry it, and asserts its *absence* for `unsupported`/`denied`. All five positive assertions failed against the prior mock before the fix (verified), and pass now.

Full `web-full-gate` (`ci/run_tests.sh ci`, including Playwright e2e default/onboarding/context-fabric/pagerduty-final-qa suites) is green: unit 412 files / 3726 passed / 8 skipped; e2e 320+2 skipped/10/21/23 all passed. In particular `ask-dev-shared.spec.ts`'s denylist tests for both `scope_forbidden_error` and `source_unavailable_error` still pass, confirming no leak into the rendered UI.

## Not in scope

No web consumer change: `reduceDevConversationStream` (`src/lib/dev/client.ts`) has no case for `scope.resolved` — it falls through to `default: return state` — so this is fixture fidelity only, per the ticket.

TEST-WAIVER: not needed — `tests/mocks/devScenario.test.ts` is updated alongside the `src/`-adjacent mock change (governance gate looks at the `tests/` tree here since the change is entirely test-infrastructure).