### PR TITLE
feat(ask-dev): ask for real feedback reasons instead of inventing one

### DIFF
--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -16,7 +16,11 @@ import { ClaimsSection } from "./answer/ClaimsSection";
 import { ConflictsSection } from "./answer/ConflictsSection";
 import { CoverageSection } from "./answer/CoverageSection";
 import { EvidenceSection } from "./answer/EvidenceSection";
-import { FeedbackFooter, type FeedbackState } from "./answer/FeedbackFooter";
+import {
+    FeedbackFooter,
+    type FeedbackState,
+    type FeedbackSubmission,
+} from "./answer/FeedbackFooter";
 import { FollowUpSection } from "./answer/FollowUpSection";
 import type { CitationTargets } from "./answer/InlineCitations";
 import type { SafeProse } from "./answer/labels";
@@ -441,12 +445,16 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
         openMetric: openMetricDetail,
     };
 
-    const sendFeedback = async (rating: "helpful" | "not_helpful") => {
+    const sendFeedback = async (submission: FeedbackSubmission) => {
         setFeedback("saving");
         setFeedbackError(null);
         try {
-            await submitAnswerFeedback(answer.answer_id, rating);
-            setFeedback(rating);
+            await submitAnswerFeedback(answer.answer_id, {
+                rating: submission.rating,
+                reasons: submission.reasons,
+                comment: submission.comment,
+            });
+            setFeedback(submission.rating);
         } catch (caught) {
             setFeedback(null);
             setFeedbackError(
@@ -547,7 +555,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
 
             <FeedbackFooter
                 error={feedbackError}
-                onRate={(rating) => void sendFeedback(rating)}
+                onSubmit={(submission) => void sendFeedback(submission)}
                 state={feedback}
             />
         </article>

--- a/src/components/ask-dev/AskDevProvider.tsx
+++ b/src/components/ask-dev/AskDevProvider.tsx
@@ -12,7 +12,12 @@ import {
     type ReactNode,
 } from "react";
 
-import type { DevApiClient, DevConversationList, DevWebError } from "@/lib/dev/client";
+import type {
+    DevApiClient,
+    DevConversationList,
+    DevFeedbackInput,
+    DevWebError,
+} from "@/lib/dev/client";
 import {
     devApiClient,
     initialDevConversationStreamState,
@@ -107,7 +112,7 @@ type AskDevContextValue = {
     returnToPersistentWindow: () => void;
     setPanelMode: (mode: AskDevPanelMode) => void;
     startNewConversation: () => void;
-    submitAnswerFeedback: (answerId: string, rating: "helpful" | "not_helpful") => Promise<void>;
+    submitAnswerFeedback: (answerId: string, input: DevFeedbackInput) => Promise<void>;
     submitQuestion: (question: string) => Promise<void>;
 };
 
@@ -656,12 +661,19 @@ export function AskDevProvider({
         [client],
     );
 
+    /**
+     * Forward exactly what the reader expressed.
+     *
+     * This previously derived `reasons` from the rating alone
+     * (`helpful -> ["useful"]`, `not_helpful -> ["unclear"]`). The positive half
+     * was faithful; the negative half recorded the specific diagnosis "unclear"
+     * for every unhelpful rating, chosen by nobody. The wire requires at least
+     * one reason, so the caller now collects real ones -- see `FeedbackFooter`
+     * for why the two paths differ.
+     */
     const submitAnswerFeedback = useCallback(
-        async (answerId: string, rating: "helpful" | "not_helpful") => {
-            await client.submitFeedback(answerId, {
-                rating,
-                reasons: rating === "helpful" ? ["useful"] : ["unclear"],
-            });
+        async (answerId: string, input: DevFeedbackInput) => {
+            await client.submitFeedback(answerId, input);
         },
         [client],
     );

--- a/src/components/ask-dev/answer/FeedbackFooter.test.tsx
+++ b/src/components/ask-dev/answer/FeedbackFooter.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * The feedback footer, with one invariant above all others: a reason is never
+ * recorded that the reader did not express.
+ *
+ * The implementation this replaced sent `["unclear"]` for every unhelpful
+ * rating. Nothing tested the feedback flow at all, which is exactly how that
+ * survived — so these assert the SUBMITTED PAYLOAD, not that a click happened
+ * or a spinner appeared.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FeedbackFooter, type FeedbackSubmission } from "./FeedbackFooter";
+import {
+    FEEDBACK_REASON_LABELS,
+    NEGATIVE_FEEDBACK_REASONS,
+    POSITIVE_FEEDBACK_REASON,
+} from "./feedbackReasons";
+
+const onSubmit = vi.fn<(submission: FeedbackSubmission) => void>();
+
+function renderFooter(state: "helpful" | "not_helpful" | "saving" | null = null) {
+    return render(<FeedbackFooter error={null} onSubmit={onSubmit} state={state} />);
+}
+
+const label = (reason: (typeof NEGATIVE_FEEDBACK_REASONS)[number]) =>
+    FEEDBACK_REASON_LABELS[reason];
+
+describe("FeedbackFooter positive path", () => {
+    beforeEach(() => onSubmit.mockReset());
+
+    it("submits on one click, recording only the reason that restates the button", async () => {
+        renderFooter();
+        await userEvent.click(screen.getByRole("button", { name: "Helpful" }));
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls[0]![0]).toEqual({
+            rating: "helpful",
+            reasons: [POSITIVE_FEEDBACK_REASON],
+            comment: null,
+        });
+    });
+});
+
+describe("FeedbackFooter negative path", () => {
+    beforeEach(() => onSubmit.mockReset());
+
+    it("does NOT submit when the rating is chosen — it asks first", async () => {
+        renderFooter();
+        await userEvent.click(screen.getByRole("button", { name: "Not helpful" }));
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.getByText(/pick at least one/iu)).toBeInTheDocument();
+    });
+
+    it("keeps Save disabled until a reason is actually chosen", async () => {
+        renderFooter();
+        await userEvent.click(screen.getByRole("button", { name: "Not helpful" }));
+        const save = screen.getByRole("button", { name: "Save" });
+        expect(save).toBeDisabled();
+
+        await userEvent.click(screen.getByRole("button", { name: label("unclear") }));
+        expect(save).toBeEnabled();
+    });
+
+    it("cannot be made to submit with no reason, even by clicking a disabled Save", async () => {
+        renderFooter();
+        await userEvent.click(screen.getByRole("button", { name: "Not helpful" }));
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("records exactly the reasons chosen, and nothing inferred", async () => {
+        renderFooter();
+        await userEvent.click(screen.getByRole("button", { name: "Not helpful" }));
+        await userEvent.click(screen.getByRole("button", { name: label("missing_evidence") }));
+        await userEvent.click(screen.getByRole("button", { name: label("stale_data") }));
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        const submission = onSubmit.mock.calls[0]![0];
+        expect(submission.rating).toBe("not_helpful");
+        expect(submission.reasons.slice().sort()).toEqual(["missing_evidence", "stale_data"]);
+        // The specific regression: no diagnosis the reader never picked.
+        expect(submission.reasons).not.toContain("unclear");
+        expect(submission.comment).toBeNull();
+    });
+
+    it("deselects a reason on a second click and records the remainder", async () => {
+        renderFooter();
+        await userEvent.click(screen.getByRole("button", { name: "Not helpful" }));
+        const incorrect = screen.getByRole("button", { name: label("incorrect") });
+        await userEvent.click(incorrect);
+        expect(incorrect).toHaveAttribute("aria-pressed", "true");
+        await userEvent.click(incorrect);
+        expect(incorrect).toHaveAttribute("aria-pressed", "false");
+
+        await userEvent.click(screen.getByRole("button", { name: label("wrong_scope") }));
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+        expect(onSubmit.mock.calls[0]![0].reasons).toEqual(["wrong_scope"]);
+    });
+
+    it("passes a trimmed comment, and null when it is blank or whitespace", async () => {
+        renderFooter();
+        await userEvent.click(screen.getByRole("button", { name: "Not helpful" }));
+        await userEvent.click(screen.getByRole("button", { name: label("incorrect") }));
+        await userEvent.type(screen.getByRole("textbox"), "   the cohort was wrong   ");
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+        expect(onSubmit.mock.calls[0]![0].comment).toBe("the cohort was wrong");
+
+        onSubmit.mockReset();
+        renderFooter();
+        const notHelpful = screen.getAllByRole("button", { name: "Not helpful" }).at(-1)!;
+        await userEvent.click(notHelpful);
+        const chips = screen.getAllByRole("button", { name: label("incorrect") });
+        await userEvent.click(chips.at(-1)!);
+        await userEvent.type(screen.getAllByRole("textbox").at(-1)!, "    ");
+        await userEvent.click(screen.getAllByRole("button", { name: "Save" }).at(-1)!);
+        expect(onSubmit.mock.calls[0]![0].comment).toBeNull();
+    });
+
+    it("never offers the positive reason as an explanation for an unhelpful rating", async () => {
+        renderFooter();
+        await userEvent.click(screen.getByRole("button", { name: "Not helpful" }));
+        expect(
+            screen.queryByRole("button", {
+                name: FEEDBACK_REASON_LABELS[POSITIVE_FEEDBACK_REASON],
+            }),
+        ).toBeNull();
+    });
+
+    it("Cancel abandons the selection without submitting anything", async () => {
+        renderFooter();
+        await userEvent.click(screen.getByRole("button", { name: "Not helpful" }));
+        await userEvent.click(screen.getByRole("button", { name: label("incorrect") }));
+        await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    });
+});
+
+describe("FeedbackFooter committed and in-flight states", () => {
+    beforeEach(() => onSubmit.mockReset());
+
+    it("reports a settled rating and stops accepting another", async () => {
+        renderFooter("helpful");
+        expect(screen.getByRole("status")).toHaveTextContent("Feedback saved.");
+        expect(screen.getByRole("button", { name: "Helpful" })).toBeDisabled();
+        expect(screen.getByRole("button", { name: "Not helpful" })).toBeDisabled();
+        await userEvent.click(screen.getByRole("button", { name: "Helpful" }));
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a save failure as an alert", () => {
+        render(
+            <FeedbackFooter
+                error="Feedback could not be saved."
+                onSubmit={onSubmit}
+                state={null}
+            />,
+        );
+        expect(screen.getByRole("alert")).toHaveTextContent("Feedback could not be saved.");
+    });
+});

--- a/src/components/ask-dev/answer/FeedbackFooter.tsx
+++ b/src/components/ask-dev/answer/FeedbackFooter.tsx
@@ -1,57 +1,181 @@
 "use client";
 
+import { useState } from "react";
+
 import { CTA_LABELS } from "@/lib/design/cta";
+
+import {
+    FEEDBACK_COMMENT_MAX_LENGTH,
+    FEEDBACK_REASON_LABELS,
+    NEGATIVE_FEEDBACK_REASONS,
+    POSITIVE_FEEDBACK_REASON,
+    type DevFeedbackReason,
+} from "./feedbackReasons";
 
 /** The rating this footer has committed, or `saving` while the request is in
  * flight. `null` means nothing has been submitted for this answer yet. */
 export type FeedbackState = "helpful" | "not_helpful" | "saving" | null;
 
+export type FeedbackSubmission = Readonly<{
+    rating: "helpful" | "not_helpful";
+    reasons: readonly DevFeedbackReason[];
+    comment: string | null;
+}>;
+
 /**
  * Beta feedback for one answer.
  *
- * Deliberately narrow today: a binary rating is all the wire vocabulary
- * supports being asked for honestly. The reason dimensions the contract
- * already carries are not surfaced yet, and the two the provider currently
- * sends are inferred from the rating rather than chosen by the reader — so
- * this component asks only the question it can actually record.
+ * The two paths are deliberately asymmetric, and the asymmetry is the point.
+ *
+ * `reasons` is required on the wire with `minItems: 1`, so *something* must
+ * always be sent. A positive rating can satisfy that honestly: `useful`
+ * restates the button the reader pressed. A negative rating cannot — any reason
+ * filled in on the reader's behalf is a specific diagnosis nobody made. The
+ * previous implementation sent `["unclear"]` for every unhelpful rating, which
+ * recorded "the answer was unclear" for every thumbs-down whether or not it
+ * was: a measurement that never happened, stored as one that did, inside the
+ * very signal this beta collects. So the negative path asks, and `Save` stays
+ * disabled until at least one reason is actually chosen.
+ *
+ * If a neutral "declined to say" member is added to the contract, the negative
+ * path can go back to one click and record that member instead — an honest
+ * value for an honest absence. Until then, asking is the only truthful option.
  */
 export function FeedbackFooter({
     error,
-    onRate,
+    onSubmit,
     state,
 }: {
     error: string | null;
-    onRate: (rating: "helpful" | "not_helpful") => void;
+    onSubmit: (submission: FeedbackSubmission) => void;
     state: FeedbackState;
 }) {
+    const [reasonsOpen, setReasonsOpen] = useState(false);
+    const [selected, setSelected] = useState<ReadonlySet<DevFeedbackReason>>(() => new Set());
+    const [comment, setComment] = useState("");
+
+    const settled = state === "helpful" || state === "not_helpful";
+    const saving = state === "saving";
+
+    const toggleReason = (reason: DevFeedbackReason) => {
+        setSelected((current) => {
+            const next = new Set(current);
+            if (next.has(reason)) next.delete(reason);
+            else next.add(reason);
+            return next;
+        });
+    };
+
+    const submitNegative = () => {
+        if (!selected.size) return;
+        const trimmed = comment.trim();
+        onSubmit({
+            rating: "not_helpful",
+            // Sorted so the recorded order reflects the sanctioned reason order
+            // rather than the order the reader happened to click in.
+            reasons: NEGATIVE_FEEDBACK_REASONS.filter((reason) => selected.has(reason)),
+            comment: trimmed.length ? trimmed : null,
+        });
+    };
+
     return (
-        <footer className="flex flex-wrap items-center gap-2 border-t border-(--border) pt-4">
-            <span className="mr-1 text-xs text-(--text-muted)">Was this useful?</span>
-            <button
-                type="button"
-                disabled={state === "saving" || state === "helpful"}
-                onClick={() => onRate("helpful")}
-                className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--positive)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--positive)/45 disabled:opacity-55"
-            >
-                {CTA_LABELS.askDevHelpful}
-            </button>
-            <button
-                type="button"
-                disabled={state === "saving" || state === "not_helpful"}
-                onClick={() => onRate("not_helpful")}
-                className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--caution)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--caution)/45 disabled:opacity-55"
-            >
-                {CTA_LABELS.askDevNotHelpful}
-            </button>
-            {state === "helpful" || state === "not_helpful" ? (
-                <span role="status" className="text-xs text-(--positive)">
-                    Feedback saved.
-                </span>
-            ) : null}
-            {error ? (
-                <span role="alert" className="text-xs text-(--negative)">
-                    {error}
-                </span>
+        <footer className="space-y-3 border-t border-(--border) pt-4">
+            <div className="flex flex-wrap items-center gap-2">
+                <span className="mr-1 text-xs text-(--text-muted)">Was this useful?</span>
+                <button
+                    type="button"
+                    disabled={saving || settled}
+                    onClick={() =>
+                        onSubmit({
+                            rating: "helpful",
+                            reasons: [POSITIVE_FEEDBACK_REASON],
+                            comment: null,
+                        })
+                    }
+                    className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--positive)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--positive)/45 disabled:opacity-55"
+                >
+                    {CTA_LABELS.askDevHelpful}
+                </button>
+                <button
+                    type="button"
+                    disabled={saving || settled}
+                    aria-expanded={reasonsOpen}
+                    onClick={() => setReasonsOpen(true)}
+                    className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs text-(--text-secondary) hover:border-(--caution)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--caution)/45 disabled:opacity-55"
+                >
+                    {CTA_LABELS.askDevNotHelpful}
+                </button>
+                {settled ? (
+                    <span role="status" className="text-xs text-(--positive)">
+                        Feedback saved.
+                    </span>
+                ) : null}
+                {error ? (
+                    <span role="alert" className="text-xs text-(--negative)">
+                        {error}
+                    </span>
+                ) : null}
+            </div>
+
+            {reasonsOpen && !settled ? (
+                <div className="space-y-2" aria-label="What was wrong with this answer?">
+                    <p className="text-xs text-(--text-muted)">
+                        Tell us what was wrong. Pick at least one.
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                        {NEGATIVE_FEEDBACK_REASONS.map((reason) => (
+                            <button
+                                key={reason}
+                                type="button"
+                                disabled={saving}
+                                aria-pressed={selected.has(reason)}
+                                onClick={() => toggleReason(reason)}
+                                className={
+                                    selected.has(reason)
+                                        ? "rounded-(--radius-pill) border border-(--caution)/60 bg-(--caution)/12 px-3 py-1 text-xs text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--caution)/45"
+                                        : "rounded-(--radius-pill) border border-(--border) px-3 py-1 text-xs text-(--text-secondary) hover:border-(--caution)/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--caution)/45 disabled:opacity-55"
+                                }
+                            >
+                                {FEEDBACK_REASON_LABELS[reason]}
+                            </button>
+                        ))}
+                    </div>
+                    <label className="block space-y-1">
+                        <span className="text-xs text-(--text-muted)">
+                            Anything else? (optional)
+                        </span>
+                        <textarea
+                            value={comment}
+                            onChange={(event) => setComment(event.target.value)}
+                            maxLength={FEEDBACK_COMMENT_MAX_LENGTH}
+                            rows={2}
+                            disabled={saving}
+                            className="w-full rounded-(--radius-sm) border border-(--border) bg-(--background)/60 px-2 py-1.5 text-xs text-(--text-primary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-55"
+                        />
+                    </label>
+                    <div className="flex flex-wrap items-center gap-2">
+                        <button
+                            type="button"
+                            disabled={saving || selected.size === 0}
+                            onClick={submitNegative}
+                            className="rounded-(--radius-sm) border border-(--border) px-2.5 py-1.5 text-xs font-medium text-(--text-secondary) hover:border-(--accent)/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-55"
+                        >
+                            {saving ? CTA_LABELS.saving : CTA_LABELS.save}
+                        </button>
+                        <button
+                            type="button"
+                            disabled={saving}
+                            onClick={() => {
+                                setReasonsOpen(false);
+                                setSelected(new Set());
+                                setComment("");
+                            }}
+                            className="rounded-(--radius-sm) px-2.5 py-1.5 text-xs text-(--text-muted) hover:text-(--text-secondary) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent)/45 disabled:opacity-55"
+                        >
+                            {CTA_LABELS.cancel}
+                        </button>
+                    </div>
+                </div>
             ) : null}
         </footer>
     );

--- a/src/components/ask-dev/answer/FeedbackFooter.tsx
+++ b/src/components/ask-dev/answer/FeedbackFooter.tsx
@@ -6,9 +6,9 @@ import { CTA_LABELS } from "@/lib/design/cta";
 
 import {
     FEEDBACK_COMMENT_MAX_LENGTH,
-    FEEDBACK_REASON_LABELS,
     NEGATIVE_FEEDBACK_REASONS,
     POSITIVE_FEEDBACK_REASON,
+    feedbackReasonLabel,
     type DevFeedbackReason,
 } from "./feedbackReasons";
 
@@ -136,7 +136,7 @@ export function FeedbackFooter({
                                         : "rounded-(--radius-pill) border border-(--border) px-3 py-1 text-xs text-(--text-secondary) hover:border-(--caution)/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--caution)/45 disabled:opacity-55"
                                 }
                             >
-                                {FEEDBACK_REASON_LABELS[reason]}
+                                {feedbackReasonLabel(reason)}
                             </button>
                         ))}
                     </div>

