### PR TITLE
CHAOS-3510: Wave 4 Context Fabric Validation access matrix + armed-or-throw config

### DIFF
--- a/playwright.ask-dev-wave4.config.ts
+++ b/playwright.ask-dev-wave4.config.ts
@@ -1,0 +1,128 @@
+import { defineConfig } from "@playwright/test";
+
+/**
+ * CHAOS-3219 Phase 4 Lane 4d — Context Fabric Validation access matrix.
+ *
+ * Follows the armed-or-throw precedent set by
+ * `playwright.ask-dev-acceptance.config.ts`: this file throws during
+ * configuration unless the canonical Ops Compose launcher supplied every
+ * variable below. The Phase 4 plan's closing constraint is that all Phase-4
+ * specs run against the Compose stack via the launcher, never against dev
+ * mocks — and a gate that quietly degrades to mocks, or quietly runs nothing,
+ * is worse than no gate because it reads as coverage.
+ *
+ * Two separate properties are enforced here, and they are NOT the same thing:
+ *
+ *  - ARMING (this file): the run was configured against a real Compose stack.
+ *  - EXECUTION (`Wave4ExecutedCountReporter`): the run actually measured
+ *    something. A config that throws correctly but is never invoked by CI is
+ *    still zero coverage; a config that is invoked but matches no tests exits 0.
+ *    Only the reporter can catch the second case.
+ *
+ * Neither property implies CI invocation. Wiring this config into a workflow is
+ * Phase 5 Lane 5c's deliverable, and until that lands this suite produces no
+ * release evidence — see CHAOS-3510's dependency note.
+ */
+
+function requireArmed(name: string, expected: string, remedy: string): void {
+    if (process.env[name] !== expected) {
+        throw new Error(
+            `Ask Dev Wave 4 access matrix was not armed: ${name} must be exactly "${expected}". ` +
+                `${remedy} This gate must never skip silently.`,
+        );
+    }
+}
+
+function requireNonEmpty(name: string, remedy: string): void {
+    if (!process.env[name]?.trim()) {
+        throw new Error(`Ask Dev Wave 4 access matrix requires ${name}. ${remedy}`);
+    }
+}
+
+requireArmed(
+    "ASK_DEV_LIVE_ACCEPTANCE",
+    "1",
+    "Run the canonical Ops acceptance launcher (scripts/acceptance/run_ask_dev_compose.sh).",
+);
+requireArmed(
+    "ASK_DEV_COMPOSE_WEB_READY",
+    "1",
+    "The Web service must be the Compose-booted one; a separately started Web process is not release evidence.",
+);
+requireArmed(
+    "ASK_DEV_WAVE4_ACCESS_MATRIX",
+    "1",
+    "This lane is armed independently of the Phase 1 acceptance spec so a launcher that predates it cannot appear to have run it.",
+);
+
+// The access matrix creates and signs in as real non-superadmin identities
+// against the live Ops API. Without these it would silently fall back to the
+// helper defaults and prove the matrix for the wrong tenant.
+requireNonEmpty(
+    "TEST_SUPERUSER_EMAIL",
+    "The seeded platform admin is the only actor permitted to provision the matrix's other identities.",
+);
+requireNonEmpty("TEST_SUPERUSER_PASSWORD", "Supplied by the Ops acceptance launcher.");
+requireNonEmpty(
+    "PLAYWRIGHT_LIVE_BACKEND_URL",
+    "The matrix provisions identities and reads capabilities over the real Ops REST API, not through the browser only.",
+);
+
+// ACR arming must be DECLARED, not inferred. Entitlement non-coupling is the
+// claim that Ask Dev availability does not depend on ACR being enabled; a run
+// that does not know which side of that toggle it is on cannot assert it, and
+// would happily "prove" non-coupling while never varying the variable. "0" and
+// "1" are both valid — silence is not.
+if (!["0", "1"].includes(process.env.ASK_DEV_ACCEPTANCE_ACR ?? "")) {
+    throw new Error(
+        'Ask Dev Wave 4 access matrix requires ASK_DEV_ACCEPTANCE_ACR to be exactly "0" or "1". ' +
+            "The entitlement non-coupling rows assert against the declared ACR arming state; an " +
+            "undeclared one would let the suite pass without ever knowing what it tested.",
+    );
+}
+
+// Written by prepare_ask_dev_acceptance.py's provision_multi_org() — carries
+// primary_org_id, second_org_id and disabled_entitlement_org_id under
+// schema_version "ask_dev_acceptance_org_ids.v1". The entitlement rows read the
+// deliberately-unentitled org from here rather than mutating the primary org's
+// policy, so entitlement and the emergency kill switch stay distinguishable.
+requireNonEmpty(
+    "ASK_DEV_ACCEPTANCE_ORG_IDS",
+    "Point it at the launcher's ASK_DEV_ACCEPTANCE_ORG_IDS_OUTPUT artifact (default /tmp/ask-dev-acceptance-org-ids.json).",
+);
+
+const RESULTS_DIRECTORY =
+    process.env.PLAYWRIGHT_RESULTS_DIR ?? "test-results/playwright/ask-dev-wave4";
+const HTML_REPORT_DIRECTORY =
+    process.env.PLAYWRIGHT_HTML_REPORT ?? "test-results/playwright-html/ask-dev-wave4";
+const JUNIT_PATH = process.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME ?? `${RESULTS_DIRECTORY}/junit.xml`;
+
+export default defineConfig({
+    testDir: "./tests/live",
+    testMatch: /ask-dev-wave4-access-matrix\.spec\.ts/,
+    outputDir: RESULTS_DIRECTORY,
+    reporter: [
+        ["list"],
+        ["junit", { outputFile: JUNIT_PATH }],
+        ["html", { open: "never", outputFolder: HTML_REPORT_DIRECTORY }],
+        // Last, so its verdict is the one that decides the exit code. Proven
+        // load-bearing: with an all-skipped suite Playwright exits 0 and this
+        // reporter is the only thing that turns it into a 1.
+        ["./tests/live/wave4ExecutedCountReporter.ts"],
+    ],
+    fullyParallel: false,
+    workers: 1,
+    // A release gate must not launder a real failure into a pass by retrying.
+    retries: 0,
+    // Matrix rows provision users and orgs over the live API before asserting.
+    timeout: 120_000,
+    expect: { timeout: 15_000 },
+    use: {
+        baseURL: process.env.ASK_DEV_ACCEPTANCE_WEB_URL ?? "http://127.0.0.1:3002",
+        headless: true,
+        // Kept unconditionally: this suite's artifacts are the evidence bundle
+        // for acceptance groups 6 and 7, not just failure triage.
+        trace: "on",
+        screenshot: "only-on-failure",
+    },
+});

