### PR TITLE
fix(ask-dev): tolerate a server ahead of the pinned contract instead of failing the run

### DIFF
--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -1,15 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo, useState } from "react";
 
-import { CTA_LABELS, toggleEvidenceItem } from "@/lib/design/cta";
-import type {
-    DevAnswer,
-    DevEvidenceExpansion,
-    DevEvidenceRef,
-    DevScope,
-} from "@/lib/dev/generated";
+import type { DevAnswer, DevEvidenceExpansion } from "@/lib/dev/generated";
 import {
     buildInternalTokenDenylist,
     findInternalToken,
@@ -17,14 +10,20 @@ import {
     safeCopy,
     WITHHELD_COPY,
 } from "@/lib/dev/internalTokens";
-import { formatMetricValue, formatNumber, formatPercent, formatTimestamp } from "@/lib/formatters";
 
+import { AnswerHeaderSection } from "./answer/AnswerHeaderSection";
+import { ClaimsSection } from "./answer/ClaimsSection";
+import { ConflictsSection } from "./answer/ConflictsSection";
+import { CoverageSection } from "./answer/CoverageSection";
+import { EvidenceSection } from "./answer/EvidenceSection";
+import { FeedbackFooter, type FeedbackState } from "./answer/FeedbackFooter";
+import { FollowUpSection } from "./answer/FollowUpSection";
+import type { CitationTargets } from "./answer/InlineCitations";
+import type { SafeProse } from "./answer/labels";
+import { LimitationsSection } from "./answer/LimitationsSection";
+import { MetricsSection } from "./answer/MetricsSection";
+import { ScopeSection } from "./answer/ScopeSection";
 import { useAskDev } from "./AskDevProvider";
-
-function safeExcerpt(value: string | null | undefined): string | null {
-    if (!value) return null;
-    return value.replace(/^UNTRUSTED_DATA\r?\n/u, "").replace(/\r?\nEND_UNTRUSTED_DATA$/u, "");
-}
 
 // Grounded in the sanctioned framing from ops/docs/use/ai-workflows/index.md
 // ("Ask Dev: window and full-page workspace"): "A partial, degraded,
@@ -50,6 +49,15 @@ function safeExcerpt(value: string | null | undefined): string | null {
 // AskDevAnswer.test.tsx can assert Object.keys(...) coverage against the
 // real generated union directly, instead of duplicating a second copy of
 // the member list in the test file that could itself drift.
+//
+// This file is also read as TEXT by tests/ask-dev-vocabulary.spec.ts, which
+// locates `export const <NAME> = {` by name to cross-check the keys against
+// the pinned JSON Schema enums (it cannot import this module: the "use
+// client" graph reaches a PNG asset that Playwright's standalone esbuild
+// transform has no loader for). Both label maps below must therefore stay in
+// THIS file, in that literal shape — moving them to a sibling module is a
+// loud test failure, not a silent one, but a failure with a cause that is
+// invisible from the constant's new home.
 export const ANSWER_STATUS_LABELS: Record<DevAnswer["status"], string> = {
     complete: "Complete",
     degraded: "Degraded",
@@ -228,170 +236,21 @@ const STATUS_EXPLANATIONS: Partial<Record<DevAnswer["status"], string>> = {
         "Refused: Ask Dev did not answer this question. A result with limitations, not a silent success.",
 };
 
-function validityScopeLabel(scope: DevScope | null | undefined): string | null {
-    if (!scope) return null;
-    const namedEntity = scope.entity_refs?.find(
-        (entity) => entity.entity_type === scope.direct_scope,
-    );
-    if (namedEntity) return namedEntity.display_label;
-    if (scope.direct_scope === "organization") return "Organization";
-    const count =
-        scope.direct_scope === "repository"
-            ? (scope.repositories?.length ?? 0)
-            : (scope.entity_refs?.filter((entity) => entity.entity_type === scope.direct_scope)
-                  .length ?? 0);
-    const label = scope.direct_scope.replaceAll("_", " ");
-    return count > 0 ? `${count} ${label}${count === 1 ? "" : "s"}` : label;
-}
-
 /**
- * The scope-outcome row's secondary line (CHAOS-3377 defect 4).
+ * The answer container.
  *
- * Previously always rendered "{authorized_repository_ids.length} authorized
- * repositories", regardless of the resolved scope's own kind -- correct for
- * a REPOSITORY-scoped answer, but for a PROJECT (or any other non-repository)
- * scope the repository count is at best incidental and at worst reads as
- * "0 authorized repositories" for a subject that has real, substantive
- * content and simply carries no repository dimension on the wire (see
- * ops's `ScopeResolutionService`/`DevScope.repositories`, which is only
- * ever populated for a REPOSITORY commit). Reuses `validityScopeLabel` --
- * the same "name the subject, not a count" logic `claim.validity_scope`
- * already renders -- so a project scope shows its subject ("Falcon Nine")
- * instead. Falls back to the repository count whenever the scope itself is
- * missing or genuinely repository-scoped, which is unchanged behavior.
+ * Owns every piece of state, every handler, and every judgement about what
+ * this answer is (no-match, refused-with-grounding, trustworthy scope row).
+ * The `answer/*` components it composes are presentational: they receive
+ * resolved copy, an already-bound `safeProse` sanitizer, and callbacks. That
+ * split is what keeps a new section additive — and it is why no section can
+ * render model-authored prose without a sanitizer, since it never holds the
+ * denylist to forget in the first place.
  */
-function scopeCoverageLabel(scopeResolution: NonNullable<DevAnswer["resolved_scope"]>): string {
-    const scope = scopeResolution.resolved_scope ?? scopeResolution.requested_scope;
-    if (scope && scope.direct_scope !== "repository") {
-        const subjectLabel = validityScopeLabel(scope);
-        if (subjectLabel) return subjectLabel;
-    }
-    const count = scopeResolution.authorized_repository_ids?.length ?? 0;
-    return `${count} authorized repositories`;
-}
-
-/**
- * CHAOS-3524 (chris's evidence-layout ruling): each evidence item is its own
- * accordion row, default folded. The row's header (label + provenance) stays
- * visible even folded — that's the disclosure trigger a reader sees and
- * clicks — only the detail beneath it (citation text, the "Open evidence"
- * fetch action, the fetched excerpt, errors, the artifact link) is hidden
- * until `open`. The fold toggle itself is icon-only (a chevron, aria-label
- * carries the real name) per chris's "buttons/iconography only, no text
- * labels" rule; `evidence.display_label` sitting in the same clickable
- * header is the row's identifying TITLE, not an instructional fold/unfold
- * label, so it stays as visible text.
- */
-function EvidenceRow({
-    anchorId,
-    error,
-    evidence,
-    expansion,
-    loading,
-    onToggleOpen,
-    open,
-    openExpansion,
-}: {
-    anchorId: string;
-    error: string | null;
-    evidence: DevEvidenceRef;
-    expansion: DevEvidenceExpansion | null;
-    loading: boolean;
-    onToggleOpen: () => void;
-    open: boolean;
-    openExpansion: () => Promise<void>;
-}) {
-    const internalPath = evidence.link?.internal_path;
-
-    return (
-        <div
-            id={anchorId}
-            tabIndex={-1}
-            className="scroll-mt-6 space-y-1.5 border-l-2 border-(--border) pl-3 outline-none focus-visible:border-(--accent)"
-        >
-            <button
-                type="button"
-                onClick={onToggleOpen}
-                aria-expanded={open}
-                aria-label={toggleEvidenceItem(evidence.display_label, open)}
-                className="flex w-full min-w-0 items-start gap-2 rounded-(--radius-sm) py-0.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-            >
-                <span aria-hidden="true" className="mt-0.5 shrink-0 text-(--text-muted)">
-                    {open ? "▾" : "▸"}
-                </span>
-                <span className="flex min-w-0 flex-col gap-0.5">
-                    <span className="text-sm text-(--text-secondary)">
-                        {evidence.display_label}
-                    </span>
-                    <span className="text-xs text-(--text-muted)">
-                        {evidence.provenance} · {formatTimestamp(evidence.observed_at)}
-                    </span>
-                </span>
-            </button>
-            {open ? (
-                <div className="space-y-1.5 pl-5">
-                    {evidence.citation_text ? (
-                        <p className="text-xs leading-5 text-(--text-muted)">
-                            {evidence.citation_text}
-                        </p>
-                    ) : null}
-                    {/*
-                     * Quiet by default (text-muted, no fill) — this is a
-                     * secondary, on-demand affordance, not a primary CTA; it
-                     * only picks up accent color on hover/focus (CHAOS-3291).
-                     * Unlike the fold toggle above, this triggers a real
-                     * server fetch (the deep excerpt) rather than showing
-                     * already-loaded content, so it keeps its sanctioned
-                     * text label rather than becoming icon-only.
-                     */}
-                    <button
-                        type="button"
-                        onClick={() => void openExpansion()}
-                        disabled={loading}
-                        className="rounded-(--radius-sm) px-2 py-1 text-xs font-medium text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
-                    >
-                        {loading ? "Opening…" : CTA_LABELS.openEvidence}
-                    </button>
-                    {expansion ? (
-                        <div className="rounded-(--radius-md) bg-(--background)/60 p-3 text-sm leading-6 text-(--text-secondary)">
-                            <p className="text-label-caps text-(--text-muted)">
-                                {expansion.state.replaceAll("_", " ")}
-                            </p>
-                            {safeExcerpt(expansion.safe_excerpt) ? (
-                                <p className="mt-2 whitespace-pre-wrap">
-                                    {safeExcerpt(expansion.safe_excerpt)}
-                                </p>
-                            ) : (
-                                <p className="mt-2">No additional excerpt is available.</p>
-                            )}
-                            {expansion.warning ? (
-                                <p className="mt-2 text-(--caution)">{expansion.warning}</p>
-                            ) : null}
-                        </div>
-                    ) : null}
-                    {error ? (
-                        <p role="alert" className="text-xs text-(--negative)">
-                            {error}
-                        </p>
-                    ) : null}
-                    {internalPath ? (
-                        <Link
-                            href={internalPath}
-                            className="inline-flex text-xs font-medium text-(--accent) underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                        >
-                            {CTA_LABELS.openArtifact}
-                        </Link>
-                    ) : null}
-                </div>
-            ) : null}
-        </div>
-    );
-}
-
 export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     const { expandEvidence, selectProposedEntity, submitAnswerFeedback, submitQuestion } =
         useAskDev();
-    const [feedback, setFeedback] = useState<"helpful" | "not_helpful" | "saving" | null>(null);
+    const [feedback, setFeedback] = useState<FeedbackState>(null);
     const [feedbackError, setFeedbackError] = useState<string | null>(null);
     const [evidenceExpansions, setEvidenceExpansions] = useState<
         Readonly<Record<string, DevEvidenceExpansion>>
@@ -481,6 +340,12 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         [answer.metrics],
     );
 
+    // Bound once here, handed to every section that renders model-authored
+    // prose. Not a hook: it closes over `attested` and is cheap, and keeping
+    // it a plain function means the sections re-render exactly as often as
+    // they did when this logic was inline in one component.
+    const safeProse: SafeProse = (value) => safeCopy(value, INTERNAL_TOKEN_DENYLIST, attested);
+
     // Detail-panel ids are scoped by answer.answer_id, not just position: a
     // transcript can contain many answers, and position-only ids (e.g.
     // "ask-dev-evidence-1") collide across every one of them, so
@@ -568,51 +433,12 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         setOpenEvidenceRowIds(new Set((answer.evidence ?? []).map((item) => item.evidence_ref_id)));
     };
 
-    const renderInlineCitations = (
-        evidenceRefIds: readonly string[] = [],
-        metricRefIds: readonly string[] = [],
-        ownerLabel: string,
-    ) => {
-        const knownEvidenceRefs = evidenceRefIds.filter((id) => evidencePositionById.has(id));
-        const knownMetricRefs = metricRefIds.filter((id) => metricPositionById.has(id));
-        if (!knownEvidenceRefs.length && !knownMetricRefs.length) return null;
-
-        return (
-            <span
-                className="ml-2 inline-flex flex-wrap gap-1 align-baseline"
-                aria-label="Citations"
-            >
-                {knownEvidenceRefs.map((evidenceRefId) => {
-                    const position = evidencePositionById.get(evidenceRefId)!;
-                    return (
-                        <button
-                            key={evidenceRefId}
-                            type="button"
-                            onClick={() => void openEvidenceDetail(evidenceRefId)}
-                            disabled={loadingEvidenceIds.has(evidenceRefId)}
-                            aria-label={`Open evidence citation ${position + 1} for ${ownerLabel}`}
-                            className="rounded-(--radius-sm) bg-(--accent)/10 px-1.5 py-0.5 font-mono text-[0.6875rem] font-medium leading-none text-(--accent) hover:bg-(--accent)/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
-                        >
-                            E{position + 1}
-                        </button>
-                    );
-                })}
-                {knownMetricRefs.map((metricRefId) => {
-                    const position = metricPositionById.get(metricRefId)!;
-                    return (
-                        <button
-                            key={metricRefId}
-                            type="button"
-                            onClick={() => openMetricDetail(metricRefId)}
-                            aria-label={`Open metric citation ${position + 1} for ${ownerLabel}`}
-                            className="rounded-(--radius-sm) bg-(--accent-ai)/10 px-1.5 py-0.5 font-mono text-[0.6875rem] font-medium leading-none text-(--accent-ai) hover:bg-(--accent-ai)/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45"
-                        >
-                            M{position + 1}
-                        </button>
-                    );
-                })}
-            </span>
-        );
+    const citationTargets: CitationTargets = {
+        evidencePositionById,
+        metricPositionById,
+        loadingEvidenceIds,
+        openEvidence: (evidenceRefId) => void openEvidenceDetail(evidenceRefId),
+        openMetric: openMetricDetail,
     };
 
     const sendFeedback = async (rating: "helpful" | "not_helpful") => {
@@ -636,142 +462,27 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
             className="space-y-5 outline-none"
             aria-label="Ask Dev answer"
         >
-            <div className="flex flex-wrap items-center gap-2">
-                <span className="rounded-(--radius-pill) bg-(--accent-ai)/12 px-2.5 py-1 text-label-caps text-(--accent-ai)">
-                    AI-generated
-                </span>
-                <span className="rounded-(--radius-pill) border border-(--border) px-2.5 py-1 text-label-caps text-(--text-muted)">
-                    {statusLabel}
-                </span>
-                <span className="text-xs text-(--text-muted)">
-                    As of {formatTimestamp(answer.as_of)}
-                </span>
-            </div>
-
-            {/*
-             * The direct answer is the primary content (TRD §16: scope →
-             * question → answer → evidence/metrics → follow-up; CHAOS-3291).
-             * Previously the status caption rendered as an isolated text-xs
-             * line and direct_summary as plain text-body — same visual
-             * weight as the supporting chrome below it, so a thin answer
-             * (e.g. "Status: partial.") read as smaller and less important
-             * than the Evidence block. Keeping the caption tightly coupled
-             * to the summary (one block, no separating chrome) and giving
-             * the summary the same display-font treatment used for section
-             * headings elsewhere makes it read as one coherent answer
-             * rather than badge + boilerplate + terse line.
-             */}
-            <div className="space-y-1.5">
-                {statusExplanation ? (
-                    <p className="text-sm leading-6 text-(--text-secondary)">{statusExplanation}</p>
-                ) : null}
-                <p className="font-(--font-display) text-h3 text-(--text-primary)">
-                    {refusedWithGrounding
-                        ? WITHHELD_COPY
-                        : safeCopy(answer.direct_summary, INTERNAL_TOKEN_DENYLIST, attested)}
-                </p>
-            </div>
+            <AnswerHeaderSection
+                asOf={answer.as_of}
+                statusExplanation={statusExplanation}
+                statusLabel={statusLabel}
+                summary={refusedWithGrounding ? WITHHELD_COPY : safeProse(answer.direct_summary)}
+            />
 
             {scopeResolution ? (
-                <section
-                    className="border-y border-(--border) py-3"
-                    aria-label="Resolved answer scope"
-                >
-                    <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
-                        <span className="text-(--text-muted)">
-                            Scope outcome:{" "}
-                            <strong className="font-medium text-(--text-secondary)">
-                                {scopeOutcomeTrusted
-                                    ? SCOPE_OUTCOME_LABELS[scopeResolution.outcome]
-                                    : SCOPE_OUTCOME_LABELS.forbidden_or_not_found}
-                            </strong>
-                        </span>
-                        <span className="text-(--text-muted)">
-                            {scopeCoverageLabel(scopeResolution)}
-                        </span>
-                    </div>
-                    {scopeResolution.candidates?.length ? (
-                        <div className="mt-3">
-                            {/*
-                             * Two different situations share this list.
-                             * Ambiguity means several authorized entities DID
-                             * match and one must be picked; a no-match means
-                             * none did and these are only the nearest names
-                             * (CHAOS-3366 fills them; empty today). Calling
-                             * the second "possible scope matches" would assert
-                             * the subject exists, which is the substitution
-                             * §12 prohibits.
-                             */}
-                            <p className="text-label-caps text-(--caution)">
-                                {noMatch ? "Closest matches" : "Possible scope matches"}
-                            </p>
-                            <ul className="mt-2 space-y-1 text-sm text-(--text-secondary)">
-                                {scopeResolution.candidates.map((candidate) => (
-                                    <li
-                                        key={`${candidate.entity_ref.entity_type}:${candidate.entity_ref.entity_id}`}
-                                        className="flex flex-wrap items-center justify-between gap-2"
-                                    >
-                                        <span>
-                                            {candidate.entity_ref.display_label} —{" "}
-                                            {candidate.reason}
-                                        </span>
-                                        <button
-                                            type="button"
-                                            onClick={() =>
-                                                selectProposedEntity(candidate.entity_ref)
-                                            }
-                                            className="rounded-(--radius-sm) border border-(--border) px-2 py-1 text-xs font-medium hover:border-(--accent)/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                                        >
-                                            {CTA_LABELS.useAskDevScope}
-                                        </button>
-                                    </li>
-                                ))}
-                            </ul>
-                            <p className="mt-2 text-xs text-(--text-muted)">
-                                {noMatch
-                                    ? "None of these is the subject you named. Pick one to ask about it instead."
-                                    : "Choose or remove the proposed context before asking the next question."}
-                            </p>
-                        </div>
-                    ) : null}
-                </section>
+                <ScopeSection
+                    noMatch={noMatch}
+                    onSelectCandidate={selectProposedEntity}
+                    outcomeLabel={
+                        scopeOutcomeTrusted
+                            ? SCOPE_OUTCOME_LABELS[scopeResolution.outcome]
+                            : SCOPE_OUTCOME_LABELS.forbidden_or_not_found
+                    }
+                    scopeResolution={scopeResolution}
+                />
             ) : null}
 
-            {showCoverage ? (
-                <section
-                    aria-label="Evidence coverage"
-                    className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-(--text-muted)"
-                >
-                    <span>
-                        Coverage:{" "}
-                        {formatNumber(answer.coverage?.available_source_count ?? 0, {
-                            maximumFractionDigits: 0,
-                        })}{" "}
-                        of{" "}
-                        {formatNumber(answer.coverage?.required_source_count ?? 0, {
-                            maximumFractionDigits: 0,
-                        })}{" "}
-                        sources
-                    </span>
-                    {answer.coverage?.unavailable_required_sources?.length ? (
-                        <span className="text-(--caution)">
-                            {answer.coverage.unavailable_required_sources.length} required sources
-                            unavailable
-                        </span>
-                    ) : null}
-                    {answer.coverage?.degraded_required_sources?.length ? (
-                        <span className="text-(--caution)">
-                            {answer.coverage.degraded_required_sources.length} required sources
-                            degraded
-                        </span>
-                    ) : null}
-                    {answer.coverage?.stale_required_sources?.length ? (
-                        <span className="text-(--caution)">
-                            {answer.coverage.stale_required_sources.length} required sources stale
-                        </span>
-                    ) : null}
-                </section>
-            ) : null}
+            {showCoverage ? <CoverageSection coverage={answer.coverage} /> : null}
 
             {/*
              * CHAOS-3377 HIGH: claims are model-authored prose, exactly
@@ -780,311 +491,65 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
              * relabeled-but-invented status.
              */}
             {!refusedWithGrounding && answer.claims?.length ? (
-                <section
-                    className="space-y-3 border-t border-(--border) pt-4"
-                    aria-labelledby={findingsHeadingId}
-                >
-                    <h3 id={findingsHeadingId} className="text-label-caps text-(--text-muted)">
-                        What the evidence suggests
-                    </h3>
-                    <ul className="space-y-3">
-                        {answer.claims.map((claim) => (
-                            <li key={claim.claim_id} className="flex gap-3 text-sm leading-6">
-                                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-(--accent)" />
-                                <div className="min-w-0">
-                                    <p>
-                                        {safeCopy(claim.text, INTERNAL_TOKEN_DENYLIST, attested)}
-                                        {renderInlineCitations(
-                                            claim.evidence_ref_ids,
-                                            claim.metric_ref_ids,
-                                            "claim",
-                                        )}
-                                    </p>
-                                    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-(--text-muted)">
-                                        <span>
-                                            {claim.kind.replaceAll("_", " ")} ·{" "}
-                                            {formatPercent(claim.confidence * 100)} confidence
-                                        </span>
-                                        {validityScopeLabel(claim.validity_scope) ? (
-                                            <span>
-                                                Applies to{" "}
-                                                {validityScopeLabel(claim.validity_scope)}
-                                            </span>
-                                        ) : null}
-                                        {claim.flags.stale ? (
-                                            <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
-                                                Stale
-                                            </span>
-                                        ) : null}
-                                        {claim.flags.uncertain ? (
-                                            <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
-                                                Uncertain
-                                            </span>
-                                        ) : null}
-                                        {claim.flags.conflicting ? (
-                                            <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
-                                                Conflicting
-                                            </span>
-                                        ) : null}
-                                        {claim.flags.untrusted_source ? (
-                                            <span className="rounded-(--radius-pill) bg-(--negative)/10 px-2 text-(--negative)">
-                                                Untrusted source
-                                            </span>
-                                        ) : null}
-                                    </div>
-                                </div>
-                            </li>
-                        ))}
-                    </ul>
-                </section>
+                <ClaimsSection
+                    claims={answer.claims}
+                    headingId={findingsHeadingId}
+                    safeProse={safeProse}
+                    targets={citationTargets}
+                />
             ) : null}
 
             {answer.conflicts?.length ? (
-                <section
-                    className="rounded-(--radius-md) border border-(--caution)/30 bg-(--caution)/8 p-3"
-                    aria-label="Conflicting evidence"
-                >
-                    <p className="text-label-caps text-(--caution)">Conflicting evidence</p>
-                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-(--text-secondary)">
-                        {answer.conflicts.map((conflict) => (
-                            <li key={conflict.summary}>
-                                {safeCopy(conflict.summary, INTERNAL_TOKEN_DENYLIST, attested)}
-                            </li>
-                        ))}
-                    </ul>
-                </section>
+                <ConflictsSection conflicts={answer.conflicts} safeProse={safeProse} />
             ) : null}
 
             {answer.metrics?.length ? (
-                <section
-                    className="border-t border-(--border) pt-4"
-                    aria-labelledby={metricsHeadingId}
-                >
-                    <h3 id={metricsHeadingId} className="text-label-caps text-(--text-muted)">
-                        Metrics
-                    </h3>
-                    <dl className="mt-2 divide-y divide-(--border)">
-                        {answer.metrics.map((metric) => (
-                            <div
-                                key={metric.metric_ref_id}
-                                id={metricAnchorId(
-                                    metricPositionById.get(metric.metric_ref_id) ?? 0,
-                                )}
-                                tabIndex={-1}
-                                className="scroll-mt-6 grid gap-1 py-3 outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-baseline"
-                            >
-                                <dt className="text-sm text-(--text-secondary)">
-                                    {metric.label}
-                                    {renderInlineCitations(
-                                        metric.evidence_ref_ids,
-                                        [],
-                                        `metric ${metric.label}`,
-                                    )}
-                                    <span className="mt-0.5 block text-xs text-(--text-muted)">
-                                        {metric.aggregation} · {metric.freshness} ·{" "}
-                                        {formatPercent(metric.coverage * 100)} coverage
-                                    </span>
-                                </dt>
-                                <dd className="text-left sm:text-right">
-                                    <span className="font-(--font-display) text-h3 text-(--text-primary)">
-                                        {metric.value == null
-                                            ? "Unavailable"
-                                            : formatMetricValue(metric.value, metric.unit)}
-                                    </span>
-                                    {metric.comparison_value != null ? (
-                                        <span className="ml-2 text-xs text-(--text-muted)">
-                                            vs{" "}
-                                            {formatMetricValue(
-                                                metric.comparison_value,
-                                                metric.unit,
-                                            )}
-                                        </span>
-                                    ) : null}
-                                    <details
-                                        open={openMetricIds.has(metric.metric_ref_id) || undefined}
-                                        className="mt-1 text-xs text-(--text-muted)"
-                                    >
-                                        <summary className="cursor-pointer font-medium text-(--text-secondary)">
-                                            Metric definition
-                                        </summary>
-                                        <dl className="mt-2 grid gap-x-3 gap-y-1 text-left sm:grid-cols-[auto_minmax(0,1fr)]">
-                                            <dt>Unit</dt>
-                                            <dd>{metric.unit}</dd>
-                                            <dt>Definition version</dt>
-                                            <dd>{metric.definition_version}</dd>
-                                            <dt>Query version</dt>
-                                            <dd>{metric.query_version}</dd>
-                                            <dt>Source version</dt>
-                                            <dd>{metric.source_version}</dd>
-                                            <dt>Current window</dt>
-                                            <dd>
-                                                {formatTimestamp(metric.current_window.start)} –{" "}
-                                                {formatTimestamp(metric.current_window.end)}
-                                            </dd>
-                                            {metric.comparison_window ? (
-                                                <>
-                                                    <dt>Comparison window</dt>
-                                                    <dd>
-                                                        {formatTimestamp(
-                                                            metric.comparison_window.start,
-                                                        )}{" "}
-                                                        –{" "}
-                                                        {formatTimestamp(
-                                                            metric.comparison_window.end,
-                                                        )}
-                                                    </dd>
-                                                </>
-                                            ) : null}
-                                        </dl>
-                                    </details>
-                                </dd>
-                            </div>
-                        ))}
-                    </dl>
-                </section>
+                <MetricsSection
+                    headingId={metricsHeadingId}
+                    metricAnchorId={metricAnchorId}
+                    metricPositionById={metricPositionById}
+                    metrics={answer.metrics}
+                    openMetricIds={openMetricIds}
+                    targets={citationTargets}
+                />
             ) : null}
 
             {answer.evidence?.length ? (
-                <section
-                    className="space-y-3 border-t border-(--border) pt-4"
-                    aria-labelledby={evidenceHeadingId}
-                >
-                    {/*
-                     * CHAOS-3524: the lane's own fold toggle and the
-                     * "unfold all" action are icon-only buttons (chevron /
-                     * unfold glyph, aria-label carries the name) — "Evidence"
-                     * is the section's static title, not itself a
-                     * fold/unfold instruction, so it stays outside both
-                     * buttons as plain heading text.
-                     */}
-                    <div className="flex items-center justify-between gap-2">
-                        <h3 id={evidenceHeadingId} className="text-label-caps text-(--text-muted)">
-                            Evidence
-                        </h3>
-                        <div className="flex items-center gap-1">
-                            <button
-                                type="button"
-                                onClick={unfoldAllEvidence}
-                                aria-label={CTA_LABELS.unfoldAllEvidence}
-                                className="rounded-(--radius-sm) p-1 text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                            >
-                                <span aria-hidden="true">⤢</span>
-                            </button>
-                            <button
-                                type="button"
-                                onClick={() => setEvidenceLaneOpen((open) => !open)}
-                                aria-expanded={evidenceLaneOpen}
-                                aria-controls={evidenceListId}
-                                aria-label={
-                                    evidenceLaneOpen
-                                        ? CTA_LABELS.collapseEvidenceLane
-                                        : CTA_LABELS.expandEvidenceLane
-                                }
-                                className="rounded-(--radius-sm) p-1 text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                            >
-                                <span aria-hidden="true">{evidenceLaneOpen ? "▾" : "▸"}</span>
-                            </button>
-                        </div>
-                    </div>
-                    {/*
-                     * Native `hidden` attribute, not a conditional
-                     * unmount/CSS-class toggle: this codebase's tests run
-                     * without compiled Tailwind CSS (a `hidden` class
-                     * wouldn't actually hide anything for `toBeVisible()`
-                     * purposes), but the native attribute is a real HTML5 UA
-                     * behavior jsdom honors directly. Keeping the rows
-                     * always mounted (just hidden) also means
-                     * `document.getElementById(anchorId)` keeps working
-                     * immediately when a citation click both unfolds the
-                     * lane and focuses a row in the same flow, with no
-                     * mount-timing race to reason about.
-                     */}
-                    <div id={evidenceListId} hidden={!evidenceLaneOpen} className="space-y-3">
-                        {answer.evidence.map((evidence) => (
-                            <EvidenceRow
-                                key={evidence.evidence_ref_id}
-                                anchorId={evidenceAnchorId(
-                                    evidencePositionById.get(evidence.evidence_ref_id) ?? 0,
-                                )}
-                                error={evidenceErrors[evidence.evidence_ref_id] ?? null}
-                                evidence={evidence}
-                                expansion={evidenceExpansions[evidence.evidence_ref_id] ?? null}
-                                loading={loadingEvidenceIds.has(evidence.evidence_ref_id)}
-                                onToggleOpen={() => toggleEvidenceRow(evidence.evidence_ref_id)}
-                                open={openEvidenceRowIds.has(evidence.evidence_ref_id)}
-                                openExpansion={() => openEvidenceDetail(evidence.evidence_ref_id)}
-                            />
-                        ))}
-                    </div>
-                </section>
+                <EvidenceSection
+                    evidence={answer.evidence}
+                    evidenceAnchorId={evidenceAnchorId}
+                    evidenceErrors={evidenceErrors}
+                    evidenceExpansions={evidenceExpansions}
+                    evidencePositionById={evidencePositionById}
+                    headingId={evidenceHeadingId}
+                    laneOpen={evidenceLaneOpen}
+                    listId={evidenceListId}
+                    loadingEvidenceIds={loadingEvidenceIds}
+                    onOpenExpansion={openEvidenceDetail}
+                    onToggleLane={() => setEvidenceLaneOpen((open) => !open)}
+                    onToggleRow={toggleEvidenceRow}
+                    onUnfoldAll={unfoldAllEvidence}
+                    openEvidenceRowIds={openEvidenceRowIds}
+                />
             ) : null}
 
             {answer.warnings?.length ? (
-                <section
-                    className="rounded-(--radius-md) border border-(--caution)/30 bg-(--caution)/8 p-3"
-                    aria-label="Answer limitations"
-                >
-                    <p className="text-label-caps text-(--caution)">Limitations</p>
-                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-(--text-secondary)">
-                        {answer.warnings.map((warning) => (
-                            <li key={warning}>
-                                {safeCopy(warning, INTERNAL_TOKEN_DENYLIST, attested)}
-                            </li>
-                        ))}
-                    </ul>
-                </section>
+                <LimitationsSection safeProse={safeProse} warnings={answer.warnings} />
             ) : null}
 
             {answer.suggested_follow_up_questions?.length ? (
-                <section
-                    className="space-y-2 border-t border-(--border) pt-4"
-                    aria-label="Suggested follow-up questions"
-                >
-                    <p className="text-label-caps text-(--text-muted)">Ask next</p>
-                    <div className="flex flex-wrap gap-2">
-                        {answer.suggested_follow_up_questions.map((question) => (
-                            <button
-                                key={question}
-                                type="button"
-                                onClick={() => void submitQuestion(question)}
-                                className="rounded-(--radius-pill) border border-(--border) px-3 py-1.5 text-left text-xs text-(--text-secondary) hover:border-(--accent)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
-                            >
-                                {safeCopy(question, INTERNAL_TOKEN_DENYLIST, attested)}
-                            </button>
-                        ))}
-                    </div>
-                </section>
+                <FollowUpSection
+                    onAsk={(question) => void submitQuestion(question)}
+                    questions={answer.suggested_follow_up_questions}
+                    safeProse={safeProse}
+                />
             ) : null}
 
-            <footer className="flex flex-wrap items-center gap-2 border-t border-(--border) pt-4">
-                <span className="mr-1 text-xs text-(--text-muted)">Was this useful?</span>
-                <button
-                    type="button"
-                    disabled={feedback === "saving" || feedback === "helpful"}
-                    onClick={() => void sendFeedback("helpful")}
-                    className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--positive)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--positive)/45 disabled:opacity-55"
-                >
-                    {CTA_LABELS.askDevHelpful}
-                </button>
-                <button
-                    type="button"
-                    disabled={feedback === "saving" || feedback === "not_helpful"}
-                    onClick={() => void sendFeedback("not_helpful")}
-                    className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--caution)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--caution)/45 disabled:opacity-55"
-                >
-                    {CTA_LABELS.askDevNotHelpful}
-                </button>
-                {feedback === "helpful" || feedback === "not_helpful" ? (
-                    <span role="status" className="text-xs text-(--positive)">
-                        Feedback saved.
-                    </span>
-                ) : null}
-                {feedbackError ? (
-                    <span role="alert" className="text-xs text-(--negative)">
-                        {feedbackError}
-                    </span>
-                ) : null}
-            </footer>
+            <FeedbackFooter
+                error={feedbackError}
+                onRate={(rating) => void sendFeedback(rating)}
+                state={feedback}
+            />
         </article>
     );
 }