--- a/src/components/ask-dev/answer/feedbackReasons.test.ts
+++ b/src/components/ask-dev/answer/feedbackReasons.test.ts
@@ -19,6 +19,8 @@ import {
     FEEDBACK_REASON_POLARITY,
     NEGATIVE_FEEDBACK_REASONS,
     POSITIVE_FEEDBACK_REASON,
+    UNKNOWN_FEEDBACK_REASON_LABEL,
+    feedbackReasonLabel,
 } from "./feedbackReasons";
 
 const SCHEMA_PATH = path.join(
@@ -85,5 +87,37 @@ describe("feedback reason vocabulary vs. the pinned dev_feedback.v1 schema", () 
         // positive submit would start asserting something unchosen AND untrue.
         expect(FEEDBACK_REASON_POLARITY[POSITIVE_FEEDBACK_REASON]).toBe("positive");
         expect(NEGATIVE_FEEDBACK_REASONS).not.toContain(POSITIVE_FEEDBACK_REASON);
+    });
+});
+
+describe("a reason value this build does not recognise", () => {
+    it("resolves to sanctioned copy, never to the raw member", () => {
+        // `wrong_cohort` is a real member arriving in a later contract revision.
+        // The tolerance layer accepts it rather than failing the submission; this
+        // is the other half of that promise -- it must not reach a reader as a
+        // machine token.
+        expect(feedbackReasonLabel("wrong_cohort")).toBe(UNKNOWN_FEEDBACK_REASON_LABEL);
+        expect(feedbackReasonLabel("wrong_cohort")).not.toBe("wrong_cohort");
+        expect(feedbackReasonLabel("wrong_cohort")).not.toContain("_");
+    });
+
+    it("never resolves to undefined, which React would render as nothing", () => {
+        // Silently dropping a reason is worse than naming it vaguely: the reader
+        // sees a shorter list and no indication anything was omitted.
+        for (const value of ["", "unspecified", "totally_made_up", "USEFUL"]) {
+            expect(typeof feedbackReasonLabel(value)).toBe("string");
+            expect(feedbackReasonLabel(value).length).toBeGreaterThan(0);
+        }
+    });
+
+    it("still returns the sanctioned copy for every recognised member", () => {
+        for (const [reason, label] of Object.entries(FEEDBACK_REASON_LABELS)) {
+            expect(feedbackReasonLabel(reason)).toBe(label);
+        }
+    });
+
+    it("the fallback copy is itself free of internal-token shape", () => {
+        expect(UNKNOWN_FEEDBACK_REASON_LABEL).not.toContain("_");
+        expect(UNKNOWN_FEEDBACK_REASON_LABEL).toMatch(/^[A-Z]/u);
     });
 });

