### PR TITLE
chore(ask-dev): re-pin the contract to ops main ddafad6d0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
               with:
                   repository: full-chaos/dev-health-ops
-                  ref: 6b7517364eee330efd01e1c238eb50245760a62d
+                  ref: ddafad6d0d145e44ff791f6a28c8cf98fca37e6c
                   path: dev-health-ops
                   persist-credentials: false
             # CHAOS-3511 currency guard: ops main's tip as of this run, checked

--- a/scripts/ask-dev-contracts.mjs
+++ b/scripts/ask-dev-contracts.mjs
@@ -12,7 +12,7 @@ import { format } from "prettier";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ARTIFACT_ROOT = path.join(ROOT, "src/lib/dev/contracts");
 const GENERATED_PATH = path.join(ROOT, "src/lib/dev/generated.ts");
-const SOURCE_COMMIT = "6b7517364eee330efd01e1c238eb50245760a62d";
+const SOURCE_COMMIT = "ddafad6d0d145e44ff791f6a28c8cf98fca37e6c";
 const SOURCE_PREFIX = "contracts/ask-dev/v1/";
 const PRETTIER_OPTIONS = Object.freeze({
     parser: "typescript",

--- a/src/lib/dev/__tests__/contractTolerance.test.ts
+++ b/src/lib/dev/__tests__/contractTolerance.test.ts
@@ -9,10 +9,19 @@
  *
  * These assert the state the system exists to reach: a payload from a NEWER
  * server still yields an answer, while a genuinely malformed one still fails.
- * The fixtures are the checked-in canonical examples with the future surface
- * added on top, so they mirror the real producer rather than a hand-shaped
- * guess. `record_locator` and `graph_assisted` are the actual fields on their
- * way, not invented names.
+ * The base fixtures are the checked-in canonical examples, so the shapes and
+ * values around the additions are the real producer's rather than a hand-shaped
+ * guess.
+ *
+ * The UNDECLARED keys, though, are deliberately names no contract will ever
+ * adopt. An earlier revision used `record_locator` and `graph_assisted` because
+ * they were the real fields on their way -- and the re-pin that landed
+ * `record_locator` promptly made this test's premise false, since the key was
+ * no longer unknown. Asserting "this key is undeclared" against a name the
+ * contract may declare is a test that expires. The mechanism under test does not
+ * care what the key is called, only that it is absent from the schema, so the
+ * names below are reserved sentinels that keep the assertion true across every
+ * future re-pin.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -43,8 +52,8 @@ afterEach(() => resetContractDrift());
 function futureAnswer(): Record<string, unknown> {
     const answer = structuredClone(answerFixture) as Record<string, unknown>;
     const evidence = answer.evidence as Record<string, unknown>[];
-    evidence[0]!.record_locator = "gh:pr/4821";
-    answer.graph_assisted = { state: "lagging", as_of: "2026-08-10T00:00:00Z" };
+    evidence[0]!.__unpinned_nested_field = "gh:pr/4821";
+    answer.__unpinned_top_level_field = { state: "lagging", as_of: "2026-08-10T00:00:00Z" };
     return answer;
 }
 
@@ -102,11 +111,11 @@ describe("unknown properties are ignored for parsing and reported", () => {
             }),
         );
         const names = captured.map((record) => record.name);
-        expect(names).toContain("graph_assisted");
-        expect(names).toContain("record_locator");
+        expect(names).toContain("__unpinned_top_level_field");
+        expect(names).toContain("__unpinned_nested_field");
         // The nested one must carry WHERE it was, or a report cannot tell you
         // which object drifted.
-        const nested = captured.find((record) => record.name === "record_locator");
+        const nested = captured.find((record) => record.name === "__unpinned_nested_field");
         expect(nested?.path).toBe("/evidence/0");
     });
 
@@ -119,7 +128,7 @@ describe("unknown properties are ignored for parsing and reported", () => {
                 name: property.key,
             }),
         );
-        // "gh:pr/4821" is the value of record_locator; nothing about it may
+        // "gh:pr/4821" is the undeclared nested field's value; nothing about it may
         // appear anywhere in what gets reported.
         const serialized = JSON.stringify(captured);
         expect(serialized).not.toContain("gh:pr/4821");

