### PR TITLE
refactor(ask-dev): extract answer sections into presentational components

### DIFF
--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -1,15 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo, useState } from "react";
 
-import { CTA_LABELS, toggleEvidenceItem } from "@/lib/design/cta";
-import type {
-    DevAnswer,
-    DevEvidenceExpansion,
-    DevEvidenceRef,
-    DevScope,
-} from "@/lib/dev/generated";
+import type { DevAnswer, DevEvidenceExpansion } from "@/lib/dev/generated";
 import {
     buildInternalTokenDenylist,
     findInternalToken,
@@ -17,14 +10,20 @@ import {
     safeCopy,
     WITHHELD_COPY,
 } from "@/lib/dev/internalTokens";
-import { formatMetricValue, formatNumber, formatPercent, formatTimestamp } from "@/lib/formatters";
 
+import { AnswerHeaderSection } from "./answer/AnswerHeaderSection";
+import { ClaimsSection } from "./answer/ClaimsSection";
+import { ConflictsSection } from "./answer/ConflictsSection";
+import { CoverageSection } from "./answer/CoverageSection";
+import { EvidenceSection } from "./answer/EvidenceSection";
+import { FeedbackFooter, type FeedbackState } from "./answer/FeedbackFooter";
+import { FollowUpSection } from "./answer/FollowUpSection";
+import type { CitationTargets } from "./answer/InlineCitations";
+import type { SafeProse } from "./answer/labels";
+import { LimitationsSection } from "./answer/LimitationsSection";
+import { MetricsSection } from "./answer/MetricsSection";
+import { ScopeSection } from "./answer/ScopeSection";
 import { useAskDev } from "./AskDevProvider";
-
-function safeExcerpt(value: string | null | undefined): string | null {
-    if (!value) return null;
-    return value.replace(/^UNTRUSTED_DATA\r?\n/u, "").replace(/\r?\nEND_UNTRUSTED_DATA$/u, "");
-}
 
 // Grounded in the sanctioned framing from ops/docs/use/ai-workflows/index.md
 // ("Ask Dev: window and full-page workspace"): "A partial, degraded,
@@ -50,6 +49,15 @@ function safeExcerpt(value: string | null | undefined): string | null {
 // AskDevAnswer.test.tsx can assert Object.keys(...) coverage against the
 // real generated union directly, instead of duplicating a second copy of
 // the member list in the test file that could itself drift.
+//
+// This file is also read as TEXT by tests/ask-dev-vocabulary.spec.ts, which
+// locates `export const <NAME> = {` by name to cross-check the keys against
+// the pinned JSON Schema enums (it cannot import this module: the "use
+// client" graph reaches a PNG asset that Playwright's standalone esbuild
+// transform has no loader for). Both label maps below must therefore stay in
+// THIS file, in that literal shape — moving them to a sibling module is a
+// loud test failure, not a silent one, but a failure with a cause that is
+// invisible from the constant's new home.
 export const ANSWER_STATUS_LABELS: Record<DevAnswer["status"], string> = {
     complete: "Complete",
     degraded: "Degraded",
@@ -228,170 +236,21 @@ const STATUS_EXPLANATIONS: Partial<Record<DevAnswer["status"], string>> = {
         "Refused: Ask Dev did not answer this question. A result with limitations, not a silent success.",
 };
 
-function validityScopeLabel(scope: DevScope | null | undefined): string | null {
-    if (!scope) return null;
-    const namedEntity = scope.entity_refs?.find(
-        (entity) => entity.entity_type === scope.direct_scope,
-    );
-    if (namedEntity) return namedEntity.display_label;
-    if (scope.direct_scope === "organization") return "Organization";
-    const count =
-        scope.direct_scope === "repository"
-            ? (scope.repositories?.length ?? 0)
-            : (scope.entity_refs?.filter((entity) => entity.entity_type === scope.direct_scope)
-                  .length ?? 0);
-    const label = scope.direct_scope.replaceAll("_", " ");
-    return count > 0 ? `${count} ${label}${count === 1 ? "" : "s"}` : label;
-}
-
 /**
- * The scope-outcome row's secondary line (CHAOS-3377 defect 4).
+ * The answer container.
  *
- * Previously always rendered "{authorized_repository_ids.length} authorized
- * repositories", regardless of the resolved scope's own kind -- correct for
- * a REPOSITORY-scoped answer, but for a PROJECT (or any other non-repository)
- * scope the repository count is at best incidental and at worst reads as
- * "0 authorized repositories" for a subject that has real, substantive
- * content and simply carries no repository dimension on the wire (see
- * ops's `ScopeResolutionService`/`DevScope.repositories`, which is only
- * ever populated for a REPOSITORY commit). Reuses `validityScopeLabel` --
- * the same "name the subject, not a count" logic `claim.validity_scope`
- * already renders -- so a project scope shows its subject ("Falcon Nine")
- * instead. Falls back to the repository count whenever the scope itself is
- * missing or genuinely repository-scoped, which is unchanged behavior.
+ * Owns every piece of state, every handler, and every judgement about what
+ * this answer is (no-match, refused-with-grounding, trustworthy scope row).
+ * The `answer/*` components it composes are presentational: they receive
+ * resolved copy, an already-bound `safeProse` sanitizer, and callbacks. That
+ * split is what keeps a new section additive — and it is why no section can
+ * render model-authored prose without a sanitizer, since it never holds the
+ * denylist to forget in the first place.
  */
-function scopeCoverageLabel(scopeResolution: NonNullable<DevAnswer["resolved_scope"]>): string {
-    const scope = scopeResolution.resolved_scope ?? scopeResolution.requested_scope;
-    if (scope && scope.direct_scope !== "repository") {
-        const subjectLabel = validityScopeLabel(scope);
-        if (subjectLabel) return subjectLabel;
-    }
-    const count = scopeResolution.authorized_repository_ids?.length ?? 0;
-    return `${count} authorized repositories`;
-}
-
-/**
- * CHAOS-3524 (chris's evidence-layout ruling): each evidence item is its own
- * accordion row, default folded. The row's header (label + provenance) stays
- * visible even folded — that's the disclosure trigger a reader sees and
- * clicks — only the detail beneath it (citation text, the "Open evidence"
- * fetch action, the fetched excerpt, errors, the artifact link) is hidden
- * until `open`. The fold toggle itself is icon-only (a chevron, aria-label
- * carries the real name) per chris's "buttons/iconography only, no text
- * labels" rule; `evidence.display_label` sitting in the same clickable
- * header is the row's identifying TITLE, not an instructional fold/unfold
- * label, so it stays as visible text.
- */
-function EvidenceRow({
-    anchorId,
-    error,
-    evidence,
-    expansion,
-    loading,
-    onToggleOpen,
-    open,
-    openExpansion,
-}: {
-    anchorId: string;
-    error: string | null;
-    evidence: DevEvidenceRef;
-    expansion: DevEvidenceExpansion | null;
-    loading: boolean;
-    onToggleOpen: () => void;
-    open: boolean;
-    openExpansion: () => Promise<void>;
-}) {
-    const internalPath = evidence.link?.internal_path;
-
-    return (
-        <div
-            id={anchorId}
-            tabIndex={-1}
-            className="scroll-mt-6 space-y-1.5 border-l-2 border-(--border) pl-3 outline-none focus-visible:border-(--accent)"
-        >
-            <button
-                type="button"
-                onClick={onToggleOpen}
-                aria-expanded={open}
-                aria-label={toggleEvidenceItem(evidence.display_label, open)}
-                className="flex w-full min-w-0 items-start gap-2 rounded-(--radius-sm) py-0.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-            >
-                <span aria-hidden="true" className="mt-0.5 shrink-0 text-(--text-muted)">
-                    {open ? "▾" : "▸"}
-                </span>
-                <span className="flex min-w-0 flex-col gap-0.5">
-                    <span className="text-sm text-(--text-secondary)">
-                        {evidence.display_label}
-                    </span>
-                    <span className="text-xs text-(--text-muted)">
-                        {evidence.provenance} · {formatTimestamp(evidence.observed_at)}
-                    </span>
-                </span>
-            </button>
-            {open ? (
-                <div className="space-y-1.5 pl-5">
-                    {evidence.citation_text ? (
-                        <p className="text-xs leading-5 text-(--text-muted)">
-                            {evidence.citation_text}
-                        </p>
-                    ) : null}
-                    {/*
-                     * Quiet by default (text-muted, no fill) — this is a
-                     * secondary, on-demand affordance, not a primary CTA; it
-                     * only picks up accent color on hover/focus (CHAOS-3291).
-                     * Unlike the fold toggle above, this triggers a real
-                     * server fetch (the deep excerpt) rather than showing
-                     * already-loaded content, so it keeps its sanctioned
-                     * text label rather than becoming icon-only.
-                     */}
-                    <button
-                        type="button"
-                        onClick={() => void openExpansion()}
-                        disabled={loading}
-                        className="rounded-(--radius-sm) px-2 py-1 text-xs font-medium text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
-                    >
-                        {loading ? "Opening…" : CTA_LABELS.openEvidence}
-                    </button>
-                    {expansion ? (
-                        <div className="rounded-(--radius-md) bg-(--background)/60 p-3 text-sm leading-6 text-(--text-secondary)">
-                            <p className="text-label-caps text-(--text-muted)">
-                                {expansion.state.replaceAll("_", " ")}
-                            </p>
-                            {safeExcerpt(expansion.safe_excerpt) ? (
-                                <p className="mt-2 whitespace-pre-wrap">
-                                    {safeExcerpt(expansion.safe_excerpt)}
-                                </p>
-                            ) : (
-                                <p className="mt-2">No additional excerpt is available.</p>
-                            )}
-                            {expansion.warning ? (
-                                <p className="mt-2 text-(--caution)">{expansion.warning}</p>
-                            ) : null}
-                        </div>
-                    ) : null}
-                    {error ? (
-                        <p role="alert" className="text-xs text-(--negative)">
-                            {error}
-                        </p>
-                    ) : null}
-                    {internalPath ? (
-                        <Link
-                            href={internalPath}
-                            className="inline-flex text-xs font-medium text-(--accent) underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                        >
-                            {CTA_LABELS.openArtifact}
-                        </Link>
-                    ) : null}
-                </div>
-            ) : null}
-        </div>
-    );
-}
-
 export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     const { expandEvidence, selectProposedEntity, submitAnswerFeedback, submitQuestion } =
         useAskDev();
-    const [feedback, setFeedback] = useState<"helpful" | "not_helpful" | "saving" | null>(null);
+    const [feedback, setFeedback] = useState<FeedbackState>(null);
     const [feedbackError, setFeedbackError] = useState<string | null>(null);
     const [evidenceExpansions, setEvidenceExpansions] = useState<
         Readonly<Record<string, DevEvidenceExpansion>>
@@ -481,6 +340,12 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         [answer.metrics],
     );
 
+    // Bound once here, handed to every section that renders model-authored
+    // prose. Not a hook: it closes over `attested` and is cheap, and keeping
+    // it a plain function means the sections re-render exactly as often as
+    // they did when this logic was inline in one component.
+    const safeProse: SafeProse = (value) => safeCopy(value, INTERNAL_TOKEN_DENYLIST, attested);
+
     // Detail-panel ids are scoped by answer.answer_id, not just position: a
     // transcript can contain many answers, and position-only ids (e.g.
     // "ask-dev-evidence-1") collide across every one of them, so
@@ -568,51 +433,12 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         setOpenEvidenceRowIds(new Set((answer.evidence ?? []).map((item) => item.evidence_ref_id)));
     };
 
-    const renderInlineCitations = (
-        evidenceRefIds: readonly string[] = [],
-        metricRefIds: readonly string[] = [],
-        ownerLabel: string,
-    ) => {
-        const knownEvidenceRefs = evidenceRefIds.filter((id) => evidencePositionById.has(id));
-        const knownMetricRefs = metricRefIds.filter((id) => metricPositionById.has(id));
-        if (!knownEvidenceRefs.length && !knownMetricRefs.length) return null;
-
-        return (
-            <span
-                className="ml-2 inline-flex flex-wrap gap-1 align-baseline"
-                aria-label="Citations"
-            >
-                {knownEvidenceRefs.map((evidenceRefId) => {
-                    const position = evidencePositionById.get(evidenceRefId)!;
-                    return (
-                        <button
-                            key={evidenceRefId}
-                            type="button"
-                            onClick={() => void openEvidenceDetail(evidenceRefId)}
-                            disabled={loadingEvidenceIds.has(evidenceRefId)}
-                            aria-label={`Open evidence citation ${position + 1} for ${ownerLabel}`}
-                            className="rounded-(--radius-sm) bg-(--accent)/10 px-1.5 py-0.5 font-mono text-[0.6875rem] font-medium leading-none text-(--accent) hover:bg-(--accent)/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
-                        >
-                            E{position + 1}
-                        </button>
-                    );
-                })}
-                {knownMetricRefs.map((metricRefId) => {
-                    const position = metricPositionById.get(metricRefId)!;
-                    return (
-                        <button
-                            key={metricRefId}
-                            type="button"
-                            onClick={() => openMetricDetail(metricRefId)}
-                            aria-label={`Open metric citation ${position + 1} for ${ownerLabel}`}
-                            className="rounded-(--radius-sm) bg-(--accent-ai)/10 px-1.5 py-0.5 font-mono text-[0.6875rem] font-medium leading-none text-(--accent-ai) hover:bg-(--accent-ai)/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45"
-                        >
-                            M{position + 1}
-                        </button>
-                    );
-                })}
-            </span>
-        );
+    const citationTargets: CitationTargets = {
+        evidencePositionById,
+        metricPositionById,
+        loadingEvidenceIds,
+        openEvidence: (evidenceRefId) => void openEvidenceDetail(evidenceRefId),
+        openMetric: openMetricDetail,
     };
 
     const sendFeedback = async (rating: "helpful" | "not_helpful") => {
@@ -636,142 +462,27 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
             className="space-y-5 outline-none"
             aria-label="Ask Dev answer"
         >
-            <div className="flex flex-wrap items-center gap-2">
-                <span className="rounded-(--radius-pill) bg-(--accent-ai)/12 px-2.5 py-1 text-label-caps text-(--accent-ai)">
-                    AI-generated
-                </span>
-                <span className="rounded-(--radius-pill) border border-(--border) px-2.5 py-1 text-label-caps text-(--text-muted)">
-                    {statusLabel}
-                </span>
-                <span className="text-xs text-(--text-muted)">
-                    As of {formatTimestamp(answer.as_of)}
-                </span>
-            </div>
-
-            {/*
-             * The direct answer is the primary content (TRD §16: scope →
-             * question → answer → evidence/metrics → follow-up; CHAOS-3291).
-             * Previously the status caption rendered as an isolated text-xs
-             * line and direct_summary as plain text-body — same visual
-             * weight as the supporting chrome below it, so a thin answer
-             * (e.g. "Status: partial.") read as smaller and less important
-             * than the Evidence block. Keeping the caption tightly coupled
-             * to the summary (one block, no separating chrome) and giving
-             * the summary the same display-font treatment used for section
-             * headings elsewhere makes it read as one coherent answer
-             * rather than badge + boilerplate + terse line.
-             */}
-            <div className="space-y-1.5">
-                {statusExplanation ? (
-                    <p className="text-sm leading-6 text-(--text-secondary)">{statusExplanation}</p>
-                ) : null}
-                <p className="font-(--font-display) text-h3 text-(--text-primary)">
-                    {refusedWithGrounding
-                        ? WITHHELD_COPY
-                        : safeCopy(answer.direct_summary, INTERNAL_TOKEN_DENYLIST, attested)}
-                </p>
-            </div>
+            <AnswerHeaderSection
+                asOf={answer.as_of}
+                statusExplanation={statusExplanation}
+                statusLabel={statusLabel}
+                summary={refusedWithGrounding ? WITHHELD_COPY : safeProse(answer.direct_summary)}
+            />
 
             {scopeResolution ? (
-                <section
-                    className="border-y border-(--border) py-3"
-                    aria-label="Resolved answer scope"
-                >
-                    <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
-                        <span className="text-(--text-muted)">
-                            Scope outcome:{" "}
-                            <strong className="font-medium text-(--text-secondary)">
-                                {scopeOutcomeTrusted
-                                    ? SCOPE_OUTCOME_LABELS[scopeResolution.outcome]
-                                    : SCOPE_OUTCOME_LABELS.forbidden_or_not_found}
-                            </strong>
-                        </span>
-                        <span className="text-(--text-muted)">
-                            {scopeCoverageLabel(scopeResolution)}
-                        </span>
-                    </div>
-                    {scopeResolution.candidates?.length ? (
-                        <div className="mt-3">
-                            {/*
-                             * Two different situations share this list.
-                             * Ambiguity means several authorized entities DID
-                             * match and one must be picked; a no-match means
-                             * none did and these are only the nearest names
-                             * (CHAOS-3366 fills them; empty today). Calling
-                             * the second "possible scope matches" would assert
-                             * the subject exists, which is the substitution
-                             * §12 prohibits.
-                             */}
-                            <p className="text-label-caps text-(--caution)">
-                                {noMatch ? "Closest matches" : "Possible scope matches"}
-                            </p>
-                            <ul className="mt-2 space-y-1 text-sm text-(--text-secondary)">
-                                {scopeResolution.candidates.map((candidate) => (
-                                    <li
-                                        key={`${candidate.entity_ref.entity_type}:${candidate.entity_ref.entity_id}`}
-                                        className="flex flex-wrap items-center justify-between gap-2"
-                                    >
-                                        <span>
-                                            {candidate.entity_ref.display_label} —{" "}
-                                            {candidate.reason}
-                                        </span>
-                                        <button
-                                            type="button"
-                                            onClick={() =>
-                                                selectProposedEntity(candidate.entity_ref)
-                                            }
-                                            className="rounded-(--radius-sm) border border-(--border) px-2 py-1 text-xs font-medium hover:border-(--accent)/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                                        >
-                                            {CTA_LABELS.useAskDevScope}
-                                        </button>
-                                    </li>
-                                ))}
-                            </ul>
-                            <p className="mt-2 text-xs text-(--text-muted)">
-                                {noMatch
-                                    ? "None of these is the subject you named. Pick one to ask about it instead."
-                                    : "Choose or remove the proposed context before asking the next question."}
-                            </p>
-                        </div>
-                    ) : null}
-                </section>
+                <ScopeSection
+                    noMatch={noMatch}
+                    onSelectCandidate={selectProposedEntity}
+                    outcomeLabel={
+                        scopeOutcomeTrusted
+                            ? SCOPE_OUTCOME_LABELS[scopeResolution.outcome]
+                            : SCOPE_OUTCOME_LABELS.forbidden_or_not_found
+                    }
+                    scopeResolution={scopeResolution}
+                />
             ) : null}
 
-            {showCoverage ? (
-                <section
-                    aria-label="Evidence coverage"
-                    className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-(--text-muted)"
-                >
-                    <span>
-                        Coverage:{" "}
-                        {formatNumber(answer.coverage?.available_source_count ?? 0, {
-                            maximumFractionDigits: 0,
-                        })}{" "}
-                        of{" "}
-                        {formatNumber(answer.coverage?.required_source_count ?? 0, {
-                            maximumFractionDigits: 0,
-                        })}{" "}
-                        sources
-                    </span>
-                    {answer.coverage?.unavailable_required_sources?.length ? (
-                        <span className="text-(--caution)">
-                            {answer.coverage.unavailable_required_sources.length} required sources
-                            unavailable
-                        </span>
-                    ) : null}
-                    {answer.coverage?.degraded_required_sources?.length ? (
-                        <span className="text-(--caution)">
-                            {answer.coverage.degraded_required_sources.length} required sources
-                            degraded
-                        </span>
-                    ) : null}
-                    {answer.coverage?.stale_required_sources?.length ? (
-                        <span className="text-(--caution)">
-                            {answer.coverage.stale_required_sources.length} required sources stale
-                        </span>
-                    ) : null}
-                </section>
-            ) : null}
+            {showCoverage ? <CoverageSection coverage={answer.coverage} /> : null}
 
             {/*
              * CHAOS-3377 HIGH: claims are model-authored prose, exactly
@@ -780,311 +491,65 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
              * relabeled-but-invented status.
              */}
             {!refusedWithGrounding && answer.claims?.length ? (
-                <section
-                    className="space-y-3 border-t border-(--border) pt-4"
-                    aria-labelledby={findingsHeadingId}
-                >
-                    <h3 id={findingsHeadingId} className="text-label-caps text-(--text-muted)">
-                        What the evidence suggests
-                    </h3>
-                    <ul className="space-y-3">
-                        {answer.claims.map((claim) => (
-                            <li key={claim.claim_id} className="flex gap-3 text-sm leading-6">
-                                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-(--accent)" />
-                                <div className="min-w-0">
-                                    <p>
-                                        {safeCopy(claim.text, INTERNAL_TOKEN_DENYLIST, attested)}
-                                        {renderInlineCitations(
-                                            claim.evidence_ref_ids,
-                                            claim.metric_ref_ids,
-                                            "claim",
-                                        )}
-                                    </p>
-                                    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-(--text-muted)">
-                                        <span>
-                                            {claim.kind.replaceAll("_", " ")} ·{" "}
-                                            {formatPercent(claim.confidence * 100)} confidence
-                                        </span>
-                                        {validityScopeLabel(claim.validity_scope) ? (
-                                            <span>
-                                                Applies to{" "}
-                                                {validityScopeLabel(claim.validity_scope)}
-                                            </span>
-                                        ) : null}
-                                        {claim.flags.stale ? (
-                                            <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
-                                                Stale
-                                            </span>
-                                        ) : null}
-                                        {claim.flags.uncertain ? (
-                                            <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
-                                                Uncertain
-                                            </span>
-                                        ) : null}
-                                        {claim.flags.conflicting ? (
-                                            <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
-                                                Conflicting
-                                            </span>
-                                        ) : null}
-                                        {claim.flags.untrusted_source ? (
-                                            <span className="rounded-(--radius-pill) bg-(--negative)/10 px-2 text-(--negative)">
-                                                Untrusted source
-                                            </span>
-                                        ) : null}
-                                    </div>
-                                </div>
-                            </li>
-                        ))}
-                    </ul>
-                </section>
+                <ClaimsSection
+                    claims={answer.claims}
+                    headingId={findingsHeadingId}
+                    safeProse={safeProse}
+                    targets={citationTargets}
+                />
             ) : null}
 
             {answer.conflicts?.length ? (
-                <section
-                    className="rounded-(--radius-md) border border-(--caution)/30 bg-(--caution)/8 p-3"
-                    aria-label="Conflicting evidence"
-                >
-                    <p className="text-label-caps text-(--caution)">Conflicting evidence</p>
-                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-(--text-secondary)">
-                        {answer.conflicts.map((conflict) => (
-                            <li key={conflict.summary}>
-                                {safeCopy(conflict.summary, INTERNAL_TOKEN_DENYLIST, attested)}
-                            </li>
-                        ))}
-                    </ul>
-                </section>
+                <ConflictsSection conflicts={answer.conflicts} safeProse={safeProse} />
             ) : null}
 
             {answer.metrics?.length ? (
-                <section
-                    className="border-t border-(--border) pt-4"
-                    aria-labelledby={metricsHeadingId}
-                >
-                    <h3 id={metricsHeadingId} className="text-label-caps text-(--text-muted)">
-                        Metrics
-                    </h3>
-                    <dl className="mt-2 divide-y divide-(--border)">
-                        {answer.metrics.map((metric) => (
-                            <div
-                                key={metric.metric_ref_id}
-                                id={metricAnchorId(
-                                    metricPositionById.get(metric.metric_ref_id) ?? 0,
-                                )}
-                                tabIndex={-1}
-                                className="scroll-mt-6 grid gap-1 py-3 outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-baseline"
-                            >
-                                <dt className="text-sm text-(--text-secondary)">
-                                    {metric.label}
-                                    {renderInlineCitations(
-                                        metric.evidence_ref_ids,
-                                        [],
-                                        `metric ${metric.label}`,
-                                    )}
-                                    <span className="mt-0.5 block text-xs text-(--text-muted)">
-                                        {metric.aggregation} · {metric.freshness} ·{" "}
-                                        {formatPercent(metric.coverage * 100)} coverage
-                                    </span>
-                                </dt>
-                                <dd className="text-left sm:text-right">
-                                    <span className="font-(--font-display) text-h3 text-(--text-primary)">
-                                        {metric.value == null
-                                            ? "Unavailable"
-                                            : formatMetricValue(metric.value, metric.unit)}
-                                    </span>
-                                    {metric.comparison_value != null ? (
-                                        <span className="ml-2 text-xs text-(--text-muted)">
-                                            vs{" "}
-                                            {formatMetricValue(
-                                                metric.comparison_value,
-                                                metric.unit,
-                                            )}
-                                        </span>
-                                    ) : null}
-                                    <details
-                                        open={openMetricIds.has(metric.metric_ref_id) || undefined}
-                                        className="mt-1 text-xs text-(--text-muted)"
-                                    >
-                                        <summary className="cursor-pointer font-medium text-(--text-secondary)">
-                                            Metric definition
-                                        </summary>
-                                        <dl className="mt-2 grid gap-x-3 gap-y-1 text-left sm:grid-cols-[auto_minmax(0,1fr)]">
-                                            <dt>Unit</dt>
-                                            <dd>{metric.unit}</dd>
-                                            <dt>Definition version</dt>
-                                            <dd>{metric.definition_version}</dd>
-                                            <dt>Query version</dt>
-                                            <dd>{metric.query_version}</dd>
-                                            <dt>Source version</dt>
-                                            <dd>{metric.source_version}</dd>
-                                            <dt>Current window</dt>
-                                            <dd>
-                                                {formatTimestamp(metric.current_window.start)} –{" "}
-                                                {formatTimestamp(metric.current_window.end)}
-                                            </dd>
-                                            {metric.comparison_window ? (
-                                                <>
-                                                    <dt>Comparison window</dt>
-                                                    <dd>
-                                                        {formatTimestamp(
-                                                            metric.comparison_window.start,
-                                                        )}{" "}
-                                                        –{" "}
-                                                        {formatTimestamp(
-                                                            metric.comparison_window.end,
-                                                        )}
-                                                    </dd>
-                                                </>
-                                            ) : null}
-                                        </dl>
-                                    </details>
-                                </dd>
-                            </div>
-                        ))}
-                    </dl>
-                </section>
+                <MetricsSection
+                    headingId={metricsHeadingId}
+                    metricAnchorId={metricAnchorId}
+                    metricPositionById={metricPositionById}
+                    metrics={answer.metrics}
+                    openMetricIds={openMetricIds}
+                    targets={citationTargets}
+                />
             ) : null}
 
             {answer.evidence?.length ? (
-                <section
-                    className="space-y-3 border-t border-(--border) pt-4"
-                    aria-labelledby={evidenceHeadingId}
-                >
-                    {/*
-                     * CHAOS-3524: the lane's own fold toggle and the
-                     * "unfold all" action are icon-only buttons (chevron /
-                     * unfold glyph, aria-label carries the name) — "Evidence"
-                     * is the section's static title, not itself a
-                     * fold/unfold instruction, so it stays outside both
-                     * buttons as plain heading text.
-                     */}
-                    <div className="flex items-center justify-between gap-2">
-                        <h3 id={evidenceHeadingId} className="text-label-caps text-(--text-muted)">
-                            Evidence
-                        </h3>
-                        <div className="flex items-center gap-1">
-                            <button
-                                type="button"
-                                onClick={unfoldAllEvidence}
-                                aria-label={CTA_LABELS.unfoldAllEvidence}
-                                className="rounded-(--radius-sm) p-1 text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                            >
-                                <span aria-hidden="true">⤢</span>
-                            </button>
-                            <button
-                                type="button"
-                                onClick={() => setEvidenceLaneOpen((open) => !open)}
-                                aria-expanded={evidenceLaneOpen}
-                                aria-controls={evidenceListId}
-                                aria-label={
-                                    evidenceLaneOpen
-                                        ? CTA_LABELS.collapseEvidenceLane
-                                        : CTA_LABELS.expandEvidenceLane
-                                }
-                                className="rounded-(--radius-sm) p-1 text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                            >
-                                <span aria-hidden="true">{evidenceLaneOpen ? "▾" : "▸"}</span>
-                            </button>
-                        </div>
-                    </div>
-                    {/*
-                     * Native `hidden` attribute, not a conditional
-                     * unmount/CSS-class toggle: this codebase's tests run
-                     * without compiled Tailwind CSS (a `hidden` class
-                     * wouldn't actually hide anything for `toBeVisible()`
-                     * purposes), but the native attribute is a real HTML5 UA
-                     * behavior jsdom honors directly. Keeping the rows
-                     * always mounted (just hidden) also means
-                     * `document.getElementById(anchorId)` keeps working
-                     * immediately when a citation click both unfolds the
-                     * lane and focuses a row in the same flow, with no
-                     * mount-timing race to reason about.
-                     */}
-                    <div id={evidenceListId} hidden={!evidenceLaneOpen} className="space-y-3">
-                        {answer.evidence.map((evidence) => (
-                            <EvidenceRow
-                                key={evidence.evidence_ref_id}
-                                anchorId={evidenceAnchorId(
-                                    evidencePositionById.get(evidence.evidence_ref_id) ?? 0,
-                                )}
-                                error={evidenceErrors[evidence.evidence_ref_id] ?? null}
-                                evidence={evidence}
-                                expansion={evidenceExpansions[evidence.evidence_ref_id] ?? null}
-                                loading={loadingEvidenceIds.has(evidence.evidence_ref_id)}
-                                onToggleOpen={() => toggleEvidenceRow(evidence.evidence_ref_id)}
-                                open={openEvidenceRowIds.has(evidence.evidence_ref_id)}
-                                openExpansion={() => openEvidenceDetail(evidence.evidence_ref_id)}
-                            />
-                        ))}
-                    </div>
-                </section>
+                <EvidenceSection
+                    evidence={answer.evidence}
+                    evidenceAnchorId={evidenceAnchorId}
+                    evidenceErrors={evidenceErrors}
+                    evidenceExpansions={evidenceExpansions}
+                    evidencePositionById={evidencePositionById}
+                    headingId={evidenceHeadingId}
+                    laneOpen={evidenceLaneOpen}
+                    listId={evidenceListId}
+                    loadingEvidenceIds={loadingEvidenceIds}
+                    onOpenExpansion={openEvidenceDetail}
+                    onToggleLane={() => setEvidenceLaneOpen((open) => !open)}
+                    onToggleRow={toggleEvidenceRow}
+                    onUnfoldAll={unfoldAllEvidence}
+                    openEvidenceRowIds={openEvidenceRowIds}
+                />
             ) : null}
 
             {answer.warnings?.length ? (
-                <section
-                    className="rounded-(--radius-md) border border-(--caution)/30 bg-(--caution)/8 p-3"
-                    aria-label="Answer limitations"
-                >
-                    <p className="text-label-caps text-(--caution)">Limitations</p>
-                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-(--text-secondary)">
-                        {answer.warnings.map((warning) => (
-                            <li key={warning}>
-                                {safeCopy(warning, INTERNAL_TOKEN_DENYLIST, attested)}
-                            </li>
-                        ))}
-                    </ul>
-                </section>
+                <LimitationsSection safeProse={safeProse} warnings={answer.warnings} />
             ) : null}
 
             {answer.suggested_follow_up_questions?.length ? (
-                <section
-                    className="space-y-2 border-t border-(--border) pt-4"
-                    aria-label="Suggested follow-up questions"
-                >
-                    <p className="text-label-caps text-(--text-muted)">Ask next</p>
-                    <div className="flex flex-wrap gap-2">
-                        {answer.suggested_follow_up_questions.map((question) => (
-                            <button
-                                key={question}
-                                type="button"
-                                onClick={() => void submitQuestion(question)}
-                                className="rounded-(--radius-pill) border border-(--border) px-3 py-1.5 text-left text-xs text-(--text-secondary) hover:border-(--accent)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                            >
-                                {safeCopy(question, INTERNAL_TOKEN_DENYLIST, attested)}
-                            </button>
-                        ))}
-                    </div>
-                </section>
+                <FollowUpSection
+                    onAsk={(question) => void submitQuestion(question)}
+                    questions={answer.suggested_follow_up_questions}
+                    safeProse={safeProse}
+                />
             ) : null}
 
-            <footer className="flex flex-wrap items-center gap-2 border-t border-(--border) pt-4">
-                <span className="mr-1 text-xs text-(--text-muted)">Was this useful?</span>
-                <button
-                    type="button"
-                    disabled={feedback === "saving" || feedback === "helpful"}
-                    onClick={() => void sendFeedback("helpful")}
-                    className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--positive)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--positive)/45 disabled:opacity-55"
-                >
-                    {CTA_LABELS.askDevHelpful}
-                </button>
-                <button
-                    type="button"
-                    disabled={feedback === "saving" || feedback === "not_helpful"}
-                    onClick={() => void sendFeedback("not_helpful")}
-                    className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--caution)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--caution)/45 disabled:opacity-55"
-                >
-                    {CTA_LABELS.askDevNotHelpful}
-                </button>
-                {feedback === "helpful" || feedback === "not_helpful" ? (
-                    <span role="status" className="text-xs text-(--positive)">
-                        Feedback saved.
-                    </span>
-                ) : null}
-                {feedbackError ? (
-                    <span role="alert" className="text-xs text-(--negative)">
-                        {feedbackError}
-                    </span>
-                ) : null}
-            </footer>
+            <FeedbackFooter
+                error={feedbackError}
+                onRate={(rating) => void sendFeedback(rating)}
+                state={feedback}
+            />
         </article>
     );
 }