--- a/src/components/ask-dev/answer/feedbackReasons.test.ts
+++ b/src/components/ask-dev/answer/feedbackReasons.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The feedback vocabulary against the pinned contract.
+ *
+ * `FEEDBACK_REASON_LABELS` and `FEEDBACK_REASON_POLARITY` are TOTAL `Record`s
+ * over a union derived from the generated types, so a re-pin that adds a reason
+ * already fails to compile until both are extended. TypeScript is not the whole
+ * guard though: totality is only as good as the union, and the union is only as
+ * good as the generated file. This reads the pinned JSON Schema itself — the
+ * artifact the generator consumed — so a generator that dropped a member, or a
+ * generated file edited by hand, is caught rather than believed.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+    FEEDBACK_REASON_LABELS,
+    FEEDBACK_REASON_POLARITY,
+    NEGATIVE_FEEDBACK_REASONS,
+    POSITIVE_FEEDBACK_REASON,
+} from "./feedbackReasons";
+
+const SCHEMA_PATH = path.join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "lib",
+    "dev",
+    "contracts",
+    "schemas",
+    "dev_feedback.v1.schema.json",
+);
+
+function pinnedReasonEnum(): readonly string[] {
+    const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8")) as {
+        properties?: { reasons?: { items?: { enum?: unknown } } };
+    };
+    const members = schema.properties?.reasons?.items?.enum;
+    if (!Array.isArray(members) || members.length === 0) {
+        throw new Error("dev_feedback.v1 reasons enum missing — schema shape changed.");
+    }
+    return members as readonly string[];
+}
+
+describe("feedback reason vocabulary vs. the pinned dev_feedback.v1 schema", () => {
+    it("labels cover exactly the pinned reason enum", () => {
+        expect(Object.keys(FEEDBACK_REASON_LABELS).slice().sort()).toEqual(
+            pinnedReasonEnum().slice().sort(),
+        );
+    });
+
+    it("polarity covers exactly the pinned reason enum", () => {
+        expect(Object.keys(FEEDBACK_REASON_POLARITY).slice().sort()).toEqual(
+            pinnedReasonEnum().slice().sort(),
+        );
+    });
+
+    it("no reason is left unlabelled or labelled with its raw member name", () => {
+        for (const [reason, label] of Object.entries(FEEDBACK_REASON_LABELS)) {
+            expect(label.length, `${reason} has no copy`).toBeGreaterThan(0);
+            // A raw member would leak an internal token: every member is
+            // underscore-or-lowercase machine vocabulary, never sanctioned copy.
+            expect(label, `${reason} renders its raw member name`).not.toBe(reason);
+        }
+    });
+
+    it("offers every negative reason as a chip and no positive or neutral one", () => {
+        const expectedNegative = Object.keys(FEEDBACK_REASON_POLARITY).filter(
+            (reason) =>
+                FEEDBACK_REASON_POLARITY[reason as keyof typeof FEEDBACK_REASON_POLARITY] ===
+                "negative",
+        );
+        expect(NEGATIVE_FEEDBACK_REASONS.slice().sort()).toEqual(expectedNegative.slice().sort());
+        for (const reason of NEGATIVE_FEEDBACK_REASONS) {
+            expect(FEEDBACK_REASON_POLARITY[reason]).toBe("negative");
+        }
+    });
+
+    it("the one auto-supplied reason is positive, and is never offered as a negative chip", () => {
+        // The positive path records POSITIVE_FEEDBACK_REASON without the reader
+        // choosing it. That is only defensible while the member genuinely means
+        // "this was useful" -- if it were ever reclassified, the one-click
+        // positive submit would start asserting something unchosen AND untrue.
+        expect(FEEDBACK_REASON_POLARITY[POSITIVE_FEEDBACK_REASON]).toBe("positive");
+        expect(NEGATIVE_FEEDBACK_REASONS).not.toContain(POSITIVE_FEEDBACK_REASON);
+    });
+});

