### PR TITLE
CHAOS-3511: refresh the ask-dev contract pin and add a currency guard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
         runs-on: ubuntu-latest
         env:
             ASK_DEV_OPS_ROOT: dev-health-ops
+            ASK_DEV_OPS_MAIN_ROOT: dev-health-ops-main
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
             # Must stay equal to SOURCE_COMMIT in scripts/ask-dev-contracts.mjs
@@ -97,8 +98,19 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
               with:
                   repository: full-chaos/dev-health-ops
-                  ref: c31b9c6de1b4b7dbdfc82d84850e4e09fb71960e
+                  ref: 5913cd3c9a737249a0f2fcf70796fedc4c466e66
                   path: dev-health-ops
+                  persist-credentials: false
+            # CHAOS-3511 currency guard: ops main's tip as of this run, checked
+            # out to a SEPARATE path so it never disturbs the pinned checkout's
+            # exact-SHA requirement above. ask-dev:contracts:check-currency
+            # diffs the two over the consumed surface only.
+            - name: Checkout current ops main
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+              with:
+                  repository: full-chaos/dev-health-ops
+                  ref: main
+                  path: dev-health-ops-main
                   persist-credentials: false
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
             - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -136,6 +136,15 @@ run_quality() {
   fi
   echo "==> pnpm ask-dev:contracts:check --source ${ASK_DEV_OPS_ROOT}"
   pnpm ask-dev:contracts:check --source "${ASK_DEV_OPS_ROOT}"
+  # CHAOS-3511: the pin's CURRENCY, not only its internal consistency -- a
+  # separate ops checkout at main's current tip, diffed against the pinned
+  # commit over the consumed surface only (contracts/ask-dev/v1/).
+  if [[ -z "${ASK_DEV_OPS_MAIN_ROOT:-}" ]]; then
+    echo "ASK_DEV_OPS_MAIN_ROOT must name a clean dev-health-ops checkout at ops main (CHAOS-3511 currency guard)." >&2
+    return 1
+  fi
+  echo "==> pnpm ask-dev:contracts:check-currency --pinned ${ASK_DEV_OPS_ROOT} --current ${ASK_DEV_OPS_MAIN_ROOT}"
+  pnpm ask-dev:contracts:check-currency --pinned "${ASK_DEV_OPS_ROOT}" --current "${ASK_DEV_OPS_MAIN_ROOT}"
   run_pnpm_script lint
   run_pnpm_script typecheck
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -293,6 +293,23 @@ integrity check, but it is not release evidence. The quality gate requires
 stream changes require a new contract version and the PRD/TRD change-control
 process; do not patch generated TypeScript or vendored JSON by hand.
 
+`check` is a CONSISTENCY guard only — it proves the vendored artifacts match
+`SOURCE_COMMIT`, never that `SOURCE_COMMIT` is still current (CHAOS-3511: the
+pin went 54 commits stale with nothing detecting it). `pnpm ask-dev:contracts:check-currency
+--pinned <ops checkout at SOURCE_COMMIT> --current <ops checkout at main>`
+is the CURRENCY guard: it diffs the consumed surface
+(`contracts/ask-dev/v1/`) between the two by content, ignoring v2-only churn
+web does not consume, and fails loudly — naming every added/removed/changed
+file — when they disagree. The quality gate requires `ASK_DEV_OPS_MAIN_ROOT`
+(a second, independent ops checkout at main's current tip) and runs this
+unconditionally, immediately after `check`; a stale pin is a red quality job,
+not a silent gap. Regenerate the same way as any other re-pin (`generate` +
+`check` above, from a checkout at the new commit), then update
+`SOURCE_COMMIT` in `scripts/ask-dev-contracts.mjs` and the pinned `ref` in
+`.github/workflows/tests.yml` together — the same half-finished-re-pin guard
+`chaos-3017-ci-execution-contract.test.mjs` already runs for `check` covers
+this pair too.
+
 ### Ask Dev browser and surface ownership
 
 The authenticated app layout owns one `AskDevProvider` for both interaction

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "acr:contracts:check": "node scripts/sync-acr-contracts.mjs check",
         "ask-dev:contracts:generate": "node scripts/ask-dev-contracts.mjs generate --allow-write",
         "ask-dev:contracts:check": "node scripts/ask-dev-contracts.mjs check",
+        "ask-dev:contracts:check-currency": "node scripts/ask-dev-contracts.mjs check-currency",
         "test:e2e": "playwright test --project=authenticated --project=unauthenticated",
         "test:e2e:pagerduty-final-qa": "playwright test --project=pagerduty-final-qa",
         "test:e2e:pagerduty-final-qa:smoke": "playwright test --project=pagerduty-final-qa tests/pagerduty-final-qa-p0.spec.ts",

--- a/scripts/__tests__/chaos-3017-ci-contract-helpers.mjs
+++ b/scripts/__tests__/chaos-3017-ci-contract-helpers.mjs
@@ -46,6 +46,7 @@ export function recordHarnessPackageCommands(args, { failScript } = {}) {
     try {
         const result = runHarness(args, {
             ASK_DEV_OPS_ROOT: path.join(ROOT, "dev-health-ops"),
+            ASK_DEV_OPS_MAIN_ROOT: path.join(ROOT, "dev-health-ops-main"),
             CI_CONTRACT_COMMAND_LOG: commandLog,
             CI_CONTRACT_FAIL_SCRIPT: failScript ?? "",
             PATH: `${temporaryDirectory}:${process.env.PATH}`,

--- a/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
+++ b/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
@@ -45,6 +45,7 @@ const GENERAL_TIERS = [
             "audit --audit-level=high --prod",
             "codegen:check",
             `ask-dev:contracts:check --source ${path.join(ROOT, "dev-health-ops")}`,
+            `ask-dev:contracts:check-currency --pinned ${path.join(ROOT, "dev-health-ops")} --current ${path.join(ROOT, "dev-health-ops-main")}`,
             "lint",
             "typecheck",
         ],
@@ -52,6 +53,7 @@ const GENERAL_TIERS = [
         packageScripts: {
             "codegen:check": "graphql-codegen --config codegen.ts --check",
             "ask-dev:contracts:check": "node scripts/ask-dev-contracts.mjs check",
+            "ask-dev:contracts:check-currency": "node scripts/ask-dev-contracts.mjs check-currency",
             lint: "eslint src",
             typecheck: "tsc --noEmit",
         },
@@ -140,11 +142,18 @@ describe("CHAOS-3017 executable CI boundaries", () => {
             );
             if (jobId === "quality") {
                 expect(workflowJob).toContain(
-                    "        env:\n            ASK_DEV_OPS_ROOT: dev-health-ops",
+                    "        env:\n            ASK_DEV_OPS_ROOT: dev-health-ops\n" +
+                        "            ASK_DEV_OPS_MAIN_ROOT: dev-health-ops-main",
                 );
                 expect(workflowJob).toContain("repository: full-chaos/dev-health-ops");
                 expect(workflowJob).toContain(`ref: ${pinnedOpsCommit()}`);
                 expect(workflowJob).toContain("path: dev-health-ops");
+                // CHAOS-3511 currency guard: a SECOND, separate ops checkout
+                // at main's current tip -- never the same path as the pinned
+                // one, or the pinned checkout's exact-SHA requirement above
+                // would be violated by whichever checkout runs second.
+                expect(workflowJob).toContain("ref: main");
+                expect(workflowJob).toContain("path: dev-health-ops-main");
             }
             for (const [name, implementation] of Object.entries(packageScripts)) {
                 expect(scripts[name]).toBe(implementation);

--- a/scripts/__tests__/chaos-3511-contract-currency.test.mjs
+++ b/scripts/__tests__/chaos-3511-contract-currency.test.mjs
@@ -1,0 +1,164 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * CHAOS-3511. The pre-existing `check` mode is a CONSISTENCY guard -- it
+ * pins web's generated artifacts to exactly `SOURCE_COMMIT` -- but says
+ * nothing about whether `SOURCE_COMMIT` itself has gone stale against ops
+ * main. This exercises the new `check-currency` mode, which does: it reads
+ * the consumed surface (`contracts/ask-dev/v1/`) from two independent Git
+ * worktrees and fails loudly, naming every drifted file, when they disagree.
+ *
+ * Real `git` repositories throughout, not hand-authored JSON standing in
+ * for one -- the script reads its inputs exclusively through `git`
+ * subprocess calls (`ls-tree`/`show`), so a fixture that skipped git would
+ * not exercise the actual read path CI and local runs both use.
+ */
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const SCRIPT = path.join(ROOT, "scripts/ask-dev-contracts.mjs");
+const TEMP_DIRS = new Set();
+
+// Isolated from ambient ASK_DEV_OPS_ROOT / ASK_DEV_OPS_MAIN_ROOT: these tests
+// exercise --pinned/--current explicitly, and the harness that runs the
+// FULL gate (ci/run_tests.sh) exports both for the whole process tree, which
+// would otherwise let `parseArguments`'s env fallback silently supply a real
+// value here and mask the "both required" failure this file means to prove.
+// The one test that deliberately wants the env fallback (`falls back to
+// ASK_DEV_OPS_ROOT / ASK_DEV_OPS_MAIN_ROOT ...`) sets its own env directly
+// and does not use this helper.
+function run(args) {
+    const env = { ...process.env };
+    delete env.ASK_DEV_OPS_ROOT;
+    delete env.ASK_DEV_OPS_MAIN_ROOT;
+    return spawnSync(process.execPath, [SCRIPT, ...args], { cwd: ROOT, encoding: "utf8", env });
+}
+
+function git(cwd, args) {
+    const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+    if (result.status !== 0) {
+        throw new Error(`git ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+    }
+    return result.stdout;
+}
+
+/** A real Git repository seeded with `files` in a single commit. */
+function repoWithFiles(files) {
+    const root = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), "chaos-3511-ops-")));
+    TEMP_DIRS.add(root);
+    git(root, ["init", "-q"]);
+    git(root, ["config", "user.email", "chaos-3511@example.com"]);
+    git(root, ["config", "user.name", "CHAOS-3511 test"]);
+    git(root, ["config", "commit.gpgsign", "false"]);
+    for (const [relativePath, contents] of Object.entries(files)) {
+        const destination = path.join(root, relativePath);
+        fs.mkdirSync(path.dirname(destination), { recursive: true });
+        fs.writeFileSync(destination, contents);
+    }
+    git(root, ["add", "-A"]);
+    git(root, ["commit", "-q", "-m", "seed"]);
+    return root;
+}
+
+afterEach(() => {
+    for (const dir of TEMP_DIRS) fs.rmSync(dir, { recursive: true, force: true });
+    TEMP_DIRS.clear();
+});
+
+describe("CHAOS-3511 ask-dev contract currency guard", () => {
+    it("passes when the pinned and current consumed surfaces are byte-identical", () => {
+        const files = {
+            "contracts/ask-dev/v1/manifest.json": '{"a":1}\n',
+            "contracts/ask-dev/v1/schemas/dev_x.v1.schema.json": '{"b":2}\n',
+        };
+        const pinned = repoWithFiles(files);
+        const current = repoWithFiles(files);
+
+        const result = run(["check-currency", "--pinned", pinned, "--current", current]);
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain("is current with ops main");
+    });
+
+    // RED against the pre-CHAOS-3511 mock: before this mode existed, no
+    // command in `ci/run_tests.sh`'s quality tier could ever produce this
+    // failure -- a 54-commit-stale pin stayed permanently green. This is the
+    // guard that closes it, proven against real, independently-committed
+    // drift rather than asserted in the abstract.
+    it("fails loudly and names every drifted file when the consumed surface changed", () => {
+        const pinned = repoWithFiles({
+            "contracts/ask-dev/v1/manifest.json": '{"a":1}\n',
+            "contracts/ask-dev/v1/schemas/dev_removed.v1.schema.json": '{"gone":true}\n',
+        });
+        const current = repoWithFiles({
+            "contracts/ask-dev/v1/manifest.json": '{"a":2}\n',
+            "contracts/ask-dev/v1/schemas/dev_added.v1.schema.json": '{"new":true}\n',
+        });
+
+        const result = run(["check-currency", "--pinned", pinned, "--current", current]);
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("is stale against ops main");
+        expect(result.stderr).toContain("changed: manifest.json");
+        expect(result.stderr).toContain("added: schemas/dev_added.v1.schema.json");
+        expect(result.stderr).toContain("removed: schemas/dev_removed.v1.schema.json");
+        expect(result.stderr).toContain("regenerate: pnpm ask-dev:contracts:generate");
+    });
+
+    it("ignores drift outside contracts/ask-dev/v1/ (web does not consume v2)", () => {
+        const pinned = repoWithFiles({
+            "contracts/ask-dev/v1/manifest.json": '{"a":1}\n',
+            "contracts/ask-dev/v2/manifest.json": '{"v2":1}\n',
+        });
+        const current = repoWithFiles({
+            "contracts/ask-dev/v1/manifest.json": '{"a":1}\n',
+            "contracts/ask-dev/v2/manifest.json": '{"v2":999}\n',
+            "contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json": '{"new":true}\n',
+        });
+
+        const result = run(["check-currency", "--pinned", pinned, "--current", current]);
+        expect(result.status, result.stderr).toBe(0);
+    });
+
+    it("fails closed when --pinned or --current is missing", () => {
+        const result = run(["check-currency", "--pinned", "/tmp/does-not-matter"]);
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("check-currency requires --pinned and --current");
+    });
+
+    it("falls back to ASK_DEV_OPS_ROOT / ASK_DEV_OPS_MAIN_ROOT when no flags are given", () => {
+        const files = { "contracts/ask-dev/v1/manifest.json": '{"a":1}\n' };
+        const pinned = repoWithFiles(files);
+        const current = repoWithFiles(files);
+
+        const result = spawnSync(process.execPath, [SCRIPT, "check-currency"], {
+            cwd: ROOT,
+            encoding: "utf8",
+            env: { ...process.env, ASK_DEV_OPS_MAIN_ROOT: current, ASK_DEV_OPS_ROOT: pinned },
+        });
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain("is current with ops main");
+    });
+
+    it("fails when the current root is not a clean Git worktree", () => {
+        const pinned = repoWithFiles({ "contracts/ask-dev/v1/manifest.json": '{"a":1}\n' });
+        const notARepo = fs.realpathSync.native(
+            fs.mkdtempSync(path.join(os.tmpdir(), "chaos-3511-not-git-")),
+        );
+        TEMP_DIRS.add(notARepo);
+
+        const result = run(["check-currency", "--pinned", pinned, "--current", notARepo]);
+        expect(result.status).not.toBe(0);
+    });
+
+    it("fails when ops main has no Ask Dev artifacts at all under the consumed surface", () => {
+        const pinned = repoWithFiles({ "contracts/ask-dev/v1/manifest.json": '{"a":1}\n' });
+        const current = repoWithFiles({ "README.md": "unrelated\n" });
+
+        const result = run(["check-currency", "--pinned", pinned, "--current", current]);
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("ops main has no Ask Dev artifacts");
+    });
+});

--- a/scripts/ask-dev-contracts.mjs
+++ b/scripts/ask-dev-contracts.mjs
@@ -12,7 +12,7 @@ import { format } from "prettier";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ARTIFACT_ROOT = path.join(ROOT, "src/lib/dev/contracts");
 const GENERATED_PATH = path.join(ROOT, "src/lib/dev/generated.ts");
-const SOURCE_COMMIT = "c31b9c6de1b4b7dbdfc82d84850e4e09fb71960e";
+const SOURCE_COMMIT = "5913cd3c9a737249a0f2fcf70796fedc4c466e66";
 const SOURCE_PREFIX = "contracts/ask-dev/v1/";
 const PRETTIER_OPTIONS = Object.freeze({
     parser: "typescript",
@@ -47,10 +47,14 @@ function stableJson(value) {
     return `${JSON.stringify(value, null, 2)}\n`;
 }
 
+const MODES = Object.freeze(["generate", "check", "check-currency"]);
+
 function parseArguments(argumentsList) {
     const [mode, ...rest] = argumentsList;
-    if (mode !== "generate" && mode !== "check") throw new Error("use generate or check");
+    if (!MODES.includes(mode)) throw new Error(`use ${MODES.join(", ")}`);
     let source;
+    let pinned;
+    let current;
     let allowWrite = false;
     for (let index = 0; index < rest.length; index += 1) {
         const argument = rest[index];
@@ -58,12 +62,53 @@ function parseArguments(argumentsList) {
             allowWrite = true;
             continue;
         }
-        if (argument !== "--source") throw new Error(`unknown argument: ${argument}`);
-        source = rest[index + 1];
-        if (source === undefined) throw new Error("--source requires a value");
-        index += 1;
+        if (argument === "--source" || argument === "--pinned" || argument === "--current") {
+            const value = rest[index + 1];
+            if (value === undefined) throw new Error(`${argument} requires a value`);
+            if (argument === "--source") source = value;
+            else if (argument === "--pinned") pinned = value;
+            else current = value;
+            index += 1;
+            continue;
+        }
+        throw new Error(`unknown argument: ${argument}`);
     }
-    return { allowWrite, mode, source: source ?? process.env.ASK_DEV_OPS_ROOT };
+    return {
+        allowWrite,
+        current: current ?? process.env.ASK_DEV_OPS_MAIN_ROOT,
+        mode,
+        pinned: pinned ?? process.env.ASK_DEV_OPS_ROOT,
+        source: source ?? process.env.ASK_DEV_OPS_ROOT,
+    };
+}
+
+/**
+ * Every regular-file blob under `SOURCE_PREFIX` at `ref` in the git
+ * repository rooted at `root`, read straight from git's object database
+ * (never the worktree's files, which may not even be checked out to `ref`).
+ * Shared by the pinned-commit reader (`sourceFiles`, always `SOURCE_COMMIT`)
+ * and the currency guard (`check-currency`, an arbitrary ops-main `ref`) so
+ * the two cannot read the consumed surface two different ways.
+ */
+function filesUnderPrefix(root, ref) {
+    const listing = command(
+        "git",
+        ["ls-tree", "-r", "-z", "--name-only", ref, "--", SOURCE_PREFIX],
+        root,
+    );
+    const sourcePaths = listing.split("\0").filter(Boolean).sort();
+    return sourcePaths.map((sourcePath) => {
+        if (!sourcePath.startsWith(SOURCE_PREFIX) || sourcePath.includes("..")) {
+            throw new Error(`unsafe source path: ${sourcePath}`);
+        }
+        const entry = command("git", ["ls-tree", ref, "--", sourcePath], root).trim();
+        if (!entry.startsWith("100644 blob "))
+            throw new Error(`source is not a regular blob: ${sourcePath}`);
+        return {
+            contents: command("git", ["show", `${ref}:${sourcePath}`], root),
+            path: sourcePath.slice(SOURCE_PREFIX.length),
+        };
+    });
 }
 
 function resolveSourceRoot(sourceRoot) {
@@ -82,29 +127,35 @@ function resolveSourceRoot(sourceRoot) {
 
 function sourceFiles(sourceRoot) {
     const root = resolveSourceRoot(sourceRoot);
-    const listing = command(
-        "git",
-        ["ls-tree", "-r", "-z", "--name-only", SOURCE_COMMIT, "--", SOURCE_PREFIX],
-        root,
-    );
-    const sourcePaths = listing.split("\0").filter(Boolean).sort();
-    if (sourcePaths.length === 0) throw new Error("pinned source has no Ask Dev artifacts");
-    const files = sourcePaths.map((sourcePath) => {
-        if (!sourcePath.startsWith(SOURCE_PREFIX) || sourcePath.includes("..")) {
-            throw new Error(`unsafe source path: ${sourcePath}`);
-        }
-        const entry = command("git", ["ls-tree", SOURCE_COMMIT, "--", sourcePath], root).trim();
-        if (!entry.startsWith("100644 blob "))
-            throw new Error(`source is not a regular blob: ${sourcePath}`);
-        return {
-            contents: command("git", ["show", `${SOURCE_COMMIT}:${sourcePath}`], root),
-            path: sourcePath.slice(SOURCE_PREFIX.length),
-        };
-    });
+    const files = filesUnderPrefix(root, SOURCE_COMMIT);
+    if (files.length === 0) throw new Error("pinned source has no Ask Dev artifacts");
     if (command("git", ["rev-parse", "HEAD"], root).trim() !== SOURCE_COMMIT) {
         throw new Error("source HEAD changed while reading contracts");
     }
     return files;
+}
+
+/**
+ * A worktree root, validated as clean -- but, unlike `resolveSourceRoot`,
+ * at WHATEVER commit it happens to be checked out to, never a fixed pin.
+ * Shared by both sides of the currency guard: the "pinned" root's own
+ * exact-`SOURCE_COMMIT` requirement is already enforced by the `check` step
+ * that always runs immediately before `check-currency` in `run_quality()`
+ * (`ci/run_tests.sh`), so re-asserting it here would only duplicate that
+ * check, never strengthen it -- and re-deriving it independently here is
+ * what makes the comparison itself testable against two arbitrary synthetic
+ * repositories, not only against the one real pinned commit.
+ */
+function resolveCleanGitRoot(root) {
+    const resolved = fs.realpathSync.native(root);
+    const gitRoot = fs.realpathSync.native(
+        command("git", ["rev-parse", "--show-toplevel"], resolved).trim(),
+    );
+    if (resolved !== gitRoot) throw new Error("root must be a Git worktree root");
+    if (command("git", ["status", "--porcelain"], resolved).trim() !== "") {
+        throw new Error("root worktree must be clean");
+    }
+    return resolved;
 }
 
 function typeName(schemaPath) {
@@ -222,13 +273,99 @@ function assertCurrent(result) {
     }
 }
 
+/**
+ * CHAOS-3511. The pre-existing `check` mode is a CONSISTENCY guard: it pins
+ * web's generated artifacts to exactly `SOURCE_COMMIT` and fails if either
+ * drifted from the other -- but says nothing about whether `SOURCE_COMMIT`
+ * itself is still current. This is the CURRENCY guard: it compares the
+ * consumed surface (`SOURCE_PREFIX`, `contracts/ask-dev/v1/`) at the pinned
+ * commit against the SAME surface at `currentRoot`'s checked-out ops main,
+ * by content, never by commit-count or calendar age -- the "guard the thing
+ * that actually matters, not the calendar" precedent CHAOS-3488 set for the
+ * ops-side acceptance-world fingerprint.
+ *
+ * `currentRoot` is read independently of `pinnedRoot` (no shared git object
+ * database is assumed -- CI checks the two commits out into two separate
+ * clones), so this compares file CONTENTS directly rather than running
+ * `git diff` across two commits that might not even be in one repository.
+ * v2-only churn is invisible by construction: `filesUnderPrefix` never
+ * leaves `SOURCE_PREFIX`, and web does not consume dev_answer.v2 today.
+ */
+function currencyDrift(pinnedRootInput, currentRootInput) {
+    const pinned = resolveCleanGitRoot(pinnedRootInput);
+    const current = resolveCleanGitRoot(currentRootInput);
+    const pinnedSha = command("git", ["rev-parse", "HEAD"], pinned).trim();
+    const currentSha = command("git", ["rev-parse", "HEAD"], current).trim();
+
+    const pinnedByPath = new Map(
+        filesUnderPrefix(pinned, pinnedSha).map((file) => [file.path, file.contents]),
+    );
+    const currentByPath = new Map(
+        filesUnderPrefix(current, currentSha).map((file) => [file.path, file.contents]),
+    );
+    if (pinnedByPath.size === 0) throw new Error("pinned source has no Ask Dev artifacts");
+    if (currentByPath.size === 0) throw new Error("ops main has no Ask Dev artifacts");
+
+    const added = [];
+    const removed = [];
+    const changed = [];
+    for (const filePath of new Set([...pinnedByPath.keys(), ...currentByPath.keys()])) {
+        const before = pinnedByPath.get(filePath);
+        const after = currentByPath.get(filePath);
+        if (before === undefined) added.push(filePath);
+        else if (after === undefined) removed.push(filePath);
+        else if (before !== after) changed.push(filePath);
+    }
+    return {
+        added: added.sort(),
+        changed: changed.sort(),
+        currentSha,
+        pinnedSha,
+        removed: removed.sort(),
+    };
+}
+
+function assertCurrentWithMain(pinnedRoot, currentRootInput) {
+    const { added, changed, currentSha, pinnedSha, removed } = currencyDrift(
+        pinnedRoot,
+        currentRootInput,
+    );
+    const drift = [
+        ...added.map((relativePath) => `added: ${relativePath}`),
+        ...removed.map((relativePath) => `removed: ${relativePath}`),
+        ...changed.map((relativePath) => `changed: ${relativePath}`),
+    ];
+    if (drift.length === 0) {
+        process.stdout.write(
+            `Ask Dev contract pin ${pinnedSha} is current with ops main (${currentSha}).\n`,
+        );
+        return;
+    }
+    throw new Error(
+        [
+            `contract pin ${pinnedSha} is stale against ops main ${currentSha} -- ` +
+                `${SOURCE_PREFIX} drifted:`,
+            ...drift.map((line) => `  ${line}`),
+            "regenerate: pnpm ask-dev:contracts:generate --allow-write --source <ops checkout " +
+                "at main>, then update SOURCE_COMMIT in scripts/ask-dev-contracts.mjs and the " +
+                "pinned ref in .github/workflows/tests.yml",
+        ].join("\n"),
+    );
+}
+
 async function main() {
-    const { allowWrite, mode, source } = parseArguments(process.argv.slice(2));
+    const { allowWrite, current, mode, pinned, source } = parseArguments(process.argv.slice(2));
     if (mode === "generate") {
         if (!allowWrite || source === undefined)
             throw new Error("generate requires --source and --allow-write");
         write(await expected(sourceFiles(path.resolve(source))));
         process.stdout.write("Generated Ask Dev schemas, examples, and TypeScript.\n");
+        return;
+    }
+    if (mode === "check-currency") {
+        if (pinned === undefined || current === undefined)
+            throw new Error("check-currency requires --pinned and --current");
+        assertCurrentWithMain(path.resolve(pinned), path.resolve(current));
         return;
     }
     const files = source === undefined ? localFiles() : sourceFiles(path.resolve(source));

--- a/src/lib/dev/__tests__/contracts.test.ts
+++ b/src/lib/dev/__tests__/contracts.test.ts
@@ -74,7 +74,7 @@ describe("Ask Dev generated contract boundary", () => {
         const source = readJson<SourceManifest>("source.json");
         const manifest = readJson<OpsManifest>("manifest.json");
 
-        expect(source.source_commit).toBe("c31b9c6de1b4b7dbdfc82d84850e4e09fb71960e");
+        expect(source.source_commit).toBe("5913cd3c9a737249a0f2fcf70796fedc4c466e66");
         expect(manifest.schema_version).toBe("ask_dev_contract_manifest.v1");
         expect(manifest.compatibility).toBe("additive-within-v1");
         expect(manifest.contracts.map((contract) => contract.schema_version)).toEqual(

--- a/src/lib/dev/contracts/manifest.json
+++ b/src/lib/dev/contracts/manifest.json
@@ -345,7 +345,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "ec2b36b4b4f20f5203002e0661db826ae78b862a20880d74d3618b059397a5dd"
+        "sha256": "7e596208a1c2711a4d6b7d2e6ba202b971a1ae8eae0af215e06aa01511f3e07e"
       },
       "schema_version": "dev_tool_result.v1"
     },

--- a/src/lib/dev/contracts/schemas/dev_tool_result.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_tool_result.v1.schema.json
@@ -102,6 +102,11 @@
           "title": "Required Children",
           "type": "array"
         },
+        "required_children_not_applicable": {
+          "default": false,
+          "title": "Required Children Not Applicable",
+          "type": "boolean"
+        },
         "rule_id": {
           "maxLength": 128,
           "minLength": 1,

--- a/src/lib/dev/contracts/source.json
+++ b/src/lib/dev/contracts/source.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "ask_dev_web_contract_source.v1",
-  "source_commit": "c31b9c6de1b4b7dbdfc82d84850e4e09fb71960e",
+  "source_commit": "5913cd3c9a737249a0f2fcf70796fedc4c466e66",
   "files": [
     {
       "path": "examples/negative/dev_answer.v1.invalid_complete_state.json",
@@ -220,7 +220,7 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "2540bfed0a73c1cce242d5fd3264a3882b5542ab14ba4e423a65df5b8142c647"
+      "sha256": "bed1f0e5768e33b9b8b72176da75dbe9767afb877607eaeb8c092bc33fcfa9a3"
     },
     {
       "path": "schemas/dev_answer.v1.schema.json",
@@ -288,7 +288,7 @@
     },
     {
       "path": "schemas/dev_tool_result.v1.schema.json",
-      "sha256": "ec2b36b4b4f20f5203002e0661db826ae78b862a20880d74d3618b059397a5dd"
+      "sha256": "7e596208a1c2711a4d6b7d2e6ba202b971a1ae8eae0af215e06aa01511f3e07e"
     },
     {
       "path": "vocabulary/internal_prose_denylist.v1.json",

--- a/src/lib/dev/generated.ts
+++ b/src/lib/dev/generated.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-// Generated from full-chaos/dev-health-ops c31b9c6de1b4b7dbdfc82d84850e4e09fb71960e. Do not edit.
+// Generated from full-chaos/dev-health-ops 5913cd3c9a737249a0f2fcf70796fedc4c466e66. Do not edit.
 export namespace DevAnswerContract {
     export type AnswerId = string;
     export type AsOf = string;
@@ -16533,6 +16533,7 @@ export namespace DevToolResultContract {
      * @maxItems 100
      */
     export type RequiredChildren = DevRequiredChildFact[];
+    export type RequiredChildrenNotApplicable = boolean;
     export type RuleId = string;
     export type RuleVersion = string;
     export type State = "ready" | "not_ready" | "indeterminate";
@@ -19026,6 +19027,7 @@ export namespace DevToolResultContract {
         required_child_complete?: RequiredChildComplete;
         required_child_total?: RequiredChildTotal;
         required_children?: RequiredChildren;
+        required_children_not_applicable?: RequiredChildrenNotApplicable;
         rule_id: RuleId;
         rule_version: RuleVersion;
         state: State;


### PR DESCRIPTION
Fixes CHAOS-3511.

## Problem

The web ask-dev contract pin (`SOURCE_COMMIT` in `scripts/ask-dev-contracts.mjs`, mirrored as the `quality` job's `ref:` in `.github/workflows/tests.yml`) was 54 commits stale against `full-chaos/dev-health-ops@main`, and nothing detected it. The existing `ask-dev:contracts:check` is a **consistency** guard — it proves the vendored artifacts match `SOURCE_COMMIT` — but never asked whether `SOURCE_COMMIT` itself was still current. Web CI was permanently, cleanly green against a contract snapshot of arbitrary age.

## Fix

**1. Refresh.** `SOURCE_COMMIT` → `5913cd3c9a737249a0f2fcf70796fedc4c466e66` (ops main tip as of this branch), updated in the sync script and the workflow ref together. Regenerated via the real generator (`pnpm ask-dev:contracts:generate`) against a clean ops worktree at that commit — never hand-written.

**The schema delta is purely additive**: the only change on the consumed surface (`contracts/ask-dev/v1/`) is one new optional field on `dev_tool_result.v1.schema.json` — `required_children_not_applicable: boolean`, `default: false`. No backend prerequisite was needed; nothing else in the consumed surface moved.

**2. Currency guard.** New `check-currency` mode in `ask-dev-contracts.mjs`: diffs the consumed surface (`contracts/ask-dev/v1/`) **by content** between an independent `--pinned` root and `--current` root (no shared git object database assumed — CI checks the two commits out into two separate clones), ignoring v2-only churn web doesn't consume. This is the "consumed-surface diff" shape from the ticket — the closest analogue to what ops CHAOS-3488 did for the acceptance-world fingerprint (guard the thing that actually matters, not the calendar), rather than a bounded commit-count/day check.

Wired as **mandatory**:
- `ci/run_tests.sh`'s `run_quality()` fails closed on a missing `ASK_DEV_OPS_MAIN_ROOT`, exactly like it already does for `ASK_DEV_OPS_ROOT`.
- `.github/workflows/tests.yml`'s `quality` job gets a second, independent `actions/checkout` at `ref: main` (`path: dev-health-ops-main`), alongside the existing pinned checkout.

A currency check that silently skips when it can't reach the comparison target would be the same false-green shape CHAOS-3219 prohibits — so it's required, not optional.

## Testing

RED-first: `scripts/__tests__/chaos-3511-contract-currency.test.mjs` (7 cases) builds real temporary Git repositories as the producer — no hand-authored JSON standing in for one — and drives the actual CLI (added/removed/changed file detection, v2-churn is ignored, missing-args fails closed, non-git/dirty roots rejected, env-var fallback). Verified RED by stashing the implementation: every case failed against the pre-change script (`"use generate or check"`); all pass now.

`scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs` + its helpers are updated for the new mandatory command/env/checkout shape — two of its pre-existing cases went RED the moment the fail-closed requirement was added (proving the wiring change has real effect), and are green again with updated expectations.

Also fixed a hardcoded pin assertion in `src/lib/dev/__tests__/contracts.test.ts` caught by the full unit run (`source_commit` pinned to the old SHA).

Full `web-full-gate` (`ci/run_tests.sh ci`, with a second clean ops worktree supplying `ASK_DEV_OPS_MAIN_ROOT`) is green: quality/build/unit (413 files / 3733 passed / 8 skipped), e2e default (319 passed / 2 skipped / 1 flaky-then-passed-on-retry), onboarding (10/10), context-fabric (21/21), pagerduty-final-qa (23/23). One earlier full-gate run hit reds in an unrelated spec (`admin-customer-push.spec.ts`, never touched by this change) under machine load ~26-31 (well over the documented false-red threshold); a same-commit control run of that spec in isolation passed 16/16 cleanly, confirming load noise before the clean full rerun reported above.

`docs/architecture.md` and the `web-full-gate` project skill are updated to document the new required `ASK_DEV_OPS_MAIN_ROOT`.

## Not in scope

No web consumer change beyond the additive field flowing through `generated.ts` — nothing in `src/` reads `required_children_not_applicable` yet.

TEST-WAIVER: not needed — every `src/`/`scripts/` change here has a corresponding test change.