--- a/src/components/ask-dev/answer/AnswerHeaderSection.tsx
+++ b/src/components/ask-dev/answer/AnswerHeaderSection.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { formatTimestamp } from "@/lib/formatters";
+
+/**
+ * The answer's identity row and its primary content.
+ *
+ * Returns a Fragment, not a wrapper element: the two blocks are direct
+ * children of the answer `article`, whose `space-y-5` supplies the rhythm
+ * between every top-level section. Wrapping them would collapse that gap into
+ * one slot and silently re-space the whole answer.
+ *
+ * `summary` and `statusExplanation` arrive already resolved by the container —
+ * the withhold-vs-render decision for a self-contradictory row belongs in one
+ * place beside the predicates that diagnose it, not duplicated per section.
+ *
+ * The direct answer is the primary content (TRD §16: scope → question →
+ * answer → evidence/metrics → follow-up; CHAOS-3291). Previously the status
+ * caption rendered as an isolated text-xs line and direct_summary as plain
+ * text-body — same visual weight as the supporting chrome below it, so a thin
+ * answer (e.g. "Status: partial.") read as smaller and less important than
+ * the Evidence block. Keeping the caption tightly coupled to the summary (one
+ * block, no separating chrome) and giving the summary the same display-font
+ * treatment used for section headings elsewhere makes it read as one coherent
+ * answer rather than badge + boilerplate + terse line.
+ */
+export function AnswerHeaderSection({
+    asOf,
+    statusExplanation,
+    statusLabel,
+    summary,
+}: {
+    asOf: string;
+    statusExplanation: string | undefined;
+    statusLabel: string;
+    summary: string;
+}) {
+    return (
+        <>
+            <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-(--radius-pill) bg-(--accent-ai)/12 px-2.5 py-1 text-label-caps text-(--accent-ai)">
+                    AI-generated
+                </span>
+                <span className="rounded-(--radius-pill) border border-(--border) px-2.5 py-1 text-label-caps text-(--text-muted)">
+                    {statusLabel}
+                </span>
+                <span className="text-xs text-(--text-muted)">As of {formatTimestamp(asOf)}</span>
+            </div>
+
+            <div className="space-y-1.5">
+                {statusExplanation ? (
+                    <p className="text-sm leading-6 text-(--text-secondary)">{statusExplanation}</p>
+                ) : null}
+                <p className="font-(--font-display) text-h3 text-(--text-primary)">{summary}</p>
+            </div>
+        </>
+    );
+}