--- a/src/components/ask-dev/answer/feedbackReasons.ts
+++ b/src/components/ask-dev/answer/feedbackReasons.ts
@@ -1,0 +1,82 @@
+import type { DevFeedback } from "@/lib/dev/generated";
+
+/**
+ * One `dev_feedback.v1` reason, derived from the generated contract rather
+ * than restated.
+ *
+ * `reasons` is a tuple union on the wire (it carries `minItems`/`maxItems`), so
+ * indexing with `number` yields the member union. Deriving it is the whole
+ * point: a re-pin that adds a member has to break the two TOTAL records below
+ * until each new member is given sanctioned copy and a polarity. A hand-written
+ * copy of this union would keep compiling against a stale vocabulary and the
+ * new members would never reach the UI.
+ */
+export type DevFeedbackReason = DevFeedback["reasons"][number];
+
+/**
+ * Sanctioned reader-facing copy per reason. TOTAL — an unmapped member is a
+ * build error, never a raw enum value on a chip.
+ *
+ * Wording stays faithful to the member it names and no wider. `wrong_scope`
+ * reads "Wrong scope", not "Wrong subject or scope": the beta's own
+ * requirements list a distinct wrong-subject dimension, and borrowing that
+ * meaning now would make the two indistinguishable in the corpus the moment
+ * the real member lands.
+ */
+export const FEEDBACK_REASON_LABELS: Record<DevFeedbackReason, string> = {
+    incorrect: "Incorrect",
+    missing_evidence: "Missing evidence",
+    stale_data: "Stale data",
+    unclear: "Unclear",
+    useful: "Useful",
+    wrong_scope: "Wrong scope",
+};
+
+/**
+ * Which rating a reason can honestly accompany. Also TOTAL, for a reason
+ * beyond drift-protection: it is what stops a positive member being offered as
+ * an explanation for a negative rating (and the reverse).
+ *
+ * `neutral` exists ahead of any neutral member because the decision it encodes
+ * is already made: a reason meaning "the reader declined to say" is never an
+ * option to click, it is what gets recorded when nothing was clicked. Having
+ * the third case here means such a member classifies correctly on arrival
+ * instead of being forced into `negative` and silently appearing as a chip.
+ */
+export const FEEDBACK_REASON_POLARITY: Record<
+    DevFeedbackReason,
+    "positive" | "negative" | "neutral"
+> = {
+    incorrect: "negative",
+    missing_evidence: "negative",
+    stale_data: "negative",
+    unclear: "negative",
+    useful: "positive",
+    wrong_scope: "negative",
+};
+
+/**
+ * The reasons offered when a reader rates an answer unhelpful, derived from the
+ * polarity table so the list cannot fall behind it. Sorted for a stable
+ * rendering order that no separate hand-maintained list has to keep in step.
+ */
+export const NEGATIVE_FEEDBACK_REASONS: readonly DevFeedbackReason[] = (
+    Object.keys(FEEDBACK_REASON_POLARITY) as DevFeedbackReason[]
+)
+    .filter((reason) => FEEDBACK_REASON_POLARITY[reason] === "negative")
+    .sort((left, right) =>
+        FEEDBACK_REASON_LABELS[left].localeCompare(FEEDBACK_REASON_LABELS[right]),
+    );
+
+/**
+ * The reason recorded for a one-click positive rating.
+ *
+ * This is the ONE place a reason is supplied without the reader choosing it,
+ * and it is sound because it restates the button they pressed: they clicked
+ * "Helpful" and `useful` means exactly that. The negative path deliberately has
+ * no counterpart — see `FeedbackFooter`.
+ */
+export const POSITIVE_FEEDBACK_REASON: DevFeedbackReason = "useful";
+
+/** The wire cap on `comment`, mirrored so the field can bound its own input. */
+export const FEEDBACK_COMMENT_MAX_LENGTH = 2048;

