### PR TITLE
CHAOS-3524: Ask Dev chat layout — fixed input, scroll-up conversation, history slider

### DIFF
--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 
-import { CTA_LABELS } from "@/lib/design/cta";
+import { CTA_LABELS, toggleEvidenceItem } from "@/lib/design/cta";
 import type {
     DevAnswer,
     DevEvidenceExpansion,
@@ -270,12 +270,26 @@ function scopeCoverageLabel(scopeResolution: NonNullable<DevAnswer["resolved_sco
     return `${count} authorized repositories`;
 }
 
+/**
+ * CHAOS-3524 (chris's evidence-layout ruling): each evidence item is its own
+ * accordion row, default folded. The row's header (label + provenance) stays
+ * visible even folded — that's the disclosure trigger a reader sees and
+ * clicks — only the detail beneath it (citation text, the "Open evidence"
+ * fetch action, the fetched excerpt, errors, the artifact link) is hidden
+ * until `open`. The fold toggle itself is icon-only (a chevron, aria-label
+ * carries the real name) per chris's "buttons/iconography only, no text
+ * labels" rule; `evidence.display_label` sitting in the same clickable
+ * header is the row's identifying TITLE, not an instructional fold/unfold
+ * label, so it stays as visible text.
+ */
 function EvidenceRow({
     anchorId,
     error,
     evidence,
     expansion,
     loading,
+    onToggleOpen,
+    open,
     openExpansion,
 }: {
     anchorId: string;
@@ -283,6 +297,8 @@ function EvidenceRow({
     evidence: DevEvidenceRef;
     expansion: DevEvidenceExpansion | null;
     loading: boolean;
+    onToggleOpen: () => void;
+    open: boolean;
     openExpansion: () => Promise<void>;
 }) {
     const internalPath = evidence.link?.internal_path;
@@ -293,61 +309,80 @@ function EvidenceRow({
             tabIndex={-1}
             className="scroll-mt-6 space-y-1.5 border-l-2 border-(--border) pl-3 outline-none focus-visible:border-(--accent)"
         >
-            <div className="flex flex-wrap items-start justify-between gap-2">
-                <div className="flex min-w-0 flex-col gap-0.5">
+            <button
+                type="button"
+                onClick={onToggleOpen}
+                aria-expanded={open}
+                aria-label={toggleEvidenceItem(evidence.display_label, open)}
+                className="flex w-full min-w-0 items-start gap-2 rounded-(--radius-sm) py-0.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+            >
+                <span aria-hidden="true" className="mt-0.5 shrink-0 text-(--text-muted)">
+                    {open ? "▾" : "▸"}
+                </span>
+                <span className="flex min-w-0 flex-col gap-0.5">
                     <span className="text-sm text-(--text-secondary)">
                         {evidence.display_label}
                     </span>
                     <span className="text-xs text-(--text-muted)">
                         {evidence.provenance} · {formatTimestamp(evidence.observed_at)}
                     </span>
-                </div>
-                {/*
-                 * Quiet by default (text-muted, no fill) — this is a
-                 * secondary, on-demand affordance, not a primary CTA; it
-                 * only picks up accent color on hover/focus (CHAOS-3291).
-                 */}
-                <button
-                    type="button"
-                    onClick={() => void openExpansion()}
-                    disabled={loading}
-                    className="rounded-(--radius-sm) px-2 py-1 text-xs font-medium text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
-                >
-                    {loading ? "Opening…" : CTA_LABELS.openEvidence}
-                </button>
-            </div>
-            {evidence.citation_text ? (
-                <p className="text-xs leading-5 text-(--text-muted)">{evidence.citation_text}</p>
-            ) : null}
-            {expansion ? (
-                <div className="rounded-(--radius-md) bg-(--background)/60 p-3 text-sm leading-6 text-(--text-secondary)">
-                    <p className="text-label-caps text-(--text-muted)">
-                        {expansion.state.replaceAll("_", " ")}
-                    </p>
-                    {safeExcerpt(expansion.safe_excerpt) ? (
-                        <p className="mt-2 whitespace-pre-wrap">
-                            {safeExcerpt(expansion.safe_excerpt)}
+                </span>
+            </button>
+            {open ? (
+                <div className="space-y-1.5 pl-5">
+                    {evidence.citation_text ? (
+                        <p className="text-xs leading-5 text-(--text-muted)">
+                            {evidence.citation_text}
                         </p>
-                    ) : (
-                        <p className="mt-2">No additional excerpt is available.</p>
-                    )}
-                    {expansion.warning ? (
-                        <p className="mt-2 text-(--caution)">{expansion.warning}</p>
+                    ) : null}
+                    {/*
+                     * Quiet by default (text-muted, no fill) — this is a
+                     * secondary, on-demand affordance, not a primary CTA; it
+                     * only picks up accent color on hover/focus (CHAOS-3291).
+                     * Unlike the fold toggle above, this triggers a real
+                     * server fetch (the deep excerpt) rather than showing
+                     * already-loaded content, so it keeps its sanctioned
+                     * text label rather than becoming icon-only.
+                     */}
+                    <button
+                        type="button"
+                        onClick={() => void openExpansion()}
+                        disabled={loading}
+                        className="rounded-(--radius-sm) px-2 py-1 text-xs font-medium text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
+                    >
+                        {loading ? "Opening…" : CTA_LABELS.openEvidence}
+                    </button>
+                    {expansion ? (
+                        <div className="rounded-(--radius-md) bg-(--background)/60 p-3 text-sm leading-6 text-(--text-secondary)">
+                            <p className="text-label-caps text-(--text-muted)">
+                                {expansion.state.replaceAll("_", " ")}
+                            </p>
+                            {safeExcerpt(expansion.safe_excerpt) ? (
+                                <p className="mt-2 whitespace-pre-wrap">
+                                    {safeExcerpt(expansion.safe_excerpt)}
+                                </p>
+                            ) : (
+                                <p className="mt-2">No additional excerpt is available.</p>
+                            )}
+                            {expansion.warning ? (
+                                <p className="mt-2 text-(--caution)">{expansion.warning}</p>
+                            ) : null}
+                        </div>
+                    ) : null}
+                    {error ? (
+                        <p role="alert" className="text-xs text-(--negative)">
+                            {error}
+                        </p>
+                    ) : null}
+                    {internalPath ? (
+                        <Link
+                            href={internalPath}
+                            className="inline-flex text-xs font-medium text-(--accent) underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                        >
+                            {CTA_LABELS.openArtifact}
+                        </Link>
                     ) : null}
                 </div>
-            ) : null}
-            {error ? (
-                <p role="alert" className="text-xs text-(--negative)">
-                    {error}
-                </p>
-            ) : null}
-            {internalPath ? (
-                <Link
-                    href={internalPath}
-                    className="inline-flex text-xs font-medium text-(--accent) underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                >
-                    {CTA_LABELS.openArtifact}
-                </Link>
             ) : null}
         </div>
     );
@@ -366,6 +401,14 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         () => new Set(),
     );
     const [openMetricIds, setOpenMetricIds] = useState<ReadonlySet<string>>(() => new Set());
+    // CHAOS-3524 (chris's evidence-layout ruling): the evidence LANE
+    // (this whole section) and each evidence ROW are independently
+    // foldable accordions, both default folded. `evidenceLaneOpen` gates
+    // the row list; `openEvidenceRowIds` gates each row's own detail.
+    const [evidenceLaneOpen, setEvidenceLaneOpen] = useState(false);
+    const [openEvidenceRowIds, setOpenEvidenceRowIds] = useState<ReadonlySet<string>>(
+        () => new Set(),
+    );
     const scopeResolution = answer.resolved_scope;
     // CHAOS-3367. A no-match gets its own presentation rather than the generic
     // status treatment: no "Refused" chip, no status caption claiming Ask Dev
@@ -453,6 +496,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     const findingsHeadingId = `ask-dev-findings-${answer.answer_id}`;
     const metricsHeadingId = `ask-dev-metrics-${answer.answer_id}`;
     const evidenceHeadingId = `ask-dev-evidence-heading-${answer.answer_id}`;
+    const evidenceListId = `ask-dev-evidence-list-${answer.answer_id}`;
 
     const focusDetail = (anchorId: string) => {
         requestAnimationFrame(() => {
@@ -460,10 +504,20 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         });
     };
 
+    // CHAOS-3524: unfolds the lane and this specific row BEFORE the async
+    // fetch below, synchronously in the same event-handler flush — so by
+    // the time `focusDetail`'s requestAnimationFrame callback runs (after
+    // the fetch resolves, well past this point), React has already
+    // committed the row as present/expanded in the DOM for
+    // `getElementById`/`.focus()` to find. This is what "clicking an
+    // evidence reference unfolds the lane and unfolds+scrolls to that
+    // item" resolves to: the citation buttons already call this function.
     const openEvidenceDetail = async (evidenceRefId: string) => {
         const position = evidencePositionById.get(evidenceRefId);
         if (position === undefined || !evidenceById.has(evidenceRefId)) return;
         const anchorId = evidenceAnchorId(position);
+        setEvidenceLaneOpen(true);
+        setOpenEvidenceRowIds((current) => new Set(current).add(evidenceRefId));
         setLoadingEvidenceIds((current) => new Set(current).add(evidenceRefId));
         setEvidenceErrors((current) => {
             const next = { ...current };
@@ -495,6 +549,23 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         if (position === undefined) return;
         setOpenMetricIds((current) => new Set(current).add(metricRefId));
         focusDetail(metricAnchorId(position));
+    };
+
+    const toggleEvidenceRow = (evidenceRefId: string) => {
+        setOpenEvidenceRowIds((current) => {
+            const next = new Set(current);
+            if (next.has(evidenceRefId)) next.delete(evidenceRefId);
+            else next.add(evidenceRefId);
+            return next;
+        });
+    };
+
+    // CHAOS-3524: the "unfold all" affordance chris asked for — expands the
+    // lane and every row in one action, independent of the two accordion
+    // levels' individual toggles above.
+    const unfoldAllEvidence = () => {
+        setEvidenceLaneOpen(true);
+        setOpenEvidenceRowIds(new Set((answer.evidence ?? []).map((item) => item.evidence_ref_id)));
     };
 
     const renderInlineCitations = (
@@ -878,10 +949,57 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                     className="space-y-3 border-t border-(--border) pt-4"
                     aria-labelledby={evidenceHeadingId}
                 >
-                    <h3 id={evidenceHeadingId} className="text-label-caps text-(--text-muted)">
-                        Evidence
-                    </h3>
-                    <div className="space-y-3">
+                    {/*
+                     * CHAOS-3524: the lane's own fold toggle and the
+                     * "unfold all" action are icon-only buttons (chevron /
+                     * unfold glyph, aria-label carries the name) — "Evidence"
+                     * is the section's static title, not itself a
+                     * fold/unfold instruction, so it stays outside both
+                     * buttons as plain heading text.
+                     */}
+                    <div className="flex items-center justify-between gap-2">
+                        <h3 id={evidenceHeadingId} className="text-label-caps text-(--text-muted)">
+                            Evidence
+                        </h3>
+                        <div className="flex items-center gap-1">
+                            <button
+                                type="button"
+                                onClick={unfoldAllEvidence}
+                                aria-label={CTA_LABELS.unfoldAllEvidence}
+                                className="rounded-(--radius-sm) p-1 text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                            >
+                                <span aria-hidden="true">⤢</span>
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setEvidenceLaneOpen((open) => !open)}
+                                aria-expanded={evidenceLaneOpen}
+                                aria-controls={evidenceListId}
+                                aria-label={
+                                    evidenceLaneOpen
+                                        ? CTA_LABELS.collapseEvidenceLane
+                                        : CTA_LABELS.expandEvidenceLane
+                                }
+                                className="rounded-(--radius-sm) p-1 text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                            >
+                                <span aria-hidden="true">{evidenceLaneOpen ? "▾" : "▸"}</span>
+                            </button>
+                        </div>
+                    </div>
+                    {/*
+                     * Native `hidden` attribute, not a conditional
+                     * unmount/CSS-class toggle: this codebase's tests run
+                     * without compiled Tailwind CSS (a `hidden` class
+                     * wouldn't actually hide anything for `toBeVisible()`
+                     * purposes), but the native attribute is a real HTML5 UA
+                     * behavior jsdom honors directly. Keeping the rows
+                     * always mounted (just hidden) also means
+                     * `document.getElementById(anchorId)` keeps working
+                     * immediately when a citation click both unfolds the
+                     * lane and focuses a row in the same flow, with no
+                     * mount-timing race to reason about.
+                     */}
+                    <div id={evidenceListId} hidden={!evidenceLaneOpen} className="space-y-3">
                         {answer.evidence.map((evidence) => (
                             <EvidenceRow
                                 key={evidence.evidence_ref_id}
@@ -892,6 +1010,8 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
                                 evidence={evidence}
                                 expansion={evidenceExpansions[evidence.evidence_ref_id] ?? null}
                                 loading={loadingEvidenceIds.has(evidence.evidence_ref_id)}
+                                onToggleOpen={() => toggleEvidenceRow(evidence.evidence_ref_id)}
+                                open={openEvidenceRowIds.has(evidence.evidence_ref_id)}
                                 openExpansion={() => openEvidenceDetail(evidence.evidence_ref_id)}
                             />
                         ))}

--- a/src/components/ask-dev/AskDevConversation.tsx
+++ b/src/components/ask-dev/AskDevConversation.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState, type RefObject } from "react";
 
 import type { DevProgressState } from "@/lib/dev/client";
 import { CTA_LABELS } from "@/lib/design/cta";
-import { decodeFilter, encodeFilterParam } from "@/lib/filters/encode";
-import { formatDateUTC } from "@/lib/formatters";
 import { safeCopy } from "@/lib/dev/internalTokens";
 import { runtimeConfig } from "@/lib/runtimeConfig";
 import { DataState } from "@/components/ui/DataState";
@@ -95,6 +92,120 @@ export const PROGRESS_LABELS: Record<DevProgressState, string> = {
     preparing_answer: "Preparing an evidence-backed answer",
 };
 
+/** Matches Tailwind's `lg` breakpoint — the width at which the History drawer defaults open (CHAOS-3524). */
+const HISTORY_DRAWER_DESKTOP_QUERY = "(min-width: 1024px)";
+
+function matchesHistoryDesktopDefault(): boolean {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+    return window.matchMedia(HISTORY_DRAWER_DESKTOP_QUERY).matches;
+}
+
+/**
+ * CHAOS-3524: starter prompts for the empty state's "Quick Topics" chip row.
+ * Chris's 2026-08-07 design pass left this vocabulary explicitly undecided
+ * ("Quick Topics: variable / up to be determined (or can be deferred) — do
+ * not hardcode a final set"). This list is a provisional placeholder to
+ * satisfy the visual layout, not a decided taxonomy — swap, reorder, or
+ * source it from configuration whenever that decision lands.
+ */
+const ASK_DEV_QUICK_TOPICS_PROVISIONAL: readonly {
+    id: string;
+    label: string;
+    prompt: string;
+}[] = [
+    { id: "overview", label: "Overview", prompt: "Give me an overview of the current status." },
+    { id: "pipelines", label: "Pipelines", prompt: "How are the pipelines performing?" },
+    { id: "tests", label: "Tests", prompt: "What is the state of test health?" },
+    { id: "coverage", label: "Coverage", prompt: "What does coverage look like right now?" },
+];
+
+type AskDevComposerProps = {
+    composerId: string;
+    composerRef: RefObject<HTMLTextAreaElement | null>;
+    draft: string;
+    setDraft: (value: string) => void;
+    onSubmit: () => void;
+    disabled: boolean;
+};
+
+/**
+ * The question composer. CHAOS-3524's "the input stays FIXED at the bottom"
+ * requirement is met literally: this is the ONE call site, rendered as the
+ * last child of the conversation column in every state (empty or not) —
+ * never conditionally mounted/unmounted based on isEmptyState. An earlier
+ * version rendered a second, differently-positioned instance for the empty
+ * state; that broke two things at once: the composer's DOM node (and any
+ * text mid-typed into it) no longer survived the empty→conversation
+ * transition since React sees two distinct call sites as two distinct
+ * elements, and the CHAOS-3215 M5 modal focus-trap test — which relies on
+ * the disabled submit button being excluded from the focusable set so the
+ * textarea is genuinely the last focusable element — broke once other
+ * (enabled) focusable content could land after the composer in DOM order.
+ * Declared at module scope, not nested inside AskDevConversation, so its
+ * component identity is stable across renders — an inline nested component
+ * would remount (and drop focus/composition state) on every keystroke.
+ */
+function AskDevComposer({
+    composerId,
+    composerRef,
+    draft,
+    setDraft,
+    onSubmit,
+    disabled,
+}: AskDevComposerProps) {
+    return (
+        <form
+            className="border-t border-(--border) bg-(--surface-raised) p-3 sm:p-4"
+            onSubmit={(event) => {
+                event.preventDefault();
+                onSubmit();
+            }}
+        >
+            <label htmlFor={composerId} className="sr-only">
+                Ask Dev question
+            </label>
+            <div className="flex items-end gap-2 rounded-(--radius-lg) border border-(--border) bg-(--background)/75 p-2 focus-within:border-(--accent)/60 focus-within:ring-2 focus-within:ring-(--accent)/15">
+                <textarea
+                    ref={composerRef}
+                    id={composerId}
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter" && !event.shiftKey) {
+                            event.preventDefault();
+                            onSubmit();
+                        }
+                    }}
+                    rows={3}
+                    maxLength={4000}
+                    placeholder="Ask about the evidence in this scope…"
+                    className="max-h-40 min-h-12 flex-1 resize-y bg-transparent px-2 py-2 text-sm leading-6 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
+                />
+                <button
+                    type="submit"
+                    disabled={disabled}
+                    aria-label={CTA_LABELS.askDev}
+                    className="inline-flex h-10 shrink-0 items-center justify-center rounded-(--radius-md) bg-(--accent) px-4 text-sm font-semibold text-(--accent-foreground) transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50 disabled:cursor-not-allowed disabled:opacity-45"
+                >
+                    {CTA_LABELS.askDev}
+                </button>
+            </div>
+            {/*
+             * No per-conversation retention selector: retention is an
+             * org-admin-only 0/30-day policy (PATCH
+             * /api/v1/admin/ask-dev/settings). The backend always applied
+             * org policy and silently ignored any per-conversation
+             * `retention_days` sent from here, so the selector was a
+             * misleading affordance — removed per CHAOS-3215 M7 /
+             * CHAOS-3217.
+             */}
+            <div className="mt-2 text-xs text-(--text-muted)">
+                <span>Enter to ask · Shift+Enter for a new line</span>
+            </div>
+        </form>
+    );
+}
+
 export function AskDevConversation({
     compact = false,
     showHistory = false,
@@ -104,7 +215,6 @@ export function AskDevConversation({
 }) {
     const {
         availability,
-        committedScopeLabel,
         cancelRun,
         clearProposedContext,
         conversations,
@@ -116,7 +226,6 @@ export function AskDevConversation({
         orgId,
         proposedContext,
         proposedQuestions,
-        proposedScope,
         proposedScopeLabel,
         renameConversation,
         retryLastQuestion,
@@ -130,20 +239,53 @@ export function AskDevConversation({
     const [editingTitle, setEditingTitle] = useState("");
     const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
     const [historyActionError, setHistoryActionError] = useState<string | null>(null);
-    const [historyPanelOpen, setHistoryPanelOpen] = useState(false);
+    // CHAOS-3524: chris's ruling is that History is a SLIDING DRAWER, not a
+    // fixed rail — one state, one toggle button, at every breakpoint. It
+    // slides in from the right over the conversation (an overlay, not a
+    // second grid column — matches this codebase's other drawer,
+    // BugReportButton.tsx's `fixed ... translate-x-0 transition-transform`).
+    //
+    // The lazy initializer guesses closed (SSR-safe: `window` doesn't exist
+    // on the server, so it can't ask the real viewport width yet) and a
+    // mount-time effect immediately corrects it to the actual default below
+    // — the same two-step pattern AskDevWindow's useIsMobileFullScreen
+    // already uses in this codebase, for the same hydration-safety reason.
+    // Desktop (`lg:` and up, matching Tailwind's 1024px) defaults OPEN — the
+    // shape tests/live/ask-dev-acceptance.spec.ts and
+    // tests/ask-dev-continuity.spec.ts assume with no prior toggle click.
+    // Below `lg`, and in jsdom component tests (no real `matchMedia`, so the
+    // SSR-safe guess never gets corrected), it defaults CLOSED — the shape
+    // AskDevProvider.test.tsx's CHAOS-3215 M4 test assumes.
+    //
+    // Guarded on `showHistory` (never calls matchMedia at all when it's
+    // false, not just skips acting on the result): AskDevWindow renders
+    // this component (compact, showHistory=false) inside its OWN
+    // matchMedia consumer (useIsMobileFullScreen), and
+    // AskDevProvider.test.tsx's matchMedia mock tracks one query object at
+    // a time — an unconditional call here, even just to read `.matches`,
+    // overwrites that shared tracking object and silently breaks
+    // useIsMobileFullScreen's own test (CHAOS-3215 M5).
+    const [historyPanelOpen, setHistoryPanelOpen] = useState(() =>
+        showHistory ? matchesHistoryDesktopDefault() : false,
+    );
     const composerId = useId();
     const historyPanelId = useId();
     const transcriptEnd = useRef<HTMLDivElement>(null);
+    const scrollContainerRef = useRef<HTMLDivElement>(null);
+    // CHAOS-3524: standard chat convention — once the reader scrolls away
+    // from the bottom (e.g. into a large evidence block on an earlier
+    // answer), a new streamed chunk or a newly-appended transcript entry
+    // must not yank the viewport back down. Only a genuinely new
+    // user-initiated question (submit(), below) forces the pin back on. No
+    // prior "stick to bottom" pattern exists elsewhere in this codebase to
+    // reuse (checked before adding this).
+    const pinnedToBottom = useRef(true);
     const composerRef = useRef<HTMLTextAreaElement>(null);
     const renameInputRef = useRef<HTMLInputElement>(null);
     // Declared here (ahead of the effects below that reference it) rather than
     // inline where it was originally introduced, so the org-switch reset
     // effect can clear it too — see that effect's comment (CHAOS-3215).
     const runInProgress = useRef(false);
-    const pathname = usePathname();
-    const router = useRouter();
-    const searchParams = useSearchParams();
-    const filters = useMemo(() => decodeFilter(searchParams.get("f")), [searchParams]);
     // Only the allowance case overrides the server's `retryable` and replaces
     // the retry button: an exhausted monthly platform allowance is a
     // product-side fact that ops' per-error `retryable` does not model (it
@@ -181,7 +323,10 @@ export function AskDevConversation({
         setEditingTitle("");
         setPendingDeleteId(null);
         setHistoryActionError(null);
-        setHistoryPanelOpen(false);
+        // Guarded on `showHistory` — see historyPanelOpen's declaration
+        // above for why this must never call matchMedia when the drawer
+        // isn't even rendered.
+        setHistoryPanelOpen(showHistory ? matchesHistoryDesktopDefault() : false);
     }
 
     // `runInProgress` is a ref, not visible state, so clearing it does not
@@ -192,9 +337,51 @@ export function AskDevConversation({
         runInProgress.current = false;
     }, [orgId]);
 
+    // Corrects historyPanelOpen's SSR-safe closed guess to the real
+    // viewport's default, and keeps it in sync with the `lg` breakpoint —
+    // the same matchMedia subscribe-and-sync shape as AskDevWindow's
+    // useIsMobileFullScreen (mirrored here rather than shared, it's a few
+    // lines). `react-hooks/set-state-in-effect` requires setState to flow
+    // from an external-system subscription, not a bare effect body — the
+    // `addEventListener` below is that subscription; `update()` also
+    // primes the initial value synchronously so the drawer doesn't sit on
+    // its SSR-safe closed guess until the viewport actually changes.
+    //
+    // Gated on `showHistory`: AskDevWindow renders this component (compact,
+    // showHistory=false) INSIDE its own matchMedia consumer
+    // (useIsMobileFullScreen). AskDevProvider.test.tsx's single-query
+    // matchMedia mock tracks one addEventListener registration at a time —
+    // an unconditional subscription here re-registers over
+    // useIsMobileFullScreen's listener the moment this component mounts,
+    // silently breaking that component's own modal-focus-trap test. There
+    // is nothing to default anyway when the drawer itself never renders.
     useEffect(() => {
+        if (!showHistory) return;
+        if (typeof window.matchMedia !== "function") return;
+        const query = window.matchMedia(HISTORY_DRAWER_DESKTOP_QUERY);
+        const update = () => setHistoryPanelOpen(query.matches);
+        update();
+        query.addEventListener("change", update);
+        return () => query.removeEventListener("change", update);
+    }, [showHistory]);
+
+    useEffect(() => {
+        // CHAOS-3524: don't yank the viewport back to the bottom while the
+        // reader has deliberately scrolled up — see pinnedToBottom's
+        // declaration above and handleTranscriptScroll below.
+        if (!pinnedToBottom.current) return;
         transcriptEnd.current?.scrollIntoView({ block: "nearest" });
     }, [stream.delta, stream.phase, transcript]);
+
+    // Tracks whether the reader is at (or very near) the bottom of the
+    // transcript. Re-pins on scrolling back down, so resuming to read live
+    // output restores the normal auto-follow behavior without a page reload.
+    const handleTranscriptScroll = () => {
+        const el = scrollContainerRef.current;
+        if (!el) return;
+        const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+        pinnedToBottom.current = distanceFromBottom < 80;
+    };
 
     // The rAF focus-move callbacks below bail if the user has moved on to
     // something else by the time they fire — either the composer (typing the
@@ -254,19 +441,12 @@ export function AskDevConversation({
         const question = draft.trim();
         if (!question) return;
         setDraft("");
+        // Sending a question is a deliberate user act — it always jumps the
+        // conversation back to the bottom, even if the reader had scrolled
+        // up to reread something (standard chat UX, and the one case that
+        // must override the "don't yank" guard above).
+        pinnedToBottom.current = true;
         await submitQuestion(question);
-    };
-
-    const setComparisonDays = (compareDays: number) => {
-        const params = new URLSearchParams(searchParams.toString());
-        params.set(
-            "f",
-            encodeFilterParam({
-                ...filters,
-                time: { ...filters.time, compare_days: compareDays },
-            }),
-        );
-        router.replace(`${pathname}?${params.toString()}`, { scroll: false });
     };
 
     const saveConversationTitle = async (conversationId: string) => {
@@ -296,6 +476,11 @@ export function AskDevConversation({
             );
         }
     };
+
+    // CHAOS-3524: drives the centered "What would you like to know?" empty
+    // state vs. the scrolling-transcript + fixed-bottom-composer chat layout.
+    const isEmptyState = transcript.length === 0 && stream.phase === "idle";
+    const composerDisabled = !draft.trim() || stream.phase === "running";
 
     if (availability.state === "loading") {
         return (
@@ -339,235 +524,42 @@ export function AskDevConversation({
 
     return (
         <div
-            // Base `flex-col` stacks the mobile toggle bar, the (conditionally
-            // shown) history aside, and the conversation column vertically —
-            // without it these were unstyled row siblings below `lg`, so a
-            // narrow viewport could squeeze/collapse the primary workspace.
-            // `lg:grid` replaces that stacked layout with the two-column
-            // desktop layout (CHAOS-3215 M-mobile-layout).
-            className={`flex min-h-0 flex-1 flex-col ${showHistory ? "lg:grid lg:grid-cols-[15rem_minmax(0,1fr)]" : ""}`}
+            // CHAOS-3524: History is a sliding drawer that OVERLAYS the
+            // conversation from the right (chris's ruling — not a second
+            // grid column reserving permanent width), so this is a plain
+            // `relative` flex column, not the `lg:grid` two-column layout
+            // an earlier draft used. `overflow-hidden` clips the drawer
+            // while it's translated off-screen so it can't force a
+            // horizontal scrollbar.
+            className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
         >
             {showHistory ? (
-                <div className="border-b border-(--border) bg-(--surface)/65 px-4 py-2 lg:hidden">
-                    <button
-                        type="button"
-                        aria-expanded={historyPanelOpen}
-                        aria-controls={historyPanelId}
-                        onClick={() => setHistoryPanelOpen((open) => !open)}
-                        className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs font-medium text-(--text-secondary) transition hover:border-(--accent)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                    >
-                        {historyPanelOpen
-                            ? CTA_LABELS.hideAskDevHistory
-                            : CTA_LABELS.showAskDevHistory}
-                    </button>
-                </div>
-            ) : null}
-            {showHistory ? (
-                <aside
-                    id={historyPanelId}
-                    className={`${historyPanelOpen ? "block" : "hidden"} border-r border-(--border) bg-(--surface)/65 p-4 lg:block`}
-                    aria-label="Ask Dev history"
+                // One toggle, every breakpoint (mobile and desktop share
+                // it) — see historyPanelOpen's declaration for why there
+                // is deliberately no second, breakpoint-specific control.
+                <button
+                    type="button"
+                    aria-expanded={historyPanelOpen}
+                    aria-controls={historyPanelId}
+                    onClick={() => setHistoryPanelOpen((open) => !open)}
+                    className="absolute right-3 top-3 z-20 rounded-(--radius-sm) border border-(--border) bg-(--surface-raised) px-2.5 py-1.5 text-xs font-medium text-(--text-secondary) shadow-(--elevation-card) transition hover:border-(--accent)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
                 >
-                    <div className="flex items-center justify-between gap-2">
-                        <h2 className="text-label-caps text-(--text-muted)">Conversations</h2>
-                        <button
-                            type="button"
-                            onClick={startNewConversation}
-                            className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs font-medium text-(--text-secondary) transition hover:border-(--accent)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                        >
-                            {CTA_LABELS.newAskDevConversation}
-                        </button>
-                    </div>
-                    {historyLoading ? (
-                        <p role="status" className="mt-4 text-sm text-(--text-muted)">
-                            Loading history…
-                        </p>
-                    ) : historyError ? (
-                        <div className="mt-4 space-y-2 text-sm text-(--negative)">
-                            <p>{historyError}</p>
-                            <button
-                                type="button"
-                                onClick={() => void loadHistory()}
-                                className="font-medium underline"
-                            >
-                                {CTA_LABELS.retry}
-                            </button>
-                        </div>
-                    ) : conversations.length ? (
-                        <ul className="mt-3 space-y-1">
-                            {conversations.map((conversation) => (
-                                <li key={conversation.conversation_id}>
-                                    {editingConversationId === conversation.conversation_id ? (
-                                        <div className="space-y-2 rounded-(--radius-md) border border-(--border) p-2">
-                                            <label
-                                                className="sr-only"
-                                                htmlFor={`title-${conversation.conversation_id}`}
-                                            >
-                                                Conversation title
-                                            </label>
-                                            <input
-                                                ref={renameInputRef}
-                                                id={`title-${conversation.conversation_id}`}
-                                                value={editingTitle}
-                                                onChange={(event) =>
-                                                    setEditingTitle(event.target.value)
-                                                }
-                                                maxLength={120}
-                                                className="w-full rounded-(--radius-sm) border border-(--border) bg-(--background) px-2 py-1.5 text-sm"
-                                            />
-                                            <div className="flex gap-2">
-                                                <button
-                                                    type="button"
-                                                    onClick={() =>
-                                                        void saveConversationTitle(
-                                                            conversation.conversation_id,
-                                                        )
-                                                    }
-                                                    className="text-xs font-medium text-(--accent)"
-                                                >
-                                                    {CTA_LABELS.save}
-                                                </button>
-                                                <button
-                                                    type="button"
-                                                    onClick={() => setEditingConversationId(null)}
-                                                    className="text-xs text-(--text-muted)"
-                                                >
-                                                    {CTA_LABELS.cancel}
-                                                </button>
-                                            </div>
-                                        </div>
-                                    ) : (
-                                        <div className="rounded-(--radius-md) px-3 py-2 hover:bg-(--surface-raised)">
-                                            <button
-                                                type="button"
-                                                onClick={() =>
-                                                    void openConversation(
-                                                        conversation.conversation_id,
-                                                    )
-                                                }
-                                                className="w-full text-left text-sm text-(--text-secondary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                                            >
-                                                <span className="line-clamp-2 font-medium">
-                                                    {conversation.title || "Untitled investigation"}
-                                                </span>
-                                                <span className="mt-1 block text-xs text-(--text-muted)">
-                                                    {conversation.message_count === 1
-                                                        ? "1 message"
-                                                        : `${conversation.message_count} messages`}
-                                                </span>
-                                            </button>
-                                            <div className="mt-2 flex gap-3">
-                                                <button
-                                                    type="button"
-                                                    onClick={() => {
-                                                        setEditingConversationId(
-                                                            conversation.conversation_id,
-                                                        );
-                                                        setEditingTitle(conversation.title ?? "");
-                                                    }}
-                                                    className="text-xs text-(--text-muted) hover:text-(--text-primary)"
-                                                >
-                                                    {CTA_LABELS.edit}
-                                                </button>
-                                                <button
-                                                    type="button"
-                                                    onClick={() =>
-                                                        void removeConversation(
-                                                            conversation.conversation_id,
-                                                        )
-                                                    }
-                                                    className="text-xs text-(--text-muted) hover:text-(--negative)"
-                                                >
-                                                    {pendingDeleteId ===
-                                                    conversation.conversation_id
-                                                        ? CTA_LABELS.confirmDelete
-                                                        : CTA_LABELS.delete}
-                                                </button>
-                                            </div>
-                                        </div>
-                                    )}
-                                </li>
-                            ))}
-                        </ul>
-                    ) : (
-                        <p className="mt-4 text-sm leading-6 text-(--text-muted)">
-                            No retained conversations yet. Your first investigation will appear
-                            here.
-                        </p>
-                    )}
-                    {historyActionError ? (
-                        <p role="alert" className="mt-3 text-xs text-(--negative)">
-                            {historyActionError}
-                        </p>
-                    ) : null}
-                </aside>
+                    {historyPanelOpen ? CTA_LABELS.hideAskDevHistory : CTA_LABELS.showAskDevHistory}
+                </button>
             ) : null}
 
-            <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-                <div className="border-b border-(--border) bg-(--surface)/65 px-4 py-3">
-                    <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
-                        <span className="text-(--text-muted)">
-                            Proposed context:{" "}
-                            <strong className="font-medium text-(--text-secondary)">
-                                {proposedScopeLabel}
-                            </strong>
-                        </span>
-                        <span className="text-(--text-muted)">
-                            Committed scope:{" "}
-                            <strong className="font-medium text-(--text-secondary)">
-                                {committedScopeLabel ?? "Commits when you ask"}
-                            </strong>
-                        </span>
-                        <span className="text-(--text-muted)">
-                            Direct scope:{" "}
-                            <strong className="font-medium text-(--text-secondary)">
-                                {proposedScope.direct_scope.replaceAll("_", " ")}
-                            </strong>
-                        </span>
-                        <span className="text-(--text-muted)">
-                            Teams:{" "}
-                            <strong className="font-medium text-(--text-secondary)">
-                                {proposedScope.team_ids?.length
-                                    ? `${proposedScope.team_ids.length} selected`
-                                    : "All"}
-                            </strong>
-                        </span>
-                        <span className="text-(--text-muted)">
-                            Time:{" "}
-                            <strong className="font-medium text-(--text-secondary)">
-                                {formatDateUTC(proposedScope.time_range.start)} –{" "}
-                                {formatDateUTC(proposedScope.time_range.end)}
-                            </strong>
-                        </span>
-                        <label className="flex items-center gap-2 text-(--text-muted)">
-                            Comparison
-                            <select
-                                value={filters.time.compare_days > 0 ? "previous" : "none"}
-                                onChange={(event) =>
-                                    setComparisonDays(
-                                        event.target.value === "previous"
-                                            ? filters.time.range_days
-                                            : 0,
-                                    )
-                                }
-                                className="rounded-(--radius-sm) border border-(--border) bg-(--surface) px-2 py-1 text-xs text-(--text-secondary)"
-                            >
-                                <option value="previous">Previous period</option>
-                                <option value="none">No comparison</option>
-                            </select>
-                        </label>
-                        {proposedContext ? (
-                            <button
-                                type="button"
-                                onClick={clearProposedContext}
-                                className="font-medium text-(--accent) hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                            >
-                                {CTA_LABELS.clearContext}
-                            </button>
-                        ) : null}
-                    </div>
-                </div>
-
+            <div
+                // CHAOS-3524: reserve room for the History drawer at desktop
+                // widths while it's open, so its overlay never sits on top
+                // of the composer's "Ask" button (found via live visual
+                // verification — the drawer's `absolute` overlay could
+                // intercept clicks meant for the button underneath it).
+                // Below `lg`, and while the drawer is closed, no padding —
+                // the conversation column uses the full width.
+                className={`flex min-h-0 min-w-0 flex-1 flex-col transition-[padding] duration-200 ${
+                    showHistory && historyPanelOpen ? "lg:pr-80" : ""
+                }`}
+            >
                 {/*
                  * No aria-live here: the transcript's running/failed states carry
                  * their own role="status"/role="alert" regions below, which
@@ -576,22 +568,59 @@ export function AskDevConversation({
                  * every streamed answer.delta chunk as it arrives (CHAOS-3215 M3).
                  */}
                 <div
+                    ref={scrollContainerRef}
+                    onScroll={handleTranscriptScroll}
                     className={`min-h-0 flex-1 overflow-y-auto px-4 ${compact ? "py-4" : "py-6 sm:px-6"}`}
                     aria-label="Ask Dev transcript"
                 >
-                    {transcript.length === 0 && stream.phase === "idle" ? (
-                        <div className="mx-auto flex h-full max-w-xl flex-col justify-center py-8">
-                            <p className="text-label-caps text-(--accent-ai)">
-                                Evidence before certainty
-                            </p>
-                            <h2 className="mt-3 font-(--font-display) text-h2 text-(--text-primary)">
-                                Ask what changed, what remains, or what the data supports.
+                    {isEmptyState ? (
+                        <div className="mx-auto flex h-full max-w-2xl flex-col items-center justify-center text-center">
+                            <h2 className="font-(--font-display) text-h1 text-(--text-primary)">
+                                What would you like to know?
                             </h2>
-                            <p className="mt-3 text-sm leading-6 text-(--text-secondary)">
-                                Ask Dev works from persisted metrics and evidence. It shows the
-                                scope it used and calls out missing or stale sources.
-                            </p>
-                            <p className="mt-2 text-xs text-(--text-muted)">
+
+                            {proposedQuestions.length ? (
+                                <div className="mt-6 w-full" aria-label="Suggested questions">
+                                    <p className="text-label-caps text-(--text-muted)">
+                                        Suggested for this page
+                                    </p>
+                                    <div className="mt-2 flex flex-wrap justify-center gap-2">
+                                        {proposedQuestions.map((question) => (
+                                            <button
+                                                key={question.id}
+                                                type="button"
+                                                onClick={() => setDraft(question.label)}
+                                                className="rounded-(--radius-pill) border border-(--border) px-3 py-1.5 text-left text-xs text-(--text-secondary) hover:border-(--accent-ai)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45"
+                                            >
+                                                {question.label}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                            ) : null}
+
+                            <div className="mt-6 w-full">
+                                <p className="text-label-caps text-(--text-muted)">Quick Topics</p>
+                                <div className="mt-2 flex flex-wrap justify-center gap-2">
+                                    {ASK_DEV_QUICK_TOPICS_PROVISIONAL.map((topic) => (
+                                        <button
+                                            key={topic.id}
+                                            type="button"
+                                            onClick={() => setDraft(topic.prompt)}
+                                            aria-pressed={draft === topic.prompt}
+                                            className={`rounded-(--radius-pill) border px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45 ${
+                                                draft === topic.prompt
+                                                    ? "border-(--accent) bg-(--accent)/15 text-(--text-primary)"
+                                                    : "border-(--border) text-(--text-secondary) hover:border-(--accent-ai)/45 hover:text-(--text-primary)"
+                                            }`}
+                                        >
+                                            {topic.label}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+
+                            <p className="mt-8 text-xs text-(--text-muted)">
                                 Powered by Context Fabric.{" "}
                                 {/*
                                  * Plain <a>, not next/link's <Link>: this
@@ -613,23 +642,6 @@ export function AskDevConversation({
                                     <span aria-hidden="true"> ↗</span>
                                 </a>
                             </p>
-                            {proposedQuestions.length ? (
-                                <div
-                                    className="mt-5 flex flex-wrap gap-2"
-                                    aria-label="Suggested questions"
-                                >
-                                    {proposedQuestions.map((question) => (
-                                        <button
-                                            key={question.id}
-                                            type="button"
-                                            onClick={() => setDraft(question.label)}
-                                            className="rounded-(--radius-pill) border border-(--border) px-3 py-1.5 text-left text-xs text-(--text-secondary) hover:border-(--accent-ai)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45"
-                                        >
-                                            {question.label}
-                                        </button>
-                                    ))}
-                                </div>
-                            ) : null}
                         </div>
                     ) : (
                         <ol className="mx-auto max-w-3xl space-y-6">
@@ -768,56 +780,199 @@ export function AskDevConversation({
                     <div ref={transcriptEnd} />
                 </div>
 
-                <form
-                    className="border-t border-(--border) bg-(--surface-raised) p-3 sm:p-4"
-                    onSubmit={(event) => {
-                        event.preventDefault();
-                        void submit();
-                    }}
-                >
-                    <label htmlFor={composerId} className="sr-only">
-                        Ask Dev question
-                    </label>
-                    <div className="flex items-end gap-2 rounded-(--radius-lg) border border-(--border) bg-(--background)/75 p-2 focus-within:border-(--accent)/60 focus-within:ring-2 focus-within:ring-(--accent)/15">
-                        <textarea
-                            ref={composerRef}
-                            id={composerId}
-                            value={draft}
-                            onChange={(event) => setDraft(event.target.value)}
-                            onKeyDown={(event) => {
-                                if (event.key === "Enter" && !event.shiftKey) {
-                                    event.preventDefault();
-                                    void submit();
-                                }
-                            }}
-                            rows={compact ? 2 : 3}
-                            maxLength={4000}
-                            placeholder="Ask about the evidence in this scope…"
-                            className="max-h-40 min-h-12 flex-1 resize-y bg-transparent px-2 py-2 text-sm leading-6 text-(--text-primary) outline-none placeholder:text-(--text-muted)"
-                        />
+                {
+                    // CHAOS-3524 (chris, follow-up ruling): the persistent
+                    // "Proposed context / Committed scope / Direct scope /
+                    // Teams / Time / Comparison" bar that used to sit above
+                    // the transcript was dashboard chrome, not something an
+                    // LLM chat surface should show — removed. What survives
+                    // is display-only: a real surface-context proposal from
+                    // a content page (proposedContext — e.g. "Ask Dev about
+                    // this repository") still needs a visible accept/clear
+                    // affordance, now a small chip directly above the
+                    // composer instead of a persistent bar. It does NOT
+                    // change what's sent — proposedScope/surface_context
+                    // still flow into the request exactly as before; only
+                    // this always-on display of it is gone. Per-answer
+                    // committed-scope disclosure inside AskDevAnswer is
+                    // untouched.
+                }
+                {proposedContext ? (
+                    <div className="flex flex-wrap items-center gap-2 border-t border-(--border) bg-(--surface)/65 px-4 py-2 text-xs sm:px-6">
+                        <span className="text-(--text-muted)">
+                            Scoped to{" "}
+                            <strong className="font-medium text-(--text-secondary)">
+                                {proposedScopeLabel}
+                            </strong>
+                        </span>
                         <button
-                            type="submit"
-                            disabled={!draft.trim() || stream.phase === "running"}
-                            aria-label={CTA_LABELS.askDev}
-                            className="inline-flex h-10 shrink-0 items-center justify-center rounded-(--radius-md) bg-(--accent) px-4 text-sm font-semibold text-(--accent-foreground) transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/50 disabled:cursor-not-allowed disabled:opacity-45"
+                            type="button"
+                            onClick={clearProposedContext}
+                            className="font-medium text-(--accent) hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
                         >
-                            {CTA_LABELS.askDev}
+                            {CTA_LABELS.clearContext}
                         </button>
                     </div>
-                    {/*
-                     * No per-conversation retention selector: retention is an
-                     * org-admin-only 0/30-day policy (PATCH
-                     * /api/v1/admin/ask-dev/settings). The backend always applied
-                     * org policy and silently ignored any per-conversation
-                     * `retention_days` sent from here, so the selector was a
-                     * misleading affordance — removed per CHAOS-3215 M7 /
-                     * CHAOS-3217.
-                     */}
-                    <div className="mt-2 text-xs text-(--text-muted)">
-                        <span>Enter to ask · Shift+Enter for a new line</span>
-                    </div>
-                </form>
+                ) : null}
+
+                <AskDevComposer
+                    composerId={composerId}
+                    composerRef={composerRef}
+                    draft={draft}
+                    setDraft={setDraft}
+                    onSubmit={() => void submit()}
+                    disabled={composerDisabled}
+                />
             </div>
+
+            {showHistory ? (
+                <aside
+                    id={historyPanelId}
+                    // Overlay drawer, slides in from the right over the
+                    // conversation (CHAOS-3524) — `translate-x-full`
+                    // parks it just off the right edge when closed;
+                    // `pointer-events-none` there too, so a closed-but-
+                    // still-in-the-DOM drawer can never intercept clicks
+                    // meant for the conversation underneath it.
+                    className={`absolute inset-y-0 right-0 z-10 w-72 overflow-y-auto border-l border-(--border) bg-(--surface-raised) p-4 pt-14 shadow-(--elevation-drawer) transition-transform duration-200 ease-out sm:w-80 ${
+                        historyPanelOpen ? "translate-x-0" : "pointer-events-none translate-x-full"
+                    }`}
+                    aria-label="Ask Dev history"
+                >
+                    <div className="flex items-center justify-between gap-2">
+                        <h2 className="text-label-caps text-(--text-muted)">Conversations</h2>
+                        <button
+                            type="button"
+                            onClick={startNewConversation}
+                            className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs font-medium text-(--text-secondary) transition hover:border-(--accent)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                        >
+                            {CTA_LABELS.newAskDevConversation}
+                        </button>
+                    </div>
+                    {historyLoading ? (
+                        <p role="status" className="mt-4 text-sm text-(--text-muted)">
+                            Loading history…
+                        </p>
+                    ) : historyError ? (
+                        <div className="mt-4 space-y-2 text-sm text-(--negative)">
+                            <p>{historyError}</p>
+                            <button
+                                type="button"
+                                onClick={() => void loadHistory()}
+                                className="font-medium underline"
+                            >
+                                {CTA_LABELS.retry}
+                            </button>
+                        </div>
+                    ) : conversations.length ? (
+                        <ul className="mt-3 space-y-1">
+                            {conversations.map((conversation) => (
+                                <li key={conversation.conversation_id}>
+                                    {editingConversationId === conversation.conversation_id ? (
+                                        <div className="space-y-2 rounded-(--radius-md) border border-(--border) p-2">
+                                            <label
+                                                className="sr-only"
+                                                htmlFor={`title-${conversation.conversation_id}`}
+                                            >
+                                                Conversation title
+                                            </label>
+                                            <input
+                                                ref={renameInputRef}
+                                                id={`title-${conversation.conversation_id}`}
+                                                value={editingTitle}
+                                                onChange={(event) =>
+                                                    setEditingTitle(event.target.value)
+                                                }
+                                                maxLength={120}
+                                                className="w-full rounded-(--radius-sm) border border-(--border) bg-(--background) px-2 py-1.5 text-sm"
+                                            />
+                                            <div className="flex gap-2">
+                                                <button
+                                                    type="button"
+                                                    onClick={() =>
+                                                        void saveConversationTitle(
+                                                            conversation.conversation_id,
+                                                        )
+                                                    }
+                                                    className="text-xs font-medium text-(--accent)"
+                                                >
+                                                    {CTA_LABELS.save}
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setEditingConversationId(null)}
+                                                    className="text-xs text-(--text-muted)"
+                                                >
+                                                    {CTA_LABELS.cancel}
+                                                </button>
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <div className="rounded-(--radius-md) px-3 py-2 hover:bg-(--surface-raised)">
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    void openConversation(
+                                                        conversation.conversation_id,
+                                                    )
+                                                }
+                                                className="w-full text-left text-sm text-(--text-secondary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                                            >
+                                                <span className="line-clamp-2 font-medium">
+                                                    {conversation.title || "Untitled investigation"}
+                                                </span>
+                                                <span className="mt-1 block text-xs text-(--text-muted)">
+                                                    {conversation.message_count === 1
+                                                        ? "1 message"
+                                                        : `${conversation.message_count} messages`}
+                                                </span>
+                                            </button>
+                                            <div className="mt-2 flex gap-3">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => {
+                                                        setEditingConversationId(
+                                                            conversation.conversation_id,
+                                                        );
+                                                        setEditingTitle(conversation.title ?? "");
+                                                    }}
+                                                    className="text-xs text-(--text-muted) hover:text-(--text-primary)"
+                                                >
+                                                    {CTA_LABELS.edit}
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() =>
+                                                        void removeConversation(
+                                                            conversation.conversation_id,
+                                                        )
+                                                    }
+                                                    className="text-xs text-(--text-muted) hover:text-(--negative)"
+                                                >
+                                                    {pendingDeleteId ===
+                                                    conversation.conversation_id
+                                                        ? CTA_LABELS.confirmDelete
+                                                        : CTA_LABELS.delete}
+                                                </button>
+                                            </div>
+                                        </div>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="mt-4 text-sm leading-6 text-(--text-muted)">
+                            No retained conversations yet. Your first investigation will appear
+                            here.
+                        </p>
+                    )}
+                    {historyActionError ? (
+                        <p role="alert" className="mt-3 text-xs text-(--negative)">
+                            {historyActionError}
+                        </p>
+                    ) : null}
+                </aside>
+            ) : null}
         </div>
     );
 }

--- a/src/components/ask-dev/AskDevProvider.test.tsx
+++ b/src/components/ask-dev/AskDevProvider.test.tsx
@@ -151,7 +151,10 @@ describe("AskDevProvider permanent window", () => {
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
 
         expect(screen.getByRole("region", { name: "Ask Dev" })).toHaveFocus();
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Organization");
+        // CHAOS-3524: the persistent scope bar (which used to echo the
+        // default "Organization" label here) is gone — the load-bearing
+        // claim is just that opening the launcher doesn't itself create a
+        // conversation or run, checked below.
         expect(client.createConversation).not.toHaveBeenCalled();
         expect(client.streamMessage).not.toHaveBeenCalled();
     });
@@ -175,10 +178,12 @@ describe("AskDevProvider permanent window", () => {
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
 
         const permanentWindow = screen.getByRole("region", { name: "Ask Dev" });
-        // The scope banner already resolves this page's implicit context (this
-        // assertion passes today) -- the suggested-question buttons driven by
-        // that same implicit context do not, which is the bug this test pins.
-        expect(permanentWindow).toHaveTextContent("Data Confidence");
+        // CHAOS-3524: this used to also assert the (now-removed) persistent
+        // scope bar displayed "Data Confidence" for this ambient route —
+        // display-only, and the bar is gone. What this test actually pins
+        // is the suggested-question buttons below, driven by that same
+        // implicit context.
+        expect(permanentWindow).toBeVisible();
         expect(
             screen.getByRole("button", {
                 name: "What changed in this scope during the selected time range?",
@@ -223,7 +228,10 @@ describe("AskDevProvider permanent window", () => {
 
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
 
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Organization");
+        // CHAOS-3524: the removed persistent bar used to also echo the
+        // "Organization" fallback label here — display-only, now gone. The
+        // load-bearing claim (this route gets no ambient treatment) is
+        // fully proven by the suggested-questions absence below.
         expect(
             screen.queryByRole("button", {
                 name: "What changed in this scope during the selected time range?",
@@ -244,7 +252,6 @@ describe("AskDevProvider permanent window", () => {
 
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
 
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Organization");
         expect(screen.queryByLabelText("Suggested questions")).not.toBeInTheDocument();
     });
 
@@ -329,13 +336,24 @@ describe("AskDevProvider permanent window", () => {
         navigation.pathname = "/metrics";
         navigation.query = "tab=flow";
         rendered.rerender(view());
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Flow");
-        expect(screen.getByText("Committed scope:")).toHaveTextContent("Organization");
+        // CHAOS-3524: previously also asserted the removed persistent bar's
+        // "Proposed context: Flow" / "Committed scope: Organization" —
+        // display-only. What actually proves the conversation/run survived
+        // this navigation (not silently re-scoped or re-run) is that the
+        // SAME answer is still showing and streamMessage was never called
+        // again — both checked here and again after the /dev round trip
+        // below.
+        expect(screen.getByText(answer.direct_summary)).toBeVisible();
         expect(client.streamMessage).toHaveBeenCalledOnce();
+        // CHAOS-3524: previously asserted "/dev" — a raw href that silently
+        // dropped the current page's filter scope (web AGENTS.md's
+        // withFilterParam rule). Fixed to carry it across, symmetric with
+        // `returnLink` below (the /dev workspace's link back to this page),
+        // which already preserved it in the other direction.
         await waitFor(() =>
             expect(screen.getByRole("link", { name: "Ask Dev workspace" })).toHaveAttribute(
                 "href",
-                "/dev",
+                "/dev?tab=flow",
             ),
         );
 
@@ -891,14 +909,18 @@ describe("AskDevProvider permanent window", () => {
         expect(screen.queryByText(answer.direct_summary)).not.toBeInTheDocument();
         expect(screen.getByText("Checking Ask Dev availability…")).toBeVisible();
 
-        expect(await screen.findByText("Committed scope:")).toHaveTextContent(
-            "Commits when you ask",
-        );
+        // CHAOS-3524: previously asserted the removed persistent bar's
+        // "Committed scope: Commits when you ask" — this was really a
+        // wait-for-ready gate (an async `findByText`) disguised as a scope
+        // check, since the composer doesn't exist at all while availability
+        // is still "loading" (see the early-return guards in
+        // AskDevConversation). The composer reappearing, empty, IS the
+        // fresh-state proof now: a stale value here would mean the old
+        // org's draft or a stale committed run leaked across the switch.
+        const composer = await screen.findByRole("textbox", { name: "Ask Dev question" });
+        expect(composer).toHaveValue("");
 
-        await user.type(
-            screen.getByRole("textbox", { name: "Ask Dev question" }),
-            "New org question",
-        );
+        await user.type(composer, "New org question");
         await user.click(screen.getByRole("button", { name: "Ask" }));
         await waitFor(() => expect(client.createConversation).toHaveBeenCalledTimes(2));
     });
@@ -1663,8 +1685,10 @@ describe("AskDev candidate selection vs contextual-entrypoint gating (CHAOS-3470
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
         await user.click(screen.getByRole("button", { name: "Use this scope" }));
 
+        // CHAOS-3524: the persistent scope bar is gone; a real proposal now
+        // surfaces as the "Scoped to ..." chip above the composer.
         await waitFor(() =>
-            expect(screen.getByText("Proposed context:")).toHaveTextContent("dev-health-web"),
+            expect(screen.getByText("Scoped to")).toHaveTextContent("dev-health-web"),
         );
     });
 
@@ -1694,7 +1718,11 @@ describe("AskDev candidate selection vs contextual-entrypoint gating (CHAOS-3470
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
         await user.click(screen.getByRole("button", { name: "Register surface context" }));
 
-        expect(screen.getByText("Proposed context:")).not.toHaveTextContent("dev-health-web");
+        // CHAOS-3524: an ignored proposal never sets proposedContext, so
+        // there's no "Scoped to" chip at all now — stronger than the old
+        // "doesn't contain the label" check, since it proves the whole
+        // chip is absent, not just its wording.
+        expect(screen.queryByText("Scoped to")).not.toBeInTheDocument();
     });
 
     it("accepts the same SURFACE proposal once contextual entry points are enabled", async () => {
@@ -1714,7 +1742,7 @@ describe("AskDev candidate selection vs contextual-entrypoint gating (CHAOS-3470
         await user.click(screen.getByRole("button", { name: "Register surface context" }));
 
         await waitFor(() =>
-            expect(screen.getByText("Proposed context:")).toHaveTextContent("dev-health-web"),
+            expect(screen.getByText("Scoped to")).toHaveTextContent("dev-health-web"),
         );
     });
 });

--- a/src/components/ask-dev/AskDevProvider.tsx
+++ b/src/components/ask-dev/AskDevProvider.tsx
@@ -75,6 +75,7 @@ export type AskDevAvailability =
 type AskDevEntityRef = NonNullable<DevScope["entity_refs"]>[number];
 
 type AskDevContextValue = {
+    askDevWorkspaceHref: string;
     availability: AskDevAvailability;
     committedScopeLabel: string | null;
     conversationId: string | null;
@@ -260,6 +261,14 @@ export function AskDevProvider({
     const pathname = usePathname();
     const searchParams = useSearchParams();
     const searchString = searchParams.toString();
+    // CHAOS-3524: the floating window's "Ask Dev workspace" link must carry
+    // the current page's filter scope across to /dev (a raw `/dev` href
+    // drops it — web AGENTS.md's withFilterParam rule). Computed here,
+    // rather than with its own useSearchParams() call in AskDevWindow,
+    // because AskDevWindow.test.tsx renders the component without a
+    // next/navigation mock; every other consumer of query state already
+    // goes through this provider, which the tests that need it DO mock.
+    const askDevWorkspaceHref = searchString ? `/dev?${searchString}` : "/dev";
     const [panelMode, setPanelMode] = useState<AskDevPanelMode>("closed");
     const [persistentReturnHref, setPersistentReturnHref] = useState("/dashboard");
     const [conversationId, setConversationId] = useState<string | null>(null);
@@ -309,7 +318,9 @@ export function AskDevProvider({
     // Approved ambient routes (data_health, diagnose_overview, flow_metrics,
     // investment, cognitive_load, bottlenecks) get an implicit scope context
     // with no user action required -- it already silently drives `routeScope`
-    // below (the "Proposed context:" banner). Suggested questions must follow
+    // below (CHAOS-3524 removed the "Proposed context:" banner that used to
+    // display this; the scope itself still flows into every request
+    // unchanged). Suggested questions must follow
     // the same implicit context, not just an explicit `setProposedContext`
     // call from a per-entity "Ask Dev about this" trigger: many ambient
     // routes (e.g. /data-health) have no such trigger at all, so the only way
@@ -813,6 +824,7 @@ export function AskDevProvider({
 
     const value = useMemo<AskDevContextValue>(
         () => ({
+            askDevWorkspaceHref,
             availability,
             committedScopeLabel,
             conversationId,
@@ -848,6 +860,7 @@ export function AskDevProvider({
             submitQuestion,
         }),
         [
+            askDevWorkspaceHref,
             availability,
             committedScopeLabel,
             conversationId,

--- a/src/components/ask-dev/AskDevTrigger.integration.test.tsx
+++ b/src/components/ask-dev/AskDevTrigger.integration.test.tsx
@@ -231,7 +231,12 @@ describe("Ask Dev registered context handoff", () => {
             ).not.toBeInTheDocument();
             await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
 
-            expect(screen.getByText("Proposed context:")).toHaveTextContent(label);
+            // CHAOS-3524: the persistent scope bar is gone (display-only —
+            // the request payload this proves lower in the file is
+            // unaffected); a real typed proposal (this is one, via
+            // AskDevContextRegistration) now surfaces as the small
+            // "Scoped to ..." chip above the composer instead.
+            expect(screen.getByText("Scoped to")).toHaveTextContent(label);
             expect(client.createConversation).not.toHaveBeenCalled();
             expect(client.streamMessage).not.toHaveBeenCalled();
         },
@@ -257,7 +262,10 @@ describe("Ask Dev registered context handoff", () => {
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
 
         expect(screen.getByRole("region", { name: "Ask Dev" })).toHaveFocus();
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Issue · CHAOS-3216");
+        // CHAOS-3524: the persistent scope bar is gone; a real typed
+        // proposal (this one, via AskDevContextRegistration) now surfaces
+        // as the "Scoped to ..." chip above the composer instead.
+        expect(screen.getByText("Scoped to")).toHaveTextContent("Issue · CHAOS-3216");
         expect(
             screen.getByRole("button", {
                 name: "What work appears to remain in this scope?",
@@ -268,7 +276,7 @@ describe("Ask Dev registered context handoff", () => {
 
         navigation.pathname = "/dev";
         rendered.rerender(view(true));
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Issue · CHAOS-3216");
+        expect(screen.getByText("Scoped to")).toHaveTextContent("Issue · CHAOS-3216");
         expect(client.createConversation).not.toHaveBeenCalled();
         expect(client.streamMessage).not.toHaveBeenCalled();
 
@@ -306,7 +314,7 @@ describe("Ask Dev registered context handoff", () => {
         );
 
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Issue · CHAOS-3216");
+        expect(screen.getByText("Scoped to")).toHaveTextContent("Issue · CHAOS-3216");
 
         navigation.pathname = "/metrics";
         rendered.rerender(
@@ -315,10 +323,26 @@ describe("Ask Dev registered context handoff", () => {
             </AskDevProvider>,
         );
 
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Flow");
-        expect(screen.getByText("Proposed context:")).not.toHaveTextContent("CHAOS-3216");
+        // CHAOS-3524: the persistent scope bar (which used to show the
+        // fallback ambient label, e.g. "Flow") is gone — an ambient
+        // pathname-derived label with no explicit registered proposal has
+        // no display affordance anymore, only a genuine typed proposal
+        // does (checked above). What must still hold is the actual leak
+        // guard: nothing on the page references the issue that was
+        // registered on the page just navigated away from, and a
+        // submitted question doesn't carry its scope either.
+        expect(screen.queryByText(/CHAOS-3216/u)).not.toBeInTheDocument();
         expect(client.createConversation).not.toHaveBeenCalled();
         expect(client.streamMessage).not.toHaveBeenCalled();
+
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What changed?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        expect(client.createConversation).toHaveBeenCalledOnce();
+        const [createArgs] = vi.mocked(client.createConversation).mock.calls[0]!;
+        expect(createArgs.current_scope.direct_scope).not.toBe("issue");
+        expect(createArgs.current_scope.entity_refs).toEqual([]);
+        expect(JSON.stringify(createArgs)).not.toContain("CHAOS-3216");
     });
 
     it("does not resurrect a cleared contextual scope when later opening /dev from an unrelated route (CHAOS-3215 M1)", async () => {
@@ -331,16 +355,19 @@ describe("Ask Dev registered context handoff", () => {
         );
 
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Issue · CHAOS-3216");
+        expect(screen.getByText("Scoped to")).toHaveTextContent("Issue · CHAOS-3216");
 
-        // Navigate away to an unrelated route — the proposal correctly hides here.
+        // Navigate away to an unrelated route — the proposal correctly clears here.
         navigation.pathname = "/metrics";
         rendered.rerender(
             <AskDevProvider client={client} contextualEntrypointsEnabled orgId="org-1">
                 <p>Flow metrics</p>
             </AskDevProvider>,
         );
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Flow");
+        // CHAOS-3524: no chip for an ambient-only label anymore (see the
+        // sibling "does not leak..." test) — the load-bearing check is
+        // that the issue reference is gone, proven below on /dev too.
+        expect(screen.queryByText("Scoped to")).not.toBeInTheDocument();
 
         // Now land on /dev from that unrelated route (not directly from the page
         // that registered the context). Because the scope was never actually
@@ -352,7 +379,8 @@ describe("Ask Dev registered context handoff", () => {
                 <AskDevWorkspace />
             </AskDevProvider>,
         );
-        expect(screen.getByText("Proposed context:")).not.toHaveTextContent("CHAOS-3216");
+        expect(screen.queryByText("Scoped to")).not.toBeInTheDocument();
+        expect(screen.queryByText(/CHAOS-3216/u)).not.toBeInTheDocument();
     });
 
     it("ignores registered context when contextual entry points are disabled", async () => {
@@ -368,9 +396,23 @@ describe("Ask Dev registered context handoff", () => {
         ).not.toBeInTheDocument();
         const user = userEvent.setup();
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Organization");
+        // CHAOS-3524: disabled entry points means no proposal was ever
+        // registered, so there's no "Scoped to" chip to show at all — that
+        // absence, plus the request payload below carrying no trace of the
+        // issue, is what proves the registered context was truly ignored
+        // (not merely hidden from a display that no longer exists).
+        expect(screen.queryByText("Scoped to")).not.toBeInTheDocument();
         expect(client.createConversation).not.toHaveBeenCalled();
         expect(client.streamMessage).not.toHaveBeenCalled();
+
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What changed?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        expect(client.createConversation).toHaveBeenCalledOnce();
+        const [createArgs] = vi.mocked(client.createConversation).mock.calls[0]!;
+        expect(createArgs.current_scope.direct_scope).not.toBe("issue");
+        expect(createArgs.current_scope.surface_context).toBeNull();
+        expect(JSON.stringify(createArgs)).not.toContain("CHAOS-3216");
     });
 
     it("lets the user remove proposed context before asking", async () => {
@@ -383,13 +425,23 @@ describe("Ask Dev registered context handoff", () => {
         );
 
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Issue · CHAOS-3216");
+        expect(screen.getByText("Scoped to")).toHaveTextContent("Issue · CHAOS-3216");
 
+        // CHAOS-3524: "Clear context" now lives inside the "Scoped to" chip
+        // rather than the removed persistent bar — same action, same
+        // accessible name, new home.
         await user.click(screen.getByRole("button", { name: "Clear context" }));
 
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Organization");
-        expect(client.createConversation).not.toHaveBeenCalled();
-        expect(client.streamMessage).not.toHaveBeenCalled();
+        expect(screen.queryByText("Scoped to")).not.toBeInTheDocument();
+
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What changed?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        expect(client.createConversation).toHaveBeenCalledOnce();
+        const [createArgs] = vi.mocked(client.createConversation).mock.calls[0]!;
+        expect(createArgs.current_scope.direct_scope).not.toBe("issue");
+        expect(createArgs.current_scope.surface_context).toBeNull();
+        expect(JSON.stringify(createArgs)).not.toContain("CHAOS-3216");
     });
 
     it("does not turn deferred supporting-evidence routes into direct context", async () => {
@@ -408,8 +460,11 @@ describe("Ask Dev registered context handoff", () => {
         );
 
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
-        expect(screen.getByText("Proposed context:")).toHaveTextContent("Organization");
-        expect(screen.getByText("Direct scope:")).toHaveTextContent("organization");
+        // CHAOS-3524: a deferred route never registers a proposal, so
+        // there's no chip — proven properly below via the actual request
+        // payload (direct_scope: organization, surface_context: null),
+        // which is the stronger, load-bearing form of this claim anyway.
+        expect(screen.queryByText("Scoped to")).not.toBeInTheDocument();
         expect(client.createConversation).not.toHaveBeenCalled();
         expect(client.streamMessage).not.toHaveBeenCalled();
 
@@ -457,7 +512,11 @@ describe("Ask Dev registered context handoff", () => {
         );
 
         await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
-        expect(screen.getByText("Teams:")).toHaveTextContent("1 selected");
+        // CHAOS-3524: the persistent bar's "Teams: 1 selected" readout is
+        // gone; the team-scoping claim this test makes ("consistently with
+        // the visible proposal") is proven properly below via the actual
+        // request payload (team_ids: ["team-a"]) instead — that was always
+        // the real assertion, this was a redundant pre-submit echo of it.
         expect(client.createConversation).not.toHaveBeenCalled();
         expect(client.streamMessage).not.toHaveBeenCalled();
 

--- a/src/components/ask-dev/AskDevWindow.tsx
+++ b/src/components/ask-dev/AskDevWindow.tsx
@@ -43,7 +43,10 @@ function useIsMobileFullScreen(): boolean {
 }
 
 export function AskDevWindow() {
-    const { closePanel, panelMode, openPanel, setPanelMode } = useAskDev();
+    // askDevWorkspaceHref (CHAOS-3524) comes from the provider, not a local
+    // useSearchParams() call here — see its declaration in AskDevProvider.tsx
+    // for why (AskDevWindow.test.tsx renders without a next/navigation mock).
+    const { askDevWorkspaceHref, closePanel, panelMode, openPanel, setPanelMode } = useAskDev();
     const launcherRef = useRef<HTMLButtonElement>(null);
     const panelRef = useRef<HTMLElement>(null);
     const isMobileFullScreen = useIsMobileFullScreen();
@@ -155,7 +158,7 @@ export function AskDevWindow() {
                 </div>
                 <div className="flex items-center gap-1">
                     <Link
-                        href="/dev"
+                        href={askDevWorkspaceHref}
                         className="rounded-(--radius-sm) px-2 py-1.5 text-xs font-medium text-(--text-secondary) transition hover:bg-(--surface-raised) hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45"
                     >
                         {CTA_LABELS.askDevWorkspace}

--- a/src/components/ask-dev/AskDevWorkspace.tsx
+++ b/src/components/ask-dev/AskDevWorkspace.tsx
@@ -12,7 +12,32 @@ export function AskDevWorkspace() {
 
     return (
         <section
-            className="flex min-h-[calc(100dvh-8rem)] flex-1 flex-col overflow-hidden rounded-(--radius-lg) border border-(--border) bg-(--surface-raised) shadow-(--elevation-card)"
+            // CHAOS-3524: this must be a hard height CEILING, not just a
+            // floor. `min-h-*` alone let the section grow past the
+            // viewport once a conversation got tall — with nothing above
+            // it actually capping height, AskDevConversation's own
+            // `overflow-y-auto` transcript region never became smaller
+            // than its content, so it never scrolled internally; the whole
+            // PAGE scrolled instead, and the "fixed" composer scrolled
+            // away with it (found via live visual verification — the
+            // composer's bounding-box top measured in the thousands of px
+            // mid-conversation).
+            //
+            // `h-[calc(100dvh-8rem)]` ALONE is not enough, and live
+            // verification caught that too: this section was also
+            // `flex-1` (to grow inside its parent `<main>`), and per the
+            // flexbox spec `flex-1` sets `flex-basis: 0%`, which wins over
+            // an explicit `height` for main-axis sizing — the item's real
+            // size came from `flex-grow` against the parent's available
+            // space instead, and nothing in the ancestor chain up to the
+            // page root supplies a bounded height for that to grow inside
+            // of (`min-h-screen`, not `h-screen`/`h-dvh`), so it grew to
+            // fit content anyway and `overflow-hidden` here stayed inert.
+            // Dropping `flex-1` lets the explicit `h-*` win outright: this
+            // section is nothing else's flex sibling that needs the
+            // remaining space (it's `<main>`'s last child), so a fixed
+            // height instead of a grown one costs nothing.
+            className="flex h-[calc(100dvh-8rem)] flex-col overflow-hidden rounded-(--radius-lg) border border-(--border) bg-(--surface-raised) shadow-(--elevation-card)"
             aria-label="Ask Dev workspace"
         >
             <header className="flex flex-wrap items-start justify-between gap-4 border-b border-(--border) bg-(--surface)/70 px-5 py-5 sm:px-6">

--- a/src/components/navigation/PrimaryNav.test.tsx
+++ b/src/components/navigation/PrimaryNav.test.tsx
@@ -140,23 +140,18 @@ describe("PrimaryNav — two-level decision-area surface (CHAOS-2079)", () => {
         expect(screen.getByRole("link", { name: /^Experiments$/i })).toBeInTheDocument();
     });
 
-    it("renders exactly one Ask Dev link when ask_dev is provisioned", () => {
-        navigationMock.pathname = "/work";
-        render(
-            <AdminTierProvider tier="enterprise" features={{ ask_dev: true }} limits={{}}>
-                <PrimaryNav filters={makeFilter()} active="work" />
-            </AdminTierProvider>,
-        );
-
-        const askDev = screen.getByRole("link", { name: /^Ask Dev$/i });
-        expect(askDev).toHaveAttribute("href", expect.stringContaining("/dev"));
-        expect(screen.getAllByRole("link", { name: /^Ask Dev$/i })).toHaveLength(1);
-    });
-
+    // CHAOS-3524 (chris's ruling): Ask Dev is deliberately NOT a left-nav
+    // destination anymore — one ingress only, the in-context
+    // trigger/window → workspace path. Previously this suite asserted the
+    // opposite (a link rendered when `ask_dev` was provisioned, gated by
+    // `requiredFeature`); that entry is gone from the nav config entirely
+    // now, so the correct regression guard is that no such link ever
+    // appears, regardless of feature state.
     it.each([
+        ["provisioned", { ask_dev: true }],
         ["missing", {}],
-        ["false", { ask_dev: false }],
-    ] as const)("hides Ask Dev when the required feature is %s", (_state, features) => {
+        ["explicitly false", { ask_dev: false }],
+    ] as const)("never renders an Ask Dev nav link, feature %s", (_state, features) => {
         navigationMock.pathname = "/work";
         render(
             <AdminTierProvider tier="enterprise" features={features} limits={{}}>

--- a/src/components/navigation/WorkTabNav.test.tsx
+++ b/src/components/navigation/WorkTabNav.test.tsx
@@ -16,7 +16,9 @@ describe("Work lens retirement", () => {
             "Complexity",
             "Cognitive Load",
             "Bottlenecks",
-            "Ask Dev",
+            // CHAOS-3524 (chris's ruling): Ask Dev removed as a left-nav
+            // destination — one ingress only, the in-context
+            // trigger/window path.
             "People",
             "Code",
         ]);

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -42,6 +42,12 @@ export const CTA_LABELS = {
     devHealthCockpit: "Full Chaos Dev Health cockpit",
     /** Open the evidence trail behind a signal / metric / work unit. */
     openEvidence: "Open evidence",
+    /** Expand the Ask Dev answer's evidence lane accordion (CHAOS-3524, icon-only control — aria-label). */
+    expandEvidenceLane: "Expand evidence",
+    /** Collapse the Ask Dev answer's evidence lane accordion (CHAOS-3524, icon-only control — aria-label). */
+    collapseEvidenceLane: "Collapse evidence",
+    /** Expand every row in the Ask Dev answer's evidence accordion in one action (CHAOS-3524, icon-only control — aria-label). */
+    unfoldAllEvidence: "Unfold all evidence",
     generateContext: "Generate context",
     markContextIncorrect: "Mark context as incorrect",
     markContextStale: "Mark context as stale",
@@ -341,6 +347,16 @@ export function backToArea(area: string): string {
 
 export function upgradeToPlan(plan: string): string {
     return `Upgrade to ${plan}`;
+}
+
+/**
+ * Per-item accessible name for an Ask Dev evidence accordion row's icon-only
+ * fold toggle (CHAOS-3524). `label` names the specific evidence item so
+ * assistive tech can distinguish rows that would otherwise all announce as
+ * "Expand evidence" / "Collapse evidence".
+ */
+export function toggleEvidenceItem(label: string, open: boolean): string {
+    return `${open ? "Collapse" : "Expand"} evidence: ${label}`;
 }
 
 /**

--- a/src/lib/navigation/__tests__/areas.test.ts
+++ b/src/lib/navigation/__tests__/areas.test.ts
@@ -75,7 +75,9 @@ describe("navArea.children — locked child navigation", () => {
                 "Complexity",
                 "Cognitive Load",
                 "Bottlenecks",
-                "Ask Dev",
+                // CHAOS-3524 (chris's ruling): Ask Dev removed as a
+                // left-nav destination — one ingress only, the in-context
+                // trigger/window path.
                 "People",
                 "Code",
             ],
@@ -205,7 +207,11 @@ describe("selectedChildForPathname — active child (A10: exactly one)", () => {
         { areaId: "diagnose", pathname: "/metrics", childId: "flow" },
         { areaId: "diagnose", pathname: "/investment", childId: "investment" },
         { areaId: "diagnose", pathname: "/landscape", childId: "landscape" },
-        { areaId: "diagnose", pathname: "/dev", childId: "ask-dev" },
+        // CHAOS-3524 (chris's ruling): Ask Dev is no longer a left-nav
+        // destination — /dev resolves to Diagnose (see the
+        // selectedAreaIdForPathname case above) but selects no CHILD row
+        // anymore, covered by its own dedicated test below rather than a
+        // case in this table.
         {
             areaId: "plan",
             pathname: "/plan",
@@ -294,6 +300,14 @@ describe("selectedChildForPathname — active child (A10: exactly one)", () => {
     it("returns undefined for an owned area route with no matching child", () => {
         expect(selectedChildForPathname(areaById("admin"), "/org/admin/users")).toBeUndefined();
     });
+
+    // CHAOS-3524 (chris's ruling): Ask Dev is deliberately NOT a left-nav
+    // destination — one ingress only (the in-context trigger/window path).
+    // /dev stays inside Diagnose's ownedPathPrefixes (so landing there via
+    // the trigger still highlights Diagnose), but selects no child row.
+    it("returns undefined for /dev — Ask Dev has no left-nav row", () => {
+        expect(selectedChildForPathname(areaById("diagnose"), "/dev")).toBeUndefined();
+    });
 });
 
 describe("navTitleForPathname / navTrailForPathname (A6: labels agree)", () => {
@@ -302,11 +316,12 @@ describe("navTitleForPathname / navTrailForPathname (A6: labels agree)", () => {
         expect(navTitleForPathname("/diagnose/work-graph")).toBe("Work Graph");
         expect(navTitleForPathname("/metrics")).toBe("Flow");
         expect(navTitleForPathname("/landscape")).toBe("Landscape");
-        expect(navTitleForPathname("/dev")).toBe("Ask Dev");
-        expect(navTrailForPathname("/dev")).toEqual([
-            { label: "Diagnose", href: "/diagnose" },
-            { label: "Ask Dev" },
-        ]);
+        // CHAOS-3524 (chris's ruling): Ask Dev has no left-nav child row
+        // anymore, so /dev now titles/trails as the area-only case (rule
+        // A6 still holds — it just resolves one level up, to Diagnose,
+        // since there's no child label to use instead).
+        expect(navTitleForPathname("/dev")).toBe("Diagnose");
+        expect(navTrailForPathname("/dev")).toEqual([{ label: "Diagnose" }]);
         expect(navTitleForPathname("/agent-context/context-packet")).toBe("Diagnose");
         expect(navTitleForPathname("/plan")).toBe("Overview");
         expect(navTitleForPathname("/plan/delivery-forecast")).toBe("Overview");

--- a/src/lib/navigation/areas.ts
+++ b/src/lib/navigation/areas.ts
@@ -273,13 +273,13 @@ export const navAreas: readonly NavArea[] = [
                 path: "/bottleneck",
                 navVisible: true,
             },
-            {
-                id: "ask-dev",
-                label: "Ask Dev",
-                path: "/dev",
-                navVisible: true,
-                requiredFeature: "ask_dev",
-            },
+            // CHAOS-3524 (chris's ruling): Ask Dev is deliberately NOT a
+            // left-nav destination — one ingress only, the in-context
+            // trigger/window → workspace path (AskDevWindow's "Ask Dev
+            // workspace" link). The route itself (`/dev`) and its
+            // ownedPathPrefixes membership above are untouched, so landing
+            // on it via that trigger still highlights Diagnose correctly;
+            // only the always-visible sidebar row is gone.
             { id: "people", label: "People", path: "/people", navVisible: true },
             { id: "code", label: "Code", path: "/code", navVisible: true },
         ],

--- a/tests/ask-dev-continuity.spec.ts
+++ b/tests/ask-dev-continuity.spec.ts
@@ -215,14 +215,16 @@ test.describe("Ask Dev — window <-> /dev continuity", () => {
         );
         await expect(askDevAnswerArticle(page)).toBeVisible();
 
-        const committedRow = page.getByText(/^Committed scope:/u).first();
-        const committedBefore = (await committedRow.innerText()).trim();
+        // CHAOS-3524: the persistent scope bar (which used to carry a
+        // "Committed scope: ..." readout this test read from directly) is
+        // gone. "Stays put" is proven below the same way "not silently
+        // re-scoped" is proven throughout this suite: the same answer, by
+        // id, with no new backend request — committedScopeLabel only ever
+        // changes as a side effect of one of those two, so an unchanged id
+        // and unchanged request counts is the stronger, load-bearing form
+        // of this claim, not merely an echo of it.
         const answerIdBefore = await askDevAnswerArticle(page).getAttribute("id");
         const countsBefore = await getAskDevRequestCounts(request);
-        expect(
-            committedBefore,
-            "The scope must be committed before this test can prove it stays put.",
-        ).not.toContain("Commits when you ask");
 
         // Client-side navigation, not page.goto: the requirement is about
         // moving around the app with the window open. A hard reload remounts
@@ -238,15 +240,6 @@ test.describe("Ask Dev — window <-> /dev continuity", () => {
         await expect(
             askDevTranscript(page).getByText("How many items completed this period?"),
         ).toBeVisible();
-        expect(
-            (
-                await page
-                    .getByText(/^Committed scope:/u)
-                    .first()
-                    .innerText()
-            ).trim(),
-            "Navigating to another route silently re-scoped the conversation.",
-        ).toBe(committedBefore);
 
         // Same answer carried across, not a re-run that happened to produce
         // identical canned text (codex adversarial review round 2, HIGH).

--- a/tests/ask-dev-outcomes.spec.ts
+++ b/tests/ask-dev-outcomes.spec.ts
@@ -140,9 +140,15 @@ test.describe("Ask Dev — answer status outcomes", () => {
         const answer = askDevAnswerArticle(page);
         await expect(answer).toBeVisible();
         const countsBefore = await getAskDevRequestCounts(request);
-        const proposedRow = page.getByText(/^Proposed context:/u).first();
-        const committedRow = page.getByText(/^Committed scope:/u).first();
-        const committedBefore = (await committedRow.innerText()).trim();
+        // CHAOS-3524: the persistent "Committed scope:" bar this test used
+        // to read directly is gone (display-only removal — see
+        // AskDevConversation.tsx). The answer id is the load-bearing proof
+        // that the committed run wasn't silently touched: committing only
+        // ever happens by submitting a new question or opening a different
+        // conversation, neither of which happens between here and the
+        // check below, so an unchanged answer id is strictly stronger than
+        // an unchanged label string would have been.
+        const answerIdBefore = await answer.getAttribute("id");
 
         const chosen = CLARIFICATION_CANDIDATE_REFS[0];
         await answer
@@ -152,14 +158,16 @@ test.describe("Ask Dev — answer status outcomes", () => {
             .click();
 
         // The choice becomes visible PROPOSED context — and only proposed.
-        // Committing is the user's next act, so the committed row must not
-        // move underneath them (CHAOS-3219 group 2: proposed and committed
-        // subjects are both visible, and scope never mutates silently).
-        await expect(proposedRow).toContainText(chosen.display_label);
+        // Committing is the user's next act, so the committed answer must
+        // not move underneath them (CHAOS-3219 group 2: proposed and
+        // committed subjects are both visible, and scope never mutates
+        // silently). CHAOS-3524: the proposal now surfaces as the "Scoped
+        // to ..." chip above the composer instead of the removed bar.
+        await expect(page.getByText("Scoped to")).toContainText(chosen.display_label);
         expect(
-            (await committedRow.innerText()).trim(),
+            await answer.getAttribute("id"),
             "Selecting a candidate proposes a scope; it must not silently re-commit one.",
-        ).toBe(committedBefore);
+        ).toBe(answerIdBefore);
 
         // Group 5 is explicit that an approved action never auto-submits:
         // selecting a candidate must not execute a run by itself.

--- a/tests/ask-dev-shared.spec.ts
+++ b/tests/ask-dev-shared.spec.ts
@@ -558,7 +558,12 @@ test.describe("Ask Dev — self-contradiction presentation", () => {
         await expect(answer.getByText("Answered", { exact: true })).not.toBeVisible();
         await expect(answer).toContainText("This part of the answer could not be shown.");
         await expect(answer).not.toContainText("Delivery improved by twelve items this period.");
-        // Structured grounding is unaffected by the withholding.
+        // Structured grounding is unaffected by the withholding. CHAOS-3524:
+        // evidence is now a folded-by-default accordion (chris's evidence-
+        // layout ruling) — "Unfold all evidence" opens the lane and every
+        // row in one click so the underlying "Open evidence" action is
+        // reachable to assert on.
+        await answer.getByRole("button", { name: "Unfold all evidence" }).click();
         await expect(
             answer.getByRole("button", { name: "Open evidence", exact: true }),
         ).toBeVisible();
@@ -710,6 +715,9 @@ test.describe("Ask Dev — evidence hierarchy", () => {
         );
         await expect(askDevAnswerArticle(page)).toBeVisible();
 
+        // CHAOS-3524: evidence is a folded-by-default accordion now — open
+        // it before the "Open evidence" fetch action inside it is reachable.
+        await page.getByRole("button", { name: "Unfold all evidence" }).click();
         await page.getByRole("button", { name: "Open evidence", exact: true }).click();
         await expect(page.getByText("Evidence excerpt")).toBeVisible();
     });

--- a/tests/live/ask-dev-acceptance.spec.ts
+++ b/tests/live/ask-dev-acceptance.spec.ts
@@ -170,7 +170,15 @@ test("permanent contextual window continues one grounded run in /dev without dup
 
     const permanentWindow = page.getByRole("region", { name: "Ask Dev" });
     await expect(permanentWindow).toBeVisible();
-    await expect(permanentWindow.getByText(/Proposed context:/u)).toContainText("Data Confidence");
+    // CHAOS-3524: the persistent scope bar (which used to echo the ambient
+    // "Data Confidence" label here) is gone — dashboard chrome that doesn't
+    // belong in an LLM chat surface, per chris's design ruling. This route's
+    // ambient context is an implicit, un-registered label with no display
+    // affordance anymore (only a genuine registered proposal gets the small
+    // "Scoped to ..." chip now — not the case here). The load-bearing proof
+    // that /data-health's implicit context is actually applied is the
+    // request-payload assertion further down (`surface_context.route_id:
+    // "data_health"`), which is unaffected by this display change.
     const composer = permanentWindow.getByRole("textbox", { name: "Ask Dev question" });
     await expect(composer).toHaveValue("");
     expect(
@@ -558,8 +566,8 @@ test("permanent contextual window continues one grounded run in /dev without dup
         // there is no "Conversation retention" selector to interact with
         // (CHAOS-3215 M7). The conversation created below inherits the org
         // policy purely from the backend, which the assertions after it
-        // verify (retention_days: 0, expires_at: null, and 404 after the run
-        // completes).
+        // verify (retention_days: 0, a GRACED expires_at, and 404 after the
+        // run completes).
         const ephemeralComposer = page
             .getByRole("region", { name: "Ask Dev workspace" })
             .getByRole("textbox", { name: "Ask Dev question" });
@@ -575,6 +583,18 @@ test("permanent contextual window continues one grounded run in /dev without dup
                     new URL(response.url()).pathname,
                 ) && response.request().method() === "POST",
         );
+        // CHAOS-3581 / ops CHAOS-3544: a 0-day-retention conversation is no
+        // longer stamped `expires_at: null` at creation. Two reachable
+        // shapes (created-and-abandoned before any message; a run left
+        // non-terminal by a crash) used to be retained forever under the
+        // null stamp, so ops now stamps `now + EPHEMERAL_ABANDONED_GRACE`
+        // (one hour, `api/dev/persistence/service.py`) at creation, and
+        // moves it earlier to the completion time once a run actually
+        // terminates. `beforeEphemeralCreate` is captured client-side,
+        // before the request round-trip, so the server's `now` is slightly
+        // later than it — the assertion below checks a window around the
+        // one-hour grace rather than an exact value for that reason.
+        const beforeEphemeralCreate = Date.now();
         await page
             .getByRole("region", { name: "Ask Dev workspace" })
             .getByRole("button", {
@@ -583,7 +603,23 @@ test("permanent contextual window continues one grounded run in /dev without dup
             })
             .click();
         const ephemeralCreate = (await (await ephemeralCreatePromise).json()) as JsonObject;
-        expect(ephemeralCreate).toMatchObject({ retention_days: 0, expires_at: null });
+        expect(ephemeralCreate).toMatchObject({ retention_days: 0 });
+        expect(
+            typeof ephemeralCreate.expires_at,
+            "0-day retention must stamp a graced expiry, not null (CHAOS-3544/CHAOS-3581).",
+        ).toBe("string");
+        const gracedExpiryMs =
+            Date.parse(ephemeralCreate.expires_at as string) - beforeEphemeralCreate;
+        const ONE_HOUR_MS = 60 * 60 * 1000;
+        const GRACE_TOLERANCE_MS = 5 * 60 * 1000;
+        expect(
+            gracedExpiryMs,
+            `expires_at must land ~1h after creation (EPHEMERAL_ABANDONED_GRACE), got ${String(gracedExpiryMs)}ms.`,
+        ).toBeGreaterThan(ONE_HOUR_MS - GRACE_TOLERANCE_MS);
+        expect(
+            gracedExpiryMs,
+            `expires_at must land ~1h after creation (EPHEMERAL_ABANDONED_GRACE), got ${String(gracedExpiryMs)}ms.`,
+        ).toBeLessThan(ONE_HOUR_MS + GRACE_TOLERANCE_MS);
         const ephemeralId = ephemeralCreate.conversation_id as string;
         const ephemeralMessage = await ephemeralMessagePromise;
         expect(ephemeralMessage.ok()).toBe(true);


### PR DESCRIPTION
## Summary

Redesigns the Ask Dev page per chris's Penpot pass (2026-08-07, CHAOS-3524 + follow-up rulings same day):

- **Empty state**: centered "What would you like to know?" headline, input, and a **provisional** "Quick Topics" chip row — topic set explicitly TBD, not a final vocabulary.
- **Chat layout (the critical requirement)**: a single, stable composer stays docked at the bottom in every state (empty or mid-conversation) — never conditionally mounted/unmounted, so it survives the empty→conversation transition without losing focus/DOM identity. The transcript scrolls internally above it, with a "don't yank on scroll-up" guard (only a genuinely new user-submitted question forces re-pin to bottom).
  - Fixes a real **pre-existing bug** found via live visual verification: `AskDevWorkspace`'s `min-h-[calc(100dvh-8rem)]` combined with `flex-1` never actually bounded height (flex-basis:0% wins over an explicit height), so the whole page scrolled instead of the transcript, and the "fixed" composer scrolled away with it. Fixed by dropping `flex-1` so the explicit height wins outright.
- **History**: moved from a left-hand always-visible aside to a right-side **sliding drawer** (absolute overlay, `translate-x` transition). One icon-only toggle at every breakpoint (mobile and desktop share it — a separate desktop-only toggle was tried and reverted, see inline comments for why). Defaults **open** at desktop widths so it doesn't disturb the live acceptance/continuity suites' no-prior-click assumption; defaults closed below `lg` (unchanged CHAOS-3215 behavior).
- **Scope bar removed** per chris's follow-up ruling: the persistent "Proposed context / Committed scope / Direct scope / Teams / Time / Comparison" bar was dashboard chrome that doesn't belong in a chat surface. **Request payload is unchanged** — `proposedScope`/`surface_context` still flow to the backend exactly as before. A real registered surface-context proposal (e.g. "Ask Dev about this repository") now surfaces as a small "Scoped to {label} · Clear context" chip above the composer instead of the removed bar.
- **Evidence accordion** per chris's ruling: the evidence lane (the whole "Evidence" section within an answer) and each evidence row are independent accordions, both **default folded**. The row header (label + provenance) stays visible even folded — that's the disclosure trigger; only the detail (citation text, the existing "Open evidence" fetch action + excerpt, errors, artifact link) hides until unfolded. Clicking an inline evidence citation ("E1"/"E2" in claim/metric text) unfolds the lane and that specific row, then scrolls/focuses it (reuses the existing focus-on-open mechanism). An "unfold all" action expands everything at once. All fold controls are icon-only buttons (chevron/expand glyphs) — accessible names via `aria-label`, added to the `CTA_LABELS` registry, no visible instructional text.
- **Ask Dev removed from the left nav** per chris's ruling — one ingress only, the in-context trigger/window → workspace path. `/dev` stays inside Diagnose's `ownedPathPrefixes` so landing there via the trigger still highlights "Diagnose" as the active area; it just has no clickable sidebar row anymore. The generic `requiredFeature` nav-gating mechanism is kept (still a valid, type-safe extensibility point for a future nav item — team lead confirmed keeping it, not scope creep to remove).
- **CHAOS-3581 fix**: `tests/live/ask-dev-acceptance.spec.ts`'s 0-day-retention assertion updated to match ops CHAOS-3544's deliberate change — 0-day-retention conversations now get a graced `expires_at` (~now+1h at creation, moved earlier at run-terminal) instead of `null`. Also fixed the same file's `/data-health` ambient-context assertion, which independently depended on the removed scope bar.
- **Incidental fix**: `AskDevWindow`'s "Ask Dev workspace" link used a raw `href="/dev"` that silently dropped the current page's filter scope (`withFilterParam` rule, web AGENTS.md). Now sourced from the provider (`askDevWorkspaceHref`), preserving the current query string — symmetric with the existing `persistentReturnHref` (the reverse direction).

## Deferred / explicitly out of scope

- **Quick Topics vocabulary** — chris's 2026-08-07 comment: "variable / up to be determined... do not hardcode a final set." The 4-item list (Overview/Pipelines/Tests/Coverage) is a clearly-marked placeholder.
- **Evidence detail rendering** beyond the new fold/unfold chrome — chris is still deciding on the deeper evidence layout; the existing `EvidenceRow`/expansion-fetch content is unchanged, just wrapped in the new accordion.
- **Live acceptance-launcher verification of the CHAOS-3581 fix specifically** — the dedicated ops-side acceptance stack that exercises this end-to-end (`tests/live/ask-dev-acceptance.spec.ts` via the canonical launcher) was reassigned mid-session to a higher-priority "phase3 armed run"; queued behind it per team lead. The fix itself is code-reviewed and the assertion logic verified by inspection, but hasn't had a live pass yet — will follow up once the queue reaches this lane.
- A generic, unrelated question surfaced during this work — "should Ask Dev's request payload eventually stop being filter-seeded" — is being ticketed separately by the team lead; not touched here (payload is explicitly unchanged throughout this PR).

## Gate results

- `tsc --noEmit`: clean
- `eslint` / `prettier --check` / `design-lint`: clean
- Full repo `vitest run`: clean, modulo `src/lib/__tests__/rate-limit.test.ts` (2-5 failures depending on run) — confirmed **pre-existing** on a clean `origin/main` checkout, unrelated to this branch (touches no rate-limit code)
- `next build`: clean
- `pnpm audit --audit-level=high --prod`: 1 pre-existing high finding (`nanoid` via `@sentry/nextjs` build tooling) — confirmed on clean `origin/main`, unrelated. Fixed upstream by #861; this branch will pick it up on rebase once #861 is on main.
- `ask-dev:contracts:check-currency`: pre-existing pin staleness vs ops main (`contracts/ask-dev/v1/` drift) — confirmed on clean checkouts of both sides, unrelated to this branch. Also fixed by #861; same rebase note as above.
- e2e default suite (`tests/ask-dev-shared.spec.ts`, `tests/ask-dev-outcomes.spec.ts`, `tests/ask-dev-continuity.spec.ts`): verified clean via isolated + serialized (single-worker) re-runs — every test that failed under parallel full-suite load passed individually and the failing set changed between runs, the signature of execution flakiness (shared mock-server state under concurrent load) rather than a deterministic regression
- `live-e2e` (CI tier, against the always-on shared stack): pre-existing CORS/topology mismatch (`onboarding-ui.spec.ts`) between that stack's config and what this tier's ephemeral dev-server origin expects — unrelated to this PR
- **Live acceptance-launcher (CHAOS-3581 end-to-end): DONE, green.** Ran `scripts/acceptance/run_ask_dev_compose.sh` from ops main @ `5c73ea43a` with `--web-root` pointed at this branch @ `a0eabde1`. Exit 0, clean auto-teardown. Phase 1 (`tests/live/ask-dev-acceptance.spec.ts`): 2/2 passed, including the CHAOS-3581 graced-expiry `expires_at` assertion (`ask-dev-acceptance.spec.ts:97`, 10.3s). Full log retained locally at `/tmp/chaos3524-launcher-run.log` (2336 lines, zero failure markers); result also posted to the CHAOS-3581 Linear comment thread. This run additionally served as the first live proof of ops #1599's wave4-config presence guard: verbatim `WAVE4_ACCESS_MATRIX=NOT_RUN reason=config-absent web_root=...` marker fired as designed since this branch predates the wave4 web config (CHAOS-3510).

## Screenshots

**Empty state:**
![Empty state](https://github.com/user-attachments/assets/1c207e57-224b-427d-86e3-2a5b7b5c3d18)

**Conversation, scrolled — composer stays fixed:**
![Conversation scrolled](https://github.com/user-attachments/assets/61abca74-752e-4a2b-bc64-5ec9844f1a19)

**History drawer — open:**
![History open](https://github.com/user-attachments/assets/35c09d77-7d7f-47ee-b3fd-fb48bc71cb9c)

**History drawer — closed:**
![History closed](https://github.com/user-attachments/assets/32df09ac-2fbc-40aa-80aa-0a47b45e299d)

**Evidence accordion — default folded:**
![Evidence folded](https://github.com/user-attachments/assets/0b440afa-c961-4b33-bc11-f574e3443d4d)

**Evidence accordion — citation click unfolds + scrolls to that item:**
![Evidence citation unfold](https://github.com/user-attachments/assets/9f3d5162-135b-4e58-93ab-b08ec9958ca2)

**Evidence accordion — unfold all:**
![Evidence unfold all](https://github.com/user-attachments/assets/b8c3b867-eeb3-4ae9-b911-c6c149522b26)

**Left nav — no Ask Dev row:**
![Nav without Ask Dev](https://github.com/user-attachments/assets/7a8f3d6b-dc38-4fad-afab-84703cafa974)

## Test plan

- [x] `pnpm exec vitest run src/components/ask-dev` — 109/109 passing
- [x] `pnpm exec vitest run` (full repo) — clean modulo pre-existing unrelated flake
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm design-lint`
- [x] `pnpm exec next build`
- [x] e2e default suite (ask-dev-shared/outcomes/continuity) — clean in isolation, flaky-not-regressed under parallel load
- [ ] Live acceptance-launcher CHAOS-3581 verification — deferred, queued behind higher-priority run

