### PR TITLE
fix(live-e2e): prove credential existence before testing it, and lift the register throttle

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -167,6 +167,18 @@ jobs:
                   # onboarding-ui regression for weeks.
                   JWT_SECRET_KEY: live-e2e-test-secret-do-not-use-in-production
                   SETTINGS_ENCRYPTION_KEY: live-e2e-test-settings-key-do-not-use
+                  # Ops default is 3/hour per IP (rate_limit.py: AUTH_REGISTER_LIMIT
+                  # falls back to "3/hour" when unset). This suite is
+                  # self-bootstrapping: nearly every describe group registers its own
+                  # user, and in CI every request arrives from one IP -- so past the
+                  # third registration the rest of the run is talking to a throttle
+                  # instead of the API, and the tests that depend on that identity
+                  # skip or fail for reasons unrelated to what they assert.
+                  #
+                  # Raised HERE only. The production default is untouched: it lives in
+                  # the ops fallback, not in this file, so nothing about this line
+                  # changes deployed behaviour.
+                  AUTH_REGISTER_LIMIT: 1000/hour
               run: |
                   nohup python -m dev_health_ops.cli \
                     --db "$DATABASE_URI" \

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -60,6 +60,12 @@ jobs:
                     - 5432:5432
                 options: >-
                     --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+            redis:
+                image: redis:7
+                ports:
+                    - 6379:6379
+                options: >-
+                    --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
             clickhouse:
                 image: clickhouse/clickhouse-server:25.1
                 env:
@@ -155,10 +161,13 @@ jobs:
                   DATABASE_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
                   CLICKHOUSE_URI: clickhouse://ch:ch@localhost:8123/default
                   POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+                  REDIS_URL: redis://localhost:6379/0
+                  CELERY_BROKER_URL: redis://localhost:6379/0
+                  CELERY_RESULT_BACKEND: redis://localhost:6379/0
                   CORS_ALLOWED_ORIGINS: "http://127.0.0.1:3002,http://localhost:3002,http://127.0.0.1:8000"
                   # Ops CHAOS-1553/1554 fail-closed rate-limit posture refuses to start
-                  # without REDIS_URL unless ENVIRONMENT=development. Live-e2e runs a
-                  # single ops replica and does not need shared Redis state.
+                  # without REDIS_URL unless ENVIRONMENT=development. Live-e2e provides
+                  # a local Redis service for rate limiting and Celery endpoints.
                   ENVIRONMENT: development
                   # Backend auth service requires a JWT signing secret; derivation
                   # from SETTINGS_ENCRYPTION_KEY was removed. Without this every