--- a/src/components/ask-dev/answer/feedbackReasons.ts
+++ b/src/components/ask-dev/answer/feedbackReasons.ts
@@ -80,3 +80,34 @@ export const POSITIVE_FEEDBACK_REASON: DevFeedbackReason = "useful";
 
 /** The wire cap on `comment`, mirrored so the field can bound its own input. */
 export const FEEDBACK_COMMENT_MAX_LENGTH = 2048;
+
+/**
+ * Sanctioned copy for a reason this build does not recognise.
+ *
+ * The tolerance layer accepts a reason member the pinned contract lacks rather
+ * than failing the submission (a rating the server stored must not be rejected
+ * on its way back). That acceptance would be worthless if the value then
+ * reached a reader as `wrong_cohort` -- an internal machine token on screen is
+ * exactly what the beta forbids. So the lookup below has no raw-value branch at
+ * all: an unrecognised member resolves to this phrase.
+ *
+ * Deliberately vague rather than guessing. Naming a reason we do not have copy
+ * for would be inventing a meaning; "another reason" is true of every member
+ * this build has not been taught.
+ */
+export const UNKNOWN_FEEDBACK_REASON_LABEL = "Another reason";
+
+/**
+ * Reader-facing copy for any reason value, recognised or not.
+ *
+ * The single lookup used everywhere reasons are displayed. Written as a function
+ * rather than leaving callers to index `FEEDBACK_REASON_LABELS` directly so the
+ * fallback cannot be forgotten at a future call site -- indexing the record with
+ * an unknown key yields `undefined`, and React renders that as nothing, which
+ * would silently drop a reason instead of naming it.
+ */
+export function feedbackReasonLabel(reason: string): string {
+    return Object.hasOwn(FEEDBACK_REASON_LABELS, reason)
+        ? FEEDBACK_REASON_LABELS[reason as DevFeedbackReason]
+        : UNKNOWN_FEEDBACK_REASON_LABEL;
+}

