### PR TITLE
fix(ask-dev): declare pinned stream contract on message requests

### DIFF
--- a/src/components/ask-dev/AskDevProvider.test.tsx
+++ b/src/components/ask-dev/AskDevProvider.test.tsx
@@ -509,6 +509,25 @@ describe("AskDevProvider permanent window", () => {
         await waitFor(() => expect(client.streamMessage).toHaveBeenCalledOnce());
     });
 
+    it("declares the pinned stream contract on the production message path", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "What changed?");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        await waitFor(() => expect(client.streamMessage).toHaveBeenCalledOnce());
+        expect(vi.mocked(client.streamMessage).mock.calls[0]?.[1]).toMatchObject({
+            client_contract_version: "dev_stream_event.v1",
+        });
+    });
+
     it("aborts the active stream and retries in the same conversation", async () => {
         const user = userEvent.setup();
         const client = makeClient();

--- a/src/components/ask-dev/AskDevProvider.tsx
+++ b/src/components/ask-dev/AskDevProvider.tsx
@@ -21,6 +21,7 @@ import type {
 import {
     devApiClient,
     initialDevConversationStreamState,
+    PINNED_DEV_STREAM_CONTRACT_VERSION,
     reduceDevConversationStream,
 } from "@/lib/dev/client";
 import {
@@ -746,6 +747,7 @@ export function AskDevProvider({
 
                 const request: DevMessageRequest = {
                     schema_version: "dev_message_request.v1",
+                    client_contract_version: PINNED_DEV_STREAM_CONTRACT_VERSION,
                     client_message_id: userEntryId,
                     request_id: crypto.randomUUID(),
                     conversation_id: activeConversationId,

--- a/src/lib/dev/__tests__/clientContractVersion.test.ts
+++ b/src/lib/dev/__tests__/clientContractVersion.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DevMessageRequest } from "../generated";
+import { createDevApiClient } from "../client";
+
+const request: DevMessageRequest = {
+    schema_version: "dev_message_request.v1",
+    client_message_id: "message_01",
+    request_id: "request_01",
+    conversation_id: "conversation_01",
+    question: "What changed?",
+    question_class: "investigation",
+    scope: {
+        schema_version: "dev_scope.v1",
+        organization_id: "org_01",
+        direct_scope: "organization",
+        entity_refs: [],
+        repositories: [],
+        team_ids: [],
+        time_range: {
+            start: "2026-07-01T00:00:00Z",
+            end: "2026-08-01T00:00:00Z",
+            timezone: "UTC",
+        },
+        surface_context: null,
+    },
+};
+
+describe("Ask Dev client contract declaration", () => {
+    it("declares the pinned stream contract on every outgoing message request", async () => {
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+            Response.json(
+                {
+                    schema_version: "dev_web_error.v1",
+                    code: "upstream_unavailable",
+                    safe_message: "Ask Dev is temporarily unavailable.",
+                    retryable: true,
+                },
+                { status: 503 },
+            ),
+        );
+        const client = createDevApiClient({ fetch: fetchMock });
+
+        await expect(client.streamMessage("conversation_01", request)).rejects.toMatchObject({
+            status: 503,
+        });
+
+        const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+        expect(body.client_contract_version).toBe("dev_stream_event.v1");
+    });
+
+    it("normalizes a legacy caller declaration to the pinned version", async () => {
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+            Response.json(
+                {
+                    schema_version: "dev_web_error.v1",
+                    code: "upstream_unavailable",
+                    safe_message: "Ask Dev is temporarily unavailable.",
+                    retryable: true,
+                },
+                { status: 503 },
+            ),
+        );
+        const client = createDevApiClient({ fetch: fetchMock });
+
+        await expect(
+            client.streamMessage("conversation_01", {
+                ...request,
+                client_contract_version: "dev_message_request.v1",
+            }),
+        ).rejects.toMatchObject({ status: 503 });
+
+        const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+        expect(body.client_contract_version).toBe("dev_stream_event.v1");
+    });
+});

--- a/src/lib/dev/client.ts
+++ b/src/lib/dev/client.ts
@@ -45,6 +45,14 @@ export class DevApiError extends Error {
 export type DevRequestOptions = Readonly<{ signal?: AbortSignal }>;
 export type DevStreamOptions = DevRequestOptions &
     Readonly<{ onEvent?: (event: DevStreamEvent) => void }>;
+
+/**
+ * The newest streamed contract this web pin can parse. The server uses the
+ * request declaration to decide whether it may emit additive stream members
+ * such as `graph.state`; keep the value tied to the generated v1 contract.
+ */
+export const PINNED_DEV_STREAM_CONTRACT_VERSION: DevStreamEvent["schema_version"] =
+    "dev_stream_event.v1";
 export type DevListConversationsOptions = DevRequestOptions &
     Readonly<{ cursor?: string; limit?: number }>;
 export type DevConversationTranscriptOptions = DevRequestOptions &
@@ -673,7 +681,14 @@ export function createDevApiClient(options: ClientOptions = {}): DevApiClient {
         async streamMessage(conversationId, input, streamOptions = {}) {
             const response = await request(
                 `/api/v1/dev/conversations/${encodeId(conversationId)}/messages`,
-                jsonMutation("POST", input, streamOptions.signal),
+                jsonMutation(
+                    "POST",
+                    {
+                        ...input,
+                        client_contract_version: PINNED_DEV_STREAM_CONTRACT_VERSION,
+                    },
+                    streamOptions.signal,
+                ),
             );
             return consumeDevSseStream(response, streamOptions);
         },


### PR DESCRIPTION
Summary

- Populate every outgoing dev_message_request with the pinned stream contract version dev_stream_event.v1.
- Normalize legacy caller declarations at the client boundary and cover the provider path.

Verification

- Baseline RED at 914a40ca7a5541715feccac5e3109547657c0745: the captured production POST body had client_contract_version undefined instead of dev_stream_event.v1.
- Post-fix: 63 focused Vitest tests passed.
- TypeScript, ESLint, Prettier, and pinned contract consistency checks passed.

SCREENSHOT-WAIVER: type-only/request-contract change; no rendered UI changes.