--- a/src/lib/dev/__tests__/contracts.test.ts
+++ b/src/lib/dev/__tests__/contracts.test.ts
@@ -74,7 +74,7 @@ describe("Ask Dev generated contract boundary", () => {
         const source = readJson<SourceManifest>("source.json");
         const manifest = readJson<OpsManifest>("manifest.json");
 
-        expect(source.source_commit).toBe("6b7517364eee330efd01e1c238eb50245760a62d");
+        expect(source.source_commit).toBe("ddafad6d0d145e44ff791f6a28c8cf98fca37e6c");
         expect(manifest.schema_version).toBe("ask_dev_contract_manifest.v1");
         expect(manifest.compatibility).toBe("additive-within-v1");
         expect(manifest.contracts.map((contract) => contract.schema_version)).toEqual(

--- a/src/lib/dev/contracts/manifest.json
+++ b/src/lib/dev/contracts/manifest.json
@@ -16,7 +16,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_capabilities.v1.schema.json",
-        "sha256": "66f9dd47b340f1ca3b3d545761912e69a0833b1550868a8f45a6ab2836ec2050"
+        "sha256": "e213726e709177362829dedf284c8a8118d883725dd5b0b6b45b51197c4b491b"
       },
       "schema_version": "dev_capabilities.v1"
     },
@@ -78,7 +78,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
-        "sha256": "d0df8dccbf190a280412e6d4872006459072128d87c7cf8d9e9facc016ab62a3"
+        "sha256": "8712d49d50e56e71030e3dbe27e70c9387a749ee0367c712e48b6940eb5df17f"
       },
       "schema_version": "dev_conversation_transcript.v1"
     },
@@ -112,7 +112,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_message_request.v1.schema.json",
-        "sha256": "258a495a3ac72ec52164b37164d71b4f01b60d8f1008b046965cd2f002c7b2bc"
+        "sha256": "2ac58a542edcc35e32b0f7a592920b4ab53a588b433ac00b9b224271a76011b5"
       },
       "schema_version": "dev_message_request.v1"
     },
@@ -156,7 +156,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
-        "sha256": "e156ced39c676bae4e08f5c5e5acc86a4d7120b472ab628ba20f1a605a8ce6fc"
+        "sha256": "8c92ecc438cef1331ef130862bc75bf565c4111e74d8a03b67eb229e620d41ae"
       },
       "schema_version": "dev_answer.v1"
     },
@@ -213,7 +213,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_evidence_ref.v1.schema.json",
-        "sha256": "ec835b4334f2f627a14fbb361244b403fd8faed8825b051122e16780918cdf2b"
+        "sha256": "4f523fa4b63df80da741a75e0483384467b74e082bcd0648f9bd12d863422620"
       },
       "schema_version": "dev_evidence_ref.v1"
     },
@@ -232,7 +232,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_evidence_expansion.v1.schema.json",
-        "sha256": "615e2e20b938e0e1181dcd5681495352f30d515f7a45f3fb0dd6879d6cdc0628"
+        "sha256": "d3ab1a7dfe7c667ab05f58b210f9cf7274d7dc7b34d1c1861baf708e86023d38"
       },
       "schema_version": "dev_evidence_expansion.v1"
     },
@@ -345,7 +345,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "21698013ea1dac591a15bcd965431c102d5a9e49a108ad97c08db748b5fdfd56"
+        "sha256": "d06aedb5245ea51239d7020e4202a8c9cd97499bd1b7448e05bef4f379c596a2"
       },
       "schema_version": "dev_tool_result.v1"
     },
@@ -383,7 +383,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
-        "sha256": "379012a91746699a38240c4e679bc2d7100c7fb4ff0c99cb966cb55e46045e39"
+        "sha256": "e828ee78e46df0ea49d070c873f263588fc6cc1012f0728d2326d1f9577f1649"
       },
       "schema_version": "dev_stream_event.v1"
     },

--- a/src/lib/dev/contracts/schemas/dev_answer.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_answer.v1.schema.json
@@ -514,6 +514,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/src/lib/dev/contracts/schemas/dev_capabilities.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_capabilities.v1.schema.json
@@ -97,6 +97,11 @@
       "title": "Ask Dev",
       "type": "boolean"
     },
+    "ask_dev_graph_routing": {
+      "default": false,
+      "title": "Ask Dev Graph Routing",
+      "type": "boolean"
+    },
     "byo_llm": {
       "default": false,
       "title": "Byo Llm",

--- a/src/lib/dev/contracts/schemas/dev_conversation_transcript.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_conversation_transcript.v1.schema.json
@@ -636,6 +636,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/src/lib/dev/contracts/schemas/dev_evidence_expansion.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_evidence_expansion.v1.schema.json
@@ -156,6 +156,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/src/lib/dev/contracts/schemas/dev_evidence_ref.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_evidence_ref.v1.schema.json
@@ -168,6 +168,21 @@
       "title": "Provenance",
       "type": "string"
     },