--- a/src/lib/dev/client.ts
+++ b/src/lib/dev/client.ts
@@ -59,11 +59,19 @@ export type DevConversationCreateInput = Readonly<{
     title?: string | null;
 }>;
 export type DevConversationRenameInput = Readonly<{ title: string | null }>;
+/**
+ * The feedback request body.
+ *
+ * `rating` and `reasons` are DERIVED from the generated `dev_feedback.v1` types
+ * rather than restated. They were previously hand-written copies of the same
+ * unions, which meant a re-pin that added a reason (or a rating) kept compiling
+ * against the stale vocabulary and the new member could never be sent -- the
+ * exact drift the pinned-contract workflow exists to prevent, reintroduced one
+ * layer above it.
+ */
 export type DevFeedbackInput = Readonly<{
-    rating: "helpful" | "not_helpful";
-    reasons: (
-        "incorrect" | "missing_evidence" | "wrong_scope" | "stale_data" | "unclear" | "useful"
-    )[];
+    rating: DevFeedback["rating"];
+    reasons: readonly DevFeedback["reasons"][number][];
     comment?: string | null;
 }>;
 

--- a/tests/ask-dev-feedback.spec.ts
+++ b/tests/ask-dev-feedback.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "@playwright/test";
+
+import {
+    askDevAnswerArticle,
+    openAskDevWindow,
+    resetAskDevMock,
+    scenarioQuestion,
+    submitAskDevQuestion,
+} from "./helpers/askDev";
+
+/**
+ * Beta feedback, asserted on the WIRE.
+ *
+ * The unit tests around `FeedbackFooter` assert what the component hands its
+ * caller. That is necessary but not sufficient: the value that matters is what
+ * actually leaves the browser and lands in the corpus, and between the two sit
+ * the container, the provider, the API client and the Next proxy. The defect
+ * this replaced lived in the provider, not the component — the footer of the day
+ * was innocent and the payload was still wrong.
+ *
+ * So these read the intercepted POST body. The mock deliberately cannot serve as
+ * the oracle here: `submitFeedback` in devScenario.ts echoes whatever `reasons`
+ * it receives, so asserting the response would be asserting our own input.
+ */
+
+type FeedbackBody = {
+    rating: string;
+    reasons: string[];
+    comment: string | null;
+};
+
+const FEEDBACK_ROUTE = "**/api/v1/dev/answers/*/feedback";
+
+/** Capture every feedback POST body, letting the request proceed untouched. */
+async function captureFeedbackBodies(
+    page: import("@playwright/test").Page,
+): Promise<readonly FeedbackBody[]> {
+    const bodies: FeedbackBody[] = [];
+    await page.route(FEEDBACK_ROUTE, async (route) => {
+        const raw = route.request().postData();
+        if (raw) bodies.push(JSON.parse(raw) as FeedbackBody);
+        await route.continue();
+    });
+    return bodies;
+}
+
+async function renderAnswer(page: import("@playwright/test").Page): Promise<void> {
+    // The launcher only exists inside the authenticated shell — the persistent
+    // window is mounted by app/(app)/layout.tsx, not by the bare page.
+    await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+    await openAskDevWindow(page);
+    await submitAskDevQuestion(page, scenarioQuestion("complete", "What changed this week?"));
+    await expect(askDevAnswerArticle(page)).toBeVisible();
+}
+
+test.beforeEach(async ({ request }) => {
+    await resetAskDevMock(request);
+});
+
+test.describe("Ask Dev — beta feedback reaches the wire as expressed", () => {
+    test("a helpful rating sends one reason that restates the button, and no comment", async ({
+        page,
+    }) => {
+        const bodies = await captureFeedbackBodies(page);
+        await renderAnswer(page);
+
+        await page.getByRole("button", { name: "Helpful", exact: true }).click();
+        await expect(page.getByRole("status").filter({ hasText: "Feedback saved." })).toBeVisible();
+
+        expect(bodies).toHaveLength(1);
+        expect(bodies[0]!.rating).toBe("helpful");
+        expect(bodies[0]!.reasons).toEqual(["useful"]);
+        expect(bodies[0]!.comment ?? null).toBeNull();
+    });
+
+    test("an unhelpful rating sends NOTHING until a reason is chosen", async ({ page }) => {
+        const bodies = await captureFeedbackBodies(page);
+        await renderAnswer(page);
+
+        await page.getByRole("button", { name: "Not helpful" }).click();
+        // The reason panel is open and the rating is NOT yet recorded. This is
+        // the anti-fabrication invariant at the transport layer: no request has
+        // left the browser, so no phantom diagnosis can have been stored.
+        await expect(page.getByRole("button", { name: "Save" })).toBeDisabled();
+        expect(bodies).toHaveLength(0);
+    });
+
+    test("an unhelpful rating sends exactly the chosen reasons and the typed comment", async ({
+        page,
+    }) => {
+        const bodies = await captureFeedbackBodies(page);
+        await renderAnswer(page);
+
+        await page.getByRole("button", { name: "Not helpful" }).click();
+        await page.getByRole("button", { name: "Missing evidence" }).click();
+        await page.getByRole("button", { name: "Stale data" }).click();
+        await page
+            .getByRole("textbox", { name: "Anything else?" })
+            .fill("  the numbers are from last month  ");
+        await page.getByRole("button", { name: "Save" }).click();
+        await expect(page.getByRole("status").filter({ hasText: "Feedback saved." })).toBeVisible();
+
+        expect(bodies).toHaveLength(1);
+        const body = bodies[0]!;
+        expect(body.rating).toBe("not_helpful");
+        expect(body.reasons.slice().sort()).toEqual(["missing_evidence", "stale_data"]);
+        // The regression that made this spec exist: every unhelpful rating used
+        // to carry "unclear", chosen by nobody.
+        expect(body.reasons).not.toContain("unclear");
+        expect(body.comment).toBe("the numbers are from last month");
+    });
+
+    test("cancelling an unhelpful rating records nothing at all", async ({ page }) => {
+        const bodies = await captureFeedbackBodies(page);
+        await renderAnswer(page);
+
+        await page.getByRole("button", { name: "Not helpful" }).click();
+        await page.getByRole("button", { name: "Incorrect" }).click();
+        await page.getByRole("button", { name: "Cancel" }).click();
+
+        await expect(page.getByRole("button", { name: "Save" })).toBeHidden();
+        expect(bodies).toHaveLength(0);
+    });
+
+    test("the reason chips are keyboard reachable and expose their pressed state", async ({
+        page,
+    }) => {
+        await renderAnswer(page);
+        await page.getByRole("button", { name: "Not helpful" }).click();
+
+        const chip = page.getByRole("button", { name: "Unclear" });
+        await chip.focus();
+        await expect(chip).toBeFocused();
+        await expect(chip).toHaveAttribute("aria-pressed", "false");
+        await page.keyboard.press("Enter");
+        await expect(chip).toHaveAttribute("aria-pressed", "true");
+        await expect(page.getByRole("button", { name: "Save" })).toBeEnabled();
+    });
+});