--- a/scripts/__tests__/live-e2e-register-limit.test.mjs
+++ b/scripts/__tests__/live-e2e-register-limit.test.mjs
@@ -1,5 +1,5 @@
 /**
- * Guards the registration-limit override for the live-e2e backend.
+ * Guards runtime dependencies for the live-e2e backend workflow.
  *
  * Ops defaults `AUTH_REGISTER_LIMIT` to `3/hour` per IP. The live suite is
  * self-bootstrapping — nearly every describe group registers its own user — and
@@ -50,6 +50,54 @@ function registerLimit(block) {
     return { count: Number(match[1]), per: match[2] };
 }
 
+function jobBlock(source, jobName) {
+    const jobHeader = `\n    ${jobName}:\n`;
+    const jobStart = source.indexOf(jobHeader);
+    if (jobStart === -1) return null;
+
+    const rest = source.slice(jobStart + jobHeader.length);
+    const nextJob = rest.search(/\n    [A-Za-z0-9_-]+:\n/u);
+    return nextJob === -1 ? rest : rest.slice(0, nextJob);
+}
+
+function serviceBlock(source, serviceName) {
+    const servicesHeader = "\n        services:\n";
+    const servicesStart = source.indexOf(servicesHeader);
+    if (servicesStart === -1) return null;
+
+    const serviceHeader = `\n            ${serviceName}:\n`;
+    const serviceStart = source.indexOf(serviceHeader, servicesStart + servicesHeader.length);
+    if (serviceStart === -1) return null;
+
+    const rest = source.slice(serviceStart + serviceHeader.length);
+    const nextService = rest.search(/\n            [A-Za-z0-9_-]+:/u);
+    return nextService === -1 ? rest : rest.slice(0, nextService);
+}
+
+function serviceValue(block, propertyName) {
+    if (block === null) return null;
+    const match = new RegExp(`^\\s+${propertyName}:\\s*([^\\s#]+)\\s*$`, "mu").exec(block);
+    return match?.[1] ?? null;
+}
+
+function hasPortMapping(block, port) {
+    if (block === null) return false;
+    return new RegExp(`^\\s+-\\s+${port}:${port}\\s*$`, "mu").test(block);
+}
+
+function healthCommand(block) {
+    if (block === null) return null;
+    const match = /^\s+--health-cmd\s+"([^"]+)"/mu.exec(block);
+    return match?.[1] ?? null;
+}
+
+function envValue(block, variableName) {
+    const match = new RegExp(`^\\s+${variableName}:\\s*"?([^"\\s#]+)"?\\s*$`, "mu").exec(block);
+    return match?.[1] ?? null;
+}
+
+const REDIS_URL = "redis://localhost:6379/0";
+
 describe("live-e2e backend raises the registration limit", () => {
     it("sets AUTH_REGISTER_LIMIT in the step that starts the API", () => {
         const block = stepBlock(readFileSync(WORKFLOW_PATH, "utf8"), START_STEP);
@@ -73,5 +121,34 @@ describe("live-e2e backend raises the registration limit", () => {
         const inStartStep = registerLimit(stepBlock(source, START_STEP)) !== null;
         expect(inStartStep).toBe(true);
         expect(occurrences.length).toBeGreaterThan(0);
+    });
+});
+
+describe("live-e2e backend supplies Celery Redis", () => {
+    it("declares a healthy Redis service on the job", () => {
+        // Given: the live-e2e workflow source.
+        const source = readFileSync(WORKFLOW_PATH, "utf8");
+
+        // When: the Redis service mapping is selected from the live-e2e job.
+        const liveE2eJob = jobBlock(source, "live-e2e");
+        const redis = liveE2eJob === null ? null : serviceBlock(liveE2eJob, "redis");
+
+        // Then: GitHub Actions can start and health-check the Redis endpoint.
+        expect(serviceValue(redis, "image")).toBe("redis:7");
+        expect(hasPortMapping(redis, 6379)).toBe(true);
+        expect(healthCommand(redis)).toBe("redis-cli ping");
+    });
+
+    it("passes explicit Celery broker and result-backend URLs to API startup", () => {
+        // Given: the environment mapping for the API-start step.
+        const block = stepBlock(readFileSync(WORKFLOW_PATH, "utf8"), START_STEP);
+
+        // When: the Celery endpoint values are read from that step's env mapping.
+        const brokerUrl = envValue(block, "CELERY_BROKER_URL");
+        const resultBackendUrl = envValue(block, "CELERY_RESULT_BACKEND");
+
+        // Then: both Celery roles point at the published Redis service.
+        expect(brokerUrl).toBe(REDIS_URL);
+        expect(resultBackendUrl).toBe(REDIS_URL);
     });
 });

--- a/scripts/__tests__/live-e2e-register-limit.test.mjs
+++ b/scripts/__tests__/live-e2e-register-limit.test.mjs
@@ -1,0 +1,77 @@
+/**
+ * Guards the registration-limit override for the live-e2e backend.
+ *
+ * Ops defaults `AUTH_REGISTER_LIMIT` to `3/hour` per IP. The live suite is
+ * self-bootstrapping — nearly every describe group registers its own user — and
+ * in CI every request arrives from a single IP, so past the third registration
+ * the run is talking to a throttle rather than the API. The tests that depend on
+ * those identities then skip or fail for reasons unrelated to what they assert,
+ * which is the most expensive kind of red: it looks like a product failure.
+ *
+ * Three things have to hold, and the second and third are the ones a
+ * well-meaning edit breaks:
+ *
+ * 1. the override is present at all;
+ * 2. it is in the step that actually starts the API — an env var in a
+ *    neighbouring step is inert, and inert in a way nothing would report;
+ * 3. it is genuinely permissive. Narrowing it to a tidy-looking `10/hour` would
+ *    re-introduce the throttle for a suite that registers more users than that,
+ *    and the symptom would again be unrelated tests failing.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const WORKFLOW_PATH = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    ".github",
+    "workflows",
+    "live-e2e.yml",
+);
+
+const START_STEP = "name: Start dev-health-ops API";
+
+/** The text of one workflow step, by its `name:` line. */
+function stepBlock(source, stepName) {
+    const start = source.indexOf(stepName);
+    if (start === -1) throw new Error(`Workflow step "${stepName}" not found in live-e2e.yml.`);
+    const rest = source.slice(start + stepName.length);
+    const nextStep = rest.search(/\n\s*- name:/u);
+    return nextStep === -1 ? rest : rest.slice(0, nextStep);
+}
+
+function registerLimit(block) {
+    const match = /AUTH_REGISTER_LIMIT:\s*"?(\d+)\/(second|minute|hour|day)"?/u.exec(block);
+    if (!match) return null;
+    return { count: Number(match[1]), per: match[2] };
+}
+
+describe("live-e2e backend raises the registration limit", () => {
+    it("sets AUTH_REGISTER_LIMIT in the step that starts the API", () => {
+        const block = stepBlock(readFileSync(WORKFLOW_PATH, "utf8"), START_STEP);
+        expect(registerLimit(block)).not.toBeNull();
+    });
+
+    it("sets it permissively enough for a suite that registers many users", () => {
+        const limit = registerLimit(stepBlock(readFileSync(WORKFLOW_PATH, "utf8"), START_STEP));
+        expect(limit).not.toBeNull();
+        // Well above the number of registrations the live suite performs, and far
+        // above the 3/hour production default this overrides.
+        expect(limit.per).toBe("hour");
+        expect(limit.count).toBeGreaterThanOrEqual(100);
+    });
+
+    it("does not rely on the variable appearing somewhere else in the workflow", () => {
+        // An override in another step would be inert. Assert the API-start step
+        // carries it rather than merely that the file mentions it once.
+        const source = readFileSync(WORKFLOW_PATH, "utf8");
+        const occurrences = source.match(/AUTH_REGISTER_LIMIT:/gu) ?? [];
+        const inStartStep = registerLimit(stepBlock(source, START_STEP)) !== null;
+        expect(inStartStep).toBe(true);
+        expect(occurrences.length).toBeGreaterThan(0);
+    });
+});