--- a/src/components/ask-dev/answer/ClaimsSection.tsx
+++ b/src/components/ask-dev/answer/ClaimsSection.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+import { formatPercent } from "@/lib/formatters";
+
+import { InlineCitations, type CitationTargets } from "./InlineCitations";
+import { validityScopeLabel, type SafeProse } from "./labels";
+
+/**
+ * The claim list ("What the evidence suggests").
+ *
+ * Claim text is model-authored, so it goes through `safeProse` exactly as
+ * `direct_summary` does. Whether the section renders at all is the container's
+ * call: CHAOS-3377 HIGH withholds a refused-with-grounding row's claims
+ * entirely rather than showing them under a relabeled status.
+ */
+export function ClaimsSection({
+    claims,
+    headingId,
+    safeProse,
+    targets,
+}: {
+    claims: NonNullable<DevAnswer["claims"]>;
+    headingId: string;
+    safeProse: SafeProse;
+    targets: CitationTargets;
+}) {
+    return (
+        <section className="space-y-3 border-t border-(--border) pt-4" aria-labelledby={headingId}>
+            <h3 id={headingId} className="text-label-caps text-(--text-muted)">
+                What the evidence suggests
+            </h3>
+            <ul className="space-y-3">
+                {claims.map((claim) => (
+                    <li key={claim.claim_id} className="flex gap-3 text-sm leading-6">
+                        <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-(--accent)" />
+                        <div className="min-w-0">
+                            <p>
+                                {safeProse(claim.text)}
+                                <InlineCitations
+                                    evidenceRefIds={claim.evidence_ref_ids}
+                                    metricRefIds={claim.metric_ref_ids}
+                                    ownerLabel="claim"
+                                    targets={targets}
+                                />
+                            </p>
+                            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-(--text-muted)">
+                                <span>
+                                    {claim.kind.replaceAll("_", " ")} ·{" "}
+                                    {formatPercent(claim.confidence * 100)} confidence
+                                </span>
+                                {validityScopeLabel(claim.validity_scope) ? (
+                                    <span>
+                                        Applies to {validityScopeLabel(claim.validity_scope)}
+                                    </span>
+                                ) : null}
+                                {claim.flags.stale ? (
+                                    <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
+                                        Stale
+                                    </span>
+                                ) : null}
+                                {claim.flags.uncertain ? (
+                                    <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
+                                        Uncertain
+                                    </span>
+                                ) : null}
+                                {claim.flags.conflicting ? (
+                                    <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
+                                        Conflicting
+                                    </span>
+                                ) : null}
+                                {claim.flags.untrusted_source ? (
+                                    <span className="rounded-(--radius-pill) bg-(--negative)/10 px-2 text-(--negative)">
+                                        Untrusted source
+                                    </span>
+                                ) : null}
+                            </div>
+                        </div>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/ConflictsSection.tsx
+++ b/src/components/ask-dev/answer/ConflictsSection.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+
+import type { SafeProse } from "./labels";
+
+/** Server-declared disagreements between sources. Model-authored prose, so
+ * every summary goes through `safeProse`. */
+export function ConflictsSection({
+    conflicts,
+    safeProse,
+}: {
+    conflicts: NonNullable<DevAnswer["conflicts"]>;
+    safeProse: SafeProse;
+}) {
+    return (
+        <section
+            className="rounded-(--radius-md) border border-(--caution)/30 bg-(--caution)/8 p-3"
+            aria-label="Conflicting evidence"
+        >
+            <p className="text-label-caps text-(--caution)">Conflicting evidence</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-(--text-secondary)">
+                {conflicts.map((conflict) => (
+                    <li key={conflict.summary}>{safeProse(conflict.summary)}</li>
+                ))}
+            </ul>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/CoverageSection.tsx
+++ b/src/components/ask-dev/answer/CoverageSection.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+import { formatNumber } from "@/lib/formatters";
+
+/**
+ * Per-source coverage for this answer.
+ *
+ * Whether this block appears at all is the container's call (see
+ * `showCoverage`): "0 of 0 sources" reads as a measurement that happened, and
+ * a source plan that never ran must not render one. Once mounted, every
+ * required-source state the answer actually carries is named — a visibly
+ * downgraded answer with nothing on screen explaining the downgrade is the
+ * defect CHAOS-3219 W4 fixed.
+ */
+export function CoverageSection({ coverage }: { coverage: DevAnswer["coverage"] }) {
+    return (
+        <section
+            aria-label="Evidence coverage"
+            className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-(--text-muted)"
+        >
+            <span>
+                Coverage:{" "}
+                {formatNumber(coverage?.available_source_count ?? 0, {
+                    maximumFractionDigits: 0,
+                })}{" "}
+                of{" "}
+                {formatNumber(coverage?.required_source_count ?? 0, {
+                    maximumFractionDigits: 0,
+                })}{" "}
+                sources
+            </span>
+            {coverage?.unavailable_required_sources?.length ? (
+                <span className="text-(--caution)">
+                    {coverage.unavailable_required_sources.length} required sources unavailable
+                </span>
+            ) : null}
+            {coverage?.degraded_required_sources?.length ? (
+                <span className="text-(--caution)">
+                    {coverage.degraded_required_sources.length} required sources degraded
+                </span>
+            ) : null}
+            {coverage?.stale_required_sources?.length ? (
+                <span className="text-(--caution)">
+                    {coverage.stale_required_sources.length} required sources stale
+                </span>
+            ) : null}
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/EvidenceRow.tsx
+++ b/src/components/ask-dev/answer/EvidenceRow.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import Link from "next/link";
+
+import { CTA_LABELS, toggleEvidenceItem } from "@/lib/design/cta";
+import type { DevEvidenceExpansion, DevEvidenceRef } from "@/lib/dev/generated";
+import { formatTimestamp } from "@/lib/formatters";
+
+import { safeExcerpt } from "./labels";
+
+/**
+ * CHAOS-3524 (chris's evidence-layout ruling): each evidence item is its own
+ * accordion row, default folded. The row's header (label + provenance) stays
+ * visible even folded — that's the disclosure trigger a reader sees and
+ * clicks — only the detail beneath it (citation text, the "Open evidence"
+ * fetch action, the fetched excerpt, errors, the artifact link) is hidden
+ * until `open`. The fold toggle itself is icon-only (a chevron, aria-label
+ * carries the real name) per chris's "buttons/iconography only, no text
+ * labels" rule; `evidence.display_label` sitting in the same clickable
+ * header is the row's identifying TITLE, not an instructional fold/unfold
+ * label, so it stays as visible text.
+ */
+export function EvidenceRow({
+    anchorId,
+    error,
+    evidence,
+    expansion,
+    loading,
+    onToggleOpen,
+    open,
+    openExpansion,
+}: {
+    anchorId: string;
+    error: string | null;
+    evidence: DevEvidenceRef;
+    expansion: DevEvidenceExpansion | null;
+    loading: boolean;
+    onToggleOpen: () => void;
+    open: boolean;
+    openExpansion: () => Promise<void>;
+}) {
+    const internalPath = evidence.link?.internal_path;
+
+    return (
+        <div
+            id={anchorId}
+            tabIndex={-1}
+            className="scroll-mt-6 space-y-1.5 border-l-2 border-(--border) pl-3 outline-none focus-visible:border-(--accent)"
+        >
+            <button
+                type="button"
+                onClick={onToggleOpen}
+                aria-expanded={open}
+                aria-label={toggleEvidenceItem(evidence.display_label, open)}
+                className="flex w-full min-w-0 items-start gap-2 rounded-(--radius-sm) py-0.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+            >
+                <span aria-hidden="true" className="mt-0.5 shrink-0 text-(--text-muted)">
+                    {open ? "▾" : "▸"}
+                </span>
+                <span className="flex min-w-0 flex-col gap-0.5">
+                    <span className="text-sm text-(--text-secondary)">
+                        {evidence.display_label}
+                    </span>
+                    <span className="text-xs text-(--text-muted)">
+                        {evidence.provenance} · {formatTimestamp(evidence.observed_at)}
+                    </span>
+                </span>
+            </button>
+            {open ? (
+                <div className="space-y-1.5 pl-5">
+                    {evidence.citation_text ? (
+                        <p className="text-xs leading-5 text-(--text-muted)">
+                            {evidence.citation_text}
+                        </p>
+                    ) : null}
+                    {/*
+                     * Quiet by default (text-muted, no fill) — this is a
+                     * secondary, on-demand affordance, not a primary CTA; it
+                     * only picks up accent color on hover/focus (CHAOS-3291).
+                     * Unlike the fold toggle above, this triggers a real
+                     * server fetch (the deep excerpt) rather than showing
+                     * already-loaded content, so it keeps its sanctioned
+                     * text label rather than becoming icon-only.
+                     */}
+                    <button
+                        type="button"
+                        onClick={() => void openExpansion()}
+                        disabled={loading}
+                        className="rounded-(--radius-sm) px-2 py-1 text-xs font-medium text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
+                    >
+                        {loading ? "Opening…" : CTA_LABELS.openEvidence}
+                    </button>
+                    {expansion ? (
+                        <div className="rounded-(--radius-md) bg-(--background)/60 p-3 text-sm leading-6 text-(--text-secondary)">
+                            <p className="text-label-caps text-(--text-muted)">
+                                {expansion.state.replaceAll("_", " ")}
+                            </p>
+                            {safeExcerpt(expansion.safe_excerpt) ? (
+                                <p className="mt-2 whitespace-pre-wrap">
+                                    {safeExcerpt(expansion.safe_excerpt)}
+                                </p>
+                            ) : (
+                                <p className="mt-2">No additional excerpt is available.</p>
+                            )}
+                            {expansion.warning ? (
+                                <p className="mt-2 text-(--caution)">{expansion.warning}</p>
+                            ) : null}
+                        </div>
+                    ) : null}
+                    {error ? (
+                        <p role="alert" className="text-xs text-(--negative)">
+                            {error}
+                        </p>
+                    ) : null}
+                    {internalPath ? (
+                        <Link
+                            href={internalPath}
+                            className="inline-flex text-xs font-medium text-(--accent) underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                        >
+                            {CTA_LABELS.openArtifact}
+                        </Link>
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/src/components/ask-dev/answer/EvidenceSection.tsx
+++ b/src/components/ask-dev/answer/EvidenceSection.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { DevAnswer, DevEvidenceExpansion } from "@/lib/dev/generated";
+
+import { EvidenceRow } from "./EvidenceRow";
+
+/**
+ * The evidence lane: a foldable list of independently foldable rows.
+ *
+ * CHAOS-3524 (chris's evidence-layout ruling): the lane's own fold toggle and
+ * the "unfold all" action are icon-only buttons (chevron / unfold glyph,
+ * aria-label carries the name) — "Evidence" is the section's static title, not
+ * itself a fold/unfold instruction, so it stays outside both buttons as plain
+ * heading text.
+ *
+ * All fold state lives in the container, not here: a citation click has to
+ * unfold the lane AND one specific row synchronously, in the same handler
+ * flush, before the focus call that follows the async excerpt fetch can find
+ * the row in the DOM.
+ */
+export function EvidenceSection({
+    evidence,
+    evidenceAnchorId,
+    evidenceErrors,
+    evidenceExpansions,
+    evidencePositionById,
+    headingId,
+    laneOpen,
+    listId,
+    loadingEvidenceIds,
+    onOpenExpansion,
+    onToggleLane,
+    onToggleRow,
+    onUnfoldAll,
+    openEvidenceRowIds,
+}: {
+    evidence: NonNullable<DevAnswer["evidence"]>;
+    evidenceAnchorId: (position: number) => string;
+    evidenceErrors: Readonly<Record<string, string>>;
+    evidenceExpansions: Readonly<Record<string, DevEvidenceExpansion>>;
+    evidencePositionById: ReadonlyMap<string, number>;
+    headingId: string;
+    laneOpen: boolean;
+    listId: string;
+    loadingEvidenceIds: ReadonlySet<string>;
+    onOpenExpansion: (evidenceRefId: string) => Promise<void>;
+    onToggleLane: () => void;
+    onToggleRow: (evidenceRefId: string) => void;
+    onUnfoldAll: () => void;
+    openEvidenceRowIds: ReadonlySet<string>;
+}) {
+    return (
+        <section className="space-y-3 border-t border-(--border) pt-4" aria-labelledby={headingId}>
+            <div className="flex items-center justify-between gap-2">
+                <h3 id={headingId} className="text-label-caps text-(--text-muted)">
+                    Evidence
+                </h3>
+                <div className="flex items-center gap-1">
+                    <button
+                        type="button"
+                        onClick={onUnfoldAll}
+                        aria-label={CTA_LABELS.unfoldAllEvidence}
+                        className="rounded-(--radius-sm) p-1 text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                    >
+                        <span aria-hidden="true">⤢</span>
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onToggleLane}
+                        aria-expanded={laneOpen}
+                        aria-controls={listId}
+                        aria-label={
+                            laneOpen
+                                ? CTA_LABELS.collapseEvidenceLane
+                                : CTA_LABELS.expandEvidenceLane
+                        }
+                        className="rounded-(--radius-sm) p-1 text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                    >
+                        <span aria-hidden="true">{laneOpen ? "▾" : "▸"}</span>
+                    </button>
+                </div>
+            </div>
+            {/*
+             * Native `hidden` attribute, not a conditional
+             * unmount/CSS-class toggle: this codebase's tests run
+             * without compiled Tailwind CSS (a `hidden` class
+             * wouldn't actually hide anything for `toBeVisible()`
+             * purposes), but the native attribute is a real HTML5 UA
+             * behavior jsdom honors directly. Keeping the rows
+             * always mounted (just hidden) also means
+             * `document.getElementById(anchorId)` keeps working
+             * immediately when a citation click both unfolds the
+             * lane and focuses a row in the same flow, with no
+             * mount-timing race to reason about.
+             */}
+            <div id={listId} hidden={!laneOpen} className="space-y-3">
+                {evidence.map((item) => (
+                    <EvidenceRow
+                        key={item.evidence_ref_id}
+                        anchorId={evidenceAnchorId(
+                            evidencePositionById.get(item.evidence_ref_id) ?? 0,
+                        )}
+                        error={evidenceErrors[item.evidence_ref_id] ?? null}
+                        evidence={item}
+                        expansion={evidenceExpansions[item.evidence_ref_id] ?? null}
+                        loading={loadingEvidenceIds.has(item.evidence_ref_id)}
+                        onToggleOpen={() => onToggleRow(item.evidence_ref_id)}
+                        open={openEvidenceRowIds.has(item.evidence_ref_id)}
+                        openExpansion={() => onOpenExpansion(item.evidence_ref_id)}
+                    />
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/FeedbackFooter.tsx
+++ b/src/components/ask-dev/answer/FeedbackFooter.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { CTA_LABELS } from "@/lib/design/cta";
+
+/** The rating this footer has committed, or `saving` while the request is in
+ * flight. `null` means nothing has been submitted for this answer yet. */
+export type FeedbackState = "helpful" | "not_helpful" | "saving" | null;
+
+/**
+ * Beta feedback for one answer.
+ *
+ * Deliberately narrow today: a binary rating is all the wire vocabulary
+ * supports being asked for honestly. The reason dimensions the contract
+ * already carries are not surfaced yet, and the two the provider currently
+ * sends are inferred from the rating rather than chosen by the reader — so
+ * this component asks only the question it can actually record.
+ */
+export function FeedbackFooter({
+    error,
+    onRate,
+    state,
+}: {
+    error: string | null;
+    onRate: (rating: "helpful" | "not_helpful") => void;
+    state: FeedbackState;
+}) {
+    return (
+        <footer className="flex flex-wrap items-center gap-2 border-t border-(--border) pt-4">
+            <span className="mr-1 text-xs text-(--text-muted)">Was this useful?</span>
+            <button
+                type="button"
+                disabled={state === "saving" || state === "helpful"}
+                onClick={() => onRate("helpful")}
+                className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--positive)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--positive)/45 disabled:opacity-55"
+            >
+                {CTA_LABELS.askDevHelpful}
+            </button>
+            <button
+                type="button"
+                disabled={state === "saving" || state === "not_helpful"}
+                onClick={() => onRate("not_helpful")}
+                className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--caution)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--caution)/45 disabled:opacity-55"
+            >
+                {CTA_LABELS.askDevNotHelpful}
+            </button>
+            {state === "helpful" || state === "not_helpful" ? (
+                <span role="status" className="text-xs text-(--positive)">
+                    Feedback saved.
+                </span>
+            ) : null}
+            {error ? (
+                <span role="alert" className="text-xs text-(--negative)">
+                    {error}
+                </span>
+            ) : null}
+        </footer>
+    );
+}

--- a/src/components/ask-dev/answer/FollowUpSection.tsx
+++ b/src/components/ask-dev/answer/FollowUpSection.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { SafeProse } from "./labels";
+
+/**
+ * Server-suggested next questions.
+ *
+ * These are prompts, not answers: clicking one submits that question as a new
+ * run through the same path a typed question takes. Nothing here pre-computes
+ * or hardcodes a result, and nothing here changes the committed scope.
+ */
+export function FollowUpSection({
+    onAsk,
+    questions,
+    safeProse,
+}: {
+    onAsk: (question: string) => void;
+    questions: readonly string[];
+    safeProse: SafeProse;
+}) {
+    return (
+        <section
+            className="space-y-2 border-t border-(--border) pt-4"
+            aria-label="Suggested follow-up questions"
+        >
+            <p className="text-label-caps text-(--text-muted)">Ask next</p>
+            <div className="flex flex-wrap gap-2">
+                {questions.map((question) => (
+                    <button
+                        key={question}
+                        type="button"
+                        onClick={() => onAsk(question)}
+                        className="rounded-(--radius-pill) border border-(--border) px-3 py-1.5 text-left text-xs text-(--text-secondary) hover:border-(--accent)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                    >
+                        {safeProse(question)}
+                    </button>
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/InlineCitations.tsx
+++ b/src/components/ask-dev/answer/InlineCitations.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * Everything an inline citation badge needs to resolve a ref id into a
+ * clickable, correctly-numbered anchor.
+ *
+ * Positions come from the answer's OWN evidence/metric arrays, so `E3` always
+ * means "the third evidence entry of this answer" — a citation can never
+ * address a ref this answer does not carry, and an unknown id renders nothing
+ * rather than a badge that leads somewhere else (CHAOS-3215 M6: detail-panel
+ * ids are scoped per answer for the same reason).
+ */
+export type CitationTargets = Readonly<{
+    evidencePositionById: ReadonlyMap<string, number>;
+    metricPositionById: ReadonlyMap<string, number>;
+    loadingEvidenceIds: ReadonlySet<string>;
+    openEvidence: (evidenceRefId: string) => void;
+    openMetric: (metricRefId: string) => void;
+}>;
+
+export function InlineCitations({
+    evidenceRefIds = [],
+    metricRefIds = [],
+    ownerLabel,
+    targets,
+}: {
+    evidenceRefIds?: readonly string[];
+    metricRefIds?: readonly string[];
+    ownerLabel: string;
+    targets: CitationTargets;
+}) {
+    const {
+        evidencePositionById,
+        loadingEvidenceIds,
+        metricPositionById,
+        openEvidence,
+        openMetric,
+    } = targets;
+    const knownEvidenceRefs = evidenceRefIds.filter((id) => evidencePositionById.has(id));
+    const knownMetricRefs = metricRefIds.filter((id) => metricPositionById.has(id));
+    if (!knownEvidenceRefs.length && !knownMetricRefs.length) return null;
+
+    return (
+        <span className="ml-2 inline-flex flex-wrap gap-1 align-baseline" aria-label="Citations">
+            {knownEvidenceRefs.map((evidenceRefId) => {
+                const position = evidencePositionById.get(evidenceRefId)!;
+                return (
+                    <button
+                        key={evidenceRefId}
+                        type="button"
+                        onClick={() => openEvidence(evidenceRefId)}
+                        disabled={loadingEvidenceIds.has(evidenceRefId)}
+                        aria-label={`Open evidence citation ${position + 1} for ${ownerLabel}`}
+                        className="rounded-(--radius-sm) bg-(--accent)/10 px-1.5 py-0.5 font-mono text-[0.6875rem] font-medium leading-none text-(--accent) hover:bg-(--accent)/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
+                    >
+                        E{position + 1}
+                    </button>
+                );
+            })}
+            {knownMetricRefs.map((metricRefId) => {
+                const position = metricPositionById.get(metricRefId)!;
+                return (
+                    <button
+                        key={metricRefId}
+                        type="button"
+                        onClick={() => openMetric(metricRefId)}
+                        aria-label={`Open metric citation ${position + 1} for ${ownerLabel}`}
+                        className="rounded-(--radius-sm) bg-(--accent-ai)/10 px-1.5 py-0.5 font-mono text-[0.6875rem] font-medium leading-none text-(--accent-ai) hover:bg-(--accent-ai)/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45"
+                    >
+                        M{position + 1}
+                    </button>
+                );
+            })}
+        </span>
+    );
+}

--- a/src/components/ask-dev/answer/LimitationsSection.tsx
+++ b/src/components/ask-dev/answer/LimitationsSection.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+
+import type { SafeProse } from "./labels";
+
+/**
+ * The answer's own declared limitations.
+ *
+ * `warnings` is free-text on the wire today, and model-authored, so each entry
+ * goes through `safeProse`. A typed limitation vocabulary would let this
+ * render a stable caption per kind instead of echoing prose; until the wire
+ * carries one, sanitizing is the only guard there is.
+ */
+export function LimitationsSection({
+    safeProse,
+    warnings,
+}: {
+    safeProse: SafeProse;
+    warnings: NonNullable<DevAnswer["warnings"]>;
+}) {
+    return (
+        <section
+            className="rounded-(--radius-md) border border-(--caution)/30 bg-(--caution)/8 p-3"
+            aria-label="Answer limitations"
+        >
+            <p className="text-label-caps text-(--caution)">Limitations</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-(--text-secondary)">
+                {warnings.map((warning) => (
+                    <li key={warning}>{safeProse(warning)}</li>
+                ))}
+            </ul>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/MetricsSection.tsx
+++ b/src/components/ask-dev/answer/MetricsSection.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+import { formatMetricValue, formatPercent, formatTimestamp } from "@/lib/formatters";
+
+import { InlineCitations, type CitationTargets } from "./InlineCitations";
+
+/**
+ * Registered metrics with their definition provenance.
+ *
+ * Every value is rendered through the shared formatters — a raw number here
+ * would be a design-lint failure as well as a units-free claim. `openMetricIds`
+ * comes from the container so a citation click can force the matching
+ * definition panel open and focus it (CHAOS-3215 M6).
+ */
+export function MetricsSection({
+    headingId,
+    metricAnchorId,
+    metricPositionById,
+    metrics,
+    openMetricIds,
+    targets,
+}: {
+    headingId: string;
+    metricAnchorId: (position: number) => string;
+    metricPositionById: ReadonlyMap<string, number>;
+    metrics: NonNullable<DevAnswer["metrics"]>;
+    openMetricIds: ReadonlySet<string>;
+    targets: CitationTargets;
+}) {
+    return (
+        <section className="border-t border-(--border) pt-4" aria-labelledby={headingId}>
+            <h3 id={headingId} className="text-label-caps text-(--text-muted)">
+                Metrics
+            </h3>
+            <dl className="mt-2 divide-y divide-(--border)">
+                {metrics.map((metric) => (
+                    <div
+                        key={metric.metric_ref_id}
+                        id={metricAnchorId(metricPositionById.get(metric.metric_ref_id) ?? 0)}
+                        tabIndex={-1}
+                        className="scroll-mt-6 grid gap-1 py-3 outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-baseline"
+                    >
+                        <dt className="text-sm text-(--text-secondary)">
+                            {metric.label}
+                            <InlineCitations
+                                evidenceRefIds={metric.evidence_ref_ids}
+                                ownerLabel={`metric ${metric.label}`}
+                                targets={targets}
+                            />
+                            <span className="mt-0.5 block text-xs text-(--text-muted)">
+                                {metric.aggregation} · {metric.freshness} ·{" "}
+                                {formatPercent(metric.coverage * 100)} coverage
+                            </span>
+                        </dt>
+                        <dd className="text-left sm:text-right">
+                            <span className="font-(--font-display) text-h3 text-(--text-primary)">
+                                {metric.value == null
+                                    ? "Unavailable"
+                                    : formatMetricValue(metric.value, metric.unit)}
+                            </span>
+                            {metric.comparison_value != null ? (
+                                <span className="ml-2 text-xs text-(--text-muted)">
+                                    vs {formatMetricValue(metric.comparison_value, metric.unit)}
+                                </span>
+                            ) : null}
+                            <details
+                                open={openMetricIds.has(metric.metric_ref_id) || undefined}
+                                className="mt-1 text-xs text-(--text-muted)"
+                            >
+                                <summary className="cursor-pointer font-medium text-(--text-secondary)">
+                                    Metric definition
+                                </summary>
+                                <dl className="mt-2 grid gap-x-3 gap-y-1 text-left sm:grid-cols-[auto_minmax(0,1fr)]">
+                                    <dt>Unit</dt>
+                                    <dd>{metric.unit}</dd>
+                                    <dt>Definition version</dt>
+                                    <dd>{metric.definition_version}</dd>
+                                    <dt>Query version</dt>
+                                    <dd>{metric.query_version}</dd>
+                                    <dt>Source version</dt>
+                                    <dd>{metric.source_version}</dd>
+                                    <dt>Current window</dt>
+                                    <dd>
+                                        {formatTimestamp(metric.current_window.start)} –{" "}
+                                        {formatTimestamp(metric.current_window.end)}
+                                    </dd>
+                                    {metric.comparison_window ? (
+                                        <>
+                                            <dt>Comparison window</dt>
+                                            <dd>
+                                                {formatTimestamp(metric.comparison_window.start)} –{" "}
+                                                {formatTimestamp(metric.comparison_window.end)}
+                                            </dd>
+                                        </>
+                                    ) : null}
+                                </dl>
+                            </details>
+                        </dd>
+                    </div>
+                ))}
+            </dl>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/ScopeSection.tsx
+++ b/src/components/ask-dev/answer/ScopeSection.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { DevAnswer, DevScope } from "@/lib/dev/generated";
+
+import { scopeCoverageLabel } from "./labels";
+
+/**
+ * The entity-ref shape a candidate carries, derived from the scope contract
+ * rather than named directly — the generated module exposes `DevEntityRef`
+ * only inside positional tuple types. Structurally identical to
+ * `AskDevProvider`'s own private alias, so `selectProposedEntity` accepts one
+ * of these unchanged.
+ */
+type ScopeEntityRef = NonNullable<DevScope["entity_refs"]>[number];
+
+/**
+ * The resolved-scope row and, when the resolver returned any, the candidate
+ * list.
+ *
+ * `outcomeLabel` is resolved by the container rather than looked up here: a
+ * legacy row whose prose contradicts its own outcome has its outcome value
+ * WITHHELD (replaced with the collapsed no-authorized-match label), and that
+ * judgement belongs beside the predicate that makes it.
+ *
+ * Selecting a candidate proposes it as context — it never submits. CHAOS-3665
+ * and the PRD both forbid auto-selecting the first result, so this list has no
+ * default, no preselection, and no implicit commit.
+ */
+export function ScopeSection({
+    noMatch,
+    onSelectCandidate,
+    outcomeLabel,
+    scopeResolution,
+}: {
+    noMatch: boolean;
+    onSelectCandidate: (entityRef: ScopeEntityRef) => void;
+    outcomeLabel: string;
+    scopeResolution: NonNullable<DevAnswer["resolved_scope"]>;
+}) {
+    return (
+        <section className="border-y border-(--border) py-3" aria-label="Resolved answer scope">
+            <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
+                <span className="text-(--text-muted)">
+                    Scope outcome:{" "}
+                    <strong className="font-medium text-(--text-secondary)">{outcomeLabel}</strong>
+                </span>
+                <span className="text-(--text-muted)">{scopeCoverageLabel(scopeResolution)}</span>
+            </div>
+            {scopeResolution.candidates?.length ? (
+                <div className="mt-3">
+                    {/*
+                     * Two different situations share this list.
+                     * Ambiguity means several authorized entities DID
+                     * match and one must be picked; a no-match means
+                     * none did and these are only the nearest names
+                     * (CHAOS-3366 fills them; empty today). Calling
+                     * the second "possible scope matches" would assert
+                     * the subject exists, which is the substitution
+                     * §12 prohibits.
+                     */}
+                    <p className="text-label-caps text-(--caution)">
+                        {noMatch ? "Closest matches" : "Possible scope matches"}
+                    </p>
+                    <ul className="mt-2 space-y-1 text-sm text-(--text-secondary)">
+                        {scopeResolution.candidates.map((candidate) => (
+                            <li
+                                key={`${candidate.entity_ref.entity_type}:${candidate.entity_ref.entity_id}`}
+                                className="flex flex-wrap items-center justify-between gap-2"
+                            >
+                                <span>
+                                    {candidate.entity_ref.display_label} — {candidate.reason}
+                                </span>
+                                <button
+                                    type="button"
+                                    onClick={() => onSelectCandidate(candidate.entity_ref)}
+                                    className="rounded-(--radius-sm) border border-(--border) px-2 py-1 text-xs font-medium hover:border-(--accent)/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                                >
+                                    {CTA_LABELS.useAskDevScope}
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                    <p className="mt-2 text-xs text-(--text-muted)">
+                        {noMatch
+                            ? "None of these is the subject you named. Pick one to ask about it instead."
+                            : "Choose or remove the proposed context before asking the next question."}
+                    </p>
+                </div>
+            ) : null}
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/labels.ts
+++ b/src/components/ask-dev/answer/labels.ts
@@ -1,0 +1,77 @@
+import type { DevAnswer, DevScope } from "@/lib/dev/generated";
+
+/**
+ * Strip the UNTRUSTED_DATA fence the evidence service wraps a fetched excerpt
+ * in. The fence is a prompt-injection boundary for the model, not copy for a
+ * human, so it is removed at the last layer before display — the excerpt
+ * inside stays untrusted either way and is never interpreted, only shown.
+ */
+export function safeExcerpt(value: string | null | undefined): string | null {
+    if (!value) return null;
+    return value.replace(/^UNTRUSTED_DATA\r?\n/u, "").replace(/\r?\nEND_UNTRUSTED_DATA$/u, "");
+}
+
+/**
+ * Name the subject a scope applies to, rather than counting anonymous ids.
+ *
+ * Prefers the entity whose type matches the scope's own `direct_scope` — that
+ * is the named subject the reader asked about. Falls back to a counted label
+ * ("3 repositories") only when no such entity is on the wire, which keeps the
+ * row honest for a scope that genuinely commits to a set rather than one
+ * subject.
+ */
+export function validityScopeLabel(scope: DevScope | null | undefined): string | null {
+    if (!scope) return null;
+    const namedEntity = scope.entity_refs?.find(
+        (entity) => entity.entity_type === scope.direct_scope,
+    );
+    if (namedEntity) return namedEntity.display_label;
+    if (scope.direct_scope === "organization") return "Organization";
+    const count =
+        scope.direct_scope === "repository"
+            ? (scope.repositories?.length ?? 0)
+            : (scope.entity_refs?.filter((entity) => entity.entity_type === scope.direct_scope)
+                  .length ?? 0);
+    const label = scope.direct_scope.replaceAll("_", " ");
+    return count > 0 ? `${count} ${label}${count === 1 ? "" : "s"}` : label;
+}
+
+/**
+ * The scope-outcome row's secondary line (CHAOS-3377 defect 4).
+ *
+ * Previously always rendered "{authorized_repository_ids.length} authorized
+ * repositories", regardless of the resolved scope's own kind -- correct for
+ * a REPOSITORY-scoped answer, but for a PROJECT (or any other non-repository)
+ * scope the repository count is at best incidental and at worst reads as
+ * "0 authorized repositories" for a subject that has real, substantive
+ * content and simply carries no repository dimension on the wire (see
+ * ops's `ScopeResolutionService`/`DevScope.repositories`, which is only
+ * ever populated for a REPOSITORY commit). Reuses `validityScopeLabel` --
+ * the same "name the subject, not a count" logic `claim.validity_scope`
+ * already renders -- so a project scope shows its subject ("Falcon Nine")
+ * instead. Falls back to the repository count whenever the scope itself is
+ * missing or genuinely repository-scoped, which is unchanged behavior.
+ */
+export function scopeCoverageLabel(
+    scopeResolution: NonNullable<DevAnswer["resolved_scope"]>,
+): string {
+    const scope = scopeResolution.resolved_scope ?? scopeResolution.requested_scope;
+    if (scope && scope.direct_scope !== "repository") {
+        const subjectLabel = validityScopeLabel(scope);
+        if (subjectLabel) return subjectLabel;
+    }
+    const count = scopeResolution.authorized_repository_ids?.length ?? 0;
+    return `${count} authorized repositories`;
+}
+
+/**
+ * A prose sanitizer with its denylist and attested-string set already bound.
+ *
+ * Every section component that renders model-authored prose takes one of
+ * these rather than importing the denylist itself. Two reasons, both
+ * load-bearing: the denylist is derived from the TOTAL label maps that live
+ * in `AskDevAnswer.tsx` (importing it back from a section would be a cycle),
+ * and a section that must be *handed* its sanitizer cannot silently forget to
+ * apply one the way a section that constructs its own arguments can.
+ */
+export type SafeProse = (value: string | null | undefined) => string;

--- a/src/components/ask-dev/answerVocabularySource.test.ts
+++ b/src/components/ask-dev/answerVocabularySource.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Guards a cross-file invariant that is invisible from either side alone.
+ *
+ * `tests/ask-dev-vocabulary.spec.ts` cross-checks the sanctioned label maps in
+ * `AskDevAnswer.tsx` against the pinned JSON Schema enums, and it does so by
+ * reading that file as TEXT — it cannot import the module, because the "use
+ * client" import graph reaches a PNG asset that Playwright's standalone esbuild
+ * transform has no loader for. Its parser locates `export const <NAME>`, then
+ * the next `{`, then the next `};`, and takes the `key:` lines between them.
+ *
+ * That makes two things load-bearing which nothing in `AskDevAnswer.tsx`
+ * declares:
+ *
+ * 1. Both maps must physically live in that file. Extracting them to a sibling
+ *    module (as the answer-section extraction was otherwise free to do) makes
+ *    the Playwright parser throw — loudly, but only in the slow e2e tier, with
+ *    a cause invisible from the constant's new home.
+ * 2. The region between the map's opening `{` and the FIRST following `};`
+ *    must be exactly the map body. A nested object literal, or a comment
+ *    containing `};`, silently truncates or extends the parsed region — and
+ *    then the Playwright assertion compares a WRONG key set against the schema
+ *    enum. It would still pass or fail for reasons unrelated to the real
+ *    vocabulary, which is the worse outcome: a check that no longer measures
+ *    what it claims to.
+ *
+ * This test re-derives the same parse in the fast unit tier and asserts it
+ * agrees with what the module actually exports. It fails in seconds on a
+ * refactor that would otherwise fail late, or silently stop measuring.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ANSWER_STATUS_LABELS, SCOPE_OUTCOME_LABELS } from "./AskDevAnswer";
+
+const SOURCE_PATH = path.join(__dirname, "AskDevAnswer.tsx");
+
+/**
+ * A deliberate duplicate of `exportedLabelMapKeys` in
+ * `tests/ask-dev-vocabulary.spec.ts`. Duplicated rather than shared on
+ * purpose: the point is to exercise the same fragile text parse the e2e spec
+ * performs, against the same real file, without importing anything from the
+ * Playwright tier.
+ */
+function exportedLabelMapKeys(sourceText: string, exportName: string): readonly string[] {
+    const start = sourceText.indexOf(`export const ${exportName}`);
+    if (start === -1) throw new Error(`Could not find "export const ${exportName}" in source.`);
+    const openBrace = sourceText.indexOf("{", start);
+    const closeBrace = sourceText.indexOf("};", openBrace);
+    if (openBrace === -1 || closeBrace === -1) {
+        throw new Error(`Could not find the object literal body for "${exportName}".`);
+    }
+    const body = sourceText.slice(openBrace + 1, closeBrace);
+    const keyPattern = /^\s*([a-z][a-z0-9_]*)\s*:/gmu;
+    const keys: string[] = [];
+    for (const match of body.matchAll(keyPattern)) keys.push(match[1]!);
+    if (keys.length === 0)
+        throw new Error(`Found no keys for "${exportName}" — parsing likely broke.`);
+    return keys;
+}
+
+describe("sanctioned label maps stay text-parseable in AskDevAnswer.tsx", () => {
+    const cases = [
+        ["ANSWER_STATUS_LABELS", ANSWER_STATUS_LABELS],
+        ["SCOPE_OUTCOME_LABELS", SCOPE_OUTCOME_LABELS],
+    ] as const;
+
+    it.each(cases)(
+        "%s parses out of the real source to exactly the keys the module exports",
+        (exportName, map) => {
+            const source = readFileSync(SOURCE_PATH, "utf8");
+            const parsed = exportedLabelMapKeys(source, exportName).slice().sort();
+            expect(parsed).toEqual(Object.keys(map).slice().sort());
+        },
+    );
+
+    it.each(cases)("%s has no duplicate keys in the parsed region", (exportName) => {
+        const source = readFileSync(SOURCE_PATH, "utf8");
+        const parsed = exportedLabelMapKeys(source, exportName);
+        // A parsed region that swallowed a NEIGHBOURING map would still match
+        // the module's key set under a plain sort+compare if the neighbour is a
+        // subset; a duplicate key is the signal that the slice ran past its own
+        // literal.
+        expect(new Set(parsed).size).toBe(parsed.length);
+    });
+});


### PR DESCRIPTION
Part of the web leg of issue 3665 (graph-assisted Ask Dev beta). This PR is
groundwork only and completes no acceptance criterion on its own.

## Why

`AskDevAnswer.tsx` was a 1090-line client component holding every section of a
rendered answer inline — status pill, scope and candidates, coverage, claims,
conflicts, metrics, the evidence lane and its rows, limitations, follow-ups and
the feedback footer — with only `EvidenceRow` extracted. The upcoming beta
slices add several more sections to that same component. Adding them to the
monolith means surgery on shared code for every slice, and there is no boundary
a second surface could reuse. This splits the rendering first, so the later
slices are additive.

## What changed

Rendering moves to `src/components/ask-dev/answer/`: `AnswerHeaderSection`,
`ScopeSection`, `CoverageSection`, `ClaimsSection`, `ConflictsSection`,
`MetricsSection`, `EvidenceSection`, `EvidenceRow`, `LimitationsSection`,
`FollowUpSection`, `FeedbackFooter`, `InlineCitations`, and pure helpers in
`labels.ts`.

The container keeps every piece of state, every handler, and every judgement
about what an answer *is* — no-match, refused-with-grounding, and whether the
scope row can be trusted. Sections are presentational and receive resolved copy
plus callbacks.

One shape change worth calling out: sections receive a pre-bound `safeProse`
sanitizer instead of reaching for the internal-token denylist themselves. The
denylist is derived from the label maps that live in the container, so importing
it back from a section would be a cycle — and a section that must be *handed* its
sanitizer cannot forget to apply one, which a section constructing its own
arguments can.

The sanctioned label maps deliberately stay in `AskDevAnswer.tsx`. See the new
test below for why that is load-bearing rather than incidental.

## No behaviour change, and how that was verified

A throwaway differential oracle: the pre-refactor component was restored from
`main` alongside the new one, both rendered over eleven fixtures derived from the
checked-in canonical `dev_answer.v1` example (the real producer's own payload,
not hand-authored shapes), and the DOM compared after every step of an
interaction script — unfold-all, evidence citation, metric citation, lane
collapse, feedback. Byte-identical at every step, for all eleven fixtures
(canonical, no-match, refused-with-grounding, genuine refusal, ambiguous with
candidates, coverage-suppressed, contradictory legacy row, degraded, partial,
insufficient-evidence, thin).

The oracle was proven able to fail before being trusted:

- a Tailwind class change in one extracted section left all 38 pre-existing
  `AskDevAnswer` tests passing while the oracle failed at step 0;
- removing the metric `details` `open` binding failed it at step 3 — the
  interaction step specifically, confirming the timeline dimension works.

It is deliberately **not** committed: a verbatim copy of the old monolith is
itself the second implementation this split exists to prevent.

## New test

`answerVocabularySource.test.ts` guards a cross-file invariant that neither side
declares. `tests/ask-dev-vocabulary.spec.ts` cross-checks the sanctioned label
maps against the pinned JSON Schema enums by reading this file as *text* — it
cannot import the module, because the `"use client"` graph reaches a PNG asset
that Playwright's standalone esbuild transform has no loader for. That makes two
things load-bearing: the maps must physically live in `AskDevAnswer.tsx`, and the
region between a map's opening brace and the first following `};` must be exactly
its body.

The second is the dangerous one. A comment containing `};` inside a map body
silently truncates the parsed region, so the e2e assertion then compares a wrong
key set against the schema enum — it keeps passing or failing for reasons
unrelated to the real vocabulary, which is worse than failing. Planting exactly
that leaves the 82 pre-existing unit tests green and fails this new test loudly.

## Gate

Run locally per stage, with real exit codes captured to file rather than read off
a wrapper command's status.

| Stage | Exit | Result |
| --- | --- | --- |
| `format` | 0 | pass |
| `quality` (audit, codegen:check, contracts:check, check-currency, lint, typecheck) | 0 | pass |
| `build` | 0 | pass |
| `unit` (vitest --coverage) | 0 | 3747 passed, 8 skipped, 415 files |
| `e2e-default 1/2` | 0 | 173/173 |
| `e2e-default 2/2` | 0 | 148 passed, 2 pre-existing documented `test.skip`s |
| `e2e-onboarding` | 0 | 10/10 |
| `e2e-context-fabric` | 1 | see below |
| `pagerduty-final-qa` | 0 | 23/23 |
| `design-lint` | 0 | pass |

`e2e-default 1/2` plus `2/2` is the script's own supported partition, so that is
the whole default suite rather than a sample.

### The one red stage, and its residual gap

`acr-context-fabric.production.spec.ts` › "closes mobile navigation with Escape
and restores focus to its control" fails deterministically **4 out of 4 runs: 2
on this branch and 2 on `main`** — same test, same assertion. It is therefore not
a regression from this PR. `main`'s CI is green and `tests.yml` does run
`e2e-context-fabric`, so this is a local macOS-only failure of a stage CI passes
on Linux.

Stated plainly because it matters for how much this local run proves: **this
PR's context-fabric coverage rests on CI, not on the local gate.**

Two `admin-settings` assertions also failed on one early run and then did not
reproduce in six further runs, including a faithful reconstruction of the exact
conditions of the failing run. Cause not established, so it is not being called
environmental. The residual risk that cannot be excluded: every authenticated
page mounts `AskDevProvider` through `app/(app)/layout.tsx`, so splitting that
bundle from one module into thirteen could marginally raise hydration latency and
make a 5s keyboard-on-mobile-nav assertion likelier to lose its race. Bounded low
(0 of 2 runs on `main`, 1 of 4 on this branch), not zero. All three failures seen
belong to the same family — mobile nav, keyboard or focus, about 5.5s — and one
of that family is deterministically broken locally on macOS, which is why the
family looks environment-sensitive here. The test-robustness concern is being
filed separately rather than absorbed into this PR.

SCREENSHOT-WAIVER: rendered output is provably unchanged. Verified by a
differential DOM oracle against the pre-refactor component over eleven canonical
fixtures, compared after each step of an interaction script, byte-identical
throughout — and the oracle itself was proven able to fail two different ways
(a styling-only change caught at step 0, a lost interaction binding caught at
step 3) before being relied on. That is strictly stronger evidence for an
unchanged-output refactor than eyeballed before/after screenshots. Any later
slice in this series that changes rendered output carries full visual evidence.