### PR DESCRIPTION
Part of the web leg of issue 3665 (graph-assisted Ask Dev beta). Fixes a
data-honesty defect in the beta's own feedback signal, and exposes the reason
dimensions the contract already carries.

## The defect

`dev_feedback.v1` requires `reasons` with `minItems: 1`, so every rating must
carry at least one. The previous code satisfied that by deriving reasons from
the rating alone:

```ts
reasons: rating === "helpful" ? ["useful"] : ["unclear"]
```

The positive half is faithful — the reader pressed "Helpful" and `useful` means
that. **The negative half recorded the specific diagnosis "the answer was
unclear" for every single thumbs-down, chosen by nobody.** A measurement that
never happened, stored as one that did, inside the exact signal this beta exists
to collect.

That matters beyond tidiness. Once wrong-cohort and wrong-driver dimensions
land, a corpus in which every negative rating also carries a phantom `unclear`
cannot answer "was the cohort wrong?" — which is one of the questions the beta
is gathering data to answer.

**Nothing tested the feedback flow at all.** That is how it survived.

## What changed

- **Helpful** still submits in one click and records only `useful`.
- **Not helpful** opens a reason picker, and `Save` stays disabled until the
  reader actually chooses something. No diagnosis is ever supplied on their
  behalf.
- The contract's `comment` field, previously unused by the UI, is exposed as
  optional free text and trimmed (blank becomes `null`).