--- a/src/components/ask-dev/answer/AnswerHeaderSection.tsx
+++ b/src/components/ask-dev/answer/AnswerHeaderSection.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { formatTimestamp } from "@/lib/formatters";
+
+/**
+ * The answer's identity row and its primary content.
+ *
+ * Returns a Fragment, not a wrapper element: the two blocks are direct
+ * children of the answer `article`, whose `space-y-5` supplies the rhythm
+ * between every top-level section. Wrapping them would collapse that gap into
+ * one slot and silently re-space the whole answer.
+ *
+ * `summary` and `statusExplanation` arrive already resolved by the container —
+ * the withhold-vs-render decision for a self-contradictory row belongs in one
+ * place beside the predicates that diagnose it, not duplicated per section.
+ *
+ * The direct answer is the primary content (TRD §16: scope → question →
+ * answer → evidence/metrics → follow-up; CHAOS-3291). Previously the status
+ * caption rendered as an isolated text-xs line and direct_summary as plain
+ * text-body — same visual weight as the supporting chrome below it, so a thin
+ * answer (e.g. "Status: partial.") read as smaller and less important than
+ * the Evidence block. Keeping the caption tightly coupled to the summary (one
+ * block, no separating chrome) and giving the summary the same display-font
+ * treatment used for section headings elsewhere makes it read as one coherent
+ * answer rather than badge + boilerplate + terse line.
+ */
+export function AnswerHeaderSection({
+    asOf,
+    statusExplanation,
+    statusLabel,
+    summary,
+}: {
+    asOf: string;
+    statusExplanation: string | undefined;
+    statusLabel: string;
+    summary: string;
+}) {
+    return (
+        <>
+            <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-(--radius-pill) bg-(--accent-ai)/12 px-2.5 py-1 text-label-caps text-(--accent-ai)">
+                    AI-generated
+                </span>
+                <span className="rounded-(--radius-pill) border border-(--border) px-2.5 py-1 text-label-caps text-(--text-muted)">
+                    {statusLabel}
+                </span>
+                <span className="text-xs text-(--text-muted)">As of {formatTimestamp(asOf)}</span>
+            </div>
+
+            <div className="space-y-1.5">
+                {statusExplanation ? (
+                    <p className="text-sm leading-6 text-(--text-secondary)">{statusExplanation}</p>
+                ) : null}
+                <p className="font-(--font-display) text-h3 text-(--text-primary)">{summary}</p>
+            </div>
+        </>
+    );
+}

