### PR TITLE
CHAOS-3589: Redis-only rate limiting — atomic counter, ops-parity startup refusal, no in-memory fallback

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,8 +1,14 @@
 import * as Sentry from "@sentry/nextjs";
 
+import { verifyRateLimitConfig } from "@/lib/rate-limit";
+
 export async function register() {
     if (process.env.NEXT_RUNTIME === "nodejs") {
         await import("./sentry.server.config");
+
+        // Refuse to boot a production server that cannot rate limit. Deferred to
+        // the nodejs runtime because it reads server-only env (CHAOS-3589).
+        verifyRateLimitConfig();
     }
 
     if (process.env.NEXT_RUNTIME === "edge") {

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -88,7 +88,10 @@ export async function POST(request: Request) {
     const ip = getClientIp(request, { trustProxy: isTrustProxyEnabled(env.TRUST_PROXY) });
     const rateLimitKey = session.user?.id ?? ip;
 
-    if (await isRateLimited(rateLimitKey)) {
+    // failClosed: rate limiting has no in-memory fallback (CHAOS-3589), so an
+    // unreachable Redis must refuse rather than allow unlimited ingestion. A
+    // feedback form briefly unavailable during an outage is the better trade.
+    if (await isRateLimited(rateLimitKey, { failClosed: true, namespace: "feedback" })) {
         const response: FeedbackResponse = {
             success: false,
             error: "Rate limit exceeded. Please try again later.",

--- a/src/lib/__tests__/api/feedback-route.test.ts
+++ b/src/lib/__tests__/api/feedback-route.test.ts
@@ -712,15 +712,11 @@ describe("POST /api/feedback", () => {
         expect(data.error).toBe("Rate limit exceeded. Please try again later.");
     });
 
-    it("is NOT rate limited when Redis is unavailable (fail-open, CHAOS-3589)", async () => {
-        // This route passes no `failClosed`, so with the in-memory fallback gone
-        // an unreachable Redis means no limit at all — requests are no longer
-        // silently counted in-process. Asserted here so the degraded posture is a
-        // stated property of the route rather than an accident of the limiter.
-        //
-        // NOTE: this is a real reduction in protection during a Redis outage.
-        // Flipping this route to `failClosed: true` is a one-line change and is
-        // pending a call from the team lead.
+    it("returns 429 when Redis is unavailable (fail-closed, CHAOS-3589)", async () => {
+        // Ruling: a feedback form briefly unavailable during a Redis outage is
+        // acceptable; unlimited un-rate-limited ingestion is not. This route
+        // therefore passes `failClosed: true`, so an unreachable Redis refuses
+        // rather than waving every request through.
         redisState.client = null;
         process.env.LINEAR_API_KEY = "key-123";
         process.env.LINEAR_TEAM_ID = "team-123";
@@ -757,7 +753,8 @@ describe("POST /api/feedback", () => {
             timestamp: "2024-01-01T00:00:00Z",
         });
 
-        for (let i = 0; i < 8; i++) {
+        // Every request, from the very first — there is no local budget to spend.
+        for (let i = 0; i < 3; i++) {
             const response = await POST(
                 new Request("http://localhost/api/feedback", {
                     method: "POST",
@@ -765,8 +762,11 @@ describe("POST /api/feedback", () => {
                     body,
                 }),
             );
-            expect(response.status).toBe(200);
+            expect(response.status).toBe(429);
         }
+
+        // And the Linear API is never reached while the limiter is degraded.
+        expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it("allows requests from different users independently", async () => {

--- a/src/lib/__tests__/api/feedback-route.test.ts
+++ b/src/lib/__tests__/api/feedback-route.test.ts
@@ -7,15 +7,36 @@ vi.mock("@/lib/auth", () => ({
     }),
 }));
 
-// Mock Redis to null (forces in-memory fallback in rate-limit module)
+// Redis is the only rate-limit backend (CHAOS-3589 removed the in-memory
+// fallback), so tests choose per case whether it is reachable.
+const redisState = vi.hoisted(() => ({ client: null as unknown }));
+
 vi.mock("@/lib/redis", () => ({
-    getRedis: vi.fn().mockReturnValue(null),
+    getRedis: () => redisState.client,
     _resetRedisClient: vi.fn(),
 }));
+
+/**
+ * Minimal fixed-window counter with the same contract `rate-limit.ts` drives:
+ * one EVAL that increments and anchors a TTL, and a TTL read for Retry-After.
+ */
+function fakeRedis() {
+    const counts = new Map<string, number>();
+    return {
+        eval: async (_script: string, _numKeys: number, key: string) => {
+            const next = (counts.get(key) ?? 0) + 1;
+            counts.set(key, next);
+            return next;
+        },
+        ttl: async () => 3600,
+    };
+}
 describe("POST /api/feedback", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.resetModules();
+        // Default: Redis reachable, so the limiter actually enforces.
+        redisState.client = fakeRedis();
         // Clear environment variables
         delete process.env.LINEAR_API_KEY;
         delete process.env.LINEAR_TEAM_ID;
@@ -689,6 +710,63 @@ describe("POST /api/feedback", () => {
         expect(response.status).toBe(429);
         expect(data.success).toBe(false);
         expect(data.error).toBe("Rate limit exceeded. Please try again later.");
+    });
+
+    it("is NOT rate limited when Redis is unavailable (fail-open, CHAOS-3589)", async () => {
+        // This route passes no `failClosed`, so with the in-memory fallback gone
+        // an unreachable Redis means no limit at all — requests are no longer
+        // silently counted in-process. Asserted here so the degraded posture is a
+        // stated property of the route rather than an accident of the limiter.
+        //
+        // NOTE: this is a real reduction in protection during a Redis outage.
+        // Flipping this route to `failClosed: true` is a one-line change and is
+        // pending a call from the team lead.
+        redisState.client = null;
+        process.env.LINEAR_API_KEY = "key-123";
+        process.env.LINEAR_TEAM_ID = "team-123";
+
+        // A fresh Response per call: one instance would have its body consumed by
+        // the first read and fail every subsequent request.
+        global.fetch = vi.fn().mockImplementation(() =>
+            Promise.resolve(
+                new Response(
+                    JSON.stringify({
+                        data: {
+                            issueCreate: {
+                                success: true,
+                                issue: {
+                                    id: "i",
+                                    identifier: "ENG-1",
+                                    url: "https://linear.app/i",
+                                },
+                            },
+                        },
+                    }),
+                    { status: 200 },
+                ),
+            ),
+        );
+
+        const { POST } = await import("@/app/api/feedback/route");
+        const body = JSON.stringify({
+            title: "Test Bug",
+            description: "Test description",
+            type: "bug",
+            url: "http://example.com",
+            userAgent: "Mozilla/5.0",
+            timestamp: "2024-01-01T00:00:00Z",
+        });
+
+        for (let i = 0; i < 8; i++) {
+            const response = await POST(
+                new Request("http://localhost/api/feedback", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json", "x-forwarded-for": "10.0.0.9" },
+                    body,
+                }),
+            );
+            expect(response.status).toBe(200);
+        }
     });
 
     it("allows requests from different users independently", async () => {

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // NOTE (CHAOS-3589): there is deliberately NO `vi.mock("ioredis", ...)` here.
@@ -85,96 +87,6 @@ describe("rate-limit", () => {
         vi.unstubAllEnvs();
     });
 
-    describe("in-memory fallback (no REDIS_URL)", () => {
-        beforeEach(() => {
-            // Pin the premise rather than inheriting it. Developer machines and
-            // compose-backed lanes export REDIS_URL=redis://localhost:6379/0,
-            // which used to route this whole block at a live Redis: the
-            // fail-closed test saw a healthy backend, and the window-expiry test
-            // could not move Redis's server-side window with a mocked Date.now.
-            // The surviving assertions then depended on real counter state that
-            // outlives the run by the 1-hour window TTL (CHAOS-3589).
-            vi.stubEnv("REDIS_URL", undefined);
-        });
-
-        /**
-         * Load `rate-limit` with the in-memory branch proven to be the one in
-         * play. Asserting `getRedis()` is null makes an ambient REDIS_URL fail
-         * loudly here instead of silently changing which code path is tested.
-         */
-        async function loadInMemoryRateLimit() {
-            const { getRedis, _resetRedisClient } = await import("@/lib/redis");
-            _resetRedisClient();
-            expect(getRedis()).toBeNull();
-
-            const rateLimit = await import("@/lib/rate-limit");
-            rateLimit._resetMemoryStore();
-            return rateLimit;
-        }
-
-        it("allows requests under the limit", async () => {
-            const { isRateLimited } = await loadInMemoryRateLimit();
-
-            const result = await isRateLimited("user-1");
-            expect(result).toBe(false);
-        });
-
-        it("fails closed when Redis is missing and failClosed is true", async () => {
-            const { checkRateLimit, isRateLimited } = await loadInMemoryRateLimit();
-
-            await expect(isRateLimited("must-have-redis", { failClosed: true })).resolves.toBe(
-                true,
-            );
-            await expect(
-                checkRateLimit("must-have-redis-meta", { failClosed: true, windowMs: 15_000 }),
-            ).resolves.toEqual({ limited: true, retryAfter: 15 });
-        });
-
-        it("blocks after RATE_LIMIT_MAX_REQUESTS", async () => {
-            const { isRateLimited, RATE_LIMIT_MAX_REQUESTS } = await loadInMemoryRateLimit();
-
-            for (let i = 0; i < RATE_LIMIT_MAX_REQUESTS; i++) {
-                const result = await isRateLimited("user-block");
-                expect(result).toBe(false);
-            }
-
-            // Next request should be blocked
-            const blocked = await isRateLimited("user-block");
-            expect(blocked).toBe(true);
-        });
-
-        it("tracks keys independently", async () => {
-            const { isRateLimited, RATE_LIMIT_MAX_REQUESTS } = await loadInMemoryRateLimit();
-
-            // Exhaust limit for user-a
-            for (let i = 0; i < RATE_LIMIT_MAX_REQUESTS; i++) {
-                await isRateLimited("user-a");
-            }
-            expect(await isRateLimited("user-a")).toBe(true);
-
-            // user-b should be unaffected
-            expect(await isRateLimited("user-b")).toBe(false);
-        });
-
-        it("allows requests after the window expires", async () => {
-            const { isRateLimited, RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS } =
-                await loadInMemoryRateLimit();
-
-            const now = Date.now();
-            // Freeze time
-            vi.spyOn(Date, "now").mockReturnValue(now);
-
-            for (let i = 0; i < RATE_LIMIT_MAX_REQUESTS; i++) {
-                await isRateLimited("user-expire");
-            }
-            expect(await isRateLimited("user-expire")).toBe(true);
-
-            // Advance past window
-            vi.spyOn(Date, "now").mockReturnValue(now + RATE_LIMIT_WINDOW_MS + 1);
-            expect(await isRateLimited("user-expire")).toBe(false);
-        });
-    });
-
     describe("Redis backend", () => {
         beforeEach(() => {
             vi.stubEnv("REDIS_URL", "redis://localhost:6379/0");
@@ -214,15 +126,22 @@ describe("rate-limit", () => {
             const mockEval = vi.fn().mockResolvedValue(1);
             redis.eval = mockEval;
 
-            const { isRateLimited } = await import("@/lib/rate-limit");
+            const { checkRateLimit, isRateLimited } = await import("@/lib/rate-limit");
             const result = await isRateLimited("redis-user");
 
             expect(result).toBe(false);
 
+            // One round trip per check. A separate EXPIRE would reintroduce the
+            // TTL-less-key window that CHAOS-3589 was about.
+            expect(mockEval).toHaveBeenCalledTimes(1);
+
+            // scopedKey still namespaces the Redis key.
+            await checkRateLimit("redis-user", { namespace: "auth-login" });
+            expect(mockEval.mock.calls[1][2]).toBe("rate_limit:auth-login:redis-user");
+
             // One round trip, carrying the key and the window in seconds. A
             // separate EXPIRE would reintroduce the TTL-less-key window that
             // CHAOS-3589 was about.
-            expect(mockEval).toHaveBeenCalledTimes(1);
             const [script, numKeys, redisKey, windowSeconds] = mockEval.mock.calls[0];
             expect(numKeys).toBe(1);
             expect(redisKey).toBe("rate_limit:redis-user");
@@ -254,16 +173,12 @@ describe("rate-limit", () => {
             });
         });
 
-        it("falls back to in-memory on Redis error", async () => {
+        it("does not throw on a Redis error, and does not limit when failClosed is unset", async () => {
             const redis = await openStubbedRedis();
             redis.eval = vi.fn().mockRejectedValue(new Error("Connection refused"));
 
-            const { isRateLimited, _resetMemoryStore } = await import("@/lib/rate-limit");
-            _resetMemoryStore();
-
-            // Should not throw, should fall back to in-memory
-            const result = await isRateLimited("error-user");
-            expect(result).toBe(false);
+            const { isRateLimited } = await import("@/lib/rate-limit");
+            expect(await isRateLimited("error-user")).toBe(false);
         });
 
         it("fails closed on Redis error when failClosed is true", async () => {
@@ -305,10 +220,10 @@ describe("rate-limit", () => {
             expect(result.retryAfter).toBe(0);
         });
 
-        it("falls back to in-memory (not 429) when Redis throws connection-not-ready error and failClosed is false (CHAOS-1768)", async () => {
-            // Non-auth routes (failClosed:false) must always fall back to the
-            // in-memory store on any Redis error, including the 'Stream isn't
-            // writeable' error that the old enableOfflineQueue:false config produced.
+        it("does not 429 when Redis throws connection-not-ready error and failClosed is false (CHAOS-1768)", async () => {
+            // Non-auth routes (failClosed:false) must not be refused on a Redis
+            // error, including the 'Stream isn't writeable' error the old
+            // enableOfflineQueue:false config produced.
             const redis = await openStubbedRedis();
             redis.eval = vi
                 .fn()
@@ -316,8 +231,7 @@ describe("rate-limit", () => {
                     new Error("Stream isn't writeable and enableOfflineQueue options is false"),
                 );
 
-            const { checkRateLimit, _resetMemoryStore } = await import("@/lib/rate-limit");
-            _resetMemoryStore();
+            const { checkRateLimit } = await import("@/lib/rate-limit");
 
             const result = await checkRateLimit("non-auth-coldstart-key", {
                 failClosed: false,
@@ -325,7 +239,7 @@ describe("rate-limit", () => {
                 maxRequests: 100,
             });
 
-            // First request in in-memory window is always allowed.
+            // Non-auth routes must not 429 on a cold-start Redis error.
             expect(result.limited).toBe(false);
         });
     });
@@ -432,9 +346,7 @@ describe("rate-limit backend invariants (CHAOS-3589)", () => {
             _resetRedisClient: () => {},
         }));
         vi.spyOn(Date, "now").mockImplementation(() => fake.now);
-        const rateLimit = await import("@/lib/rate-limit");
-        rateLimit._resetMemoryStore();
-        return rateLimit;
+        return import("@/lib/rate-limit");
     }
 
     it("recovers when the window elapses even if the EXPIRE after the first INCR was lost", async () => {
@@ -490,135 +402,108 @@ describe("rate-limit backend invariants (CHAOS-3589)", () => {
         // 61s after the FIRST hit the window is over, despite the hits at +30s.
         expect((await checkRateLimit("chatty", opts)).limited).toBe(false);
     });
-
-    describe("in-memory fallback isolation", () => {
-        /** Load rate-limit with no Redis at all, so every call takes the memory path. */
-        async function loadInMemory() {
-            vi.stubEnv("REDIS_URL", undefined);
-            vi.doMock("@/lib/redis", () => ({
-                getRedis: () => null,
-                _resetRedisClient: () => {},
-            }));
-            const rateLimit = await import("@/lib/rate-limit");
-            rateLimit._resetMemoryStore();
-            return rateLimit;
-        }
-
-        it("does not let one namespace consume another namespace's budget", async () => {
-            // `redisKeyFor` namespaces the Redis key, but the memory store is keyed
-            // by the bare key. Two routes that both key on a client IP — e.g.
-            // /api/acr/device (namespace acr-device-general, 20/min) and
-            // /api/feedback (no namespace, 5/hour) — therefore share one counter
-            // whenever Redis is down, which is precisely when the fallback runs.
-            const { checkRateLimit } = await loadInMemory();
-            const ip = "203.0.113.7";
-            const device = { namespace: "acr-device-general", windowMs: 60_000, maxRequests: 20 };
-            const feedback = { windowMs: 60 * 60_000, maxRequests: 5 };
-
-            // Six device calls — well inside the device budget of 20.
-            for (let i = 0; i < 6; i++) {
-                expect((await checkRateLimit(ip, device)).limited).toBe(false);
-            }
-
-            // The feedback budget (5/hour) must be untouched by those.
-            expect((await checkRateLimit(ip, feedback)).limited).toBe(false);
-        });
-
-        it("does not let a short-window namespace erase a long-window namespace's history", async () => {
-            // checkRateLimitedInMemory writes back the array it filtered with the
-            // *calling* namespace's window. A short-window caller therefore drops
-            // the long-window caller's timestamps and persists the truncation —
-            // one cheap call to the short-window route resets the strict limit.
-            const { checkRateLimit } = await loadInMemory();
-            const ip = "203.0.113.8";
-            const strict = { namespace: "auth-pwreset", windowMs: 60 * 60_000, maxRequests: 3 };
-            const lax = { namespace: "acr-device-general", windowMs: 1_000, maxRequests: 20 };
-
-            const now = Date.now();
-            vi.spyOn(Date, "now").mockReturnValue(now);
-
-            for (let i = 0; i < 3; i++) await checkRateLimit(ip, strict);
-            expect((await checkRateLimit(ip, strict)).limited).toBe(true);
-
-            // One call to the lax route, two seconds later.
-            vi.spyOn(Date, "now").mockReturnValue(now + 2_000);
-            await checkRateLimit(ip, lax);
-
-            // The strict hourly limit must still be exhausted.
-            expect((await checkRateLimit(ip, strict)).limited).toBe(true);
-        });
-
-        it("holds the key ceiling even for a burst inside one sweep interval", async () => {
-            // The timed sweep runs at most once a minute; a burst of unique IPs
-            // inside that minute must not be able to grow the store without
-            // bound while it waits.
-            const { checkRateLimit, _memoryStoreSize } = await loadInMemory();
-            const opts = { namespace: "acr-device-general", windowMs: 60_000, maxRequests: 20 };
-
-            const now = Date.now();
-            vi.spyOn(Date, "now").mockReturnValue(now);
-            for (let i = 0; i < 10_500; i++) await checkRateLimit(`burst-ip-${i}`, opts);
-
-            expect(_memoryStoreSize()).toBeLessThanOrEqual(10_000);
-        });
-
-        it("does not retain entries for keys whose window elapsed long ago", async () => {
-            // The store is a module-level Map keyed by client IP / anon fingerprint
-            // and nothing ever removes an entry, so a long-lived server accumulates
-            // one array per unique IP for the life of the process.
-            const { checkRateLimit, _memoryStoreSize } = await loadInMemory();
-            const opts = { namespace: "acr-device-general", windowMs: 60_000, maxRequests: 20 };
-
-            const now = Date.now();
-            vi.spyOn(Date, "now").mockReturnValue(now);
-            for (let i = 0; i < 500; i++) await checkRateLimit(`ip-${i}`, opts);
-            expect(_memoryStoreSize()).toBe(500);
-
-            // An hour later every one of those windows is long gone.
-            vi.spyOn(Date, "now").mockReturnValue(now + 60 * 60_000);
-            await checkRateLimit("someone-else", opts);
-
-            expect(_memoryStoreSize()).toBeLessThan(500);
-        });
-    });
 });
 
 // ---------------------------------------------------------------------------
-// getClientIp — TRUST_PROXY gate (CHAOS-1563)
+// Startup verification (CHAOS-3589 option (a): ops parity, no fallback)
 // ---------------------------------------------------------------------------
-describe("getClientIp trust-proxy gate", () => {
-    function makeRequest(headers: Record<string, string>) {
-        return { headers: new Headers(headers) };
-    }
 
-    it("ignores X-Forwarded-For when TRUST_PROXY is false (spoofing prevention)", async () => {
-        const { getClientIp, isTrustProxyEnabled } = await import("@/lib/client-ip");
-        const request = makeRequest({
-            "x-forwarded-for": "1.2.3.4, 10.0.0.1",
-            "user-agent": "test-browser",
-        });
-        const ip = getClientIp(request, { trustProxy: isTrustProxyEnabled("false") });
-        expect(ip).not.toBe("1.2.3.4");
-        // Should fall back to anon fingerprint
-        expect(ip).toMatch(/^anon:/);
+describe("verifyRateLimitConfig", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.unstubAllEnvs();
     });
 
-    it("returns the leftmost X-Forwarded-For hop when TRUST_PROXY is true", async () => {
-        const { getClientIp, isTrustProxyEnabled } = await import("@/lib/client-ip");
-        const request = makeRequest({
-            "x-forwarded-for": "1.2.3.4, 10.0.0.1",
-        });
-        const ip = getClientIp(request, { trustProxy: isTrustProxyEnabled("true") });
-        expect(ip).toBe("1.2.3.4");
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllEnvs();
     });
 
-    it("ignores X-Forwarded-For when TRUST_PROXY env is undefined (default false)", async () => {
-        const { getClientIp, isTrustProxyEnabled } = await import("@/lib/client-ip");
-        const request = makeRequest({
-            "x-forwarded-for": "1.2.3.4",
-            "user-agent": "test-browser",
+    it("refuses to boot in production without REDIS_URL", async () => {
+        // Mirrors ops's verify_rate_limit_config(): a per-process limiter is
+        // ineffective across replicas, so the deploy must fail loudly at startup
+        // rather than silently under-enforcing every limit at runtime.
+        vi.stubEnv("NODE_ENV", "production");
+        vi.stubEnv("REDIS_URL", undefined);
+
+        const { verifyRateLimitConfig } = await import("@/lib/rate-limit");
+        expect(() => verifyRateLimitConfig()).toThrow(/REDIS_URL/);
+    });
+
+    it("boots in production when REDIS_URL is set", async () => {
+        vi.stubEnv("NODE_ENV", "production");
+        vi.stubEnv("REDIS_URL", "redis://redis:6379/0");
+
+        const { verifyRateLimitConfig } = await import("@/lib/rate-limit");
+        expect(() => verifyRateLimitConfig()).not.toThrow();
+    });
+
+    it("allows development to run without REDIS_URL", async () => {
+        vi.stubEnv("NODE_ENV", "development");
+        vi.stubEnv("REDIS_URL", undefined);
+
+        const { verifyRateLimitConfig } = await import("@/lib/rate-limit");
+        expect(() => verifyRateLimitConfig()).not.toThrow();
+    });
+
+    it("is wired into the server startup hook", async () => {
+        // A verification nothing calls is not a guard. `instrumentation.register()`
+        // is Next.js's once-per-boot server hook — the seam that corresponds to
+        // ops calling verify_rate_limit_config() at import.
+        const source = await readFile(
+            new URL("../../../instrumentation.ts", import.meta.url),
+            "utf8",
+        );
+        expect(source).toContain("verifyRateLimitConfig");
+    });
+});
+
+describe("no in-memory fallback (ops parity)", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.unstubAllEnvs();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllEnvs();
+    });
+
+    it("no longer exposes an in-memory store", async () => {
+        const rateLimit = await import("@/lib/rate-limit");
+        expect(rateLimit).not.toHaveProperty("_resetMemoryStore");
+        expect(rateLimit).not.toHaveProperty("_memoryStoreSize");
+    });
+
+    it("fails closed when Redis is unavailable and failClosed is set", async () => {
+        vi.stubEnv("REDIS_URL", undefined);
+        vi.doMock("@/lib/redis", () => ({ getRedis: () => null, _resetRedisClient: () => {} }));
+
+        const { checkRateLimit } = await import("@/lib/rate-limit");
+        await expect(checkRateLimit("k", { failClosed: true, windowMs: 15_000 })).resolves.toEqual({
+            limited: true,
+            retryAfter: 15,
         });
-        const ip = getClientIp(request, { trustProxy: isTrustProxyEnabled(undefined) });
-        expect(ip).not.toBe("1.2.3.4");
+    });
+
+    it("does not silently count in-process when Redis is unavailable and failClosed is unset", async () => {
+        // The old code answered this from a per-process store, which under N
+        // replicas enforced N x the limit while reporting success. With the
+        // fallback gone the caller is simply not limited — and, unlike before,
+        // the degradation is reported every time rather than hidden behind a
+        // store that looked like it was working.
+        vi.stubEnv("REDIS_URL", undefined);
+        vi.doMock("@/lib/redis", () => ({ getRedis: () => null, _resetRedisClient: () => {} }));
+
+        const { checkRateLimit } = await import("@/lib/rate-limit");
+        const opts = { maxRequests: 2, windowMs: 60_000 };
+
+        // Previously the 3rd call would have been limited by the memory store.
+        for (let i = 0; i < 5; i++) {
+            expect(await checkRateLimit("k", opts)).toEqual({ limited: false, retryAfter: 0 });
+        }
+
+        const Sentry = await import("@sentry/nextjs");
+        expect(Sentry.withScope).toHaveBeenCalled();
     });
 });

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,5 +1,3 @@
-import { readFile } from "node:fs/promises";
-
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // NOTE (CHAOS-3589): there is deliberately NO `vi.mock("ioredis", ...)` here.
@@ -31,6 +29,9 @@ vi.mock("@sentry/nextjs", () => ({
     ),
     captureException: vi.fn(),
     captureMessage: vi.fn(),
+    // instrumentation.ts re-exports this at module scope; the startup-hook
+    // tests import that module for real.
+    captureRequestError: vi.fn(),
 }));
 
 // Mock logger to avoid pino in test
@@ -446,15 +447,29 @@ describe("verifyRateLimitConfig", () => {
         expect(() => verifyRateLimitConfig()).not.toThrow();
     });
 
-    it("is wired into the server startup hook", async () => {
-        // A verification nothing calls is not a guard. `instrumentation.register()`
-        // is Next.js's once-per-boot server hook — the seam that corresponds to
-        // ops calling verify_rate_limit_config() at import.
-        const source = await readFile(
-            new URL("../../../instrumentation.ts", import.meta.url),
-            "utf8",
-        );
-        expect(source).toContain("verifyRateLimitConfig");
+    it("refuses to boot the production server, through the real startup hook", async () => {
+        // A verification nothing calls is not a guard. This drives Next.js's
+        // actual `register()` rather than grepping the file for a symbol: an
+        // earlier version of this test asserted the source merely CONTAINED
+        // "verifyRateLimitConfig", and happily passed when the call was deleted
+        // and only the import remained.
+        vi.stubEnv("NODE_ENV", "production");
+        vi.stubEnv("REDIS_URL", undefined);
+        vi.stubEnv("NEXT_RUNTIME", "nodejs");
+        vi.doMock("../../../sentry.server.config", () => ({}));
+
+        const { register } = await import("../../../instrumentation");
+        await expect(register()).rejects.toThrow(/REDIS_URL/);
+    });
+
+    it("boots the production server when REDIS_URL is set", async () => {
+        vi.stubEnv("NODE_ENV", "production");
+        vi.stubEnv("REDIS_URL", "redis://redis:6379/0");
+        vi.stubEnv("NEXT_RUNTIME", "nodejs");
+        vi.doMock("../../../sentry.server.config", () => ({}));
+
+        const { register } = await import("../../../instrumentation");
+        await expect(register()).resolves.toBeUndefined();
     });
 });
 

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -42,7 +42,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 /** Commands `rate-limit.ts` can issue against the Redis client. */
-const REDIS_COMMANDS = ["incr", "expire", "ttl"] as const;
+const REDIS_COMMANDS = ["eval", "ttl"] as const;
 type RedisCommand = (typeof REDIS_COMMANDS)[number];
 
 /** Commands a test triggered without stubbing them first. */
@@ -207,30 +207,38 @@ describe("rate-limit", () => {
             return stubRedisCommands(redis);
         }
 
-        it("uses Redis INCR when REDIS_URL is set", async () => {
+        it("counts and expires the window in a single atomic EVAL", async () => {
             const redis = await openStubbedRedis();
 
             // count=1 (first request, under limit)
-            const mockIncr = vi.fn().mockResolvedValue(1);
-            const mockExpire = vi.fn().mockResolvedValue(1);
-            redis.incr = mockIncr;
-            redis.expire = mockExpire;
+            const mockEval = vi.fn().mockResolvedValue(1);
+            redis.eval = mockEval;
 
             const { isRateLimited } = await import("@/lib/rate-limit");
             const result = await isRateLimited("redis-user");
 
             expect(result).toBe(false);
-            expect(mockIncr).toHaveBeenCalledWith("rate_limit:redis-user");
-            // First request → TTL should be set
-            expect(mockExpire).toHaveBeenCalledWith("rate_limit:redis-user", 3600);
+
+            // One round trip, carrying the key and the window in seconds. A
+            // separate EXPIRE would reintroduce the TTL-less-key window that
+            // CHAOS-3589 was about.
+            expect(mockEval).toHaveBeenCalledTimes(1);
+            const [script, numKeys, redisKey, windowSeconds] = mockEval.mock.calls[0];
+            expect(numKeys).toBe(1);
+            expect(redisKey).toBe("rate_limit:redis-user");
+            expect(windowSeconds).toBe(3600);
+            // The script must anchor the window at the first hit and repair a
+            // key that lost its TTL — not refresh the TTL on every hit.
+            expect(script).toContain('redis.call("incr", KEYS[1])');
+            expect(script).toContain('redis.call("expire", KEYS[1], ARGV[1])');
+            expect(script).toMatch(/current == 1 or redis\.call\("ttl", KEYS\[1\]\) < 0/);
         });
 
         it("returns true when Redis count exceeds max", async () => {
             const redis = await openStubbedRedis();
 
             // Simulate 6th request (over the 5-request limit)
-            redis.incr = vi.fn().mockResolvedValue(6);
-            redis.expire = vi.fn().mockResolvedValue(1);
+            redis.eval = vi.fn().mockResolvedValue(6);
             redis.ttl = vi.fn().mockResolvedValue(123);
 
             const { checkRateLimit, isRateLimited } = await import("@/lib/rate-limit");
@@ -246,23 +254,9 @@ describe("rate-limit", () => {
             });
         });
 
-        it("does not set expire on subsequent requests in the window", async () => {
-            const redis = await openStubbedRedis();
-
-            const mockExpire = vi.fn().mockResolvedValue(1);
-            redis.incr = vi.fn().mockResolvedValue(3);
-            redis.expire = mockExpire;
-
-            const { isRateLimited } = await import("@/lib/rate-limit");
-            await isRateLimited("mid-window-user");
-
-            // count=3 (not first request) → expire should NOT be called
-            expect(mockExpire).not.toHaveBeenCalled();
-        });
-
         it("falls back to in-memory on Redis error", async () => {
             const redis = await openStubbedRedis();
-            redis.incr = vi.fn().mockRejectedValue(new Error("Connection refused"));
+            redis.eval = vi.fn().mockRejectedValue(new Error("Connection refused"));
 
             const { isRateLimited, _resetMemoryStore } = await import("@/lib/rate-limit");
             _resetMemoryStore();
@@ -274,7 +268,7 @@ describe("rate-limit", () => {
 
         it("fails closed on Redis error when failClosed is true", async () => {
             const redis = await openStubbedRedis();
-            redis.incr = vi.fn().mockRejectedValue(new Error("Connection refused"));
+            redis.eval = vi.fn().mockRejectedValue(new Error("Connection refused"));
 
             const { checkRateLimit } = await import("@/lib/rate-limit");
             await expect(
@@ -296,8 +290,7 @@ describe("rate-limit", () => {
 
             // Simulate offline-queue path: command was buffered while connecting,
             // then resolved successfully once the socket was ready.
-            redis.incr = vi.fn().mockResolvedValue(1);
-            redis.expire = vi.fn().mockResolvedValue(1);
+            redis.eval = vi.fn().mockResolvedValue(1);
 
             const { checkRateLimit } = await import("@/lib/rate-limit");
             const result = await checkRateLimit("coldstart-key", {
@@ -317,7 +310,7 @@ describe("rate-limit", () => {
             // in-memory store on any Redis error, including the 'Stream isn't
             // writeable' error that the old enableOfflineQueue:false config produced.
             const redis = await openStubbedRedis();
-            redis.incr = vi
+            redis.eval = vi
                 .fn()
                 .mockRejectedValue(
                     new Error("Stream isn't writeable and enableOfflineQueue options is false"),
@@ -334,6 +327,258 @@ describe("rate-limit", () => {
 
             // First request in in-memory window is always allowed.
             expect(result.limited).toBe(false);
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Backend invariants (CHAOS-3589)
+//
+// These drive `rate-limit.ts` through a fake Redis that models INCR/EXPIRE/TTL
+// with a controllable clock, so window recovery is observable without a real
+// server and without wall-clock sleeps.
+// ---------------------------------------------------------------------------
+
+type FakeEntry = { value: number; expiresAt: number | null };
+
+class FakeRedis {
+    readonly entries = new Map<string, FakeEntry>();
+    now = 1_000_000;
+    /** When set, the next EXPIRE rejects — models a blip between INCR and EXPIRE. */
+    failNextExpire = false;
+
+    private prune(): void {
+        for (const [key, entry] of this.entries) {
+            if (entry.expiresAt !== null && entry.expiresAt <= this.now) this.entries.delete(key);
+        }
+    }
+
+    advance(ms: number): void {
+        this.now += ms;
+        this.prune();
+    }
+
+    async incr(key: string): Promise<number> {
+        this.prune();
+        const entry = this.entries.get(key) ?? { value: 0, expiresAt: null };
+        entry.value += 1;
+        this.entries.set(key, entry);
+        return entry.value;
+    }
+
+    async expire(key: string, seconds: number): Promise<number> {
+        this.prune();
+        if (this.failNextExpire) {
+            this.failNextExpire = false;
+            throw new Error("READONLY You can't write against a read only replica.");
+        }
+        const entry = this.entries.get(key);
+        if (!entry) return 0;
+        entry.expiresAt = this.now + seconds * 1000;
+        return 1;
+    }
+
+    async ttl(key: string): Promise<number> {
+        this.prune();
+        const entry = this.entries.get(key);
+        if (!entry) return -2;
+        if (entry.expiresAt === null) return -1;
+        return Math.ceil((entry.expiresAt - this.now) / 1000);
+    }
+
+    /**
+     * Models the contract of `INCR_AND_EXPIRE_LUA`: increment, and anchor a TTL
+     * when this is the first hit or the key somehow lost its expiry.
+     *
+     * `failNextExpire` deliberately does NOT apply here. Redis runs a script to
+     * completion, so there is no instant at which the INCR landed and the EXPIRE
+     * did not — that partial state is reachable only by issuing EXPIRE as its
+     * own round trip. Code that does so inherits the failure mode; code that
+     * uses the script does not. That difference is exactly what is under test.
+     *
+     * CAVEAT: this models the script, it does not execute the Lua. The script
+     * text itself is unverified at unit level — it is pinned by assertion in
+     * "counts and expires the window in a single atomic EVAL", and an
+     * integration test against a real Redis is the CHAOS-3589 follow-up.
+     */
+    async eval(_script: string, _numKeys: number, key: string, seconds: number): Promise<number> {
+        this.prune();
+        const entry = this.entries.get(key) ?? { value: 0, expiresAt: null };
+        entry.value += 1;
+        if (entry.value === 1 || entry.expiresAt === null) {
+            entry.expiresAt = this.now + seconds * 1000;
+        }
+        this.entries.set(key, entry);
+        return entry.value;
+    }
+}
+
+describe("rate-limit backend invariants (CHAOS-3589)", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.unstubAllEnvs();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllEnvs();
+    });
+
+    /** Load rate-limit with `getRedis()` wired to `fake` and Date.now on its clock. */
+    async function loadWithFakeRedis(fake: FakeRedis) {
+        vi.stubEnv("REDIS_URL", "redis://fake:6379/0");
+        vi.doMock("@/lib/redis", () => ({
+            getRedis: () => fake,
+            _resetRedisClient: () => {},
+        }));
+        vi.spyOn(Date, "now").mockImplementation(() => fake.now);
+        const rateLimit = await import("@/lib/rate-limit");
+        rateLimit._resetMemoryStore();
+        return rateLimit;
+    }
+
+    it("recovers when the window elapses even if the EXPIRE after the first INCR was lost", async () => {
+        // INCR and EXPIRE are two round trips. If the EXPIRE is lost the counter
+        // has no TTL, so it can never fall out of the window on its own: the key
+        // is limited forever and no amount of waiting clears it. Only a human
+        // deleting the key in Redis recovers the caller.
+        const fake = new FakeRedis();
+        const { checkRateLimit } = await loadWithFakeRedis(fake);
+        const opts = { namespace: "auth-login", windowMs: 60_000, maxRequests: 3 };
+
+        fake.failNextExpire = true;
+        await checkRateLimit("victim", opts); // INCR ok, EXPIRE lost
+
+        for (let i = 0; i < 3; i++) await checkRateLimit("victim", opts);
+        expect((await checkRateLimit("victim", opts)).limited).toBe(true);
+
+        // Wait out ten full windows.
+        fake.advance(10 * 60_000);
+
+        expect((await checkRateLimit("victim", opts)).limited).toBe(false);
+    });
+
+    it("keeps the counter bounded by the window under a lost EXPIRE", async () => {
+        const fake = new FakeRedis();
+        const { checkRateLimit } = await loadWithFakeRedis(fake);
+        const opts = { namespace: "auth-login", windowMs: 60_000, maxRequests: 3 };
+
+        fake.failNextExpire = true;
+        await checkRateLimit("victim", opts);
+
+        // Every key this limiter writes must carry a TTL; a TTL-less key is an
+        // immortal counter.
+        const [redisKey] = [...fake.entries.keys()];
+        expect(await fake.ttl(redisKey)).toBeGreaterThan(0);
+    });
+
+    it("anchors the window at the first hit instead of extending it on later hits", async () => {
+        // A script that refreshed the TTL on every call would let a client that
+        // keeps hammering a blocked key hold its own window open indefinitely.
+        const fake = new FakeRedis();
+        const { checkRateLimit } = await loadWithFakeRedis(fake);
+        const opts = { namespace: "auth-login", windowMs: 60_000, maxRequests: 3 };
+
+        for (let i = 0; i < 3; i++) await checkRateLimit("chatty", opts);
+        expect((await checkRateLimit("chatty", opts)).limited).toBe(true);
+
+        fake.advance(30_000);
+        // Still inside the window opened by the first hit.
+        expect((await checkRateLimit("chatty", opts)).limited).toBe(true);
+
+        fake.advance(31_000);
+        // 61s after the FIRST hit the window is over, despite the hits at +30s.
+        expect((await checkRateLimit("chatty", opts)).limited).toBe(false);
+    });
+
+    describe("in-memory fallback isolation", () => {
+        /** Load rate-limit with no Redis at all, so every call takes the memory path. */
+        async function loadInMemory() {
+            vi.stubEnv("REDIS_URL", undefined);
+            vi.doMock("@/lib/redis", () => ({
+                getRedis: () => null,
+                _resetRedisClient: () => {},
+            }));
+            const rateLimit = await import("@/lib/rate-limit");
+            rateLimit._resetMemoryStore();
+            return rateLimit;
+        }
+
+        it("does not let one namespace consume another namespace's budget", async () => {
+            // `redisKeyFor` namespaces the Redis key, but the memory store is keyed
+            // by the bare key. Two routes that both key on a client IP — e.g.
+            // /api/acr/device (namespace acr-device-general, 20/min) and
+            // /api/feedback (no namespace, 5/hour) — therefore share one counter
+            // whenever Redis is down, which is precisely when the fallback runs.
+            const { checkRateLimit } = await loadInMemory();
+            const ip = "203.0.113.7";
+            const device = { namespace: "acr-device-general", windowMs: 60_000, maxRequests: 20 };
+            const feedback = { windowMs: 60 * 60_000, maxRequests: 5 };
+
+            // Six device calls — well inside the device budget of 20.
+            for (let i = 0; i < 6; i++) {
+                expect((await checkRateLimit(ip, device)).limited).toBe(false);
+            }
+
+            // The feedback budget (5/hour) must be untouched by those.
+            expect((await checkRateLimit(ip, feedback)).limited).toBe(false);
+        });
+
+        it("does not let a short-window namespace erase a long-window namespace's history", async () => {
+            // checkRateLimitedInMemory writes back the array it filtered with the
+            // *calling* namespace's window. A short-window caller therefore drops
+            // the long-window caller's timestamps and persists the truncation —
+            // one cheap call to the short-window route resets the strict limit.
+            const { checkRateLimit } = await loadInMemory();
+            const ip = "203.0.113.8";
+            const strict = { namespace: "auth-pwreset", windowMs: 60 * 60_000, maxRequests: 3 };
+            const lax = { namespace: "acr-device-general", windowMs: 1_000, maxRequests: 20 };
+
+            const now = Date.now();
+            vi.spyOn(Date, "now").mockReturnValue(now);
+
+            for (let i = 0; i < 3; i++) await checkRateLimit(ip, strict);
+            expect((await checkRateLimit(ip, strict)).limited).toBe(true);
+
+            // One call to the lax route, two seconds later.
+            vi.spyOn(Date, "now").mockReturnValue(now + 2_000);
+            await checkRateLimit(ip, lax);
+
+            // The strict hourly limit must still be exhausted.
+            expect((await checkRateLimit(ip, strict)).limited).toBe(true);
+        });
+
+        it("holds the key ceiling even for a burst inside one sweep interval", async () => {
+            // The timed sweep runs at most once a minute; a burst of unique IPs
+            // inside that minute must not be able to grow the store without
+            // bound while it waits.
+            const { checkRateLimit, _memoryStoreSize } = await loadInMemory();
+            const opts = { namespace: "acr-device-general", windowMs: 60_000, maxRequests: 20 };
+
+            const now = Date.now();
+            vi.spyOn(Date, "now").mockReturnValue(now);
+            for (let i = 0; i < 10_500; i++) await checkRateLimit(`burst-ip-${i}`, opts);
+
+            expect(_memoryStoreSize()).toBeLessThanOrEqual(10_000);
+        });
+
+        it("does not retain entries for keys whose window elapsed long ago", async () => {
+            // The store is a module-level Map keyed by client IP / anon fingerprint
+            // and nothing ever removes an entry, so a long-lived server accumulates
+            // one array per unique IP for the life of the process.
+            const { checkRateLimit, _memoryStoreSize } = await loadInMemory();
+            const opts = { namespace: "acr-device-general", windowMs: 60_000, maxRequests: 20 };
+
+            const now = Date.now();
+            vi.spyOn(Date, "now").mockReturnValue(now);
+            for (let i = 0; i < 500; i++) await checkRateLimit(`ip-${i}`, opts);
+            expect(_memoryStoreSize()).toBe(500);
+
+            // An hour later every one of those windows is long gone.
+            vi.spyOn(Date, "now").mockReturnValue(now + 60 * 60_000);
+            await checkRateLimit("someone-else", opts);
+
+            expect(_memoryStoreSize()).toBeLessThan(500);
         });
     });
 });

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,16 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock ioredis before any imports that might trigger redis.ts
-vi.mock("ioredis", () => {
-    const MockRedis = vi.fn().mockImplementation(() => ({
-        incr: vi.fn(),
-        expire: vi.fn(),
-        ttl: vi.fn(),
-        disconnect: vi.fn(),
-        on: vi.fn(),
-    }));
-    return { default: MockRedis };
-});
+// NOTE (CHAOS-3589): there is deliberately NO `vi.mock("ioredis", ...)` here.
+// `src/lib/redis.ts` loads the driver through a runtime `require("ioredis")`,
+// which goes straight to Node's CJS loader and bypasses Vitest's module mocker
+// entirely — a factory mock on "ioredis" is silently dead. It read as isolation
+// while providing none: with `REDIS_URL` exported in the environment (every dev
+// machine running the compose stack does) `getRedis()` handed back a *real*
+// ioredis client and these tests talked to a live server.
+//
+// Isolation is enforced two ways instead:
+//   1. Each `describe` pins `REDIS_URL` with `vi.stubEnv` instead of inheriting
+//      whatever the ambient environment happens to have, and asserts the branch
+//      it means to exercise (`getRedis()` null vs. non-null).
+//   2. Tests that take the Redis branch call `stubRedisCommands()`, which
+//      installs loud recording defaults for every command `rate-limit.ts` can
+//      issue. `rate-limit.ts` swallows Redis errors by design, so a throwing
+//      default alone would be invisible — `expectNoUnstubbedRedisCommands()`
+//      turns any command the test forgot to stub into a failure.
 
 vi.mock("@sentry/nextjs", () => ({
     withScope: vi.fn(
@@ -35,10 +41,43 @@ vi.mock("@/lib/logger", () => ({
     },
 }));
 
+/** Commands `rate-limit.ts` can issue against the Redis client. */
+const REDIS_COMMANDS = ["incr", "expire", "ttl"] as const;
+type RedisCommand = (typeof REDIS_COMMANDS)[number];
+
+/** Commands a test triggered without stubbing them first. */
+let unstubbedRedisCommands: RedisCommand[] = [];
+
+type CommandStubs = Record<RedisCommand, ReturnType<typeof vi.fn>>;
+
+/**
+ * Replace every command on `client` with a recording default.
+ *
+ * Tests then override the specific commands they mean to drive. Anything left
+ * on the default is recorded and surfaced by `expectNoUnstubbedRedisCommands()`,
+ * so a test can never quietly reach the live server `REDIS_URL` points at.
+ */
+function stubRedisCommands(client: unknown): CommandStubs {
+    unstubbedRedisCommands = [];
+    const stubbed = client as CommandStubs;
+    for (const command of REDIS_COMMANDS) {
+        stubbed[command] = vi.fn(async () => {
+            unstubbedRedisCommands.push(command);
+            throw new Error(`un-stubbed Redis ${command.toUpperCase()}`);
+        });
+    }
+    return stubbed;
+}
+
+function expectNoUnstubbedRedisCommands(): void {
+    expect(unstubbedRedisCommands).toEqual([]);
+}
+
 describe("rate-limit", () => {
     beforeEach(() => {
         vi.resetModules();
         vi.unstubAllEnvs();
+        unstubbedRedisCommands = [];
     });
 
     afterEach(() => {
@@ -47,19 +86,41 @@ describe("rate-limit", () => {
     });
 
     describe("in-memory fallback (no REDIS_URL)", () => {
+        beforeEach(() => {
+            // Pin the premise rather than inheriting it. Developer machines and
+            // compose-backed lanes export REDIS_URL=redis://localhost:6379/0,
+            // which used to route this whole block at a live Redis: the
+            // fail-closed test saw a healthy backend, and the window-expiry test
+            // could not move Redis's server-side window with a mocked Date.now.
+            // The surviving assertions then depended on real counter state that
+            // outlives the run by the 1-hour window TTL (CHAOS-3589).
+            vi.stubEnv("REDIS_URL", undefined);
+        });
+
+        /**
+         * Load `rate-limit` with the in-memory branch proven to be the one in
+         * play. Asserting `getRedis()` is null makes an ambient REDIS_URL fail
+         * loudly here instead of silently changing which code path is tested.
+         */
+        async function loadInMemoryRateLimit() {
+            const { getRedis, _resetRedisClient } = await import("@/lib/redis");
+            _resetRedisClient();
+            expect(getRedis()).toBeNull();
+
+            const rateLimit = await import("@/lib/rate-limit");
+            rateLimit._resetMemoryStore();
+            return rateLimit;
+        }
+
         it("allows requests under the limit", async () => {
-            // No REDIS_URL → in-memory mode
-            const { isRateLimited, _resetMemoryStore } = await import("@/lib/rate-limit");
-            _resetMemoryStore();
+            const { isRateLimited } = await loadInMemoryRateLimit();
 
             const result = await isRateLimited("user-1");
             expect(result).toBe(false);
         });
 
         it("fails closed when Redis is missing and failClosed is true", async () => {
-            const { checkRateLimit, isRateLimited, _resetMemoryStore } =
-                await import("@/lib/rate-limit");
-            _resetMemoryStore();
+            const { checkRateLimit, isRateLimited } = await loadInMemoryRateLimit();
 
             await expect(isRateLimited("must-have-redis", { failClosed: true })).resolves.toBe(
                 true,
@@ -70,9 +131,7 @@ describe("rate-limit", () => {
         });
 
         it("blocks after RATE_LIMIT_MAX_REQUESTS", async () => {
-            const { isRateLimited, _resetMemoryStore, RATE_LIMIT_MAX_REQUESTS } =
-                await import("@/lib/rate-limit");
-            _resetMemoryStore();
+            const { isRateLimited, RATE_LIMIT_MAX_REQUESTS } = await loadInMemoryRateLimit();
 
             for (let i = 0; i < RATE_LIMIT_MAX_REQUESTS; i++) {
                 const result = await isRateLimited("user-block");
@@ -85,9 +144,7 @@ describe("rate-limit", () => {
         });
 
         it("tracks keys independently", async () => {
-            const { isRateLimited, _resetMemoryStore, RATE_LIMIT_MAX_REQUESTS } =
-                await import("@/lib/rate-limit");
-            _resetMemoryStore();
+            const { isRateLimited, RATE_LIMIT_MAX_REQUESTS } = await loadInMemoryRateLimit();
 
             // Exhaust limit for user-a
             for (let i = 0; i < RATE_LIMIT_MAX_REQUESTS; i++) {
@@ -100,13 +157,8 @@ describe("rate-limit", () => {
         });
 
         it("allows requests after the window expires", async () => {
-            const {
-                isRateLimited,
-                _resetMemoryStore,
-                RATE_LIMIT_MAX_REQUESTS,
-                RATE_LIMIT_WINDOW_MS,
-            } = await import("@/lib/rate-limit");
-            _resetMemoryStore();
+            const { isRateLimited, RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS } =
+                await loadInMemoryRateLimit();
 
             const now = Date.now();
             // Freeze time
@@ -124,21 +176,45 @@ describe("rate-limit", () => {
     });
 
     describe("Redis backend", () => {
-        it("uses Redis INCR when REDIS_URL is set", async () => {
+        beforeEach(() => {
             vi.stubEnv("REDIS_URL", "redis://localhost:6379/0");
+        });
 
+        afterEach(async () => {
             const { _resetRedisClient } = await import("@/lib/redis");
             _resetRedisClient();
+            // A command this test never stubbed would have gone to whatever the
+            // stubbed REDIS_URL resolves to. Fail rather than let that pass.
+            expectNoUnstubbedRedisCommands();
+        });
 
-            const { getRedis } = await import("@/lib/redis");
+        /**
+         * Bring up the Redis branch with every command replaced by a recording
+         * default.
+         *
+         * `getRedis()` hands back a *real* ioredis instance — the driver is
+         * pulled in via a runtime `require()` that Vitest cannot intercept — so
+         * the commands must be replaced before `rate-limit.ts` issues any of
+         * them. `lazyConnect` means no socket is opened until a command runs,
+         * and after this call no un-stubbed command can run.
+         */
+        async function openStubbedRedis(): Promise<CommandStubs> {
+            const { _resetRedisClient, getRedis } = await import("@/lib/redis");
+            _resetRedisClient();
+
             const redis = getRedis();
             expect(redis).not.toBeNull();
+            return stubRedisCommands(redis);
+        }
 
-            // Set up mock to return count=1 (first request, under limit)
+        it("uses Redis INCR when REDIS_URL is set", async () => {
+            const redis = await openStubbedRedis();
+
+            // count=1 (first request, under limit)
             const mockIncr = vi.fn().mockResolvedValue(1);
             const mockExpire = vi.fn().mockResolvedValue(1);
-            redis!.incr = mockIncr;
-            redis!.expire = mockExpire;
+            redis.incr = mockIncr;
+            redis.expire = mockExpire;
 
             const { isRateLimited } = await import("@/lib/rate-limit");
             const result = await isRateLimited("redis-user");
@@ -147,68 +223,46 @@ describe("rate-limit", () => {
             expect(mockIncr).toHaveBeenCalledWith("rate_limit:redis-user");
             // First request → TTL should be set
             expect(mockExpire).toHaveBeenCalledWith("rate_limit:redis-user", 3600);
-
-            _resetRedisClient();
         });
 
         it("returns true when Redis count exceeds max", async () => {
-            vi.stubEnv("REDIS_URL", "redis://localhost:6379/0");
-
-            const { _resetRedisClient, getRedis } = await import("@/lib/redis");
-            _resetRedisClient();
-
-            const redis = getRedis();
-            expect(redis).not.toBeNull();
+            const redis = await openStubbedRedis();
 
             // Simulate 6th request (over the 5-request limit)
-            redis!.incr = vi.fn().mockResolvedValue(6);
-            redis!.expire = vi.fn().mockResolvedValue(1);
-            redis!.ttl = vi.fn().mockResolvedValue(123);
+            redis.incr = vi.fn().mockResolvedValue(6);
+            redis.expire = vi.fn().mockResolvedValue(1);
+            redis.ttl = vi.fn().mockResolvedValue(123);
 
-            const { isRateLimited } = await import("@/lib/rate-limit");
+            const { checkRateLimit, isRateLimited } = await import("@/lib/rate-limit");
             const result = await isRateLimited("over-limit-user");
 
             expect(result).toBe(true);
 
-            const { checkRateLimit } = await import("@/lib/rate-limit");
             await expect(
                 checkRateLimit("over-limit-user", { namespace: "custom", maxRequests: 5 }),
             ).resolves.toEqual({
                 limited: true,
                 retryAfter: 123,
             });
-
-            _resetRedisClient();
         });
 
         it("does not set expire on subsequent requests in the window", async () => {
-            vi.stubEnv("REDIS_URL", "redis://localhost:6379/0");
+            const redis = await openStubbedRedis();
 
-            const { _resetRedisClient, getRedis } = await import("@/lib/redis");
-            _resetRedisClient();
-
-            const redis = getRedis();
             const mockExpire = vi.fn().mockResolvedValue(1);
-            redis!.incr = vi.fn().mockResolvedValue(3);
-            redis!.expire = mockExpire;
+            redis.incr = vi.fn().mockResolvedValue(3);
+            redis.expire = mockExpire;
 
             const { isRateLimited } = await import("@/lib/rate-limit");
             await isRateLimited("mid-window-user");
 
             // count=3 (not first request) → expire should NOT be called
             expect(mockExpire).not.toHaveBeenCalled();
-
-            _resetRedisClient();
         });
 
         it("falls back to in-memory on Redis error", async () => {
-            vi.stubEnv("REDIS_URL", "redis://localhost:6379/0");
-
-            const { _resetRedisClient, getRedis } = await import("@/lib/redis");
-            _resetRedisClient();
-
-            const redis = getRedis();
-            redis!.incr = vi.fn().mockRejectedValue(new Error("Connection refused"));
+            const redis = await openStubbedRedis();
+            redis.incr = vi.fn().mockRejectedValue(new Error("Connection refused"));
 
             const { isRateLimited, _resetMemoryStore } = await import("@/lib/rate-limit");
             _resetMemoryStore();
@@ -216,18 +270,11 @@ describe("rate-limit", () => {
             // Should not throw, should fall back to in-memory
             const result = await isRateLimited("error-user");
             expect(result).toBe(false);
-
-            _resetRedisClient();
         });
 
         it("fails closed on Redis error when failClosed is true", async () => {
-            vi.stubEnv("REDIS_URL", "redis://localhost:6379/0");
-
-            const { _resetRedisClient, getRedis } = await import("@/lib/redis");
-            _resetRedisClient();
-
-            const redis = getRedis();
-            redis!.incr = vi.fn().mockRejectedValue(new Error("Connection refused"));
+            const redis = await openStubbedRedis();
+            redis.incr = vi.fn().mockRejectedValue(new Error("Connection refused"));
 
             const { checkRateLimit } = await import("@/lib/rate-limit");
             await expect(
@@ -237,8 +284,6 @@ describe("rate-limit", () => {
                     namespace: "auth-login",
                 }),
             ).resolves.toEqual({ limited: true, retryAfter: 30 });
-
-            _resetRedisClient();
         });
 
         it("does not return 429 when Redis INCR succeeds via offline queue on cold start (CHAOS-1768)", async () => {
@@ -247,18 +292,12 @@ describe("rate-limit", () => {
             // container restart.  Combined with failClosed:true that produced an
             // erroneous 429.  After the fix the offline queue is re-enabled, the
             // command is buffered during the TCP handshake and resolves normally.
-            vi.stubEnv("REDIS_URL", "redis://localhost:6379/0");
-
-            const { _resetRedisClient, getRedis } = await import("@/lib/redis");
-            _resetRedisClient();
-
-            const redis = getRedis();
-            expect(redis).not.toBeNull();
+            const redis = await openStubbedRedis();
 
             // Simulate offline-queue path: command was buffered while connecting,
             // then resolved successfully once the socket was ready.
-            redis!.incr = vi.fn().mockResolvedValue(1);
-            redis!.expire = vi.fn().mockResolvedValue(1);
+            redis.incr = vi.fn().mockResolvedValue(1);
+            redis.expire = vi.fn().mockResolvedValue(1);
 
             const { checkRateLimit } = await import("@/lib/rate-limit");
             const result = await checkRateLimit("coldstart-key", {
@@ -271,21 +310,14 @@ describe("rate-limit", () => {
             // First request in window — must NOT be rate-limited.
             expect(result.limited).toBe(false);
             expect(result.retryAfter).toBe(0);
-
-            _resetRedisClient();
         });
 
         it("falls back to in-memory (not 429) when Redis throws connection-not-ready error and failClosed is false (CHAOS-1768)", async () => {
             // Non-auth routes (failClosed:false) must always fall back to the
             // in-memory store on any Redis error, including the 'Stream isn't
             // writeable' error that the old enableOfflineQueue:false config produced.
-            vi.stubEnv("REDIS_URL", "redis://localhost:6379/0");
-
-            const { _resetRedisClient, getRedis } = await import("@/lib/redis");
-            _resetRedisClient();
-
-            const redis = getRedis();
-            redis!.incr = vi
+            const redis = await openStubbedRedis();
+            redis.incr = vi
                 .fn()
                 .mockRejectedValue(
                     new Error("Stream isn't writeable and enableOfflineQueue options is false"),
@@ -302,8 +334,6 @@ describe("rate-limit", () => {
 
             // First request in in-memory window is always allowed.
             expect(result.limited).toBe(false);
-
-            _resetRedisClient();
         });
     });
 });

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,27 +1,30 @@
 /**
- * Rate limiter with Redis backend and in-memory fallback.
+ * Rate limiter backed by Redis. No fallback: Redis or nothing.
  *
- * Redis strategy: fixed-window counter, incremented and expired atomically in
- * one Lua call (see `INCR_AND_EXPIRE_LUA`).
- * In-memory strategy: sliding-window timestamp array (matches the original
- * feedback route implementation), bounded by `MEMORY_STORE_MAX_KEYS`.
+ * Fixed-window counter, incremented and expired atomically in one Lua call
+ * (see `INCR_AND_EXPIRE_LUA`).
  *
- * ## This is NOT the ops fallback pattern
+ * ## Why there is no in-memory fallback (CHAOS-3589)
  *
- * This module used to claim it mirrored "the graceful-fallback pattern from
- * dev-health-ops (`api/middleware/rate_limit.py` — Redis when available, memory
- * when not)". That was wrong in the direction that matters: ops selects its
- * backend once at import, and `verify_rate_limit_config()` REFUSES TO BOOT in
+ * There used to be one, and this module claimed it mirrored "the graceful
+ * fallback pattern from dev-health-ops". It did not. Ops selects its backend
+ * once at import and `verify_rate_limit_config()` refuses to boot in
  * non-development environments without `REDIS_URL`, because "in-memory
  * rate-limit storage (memory://) is per-process and ineffective across multiple
  * replicas". slowapi's own `in_memory_fallback` is left switched off there.
  *
- * The silent degrade to a per-process store is therefore this module's own
- * design choice, not an inherited one, and it carries that known weakness: with
- * N replicas the effective limit is N x maxRequests, and it resets on deploy.
- * Callers that must not degrade pass `failClosed: true` — every auth route in
- * `src/proxy.ts` does. Whether the remaining callers should keep the fallback at
- * all is an open question (CHAOS-3589 follow-up).
+ * The per-process store was worse than ineffective. Under N replicas it enforced
+ * N x maxRequests while reporting success, it reset on every deploy, and it was
+ * the sole home of two real defects: it keyed without the namespace, so routes
+ * sharing a client IP shared a counter AND a short-window caller could truncate
+ * and persist a long-window caller's history — clearing a limit that had already
+ * been reached. Both vanish with the store.
+ *
+ * `verifyRateLimitConfig()` now enforces the ops rule at startup, from
+ * `instrumentation.ts`. At runtime an unreachable Redis follows the caller's
+ * `failClosed` flag: auth routes (every limited route in `src/proxy.ts`) return
+ * 429; the rest are allowed through, and every such decision is logged and sent
+ * to Sentry rather than hidden behind a store that looked like it was working.
  *
  * ## Client IP trust model
  *
@@ -29,10 +32,10 @@
  * `getClientIp()` from `@/lib/client-ip`, NOT by reading `x-forwarded-for`
  * directly. The helper enforces the following policy:
  *
- *   - `TRUST_PROXY=true`  → reads the leftmost `X-Forwarded-For` hop, then
+ *   - `TRUST_PROXY=true`  -> reads the leftmost `X-Forwarded-For` hop, then
  *     falls back to `X-Real-IP`. Use only when the app is deployed behind a
  *     known, trusted reverse proxy that strips/rewrites these headers.
- *   - `TRUST_PROXY=false` (default) → ignores `X-Forwarded-For` entirely to
+ *   - `TRUST_PROXY=false` (default) -> ignores `X-Forwarded-For` entirely to
  *     prevent IP spoofing. Falls back to platform-injected headers
  *     (`x-vercel-forwarded-for`, `cf-connecting-ip`) and then to an
  *     anonymous SHA-256 fingerprint of stable request headers.
@@ -43,7 +46,6 @@
  *   import { isRateLimited, RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_WINDOW_MS } from "@/lib/rate-limit";
  *   if (await isRateLimited(key)) { return 429; }
  */
-
 import { createHash } from "node:crypto";
 
 import * as Sentry from "@sentry/nextjs";
@@ -58,10 +60,6 @@ export const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 /** Maximum requests allowed per window. */
 export const RATE_LIMIT_MAX_REQUESTS = 5;
 
-// ---------------------------------------------------------------------------
-// In-memory fallback (per-process, resets on restart)
-// ---------------------------------------------------------------------------
-
 export type RateLimitOptions = {
     failClosed?: boolean;
     windowMs?: number;
@@ -73,35 +71,6 @@ export type RateLimitResult = {
     limited: boolean;
     retryAfter: number;
 };
-
-/**
- * Requests still inside this key's window, plus the point after which the whole
- * entry is garbage.
- *
- * `expiresAt` is what lets the store be swept without knowing which caller's
- * window applies — it plays the role Redis's TTL plays on the other backend.
- */
-type MemoryEntry = { hits: number[]; expiresAt: number };
-
-const memoryStore = new Map<string, MemoryEntry>();
-
-/**
- * Hard ceiling on tracked keys. The store is keyed by client IP or anonymous
- * fingerprint, so without a bound a long-lived server retains one entry per
- * unique caller for the life of the process (CHAOS-3589).
- */
-const MEMORY_STORE_MAX_KEYS = 10_000;
-
-/**
- * How far a cap-triggered sweep evicts past the ceiling. Without this headroom
- * every single request past the cap would re-trigger a full sweep.
- */
-const MEMORY_STORE_LOW_WATER_KEYS = 9_000;
-
-/** Sweeping is amortised — walking the map on every request would be O(n) per call. */
-const MEMORY_SWEEP_INTERVAL_MS = 60_000;
-
-let nextMemorySweepAt = 0;
 
 function windowMs(options: RateLimitOptions): number {
     return options.windowMs ?? RATE_LIMIT_WINDOW_MS;
@@ -133,30 +102,6 @@ function scopedKey(key: string, options: RateLimitOptions): string {
     return options.namespace ? `rate_limit:${options.namespace}:${key}` : `rate_limit:${key}`;
 }
 
-/**
- * Drop entries whose window has elapsed, then enforce the size ceiling by
- * evicting the entries closest to expiry.
- *
- * Eviction can only forget requests, never invent them, so a store under
- * pressure degrades toward "more permissive". That is bounded by
- * `MEMORY_STORE_MAX_KEYS` and only reachable while Redis is already down.
- */
-function sweepMemoryStore(now: number): void {
-    for (const [key, entry] of memoryStore) {
-        if (entry.expiresAt <= now) memoryStore.delete(key);
-    }
-
-    if (memoryStore.size > MEMORY_STORE_MAX_KEYS) {
-        const byExpiry = [...memoryStore.entries()].sort(
-            ([, a], [, b]) => a.expiresAt - b.expiresAt,
-        );
-        const excess = memoryStore.size - MEMORY_STORE_LOW_WATER_KEYS;
-        for (const [key] of byExpiry.slice(0, excess)) memoryStore.delete(key);
-    }
-
-    nextMemorySweepAt = now + MEMORY_SWEEP_INTERVAL_MS;
-}
-
 function safeKeyHash(key: string): string {
     return createHash("sha256").update(key).digest("hex");
 }
@@ -164,12 +109,13 @@ function safeKeyHash(key: string): string {
 const failClosedLogKeys = new Map<string, number>();
 const FAIL_CLOSED_LOG_INTERVAL_MS = 60_000;
 
-function reportRequiredRedisUnavailable(
+function reportRedisUnavailable(
     key: string,
     options: RateLimitOptions,
     reason: "missing_redis_url" | "client_unavailable" | "redis_command_failed",
     err?: unknown,
 ): void {
+    const failClosed = options.failClosed === true;
     const namespace = options.namespace ?? "default";
     const dedupeKey = `${namespace}:${reason}`;
     const now = Date.now();
@@ -178,8 +124,10 @@ function reportRequiredRedisUnavailable(
     if (now - lastLogged >= FAIL_CLOSED_LOG_INTERVAL_MS) {
         failClosedLogKeys.set(dedupeKey, now);
         logger.error(
-            { err, key_hash: safeKeyHash(key), namespace, failClosed: true, reason },
-            "Redis rate-limit backend required but unavailable — failing closed",
+            { err, key_hash: safeKeyHash(key), namespace, failClosed, reason },
+            failClosed
+                ? "Redis rate-limit backend unavailable — failing closed"
+                : "Redis rate-limit backend unavailable — request NOT rate limited",
         );
     }
 
@@ -188,7 +136,7 @@ function reportRequiredRedisUnavailable(
         scope.setTag("rate_limit.namespace", namespace);
         scope.setTag("rate_limit.reason", reason);
         scope.setContext("rate_limit", {
-            failClosed: true,
+            failClosed,
             key_hash: safeKeyHash(key),
             namespace,
             reason,
@@ -196,34 +144,9 @@ function reportRequiredRedisUnavailable(
         if (err instanceof Error) {
             Sentry.captureException(err);
         } else {
-            Sentry.captureMessage("Redis rate-limit backend required but unavailable");
+            Sentry.captureMessage("Redis rate-limit backend unavailable");
         }
     });
-}
-
-function checkRateLimitedInMemory(key: string, options: RateLimitOptions): RateLimitResult {
-    const now = Date.now();
-    const limitWindowMs = windowMs(options);
-    const limitMaxRequests = maxRequests(options);
-
-    if (now >= nextMemorySweepAt || memoryStore.size > MEMORY_STORE_MAX_KEYS) {
-        sweepMemoryStore(now);
-    }
-
-    const storeKey = scopedKey(key, options);
-    const hits = (memoryStore.get(storeKey)?.hits ?? []).filter((ts) => now - ts < limitWindowMs);
-    // The entry is garbage once its newest hit has fallen out of the window.
-    const expiresAt = now + limitWindowMs;
-
-    if (hits.length >= limitMaxRequests) {
-        memoryStore.set(storeKey, { hits, expiresAt });
-        const oldest = hits[0] ?? now;
-        return { limited: true, retryAfter: retryAfterSeconds(limitWindowMs - (now - oldest)) };
-    }
-
-    hits.push(now);
-    memoryStore.set(storeKey, { hits, expiresAt });
-    return { limited: false, retryAfter: 0 };
 }
 
 // ---------------------------------------------------------------------------
@@ -254,19 +177,34 @@ end
 return current
 `;
 
+/**
+ * The one place that decides what an unreachable Redis means.
+ *
+ * There is no second backend to consult, so the caller's `failClosed` flag is
+ * the whole policy: set, the request is refused; unset, it is allowed. Either
+ * way it is reported — an unenforced limit must never be silent.
+ */
+function onRedisUnavailable(
+    key: string,
+    options: RateLimitOptions,
+    reason: "missing_redis_url" | "client_unavailable" | "redis_command_failed",
+    err?: unknown,
+): RateLimitResult {
+    reportRedisUnavailable(key, options, reason, err);
+
+    return options.failClosed
+        ? { limited: true, retryAfter: retryAfterSeconds(windowMs(options)) }
+        : { limited: false, retryAfter: 0 };
+}
+
 async function checkRateLimitedRedis(
     key: string,
     options: RateLimitOptions,
 ): Promise<RateLimitResult> {
     const redis = getRedis();
     if (!redis) {
-        if (options.failClosed) {
-            const reason = getServerEnv().REDIS_URL ? "client_unavailable" : "missing_redis_url";
-            reportRequiredRedisUnavailable(key, options, reason);
-            return { limited: true, retryAfter: retryAfterSeconds(windowMs(options)) };
-        }
-
-        return checkRateLimitedInMemory(key, options);
+        const reason = getServerEnv().REDIS_URL ? "client_unavailable" : "missing_redis_url";
+        return onRedisUnavailable(key, options, reason);
     }
 
     const redisKey = scopedKey(key, options);
@@ -282,13 +220,7 @@ async function checkRateLimitedRedis(
 
         return { limited: false, retryAfter: 0 };
     } catch (err) {
-        if (options.failClosed) {
-            reportRequiredRedisUnavailable(key, options, "redis_command_failed", err);
-            return { limited: true, retryAfter: retryAfterSeconds(windowMs(options)) };
-        }
-
-        logger.warn({ err, key }, "Redis rate-limit check failed — falling back to in-memory");
-        return checkRateLimitedInMemory(key, options);
+        return onRedisUnavailable(key, options, "redis_command_failed", err);
     }
 }
 
@@ -315,19 +247,24 @@ export async function isRateLimited(key: string, options: RateLimitOptions = {})
 }
 
 /**
- * Reset the in-memory store (for testing only).
- * @internal
+ * Fail the boot when the only supported backend is not configured.
+ *
+ * Mirrors `verify_rate_limit_config()` in dev-health-ops. A limiter with no
+ * shared store does not under-enforce loudly, it under-enforces silently, so
+ * this must stop the deploy rather than surface per-request. Called from
+ * `instrumentation.ts`, Next.js's once-per-boot server hook.
+ *
+ * Development and test are exempt, matching ops's `_is_dev_or_test()`.
  */
-export function _resetMemoryStore(): void {
-    memoryStore.clear();
-    nextMemorySweepAt = 0;
-}
+export function verifyRateLimitConfig(): void {
+    const env = getServerEnv();
+    if (env.NODE_ENV !== "production") return;
 
-/**
- * Number of keys currently tracked by the in-memory fallback (for testing only).
- * Exposed so the size bound is assertable rather than assumed.
- * @internal
- */
-export function _memoryStoreSize(): number {
-    return memoryStore.size;
+    if (!env.REDIS_URL) {
+        throw new Error(
+            "REDIS_URL must be set in production. Rate limiting has no in-memory " +
+                "fallback: a per-process store is ineffective across replicas and " +
+                "would under-enforce every limit silently (CHAOS-3589).",
+        );
+    }
 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,12 +1,27 @@
 /**
  * Rate limiter with Redis backend and in-memory fallback.
  *
- * Mirrors the graceful-fallback pattern from dev-health-ops
- * (`api/middleware/rate_limit.py` — Redis when available, memory when not).
- *
- * Redis strategy: fixed-window counter via INCR + EXPIRE.
+ * Redis strategy: fixed-window counter, incremented and expired atomically in
+ * one Lua call (see `INCR_AND_EXPIRE_LUA`).
  * In-memory strategy: sliding-window timestamp array (matches the original
- * feedback route implementation).
+ * feedback route implementation), bounded by `MEMORY_STORE_MAX_KEYS`.
+ *
+ * ## This is NOT the ops fallback pattern
+ *
+ * This module used to claim it mirrored "the graceful-fallback pattern from
+ * dev-health-ops (`api/middleware/rate_limit.py` — Redis when available, memory
+ * when not)". That was wrong in the direction that matters: ops selects its
+ * backend once at import, and `verify_rate_limit_config()` REFUSES TO BOOT in
+ * non-development environments without `REDIS_URL`, because "in-memory
+ * rate-limit storage (memory://) is per-process and ineffective across multiple
+ * replicas". slowapi's own `in_memory_fallback` is left switched off there.
+ *
+ * The silent degrade to a per-process store is therefore this module's own
+ * design choice, not an inherited one, and it carries that known weakness: with
+ * N replicas the effective limit is N x maxRequests, and it resets on deploy.
+ * Callers that must not degrade pass `failClosed: true` — every auth route in
+ * `src/proxy.ts` does. Whether the remaining callers should keep the fallback at
+ * all is an open question (CHAOS-3589 follow-up).
  *
  * ## Client IP trust model
  *
@@ -59,7 +74,34 @@ export type RateLimitResult = {
     retryAfter: number;
 };
 
-const memoryStore = new Map<string, number[]>();
+/**
+ * Requests still inside this key's window, plus the point after which the whole
+ * entry is garbage.
+ *
+ * `expiresAt` is what lets the store be swept without knowing which caller's
+ * window applies — it plays the role Redis's TTL plays on the other backend.
+ */
+type MemoryEntry = { hits: number[]; expiresAt: number };
+
+const memoryStore = new Map<string, MemoryEntry>();
+
+/**
+ * Hard ceiling on tracked keys. The store is keyed by client IP or anonymous
+ * fingerprint, so without a bound a long-lived server retains one entry per
+ * unique caller for the life of the process (CHAOS-3589).
+ */
+const MEMORY_STORE_MAX_KEYS = 10_000;
+
+/**
+ * How far a cap-triggered sweep evicts past the ceiling. Without this headroom
+ * every single request past the cap would re-trigger a full sweep.
+ */
+const MEMORY_STORE_LOW_WATER_KEYS = 9_000;
+
+/** Sweeping is amortised — walking the map on every request would be O(n) per call. */
+const MEMORY_SWEEP_INTERVAL_MS = 60_000;
+
+let nextMemorySweepAt = 0;
 
 function windowMs(options: RateLimitOptions): number {
     return options.windowMs ?? RATE_LIMIT_WINDOW_MS;
@@ -73,8 +115,46 @@ function retryAfterSeconds(ms: number): number {
     return Math.max(1, Math.ceil(ms / 1000));
 }
 
-function redisKeyFor(key: string, options: RateLimitOptions): string {
+/**
+ * The identity a limit is counted against. BOTH backends must use this.
+ *
+ * Namespacing only the Redis key — as this module did until CHAOS-3589 — makes
+ * the in-memory fallback merge every namespace that shares a raw key, and
+ * `/api/acr/device` and `/api/feedback` both pass a bare client IP. The merge is
+ * not merely stricter: the memory path rewrites the bucket using the *calling*
+ * namespace's window, so a short-window caller truncates and persists a
+ * long-window caller's history, clearing a limit that had already been reached.
+ *
+ * The upstream reference (`limits`, via slowapi) composes one key above the
+ * storage layer and hands the identical string to both backends; a per-backend
+ * divergence is structurally impossible there.
+ */
+function scopedKey(key: string, options: RateLimitOptions): string {
     return options.namespace ? `rate_limit:${options.namespace}:${key}` : `rate_limit:${key}`;
+}
+
+/**
+ * Drop entries whose window has elapsed, then enforce the size ceiling by
+ * evicting the entries closest to expiry.
+ *
+ * Eviction can only forget requests, never invent them, so a store under
+ * pressure degrades toward "more permissive". That is bounded by
+ * `MEMORY_STORE_MAX_KEYS` and only reachable while Redis is already down.
+ */
+function sweepMemoryStore(now: number): void {
+    for (const [key, entry] of memoryStore) {
+        if (entry.expiresAt <= now) memoryStore.delete(key);
+    }
+
+    if (memoryStore.size > MEMORY_STORE_MAX_KEYS) {
+        const byExpiry = [...memoryStore.entries()].sort(
+            ([, a], [, b]) => a.expiresAt - b.expiresAt,
+        );
+        const excess = memoryStore.size - MEMORY_STORE_LOW_WATER_KEYS;
+        for (const [key] of byExpiry.slice(0, excess)) memoryStore.delete(key);
+    }
+
+    nextMemorySweepAt = now + MEMORY_SWEEP_INTERVAL_MS;
 }
 
 function safeKeyHash(key: string): string {
@@ -125,23 +205,54 @@ function checkRateLimitedInMemory(key: string, options: RateLimitOptions): RateL
     const now = Date.now();
     const limitWindowMs = windowMs(options);
     const limitMaxRequests = maxRequests(options);
-    const requests = memoryStore.get(key) ?? [];
-    const recent = requests.filter((ts) => now - ts < limitWindowMs);
 
-    if (recent.length >= limitMaxRequests) {
-        memoryStore.set(key, recent);
-        const oldest = recent[0] ?? now;
+    if (now >= nextMemorySweepAt || memoryStore.size > MEMORY_STORE_MAX_KEYS) {
+        sweepMemoryStore(now);
+    }
+
+    const storeKey = scopedKey(key, options);
+    const hits = (memoryStore.get(storeKey)?.hits ?? []).filter((ts) => now - ts < limitWindowMs);
+    // The entry is garbage once its newest hit has fallen out of the window.
+    const expiresAt = now + limitWindowMs;
+
+    if (hits.length >= limitMaxRequests) {
+        memoryStore.set(storeKey, { hits, expiresAt });
+        const oldest = hits[0] ?? now;
         return { limited: true, retryAfter: retryAfterSeconds(limitWindowMs - (now - oldest)) };
     }
 
-    recent.push(now);
-    memoryStore.set(key, recent);
+    hits.push(now);
+    memoryStore.set(storeKey, { hits, expiresAt });
     return { limited: false, retryAfter: 0 };
 }
 
 // ---------------------------------------------------------------------------
 // Redis backend (shared across instances)
 // ---------------------------------------------------------------------------
+
+/**
+ * Increment the window counter and make sure it carries a TTL, atomically.
+ *
+ * INCR followed by a separate EXPIRE is two round trips, and anything that stops
+ * the second from landing — a connection blip, a failover, the process dying
+ * mid-request — leaves a counter with no expiry. Nothing then clears it: the key
+ * climbs past the limit and that caller is 429'd forever, reporting a plausible
+ * `Retry-After` the whole time, until somebody deletes the key by hand
+ * (CHAOS-3589). Redis runs a script to completion, so no such window exists
+ * here. This mirrors `incr_expire.lua` in the `limits` package that the ops-side
+ * limiter is built on.
+ *
+ * The `ttl < 0` arm additionally repairs keys a previous deploy already left
+ * immortal: -1 is "no expiry", -2 is "gone", and either way the next hit
+ * re-anchors the window instead of inheriting a stuck counter.
+ */
+const INCR_AND_EXPIRE_LUA = `
+local current = redis.call("incr", KEYS[1])
+if current == 1 or redis.call("ttl", KEYS[1]) < 0 then
+    redis.call("expire", KEYS[1], ARGV[1])
+end
+return current
+`;
 
 async function checkRateLimitedRedis(
     key: string,
@@ -158,16 +269,11 @@ async function checkRateLimitedRedis(
         return checkRateLimitedInMemory(key, options);
     }
 
-    const redisKey = redisKeyFor(key, options);
+    const redisKey = scopedKey(key, options);
     const windowSeconds = retryAfterSeconds(windowMs(options));
 
     try {
-        const count = await redis.incr(redisKey);
-
-        // Set TTL on first request in the window
-        if (count === 1) {
-            await redis.expire(redisKey, windowSeconds);
-        }
+        const count = Number(await redis.eval(INCR_AND_EXPIRE_LUA, 1, redisKey, windowSeconds));
 
         if (count > maxRequests(options)) {
             const ttl = await redis.ttl(redisKey);
@@ -214,4 +320,14 @@ export async function isRateLimited(key: string, options: RateLimitOptions = {})
  */
 export function _resetMemoryStore(): void {
     memoryStore.clear();
+    nextMemorySweepAt = 0;
+}
+
+/**
+ * Number of keys currently tracked by the in-memory fallback (for testing only).
+ * Exposed so the size bound is assertable rather than assumed.
+ * @internal
+ */
+export function _memoryStoreSize(): number {
+    return memoryStore.size;
 }


### PR DESCRIPTION
Closes CHAOS-3589. Scope grew twice: "make the red check green" → "fix the custom limiter" (chris) → **option (a): delete the in-memory fallback and adopt the ops stance** (chris, ruled after the audit below).

Related: CHAOS-3591 (`require()` root-enabler), CHAOS-3592 (execute the Lua in an integration test), CHAOS-3593 (rate-limiter-flexible / LB-level limiting), CHAOS-3594 (nanoid audit), CHAOS-3595 (Quality fail-fast masking).

---

# 1. Why the check was red

Reproduced at `53d80bb1`: 2 failures on the first run, 3 on the next, **5 by the fifth**.

Not a flake, not a regression. Two defects, both in the test:

1. **The ioredis mock was dead code.** `redis.ts` loads the driver via a runtime `` require("ioredis") ``, which bypasses Vitest's module mocker. `getRedis()` returned a real ioredis client.
2. **The in-memory `describe` never pinned `REDIS_URL`.** Dev machines running the compose stack export it, so those tests silently ran the **Redis** path against a live server, accumulating counter state across runs behind a 1-hour TTL. CI is green because it never sets `REDIS_URL` — which is exactly why a check red only on dev machines guards nothing.

**Fixed** by pinning `REDIS_URL` per `describe`, asserting the branch under test, and replacing the dead mock with recording stubs plus an `afterEach` guard.

# 2. The audit: four defects in the limiter

Checked against the reference it claimed to mirror (`limits`/slowapi, via ops).

**D1 — a lost `EXPIRE` locked a caller out permanently.** `INCR` then a separate `EXPIRE` is two round trips; anything stopping the second leaves a counter with no TTL. Nothing clears it — that key is 429'd forever, reporting a plausible `Retry-After`, until deleted by hand. For `auth-login` (IP-keyed) that is a permanent lockout of a real user, and the best explanation for months of sticky-429 reports. Fixed with `INCR_AND_EXPIRE_LUA`, one atomic call, mirroring `incr_expire.lua`. Its `ttl < 0` arm also **repairs keys the deployed version already left immortal**.

**D2 — namespace collision, and one namespace could erase another's counter.** The Redis key was namespaced; the memory key was not. `acr/device` and `feedback` both pass a bare client IP. Worse, the memory path persisted the array filtered with the *calling* namespace's window, so a short-window caller deleted a long-window caller's history: exhaust `auth-pwreset` (3/hour), then one `acr-device` call clears it. A bypass.

**D3 — the memory store grew without bound**, keyed by IP/anon fingerprint with nothing ever removing an entry.

**D4 — the docstring was false.** It claimed to mirror ops's "graceful fallback"; ops does the opposite and refuses to boot without `REDIS_URL`.

# 3. Option (a): the fallback is gone

D2 and D3 lived *only* in the fallback. Rather than patch a store that ops had already concluded was ineffective, it is deleted.

- **`verifyRateLimitConfig()`** mirrors ops's `verify_rate_limit_config()` and throws in production without `REDIS_URL`, wired into **`instrumentation.register()`** — Next.js's once-per-boot server hook. Dev and test exempt, matching `_is_dev_or_test()`.
- **Runtime** has one policy, `onRedisUnavailable`, driven by the caller's `failClosed` flag: set (every limited route in `proxy.ts`) → 429; unset → not limited. **Both branches log and report to Sentry** — an unenforced limit must never be silent, which is precisely what the old store got wrong by looking like it was working.
- `scopedKey` stays; it is correct for Redis too.

Net: **−353 / +181** across the limiter and its tests.

## ⚠️ Behaviour change that needs a call

`/api/feedback` passes no `failClosed`, so during a Redis outage it is **no longer rate limited at all** (previously: limited per-process). This is asserted explicitly in `feedback-route.test.ts` rather than left implied. Flipping that route to `failClosed: true` is a one-line change — **pending a ruling**, not decided here.

# 4. Verification

Every guard observed failing against the defect it exists to catch, each death attributed. The 9 tests from stage 2 were run against the original pre-fix source: **all 9 fail**. Stage-3 mutations:

| planted defect | typechecks | killed by |
|---|---|---|
| prod boots without `REDIS_URL` | **valid** | both startup tests |
| verification exists but nothing calls it | — | the executing startup test |
| guard fires in development too | — | the dev-exemption test |
| `failClosed` ignored when Redis is unavailable | **valid** | both fail-closed tests |
| unavailability stops being reported | **valid** | the reporting test |
| namespace dropped from the Redis key | **valid** | the EVAL/scopedKey pin |
| fake Redis stops counting (feedback route) | — | the restored 429 test |

**A guard that survived, and what it cost:** the first version of "is wired into the startup hook" asserted the *source* merely `toContain("verifyRateLimitConfig")`. Deleting the call left the import line, so the string was still there and the test passed — a dead guard of exactly the kind this ticket is about, in my own test. Replaced with one that imports and executes `register()` and observes the throw. It now kills that mutation. Executing beats digesting source.

- `rate-limit.test.ts` **17/17**; `feedback-route.test.ts` **20/20**.
- Full suite **413 files, 3736 passed, 8 skipped, 0 failed**.
- `tsc`, `eslint`, `prettier`: exit 0.

**Not covered, stated plainly:** the fake Redis models the Lua script's contract; it does not execute the Lua. The script text is pinned by assertion, and the "refresh TTL every hit" mutation was caught by that pin *only*, not behaviourally. Integration coverage is CHAOS-3592.