The asymmetry is deliberate: a positive rating can satisfy `minItems: 1`
honestly because `useful` restates the button pressed, and a negative one
cannot. If a neutral "declined to say" member is added to the contract, the
negative path can return to one click and record that instead — an honest value
for an honest absence. Until then, asking is the only truthful option.

## Drift pressure, and one thing the type system cannot cover

Reason vocabulary lives in `answer/feedbackReasons.ts` as two TOTAL records over
a union **derived** from the generated contract (`DevFeedback["reasons"][number]`),
so a re-pin that adds a member fails the build until it is given sanctioned copy
and a polarity. Polarity is what stops a positive member being offered as an
explanation for a negative rating; it carries a `neutral` case ahead of any
neutral member because that decision is already made — such a member must never
be a clickable chip, and without the third case it would be forced into
`negative` and silently render as one.

`DevFeedbackInput` in the API client previously hand-wrote copies of the same
rating and reason unions. Those are now derived too: a hand-written copy keeps
compiling against a stale vocabulary, which would have silently defeated the
compile-pressure above one layer below it.

Display goes through one lookup, `feedbackReasonLabel()`, with no raw-value
branch — the other half of the forward-compatibility work. Accepting an
unrecognised member is worthless if it then reaches a reader as `wrong_cohort`.
It is a function rather than a record index for a reason types cannot express:
indexing with an unknown key yields `undefined`, and **React renders that as
nothing**, so a reason would silently vanish with no indication anything was
omitted — worse than naming it vaguely, because the reader cannot distinguish
that from "no reason was given".

## Verification

Tests assert the **submitted payload**, not that a click happened. The e2e spec
asserts the **intercepted POST body** — the mock cannot be the oracle there,
since it echoes back whatever reasons it receives.

Four mutations, each observed failing the right guard before the tests were
trusted:

| Mutation | Result |
| --- | --- |
| Reinstate the old fabrication (auto-`unclear`, ungate Save) | exactly the 2 anti-fabrication unit tests failed; the other 9 stayed green |
| Reclassify `useful` as negative | failed **both** the schema-vocabulary and component tests, which cross-check each other |
| Plant the fabrication in the **provider** | **11/11 component tests green** — the component genuinely is innocent there — and the wire-level spec failed |
| Return the raw member from the label fallback | 2 failed, including the assertion that no underscore-bearing token can reach a label |

The third is the one that justifies the layering: the original defect lived in
the provider, where component tests structurally cannot see it.

Full gate on a frozen tree, real exit codes captured to file rather than read
off a wrapper command's status:

| Stage | Exit | Result |
| --- | --- | --- |
| `format` | 0 | pass |
| `quality` | 0 | pass — currency checked against a freshly-fetched ops main (`ddafad6d0`), logged in the run |
| `design-lint` | 0 | pass |
| `build` | 0 | pass |
| `unit` | 0 | 3783 passed, 8 skipped, 419 files |
| `e2e-default 1/2` | 0 | 178/178 |
| `e2e-default 2/2` | 0 | 148 passed, 2 pre-existing documented skips |
| `e2e-onboarding` | 0 | 10/10 |
| `pagerduty-final-qa` | 0 | 23/23 |
| `e2e-context-fabric` | 1 | the single known macOS-only mobile-nav/focus failure (filed separately, green in CI) |

`e2e-default 1/2` plus `2/2` is the script's own supported partition, so that is
the whole default suite. Shard 1 is now 178 tests rather than 173 because this
PR adds a spec.

## Visual evidence

Captured from the shipped tree (re-captured after the rebase, so these are the
merged code's output, not an earlier revision's) via the deterministic Playwright
mock harness rather than a hand-driven browser — the fixtures are the canonical
`dev_answer.v1` example, so the states are reproducible rather than whatever the
session happened to contain.

**Resting state** — unchanged from before this PR; the two rating buttons are
still the entry point, so nothing new is asked of a reader who just wants to say
"helpful".

![resting](https://github.com/user-attachments/assets/8c811b84-d8b4-4778-a9d8-cdf4c7567903)

**Reason picker, nothing chosen yet** — `Save` is disabled. This is the state the
PR exists to create: the rating is not recorded, so no phantom diagnosis can be
stored.

![reasons open](https://github.com/user-attachments/assets/2d31e2e9-7573-4d67-979b-fe1777118c79)

**Two reasons chosen, with a comment** — `Save` becomes available only here.
Chips carry `aria-pressed`, and the order is derived from the polarity table
rather than hand-maintained.

![reasons selected](https://github.com/user-attachments/assets/2f0c87e5-9db9-42f0-990a-f97ebfa897a8)

**Committed** — the rating settles and both buttons disable, so one answer
records one rating.

![saved](https://github.com/user-attachments/assets/87e6f96a-8b93-4f6b-9c65-8befac2591fd)

**Narrow viewport (375px)** — chips wrap to two rows with no horizontal
overflow and no truncated labels.

![mobile](https://github.com/user-attachments/assets/297efc0b-e173-4a15-b0f5-70f050b617af)