--- a/src/components/ask-dev/answer/ClaimsSection.tsx
+++ b/src/components/ask-dev/answer/ClaimsSection.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+import { formatPercent } from "@/lib/formatters";
+
+import { InlineCitations, type CitationTargets } from "./InlineCitations";
+import { validityScopeLabel, type SafeProse } from "./labels";
+
+/**
+ * The claim list ("What the evidence suggests").
+ *
+ * Claim text is model-authored, so it goes through `safeProse` exactly as
+ * `direct_summary` does. Whether the section renders at all is the container's
+ * call: CHAOS-3377 HIGH withholds a refused-with-grounding row's claims
+ * entirely rather than showing them under a relabeled status.
+ */
+export function ClaimsSection({
+    claims,
+    headingId,
+    safeProse,
+    targets,
+}: {
+    claims: NonNullable<DevAnswer["claims"]>;
+    headingId: string;
+    safeProse: SafeProse;
+    targets: CitationTargets;
+}) {
+    return (
+        <section className="space-y-3 border-t border-(--border) pt-4" aria-labelledby={headingId}>
+            <h3 id={headingId} className="text-label-caps text-(--text-muted)">
+                What the evidence suggests
+            </h3>
+            <ul className="space-y-3">
+                {claims.map((claim) => (
+                    <li key={claim.claim_id} className="flex gap-3 text-sm leading-6">
+                        <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-(--accent)" />
+                        <div className="min-w-0">
+                            <p>
+                                {safeProse(claim.text)}
+                                <InlineCitations
+                                    evidenceRefIds={claim.evidence_ref_ids}
+                                    metricRefIds={claim.metric_ref_ids}
+                                    ownerLabel="claim"
+                                    targets={targets}
+                                />
+                            </p>
+                            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-(--text-muted)">
+                                <span>
+                                    {claim.kind.replaceAll("_", " ")} ·{" "}
+                                    {formatPercent(claim.confidence * 100)} confidence
+                                </span>
+                                {validityScopeLabel(claim.validity_scope) ? (
+                                    <span>
+                                        Applies to {validityScopeLabel(claim.validity_scope)}
+                                    </span>
+                                ) : null}
+                                {claim.flags.stale ? (
+                                    <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
+                                        Stale
+                                    </span>
+                                ) : null}
+                                {claim.flags.uncertain ? (
+                                    <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
+                                        Uncertain
+                                    </span>
+                                ) : null}
+                                {claim.flags.conflicting ? (
+                                    <span className="rounded-(--radius-pill) bg-(--caution)/10 px-2 text-(--caution)">
+                                        Conflicting
+                                    </span>
+                                ) : null}
+                                {claim.flags.untrusted_source ? (
+                                    <span className="rounded-(--radius-pill) bg-(--negative)/10 px-2 text-(--negative)">
+                                        Untrusted source
+                                    </span>
+                                ) : null}
+                            </div>
+                        </div>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/ConflictsSection.tsx
+++ b/src/components/ask-dev/answer/ConflictsSection.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+
+import type { SafeProse } from "./labels";
+
+/** Server-declared disagreements between sources. Model-authored prose, so
+ * every summary goes through `safeProse`. */
+export function ConflictsSection({
+    conflicts,
+    safeProse,
+}: {
+    conflicts: NonNullable<DevAnswer["conflicts"]>;
+    safeProse: SafeProse;
+}) {
+    return (
+        <section
+            className="rounded-(--radius-md) border border-(--caution)/30 bg-(--caution)/8 p-3"
+            aria-label="Conflicting evidence"
+        >
+            <p className="text-label-caps text-(--caution)">Conflicting evidence</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-(--text-secondary)">
+                {conflicts.map((conflict) => (
+                    <li key={conflict.summary}>{safeProse(conflict.summary)}</li>
+                ))}
+            </ul>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/CoverageSection.tsx
+++ b/src/components/ask-dev/answer/CoverageSection.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+import { formatNumber } from "@/lib/formatters";
+
+/**
+ * Per-source coverage for this answer.
+ *
+ * Whether this block appears at all is the container's call (see
+ * `showCoverage`): "0 of 0 sources" reads as a measurement that happened, and
+ * a source plan that never ran must not render one. Once mounted, every
+ * required-source state the answer actually carries is named — a visibly
+ * downgraded answer with nothing on screen explaining the downgrade is the
+ * defect CHAOS-3219 W4 fixed.
+ */
+export function CoverageSection({ coverage }: { coverage: DevAnswer["coverage"] }) {
+    return (
+        <section
+            aria-label="Evidence coverage"
+            className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-(--text-muted)"
+        >
+            <span>
+                Coverage:{" "}
+                {formatNumber(coverage?.available_source_count ?? 0, {
+                    maximumFractionDigits: 0,
+                })}{" "}
+                of{" "}
+                {formatNumber(coverage?.required_source_count ?? 0, {
+                    maximumFractionDigits: 0,
+                })}{" "}
+                sources
+            </span>
+            {coverage?.unavailable_required_sources?.length ? (
+                <span className="text-(--caution)">
+                    {coverage.unavailable_required_sources.length} required sources unavailable
+                </span>
+            ) : null}
+            {coverage?.degraded_required_sources?.length ? (
+                <span className="text-(--caution)">
+                    {coverage.degraded_required_sources.length} required sources degraded
+                </span>
+            ) : null}
+            {coverage?.stale_required_sources?.length ? (
+                <span className="text-(--caution)">
+                    {coverage.stale_required_sources.length} required sources stale
+                </span>
+            ) : null}
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/EvidenceRow.tsx
+++ b/src/components/ask-dev/answer/EvidenceRow.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import Link from "next/link";
+
+import { CTA_LABELS, toggleEvidenceItem } from "@/lib/design/cta";
+import type { DevEvidenceExpansion, DevEvidenceRef } from "@/lib/dev/generated";
+import { formatTimestamp } from "@/lib/formatters";
+
+import { safeExcerpt } from "./labels";
+
+/**
+ * CHAOS-3524 (chris's evidence-layout ruling): each evidence item is its own
+ * accordion row, default folded. The row's header (label + provenance) stays
+ * visible even folded — that's the disclosure trigger a reader sees and
+ * clicks — only the detail beneath it (citation text, the "Open evidence"
+ * fetch action, the fetched excerpt, errors, the artifact link) is hidden
+ * until `open`. The fold toggle itself is icon-only (a chevron, aria-label
+ * carries the real name) per chris's "buttons/iconography only, no text
+ * labels" rule; `evidence.display_label` sitting in the same clickable
+ * header is the row's identifying TITLE, not an instructional fold/unfold
+ * label, so it stays as visible text.
+ */
+export function EvidenceRow({
+    anchorId,
+    error,
+    evidence,
+    expansion,
+    loading,
+    onToggleOpen,
+    open,
+    openExpansion,
+}: {
+    anchorId: string;
+    error: string | null;
+    evidence: DevEvidenceRef;
+    expansion: DevEvidenceExpansion | null;
+    loading: boolean;
+    onToggleOpen: () => void;
+    open: boolean;
+    openExpansion: () => Promise<void>;
+}) {
+    const internalPath = evidence.link?.internal_path;
+
+    return (
+        <div
+            id={anchorId}
+            tabIndex={-1}
+            className="scroll-mt-6 space-y-1.5 border-l-2 border-(--border) pl-3 outline-none focus-visible:border-(--accent)"
+        >
+            <button
+                type="button"
+                onClick={onToggleOpen}
+                aria-expanded={open}
+                aria-label={toggleEvidenceItem(evidence.display_label, open)}
+                className="flex w-full min-w-0 items-start gap-2 rounded-(--radius-sm) py-0.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+            >
+                <span aria-hidden="true" className="mt-0.5 shrink-0 text-(--text-muted)">
+                    {open ? "▾" : "▸"}
+                </span>
+                <span className="flex min-w-0 flex-col gap-0.5">
+                    <span className="text-sm text-(--text-secondary)">
+                        {evidence.display_label}
+                    </span>
+                    <span className="text-xs text-(--text-muted)">
+                        {evidence.provenance} · {formatTimestamp(evidence.observed_at)}
+                    </span>
+                </span>
+            </button>
+            {open ? (
+                <div className="space-y-1.5 pl-5">
+                    {evidence.citation_text ? (
+                        <p className="text-xs leading-5 text-(--text-muted)">
+                            {evidence.citation_text}
+                        </p>
+                    ) : null}
+                    {/*
+                     * Quiet by default (text-muted, no fill) — this is a
+                     * secondary, on-demand affordance, not a primary CTA; it
+                     * only picks up accent color on hover/focus (CHAOS-3291).
+                     * Unlike the fold toggle above, this triggers a real
+                     * server fetch (the deep excerpt) rather than showing
+                     * already-loaded content, so it keeps its sanctioned
+                     * text label rather than becoming icon-only.
+                     */}
+                    <button
+                        type="button"
+                        onClick={() => void openExpansion()}
+                        disabled={loading}
+                        className="rounded-(--radius-sm) px-2 py-1 text-xs font-medium text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
+                    >
+                        {loading ? "Opening…" : CTA_LABELS.openEvidence}
+                    </button>
+                    {expansion ? (
+                        <div className="rounded-(--radius-md) bg-(--background)/60 p-3 text-sm leading-6 text-(--text-secondary)">
+                            <p className="text-label-caps text-(--text-muted)">
+                                {expansion.state.replaceAll("_", " ")}
+                            </p>
+                            {safeExcerpt(expansion.safe_excerpt) ? (
+                                <p className="mt-2 whitespace-pre-wrap">
+                                    {safeExcerpt(expansion.safe_excerpt)}
+                                </p>
+                            ) : (
+                                <p className="mt-2">No additional excerpt is available.</p>
+                            )}
+                            {expansion.warning ? (
+                                <p className="mt-2 text-(--caution)">{expansion.warning}</p>
+                            ) : null}
+                        </div>
+                    ) : null}
+                    {error ? (
+                        <p role="alert" className="text-xs text-(--negative)">
+                            {error}
+                        </p>
+                    ) : null}
+                    {internalPath ? (
+                        <Link
+                            href={internalPath}
+                            className="inline-flex text-xs font-medium text-(--accent) underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                        >
+                            {CTA_LABELS.openArtifact}
+                        </Link>
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/src/components/ask-dev/answer/EvidenceSection.tsx
+++ b/src/components/ask-dev/answer/EvidenceSection.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { DevAnswer, DevEvidenceExpansion } from "@/lib/dev/generated";
+
+import { EvidenceRow } from "./EvidenceRow";
+
+/**
+ * The evidence lane: a foldable list of independently foldable rows.
+ *
+ * CHAOS-3524 (chris's evidence-layout ruling): the lane's own fold toggle and
+ * the "unfold all" action are icon-only buttons (chevron / unfold glyph,
+ * aria-label carries the name) — "Evidence" is the section's static title, not
+ * itself a fold/unfold instruction, so it stays outside both buttons as plain
+ * heading text.
+ *
+ * All fold state lives in the container, not here: a citation click has to
+ * unfold the lane AND one specific row synchronously, in the same handler
+ * flush, before the focus call that follows the async excerpt fetch can find
+ * the row in the DOM.
+ */
+export function EvidenceSection({
+    evidence,
+    evidenceAnchorId,
+    evidenceErrors,
+    evidenceExpansions,
+    evidencePositionById,
+    headingId,
+    laneOpen,
+    listId,
+    loadingEvidenceIds,
+    onOpenExpansion,
+    onToggleLane,
+    onToggleRow,
+    onUnfoldAll,
+    openEvidenceRowIds,
+}: {
+    evidence: NonNullable<DevAnswer["evidence"]>;
+    evidenceAnchorId: (position: number) => string;
+    evidenceErrors: Readonly<Record<string, string>>;
+    evidenceExpansions: Readonly<Record<string, DevEvidenceExpansion>>;
+    evidencePositionById: ReadonlyMap<string, number>;
+    headingId: string;
+    laneOpen: boolean;
+    listId: string;
+    loadingEvidenceIds: ReadonlySet<string>;
+    onOpenExpansion: (evidenceRefId: string) => Promise<void>;
+    onToggleLane: () => void;
+    onToggleRow: (evidenceRefId: string) => void;
+    onUnfoldAll: () => void;
+    openEvidenceRowIds: ReadonlySet<string>;
+}) {
+    return (
+        <section className="space-y-3 border-t border-(--border) pt-4" aria-labelledby={headingId}>
+            <div className="flex items-center justify-between gap-2">
+                <h3 id={headingId} className="text-label-caps text-(--text-muted)">
+                    Evidence
+                </h3>
+                <div className="flex items-center gap-1">
+                    <button
+                        type="button"
+                        onClick={onUnfoldAll}
+                        aria-label={CTA_LABELS.unfoldAllEvidence}
+                        className="rounded-(--radius-sm) p-1 text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                    >
+                        <span aria-hidden="true">⤢</span>
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onToggleLane}
+                        aria-expanded={laneOpen}
+                        aria-controls={listId}
+                        aria-label={
+                            laneOpen
+                                ? CTA_LABELS.collapseEvidenceLane
+                                : CTA_LABELS.expandEvidenceLane
+                        }
+                        className="rounded-(--radius-sm) p-1 text-(--text-muted) hover:bg-(--accent)/10 hover:text-(--accent) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                    >
+                        <span aria-hidden="true">{laneOpen ? "▾" : "▸"}</span>
+                    </button>
+                </div>
+            </div>
+            {/*
+             * Native `hidden` attribute, not a conditional
+             * unmount/CSS-class toggle: this codebase's tests run
+             * without compiled Tailwind CSS (a `hidden` class
+             * wouldn't actually hide anything for `toBeVisible()`
+             * purposes), but the native attribute is a real HTML5 UA
+             * behavior jsdom honors directly. Keeping the rows
+             * always mounted (just hidden) also means
+             * `document.getElementById(anchorId)` keeps working
+             * immediately when a citation click both unfolds the
+             * lane and focuses a row in the same flow, with no
+             * mount-timing race to reason about.
+             */}
+            <div id={listId} hidden={!laneOpen} className="space-y-3">
+                {evidence.map((item) => (
+                    <EvidenceRow
+                        key={item.evidence_ref_id}
+                        anchorId={evidenceAnchorId(
+                            evidencePositionById.get(item.evidence_ref_id) ?? 0,
+                        )}
+                        error={evidenceErrors[item.evidence_ref_id] ?? null}
+                        evidence={item}
+                        expansion={evidenceExpansions[item.evidence_ref_id] ?? null}
+                        loading={loadingEvidenceIds.has(item.evidence_ref_id)}
+                        onToggleOpen={() => onToggleRow(item.evidence_ref_id)}
+                        open={openEvidenceRowIds.has(item.evidence_ref_id)}
+                        openExpansion={() => onOpenExpansion(item.evidence_ref_id)}
+                    />
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/FeedbackFooter.tsx
+++ b/src/components/ask-dev/answer/FeedbackFooter.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { CTA_LABELS } from "@/lib/design/cta";
+
+/** The rating this footer has committed, or `saving` while the request is in
+ * flight. `null` means nothing has been submitted for this answer yet. */
+export type FeedbackState = "helpful" | "not_helpful" | "saving" | null;
+
+/**
+ * Beta feedback for one answer.
+ *
+ * Deliberately narrow today: a binary rating is all the wire vocabulary
+ * supports being asked for honestly. The reason dimensions the contract
+ * already carries are not surfaced yet, and the two the provider currently
+ * sends are inferred from the rating rather than chosen by the reader — so
+ * this component asks only the question it can actually record.
+ */
+export function FeedbackFooter({
+    error,
+    onRate,
+    state,
+}: {
+    error: string | null;
+    onRate: (rating: "helpful" | "not_helpful") => void;
+    state: FeedbackState;
+}) {
+    return (
+        <footer className="flex flex-wrap items-center gap-2 border-t border-(--border) pt-4">
+            <span className="mr-1 text-xs text-(--text-muted)">Was this useful?</span>
+            <button
+                type="button"
+                disabled={state === "saving" || state === "helpful"}
+                onClick={() => onRate("helpful")}
+                className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--positive)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--positive)/45 disabled:opacity-55"
+            >
+                {CTA_LABELS.askDevHelpful}
+            </button>
+            <button
+                type="button"
+                disabled={state === "saving" || state === "not_helpful"}
+                onClick={() => onRate("not_helpful")}
+                className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--caution)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--caution)/45 disabled:opacity-55"
+            >
+                {CTA_LABELS.askDevNotHelpful}
+            </button>
+            {state === "helpful" || state === "not_helpful" ? (
+                <span role="status" className="text-xs text-(--positive)">
+                    Feedback saved.
+                </span>
+            ) : null}
+            {error ? (
+                <span role="alert" className="text-xs text-(--negative)">
+                    {error}
+                </span>
+            ) : null}
+        </footer>
+    );
+}

--- a/src/components/ask-dev/answer/FollowUpSection.tsx
+++ b/src/components/ask-dev/answer/FollowUpSection.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { SafeProse } from "./labels";
+
+/**
+ * Server-suggested next questions.
+ *
+ * These are prompts, not answers: clicking one submits that question as a new
+ * run through the same path a typed question takes. Nothing here pre-computes
+ * or hardcodes a result, and nothing here changes the committed scope.
+ */
+export function FollowUpSection({
+    onAsk,
+    questions,
+    safeProse,
+}: {
+    onAsk: (question: string) => void;
+    questions: readonly string[];
+    safeProse: SafeProse;
+}) {
+    return (
+        <section
+            className="space-y-2 border-t border-(--border) pt-4"
+            aria-label="Suggested follow-up questions"
+        >
+            <p className="text-label-caps text-(--text-muted)">Ask next</p>
+            <div className="flex flex-wrap gap-2">
+                {questions.map((question) => (
+                    <button
+                        key={question}
+                        type="button"
+                        onClick={() => onAsk(question)}
+                        className="rounded-(--radius-pill) border border-(--border) px-3 py-1.5 text-left text-xs text-(--text-secondary) hover:border-(--accent)/45 hover:text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                    >
+                        {safeProse(question)}
+                    </button>
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/InlineCitations.tsx
+++ b/src/components/ask-dev/answer/InlineCitations.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * Everything an inline citation badge needs to resolve a ref id into a
+ * clickable, correctly-numbered anchor.
+ *
+ * Positions come from the answer's OWN evidence/metric arrays, so `E3` always
+ * means "the third evidence entry of this answer" — a citation can never
+ * address a ref this answer does not carry, and an unknown id renders nothing
+ * rather than a badge that leads somewhere else (CHAOS-3215 M6: detail-panel
+ * ids are scoped per answer for the same reason).
+ */
+export type CitationTargets = Readonly<{
+    evidencePositionById: ReadonlyMap<string, number>;
+    metricPositionById: ReadonlyMap<string, number>;
+    loadingEvidenceIds: ReadonlySet<string>;
+    openEvidence: (evidenceRefId: string) => void;
+    openMetric: (metricRefId: string) => void;
+}>;
+
+export function InlineCitations({
+    evidenceRefIds = [],
+    metricRefIds = [],
+    ownerLabel,
+    targets,
+}: {
+    evidenceRefIds?: readonly string[];
+    metricRefIds?: readonly string[];
+    ownerLabel: string;
+    targets: CitationTargets;
+}) {
+    const {
+        evidencePositionById,
+        loadingEvidenceIds,
+        metricPositionById,
+        openEvidence,
+        openMetric,
+    } = targets;
+    const knownEvidenceRefs = evidenceRefIds.filter((id) => evidencePositionById.has(id));
+    const knownMetricRefs = metricRefIds.filter((id) => metricPositionById.has(id));
+    if (!knownEvidenceRefs.length && !knownMetricRefs.length) return null;
+
+    return (
+        <span className="ml-2 inline-flex flex-wrap gap-1 align-baseline" aria-label="Citations">
+            {knownEvidenceRefs.map((evidenceRefId) => {
+                const position = evidencePositionById.get(evidenceRefId)!;
+                return (
+                    <button
+                        key={evidenceRefId}
+                        type="button"
+                        onClick={() => openEvidence(evidenceRefId)}
+                        disabled={loadingEvidenceIds.has(evidenceRefId)}
+                        aria-label={`Open evidence citation ${position + 1} for ${ownerLabel}`}
+                        className="rounded-(--radius-sm) bg-(--accent)/10 px-1.5 py-0.5 font-mono text-[0.6875rem] font-medium leading-none text-(--accent) hover:bg-(--accent)/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-50"
+                    >
+                        E{position + 1}
+                    </button>
+                );
+            })}
+            {knownMetricRefs.map((metricRefId) => {
+                const position = metricPositionById.get(metricRefId)!;
+                return (
+                    <button
+                        key={metricRefId}
+                        type="button"
+                        onClick={() => openMetric(metricRefId)}
+                        aria-label={`Open metric citation ${position + 1} for ${ownerLabel}`}
+                        className="rounded-(--radius-sm) bg-(--accent-ai)/10 px-1.5 py-0.5 font-mono text-[0.6875rem] font-medium leading-none text-(--accent-ai) hover:bg-(--accent-ai)/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45"
+                    >
+                        M{position + 1}
+                    </button>
+                );
+            })}
+        </span>
+    );
+}

--- a/src/components/ask-dev/answer/LimitationsSection.tsx
+++ b/src/components/ask-dev/answer/LimitationsSection.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+
+import type { SafeProse } from "./labels";
+
+/**
+ * The answer's own declared limitations.
+ *
+ * `warnings` is free-text on the wire today, and model-authored, so each entry
+ * goes through `safeProse`. A typed limitation vocabulary would let this
+ * render a stable caption per kind instead of echoing prose; until the wire
+ * carries one, sanitizing is the only guard there is.
+ */
+export function LimitationsSection({
+    safeProse,
+    warnings,
+}: {
+    safeProse: SafeProse;
+    warnings: NonNullable<DevAnswer["warnings"]>;
+}) {
+    return (
+        <section
+            className="rounded-(--radius-md) border border-(--caution)/30 bg-(--caution)/8 p-3"
+            aria-label="Answer limitations"
+        >
+            <p className="text-label-caps text-(--caution)">Limitations</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-(--text-secondary)">
+                {warnings.map((warning) => (
+                    <li key={warning}>{safeProse(warning)}</li>
+                ))}
+            </ul>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/MetricsSection.tsx
+++ b/src/components/ask-dev/answer/MetricsSection.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+import { formatMetricValue, formatPercent, formatTimestamp } from "@/lib/formatters";
+
+import { InlineCitations, type CitationTargets } from "./InlineCitations";
+
+/**
+ * Registered metrics with their definition provenance.
+ *
+ * Every value is rendered through the shared formatters — a raw number here
+ * would be a design-lint failure as well as a units-free claim. `openMetricIds`
+ * comes from the container so a citation click can force the matching
+ * definition panel open and focus it (CHAOS-3215 M6).
+ */
+export function MetricsSection({
+    headingId,
+    metricAnchorId,
+    metricPositionById,
+    metrics,
+    openMetricIds,
+    targets,
+}: {
+    headingId: string;
+    metricAnchorId: (position: number) => string;
+    metricPositionById: ReadonlyMap<string, number>;
+    metrics: NonNullable<DevAnswer["metrics"]>;
+    openMetricIds: ReadonlySet<string>;
+    targets: CitationTargets;
+}) {
+    return (
+        <section className="border-t border-(--border) pt-4" aria-labelledby={headingId}>
+            <h3 id={headingId} className="text-label-caps text-(--text-muted)">
+                Metrics
+            </h3>
+            <dl className="mt-2 divide-y divide-(--border)">
+                {metrics.map((metric) => (
+                    <div
+                        key={metric.metric_ref_id}
+                        id={metricAnchorId(metricPositionById.get(metric.metric_ref_id) ?? 0)}
+                        tabIndex={-1}
+                        className="scroll-mt-6 grid gap-1 py-3 outline-none focus-visible:ring-2 focus-visible:ring-(--accent-ai)/45 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-baseline"
+                    >
+                        <dt className="text-sm text-(--text-secondary)">
+                            {metric.label}
+                            <InlineCitations
+                                evidenceRefIds={metric.evidence_ref_ids}
+                                ownerLabel={`metric ${metric.label}`}
+                                targets={targets}
+                            />
+                            <span className="mt-0.5 block text-xs text-(--text-muted)">
+                                {metric.aggregation} · {metric.freshness} ·{" "}
+                                {formatPercent(metric.coverage * 100)} coverage
+                            </span>
+                        </dt>
+                        <dd className="text-left sm:text-right">
+                            <span className="font-(--font-display) text-h3 text-(--text-primary)">
+                                {metric.value == null
+                                    ? "Unavailable"
+                                    : formatMetricValue(metric.value, metric.unit)}
+                            </span>
+                            {metric.comparison_value != null ? (
+                                <span className="ml-2 text-xs text-(--text-muted)">
+                                    vs {formatMetricValue(metric.comparison_value, metric.unit)}
+                                </span>
+                            ) : null}
+                            <details
+                                open={openMetricIds.has(metric.metric_ref_id) || undefined}
+                                className="mt-1 text-xs text-(--text-muted)"
+                            >
+                                <summary className="cursor-pointer font-medium text-(--text-secondary)">
+                                    Metric definition
+                                </summary>
+                                <dl className="mt-2 grid gap-x-3 gap-y-1 text-left sm:grid-cols-[auto_minmax(0,1fr)]">
+                                    <dt>Unit</dt>
+                                    <dd>{metric.unit}</dd>
+                                    <dt>Definition version</dt>
+                                    <dd>{metric.definition_version}</dd>
+                                    <dt>Query version</dt>
+                                    <dd>{metric.query_version}</dd>
+                                    <dt>Source version</dt>
+                                    <dd>{metric.source_version}</dd>
+                                    <dt>Current window</dt>
+                                    <dd>
+                                        {formatTimestamp(metric.current_window.start)} –{" "}
+                                        {formatTimestamp(metric.current_window.end)}
+                                    </dd>
+                                    {metric.comparison_window ? (
+                                        <>
+                                            <dt>Comparison window</dt>
+                                            <dd>
+                                                {formatTimestamp(metric.comparison_window.start)} –{" "}
+                                                {formatTimestamp(metric.comparison_window.end)}
+                                            </dd>
+                                        </>
+                                    ) : null}
+                                </dl>
+                            </details>
+                        </dd>
+                    </div>
+                ))}
+            </dl>
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/ScopeSection.tsx
+++ b/src/components/ask-dev/answer/ScopeSection.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { CTA_LABELS } from "@/lib/design/cta";
+import type { DevAnswer, DevScope } from "@/lib/dev/generated";
+
+import { scopeCoverageLabel } from "./labels";
+
+/**
+ * The entity-ref shape a candidate carries, derived from the scope contract
+ * rather than named directly — the generated module exposes `DevEntityRef`
+ * only inside positional tuple types. Structurally identical to
+ * `AskDevProvider`'s own private alias, so `selectProposedEntity` accepts one
+ * of these unchanged.
+ */
+type ScopeEntityRef = NonNullable<DevScope["entity_refs"]>[number];
+
+/**
+ * The resolved-scope row and, when the resolver returned any, the candidate
+ * list.
+ *
+ * `outcomeLabel` is resolved by the container rather than looked up here: a
+ * legacy row whose prose contradicts its own outcome has its outcome value
+ * WITHHELD (replaced with the collapsed no-authorized-match label), and that
+ * judgement belongs beside the predicate that makes it.
+ *
+ * Selecting a candidate proposes it as context — it never submits. CHAOS-3665
+ * and the PRD both forbid auto-selecting the first result, so this list has no
+ * default, no preselection, and no implicit commit.
+ */
+export function ScopeSection({
+    noMatch,
+    onSelectCandidate,
+    outcomeLabel,
+    scopeResolution,
+}: {
+    noMatch: boolean;
+    onSelectCandidate: (entityRef: ScopeEntityRef) => void;
+    outcomeLabel: string;
+    scopeResolution: NonNullable<DevAnswer["resolved_scope"]>;
+}) {
+    return (
+        <section className="border-y border-(--border) py-3" aria-label="Resolved answer scope">
+            <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
+                <span className="text-(--text-muted)">
+                    Scope outcome:{" "}
+                    <strong className="font-medium text-(--text-secondary)">{outcomeLabel}</strong>
+                </span>
+                <span className="text-(--text-muted)">{scopeCoverageLabel(scopeResolution)}</span>
+            </div>
+            {scopeResolution.candidates?.length ? (
+                <div className="mt-3">
+                    {/*
+                     * Two different situations share this list.
+                     * Ambiguity means several authorized entities DID
+                     * match and one must be picked; a no-match means
+                     * none did and these are only the nearest names
+                     * (CHAOS-3366 fills them; empty today). Calling
+                     * the second "possible scope matches" would assert
+                     * the subject exists, which is the substitution
+                     * §12 prohibits.
+                     */}
+                    <p className="text-label-caps text-(--caution)">
+                        {noMatch ? "Closest matches" : "Possible scope matches"}
+                    </p>
+                    <ul className="mt-2 space-y-1 text-sm text-(--text-secondary)">
+                        {scopeResolution.candidates.map((candidate) => (
+                            <li
+                                key={`${candidate.entity_ref.entity_type}:${candidate.entity_ref.entity_id}`}
+                                className="flex flex-wrap items-center justify-between gap-2"
+                            >
+                                <span>
+                                    {candidate.entity_ref.display_label} — {candidate.reason}
+                                </span>
+                                <button
+                                    type="button"
+                                    onClick={() => onSelectCandidate(candidate.entity_ref)}
+                                    className="rounded-(--radius-sm) border border-(--border) px-2 py-1 text-xs font-medium hover:border-(--accent)/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45"
+                                >
+                                    {CTA_LABELS.useAskDevScope}
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                    <p className="mt-2 text-xs text-(--text-muted)">
+                        {noMatch
+                            ? "None of these is the subject you named. Pick one to ask about it instead."
+                            : "Choose or remove the proposed context before asking the next question."}
+                    </p>
+                </div>
+            ) : null}
+        </section>
+    );
+}

--- a/src/components/ask-dev/answer/labels.ts
+++ b/src/components/ask-dev/answer/labels.ts
@@ -1,0 +1,77 @@
+import type { DevAnswer, DevScope } from "@/lib/dev/generated";
+
+/**
+ * Strip the UNTRUSTED_DATA fence the evidence service wraps a fetched excerpt
+ * in. The fence is a prompt-injection boundary for the model, not copy for a
+ * human, so it is removed at the last layer before display — the excerpt
+ * inside stays untrusted either way and is never interpreted, only shown.
+ */
+export function safeExcerpt(value: string | null | undefined): string | null {
+    if (!value) return null;
+    return value.replace(/^UNTRUSTED_DATA\r?\n/u, "").replace(/\r?\nEND_UNTRUSTED_DATA$/u, "");
+}
+
+/**
+ * Name the subject a scope applies to, rather than counting anonymous ids.
+ *
+ * Prefers the entity whose type matches the scope's own `direct_scope` — that
+ * is the named subject the reader asked about. Falls back to a counted label
+ * ("3 repositories") only when no such entity is on the wire, which keeps the
+ * row honest for a scope that genuinely commits to a set rather than one
+ * subject.
+ */
+export function validityScopeLabel(scope: DevScope | null | undefined): string | null {
+    if (!scope) return null;
+    const namedEntity = scope.entity_refs?.find(
+        (entity) => entity.entity_type === scope.direct_scope,
+    );
+    if (namedEntity) return namedEntity.display_label;
+    if (scope.direct_scope === "organization") return "Organization";
+    const count =
+        scope.direct_scope === "repository"
+            ? (scope.repositories?.length ?? 0)
+            : (scope.entity_refs?.filter((entity) => entity.entity_type === scope.direct_scope)
+                  .length ?? 0);
+    const label = scope.direct_scope.replaceAll("_", " ");
+    return count > 0 ? `${count} ${label}${count === 1 ? "" : "s"}` : label;
+}
+
+/**
+ * The scope-outcome row's secondary line (CHAOS-3377 defect 4).
+ *
+ * Previously always rendered "{authorized_repository_ids.length} authorized
+ * repositories", regardless of the resolved scope's own kind -- correct for
+ * a REPOSITORY-scoped answer, but for a PROJECT (or any other non-repository)
+ * scope the repository count is at best incidental and at worst reads as
+ * "0 authorized repositories" for a subject that has real, substantive
+ * content and simply carries no repository dimension on the wire (see
+ * ops's `ScopeResolutionService`/`DevScope.repositories`, which is only
+ * ever populated for a REPOSITORY commit). Reuses `validityScopeLabel` --
+ * the same "name the subject, not a count" logic `claim.validity_scope`
+ * already renders -- so a project scope shows its subject ("Falcon Nine")
+ * instead. Falls back to the repository count whenever the scope itself is
+ * missing or genuinely repository-scoped, which is unchanged behavior.
+ */
+export function scopeCoverageLabel(
+    scopeResolution: NonNullable<DevAnswer["resolved_scope"]>,
+): string {
+    const scope = scopeResolution.resolved_scope ?? scopeResolution.requested_scope;
+    if (scope && scope.direct_scope !== "repository") {
+        const subjectLabel = validityScopeLabel(scope);
+        if (subjectLabel) return subjectLabel;
+    }
+    const count = scopeResolution.authorized_repository_ids?.length ?? 0;
+    return `${count} authorized repositories`;
+}
+
+/**
+ * A prose sanitizer with its denylist and attested-string set already bound.
+ *
+ * Every section component that renders model-authored prose takes one of
+ * these rather than importing the denylist itself. Two reasons, both
+ * load-bearing: the denylist is derived from the TOTAL label maps that live
+ * in `AskDevAnswer.tsx` (importing it back from a section would be a cycle),
+ * and a section that must be *handed* its sanitizer cannot silently forget to
+ * apply one the way a section that constructs its own arguments can.
+ */
+export type SafeProse = (value: string | null | undefined) => string;

--- a/src/components/ask-dev/answerVocabularySource.test.ts
+++ b/src/components/ask-dev/answerVocabularySource.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Guards a cross-file invariant that is invisible from either side alone.
+ *
+ * `tests/ask-dev-vocabulary.spec.ts` cross-checks the sanctioned label maps in
+ * `AskDevAnswer.tsx` against the pinned JSON Schema enums, and it does so by
+ * reading that file as TEXT — it cannot import the module, because the "use
+ * client" import graph reaches a PNG asset that Playwright's standalone esbuild
+ * transform has no loader for. Its parser locates `export const <NAME>`, then
+ * the next `{`, then the next `};`, and takes the `key:` lines between them.
+ *
+ * That makes two things load-bearing which nothing in `AskDevAnswer.tsx`
+ * declares:
+ *
+ * 1. Both maps must physically live in that file. Extracting them to a sibling
+ *    module (as the answer-section extraction was otherwise free to do) makes
+ *    the Playwright parser throw — loudly, but only in the slow e2e tier, with
+ *    a cause invisible from the constant's new home.
+ * 2. The region between the map's opening `{` and the FIRST following `};`
+ *    must be exactly the map body. A nested object literal, or a comment
+ *    containing `};`, silently truncates or extends the parsed region — and
+ *    then the Playwright assertion compares a WRONG key set against the schema
+ *    enum. It would still pass or fail for reasons unrelated to the real
+ *    vocabulary, which is the worse outcome: a check that no longer measures
+ *    what it claims to.
+ *
+ * This test re-derives the same parse in the fast unit tier and asserts it
+ * agrees with what the module actually exports. It fails in seconds on a
+ * refactor that would otherwise fail late, or silently stop measuring.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ANSWER_STATUS_LABELS, SCOPE_OUTCOME_LABELS } from "./AskDevAnswer";
+
+const SOURCE_PATH = path.join(__dirname, "AskDevAnswer.tsx");
+
+/**
+ * A deliberate duplicate of `exportedLabelMapKeys` in
+ * `tests/ask-dev-vocabulary.spec.ts`. Duplicated rather than shared on
+ * purpose: the point is to exercise the same fragile text parse the e2e spec
+ * performs, against the same real file, without importing anything from the
+ * Playwright tier.
+ */
+function exportedLabelMapKeys(sourceText: string, exportName: string): readonly string[] {
+    const start = sourceText.indexOf(`export const ${exportName}`);
+    if (start === -1) throw new Error(`Could not find "export const ${exportName}" in source.`);
+    const openBrace = sourceText.indexOf("{", start);
+    const closeBrace = sourceText.indexOf("};", openBrace);
+    if (openBrace === -1 || closeBrace === -1) {
+        throw new Error(`Could not find the object literal body for "${exportName}".`);
+    }
+    const body = sourceText.slice(openBrace + 1, closeBrace);
+    const keyPattern = /^\s*([a-z][a-z0-9_]*)\s*:/gmu;
+    const keys: string[] = [];
+    for (const match of body.matchAll(keyPattern)) keys.push(match[1]!);
+    if (keys.length === 0)
+        throw new Error(`Found no keys for "${exportName}" — parsing likely broke.`);
+    return keys;
+}
+
+describe("sanctioned label maps stay text-parseable in AskDevAnswer.tsx", () => {
+    const cases = [
+        ["ANSWER_STATUS_LABELS", ANSWER_STATUS_LABELS],
+        ["SCOPE_OUTCOME_LABELS", SCOPE_OUTCOME_LABELS],
+    ] as const;
+
+    it.each(cases)(
+        "%s parses out of the real source to exactly the keys the module exports",
+        (exportName, map) => {
+            const source = readFileSync(SOURCE_PATH, "utf8");
+            const parsed = exportedLabelMapKeys(source, exportName).slice().sort();
+            expect(parsed).toEqual(Object.keys(map).slice().sort());
+        },
+    );
+
+    it.each(cases)("%s has no duplicate keys in the parsed region", (exportName) => {
+        const source = readFileSync(SOURCE_PATH, "utf8");
+        const parsed = exportedLabelMapKeys(source, exportName);
+        // A parsed region that swallowed a NEIGHBOURING map would still match
+        // the module's key set under a plain sort+compare if the neighbour is a
+        // subset; a duplicate key is the signal that the slice ran past its own
+        // literal.
+        expect(new Set(parsed).size).toBe(parsed.length);
+    });
+});

--- a/src/lib/dev/__tests__/contractTolerance.test.ts
+++ b/src/lib/dev/__tests__/contractTolerance.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Forward compatibility with a server ahead of this build's pinned contract.
+ *
+ * Every object in the pinned Ask Dev contract sets `additionalProperties:
+ * false`, and the client used to REJECT any undeclared key — so an additive
+ * server change killed the run for a web build pinned to an older commit,
+ * despite the manifest declaring "additive-within-v1". The reader saw a failed
+ * run instead of an answer.
+ *
+ * These assert the state the system exists to reach: a payload from a NEWER
+ * server still yields an answer, while a genuinely malformed one still fails.
+ * The fixtures are the checked-in canonical examples with the future surface
+ * added on top, so they mirror the real producer rather than a hand-shaped
+ * guess. `record_locator` and `graph_assisted` are the actual fields on their
+ * way, not invented names.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+    observedContractDrift,
+    resetContractDrift,
+    setContractDriftSink,
+    type ContractDriftRecord,
+} from "../contractDrift";
+import answerFixture from "../contracts/examples/positive/dev_answer.v1.json";
+import feedbackFixture from "../contracts/examples/positive/dev_feedback.v1.json";
+import answerSchema from "../contracts/schemas/dev_answer.v1.schema.json";
+import { DevApiError, consumeDevSseStream, createDevApiClient } from "../client";
+import type { DevStreamEvent } from "../generated";
+import { validatePinnedJsonSchema } from "../jsonSchemaValidation";
+
+const captured: ContractDriftRecord[] = [];
+
+beforeEach(() => {
+    resetContractDrift();
+    captured.length = 0;
+    setContractDriftSink((record) => captured.push(record));
+});
+
+afterEach(() => resetContractDrift());
+
+/** The canonical answer as a server one pin AHEAD of us would send it. */
+function futureAnswer(): Record<string, unknown> {
+    const answer = structuredClone(answerFixture) as Record<string, unknown>;
+    const evidence = answer.evidence as Record<string, unknown>[];
+    evidence[0]!.record_locator = "gh:pr/4821";
+    answer.graph_assisted = { state: "lagging", as_of: "2026-08-10T00:00:00Z" };
+    return answer;
+}
+
+function streamOf(events: readonly unknown[]): Response {
+    const body = events
+        .map(
+            (event) =>
+                `event: ${(event as { event: string }).event}\ndata: ${JSON.stringify(event)}\n\n`,
+        )
+        .join("");
+    return new Response(body, { headers: { "Content-Type": "text/event-stream" } });
+}
+
+function runWith(answer: unknown, extra: readonly unknown[] = []): readonly unknown[] {
+    return [
+        {
+            event: "run.started",
+            occurred_at: "2026-07-29T12:00:00Z",
+            run_id: "run_01",
+            schema_version: "dev_stream_event.v1",
+            sequence: 0,
+        },
+        ...extra,
+        {
+            answer,
+            event: "answer.completed",
+            occurred_at: "2026-07-29T12:00:01Z",
+            run_id: "run_01",
+            schema_version: "dev_stream_event.v1",
+            sequence: 1 + extra.length,
+        },
+        {
+            event: "done",
+            occurred_at: "2026-07-29T12:00:02Z",
+            run_id: "run_01",
+            schema_version: "dev_stream_event.v1",
+            sequence: 2 + extra.length,
+            terminal_kind: "answer",
+        },
+    ];
+}
+
+describe("unknown properties are ignored for parsing and reported", () => {
+    it("an answer carrying fields this pin does not declare still validates", () => {
+        expect(validatePinnedJsonSchema(futureAnswer(), answerSchema, () => {})).toBe(true);
+    });
+
+    it("reports the undeclared keys, at top level and nested inside a strict def", () => {
+        validatePinnedJsonSchema(futureAnswer(), answerSchema, (property) =>
+            captured.push({
+                kind: "unknown_property",
+                schemaVersion: "dev_answer.v1",
+                path: property.path,
+                name: property.key,
+            }),
+        );
+        const names = captured.map((record) => record.name);
+        expect(names).toContain("graph_assisted");
+        expect(names).toContain("record_locator");
+        // The nested one must carry WHERE it was, or a report cannot tell you
+        // which object drifted.
+        const nested = captured.find((record) => record.name === "record_locator");
+        expect(nested?.path).toBe("/evidence/0");
+    });
+
+    it("never carries a property VALUE into the report", () => {
+        validatePinnedJsonSchema(futureAnswer(), answerSchema, (property) =>
+            captured.push({
+                kind: "unknown_property",
+                schemaVersion: "dev_answer.v1",
+                path: property.path,
+                name: property.key,
+            }),
+        );
+        // "gh:pr/4821" is the value of record_locator; nothing about it may
+        // appear anywhere in what gets reported.
+        const serialized = JSON.stringify(captured);
+        expect(serialized).not.toContain("gh:pr/4821");
+        expect(serialized).not.toContain("lagging");
+        expect(captured.length).toBeGreaterThan(0);
+    });
+});
+
+describe("everything else stays strict", () => {
+    it("rejects a payload missing a required field", () => {
+        const answer = structuredClone(answerFixture) as Record<string, unknown>;
+        delete answer.direct_summary;
+        expect(validatePinnedJsonSchema(answer, answerSchema, () => {})).toBe(false);
+    });
+
+    it("rejects a declared field of the wrong type", () => {
+        const answer = structuredClone(answerFixture) as Record<string, unknown>;
+        answer.direct_summary = 42;
+        expect(validatePinnedJsonSchema(answer, answerSchema, () => {})).toBe(false);
+    });
+
+    it("rejects an unknown value for a declared enum", () => {
+        const answer = structuredClone(answerFixture) as Record<string, unknown>;
+        answer.status = "definitely_not_a_status";
+        expect(validatePinnedJsonSchema(answer, answerSchema, () => {})).toBe(false);
+    });
+});
+
+describe("a stream from a newer server still delivers its answer", () => {
+    const graphStateEvent = {
+        event: "graph.state",
+        occurred_at: "2026-07-29T12:00:00.5Z",
+        run_id: "run_01",
+        schema_version: "dev_stream_event.v1",
+        sequence: 1,
+        graph_state: "truncated",
+    };
+
+    it("ignores an unrecognised event type, consumes its sequence, and completes", async () => {
+        const answer = await consumeDevSseStream(
+            streamOf(runWith(futureAnswer(), [graphStateEvent])),
+        );
+        // The whole point: the reader gets the answer.
+        expect(answer.answer_id).toBe((answerFixture as { answer_id: string }).answer_id);
+        expect(observedContractDrift().some((record) => record.name === "graph.state")).toBe(true);
+    });
+
+    it("still rejects a stream whose FIRST frame is unrecognised", async () => {
+        await expect(
+            consumeDevSseStream(streamOf([{ ...graphStateEvent, sequence: 0 }])),
+        ).rejects.toBeInstanceOf(DevApiError);
+    });
+
+    it("still rejects an unrecognised event that breaks sequence order", async () => {
+        await expect(
+            consumeDevSseStream(
+                streamOf(runWith(futureAnswer(), [{ ...graphStateEvent, sequence: 9 }])),
+            ),
+        ).rejects.toBeInstanceOf(DevApiError);
+    });
+
+    it("still rejects an unrecognised event claiming a different run", async () => {
+        await expect(
+            consumeDevSseStream(
+                streamOf(runWith(futureAnswer(), [{ ...graphStateEvent, run_id: "run_99" }])),
+            ),
+        ).rejects.toBeInstanceOf(DevApiError);
+    });
+});
+
+describe("feedback echoed with a reason this pin lacks", () => {
+    /** The real client path, so the assertion covers `validateFeedbackSchema`
+     * rather than a restatement of the fixture. */
+    function clientReturning(payload: unknown) {
+        return createDevApiClient({
+            fetch: async () =>
+                new Response(JSON.stringify(payload), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                }),
+        });
+    }
+
+    it("is accepted by the client, and the unrecognised member is reported", async () => {
+        const feedback = structuredClone(feedbackFixture) as Record<string, unknown>;
+        feedback.reasons = ["wrong_cohort"];
+        const client = clientReturning(feedback);
+
+        await expect(
+            client.submitFeedback(feedback.answer_id as string, {
+                rating: "not_helpful",
+                reasons: ["incorrect"],
+            }),
+        ).resolves.toMatchObject({ reasons: ["wrong_cohort"] });
+
+        expect(
+            observedContractDrift().some(
+                (record) => record.kind === "unknown_enum_value" && record.name === "wrong_cohort",
+            ),
+        ).toBe(true);
+    });
+
+    it("still rejects feedback that breaks a constraint other than the member list", async () => {
+        const feedback = structuredClone(feedbackFixture) as Record<string, unknown>;
+        feedback.reasons = [];
+        const client = clientReturning(feedback);
+        await expect(
+            client.submitFeedback(feedback.answer_id as string, {
+                rating: "not_helpful",
+                reasons: ["incorrect"],
+            }),
+        ).rejects.toBeInstanceOf(DevApiError);
+    });
+});
+
+describe("drift reporting is deduplicated", () => {
+    it("reports the same drift once even across repeated runs", async () => {
+        await consumeDevSseStream(streamOf(runWith(futureAnswer())));
+        const afterFirstRun = observedContractDrift().length;
+        // The same answer is validated on two surfaces per run (nested in the
+        // stream event, and as dev_answer.v1), so more than one record for a
+        // given key name is correct -- they carry different schema/path
+        // provenance. What must NOT happen is growth on every subsequent run.
+        expect(afterFirstRun).toBeGreaterThan(0);
+
+        await consumeDevSseStream(streamOf(runWith(futureAnswer())));
+        await consumeDevSseStream(streamOf(runWith(futureAnswer())));
+        expect(observedContractDrift().length).toBe(afterFirstRun);
+    });
+});

--- a/src/lib/dev/client.ts
+++ b/src/lib/dev/client.ts
@@ -18,6 +18,7 @@ import type {
     DevMessageRequest,
     DevStreamEvent,
 } from "./generated";
+import { reportUnknownEnumValue, unknownPropertyReporter } from "./contractDrift";
 import { validatePinnedJsonSchema } from "./jsonSchemaValidation";
 
 export type DevWebError = Readonly<{
@@ -95,20 +96,93 @@ export const initialDevConversationStreamState: DevConversationStreamState = Obj
     warnings: [],
 });
 
-const validateAnswerSchema = (value: unknown) => validatePinnedJsonSchema(value, answerSchema);
+const validateAnswerSchema = (value: unknown) =>
+    validatePinnedJsonSchema(value, answerSchema, unknownPropertyReporter("dev_answer.v1"));
 const validateCapabilitiesSchema = (value: unknown) =>
-    validatePinnedJsonSchema(value, capabilitiesSchema);
+    validatePinnedJsonSchema(
+        value,
+        capabilitiesSchema,
+        unknownPropertyReporter("dev_capabilities.v1"),
+    );
 const validateConversationSchema = (value: unknown) =>
-    validatePinnedJsonSchema(value, conversationSchema);
+    validatePinnedJsonSchema(
+        value,
+        conversationSchema,
+        unknownPropertyReporter("dev_conversation.v1"),
+    );
 const validateConversationSummarySchema = (value: unknown) =>
-    validatePinnedJsonSchema(value, conversationSummarySchema);
+    validatePinnedJsonSchema(
+        value,
+        conversationSummarySchema,
+        unknownPropertyReporter("dev_conversation_summary.v1"),
+    );
 const validateConversationTranscriptSchema = (value: unknown) =>
-    validatePinnedJsonSchema(value, conversationTranscriptSchema);
+    validatePinnedJsonSchema(
+        value,
+        conversationTranscriptSchema,
+        unknownPropertyReporter("dev_conversation_transcript.v1"),
+    );
 const validateEvidenceExpansionSchema = (value: unknown) =>
-    validatePinnedJsonSchema(value, evidenceExpansionSchema);
-const validateFeedbackSchema = (value: unknown) => validatePinnedJsonSchema(value, feedbackSchema);
+    validatePinnedJsonSchema(
+        value,
+        evidenceExpansionSchema,
+        unknownPropertyReporter("dev_evidence_expansion.v1"),
+    );
 const validateStreamEventSchema = (value: unknown) =>
-    validatePinnedJsonSchema(value, streamEventSchema);
+    validatePinnedJsonSchema(
+        value,
+        streamEventSchema,
+        unknownPropertyReporter("dev_stream_event.v1"),
+    );
+
+/**
+ * The stream event names this build understands, read from the pinned schema
+ * rather than restated, so the tolerance below can never disagree with what the
+ * validator accepts.
+ */
+const KNOWN_STREAM_EVENTS: ReadonlySet<string> = new Set(
+    ((streamEventSchema as { $defs?: { StreamEventType?: { enum?: unknown } } }).$defs
+        ?.StreamEventType?.enum ?? []) as readonly string[],
+);
+
+/**
+ * `dev_feedback.v1` with the `reasons` member list relaxed.
+ *
+ * A rating echoed back carrying a reason this build's enum lacks is a stale pin,
+ * not a corrupt response -- and rejecting it would fail a submission the server
+ * accepted and stored. Every other feedback constraint (required fields, item
+ * bounds, comment length) stays enforced; unrecognised members are reported.
+ */
+const feedbackSchemaRelaxedReasons = (() => {
+    const clone = structuredClone(feedbackSchema) as {
+        properties?: { reasons?: { items?: { enum?: unknown } } };
+    };
+    delete clone.properties?.reasons?.items?.enum;
+    return clone;
+})();
+
+const KNOWN_FEEDBACK_REASONS: ReadonlySet<string> = new Set(
+    ((feedbackSchema as { properties?: { reasons?: { items?: { enum?: unknown } } } }).properties
+        ?.reasons?.items?.enum ?? []) as readonly string[],
+);
+
+const validateFeedbackSchema = (value: unknown) => {
+    const valid = validatePinnedJsonSchema(
+        value,
+        feedbackSchemaRelaxedReasons,
+        unknownPropertyReporter("dev_feedback.v1"),
+    );
+    if (!valid) return false;
+    const reasons = (value as { reasons?: unknown }).reasons;
+    if (Array.isArray(reasons)) {
+        for (const member of reasons) {
+            if (typeof member === "string" && !KNOWN_FEEDBACK_REASONS.has(member)) {
+                reportUnknownEnumValue("dev_feedback.v1", "/reasons", member);
+            }
+        }
+    }
+    return true;
+};
 
 function fromStreamError(event: DevStreamEvent): DevWebError | null {
     if (!event.error) return null;
@@ -289,6 +363,22 @@ function decodeFrame(frame: string): { eventName: string; value: unknown } {
     }
 }
 
+/**
+ * Whether a decoded frame names an event this build does not understand.
+ *
+ * Deliberately narrow: the frame must still be an object carrying a STRING
+ * event name that simply is not in the pinned vocabulary. Anything else (a
+ * non-object payload, a missing or non-string name, a name that disagrees with
+ * the SSE `event:` line) is malformed rather than merely newer, and must keep
+ * failing.
+ */
+function isUnknownStreamEvent(decoded: { eventName: string; value: unknown }): boolean {
+    if (typeof decoded.value !== "object" || decoded.value === null) return false;
+    const name = (decoded.value as { event?: unknown }).event;
+    if (typeof name !== "string" || name !== decoded.eventName) return false;
+    return !KNOWN_STREAM_EVENTS.has(name);
+}
+
 export async function consumeDevSseStream(
     response: Response,
     options: DevStreamOptions = {},
@@ -311,6 +401,28 @@ export async function consumeDevSseStream(
 
     const consumeFrame = (frame: string): void => {
         const decoded = decodeFrame(frame);
+        // FORWARD COMPATIBILITY: an event name this build does not know is a
+        // server ahead of our pin, not a corrupt stream. Ignoring it must still
+        // CONSUME its sequence number, or every later frame reads as
+        // out-of-order and the run dies for a different reason.
+        //
+        // Only tolerated once the run has properly started: a stream whose
+        // FIRST frame is unrecognised tells us nothing about the run at all, so
+        // that stays a hard failure rather than a run with no identity.
+        if (isUnknownStreamEvent(decoded)) {
+            if (runId === undefined || done) {
+                throw invalidResponse("Ask Dev stream did not start correctly.");
+            }
+            const unknown = decoded.value as { run_id?: unknown; sequence?: unknown };
+            if (unknown.sequence !== expectedSequence || unknown.run_id !== runId) {
+                throw invalidResponse("Ask Dev returned an out-of-order stream.");
+            }
+            reportUnknownEnumValue("dev_stream_event.v1", "/event", decoded.eventName);
+            expectedSequence += 1;
+            count += 1;
+            if (count > 100_000) throw invalidResponse("Ask Dev returned too many stream events.");
+            return;
+        }
         assertStreamEvent(decoded.value);
         const event = decoded.value;
         if (decoded.eventName !== event.event || done || event.sequence !== expectedSequence) {

--- a/src/lib/dev/contractDrift.ts
+++ b/src/lib/dev/contractDrift.ts
@@ -1,0 +1,96 @@
+import * as Sentry from "@sentry/nextjs";
+
+import type { UnknownContractProperty } from "./jsonSchemaValidation";
+
+/**
+ * Observability for a server that has moved ahead of this build's pinned Ask Dev
+ * contract.
+ *
+ * Undeclared response properties and unrecognised enum values no longer fail a
+ * run (see the must-ignore note in `jsonSchemaValidation.ts`), which removes an
+ * outage but would otherwise remove the signal with it: a silently-ignored new
+ * field is exactly the state where "the pin is stale" needs to be visible
+ * WITHOUT a reader ever seeing a failure. So every ignored surface is counted
+ * and reported once.
+ *
+ * NAMES ONLY, NEVER VALUES. An undeclared field is content this build cannot
+ * reason about; copying its value into a log or breadcrumb would move payload
+ * data somewhere it was never cleared for. The key path is all that is needed
+ * to know a re-pin is due.
+ */
+
+export type ContractDriftKind = "unknown_property" | "unknown_enum_value";
+
+export type ContractDriftRecord = Readonly<{
+    kind: ContractDriftKind;
+    /** The pinned schema the payload was validated against. */
+    schemaVersion: string;
+    /** Location of the offending key, or of the field holding the value. */
+    path: string;
+    /**
+     * The undeclared property name, or the unrecognised enum MEMBER. An enum
+     * member is machine vocabulary from the contract itself, not reader content
+     * or free text, which is why it is safe to name where a value never is.
+     */
+    name: string;
+}>;
+
+export type ContractDriftSink = (record: ContractDriftRecord) => void;
+
+const seen = new Set<string>();
+const records: ContractDriftRecord[] = [];
+
+function fingerprint(record: ContractDriftRecord): string {
+    return `${record.kind}:${record.schemaVersion}:${record.path}:${record.name}`;
+}
+
+/**
+ * The default sink. Reports each distinct drift once per session — a new field
+ * on a per-event payload would otherwise emit on every frame of every run.
+ */
+function defaultSink(record: ContractDriftRecord): void {
+    Sentry.captureMessage(
+        `Ask Dev contract drift: ${record.kind} ${record.schemaVersion}${record.path}/${record.name}`,
+        "warning",
+    );
+}
+
+let sink: ContractDriftSink = defaultSink;
+
+/** Swap the sink (tests, or a different transport). Returns the previous one. */
+export function setContractDriftSink(next: ContractDriftSink): ContractDriftSink {
+    const previous = sink;
+    sink = next;
+    return previous;
+}
+
+export function reportContractDrift(record: ContractDriftRecord): void {
+    const key = fingerprint(record);
+    if (seen.has(key)) return;
+    seen.add(key);
+    records.push(record);
+    sink(record);
+}
+
+/** Bind a reporter for one schema's unknown properties. */
+export function unknownPropertyReporter(
+    schemaVersion: string,
+): (property: UnknownContractProperty) => void {
+    return ({ key, path }) =>
+        reportContractDrift({ kind: "unknown_property", schemaVersion, path, name: key });
+}
+
+export function reportUnknownEnumValue(schemaVersion: string, path: string, member: string): void {
+    reportContractDrift({ kind: "unknown_enum_value", schemaVersion, path, name: member });
+}
+
+/** Everything observed this session, for tests and for a diagnostics surface. */
+export function observedContractDrift(): readonly ContractDriftRecord[] {
+    return records;
+}
+
+export function resetContractDrift(): void {
+    seen.clear();
+    records.length = 0;
+    sink = defaultSink;
+}

--- a/src/lib/dev/jsonSchemaValidation.ts
+++ b/src/lib/dev/jsonSchemaValidation.ts
@@ -1,5 +1,23 @@
 type JsonSchema = Readonly<Record<string, unknown>>;
 
+/**
+ * A property the server sent that this pinned schema does not declare.
+ *
+ * Carries the KEY NAME and its location only -- never the value. An unknown
+ * property is by definition content this build cannot reason about, so copying
+ * it anywhere (a log, a breadcrumb, telemetry) risks moving payload data
+ * somewhere it was never cleared for. The name is enough to tell us a re-pin is
+ * due; the value is never needed to know that.
+ */
+export type UnknownContractProperty = Readonly<{
+    /** JSON-pointer-ish path of the OBJECT carrying the key. "" is the root. */
+    path: string;
+    /** The undeclared key's name. */
+    key: string;
+}>;
+
+type UnknownPropertyReporter = (property: UnknownContractProperty) => void;
+
 const patternCache = new Map<string, RegExp>();
 const RFC3339_DATE_TIME =
     /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:[Zz]|[+-](\d{2}):(\d{2}))$/;
@@ -85,14 +103,22 @@ function validateString(value: string, schema: JsonSchema): boolean {
     return schema.format !== "date-time" || isDateTime(value);
 }
 
-function validateNode(value: unknown, schema: JsonSchema, root: JsonSchema): boolean {
+function validateNode(
+    value: unknown,
+    schema: JsonSchema,
+    root: JsonSchema,
+    path: string,
+    onUnknownProperty: UnknownPropertyReporter | undefined,
+): boolean {
     if (schema.$ref !== undefined) {
         const resolved = localRef(root, schema.$ref);
-        return resolved !== null && validateNode(value, resolved, root);
+        return resolved !== null && validateNode(value, resolved, root, path, onUnknownProperty);
     }
     if (Array.isArray(schema.anyOf)) {
         return schema.anyOf.some(
-            (candidate) => isRecord(candidate) && validateNode(value, candidate, root),
+            (candidate) =>
+                isRecord(candidate) &&
+                validateNode(value, candidate, root, path, onUnknownProperty),
         );
     }
     if (schema.const !== undefined && !Object.is(value, schema.const)) return false;
@@ -113,7 +139,12 @@ function validateNode(value: unknown, schema: JsonSchema, root: JsonSchema): boo
         if (typeof schema.minItems === "number" && value.length < schema.minItems) return false;
         if (typeof schema.maxItems === "number" && value.length > schema.maxItems) return false;
         const itemSchema = isRecord(schema.items) ? schema.items : null;
-        if (itemSchema && !value.every((item) => validateNode(item, itemSchema, root))) {
+        if (
+            itemSchema &&
+            !value.every((item, index) =>
+                validateNode(item, itemSchema, root, `${path}/${index}`, onUnknownProperty),
+            )
+        ) {
             return false;
         }
     }
@@ -125,13 +156,37 @@ function validateNode(value: unknown, schema: JsonSchema, root: JsonSchema): boo
         ) {
             return false;
         }
-        if (schema.additionalProperties === false) {
-            if (Object.keys(value).some((key) => !Object.hasOwn(properties, key))) return false;
+        // FORWARD COMPATIBILITY (must-ignore).
+        //
+        // Every object in the pinned Ask Dev contract sets
+        // `additionalProperties: false`, and this validator used to REJECT any
+        // undeclared key. Combined with `assertStreamEvent`/`assertAnswer`
+        // throwing on a failed validation, that made every additive server
+        // change a run-killing break for a web build pinned to an older
+        // commit -- despite the contract manifest declaring
+        // "additive-within-v1". A reader saw a failed run rather than the
+        // canonical fallback.
+        //
+        // Undeclared keys are now IGNORED for parsing and REPORTED instead, so
+        // the tripwire survives as observability rather than an outage. Every
+        // other constraint stays strict: a declared field with the wrong shape,
+        // a missing required field, or a bad enum value still fails.
+        if (schema.additionalProperties === false && onUnknownProperty) {
+            for (const key of Object.keys(value)) {
+                if (!Object.hasOwn(properties, key)) onUnknownProperty({ path, key });
+            }
         }
         for (const [key, propertySchema] of Object.entries(properties)) {
             if (
                 Object.hasOwn(value, key) &&
-                (!isRecord(propertySchema) || !validateNode(value[key], propertySchema, root))
+                (!isRecord(propertySchema) ||
+                    !validateNode(
+                        value[key],
+                        propertySchema,
+                        root,
+                        `${path}/${key}`,
+                        onUnknownProperty,
+                    ))
             ) {
                 return false;
             }
@@ -140,7 +195,18 @@ function validateNode(value: unknown, schema: JsonSchema, root: JsonSchema): boo
     return true;
 }
 
-/** CSP-safe validation for the pinned browser contract subset; performs no code generation. */
-export function validatePinnedJsonSchema(value: unknown, schema: unknown): boolean {
-    return isRecord(schema) && validateNode(value, schema, schema);
+/**
+ * CSP-safe validation for the pinned browser contract subset; performs no code
+ * generation.
+ *
+ * Undeclared properties do not fail validation -- see the must-ignore note in
+ * `validateNode`. Pass `onUnknownProperty` to observe them; omit it and they
+ * are ignored silently, which is why the client always passes one.
+ */
+export function validatePinnedJsonSchema(
+    value: unknown,
+    schema: unknown,
+    onUnknownProperty?: UnknownPropertyReporter,
+): boolean {
+    return isRecord(schema) && validateNode(value, schema, schema, "", onUnknownProperty);
 }


### PR DESCRIPTION
Prerequisite for the graph-assisted beta work on the web side, and a fix for a
hazard that exists independently of it. Stacked on the answer-section
extraction PR; retarget to main once that merges.

## The defect

`contracts/ask-dev/v1/manifest.json` declares `"compatibility":
"additive-within-v1"`. The schemas contradict that declaration, and this client
enforced the contradiction:

- every pinned schema ROOT sets `additionalProperties: false` — `dev_answer`,
  `dev_stream_event`, `dev_feedback`, `dev_capabilities`, `dev_evidence_ref`;
- so do **17 nested `$defs` in `dev_answer.v1`** and **19 in
  `dev_stream_event.v1`**, including `DevEvidenceRef`, `DevAnswer`,
  `DevCoverage`, `DevScopeResolution` and `DevClaim`;
- `src/lib/dev/jsonSchemaValidation.ts` rejected any undeclared key;
- `assertStreamEvent` / `assertAnswer` throw on a failed validation.

So an additive server change did not degrade a run for a web build pinned to an
older commit — it **killed** it. The reader saw a failed run, not an answer and
not the canonical fallback the beta requires.

This is already live rather than hypothetical. `record_locator` exists on the
context-fabric stack today and `DevEvidenceRef` is one of the strict defs, so a
runtime populating it while web is pinned without it fails **every answer
carrying an evidence reference**. Nor can the server avoid it by gating per
client: `dev_message_request` carries no client contract version and
`dev_capabilities.supported_contract_versions` runs server-to-client, so
nothing tells the server what a caller is able to parse.

## The fix

**Unknown properties: ignore for parsing, report instead of rejecting.** The
strictness was also a tripwire for a server sending unexpected data, so it
survives as observability rather than being relaxed away. Everything else stays
strict — a missing required field, a declared field of the wrong type, and an
unknown value for a *declared* enum all still fail, each with a test.

**Reports carry names, never values.** An undeclared field is by definition
content this build cannot reason about; copying its value into a log or
breadcrumb would move payload data somewhere it was never cleared for. The key
name and path are enough to know a re-pin is due, and a test asserts no value
reaches the report.

**Unknown enum values need separate handling**, because must-ignore only covers
properties:

- an unrecognised stream event is ignored **and its sequence number consumed** —
  skipping without consuming makes every later frame read as out-of-order and
  kills the run for a different reason. Tolerated only after `run.started`: a
  stream whose first frame is unrecognised says nothing about the run's
  identity, so that stays a hard failure. A frame whose name disagrees with its
  SSE `event:` line, or that is not an object, is malformed rather than newer
  and still fails.
- feedback echoed with a reason this pin lacks is accepted through a
  reasons-relaxed schema clone. The server accepted and stored that rating;
  rejecting the echo would fail a submission that succeeded. Item bounds,
  required fields and comment length stay enforced.

Drift is deduplicated per kind/schema/path/name — otherwise a new field on a
per-frame payload reports on every frame of every run.

## Verification

Fixtures are the checked-in canonical examples with the **real** incoming
surface added — `record_locator`, `graph_assisted`, and a `graph.state` event.
Those are the fields actually on the way, not invented names, so the tests
exercise the shape that is about to arrive.

The flagship test asserts what the change exists for: given a stream carrying
all three, **the reader gets their answer**.

Two mutations, each observed failing the right guard before the tests were
trusted:

| Mutation | Result |
| --- | --- |
| Restore the strict rejection (the original defect) | 5 failed, including the flagship |
| Ignore an unknown event **without** consuming its sequence | exactly 1 failed — the off-by-one that test was written for |

- Full unit suite: **3760 passed**, 8 skipped, 416 files — no regressions from a
  change that sits under every Ask Dev response path.
- Ask Dev e2e (`ask-dev-shared`, `ask-dev-outcomes`, `ask-dev-continuity`):
  **60 passed**.
- `typecheck`, `lint`, `design-lint`: clean.

## Follow-up, tracked elsewhere

A client-declared contract version on `dev_message_request` is approved
separately, so the server can gate a new stream event on declared client
support rather than on deploy ordering. This PR makes an out-of-order deploy
survivable; that change makes it unnecessary.

SCREENSHOT-WAIVER: no rendered output changes. This is response-validation and
transport-tolerance only — no component, markup, style or copy is touched, and
the Ask Dev e2e suite covering the rendered surfaces passes unchanged.