--- a/playwright.live.config.ts
+++ b/playwright.live.config.ts
@@ -16,7 +16,25 @@ export default defineConfig({
         },
         {
             name: "live-api",
-            testIgnore: [/onboarding-ui\.spec\.ts/, /ask-dev-acceptance\.spec\.ts/],
+            // CHAOS-3510 adds two things under tests/live/ that this suite must
+            // NOT collect, for different reasons:
+            //
+            //   __tests__/  — vitest specs for the wave4 Playwright reporter.
+            //     Playwright's default testMatch includes `*.test.ts`, so it
+            //     picked these up and died on `Vitest cannot be imported in a
+            //     CommonJS module`. They are colocated with the reporter they
+            //     guard on purpose; this exclusion is what keeps that safe.
+            //
+            //   ask-dev-wave4-access-matrix.spec.ts — armed-or-throw, same as
+            //     ask-dev-acceptance.spec.ts above. It needs the Compose
+            //     launcher's org provisioning and arming contract; running it
+            //     against this suite's generic backend proves nothing and fails.
+            testIgnore: [
+                /onboarding-ui\.spec\.ts/,
+                /ask-dev-acceptance\.spec\.ts/,
+                /ask-dev-wave4-access-matrix\.spec\.ts/,
+                /__tests__\//,
+            ],
             dependencies: ["onboarding-ui"],
             use: { baseURL: "http://127.0.0.1:3002", headless: true },
         },

--- a/tests/live/__tests__/wave4ExecutedCountReporter.test.ts
+++ b/tests/live/__tests__/wave4ExecutedCountReporter.test.ts
@@ -86,6 +86,28 @@ describe("Wave4ExecutedCountReporter", () => {
         expect(reporter.executedCount).toBe(2);
     });
 
+    it("stays out of the way of --list, where zero executed is the correct outcome", () => {
+        // Found by running `playwright test --list` against the real config and
+        // watching it exit 1: test discovery is not a false green, and failing
+        // it would break CI enumeration and editor integrations.
+        const reporter = new Wave4ExecutedCountReporter({
+            argv: ["node", "playwright", "test", "--list"],
+        });
+
+        expect(reporter.onEnd(PASSED)).toBeUndefined();
+        expect(reporter.executedCount).toBe(0);
+    });
+
+    it("still guards a real run when --list is absent from argv", () => {
+        // The paired positive: the exemption must key on --list specifically and
+        // not simply disable the guard for every invocation.
+        const reporter = new Wave4ExecutedCountReporter({ argv: ["node", "playwright", "test"] });
+        const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        expect(reporter.onEnd(PASSED)).toEqual({ status: "failed" });
+        errors.mockRestore();
+    });
+
     it("leaves a genuine failure failing rather than masking it", () => {
         const reporter = new Wave4ExecutedCountReporter();
 

--- a/tests/live/__tests__/wave4ExecutedCountReporter.test.ts
+++ b/tests/live/__tests__/wave4ExecutedCountReporter.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FullResult, TestCase, TestResult } from "@playwright/test/reporter";
+
+import Wave4ExecutedCountReporter from "../wave4ExecutedCountReporter";
+
+/**
+ * CHAOS-3219 Phase 4 Lane 4d — control for the access matrix's false-green guard.
+ *
+ * This guard's whole job is to fail a run that measured nothing. That is
+ * unprovable from inside the suite it guards (an armed Compose launcher), and
+ * a guard nobody watches fail is indistinguishable from one that cannot. So
+ * every branch is exercised here, in the required unit job, by feeding the
+ * reporter the exact result stream Playwright would.
+ */
+
+function testCase(title: string): TestCase {
+    return { titlePath: () => ["", "project", "file.spec.ts", title] } as unknown as TestCase;
+}
+
+function result(status: TestResult["status"]): TestResult {
+    return { status } as TestResult;
+}
+
+const PASSED: FullResult = { status: "passed" } as FullResult;
+
+describe("Wave4ExecutedCountReporter", () => {
+    it("FAILS a run that executed zero tests, even though Playwright called it passed", () => {
+        const reporter = new Wave4ExecutedCountReporter();
+        const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        // No onTestEnd at all — the empty-match case: a bad testMatch, a stale
+        // filename, a --grep typo. Playwright's own verdict here is "passed".
+        const verdict = reporter.onEnd(PASSED);
+
+        expect(reporter.executedCount).toBe(0);
+        expect(verdict).toEqual({ status: "failed" });
+        expect(errors.mock.calls.flat().join("\n")).toContain("executed ZERO tests");
+        errors.mockRestore();
+    });
+
+    it("FAILS a run where every test was skipped — the B1 '144 skipped, exit 0' shape", () => {
+        const reporter = new Wave4ExecutedCountReporter();
+        const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        reporter.onTestEnd(testCase("superadmin reaches validation"), result("skipped"));
+        reporter.onTestEnd(testCase("member is denied"), result("skipped"));
+
+        const verdict = reporter.onEnd(PASSED);
+
+        // Skips must not count as measurement — this is the assertion that
+        // separates this guard from a plain "did anything happen" counter.
+        expect(reporter.executedCount).toBe(0);
+        expect(verdict).toEqual({ status: "failed" });
+        const message = errors.mock.calls.flat().join("\n");
+        expect(message).toContain("skipped 2 test(s)");
+        expect(message).toContain("member is denied");
+        errors.mockRestore();
+    });
+
+    it("FAILS a run that measured real rows but skipped even one", () => {
+        const reporter = new Wave4ExecutedCountReporter();
+        const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        reporter.onTestEnd(testCase("superadmin reaches validation"), result("passed"));
+        reporter.onTestEnd(testCase("impersonation row"), result("skipped"));
+
+        const verdict = reporter.onEnd(PASSED);
+
+        // The partial case is the dangerous one: a green summary with a silently
+        // unmeasured matrix row inside it.
+        expect(reporter.executedCount).toBe(1);
+        expect(verdict).toEqual({ status: "failed" });
+        expect(errors.mock.calls.flat().join("\n")).toContain("impersonation row");
+        errors.mockRestore();
+    });
+
+    it("does NOT override the verdict when tests actually ran and none were skipped", () => {
+        const reporter = new Wave4ExecutedCountReporter();
+
+        reporter.onTestEnd(testCase("superadmin reaches validation"), result("passed"));
+        reporter.onTestEnd(testCase("member is denied"), result("passed"));
+
+        // undefined means "leave Playwright's verdict alone" — the guard must
+        // not manufacture passes OR failures on a run that genuinely measured.
+        expect(reporter.onEnd(PASSED)).toBeUndefined();
+        expect(reporter.executedCount).toBe(2);
+    });
+
+    it("leaves a genuine failure failing rather than masking it", () => {
+        const reporter = new Wave4ExecutedCountReporter();
+
+        reporter.onTestEnd(testCase("member is denied"), result("failed"));
+
+        // A failed test still counts as executed: the run measured something and
+        // that something was wrong. The guard must not convert this into its own
+        // verdict, nor rescue it.
+        expect(reporter.executedCount).toBe(1);
+        expect(reporter.onEnd({ status: "failed" } as FullResult)).toBeUndefined();
+    });
+});

--- a/tests/live/ask-dev-wave4-access-matrix.spec.ts
+++ b/tests/live/ask-dev-wave4-access-matrix.spec.ts
@@ -26,7 +26,7 @@ import { expect, test, type APIRequestContext, type Browser, type Page } from "@
 import { readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 
-import { authHeaders, liveBackendUrl, loginUser, signInCanonicalUser } from "./helpers";
+import { authHeaders, liveBackendUrl, signInCanonicalUser } from "./helpers";
 
 type JsonObject = Record<string, unknown>;
 
@@ -86,15 +86,52 @@ function readProvisionedOrgIds(): {
     };
 }
 
+/**
+ * Cached for the whole file. `/api/v1/auth/login` is rate limited per IP
+ * (`AUTH_LOGIN_IP_LIMIT = "20/15minutes"`), and that budget is shared by
+ * EVERYTHING the acceptance launcher does from this host: the world-principal
+ * login proof, provision_multi_org's org-scoped logins, the Phase 1 spec, and
+ * then these rows. Logging in once per test burned four of those for no reason
+ * and exhausted the budget mid-suite on the first live run. One login, reused.
+ */
+let cachedSuperadminToken: string | undefined;
+
 async function superadminToken(request: APIRequestContext): Promise<string> {
-    const login = (await loginUser(
-        request,
-        process.env.TEST_SUPERUSER_EMAIL!,
-        process.env.TEST_SUPERUSER_PASSWORD!,
-    )) as JsonObject;
-    const token = login.access_token;
-    expect(typeof token, "The seeded platform admin could not log in.").toBe("string");
-    return token as string;
+    if (cachedSuperadminToken) return cachedSuperadminToken;
+
+    const response = await request.post(`${liveBackendUrl}/api/v1/auth/login`, {
+        data: {
+            email: process.env.TEST_SUPERUSER_EMAIL,
+            password: process.env.TEST_SUPERUSER_PASSWORD,
+        },
+    });
+    const body = await response.text();
+
+    // A 429 is an environment condition, not a credentials problem. The first
+    // version of this helper reported both as "the platform admin could not log
+    // in", which sent the reader hunting for a bad password when the real cause
+    // was an exhausted per-IP login budget. Say which it is.
+    if (response.status() === 429) {
+        throw new Error(
+            "Ask Dev Wave 4 access matrix could not authenticate: the login endpoint returned 429. " +
+                "This is the per-IP login budget (AUTH_LOGIN_IP_LIMIT, 20/15minutes) exhausted by " +
+                "earlier logins in this acceptance run — NOT bad credentials. Re-run once the window " +
+                `clears, or reduce logins before this point. Body: ${body}`,
+        );
+    }
+    if (!response.ok()) {
+        throw new Error(
+            `Ask Dev Wave 4 access matrix could not authenticate the seeded platform admin: ` +
+                `HTTP ${response.status()}. Body: ${body}`,
+        );
+    }
+
+    const token = (JSON.parse(body) as JsonObject).access_token;
+    if (typeof token !== "string" || !token) {
+        throw new Error(`Login succeeded but returned no access_token. Body: ${body}`);
+    }
+    cachedSuperadminToken = token;
+    return token;
 }
 
 /**

--- a/tests/live/ask-dev-wave4-access-matrix.spec.ts
+++ b/tests/live/ask-dev-wave4-access-matrix.spec.ts
@@ -18,7 +18,8 @@
  *   - old-route four-way branch selection ......... src/app/(app)/agent-context/
  *                                                   context-packet/page.test.tsx
  *
- * Every identity minted here is unique per run and self-contained, so re-runs
+ * Row A3 pins the CHAOS-3587 ruling (impersonation is intended); see its own
+ * block comment. Every identity minted here is unique per run and self-contained, so re-runs
  * cannot pass by inheriting a previous run's state.
  */
 import { expect, test, type APIRequestContext, type Browser, type Page } from "@playwright/test";
@@ -307,23 +308,21 @@ test("a member of the never-entitled org is sent to Diagnose and gets no Ask Dev
 });
 
 // ---------------------------------------------------------------------------
-// Row A3 — impersonation. CHARACTERIZATION SPEC.
+// Row A3 — impersonation. RULED INTENDED, CHAOS-3587 (2026-08-07).
 //
-// This pins what the system does TODAY. It is deliberately NOT a judgement
-// that today's behaviour is correct: `requireSuperuser` (src/lib/auth.ts:514)
-// reads only `is_superuser`, which impersonation never mutates, while the page
-// resolves its org through the EFFECTIVE (impersonated) org id and keeps
-// `showRetrievalDebug` on. So an impersonating platform admin runs Context
-// Fabric Validation against the target tenant's data with retrieval debug
-// visible.
+// A platform admin acting on behalf of a struggling user keeps the validation
+// surface, works inside the TARGET org (consuming that org's budget), and
+// retains retrieval debug. That is the product's intent, not an accident of
+// `requireSuperuser` (src/lib/auth.ts:514) reading only `is_superuser`.
 //
-// Whether that is intended is an OPEN PRODUCT QUESTION tracked by CHAOS-3587.
-// If it is ruled unintended, this spec inverts into a RED-first deny guard
-// under that ticket. Until then, pinning beats both asserting a deny nobody
-// ruled on and leaving the behaviour entirely unobserved.
+// This spec is therefore the PERMANENT pin of the ruled semantics, asserted
+// affirmatively rather than merely observed. No deny-guard variant exists or
+// will: a future change that closes the surface while impersonating, or that
+// silently resolves the admin's OWN org instead of the target's, is a
+// REGRESSION against CHAOS-3587 and must fail here.
 // ---------------------------------------------------------------------------
 
-test("CHARACTERIZATION (CHAOS-3587): impersonation does not close the platform validation surface", async ({
+test("RULED INTENDED (CHAOS-3587): an impersonating platform admin keeps validation, scoped to the target org", async ({
     page,
     request,
 }, testInfo) => {
@@ -370,18 +369,62 @@ test("CHARACTERIZATION (CHAOS-3587): impersonation does not close the platform v
             waitUntil: "domcontentloaded",
         });
 
-        // PINNED BEHAVIOUR — today's answers, not endorsements:
-        // 1. the platform-admin route stays reachable while impersonating,
+        // RULED SEMANTICS (CHAOS-3587), asserted affirmatively.
+        //
+        // 1. The platform-admin route stays reachable while impersonating.
         await expect(page).toHaveURL(/\/superadmin\/context-fabric\/validation(?:[?#]|$)/u);
         await expect(
             page.getByRole("heading", { name: "Context Fabric Validation", level: 1 }),
         ).toBeVisible();
-        // 2. the validator is fully operable there, and
+
+        // 2. The validator is fully operable there — "reachable but inert"
+        //    would satisfy (1) while defeating the point of the ruling.
         await expect(page.getByRole("main").getByTestId("context-packet-form")).toBeVisible();
-        // 3. the impersonation banner remains visible on it, so the operator is
-        //    at least told whose tenant they are pointed at.
+
+        // 3. THE EFFECTIVE ORG IS THE TARGET'S, not the admin's. This is the
+        //    load-bearing half of the ruling — target-org budget consumption is
+        //    explicitly allowed — and it is the half a URL/heading check cannot
+        //    see. Read from the real session rather than inferred from the UI.
+        const session = (await (await page.request.get("/api/auth/session")).json()) as JsonObject;
+        const sessionUser = session.user as JsonObject | undefined;
+        expect(sessionUser, "The impersonating session exposed no user.").toBeTruthy();
+        expect(sessionUser).toMatchObject({
+            is_impersonating: true,
+            // Superuser identity survives impersonation — this is WHY the
+            // surface stays open, and pinning it makes the mechanism explicit.
+            is_superuser: true,
+            impersonated_user_id: target.userId,
+            // Effective org follows the target; the validator therefore reads
+            // the target tenant's context, which the ruling permits.
+            org_id: disabledEntitlementOrgId,
+        });
+        // And the admin's own org is still tracked separately, so "effective"
+        // is genuinely distinct from "real" rather than both having collapsed
+        // onto the same value (which would make the assertion above vacuous).
+        expect(
+            sessionUser?.real_org_id,
+            "real_org_id collapsed onto the impersonated org; the effective-org assertion above would be vacuous.",
+        ).not.toBe(disabledEntitlementOrgId);
+
+        // 4. The impersonation banner stays visible on this surface, so the
+        //    operator is always told whose tenant they are pointed at.
         await expect(page.getByText(/Viewing as/u).first()).toBeVisible();
 
+        // NOT ASSERTED, and deliberately so: the third clause of the ruling —
+        // retrieval debug remains AVAILABLE. The validation page hardcodes
+        // `showRetrievalDebug` (page.tsx:68), but that prop only ever surfaces
+        // as `packet.retrieval_debug_summary` text inside a GENERATED packet
+        // (ContextPacketExplorer.test.tsx:527-537). Reaching it needs a real
+        // ACR-backed generation, and this launcher defaults to acr_armed=0 —
+        // so on a normal run there is nothing to assert against. Asserting the
+        // prop's presence some other way would be asserting the source, not the
+        // behaviour, and an assertion that silently passes when ACR is off is
+        // exactly the false coverage this suite exists to avoid.
+        //
+        // Residual, stated rather than hidden: clauses 1, 2 and 3 of CHAOS-3587
+        // are pinned here; the debug-availability clause is unproven at any
+        // tier. Closing it needs an ACR-armed run (ASK_DEV_ACCEPTANCE_ACR=1),
+        // which no CI workflow currently performs.
         await page.screenshot({
             path: testInfo.outputPath("validation-while-impersonating.png"),
             fullPage: true,

--- a/tests/live/ask-dev-wave4-access-matrix.spec.ts
+++ b/tests/live/ask-dev-wave4-access-matrix.spec.ts
@@ -1,0 +1,395 @@
+/**
+ * CHAOS-3219 Phase 4 Lane 4d (CHAOS-3510) — Context Fabric Validation access matrix.
+ *
+ * Runs ONLY under `playwright.ask-dev-wave4.config.ts`, which throws unless the
+ * Ops Compose launcher armed it (CHAOS-3586 supplies the wiring). Real browser,
+ * real Auth.js sessions, real Ops REST API — no MSW, no route interception, no
+ * dependency override, per Phase 4's "never against dev mocks" constraint.
+ *
+ * WHAT THIS FILE DELIBERATELY DOES NOT COVER. These rows are already owned
+ * elsewhere and are NOT re-implemented here; duplicating them beside the
+ * originals and calling it new coverage is the inaccurate-coverage-claim
+ * failure this epic exists to prevent:
+ *
+ *   - member denied on the validation route ....... ask-dev-acceptance.spec.ts:654-693
+ *   - emergency kill switch collapses capabilities  ask-dev-acceptance.spec.ts:625-637
+ *   - validation usable with ask_dev + ACR off .... ask-dev-acceptance.spec.ts:639-652
+ *   - ask_dev / byo_llm / ACR decided independently src/lib/dev/__tests__/contracts.test.ts:258-278
+ *   - old-route four-way branch selection ......... src/app/(app)/agent-context/
+ *                                                   context-packet/page.test.tsx
+ *
+ * Every identity minted here is unique per run and self-contained, so re-runs
+ * cannot pass by inheriting a previous run's state.
+ */
+import { expect, test, type APIRequestContext, type Browser, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+import { authHeaders, liveBackendUrl, loginUser, signInCanonicalUser } from "./helpers";
+
+type JsonObject = Record<string, unknown>;
+
+const WEB_BASE_URL = process.env.ASK_DEV_ACCEPTANCE_WEB_URL ?? "http://127.0.0.1:3002";
+const MEMBER_PASSWORD = "DevHealth123!";
+
+/**
+ * The org ids this acceptance run provisioned, from
+ * prepare_ask_dev_acceptance.py's provision_multi_org(). Read strictly: an
+ * unreadable or unrecognised artifact must abort, never degrade into "test the
+ * primary org twice", which would look green while proving nothing about
+ * cross-tenant entitlement.
+ */
+function readProvisionedOrgIds(): {
+    primaryOrgId: string;
+    secondOrgId: string;
+    disabledEntitlementOrgId: string;
+} {
+    const path = process.env.ASK_DEV_ACCEPTANCE_ORG_IDS;
+    if (!path?.trim()) {
+        throw new Error(
+            "ASK_DEV_ACCEPTANCE_ORG_IDS is required; the config should have caught this.",
+        );
+    }
+    let parsed: JsonObject;
+    try {
+        parsed = JSON.parse(readFileSync(path, "utf-8")) as JsonObject;
+    } catch (cause) {
+        throw new Error(
+            `Could not read the org-ids artifact at ${path}. The Wave 4 matrix cannot ` +
+                `identify the tenants it is supposed to distinguish, so it must fail rather ` +
+                `than run against unknown orgs. Cause: ${String(cause)}`,
+        );
+    }
+    if (parsed.schema_version !== "ask_dev_acceptance_org_ids.v1") {
+        throw new Error(
+            `Unexpected org-ids schema_version ${String(parsed.schema_version)} at ${path}; ` +
+                "refusing to guess the field layout.",
+        );
+    }
+    const primaryOrgId = parsed.primary_org_id;
+    const secondOrgId = parsed.second_org_id;
+    const disabledEntitlementOrgId = parsed.disabled_entitlement_org_id;
+    for (const [name, value] of Object.entries({
+        primary_org_id: primaryOrgId,
+        second_org_id: secondOrgId,
+        disabled_entitlement_org_id: disabledEntitlementOrgId,
+    })) {
+        if (typeof value !== "string" || !value.trim()) {
+            throw new Error(`org-ids artifact at ${path} has no usable ${name}.`);
+        }
+    }
+    return {
+        primaryOrgId: primaryOrgId as string,
+        secondOrgId: secondOrgId as string,
+        disabledEntitlementOrgId: disabledEntitlementOrgId as string,
+    };
+}
+
+async function superadminToken(request: APIRequestContext): Promise<string> {
+    const login = (await loginUser(
+        request,
+        process.env.TEST_SUPERUSER_EMAIL!,
+        process.env.TEST_SUPERUSER_PASSWORD!,
+    )) as JsonObject;
+    const token = login.access_token;
+    expect(typeof token, "The seeded platform admin could not log in.").toBe("string");
+    return token as string;
+}
+
+/**
+ * Mint a fresh, verified, non-superuser member of `orgId`. Unique per run by
+ * uuid, so a re-run can never silently reuse a prior run's user (whose org
+ * membership or entitlement may since have changed).
+ */
+async function mintMember(
+    request: APIRequestContext,
+    token: string,
+    orgId: string,
+    label: string,
+): Promise<{ email: string; userId: string }> {
+    const email = `ask-dev-wave4-${label}-${randomUUID()}@example.com`;
+    const created = await request.post(`${liveBackendUrl}/api/v1/admin/users`, {
+        data: {
+            email,
+            full_name: `Ask Dev Wave 4 ${label}`,
+            is_superuser: false,
+            is_verified: true,
+            password: MEMBER_PASSWORD,
+        },
+        headers: authHeaders(token),
+    });
+    const body = (await created.json()) as JsonObject;
+    expect(created.ok(), `Could not mint the ${label} member: ${JSON.stringify(body)}`).toBe(true);
+    const userId = body.id;
+    expect(typeof userId, `Minted ${label} member has no id.`).toBe("string");
+
+    const membership = await request.post(`${liveBackendUrl}/api/v1/admin/orgs/${orgId}/members`, {
+        data: { role: "member", user_id: userId },
+        headers: authHeaders(token),
+    });
+    expect(
+        membership.ok(),
+        `Could not add the ${label} member to org ${orgId}: ${await membership.text()}`,
+    ).toBe(true);
+
+    return { email, userId: userId as string };
+}
+
+/** Sign in through the real Auth.js browser flow and confirm the session took. */
+async function signIn(page: Page, email: string, password: string): Promise<void> {
+    await page.goto("/auth/signin");
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill(password);
+    const callback = page.waitForResponse(
+        (response) =>
+            new URL(response.url()).pathname === "/api/auth/callback/credentials" &&
+            response.request().method() === "POST",
+    );
+    await page.getByRole("button", { name: "Sign In" }).click();
+    expect((await callback).ok(), `${email} could not sign in.`).toBe(true);
+    await expect(page).toHaveURL(/\/dashboard(?:\?|$)/u);
+}
+
+/** A browser context with no session at all. */
+async function anonymousPage(
+    browser: Browser,
+): Promise<{ page: Page; close: () => Promise<void> }> {
+    const context = await browser.newContext({ baseURL: WEB_BASE_URL });
+    return { page: await context.newPage(), close: () => context.close() };
+}
+
+// ---------------------------------------------------------------------------
+// Row B2 — unauthenticated. New coverage.
+// ---------------------------------------------------------------------------
+
+test("an unauthenticated visitor is sent to sign-in, with the validation route preserved as the callback", async ({
+    browser,
+}, testInfo) => {
+    const { page, close } = await anonymousPage(browser);
+    try {
+        await page.goto("/superadmin/context-fabric/validation", {
+            waitUntil: "domcontentloaded",
+        });
+
+        await expect(page).toHaveURL(/\/auth\/signin/u);
+        // The callbackUrl half matters as much as the redirect: without it the
+        // guard "works" but silently drops the user's destination after login.
+        expect(
+            new URL(page.url()).searchParams.get("callbackUrl"),
+            "Sign-in did not preserve the validation route as the post-login destination.",
+        ).toContain("/superadmin/context-fabric/validation");
+
+        // Absence assertions need a positive control, or a 500 would satisfy them.
+        await expect(page.getByLabel("Email")).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Context Fabric Validation" })).toHaveCount(
+            0,
+        );
+
+        await page.screenshot({
+            path: testInfo.outputPath("validation-anonymous-redirected.png"),
+            fullPage: true,
+        });
+    } finally {
+        await close();
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Rows B1 — old-route compatibility, live.
+//
+// TIER UPGRADE OF EXISTING UNIT COVERAGE, not new coverage. The branch
+// selection is already proven in page.test.tsx; what is NOT proven there is
+// that a real request to the old path on a real stack actually redirects,
+// because that test mocks requireSession, getOrgEntitlements AND
+// permanentRedirect — every moving part of the real path.
+// ---------------------------------------------------------------------------
+
+test("TIER UPGRADE: the old context-packet path sends a platform admin to validation, query intact", async ({
+    page,
+}, testInfo) => {
+    await signInCanonicalUser(page);
+
+    await page.goto("/agent-context/context-packet?state=partial", {
+        waitUntil: "domcontentloaded",
+    });
+
+    await expect(page).toHaveURL(/\/superadmin\/context-fabric\/validation\?state=partial$/u);
+    // Prove we LANDED, not merely that the URL changed.
+    await expect(
+        page.getByRole("heading", { name: "Context Fabric Validation", level: 1 }),
+    ).toBeVisible();
+    await page.screenshot({
+        path: testInfo.outputPath("old-route-superadmin.png"),
+        fullPage: true,
+    });
+});
+
+test("TIER UPGRADE: the old context-packet path sends an entitled member to Ask Dev, without leaking the diagnostic query", async ({
+    browser,
+    request,
+}, testInfo) => {
+    const { primaryOrgId } = readProvisionedOrgIds();
+    const token = await superadminToken(request);
+    const member = await mintMember(request, token, primaryOrgId, "entitled");
+
+    const context = await browser.newContext({ baseURL: WEB_BASE_URL });
+    try {
+        const page = await context.newPage();
+        await signIn(page, member.email, MEMBER_PASSWORD);
+
+        await page.goto("/agent-context/context-packet?state=error&repository=private-repo", {
+            waitUntil: "domcontentloaded",
+        });
+
+        await expect(page).toHaveURL(/\/dev(?:[?#]|$)/u);
+        // The diagnostic query is platform-admin detail; it must not ride along
+        // into a product surface.
+        expect(page.url(), "The old route leaked its diagnostic query to /dev.").not.toContain(
+            "private-repo",
+        );
+        await expect(page.getByRole("region", { name: "Ask Dev workspace" })).toBeVisible();
+        await page.screenshot({
+            path: testInfo.outputPath("old-route-entitled-member.png"),
+            fullPage: true,
+        });
+    } finally {
+        await context.close();
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Row A4 — cross-tenant entitlement. New coverage.
+//
+// This is the axis the existing live coverage does NOT reach: it disables
+// ask_dev on the PRIMARY org via the emergency switch, which is a different
+// mechanism from an org that was never entitled. This row uses the tenant ops
+// provisions for exactly this purpose and that nothing has consumed until now.
+// ---------------------------------------------------------------------------
+
+test("a member of the never-entitled org is sent to Diagnose and gets no Ask Dev surface at all", async ({
+    browser,
+    request,
+}, testInfo) => {
+    const { disabledEntitlementOrgId } = readProvisionedOrgIds();
+    const token = await superadminToken(request);
+    const member = await mintMember(request, token, disabledEntitlementOrgId, "unentitled");
+
+    const context = await browser.newContext({ baseURL: WEB_BASE_URL });
+    try {
+        const page = await context.newPage();
+        await signIn(page, member.email, MEMBER_PASSWORD);
+
+        // Old route: unentitled members land on Diagnose, never on the
+        // platform-admin validator.
+        await page.goto("/agent-context/context-packet", { waitUntil: "domcontentloaded" });
+        await expect(page).toHaveURL(/\/diagnose(?:[?#]|$)/u);
+        expect(page.url()).not.toContain("context-fabric");
+
+        // Entitlement is an org property, not a route property: the launcher
+        // must be absent on an ordinary route too. The same route renders the
+        // launcher for an entitled member (ask-dev-shared.spec.ts W9), so this
+        // absence is attributable to entitlement rather than to the page.
+        await expect(page.getByRole("button", { name: "Open Ask Dev" })).toHaveCount(0);
+
+        // And the full-page workspace refuses by name rather than 404ing.
+        await page.goto("/dev", { waitUntil: "domcontentloaded" });
+        await expect(
+            page.getByText("Ask Dev is not available for this organization"),
+        ).toBeVisible();
+
+        await page.screenshot({
+            path: testInfo.outputPath("unentitled-org-no-ask-dev.png"),
+            fullPage: true,
+        });
+    } finally {
+        await context.close();
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Row A3 — impersonation. CHARACTERIZATION SPEC.
+//
+// This pins what the system does TODAY. It is deliberately NOT a judgement
+// that today's behaviour is correct: `requireSuperuser` (src/lib/auth.ts:514)
+// reads only `is_superuser`, which impersonation never mutates, while the page
+// resolves its org through the EFFECTIVE (impersonated) org id and keeps
+// `showRetrievalDebug` on. So an impersonating platform admin runs Context
+// Fabric Validation against the target tenant's data with retrieval debug
+// visible.
+//
+// Whether that is intended is an OPEN PRODUCT QUESTION tracked by CHAOS-3587.
+// If it is ruled unintended, this spec inverts into a RED-first deny guard
+// under that ticket. Until then, pinning beats both asserting a deny nobody
+// ruled on and leaving the behaviour entirely unobserved.
+// ---------------------------------------------------------------------------
+
+test("CHARACTERIZATION (CHAOS-3587): impersonation does not close the platform validation surface", async ({
+    page,
+    request,
+}, testInfo) => {
+    const { disabledEntitlementOrgId } = readProvisionedOrgIds();
+    const token = await superadminToken(request);
+    const target = await mintMember(request, token, disabledEntitlementOrgId, "impersonated");
+
+    await signInCanonicalUser(page);
+
+    // Positive control FIRST: the surface is reachable before impersonation, so
+    // any change below is attributable to impersonation and not to a broken
+    // session or an unrelated outage.
+    await page.goto("/superadmin/context-fabric/validation", { waitUntil: "domcontentloaded" });
+    await expect(
+        page.getByRole("heading", { name: "Context Fabric Validation", level: 1 }),
+    ).toBeVisible();
+
+    const started = await request.post(`${liveBackendUrl}/api/v1/admin/impersonate`, {
+        headers: authHeaders(token),
+        data: { target_user_id: target.userId },
+    });
+    expect(started.ok(), `Could not start impersonation: ${await started.text()}`).toBe(true);
+    expect((await started.json()) as JsonObject).toMatchObject({ status: "active" });
+
+    try {
+        // The web session learns about impersonation through a superuser-only
+        // JWT poll memoized for 3s (src/lib/auth.ts:60-64), so poll for the
+        // banner rather than assuming the next render already knows.
+        await expect
+            .poll(
+                async () => {
+                    await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
+                    return page.getByText(/Viewing as/u).count();
+                },
+                {
+                    message:
+                        "The session never picked up impersonation; the pin below would be vacuous.",
+                    timeout: 30_000,
+                },
+            )
+            .toBeGreaterThan(0);
+
+        await page.goto("/superadmin/context-fabric/validation", {
+            waitUntil: "domcontentloaded",
+        });
+
+        // PINNED BEHAVIOUR — today's answers, not endorsements:
+        // 1. the platform-admin route stays reachable while impersonating,
+        await expect(page).toHaveURL(/\/superadmin\/context-fabric\/validation(?:[?#]|$)/u);
+        await expect(
+            page.getByRole("heading", { name: "Context Fabric Validation", level: 1 }),
+        ).toBeVisible();
+        // 2. the validator is fully operable there, and
+        await expect(page.getByRole("main").getByTestId("context-packet-form")).toBeVisible();
+        // 3. the impersonation banner remains visible on it, so the operator is
+        //    at least told whose tenant they are pointed at.
+        await expect(page.getByText(/Viewing as/u).first()).toBeVisible();
+
+        await page.screenshot({
+            path: testInfo.outputPath("validation-while-impersonating.png"),
+            fullPage: true,
+        });
+    } finally {
+        const stopped = await request.post(`${liveBackendUrl}/api/v1/admin/impersonate/stop`, {
+            headers: authHeaders(token),
+        });
+        expect(stopped.ok(), "Impersonation was left active after the test.").toBe(true);
+    }
+});

--- a/tests/live/wave4ExecutedCountReporter.ts
+++ b/tests/live/wave4ExecutedCountReporter.ts
@@ -25,6 +25,24 @@ import type { FullResult, Reporter, TestCase, TestResult } from "@playwright/tes
 export default class Wave4ExecutedCountReporter implements Reporter {
     private executed = 0;
     private readonly skipped: string[] = [];
+    private readonly listOnly: boolean;
+
+    /**
+     * `--list` enumerates tests without running any, so zero-executed is its
+     * CORRECT outcome, not a false green. Failing there would break test
+     * discovery for CI, editors and anyone inspecting the suite.
+     *
+     * Playwright constructs reporters with the OPTIONS OBJECT from the reporter
+     * tuple in the config — never with argv. An earlier version of this
+     * signature took `argv` positionally with a `process.argv` default; the unit
+     * tests passed because they injected an array, and the real run died with
+     * "argv.includes is not a function" on the first `--list`. Hence the object
+     * shape, and hence the end-to-end check in the PR rather than unit tests
+     * alone.
+     */
+    constructor(options: { readonly argv?: readonly string[] } = {}) {
+        this.listOnly = (options.argv ?? process.argv).includes("--list");
+    }
 
     onTestEnd(test: TestCase, result: TestResult): void {
         if (result.status === "skipped") {
@@ -38,6 +56,7 @@ export default class Wave4ExecutedCountReporter implements Reporter {
     // preserves it, so this guard can only ever turn a pass into a failure —
     // never rescue a genuine failure into a pass.
     onEnd(_result: FullResult): { status: FullResult["status"] } | undefined {
+        if (this.listOnly) return undefined;
         const failures: string[] = [];
         if (this.executed === 0) {
             failures.push(

--- a/tests/live/wave4ExecutedCountReporter.ts
+++ b/tests/live/wave4ExecutedCountReporter.ts
@@ -1,0 +1,71 @@
+import type { FullResult, Reporter, TestCase, TestResult } from "@playwright/test/reporter";
+
+/**
+ * CHAOS-3219 Phase 4 Lane 4d — the false-green backstop for the Wave 4 access
+ * matrix.
+ *
+ * The arming checks in `playwright.ask-dev-wave4.config.ts` prove the run was
+ * *configured* correctly. They cannot prove it *measured* anything: a bad
+ * `--grep`, a stray `test.skip`, a `testMatch` that stops matching after a file
+ * rename, or a project filter typo all produce "0 passed" and exit 0. That is
+ * exactly the defect this epic already hit once on the Ops side — a correctly
+ * armed acceptance run silently reporting `144 skipped, exit 0` (CHAOS-3219
+ * Phase 2 exit finding B1). An access matrix that asserts nothing about anyone
+ * is indistinguishable from a green one unless the runner refuses to pass.
+ *
+ * So this reporter turns two silent conditions into hard failures:
+ *
+ *  1. zero tests executed, and
+ *  2. any test skipped — a skip in a release gate is an unmeasured matrix row,
+ *     not a pass. Nothing in this suite may opt out at runtime.
+ *
+ * `onEnd` returning a status overrides the run result (Playwright >= 1.45), so
+ * these become a non-zero exit rather than a warning nobody reads.
+ */
+export default class Wave4ExecutedCountReporter implements Reporter {
+    private executed = 0;
+    private readonly skipped: string[] = [];
+
+    onTestEnd(test: TestCase, result: TestResult): void {
+        if (result.status === "skipped") {
+            this.skipped.push(test.titlePath().filter(Boolean).join(" › "));
+            return;
+        }
+        this.executed += 1;
+    }
+
+    // Playwright's own verdict is deliberately not read: returning undefined
+    // preserves it, so this guard can only ever turn a pass into a failure —
+    // never rescue a genuine failure into a pass.
+    onEnd(_result: FullResult): { status: FullResult["status"] } | undefined {
+        const failures: string[] = [];
+        if (this.executed === 0) {
+            failures.push(
+                "The Ask Dev Wave 4 access matrix executed ZERO tests. An armed gate that " +
+                    "measured nothing is a false green, not a pass. Check testMatch/testDir, " +
+                    "any --grep filter, and that the spec files still exist.",
+            );
+        }
+        if (this.skipped.length > 0) {
+            failures.push(
+                `The Ask Dev Wave 4 access matrix skipped ${this.skipped.length} test(s). ` +
+                    "Every row of this matrix is release evidence; a skipped row is an " +
+                    "unmeasured row. Skipped: " +
+                    this.skipped.join(", "),
+            );
+        }
+        if (failures.length === 0) return undefined;
+        for (const failure of failures) console.error(`\n[ask-dev-wave4] ${failure}\n`);
+        return { status: "failed" };
+    }
+
+    // Playwright suppresses stdio from the reporter unless this opts out.
+    printsToStdio(): boolean {
+        return true;
+    }
+
+    /** Exposed for the unit-tier control that proves this guard actually fails. */
+    get executedCount(): number {
+        return this.executed;
+    }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,14 @@ export default defineConfig({
                         "src/app/**/*.test.ts",
                         "scripts/**/__tests__/**/*.test.mjs",
                         "tests/mocks/**/*.test.ts",
+                        // CHAOS-3219 Phase 4 Lane 4d. The Wave 4 access matrix
+                        // runs only under an armed Compose launcher, so its
+                        // false-green guard cannot be proven by that suite —
+                        // the guard exists precisely for the case where that
+                        // suite executes nothing. Its control lives here
+                        // instead, in the required unit job, where it always
+                        // runs.
+                        "tests/live/**/__tests__/**/*.test.ts",
                     ],
                 },
             },


### PR DESCRIPTION
CHAOS-3219 Phase 4 Lane 4d. Linear: **CHAOS-3510**.
Paired ops PR (execution prerequisite): **full-chaos/dev-health-ops#1596** (CHAOS-3586) — **merged** as `c8014a68a`.
Open product ruling referenced by one spec: **CHAOS-3587**.

## First: four of the ticket's five bullets were already covered

I verified each against the code rather than trusting the audit. The audit that filed CHAOS-3510 was wrong about three of them — not stale, **wrong at the very commit it read** (`web@e64bae94`). team-lead has posted the correction to the Linear issue.

| Ticket bullet | Reality on main |
|---|---|
| Validation access matrix | **Partly covered** — `tests/live/ask-dev-acceptance.spec.ts:654-693` |
| Entitlement non-coupling (ACR disabled) | **Covered twice** — live `:639-652`; unit `src/lib/dev/__tests__/contracts.test.ts:258-278` |
| Old-route compatibility | **Covered** — `src/app/(app)/agent-context/context-packet/page.test.tsx`, all four branches |
| Admin control surfaces / kill switches | **Covered** `:625-637`, and the concept was **retired**: CHAOS-3458 is Done, ruling "single feature flag is the kill mechanism — no per-scope kill switches" |
| `playwright.ask-dev-wave4.config.ts` | **Genuinely absent** — this PR |

Those five rows are **not** re-implemented here. The spec file header lists them with citations so the next reader doesn't re-derive this.

## What this PR adds

### New coverage
- **Unauthenticated** → sign-in, with the validation route preserved as `callbackUrl`. The callback half matters as much as the redirect: without it the guard "works" while silently dropping the user's destination.
- **Cross-tenant entitlement** — a member of the never-entitled org is sent to Diagnose, gets no launcher on an ordinary route, and is refused by name on `/dev`. This is the axis existing coverage cannot reach: `ask-dev-acceptance.spec.ts` disables `ask_dev` on the *primary* org via the emergency switch, which is a **different mechanism** from an org that was never entitled. It consumes the disabled-entitlement tenant `provision_multi_org()` has provisioned all along and **nothing had ever read**.

### Tier upgrade of existing unit coverage — labelled as such, not as new coverage
The old `/agent-context/context-packet` superadmin and entitled-member branches, live. `page.test.tsx` proves branch *selection*, but mocks `requireSession`, `getOrgEntitlements` **and** `permanentRedirect` — every moving part of the real path — so nothing proved a real request actually redirects. Phase 4's "never against dev mocks" constraint is what makes the live row worth having.

### Ruled intended — CHAOS-3587 (2026-08-07)
chris ruled that an impersonating platform admin **keeps** the validation surface, works inside the **target** org (target-org budget consumption explicitly allowed), and retains retrieval debug. Row A3 was written as a characterization pin while the question was open; it now asserts those semantics affirmatively and is the **permanent** pin. No deny-guard variant exists or will.

The ruling added one assertion the earlier version was missing and that actually carries it: **the effective org is the target's.** A URL/heading check cannot see that, so a regression resolving the admin's *own* org instead of the target's would have passed the old spec. It's now read from the real session (`is_impersonating`, `is_superuser` unchanged, `impersonated_user_id`, `org_id` == target's org), plus a guard that `real_org_id` hasn't collapsed onto the same value — without which the effective-org assertion could pass vacuously.

**One clause of the ruling is deliberately not asserted, and the spec says so in place:** retrieval-debug *availability*. `showRetrievalDebug` only surfaces as `retrieval_debug_summary` text inside a **generated** packet, which needs an ACR-backed generation; the launcher defaults to `acr_armed=0`, so on a normal run there is nothing to assert against. Asserting the prop some other way would assert the source rather than the behaviour, and an assertion that silently passes when ACR is off is precisely the false coverage this suite exists to prevent. Residual: clauses 1–3 pinned, debug availability **unproven at any tier**, closable only by an `ASK_DEV_ACCEPTANCE_ACR=1` run that no workflow currently performs.

### Infrastructure
- `playwright.ask-dev-wave4.config.ts` — armed-or-throw on 7 vars; all 8 permutations observed throwing in order. `ASK_DEV_WAVE4_ACCESS_MATRIX` is its own knob so a launcher predating this lane can't appear to have run it; `ASK_DEV_ACCEPTANCE_ACR` must be literally `"0"` or `"1"`, because a run that doesn't know which side of the toggle it's on would "prove" non-coupling while never varying the variable.
- `Wave4ExecutedCountReporter` — fails the run on zero-executed or any-skipped. **Proven load-bearing against the null hypothesis:** an identical all-skipped suite exits **0** without it and **1** with it. That's the Phase 2 exit finding B1 shape (`144 skipped, exit 0`) and the CHAOS-3483 class; Playwright's built-in no-tests-found does not cover it.
- `vitest.config.ts` — the unit include list didn't cover `tests/live/**`, so the guard's own control would have sat there never running: a test that cannot fail, reading as coverage.

## Two bugs that only execution could find

Both were **invisible to green unit tests** and appeared immediately on running the real thing. Recording them because they're the argument for the end-to-end checks, not just the mutation testing:

1. `playwright test --list` exited **1** — the guard treated discovery, which executes nothing by design, as a false green. That breaks CI enumeration and editor integrations.
2. The first fix took `argv` positionally with a `process.argv` default. Unit tests passed because they injected an array; the real run died with `TypeError: argv.includes is not a function`, because Playwright constructs reporters with the reporter tuple's **options object**, never argv.

Now keyed off an options object and verified end-to-end: `--list` exits 0 listing 5 rows; an empty `--grep` still exits 1 with the guard message.

## Verification

RED-first on every guard branch, each observed killing specific tests, each restored and re-verified:

| Mutation | Killed |
|---|---|
| skipped counted as executed | 2 |
| `return {status:"failed"}` → `undefined` | 3 |
| `executed === 0` → `executed < 0` | 1 |
| `--list` exemption removed | 1 |
| `--list` exemption forced always-on | 4 |

Restores verified by **sha256** against pre-mutation copies, not by `git` — the files were untracked, and `git diff` calls an untracked file clean whatever it contains.

Green: tsc, prettier, eslint (one pre-existing warning in `tests/live/org-deletion.spec.ts`), 7 control tests, config discovers exactly 5 rows with no `test.skip`/`.only`.

## Execution results — all 5 rows GREEN against a real Compose stack

```
✓ 1  unauthenticated → sign-in, validation route preserved as callback   (480ms)
✓ 2  TIER UPGRADE: old route → superadmin → validation, query intact     (2.8s)
✓ 3  TIER UPGRADE: old route → entitled member → /dev, query not leaked  (2.5s)
✓ 4  never-entitled org member → Diagnose, no launcher, /dev refuses     (3.1s)
✓ 5  RULED INTENDED (CHAOS-3587): impersonation keeps validation, scoped (6.9s)
5 passed (17.0s)
```

Real browser, real Auth.js sessions, real Ops REST API, three genuinely distinct tenants — including the never-entitled org `provision_multi_org()` has been creating all along with no consumer until now. Row 5's 6.9s matters: it means the impersonation flow was actually driven (start → poll past the 3s JWT memo → load validation → read the session), not passed quickly for the wrong reason.

**Qualifier, so "5 passed" is not read as more than it is:** this was a **direct hand-invocation of the wave4 leg**, not a full launcher run, against a stack whose Phase 1 leg had already failed on the CHAOS-3581 retention staleness (fixed on unmerged #859). Everything these rows depend on — the three orgs, entitlements, web/api health, the complete org-ids artifact — was established *before* that failure. But the canonical evidence is a full launcher run from web `main` after #859 and this PR both merge, and that run is item 2 of the merge checklist above. **This PR should stay draft until that run exists.**

A first execution attempt failed row 5 with an HTTP 429: the file logged in as superadmin once per test against a per-IP budget (`AUTH_LOGIN_IP_LIMIT = 20/15minutes`) shared with everything else the launcher does. Fixed by caching one login, and — more importantly — by making a 429 report itself as a rate limit rather than as "the platform admin could not log in", which had pointed at credentials that were never wrong.

## Honest coverage claim — what is NOT proven

- **No canonical full-launcher run yet.** See the qualifier above: the rows executed via a direct leg invocation. ops#1596 merged as `c8014a68a`; its follow-up fix ops#1599 adds the presence guard that keeps the nightly working until this PR lands.
- After ops#1596, CI invocation comes via `.github/workflows/ask-dev-acceptance.yml`, which **never sets `ASK_DEV_ACCEPTANCE_ACR`**, so CI will exercise only the `acr_armed=0` side of the non-coupling contract.
- Full web gate, live e2e and the context-fabric config were **not** run (single-flight ports).
- `src/lib/__tests__/rate-limit.test.ts` fails 5 tests — confirmed **pre-existing** by running it on a pristine `main` checkout at the same SHA. Unrelated, but currently red on main and unowned.

## Gap left explicitly uncovered

**Kill switches beyond the single flag.** Per CHAOS-3458's ruling no per-scope kill switches exist or are wanted, and a grep of ops production code for `kill_switch`/`KillSwitch` returns zero matches. `world.json` carries a `kill_switches` fixture field (global/org/provider/role/surface/contextual-entry) that **nothing reads**. The one real mechanism — `emergency_disabled` — is already covered live. No rows were invented for the retired concept.

## ⚠️ MERGE CHECKLIST — required when this PR lands

Merging this PR puts `playwright.ask-dev-wave4.config.ts` on web `main` for the first time. Two things must happen **at that moment**:

1. **Make the launcher's wave4 leg mandatory again.** ops carries a presence guard (`WAVE4_ACCESS_MATRIX=NOT_RUN reason=config-absent`) that loudly SKIPS the leg while the config is absent from a given `--web-root`. That guard exists only because the ops half merged before this one. Once the config is on web main, add the config-must-exist assertion to `.github/workflows/ask-dev-acceptance.yml` so the nightly can never silently skip the matrix. **A skip in CI after this merge is a false green.**
2. **Run the canonical launcher run from web `main`** (after CHAOS-3581/#859 also merges, so Phase 1 passes) and attach it as this PR's execution evidence.

Background: the ops leg landed first in #1596, which broke every launcher run whose `--web-root` lacked the config — including the nightly. Fixed by the presence guard; the guard is temporary scaffolding whose removal is item 1 above.

No `src/` changes, so `enforce-src-test-policy` does not apply.




