### PR TITLE
test: add fail-closed W3 graph acceptance gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "test:e2e:onboarding": "playwright test -c playwright.onboarding.config.ts",
         "test:e2e:live": "playwright test -c playwright.live.config.ts",
         "test:ask-dev-acceptance": "playwright test -c playwright.ask-dev-acceptance.config.ts",
+        "test:ask-dev-graph-acceptance": "playwright test -c playwright.ask-dev-graph-acceptance.config.ts",
         "test:unit": "vitest run",
         "test:ci": "bash ci/run_tests.sh ci"
     },

--- a/playwright.ask-dev-graph-acceptance.config.ts
+++ b/playwright.ask-dev-graph-acceptance.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig } from "@playwright/test";
+
+const required = (name: string): string => {
+    const value = process.env[name]?.trim();
+    if (!value) throw new Error(`${name} is required; graph acceptance must fail closed.`);
+    return value;
+};
+
+if (process.env.ASK_DEV_GRAPH_LIVE_ACCEPTANCE !== "1") {
+    throw new Error("Set ASK_DEV_GRAPH_LIVE_ACCEPTANCE=1 to arm the graph acceptance gate.");
+}
+if (process.env.ASK_DEV_COMPOSE_WEB_READY !== "1") {
+    throw new Error("Graph acceptance requires the canonical Compose-booted Web service.");
+}
+for (const name of [
+    "ASK_DEV_GRAPH_ACCEPTANCE_QUESTION",
+    "ASK_DEV_GRAPH_ACCEPTANCE_FALLBACK_QUESTION",
+    "ASK_DEV_GRAPH_ACCEPTANCE_AMBIGUOUS_QUESTION",
+    "ASK_DEV_GRAPH_ACCEPTANCE_EXPECTED_GRAPH_STATE",
+    "ASK_DEV_GRAPH_ACCEPTANCE_EXPECTED_FALLBACK_STATE",
+    "ASK_DEV_GRAPH_ACCEPTANCE_BACKEND_SHA",
+])
+    required(name);
+
+export default defineConfig({
+    testDir: "./tests/live",
+    testMatch: /ask-dev-graph-acceptance\.spec\.ts/,
+    reporter: [["list"], ["html", { open: "never" }]],
+    fullyParallel: false,
+    workers: 1,
+    retries: 0,
+    timeout: 120_000,
+    expect: { timeout: 20_000 },
+    use: {
+        baseURL: process.env.ASK_DEV_ACCEPTANCE_WEB_URL ?? "http://127.0.0.1:3002",
+        headless: true,
+        trace: "retain-on-failure",
+        screenshot: "only-on-failure",
+    },
+});

