### PR TITLE
fix(ci): clear stale dev chunks before e2e, without discarding the build

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -109,6 +109,25 @@ prepare_playwright_artifacts() {
 
   rm -rf "${PLAYWRIGHT_REPORT_ROOT}" "${PLAYWRIGHT_RESULTS_ROOT}"
   mkdir -p "${PLAYWRIGHT_REPORT_ROOT}" "${PLAYWRIGHT_RESULTS_ROOT}"
+
+  # Drop the dev server's compiled chunks, never the production build.
+  #
+  # The `ci` tier runs `pnpm build` (which writes .next/) and then Playwright
+  # starts `next dev` (which uses .next/dev). On a fresh CI checkout .next
+  # starts empty, so those two never disagree. On a local checkout that already
+  # has a .next from earlier work, the dev server serves stale chunks against
+  # the current tree and fails with "module factory is not available" -- and the
+  # symptom is not a build error. It surfaces as unrelated PRODUCT tests
+  # failing: a broken app/global-error.tsx chunk stops an error toast
+  # rendering and stops a post-signin redirect completing, so auth specs go
+  # red and look like a real regression. Two of them cost a full gate run
+  # before the durations gave it away (10.7s and ~31s timeout-shaped failures,
+  # the same specs finishing in 575ms and 4.9s once .next was cleared).
+  #
+  # Scoped to .next/dev on purpose: wiping .next entirely would discard the
+  # production build this tier just made, so the e2e stage would silently stop
+  # exercising it.
+  rm -rf .next/dev
 }
 
 print_playwright_artifact_summary() {

--- a/scripts/__tests__/e2e-stale-dev-chunks.test.mjs
+++ b/scripts/__tests__/e2e-stale-dev-chunks.test.mjs
@@ -1,0 +1,72 @@
+/**
+ * Guards the stale-dev-chunk clear in `prepare_playwright_artifacts`, and the
+ * scoping that makes it safe.
+ *
+ * The `ci` tier runs `pnpm build` (writing `.next/`) and then Playwright starts
+ * `next dev` (using `.next/dev`). A local checkout carrying a `.next` from
+ * earlier work serves stale chunks against the current tree, and the symptom is
+ * not a build error — it is unrelated PRODUCT specs going red, because a broken
+ * `app/global-error.tsx` chunk stops an error toast rendering and a post-signin
+ * redirect completing.
+ *
+ * Two properties have to hold, and the second is the one a well-meaning
+ * simplification breaks:
+ *
+ * 1. the dev chunks ARE cleared before an e2e suite runs;
+ * 2. the PRODUCTION build is NOT — widening this to `rm -rf .next` would
+ *    discard the build the same tier just made, so the e2e stage would silently
+ *    stop exercising it. Nothing would fail; the suite would simply stop
+ *    covering the artifact it is supposed to cover, which is the worse outcome
+ *    because it still reports green.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "ci",
+    "run_tests.sh",
+);
+
+function scriptText() {
+    return readFileSync(SCRIPT_PATH, "utf8");
+}
+
+function functionBody(source, name) {
+    const start = source.indexOf(`${name}() {`);
+    if (start === -1) throw new Error(`Could not find shell function "${name}" in run_tests.sh.`);
+    const end = source.indexOf("\n}", start);
+    if (end === -1) throw new Error(`Could not find the end of "${name}".`);
+    return source.slice(start, end);
+}
+
+describe("e2e preparation clears stale dev chunks", () => {
+    it("removes .next/dev before an e2e suite runs", () => {
+        const body = functionBody(scriptText(), "prepare_playwright_artifacts");
+        expect(body).toMatch(/rm\s+-rf\s+\.next\/dev\b/u);
+    });
+
+    it("never removes the whole .next directory, which holds the production build", () => {
+        // `rm -rf .next` not followed by a path separator: the widening that
+        // would silently stop the e2e stage exercising the built app.
+        const unscoped = /rm\s+-rf\s+(?:"?\$\{?[A-Za-z_]+\}?"?\s+)*\.next(?![/\w])/u;
+        expect(scriptText()).not.toMatch(unscoped);
+    });
+
+    it("clears the chunks in the shared preparation step, not one suite's own path", () => {
+        // Every isolated suite routes through prepare_playwright_artifacts, so
+        // placing the clear there covers default/onboarding/context-fabric and
+        // anything added later. A clear that lived in only one suite's helper
+        // would leave the others on stale chunks.
+        const source = scriptText();
+        expect(functionBody(source, "run_isolated_e2e_suite")).toMatch(
+            /prepare_playwright_artifacts/u,
+        );
+        expect(functionBody(source, "run_e2e")).toMatch(/prepare_playwright_artifacts/u);
+    });
+});


### PR DESCRIPTION
A local full-gate run currently fails on specs that have nothing to do with the
change under test. This makes it trustworthy. CI is unaffected either way.

## The trap

The `ci` tier runs `pnpm build` (writing `.next/`) and then Playwright starts
`next dev` (using `.next/dev`). On a fresh CI checkout `.next` starts empty, so
the two never disagree. On a local checkout carrying a `.next` from earlier
work, the dev server serves stale chunks against the current tree and reports
`Module .../react/jsx-dev-runtime.js ... was instantiated because it was
required from module ./src/app/global-error.tsx, but the module factory is not
available`.

The symptom is not a build error, which is what makes it expensive. It surfaces
as unrelated **product** specs going red: a broken `global-error.tsx` chunk
stops an error toast rendering and stops a post-signin redirect completing, so
`auth-signin` and `auth-onboard-legacy` fail and read as a genuine auth
regression. Diagnosing that cost a full local gate run.

**The durations gave it away, not the failures.** Repeated attempts took
identical times — 10.7s ×3 and ~31s ×3, the timeout-fallback signature AGENTS.md
warns about — and the same two specs completed in **575ms** and **4.9s** once
`.next` was cleared. A real assertion failure does not get 20× faster when a
build directory is deleted.

## Why it is scoped to `.next/dev`

Wiping `.next` entirely would discard the production build this same tier just
made, so the e2e stage would **silently stop exercising it**. Nothing would
fail; the suite would simply stop covering the artifact it exists to cover,
which is worse than a red because it still reports green.

That is the property the accompanying test actually guards — not merely that the
line is present. Widening it to `rm -rf .next` fails two of its three
assertions; deleting the line fails one. Both were observed failing before the
test was trusted.

The clear lives in `prepare_playwright_artifacts` because every isolated suite
routes through it, so default, onboarding and context-fabric are all covered,
along with anything added later. A third assertion pins that placement, since a
clear living in one suite's helper would leave the others on stale chunks.

## Verification

Behavioural, not a reading of the diff. With a sentinel planted at
`.next/dev/SENTINEL` and a real production build present:

- before: `dev/SENTINEL=present BUILD_ID=present`
- after `bash ci/run_tests.sh e2e-onboarding`: `dev/SENTINEL=absent
  BUILD_ID=present`, tier exit 0, **10/10** onboarding specs passing.

Both claims in the code comment are therefore checked: the dev chunks go, the
build stays.

SCREENSHOT-WAIVER: build-script and test-only change. No application code,
markup, style or copy is touched, so there is no rendered output to capture.