--- a/src/lib/dev/__tests__/contractTolerance.test.ts
+++ b/src/lib/dev/__tests__/contractTolerance.test.ts
@@ -36,7 +36,6 @@ import feedbackFixture from "../contracts/examples/positive/dev_feedback.v1.json
 import graphStateEventFixture from "../contracts/examples/positive/dev_stream_event.v1.graph_state.json";
 import answerSchema from "../contracts/schemas/dev_answer.v1.schema.json";
 import { DevApiError, consumeDevSseStream, createDevApiClient } from "../client";
-import type { DevStreamEvent } from "../generated";
 import { validatePinnedJsonSchema } from "../jsonSchemaValidation";
 
 const captured: ContractDriftRecord[] = [];

--- a/tests/live/journey.spec.ts
+++ b/tests/live/journey.spec.ts
@@ -32,6 +32,31 @@ declare const process: { env: Record<string, string | undefined> };
 const liveGuidedOnboarding =
     process.env.LIVE_GUIDED_ONBOARDING === "true" || process.env.LIVE_GUIDED_ONBOARDING === "1";
 
+/**
+ * Every credential id this identity can currently see, asserted retrievable.
+ *
+ * Shared by the create-time existence proof and the listing test so the two
+ * cannot drift apart -- they are answering the same question ("is this row
+ * really there?") and a second copy of the response-shape handling would be a
+ * place for them to start disagreeing.
+ */
+async function listCredentialIds(
+    request: import("@playwright/test").APIRequestContext,
+    token: string,
+): Promise<readonly string[]> {
+    const res = await request.get(`${liveBackendUrl}/api/v1/admin/credentials`, {
+        headers: authHeaders(token),
+    });
+    expect(res.status(), "listing credentials failed, so existence cannot be established").toBe(
+        200,
+    );
+    const data = await res.json();
+    const list = Array.isArray(data) ? data : ((data as { items?: unknown[] }).items ?? []);
+    return (list as Array<Record<string, unknown>>)
+        .map((entry) => (entry.id ?? entry.credential_id ?? "") as string)
+        .filter((id) => id.length > 0);
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Registration & Login (2 tests — independent, no serial needed)
 // ──────────────────────────────────────────────────────────────────────────────
@@ -222,6 +247,24 @@ test.describe("credentials journey", () => {
         const data = (await res.json()) as Record<string, unknown>;
         credentialId = (data.id ?? data.credential_id ?? "") as string;
         expect(credentialId).toBeTruthy();
+
+        // Prove the credential EXISTS server-side here, rather than inferring it
+        // from "the create call handed us an id".
+        //
+        // This is load-bearing for the next test. `POST /credentials/test`
+        // answers 404 "Credential not found" for THREE different states: the row
+        // is absent, the row carries no encrypted payload, or decrypting it
+        // failed. Without an independent existence check, a 404 there cannot be
+        // told apart from any of them, and the failure reads as a mystery. With
+        // the row confirmed present in this org's own listing first, that 404
+        // narrows to "exists but the server cannot read it".
+        const ids = await listCredentialIds(request, token);
+        expect(
+            ids,
+            "the credential the create call reported was not retrievable immediately " +
+                "afterwards -- it was never persisted, or it is not visible to the " +
+                "identity that created it",
+        ).toContain(credentialId);
     });
 
     test("POST /credentials/test → success false (fake token expected)", async ({ request }) => {
@@ -236,7 +279,22 @@ test.describe("credentials journey", () => {
         });
         // The endpoint returns 200 with success:false when credential validation runs and fails.
         // Some backend versions return 422 before validation for malformed invalid credentials.
-        expect([200, 422]).toContain(res.status());
+        //
+        // Deliberately NOT widened to accept 404. The previous test proved this
+        // credential is retrievable, so a 404 here cannot mean "no such
+        // credential" -- it means the server found the row and could not use it
+        // (empty encrypted payload, or a decrypt/parse failure, both of which ops
+        // currently reports with the same status). Accepting 404 would also
+        // silence the genuinely-missing case, which is most of what this
+        // assertion exists to catch.
+        expect(
+            [200, 422],
+            "credentials/test answered 404 for a credential proven retrievable by the " +
+                "previous test: the row exists but the server could not read it. Check the " +
+                'ops API log for "Failed to decrypt/parse integration config" -- that line ' +
+                "distinguishes a decrypt failure from an empty payload. Do not widen this " +
+                "assertion to accept 404.",
+        ).toContain(res.status());
 
         if (res.status() === 200) {
             const data = (await res.json()) as { success?: boolean };
@@ -250,15 +308,7 @@ test.describe("credentials journey", () => {
             return;
         }
 
-        const res = await request.get(`${liveBackendUrl}/api/v1/admin/credentials`, {
-            headers: authHeaders(token),
-        });
-        expect(res.status()).toBe(200);
-
-        const data = await res.json();
-        const list = Array.isArray(data) ? data : ((data as { items?: unknown[] }).items ?? []);
-        const ids = (list as Array<Record<string, unknown>>).map((c) => c.id ?? c.credential_id);
-        expect(ids).toContain(credentialId);
+        expect(await listCredentialIds(request, token)).toContain(credentialId);
     });
 
     // Best-effort cleanup


### PR DESCRIPTION
The live tier exposed two independent harness defects while exercising the self-bootstrapping journey.

## What changed

### Credential existence is proven before credential testing

`POST /credentials/test` uses one 404 response for multiple states: an absent row, an empty encrypted payload, or a decrypt/JSON failure. The journey now proves the created credential appears in the authenticated identity's own listing before testing it, so a later 404 is diagnostic rather than ambiguous. The expected status remains `[200, 422]`; accepting 404 would hide a genuinely missing credential.

### Registration throttling is disabled only for this harness

Ops defaults registration to `3/hour` per IP. The live suite registers several users from one CI address, so the API-start step now sets `AUTH_REGISTER_LIMIT=1000/hour`. A structural guard verifies the override is both permissive and attached to the process that consumes it.

### Redis is now part of the live backend contract

The failing sync trigger took 19.5 seconds because Celery retried its missing Redis result backend from `0/20` through `19/20`, exhausted the retry limit, and the API mapped the queue exception to HTTP 503. The workflow now starts a health-checked Redis 7 service and passes explicit `REDIS_URL`, `CELERY_BROKER_URL`, and `CELERY_RESULT_BACKEND` values to the ops API.

No worker process is required for this assertion: the endpoint's 202 contract records and publishes the task; execution remains asynchronous. The following jobs-list assertion exercises the synchronously persisted run state.

The workflow guard was mutation-proven red against the original configuration: it reported a missing Redis service and missing Celery endpoint values. It is green with the workflow fix and is scoped specifically to the `live-e2e` job.

## Verification

- Focused workflow guard: 5 passed.
- Canonical local web gate: 420 test files passed; 3,790 tests passed and 8 skipped.
- Default Playwright: 325 passed, 2 skipped.
- Onboarding Playwright: 10 passed.
- Context Fabric Playwright: 21 passed.
- PagerDuty final QA: 23 passed.
- YAML parse, formatting, and LSP diagnostics: clean.
- Focused Oracle review: pass, no critical or warning findings.
- GitHub live-backend: 15 passed, 15 skipped; sync trigger returned 202 in 523ms and jobs listing returned 200 in 38ms.

Also removes the pre-existing dead `DevStreamEvent` import from the earlier PR revision.

SCREENSHOT-WAIVER: live-tier test coverage and CI workflow infrastructure only. No application code, markup, style, or rendered copy is changed.