--- a/playwright.live.config.ts
+++ b/playwright.live.config.ts
@@ -29,10 +29,15 @@ export default defineConfig({
             //     ask-dev-acceptance.spec.ts above. It needs the Compose
             //     launcher's org provisioning and arming contract; running it
             //     against this suite's generic backend proves nothing and fails.
+            //
+            //   ask-dev-graph-acceptance.spec.ts — separately armed graph
+            //     acceptance; importing it requires graph oracle variables.
+            //     It is collected only by playwright.ask-dev-graph-acceptance.config.ts.
             testIgnore: [
                 /onboarding-ui\.spec\.ts/,
                 /ask-dev-acceptance\.spec\.ts/,
                 /ask-dev-wave4-access-matrix\.spec\.ts/,
+                /ask-dev-graph-acceptance\.spec\.ts/,
                 /__tests__\//,
             ],
             dependencies: ["onboarding-ui"],

--- a/tests/live/ASK_DEV_GRAPH_ACCEPTANCE.md
+++ b/tests/live/ASK_DEV_GRAPH_ACCEPTANCE.md
@@ -1,0 +1,28 @@
+# Graph-assisted Ask Dev acceptance
+
+`playwright.ask-dev-graph-acceptance.config.ts` is an explicitly armed,
+production-shaped gate. The canonical Ops Compose launcher/CI job opts in by
+setting `ASK_DEV_GRAPH_LIVE_ACCEPTANCE=1` and `ASK_DEV_COMPOSE_WEB_READY=1`,
+then invokes:
+
+```sh
+./node_modules/.bin/playwright test --config=playwright.ask-dev-graph-acceptance.config.ts
+```
+
+It must run against a backend whose runtime capabilities response exposes
+`backend_sha`, `build_sha`, `commit_sha`, or `x-backend-sha`; the value is
+compared with `ASK_DEV_GRAPH_ACCEPTANCE_BACKEND_SHA`. An environment variable
+alone is never accepted as backend identity.
+
+Required oracle values are supplied by the launcher:
+
+- graph, fallback, and ambiguity questions;
+- expected graph and fallback states;
+- backend SHA.
+
+The gate fails closed when any value or the Compose readiness arm is missing.
+It does not intercept browser routes, replace the provider, or turn an
+unavailable graph into a passing native answer. It proves one stream/run and
+client-side continuity from the app-wide `/diagnose` surface to `/dev`,
+explicit fallback, ambiguity without first-candidate selection, and absence of
+internal graph terminology in SSE, rendered copy, console output, and URLs.

--- a/tests/live/ask-dev-graph-acceptance.spec.ts
+++ b/tests/live/ask-dev-graph-acceptance.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * Production-shaped graph routing acceptance. This suite intentionally has no
+ * route interception, mock server, or provider override: a missing Compose
+ * backend, entitlement, graph result, or completion signal is a failure.
+ */
+import { expect, test, type Page } from "@playwright/test";
+
+import { signInCanonicalUser } from "./helpers";
+
+type JsonObject = Record<string, unknown>;
+type Sse = { name: string; data: JsonObject };
+
+const required = (name: string): string => {
+    const value = process.env[name]?.trim();
+    if (!value) throw new Error(`${name} is required; no graph measurement may be skipped.`);
+    return value;
+};
+
+const graphQuestion = required("ASK_DEV_GRAPH_ACCEPTANCE_QUESTION");
+const fallbackQuestion = required("ASK_DEV_GRAPH_ACCEPTANCE_FALLBACK_QUESTION");
+const ambiguousQuestion = required("ASK_DEV_GRAPH_ACCEPTANCE_AMBIGUOUS_QUESTION");
+const expectedGraphState = required("ASK_DEV_GRAPH_ACCEPTANCE_EXPECTED_GRAPH_STATE");
+const expectedFallbackState = required("ASK_DEV_GRAPH_ACCEPTANCE_EXPECTED_FALLBACK_STATE");
+const backendSha = required("ASK_DEV_GRAPH_ACCEPTANCE_BACKEND_SHA");
+
+function parseSse(body: string): Sse[] {
+    const frames = body.split(/\r?\n\r?\n/u).filter((frame) => frame.trim());
+    expect(
+        frames,
+        "The real Ops stream must produce at least one completion frame.",
+    ).not.toHaveLength(0);
+    return frames.map((frame) => {
+        const eventLine = frame.split(/\r?\n/u).find((line) => line.startsWith("event: "));
+        const data = frame
+            .split(/\r?\n/u)
+            .filter((line) => line.startsWith("data: "))
+            .map((line) => line.slice(6))
+            .join("\n");
+        expect(eventLine, `Malformed SSE frame: ${frame}`).toBeDefined();
+        expect(data, `SSE frame has no data: ${frame}`).not.toBe("");
+        const parsed = JSON.parse(data) as JsonObject;
+        expect(parsed.schema_version).toBe("dev_stream_event.v1");
+        expect(parsed.event).toBe(eventLine!.slice(7));
+        return { name: eventLine!.slice(7), data: parsed };
+    });
+}
+
+function assertTerminalStream(events: Sse[]): JsonObject {
+    const names = events.map((event) => event.name);
+    expect(names.filter((name) => name === "run.started")).toHaveLength(1);
+    expect(names.filter((name) => name === "answer.completed")).toHaveLength(1);
+    expect(names.filter((name) => name === "done")).toHaveLength(1);
+    expect(names).not.toContain("error");
+    const runIds = new Set(events.map((event) => event.data.run_id).filter(Boolean));
+    expect(runIds.size, "All stream events must belong to one backend run.").toBe(1);
+    return events.find((event) => event.name === "answer.completed")!.data;
+}
+
+function assertNoInternalTokens(text: string): void {
+    expect(text).not.toMatch(
+        /\b(?:graph_assisted|Graphiti|Cypher|canonical_enrichment|resolved_scope)\b/iu,
+    );
+}
+
+function assertNarrativeSafe(value: unknown): void {
+    if (typeof value === "string") {
+        assertNoInternalTokens(value);
+        return;
+    }
+    if (Array.isArray(value)) {
+        for (const item of value) assertNarrativeSafe(item);
+        return;
+    }
+    if (!value || typeof value !== "object") return;
+    for (const [key, child] of Object.entries(value)) {
+        // Contract keys such as graph_assisted/resolved_scope are explicitly
+        // allowed; only their user-facing narrative fields are scanned.
+        if (
+            [
+                "direct_summary",
+                "text",
+                "label",
+                "safe_message",
+                "title",
+                "warning",
+                "question",
+                "summary",
+            ].includes(key)
+        ) {
+            assertNarrativeSafe(child);
+        } else if (typeof child === "object") {
+            assertNarrativeSafe(child);
+        }
+    }
+}
+
+async function armCapture(page: Page): Promise<void> {
+    await page.addInitScript(() => {
+        const target = window as Window & { __graphSse?: string[] };
+        // Preserve captured bodies across client-side navigation/reconnect.
+        target.__graphSse ??= [];
+        const nativeFetch = window.fetch.bind(window);
+        window.fetch = async (...args) => {
+            const response = await nativeFetch(...args);
+            const input = args[0];
+            const url = new URL(
+                typeof input === "string" ? input : input instanceof URL ? input : input.url,
+                location.href,
+            );
+            const method = (
+                args[1]?.method ?? (input instanceof Request ? input.method : "GET")
+            ).toUpperCase();
+            if (
+                method === "POST" &&
+                /^\/api\/v1\/dev\/conversations\/[^/]+\/messages$/u.test(url.pathname)
+            ) {
+                void response
+                    .clone()
+                    .text()
+                    .then((body) => target.__graphSse?.push(body));
+            }
+            return response;
+        };
+    });
+}
+
+async function submit(page: Page, question: string, regionName = "Ask Dev"): Promise<JsonObject> {
+    const region = page.getByRole("region", { name: regionName });
+    const before = await page.evaluate(
+        () => (window as Window & { __graphSse?: string[] }).__graphSse?.length ?? 0,
+    );
+    const composer = region.getByRole("textbox", { name: "Ask Dev question" });
+    await composer.fill(question);
+    await region.getByRole("button", { name: "Ask", exact: true }).click();
+    // Compact /diagnose has no New conversation control; the rendered answer
+    // is the surface-specific completion signal.
+    await expect(region.getByRole("article", { name: "Ask Dev answer" })).toBeVisible({
+        timeout: 100_000,
+    });
+    await page.waitForFunction(
+        (minimum) =>
+            ((window as Window & { __graphSse?: string[] }).__graphSse?.length ?? 0) > minimum,
+        before,
+    );
+    const body = await page.evaluate(
+        (index) => (window as Window & { __graphSse?: string[] }).__graphSse?.[index] ?? "",
+        before,
+    );
+    expect(body, "The browser must capture the complete real SSE response.").not.toBe("");
+    return assertTerminalStream(parseSse(body));
+}
+
+async function openSurface(page: Page, route: string): Promise<void> {
+    await page.goto(route);
+    const open = page.getByRole("button", { name: "Open Ask Dev" });
+    if (await open.count()) await open.click();
+    await expect(page.getByRole("region", { name: "Ask Dev" })).toBeVisible();
+}
+
+test("graph route, canonical fallback, ambiguity refusal, and continuity are measured", async ({
+    page,
+}, testInfo) => {
+    testInfo.annotations.push({ type: "backend", description: backendSha });
+    const devPostUrls: string[] = [];
+    const consoleLines: string[] = [];
+    page.on("request", (request) => {
+        const path = new URL(request.url()).pathname;
+        if (
+            request.method() === "POST" &&
+            /^\/api\/v1\/dev\/conversations(?:\/[^/]+\/messages)?$/u.test(path)
+        ) {
+            devPostUrls.push(path);
+        }
+    });
+    page.on("console", (message) => consoleLines.push(message.text()));
+    await armCapture(page);
+    await signInCanonicalUser(page);
+    const capabilitiesResponse = await page.request.get("/api/v1/dev/capabilities");
+    expect(capabilitiesResponse.ok()).toBe(true);
+    const capabilities = (await capabilitiesResponse.json()) as JsonObject;
+    const runtimeSha =
+        capabilities.backend_sha ??
+        capabilities.build_sha ??
+        capabilities.commit_sha ??
+        capabilitiesResponse.headers()["x-backend-sha"];
+    expect(
+        runtimeSha,
+        "Backend SHA must be returned by runtime, not self-attested by env.",
+    ).toBeTruthy();
+    expect(runtimeSha).toBe(backendSha);
+    expect(capabilities.ask_dev).toBe(true);
+    expect(capabilities.readiness).toBe("ready");
+    expect(capabilities.ask_dev_graph_routing).toBe(true);
+
+    await openSurface(page, "/diagnose");
+    const graph = await submit(page, graphQuestion);
+    const graphAnswer = (graph.answer ?? graph) as JsonObject;
+    const graphAssisted = graphAnswer.graph_assisted as JsonObject | null | undefined;
+    expect(
+        graphAssisted,
+        "The graph question must return the graph contribution object.",
+    ).toBeTruthy();
+    expect(graphAssisted!.state).toBe(expectedGraphState);
+    expect(typeof graphAnswer.direct_summary).toBe("string");
+    expect(String(graphAnswer.direct_summary)).not.toBe("");
+    assertNoInternalTokens(String(graphAnswer.direct_summary));
+    assertNarrativeSafe(graph);
+    const firstRun = graph.run_id;
+    const firstFrame = graphAnswer.answer_id;
+    expect(typeof firstRun).toBe("string");
+    expect(typeof firstFrame).toBe("string");
+    const graphPostCount = devPostUrls.length;
+    await page
+        .getByRole("region", { name: "Ask Dev" })
+        .getByRole("link", { name: "Ask Dev workspace" })
+        .click();
+    await expect(page).toHaveURL(/\/dev(?:\?|$)/u);
+    const workspace = page.getByRole("region", { name: "Ask Dev workspace" });
+    await expect(workspace.getByLabel("Ask Dev transcript")).toBeVisible();
+    const retained = await workspace.getByLabel("Ask Dev transcript").innerText();
+    expect(retained).toContain(String(graphAnswer.direct_summary));
+    assertNoInternalTokens(retained);
+    expect(devPostUrls).toHaveLength(graphPostCount);
+    expect(devPostUrls).toHaveLength(2);
+    const transcriptResponse = await page.request.get(
+        `/api/v1/dev/conversations/${encodeURIComponent(String(graphAnswer.conversation_id))}/transcript`,
+    );
+    expect(transcriptResponse.ok()).toBe(true);
+    const transcript = (await transcriptResponse.json()) as JsonObject;
+    const assistant = (transcript.items as JsonObject[]).find((item) => item.role === "assistant");
+    expect(assistant?.run_id, "Persisted frame must retain the exact run id.").toBe(firstRun);
+    expect(
+        (assistant?.answer as JsonObject | undefined)?.answer_id,
+        "Persisted frame must retain the exact answer id.",
+    ).toBe(firstFrame);
+    expect(firstRun).toBeTruthy();
+
+    await workspace.getByRole("button", { name: "New conversation" }).click();
+    const fallback = await submit(page, fallbackQuestion, "Ask Dev workspace");
+    const fallbackAnswer = (fallback.answer ?? fallback) as JsonObject;
+    const fallbackGraph = fallbackAnswer.graph_assisted as JsonObject | null | undefined;
+    expect(
+        fallbackGraph,
+        "Fallback must be explicit, not a blank or skipped measurement.",
+    ).toBeTruthy();
+    expect(fallbackGraph!.state).toBe(expectedFallbackState);
+    expect(String(fallbackAnswer.direct_summary ?? "")).not.toBe("");
+    assertNoInternalTokens(String(fallbackAnswer.direct_summary ?? ""));
+    assertNarrativeSafe(fallback);
+    assertNoInternalTokens(await workspace.getByLabel("Ask Dev transcript").innerText());
+
+    await workspace.getByRole("button", { name: "New conversation" }).click();
+    const ambiguous = await submit(page, ambiguousQuestion);
+    const ambiguousAnswer = (ambiguous.answer ?? ambiguous) as JsonObject;
+    const scope = ambiguousAnswer.resolved_scope as JsonObject | undefined;
+    expect(scope?.outcome).toBe("ambiguous");
+    expect(Array.isArray(scope?.candidates)).toBe(true);
+    expect((scope?.candidates as unknown[]).length).toBeGreaterThan(1);
+    expect(
+        scope?.resolved_scope ?? null,
+        "Ambiguity must not commit a first candidate.",
+    ).toBeNull();
+    expect(ambiguousAnswer.graph_assisted ?? null).toBeNull();
+    assertNoInternalTokens(String(ambiguousAnswer.direct_summary ?? ""));
+    assertNarrativeSafe(ambiguous);
+    assertNoInternalTokens(await workspace.getByLabel("Ask Dev transcript").innerText());
+    for (const line of consoleLines) assertNoInternalTokens(line);
+    await testInfo.attach("graph-acceptance-summary.json", {
+        body: JSON.stringify(
+            {
+                backendSha,
+                graphState: graphAssisted!.state,
+                fallbackState: fallbackGraph!.state,
+                ambiguous: scope?.outcome,
+            },
+            null,
+            2,
+        ),
+        contentType: "application/json",
+    });
+});


### PR DESCRIPTION
Relates to CHAOS-3708

## Summary
- add an opt-in Playwright gate for real graph routing through /diagnose and /dev
- verify the same persisted run, answer frame, and rendered answer survive client-side surface transition
- assert deterministic graph, fallback, and ambiguity outcomes without duplicate POSTs or committed first-candidate scope
- scan SSE and rendered narrative surfaces for internal-token leakage
- require runtime-reported backend identity and fail closed when Compose/readiness/oracle inputs are absent

## Verification
- Prettier, ESLint, TypeScript, and diff hygiene passed
- Playwright discovery finds exactly one armed graph acceptance test
- missing arm/readiness fails closed
- independent review closed compact-mode, hard-navigation, SSE-race, schema-key, ambiguity, continuity, and rendered-conflict leakage defects

## Evidence boundary
This PR publishes the test-only acceptance harness. It does not claim W3 acceptance is green. Real Compose/backend execution with the governed graph, fallback, and ambiguity oracles remains required before CHAOS-3708 or beta can close.

SCREENSHOT-WAIVER: test/configuration-only change; no production rendering behavior changed.