+    "record_locator": {
+      "anyOf": [
+        {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Record Locator"
+    },
     "repository_ids": {
       "items": {
         "maxLength": 128,

--- a/src/lib/dev/contracts/schemas/dev_message_request.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_message_request.v1.schema.json
@@ -265,6 +265,20 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
+    "client_contract_version": {
+      "anyOf": [
+        {
+          "maxLength": 128,
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Client Contract Version"
+    },
     "client_message_id": {
       "maxLength": 128,
       "minLength": 1,

--- a/src/lib/dev/contracts/schemas/dev_stream_event.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_stream_event.v1.schema.json
@@ -726,6 +726,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/src/lib/dev/contracts/schemas/dev_tool_result.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_tool_result.v1.schema.json
@@ -659,6 +659,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/src/lib/dev/contracts/source.json
+++ b/src/lib/dev/contracts/source.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "ask_dev_web_contract_source.v1",
-  "source_commit": "6b7517364eee330efd01e1c238eb50245760a62d",
+  "source_commit": "ddafad6d0d145e44ff791f6a28c8cf98fca37e6c",
   "files": [
     {
       "path": "examples/negative/dev_answer.v1.invalid_complete_state.json",
@@ -220,15 +220,15 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "a3d394a375fc218473063610c3b647c8c36a064bea306cff0beca9f76042359b"
+      "sha256": "d0e546f7766188f2e14bf6159e546aaa3033e5db8ae2e0ca2beed0c86753ed90"
     },
     {
       "path": "schemas/dev_answer.v1.schema.json",
-      "sha256": "e156ced39c676bae4e08f5c5e5acc86a4d7120b472ab628ba20f1a605a8ce6fc"
+      "sha256": "8c92ecc438cef1331ef130862bc75bf565c4111e74d8a03b67eb229e620d41ae"
     },
     {
       "path": "schemas/dev_capabilities.v1.schema.json",
-      "sha256": "66f9dd47b340f1ca3b3d545761912e69a0833b1550868a8f45a6ab2836ec2050"
+      "sha256": "e213726e709177362829dedf284c8a8118d883725dd5b0b6b45b51197c4b491b"
     },
     {
       "path": "schemas/dev_claim.v1.schema.json",
@@ -244,7 +244,7 @@
     },
     {
       "path": "schemas/dev_conversation_transcript.v1.schema.json",
-      "sha256": "d0df8dccbf190a280412e6d4872006459072128d87c7cf8d9e9facc016ab62a3"
+      "sha256": "8712d49d50e56e71030e3dbe27e70c9387a749ee0367c712e48b6940eb5df17f"
     },
     {
       "path": "schemas/dev_error.v1.schema.json",
@@ -252,11 +252,11 @@
     },
     {
       "path": "schemas/dev_evidence_expansion.v1.schema.json",
-      "sha256": "615e2e20b938e0e1181dcd5681495352f30d515f7a45f3fb0dd6879d6cdc0628"
+      "sha256": "d3ab1a7dfe7c667ab05f58b210f9cf7274d7dc7b34d1c1861baf708e86023d38"
     },
     {
       "path": "schemas/dev_evidence_ref.v1.schema.json",
-      "sha256": "ec835b4334f2f627a14fbb361244b403fd8faed8825b051122e16780918cdf2b"
+      "sha256": "4f523fa4b63df80da741a75e0483384467b74e082bcd0648f9bd12d863422620"
     },
     {
       "path": "schemas/dev_feedback.v1.schema.json",
@@ -264,7 +264,7 @@
     },
     {
       "path": "schemas/dev_message_request.v1.schema.json",
-      "sha256": "258a495a3ac72ec52164b37164d71b4f01b60d8f1008b046965cd2f002c7b2bc"
+      "sha256": "2ac58a542edcc35e32b0f7a592920b4ab53a588b433ac00b9b224271a76011b5"
     },
     {
       "path": "schemas/dev_metric_ref.v1.schema.json",
@@ -280,7 +280,7 @@
     },
     {
       "path": "schemas/dev_stream_event.v1.schema.json",
-      "sha256": "379012a91746699a38240c4e679bc2d7100c7fb4ff0c99cb966cb55e46045e39"
+      "sha256": "e828ee78e46df0ea49d070c873f263588fc6cc1012f0728d2326d1f9577f1649"
     },
     {
       "path": "schemas/dev_tool_request.v1.schema.json",
@@ -288,7 +288,7 @@
     },
     {
       "path": "schemas/dev_tool_result.v1.schema.json",
-      "sha256": "21698013ea1dac591a15bcd965431c102d5a9e49a108ad97c08db748b5fdfd56"
+      "sha256": "d06aedb5245ea51239d7020e4202a8c9cd97499bd1b7448e05bef4f379c596a2"
     },
     {
       "path": "vocabulary/internal_prose_denylist.v1.json",

--- a/src/lib/dev/generated.ts
+++ b/src/lib/dev/generated.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-// Generated from full-chaos/dev-health-ops 6b7517364eee330efd01e1c238eb50245760a62d. Do not edit.
+// Generated from full-chaos/dev-health-ops ddafad6d0d145e44ff791f6a28c8cf98fca37e6c. Do not edit.
 export namespace DevAnswerContract {
     export type AnswerId = string;
     export type AsOf = string;
@@ -1168,6 +1168,7 @@ export namespace DevAnswerContract {
     export type SourceUrl = string | null;
     export type ObservedAt = string;
     export type Provenance = string;
+    export type RecordLocator = string | null;
     /**
      * @maxItems 20
      */
@@ -2530,6 +2531,7 @@ export namespace DevAnswerContract {
         link?: DevCitationLink | null;
         observed_at: ObservedAt;
         provenance: Provenance;
+        record_locator?: RecordLocator;
         repository_ids?: RepositoryIds;
         schema_version: SchemaVersion2;
         source_system: SourceSystem;
@@ -2609,6 +2611,7 @@ export namespace DevCapabilitiesContract {
     export type AdministratorSafeFailureReason = string | null;
     export type AgentContextRuntime = boolean;
     export type AskDev = boolean;
+    export type AskDevGraphRouting = boolean;
     export type ByoLlm = boolean;
     export type CanManage = boolean;
     export type CanRead = boolean;
@@ -2840,6 +2843,7 @@ export namespace DevCapabilitiesContract {
         administrator_safe_failure_reason?: AdministratorSafeFailureReason;
         agent_context_runtime?: AgentContextRuntime;
         ask_dev?: AskDev;
+        ask_dev_graph_routing?: AskDevGraphRouting;
         byo_llm?: ByoLlm;
         can_manage?: CanManage;
         can_read?: CanRead;
@@ -4990,6 +4994,7 @@ export namespace DevConversationTranscriptContract {
     export type SourceUrl = string | null;
     export type ObservedAt = string;
     export type Provenance = string;
+    export type RecordLocator = string | null;
     /**
      * @maxItems 20
      */
@@ -6403,6 +6408,7 @@ export namespace DevConversationTranscriptContract {
         link?: DevCitationLink | null;
         observed_at: ObservedAt;
         provenance: Provenance;
+        record_locator?: RecordLocator;
         repository_ids?: RepositoryIds;
         schema_version: SchemaVersion2;
         source_system: SourceSystem;
@@ -7444,6 +7450,7 @@ export namespace DevEvidenceExpansionContract {
     export type SourceUrl = string | null;
     export type ObservedAt = string;
     export type Provenance = string;
+    export type RecordLocator = string | null;
     /**
      * @maxItems 20
      */
@@ -7832,6 +7839,7 @@ export namespace DevEvidenceExpansionContract {
         link?: DevCitationLink | null;
         observed_at: ObservedAt;
         provenance: Provenance;
+        record_locator?: RecordLocator;
         repository_ids?: RepositoryIds;
         schema_version: SchemaVersion;
         source_system: SourceSystem;
@@ -7872,6 +7880,7 @@ export namespace DevEvidenceRefContract {
     export type SourceUrl = string | null;
     export type ObservedAt = string;
     export type Provenance = string;
+    export type RecordLocator = string | null;
     /**
      * @maxItems 20
      */
@@ -8244,6 +8253,7 @@ export namespace DevEvidenceRefContract {
         link?: DevCitationLink | null;
         observed_at: ObservedAt;
         provenance: Provenance;
+        record_locator?: RecordLocator;
         repository_ids?: RepositoryIds;
         schema_version: SchemaVersion;
         source_system: SourceSystem;
@@ -8461,6 +8471,7 @@ export namespace DevFeedbackContract {
 }
 export type DevFeedback = DevFeedbackContract.DevFeedback;
 export namespace DevMessageRequestContract {
+    export type ClientContractVersion = string | null;
     export type ClientMessageId = string;
     export type ConversationId = string | null;
     export type Question = string;
@@ -9337,6 +9348,7 @@ export namespace DevMessageRequestContract {
           ];
 
     export interface DevMessageRequest {
+        client_contract_version?: ClientContractVersion;
         client_message_id: ClientMessageId;
         conversation_id?: ConversationId;
         question: Question;
@@ -13824,6 +13836,7 @@ export namespace DevStreamEventContract {
     export type SourceUrl = string | null;
     export type ObservedAt = string;
     export type Provenance = string;
+    export type RecordLocator = string | null;
     /**
      * @maxItems 20
      */
@@ -15265,6 +15278,7 @@ export namespace DevStreamEventContract {
         link?: DevCitationLink | null;
         observed_at: ObservedAt;
         provenance: Provenance;
+        record_locator?: RecordLocator;
         repository_ids?: RepositoryIds;
         schema_version: SchemaVersion2;
         source_system: SourceSystem;
@@ -16640,6 +16654,7 @@ export namespace DevToolResultContract {
     export type SourceUrl = string | null;
     export type ObservedAt2 = string;
     export type Provenance = string;
+    export type RecordLocator = string | null;
     /**
      * @maxItems 20
      */
@@ -19093,6 +19108,7 @@ export namespace DevToolResultContract {
         link?: DevCitationLink | null;
         observed_at: ObservedAt2;
         provenance: Provenance;
+        record_locator?: RecordLocator;
         repository_ids?: RepositoryIds;
         schema_version: SchemaVersion1;
         source_system: SourceSystem1;


### PR DESCRIPTION
Ops main gained schema-only additions, so the contract currency guard started
failing on **every open web PR** — not because of
anything in those PRs, but because the reference they are measured against
moved. Re-pinning is the intended response; the guard firing is it working.

## What changed

Artifacts were regenerated, never hand-edited:

Picks up two ops landings in a single pin:

- `record_locator` reserved on `DevEvidenceRef`;
- `DevCapabilities.ask_dev_graph_routing` and
  `DevMessageRequest.client_contract_version` reserved for the graph-routing wave.

```
pnpm ask-dev:contracts:generate --allow-write --source <ops checkout at ddafad6d0>
```

All three fields now appear in the generated types, so they are **declared**
rather than merely tolerated by the forward-compatibility layer.

**Nothing populates or reads them yet, and one of those gaps matters.**
`client_contract_version` exists so the server can gate a new stream event on
what the caller can actually parse. Until web *sends* it, a server that gates on
it sees nothing and correctly withholds — so the graph path would stay dark with
every check green and no error anywhere. That population is its own change, not
smuggled into a mechanical re-pin, but it must land before anything gates on the
field.

## This is a six-place change, not the five I previously counted

| # | Place |
| --- | --- |
| 1 | `src/lib/dev/contracts/**` (regenerated schemas, examples, manifest) |
| 2 | `src/lib/dev/contracts/source.json` (`source_commit`) |
| 3 | `src/lib/dev/generated.ts` (banner + types) |
| 4 | `scripts/ask-dev-contracts.mjs` (`SOURCE_COMMIT`) |
| 5 | `.github/workflows/tests.yml` (the pinned checkout's `ref:`) |
| 6 | `src/lib/dev/__tests__/contracts.test.ts` — hardcodes the commit as well |

Places 4 and 5 are cross-checked against each other by
the CI execution-contract test in `scripts/__tests__/`, and place 6 fails
on its own, so a partial re-pin cannot pass quietly. That is the only reason the
sixth place was discoverable rather than a latent trap — worth recording for
whoever does the next one.

## A test that had an expiry date, and now does not

The forward-compatibility tests used `record_locator` and `graph_assisted` as
their undeclared-key examples *precisely because* those were the real fields on
their way — the reasoning being that fixtures should mirror the real producer.

This re-pin falsified that test's premise: by declaring `record_locator`, the key
it asserted was unknown became known, and the assertion failed. Asserting "this
key is undeclared" against a name the contract may adopt is a test with a built-in
expiry.

The trade-off has therefore inverted, and the tests now use reserved sentinel
names that stay true across every future re-pin. The mechanism under test does
not care what the key is called, only that the schema lacks it. The base payloads
remain the canonical examples, so the shapes and values around the additions are
still the real producer's — which is the part of the mirror-the-producer
principle that was actually load-bearing.

## Verification

Real exit codes, not a wrapper command's status:

- `ask-dev:contracts:check` → **exit 0**, "Ask Dev contracts are current."
- `ask-dev:contracts:check-currency` → **exit 0**, "pin ddafad6d0… is current
  with ops main (ddafad6d0…)."
- Before this change, the same currency command reported changed schemas and
  **exit 1** — the CI failure this resolves.
- Full unit suite: **3763 passed**, 8 skipped, 417 files. Typecheck clean.

A second re-pin will be needed once the graph-assisted contract package lands on
ops main; that one is a prerequisite for the graph rendering work anyway.

SCREENSHOT-WAIVER: generated contract artifacts, a pinned SHA, and test
fixtures. No component, markup, style or copy is touched, so there is no
rendered output to capture.
