### PR TITLE
feat(ask-dev): resume live runs after reconnect

### DIFF
--- a/src/app/api/v1/dev/runs/[runId]/resume/route.test.ts
+++ b/src/app/api/v1/dev/runs/[runId]/resume/route.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { proxyDevRequestMock } = vi.hoisted(() => ({
+    proxyDevRequestMock: vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+}));
+
+vi.mock("../../../_proxy", () => ({ proxyDevRequest: proxyDevRequestMock }));
+
+import { POST } from "./route";
+
+describe("POST /api/v1/dev/runs/:runId/resume", () => {
+    it("proxies the encoded run as a streaming mutation", async () => {
+        const request = new Request("https://app.example.test/api/v1/dev/runs/run%2F01/resume", {
+            method: "POST",
+            body: "{}",
+        });
+
+        await POST(request, { params: Promise.resolve({ runId: "run/01" }) });
+
+        expect(proxyDevRequestMock).toHaveBeenCalledWith(
+            request,
+            "/api/v1/dev/runs/run%2F01/resume",
+            { mutation: true, stream: true },
+        );
+    });
+});

--- a/src/app/api/v1/dev/runs/[runId]/resume/route.ts
+++ b/src/app/api/v1/dev/runs/[runId]/resume/route.ts
@@ -1,0 +1,14 @@
+import { proxyDevRequest } from "../../../_proxy";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type Context = { params: Promise<{ runId: string }> };
+
+export async function POST(request: Request, context: Context): Promise<Response> {
+    const { runId } = await context.params;
+    return proxyDevRequest(request, `/api/v1/dev/runs/${encodeURIComponent(runId)}/resume`, {
+        mutation: true,
+        stream: true,
+    });
+}

--- a/src/components/ask-dev/AskDevProvider.test.tsx
+++ b/src/components/ask-dev/AskDevProvider.test.tsx
@@ -710,6 +710,48 @@ describe("AskDevProvider permanent window", () => {
         expect(client.resumeRun).toHaveBeenCalledOnce();
     });
 
+    it("aborts resume polling when the organization changes", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        vi.mocked(client.streamMessage).mockImplementationOnce(async (_id, _request, options) => {
+            options?.onEvent?.({
+                event: "run.started",
+                run_id: "run-org-switch",
+                sequence: 0,
+            } as DevStreamEvent);
+            throw new TypeError("The live stream disconnected.");
+        });
+        vi.mocked(client.resumeRun).mockRejectedValue(
+            new DevApiError(409, {
+                schema_version: "dev_web_error.v1",
+                code: "resume_unavailable",
+                safe_message: "The live run has no durable event after this cursor.",
+                retryable: true,
+            }),
+        );
+        const rendered = render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "Check risk");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+        await waitFor(() => expect(client.resumeRun).toHaveBeenCalledOnce());
+        const resumeSignal = vi.mocked(client.resumeRun).mock.calls[0]?.[2]?.signal;
+
+        rendered.rerender(
+            <AskDevProvider client={client} orgId="org-2">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await waitFor(() => expect(resumeSignal?.aborted).toBe(true));
+        expect(client.resumeRun).toHaveBeenCalledOnce();
+        expect(screen.queryByText("Check risk")).not.toBeInTheDocument();
+    });
+
     it("resumes a stored live run after reload using its original transcript scope", async () => {
         const client = makeClient();
         const resumeRun = vi.mocked(client.resumeRun);

--- a/src/components/ask-dev/AskDevProvider.test.tsx
+++ b/src/components/ask-dev/AskDevProvider.test.tsx
@@ -4,6 +4,7 @@ import { useLayoutEffect } from "react";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DevApiClient, DevConversationList } from "@/lib/dev/client";
+import { DevApiError } from "@/lib/dev/client";
 import type {
     DevAnswer,
     DevConversation,
@@ -101,6 +102,7 @@ function makeClient(): DevApiClient {
             } as DevStreamEvent);
             return answer;
         }),
+        resumeRun: vi.fn(),
         expandEvidence: vi.fn(),
         submitFeedback: vi.fn(),
     };
@@ -131,12 +133,14 @@ describe("AskDevProvider permanent window", () => {
         navigation.pathname = "/dashboard";
         navigation.query = "";
         navigation.replace.mockClear();
+        window.localStorage.clear();
     });
 
     afterEach(() => {
         // jsdom does not implement matchMedia by default; remove any per-test stub.
         // @ts-expect-error test cleanup
         delete window.matchMedia;
+        window.localStorage.clear();
     });
 
     it("opens without creating a conversation or submitting a run", async () => {
@@ -575,6 +579,409 @@ describe("AskDevProvider permanent window", () => {
         expect(streamMessage.mock.calls[1]?.[1].request_id).not.toBe(
             streamMessage.mock.calls[0]?.[1].request_id,
         );
+    });
+
+    it("rejoins a dropped stream without creating a second run or changing scope", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        const streamMessage = vi.mocked(client.streamMessage);
+        const resumeRun = vi.mocked(client.resumeRun);
+        streamMessage.mockImplementationOnce(async (_conversationId, _request, options) => {
+            options?.onEvent?.({
+                event: "run.started",
+                run_id: "run-rejoin",
+                sequence: 0,
+            } as DevStreamEvent);
+            options?.onEvent?.({
+                event: "progress",
+                progress: "checking_evidence",
+                run_id: "run-rejoin",
+                sequence: 1,
+            } as DevStreamEvent);
+            throw new Error("The live stream disconnected.");
+        });
+        resumeRun.mockImplementationOnce(async (runId, input, options) => {
+            expect(runId).toBe("run-rejoin");
+            expect(input.conversation_id).toBe("conversation-1");
+            expect(input.last_sequence).toBe(1);
+            options?.onEvent?.({
+                event: "answer.completed",
+                answer,
+                run_id: "run-rejoin",
+                sequence: 2,
+            } as DevStreamEvent);
+            options?.onEvent?.({
+                event: "done",
+                run_id: "run-rejoin",
+                sequence: 3,
+                terminal_kind: "answer",
+            } as DevStreamEvent);
+            return answer;
+        });
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "Check risk");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        expect(await screen.findByText(answer.direct_summary)).toBeVisible();
+        expect(streamMessage).toHaveBeenCalledOnce();
+        expect(resumeRun).toHaveBeenCalledOnce();
+        expect(resumeRun.mock.calls[0]?.[1].scope).toEqual(streamMessage.mock.calls[0]?.[1].scope);
+        expect(screen.getAllByText("Check risk")).toHaveLength(1);
+        expect(screen.getAllByText(answer.direct_summary)).toHaveLength(1);
+    });
+
+    it("does not retry a resume scope mismatch", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        vi.mocked(client.streamMessage).mockImplementationOnce(async (_id, _request, options) => {
+            options?.onEvent?.({
+                event: "run.started",
+                run_id: "run-scope-mismatch",
+                sequence: 0,
+            } as DevStreamEvent);
+            throw new TypeError("The live stream disconnected.");
+        });
+        vi.mocked(client.resumeRun).mockRejectedValueOnce(
+            new DevApiError(409, {
+                schema_version: "dev_web_error.v1",
+                code: "resume_scope_mismatch",
+                safe_message: "The resume scope does not match the accepted run.",
+                retryable: false,
+            }),
+        );
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "Check risk");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+
+        expect(
+            await screen.findByText("The resume scope does not match the accepted run."),
+        ).toBeVisible();
+        expect(client.streamMessage).toHaveBeenCalledOnce();
+        expect(client.resumeRun).toHaveBeenCalledOnce();
+    });
+
+    it("aborts resume polling when the user cancels", async () => {
+        const user = userEvent.setup();
+        const client = makeClient();
+        vi.mocked(client.streamMessage).mockImplementationOnce(async (_id, _request, options) => {
+            options?.onEvent?.({
+                event: "run.started",
+                run_id: "run-polling",
+                sequence: 0,
+            } as DevStreamEvent);
+            throw new TypeError("The live stream disconnected.");
+        });
+        vi.mocked(client.resumeRun).mockRejectedValue(
+            new DevApiError(409, {
+                schema_version: "dev_web_error.v1",
+                code: "resume_unavailable",
+                safe_message: "The live run has no durable event after this cursor.",
+                retryable: true,
+            }),
+        );
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <main>Dashboard</main>
+            </AskDevProvider>,
+        );
+
+        await user.click(await screen.findByRole("button", { name: "Open Ask Dev" }));
+        await user.type(screen.getByRole("textbox", { name: "Ask Dev question" }), "Check risk");
+        await user.click(screen.getByRole("button", { name: "Ask" }));
+        await waitFor(() => expect(client.resumeRun).toHaveBeenCalledOnce());
+        const resumeSignal = vi.mocked(client.resumeRun).mock.calls[0]?.[2]?.signal;
+
+        await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+        expect(await screen.findByText("The investigation was cancelled.")).toBeVisible();
+        expect(resumeSignal?.aborted).toBe(true);
+        expect(client.resumeRun).toHaveBeenCalledOnce();
+    });
+
+    it("resumes a stored live run after reload using its original transcript scope", async () => {
+        const client = makeClient();
+        const resumeRun = vi.mocked(client.resumeRun);
+        const storedScope = { ...scope, repositories: ["repo-original"] } as DevScope;
+        window.localStorage.setItem(
+            "dev-health.ask-dev.active-run.v1:org-1",
+            JSON.stringify({
+                conversationId: "conversation-1",
+                runId: "run-reload",
+                question: "Check the original scope",
+                scope: storedScope,
+                scopeLabel: "Organization",
+                lastSequence: 4,
+            }),
+        );
+        vi.mocked(client.getConversationTranscript).mockResolvedValue({
+            conversation_id: "conversation-1",
+            items: [
+                {
+                    answer: null,
+                    created_at: "2026-07-29T00:00:00Z",
+                    message_id: "message-reload",
+                    question: "Check the original scope",
+                    retry_of_run_id: null,
+                    role: "user",
+                    run_id: "run-reload",
+                    run_state: "accepted",
+                    schema_version: "dev_transcript_entry.v1",
+                    scope: storedScope,
+                },
+            ],
+            next_cursor: null,
+            schema_version: "dev_conversation_transcript.v1",
+        });
+        resumeRun.mockImplementationOnce(async (runId, input, options) => {
+            options?.onEvent?.({
+                event: "answer.completed",
+                answer,
+                run_id: runId,
+                sequence: 5,
+            } as DevStreamEvent);
+            options?.onEvent?.({
+                event: "done",
+                run_id: runId,
+                sequence: 6,
+                terminal_kind: "answer",
+            } as DevStreamEvent);
+            expect(input).toMatchObject({
+                conversation_id: "conversation-1",
+                last_sequence: 4,
+                scope: storedScope,
+            });
+            return answer;
+        });
+
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        expect(await screen.findByText(answer.direct_summary)).toBeVisible();
+        expect(client.createConversation).not.toHaveBeenCalled();
+        expect(client.streamMessage).not.toHaveBeenCalled();
+        expect(resumeRun).toHaveBeenCalledOnce();
+        expect(screen.getAllByText("Check the original scope")).toHaveLength(1);
+    });
+
+    it("keeps polling the same stored run when no durable event is available yet", async () => {
+        const client = makeClient();
+        const resumeRun = vi.mocked(client.resumeRun);
+        window.localStorage.setItem(
+            "dev-health.ask-dev.active-run.v1:org-1",
+            JSON.stringify({
+                conversationId: "conversation-1",
+                runId: "run-reload",
+                question: "Wait for the running answer",
+                scope,
+                scopeLabel: "Organization",
+                lastSequence: 4,
+            }),
+        );
+        vi.mocked(client.getConversationTranscript).mockResolvedValue({
+            conversation_id: "conversation-1",
+            items: [
+                {
+                    answer: null,
+                    created_at: "2026-07-29T00:00:00Z",
+                    message_id: "message-reload",
+                    question: "Wait for the running answer",
+                    retry_of_run_id: null,
+                    role: "user",
+                    run_id: "run-reload",
+                    run_state: "accepted",
+                    schema_version: "dev_transcript_entry.v1",
+                    scope,
+                },
+            ],
+            next_cursor: null,
+            schema_version: "dev_conversation_transcript.v1",
+        });
+        resumeRun
+            .mockRejectedValueOnce(
+                new DevApiError(409, {
+                    schema_version: "dev_web_error.v1",
+                    code: "resume_unavailable",
+                    safe_message: "The live run has no durable event after this cursor.",
+                    retryable: true,
+                }),
+            )
+            .mockImplementationOnce(async (runId, _input, options) => {
+                options?.onEvent?.({
+                    event: "progress",
+                    progress: "checking_evidence",
+                    run_id: runId,
+                    sequence: 5,
+                } as DevStreamEvent);
+                return null;
+            })
+            .mockImplementationOnce(async (runId, _input, options) => {
+                options?.onEvent?.({
+                    event: "answer.completed",
+                    answer,
+                    run_id: runId,
+                    sequence: 6,
+                } as DevStreamEvent);
+                options?.onEvent?.({
+                    event: "done",
+                    run_id: runId,
+                    sequence: 7,
+                    terminal_kind: "answer",
+                } as DevStreamEvent);
+                return answer;
+            });
+
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        expect(await screen.findByText(answer.direct_summary)).toBeVisible();
+        expect(resumeRun).toHaveBeenCalledTimes(3);
+        expect(resumeRun.mock.calls[0]?.[1].last_sequence).toBe(4);
+        expect(resumeRun.mock.calls[1]?.[1].last_sequence).toBe(4);
+        expect(resumeRun.mock.calls[2]?.[1].last_sequence).toBe(5);
+        expect(resumeRun.mock.calls[2]?.[1].request_id).not.toBe(
+            resumeRun.mock.calls[0]?.[1].request_id,
+        );
+        expect(client.streamMessage).not.toHaveBeenCalled();
+    });
+
+    it("finds the stored run on a later bounded transcript page before resuming", async () => {
+        const client = makeClient();
+        window.localStorage.setItem(
+            "dev-health.ask-dev.active-run.v1:org-1",
+            JSON.stringify({
+                conversationId: "conversation-1",
+                runId: "run-page-2",
+                question: "Resume the newest investigation",
+                scope,
+                scopeLabel: "Organization",
+                lastSequence: 4,
+            }),
+        );
+        vi.mocked(client.getConversationTranscript)
+            .mockResolvedValueOnce({
+                conversation_id: "conversation-1",
+                items: [],
+                next_cursor: "page-2",
+                schema_version: "dev_conversation_transcript.v1",
+            })
+            .mockResolvedValueOnce({
+                conversation_id: "conversation-1",
+                items: [
+                    {
+                        answer: null,
+                        created_at: "2026-07-29T00:00:00Z",
+                        message_id: "message-page-2",
+                        question: "Resume the newest investigation",
+                        retry_of_run_id: null,
+                        role: "user",
+                        run_id: "run-page-2",
+                        run_state: "accepted",
+                        schema_version: "dev_transcript_entry.v1",
+                        scope,
+                    },
+                ],
+                next_cursor: null,
+                schema_version: "dev_conversation_transcript.v1",
+            });
+        vi.mocked(client.resumeRun).mockImplementationOnce(async (runId, _input, options) => {
+            options?.onEvent?.({
+                event: "answer.completed",
+                answer,
+                run_id: runId,
+                sequence: 5,
+            } as DevStreamEvent);
+            options?.onEvent?.({
+                event: "done",
+                run_id: runId,
+                sequence: 6,
+                terminal_kind: "answer",
+            } as DevStreamEvent);
+            return answer;
+        });
+
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        expect(await screen.findByText(answer.direct_summary)).toBeVisible();
+        expect(client.getConversationTranscript).toHaveBeenNthCalledWith(1, "conversation-1", {
+            signal: expect.any(AbortSignal),
+            cursor: undefined,
+            limit: 100,
+        });
+        expect(client.getConversationTranscript).toHaveBeenNthCalledWith(2, "conversation-1", {
+            signal: expect.any(AbortSignal),
+            cursor: "page-2",
+            limit: 100,
+        });
+        expect(client.resumeRun).toHaveBeenCalledOnce();
+    });
+
+    it.each([
+        ["failed", "Ask Dev could not complete the investigation."],
+        ["cancelled", "The investigation was cancelled."],
+    ] as const)("restores a terminal %s run without polling forever", async (runState, message) => {
+        const client = makeClient();
+        window.localStorage.setItem(
+            "dev-health.ask-dev.active-run.v1:org-1",
+            JSON.stringify({
+                conversationId: "conversation-1",
+                runId: "run-terminal",
+                question: "Restore the terminal investigation",
+                scope,
+                scopeLabel: "Organization",
+                lastSequence: 5,
+            }),
+        );
+        vi.mocked(client.getConversationTranscript).mockResolvedValue({
+            conversation_id: "conversation-1",
+            items: [
+                {
+                    answer: null,
+                    created_at: "2026-07-29T00:00:00Z",
+                    message_id: "message-terminal",
+                    question: "Restore the terminal investigation",
+                    retry_of_run_id: null,
+                    role: "user",
+                    run_id: "run-terminal",
+                    run_state: runState,
+                    schema_version: "dev_transcript_entry.v1",
+                    scope,
+                },
+            ],
+            next_cursor: null,
+            schema_version: "dev_conversation_transcript.v1",
+        });
+
+        render(
+            <AskDevProvider client={client} orgId="org-1">
+                <AskDevWorkspace />
+            </AskDevProvider>,
+        );
+
+        expect(await screen.findByText(message)).toBeVisible();
+        expect(client.resumeRun).not.toHaveBeenCalled();
+        expect(window.localStorage.getItem("dev-health.ask-dev.active-run.v1:org-1")).toBeNull();
     });
 
     it("retries the latest question when it fails before a run identifier is issued", async () => {

--- a/src/components/ask-dev/AskDevProvider.tsx
+++ b/src/components/ask-dev/AskDevProvider.tsx
@@ -19,6 +19,7 @@ import type {
     DevWebError,
 } from "@/lib/dev/client";
 import {
+    DevApiError,
     devApiClient,
     initialDevConversationStreamState,
     PINNED_DEV_STREAM_CONTRACT_VERSION,
@@ -245,6 +246,214 @@ function toTranscriptEntry(entry: TranscriptEntry): AskDevTranscriptEntry {
 
 const MAX_TRANSCRIPT_PAGES = 10;
 const TRANSCRIPT_PAGE_SIZE = 100;
+const ACTIVE_RUN_STORAGE_PREFIX = "dev-health.ask-dev.active-run.v1";
+const RESUME_POLL_INTERVAL_MS = 250;
+const MAX_TRANSIENT_RESUME_FAILURES = 3;
+
+type ActiveRunResume = {
+    conversationId: string;
+    runId: string;
+    question: string;
+    scope: DevScope;
+    scopeLabel: string;
+    lastSequence: number;
+    answer?: DevAnswer;
+    error?: DevWebError;
+    done: boolean;
+};
+
+type StoredActiveRunResume = Omit<ActiveRunResume, "answer" | "error" | "done">;
+
+function activeRunStorageKey(orgId: string): string {
+    return `${ACTIVE_RUN_STORAGE_PREFIX}:${orgId}`;
+}
+
+function browserStorage(): Storage | null {
+    if (typeof window === "undefined") return null;
+    try {
+        return window.localStorage;
+    } catch {
+        return null;
+    }
+}
+
+function isStoredActiveRunResume(value: unknown): value is StoredActiveRunResume {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+    const candidate = value as Record<string, unknown>;
+    return (
+        typeof candidate.conversationId === "string" &&
+        candidate.conversationId.length > 0 &&
+        typeof candidate.runId === "string" &&
+        candidate.runId.length > 0 &&
+        typeof candidate.question === "string" &&
+        candidate.question.length > 0 &&
+        typeof candidate.scopeLabel === "string" &&
+        typeof candidate.lastSequence === "number" &&
+        Number.isInteger(candidate.lastSequence) &&
+        candidate.lastSequence >= -1 &&
+        candidate.lastSequence <= 100_000 &&
+        candidate.scope !== null &&
+        typeof candidate.scope === "object" &&
+        !Array.isArray(candidate.scope)
+    );
+}
+
+function readStoredActiveRun(orgId: string): StoredActiveRunResume | null {
+    const storage = browserStorage();
+    if (!storage) return null;
+    try {
+        const raw = storage.getItem(activeRunStorageKey(orgId));
+        if (!raw) return null;
+        const parsed: unknown = JSON.parse(raw);
+        return isStoredActiveRunResume(parsed) ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+function writeStoredActiveRun(orgId: string, run: ActiveRunResume): void {
+    const storage = browserStorage();
+    if (!storage) return;
+    const { answer: _answer, error: _error, done: _done, ...persisted } = run;
+    try {
+        storage.setItem(activeRunStorageKey(orgId), JSON.stringify(persisted));
+    } catch {
+        // Local persistence is an optimization for reload recovery. A disabled
+        // or full storage implementation must never interrupt the live run.
+    }
+}
+
+function clearStoredActiveRun(orgId: string): void {
+    const storage = browserStorage();
+    if (!storage) return;
+    try {
+        storage.removeItem(activeRunStorageKey(orgId));
+    } catch {
+        // See writeStoredActiveRun: storage failures are not stream failures.
+    }
+}
+
+function sameScope(left: DevScope, right: DevScope): boolean {
+    const sameJson = (a: unknown, b: unknown): boolean => {
+        if (Object.is(a, b)) return true;
+        if (Array.isArray(a) || Array.isArray(b)) {
+            return (
+                Array.isArray(a) &&
+                Array.isArray(b) &&
+                a.length === b.length &&
+                a.every((value, index) => sameJson(value, b[index]))
+            );
+        }
+        if (!a || !b || typeof a !== "object" || typeof b !== "object") return false;
+        const leftRecord = a as Record<string, unknown>;
+        const rightRecord = b as Record<string, unknown>;
+        const leftKeys = Object.keys(leftRecord);
+        const rightKeys = Object.keys(rightRecord);
+        return (
+            leftKeys.length === rightKeys.length &&
+            leftKeys.every(
+                (key) =>
+                    Object.hasOwn(rightRecord, key) && sameJson(leftRecord[key], rightRecord[key]),
+            )
+        );
+    };
+    return sameJson(left, right);
+}
+
+function terminalRunError(runState: TranscriptEntry["run_state"]): DevWebError | null {
+    if (runState === "cancelled") {
+        return {
+            schema_version: "dev_web_error.v1",
+            code: "cancelled",
+            safe_message: "The investigation was cancelled.",
+            retryable: true,
+        };
+    }
+    if (runState === "failed") {
+        return {
+            schema_version: "dev_web_error.v1",
+            code: "run_failed",
+            safe_message: "Ask Dev could not complete the investigation.",
+            retryable: true,
+        };
+    }
+    if (
+        runState === "completed" ||
+        runState === "insufficient_evidence" ||
+        runState === "refused"
+    ) {
+        return {
+            schema_version: "dev_web_error.v1",
+            code: "resume_stream_invalid",
+            safe_message: "The completed investigation could not be restored safely.",
+            retryable: false,
+        };
+    }
+    return null;
+}
+
+function waitForResumePoll(signal: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+        if (signal.aborted) {
+            reject(signal.reason);
+            return;
+        }
+        const onAbort = () => {
+            clearTimeout(timer);
+            reject(signal.reason);
+        };
+        const timer = setTimeout(() => {
+            signal.removeEventListener("abort", onAbort);
+            resolve();
+        }, RESUME_POLL_INTERVAL_MS);
+        signal.addEventListener("abort", onAbort, { once: true });
+    });
+}
+
+async function resumeActiveRun(
+    client: DevApiClient,
+    record: ActiveRunResume,
+    controller: AbortController,
+    onEvent: (event: DevStreamEvent) => void,
+): Promise<DevAnswer> {
+    let transientFailures = 0;
+    while (!controller.signal.aborted) {
+        try {
+            const answer = await client.resumeRun(
+                record.runId,
+                {
+                    schema_version: "dev_run_resume_request.v1",
+                    request_id: crypto.randomUUID(),
+                    conversation_id: record.conversationId,
+                    last_sequence: record.lastSequence,
+                    scope: record.scope,
+                },
+                {
+                    signal: controller.signal,
+                    initialAnswer: record.answer,
+                    initialError: record.error,
+                    onEvent,
+                },
+            );
+            transientFailures = 0;
+            if (answer) return answer;
+        } catch (error) {
+            if (record.done) throw error;
+            const stillRunning =
+                error instanceof DevApiError && error.detail.code === "resume_unavailable";
+            const transient =
+                error instanceof TypeError ||
+                (error instanceof DevApiError &&
+                    error.detail.retryable &&
+                    error.detail.code !== "invalid_response");
+            if (!stillRunning && (!transient || transientFailures >= MAX_TRANSIENT_RESUME_FAILURES))
+                throw error;
+            if (!stillRunning) transientFailures += 1;
+        }
+        await waitForResumePoll(controller.signal);
+    }
+    throw controller.signal.reason;
+}
 
 function answerRunState(answer: DevAnswer): TranscriptEntry["run_state"] {
     if (answer.status === "insufficient_evidence" || answer.status === "refused") {
@@ -303,6 +512,7 @@ export function AskDevProvider({
     // *other*, earlier organization in the session once did (CHAOS-3215).
     const [everAvailable, setEverAvailable] = useState(false);
     const activeRequest = useRef<AbortController | null>(null);
+    const activeRun = useRef<ActiveRunResume | null>(null);
     const activeHistoryRequest = useRef<AbortController | null>(null);
     const historySelection = useRef(0);
     // Mirrors the latest `orgId` prop for use inside async callbacks (after an
@@ -381,6 +591,166 @@ export function AskDevProvider({
         };
     }, [client, orgId]);
 
+    // A full reload destroys the provider's in-memory stream state. The
+    // accepted run metadata is therefore kept in a tenant-keyed local cursor,
+    // then checked against the server-owned transcript before rejoining. The
+    // transcript check is deliberate: a client-held scope is only a replay
+    // cursor, never authority to broaden the original request.
+    useEffect(() => {
+        if (availability.state !== "ready") return;
+        if (activeRequest.current || activeRun.current) return;
+        const stored = readStoredActiveRun(orgId);
+        if (!stored) return;
+
+        const controller = new AbortController();
+        const requestOrgId = orgId;
+        const record: ActiveRunResume = { ...stored, done: false };
+        activeRun.current = record;
+        activeRequest.current = controller;
+
+        const isCurrent = () =>
+            !controller.signal.aborted &&
+            activeRequest.current === controller &&
+            orgIdRef.current === requestOrgId;
+
+        const onEvent = (event: DevStreamEvent) => {
+            if (!isCurrent() || activeRun.current?.runId !== record.runId) return;
+            record.lastSequence = Math.max(record.lastSequence, event.sequence);
+            if (event.event === "answer.completed" && event.answer) {
+                record.answer = event.answer;
+                record.error = undefined;
+            } else if (event.event === "error" && event.error) {
+                record.error = {
+                    schema_version: "dev_web_error.v1",
+                    code: event.error.code,
+                    safe_message: event.error.safe_message,
+                    retryable: event.error.retryable,
+                    request_id: event.error.request_id,
+                    ...(event.error.limit_reset_at
+                        ? { limit_reset_at: event.error.limit_reset_at }
+                        : {}),
+                };
+            } else if (event.event === "done") {
+                record.done = true;
+            }
+            writeStoredActiveRun(requestOrgId, record);
+            setStream((current) => reduceDevConversationStream(current, event));
+        };
+
+        void (async () => {
+            try {
+                const entries: AskDevTranscriptEntry[] = [];
+                let cursor: string | undefined;
+                let pageCount = 0;
+                do {
+                    const page = await client.getConversationTranscript(record.conversationId, {
+                        signal: controller.signal,
+                        cursor,
+                        limit: TRANSCRIPT_PAGE_SIZE,
+                    });
+                    if (!isCurrent()) return;
+                    entries.push(...(page.items ?? []).map(toTranscriptEntry));
+                    cursor = page.next_cursor ?? undefined;
+                    pageCount += 1;
+                } while (cursor && pageCount < MAX_TRANSCRIPT_PAGES);
+                if (cursor) throw new Error("This conversation is too long to resume safely.");
+                const userEntry = entries.find(
+                    (entry): entry is Extract<AskDevTranscriptEntry, { role: "user" }> =>
+                        entry.role === "user" && entry.runId === record.runId,
+                );
+                if (
+                    !userEntry ||
+                    !userEntry.runState ||
+                    userEntry.text !== record.question ||
+                    !sameScope(userEntry.scope, record.scope)
+                ) {
+                    clearStoredActiveRun(requestOrgId);
+                    activeRun.current = null;
+                    throw new Error("The saved Ask Dev run no longer matches its accepted scope.");
+                }
+
+                const assistantEntry = entries.find(
+                    (entry): entry is Extract<AskDevTranscriptEntry, { role: "assistant" }> =>
+                        entry.role === "assistant" && entry.runId === record.runId,
+                );
+                setConversationId(record.conversationId);
+                setCommittedScopeLabel(record.scopeLabel);
+                setTranscript(entries);
+
+                // A terminal transcript means the run completed while this
+                // document was gone. It is already durable, so do not issue a
+                // second request just to redisplay it.
+                if (assistantEntry) {
+                    setStream({
+                        ...initialDevConversationStreamState,
+                        phase: "completed",
+                        runId: record.runId,
+                        answer: assistantEntry.answer,
+                    });
+                    activeRun.current = null;
+                    clearStoredActiveRun(requestOrgId);
+                    return;
+                }
+                const persistedTerminalError = terminalRunError(userEntry.runState);
+                if (persistedTerminalError) {
+                    setStream({
+                        ...initialDevConversationStreamState,
+                        phase: "failed",
+                        runId: record.runId,
+                        error: persistedTerminalError,
+                    });
+                    activeRun.current = null;
+                    clearStoredActiveRun(requestOrgId);
+                    return;
+                }
+
+                setStream({
+                    ...initialDevConversationStreamState,
+                    phase: "running",
+                    runId: record.runId,
+                    answer: null,
+                });
+                record.answer = undefined;
+                const answer = await resumeActiveRun(client, record, controller, onEvent);
+                if (!isCurrent()) return;
+                setStream({
+                    ...initialDevConversationStreamState,
+                    phase: "completed",
+                    runId: record.runId,
+                    answer,
+                });
+                setTranscript((current) => [
+                    ...current,
+                    {
+                        id: answer.answer_id,
+                        role: "assistant",
+                        answer,
+                        retryOfRunId: null,
+                        runId: record.runId,
+                        runState: answerRunState(answer),
+                    },
+                ]);
+                activeRun.current = null;
+                clearStoredActiveRun(requestOrgId);
+            } catch (error) {
+                if (isCurrent()) {
+                    setStream((current) => ({
+                        ...current,
+                        phase: "failed",
+                        error: webError(error),
+                    }));
+                }
+            } finally {
+                if (activeRequest.current === controller) activeRequest.current = null;
+            }
+        })();
+
+        return () => {
+            controller.abort();
+            if (activeRequest.current === controller) activeRequest.current = null;
+        };
+    }, [availability.state, client, orgId]);
+
     useEffect(() => {
         if (availability.state === "ready" || availability.state === "not_ready") {
             setEverAvailable(true);
@@ -429,6 +799,7 @@ export function AskDevProvider({
         // Strict Mode's dev-only double render bumps it twice: it is only ever
         // compared for (in)equality, never read as an absolute count.
         historySelection.current += 1;
+        activeRun.current = null;
         setConversationId(null);
         setCommittedScopeLabel(null);
         setTranscript([]);
@@ -600,6 +971,8 @@ export function AskDevProvider({
         historySelection.current += 1;
         activeRequest.current?.abort();
         activeRequest.current = null;
+        activeRun.current = null;
+        clearStoredActiveRun(orgIdRef.current);
         setConversationId(null);
         setCommittedScopeLabel(null);
         setTranscript([]);
@@ -611,6 +984,8 @@ export function AskDevProvider({
         if (!controller) return;
         controller.abort();
         activeRequest.current = null;
+        activeRun.current = null;
+        clearStoredActiveRun(orgIdRef.current);
         setStream((current) => ({
             ...current,
             phase: "failed",
@@ -757,28 +1132,70 @@ export function AskDevProvider({
                     ...(retry ? { retry_of_run_id: retry.runId } : {}),
                 };
 
-                const answer = await client.streamMessage(activeConversationId, request, {
-                    signal: controller.signal,
-                    onEvent: (event: DevStreamEvent) => {
-                        if (superseded()) return;
-                        if (event.event === "run.started") {
-                            activeRunId = event.run_id;
-                            setTranscript((current) =>
-                                current.map((entry) =>
-                                    entry.id === userEntryId && entry.role === "user"
-                                        ? {
-                                              ...entry,
-                                              runId: event.run_id,
-                                              runState: "accepted",
-                                          }
-                                        : entry,
-                                ),
-                            );
+                const onEvent = (event: DevStreamEvent) => {
+                    if (superseded()) return;
+                    if (event.event === "run.started") {
+                        activeRunId = event.run_id;
+                        activeRun.current = {
+                            conversationId: activeConversationId,
+                            runId: event.run_id,
+                            question: normalizedQuestion,
+                            scope: requestScope,
+                            scopeLabel: requestScopeLabel,
+                            lastSequence: event.sequence,
+                            done: false,
+                        };
+                        writeStoredActiveRun(requestOrgId, activeRun.current);
+                        setTranscript((current) =>
+                            current.map((entry) =>
+                                entry.id === userEntryId && entry.role === "user"
+                                    ? {
+                                          ...entry,
+                                          runId: event.run_id,
+                                          runState: "accepted",
+                                      }
+                                    : entry,
+                            ),
+                        );
+                    } else if (activeRun.current?.runId === event.run_id) {
+                        const record = activeRun.current;
+                        record.lastSequence = Math.max(record.lastSequence, event.sequence);
+                        if (event.event === "answer.completed" && event.answer) {
+                            record.answer = event.answer;
+                            record.error = undefined;
+                        } else if (event.event === "error" && event.error) {
+                            record.error = {
+                                schema_version: "dev_web_error.v1",
+                                code: event.error.code,
+                                safe_message: event.error.safe_message,
+                                retryable: event.error.retryable,
+                                request_id: event.error.request_id,
+                                ...(event.error.limit_reset_at
+                                    ? { limit_reset_at: event.error.limit_reset_at }
+                                    : {}),
+                            };
+                        } else if (event.event === "done") {
+                            record.done = true;
                         }
-                        setStream((current) => reduceDevConversationStream(current, event));
-                    },
-                });
+                        writeStoredActiveRun(requestOrgId, record);
+                    }
+                    setStream((current) => reduceDevConversationStream(current, event));
+                };
+
+                let answer: DevAnswer;
+                try {
+                    answer = await client.streamMessage(activeConversationId, request, {
+                        signal: controller.signal,
+                        onEvent,
+                    });
+                } catch (error) {
+                    const record = activeRun.current;
+                    if (superseded() || !record || record.done) throw error;
+                    answer = await resumeActiveRun(client, record, controller, onEvent);
+                }
                 if (superseded()) return;
+                activeRun.current = null;
+                clearStoredActiveRun(requestOrgId);
                 setTranscript((current) => [
                     ...current,
                     {

--- a/src/components/ask-dev/AskDevTrigger.integration.test.tsx
+++ b/src/components/ask-dev/AskDevTrigger.integration.test.tsx
@@ -82,6 +82,7 @@ function makeClient(): DevApiClient {
         renameConversation: vi.fn(),
         deleteConversation: vi.fn(),
         streamMessage: vi.fn().mockResolvedValue(answer),
+        resumeRun: vi.fn(),
         expandEvidence: vi.fn(),
         submitFeedback: vi.fn(),
     };

--- a/src/lib/dev/__tests__/client.test.ts
+++ b/src/lib/dev/__tests__/client.test.ts
@@ -6,7 +6,7 @@ import conversationSummaryFixture from "../contracts/examples/positive/dev_conve
 import evidenceExpansionFixture from "../contracts/examples/positive/dev_evidence_expansion.v1.json";
 import feedbackFixture from "../contracts/examples/positive/dev_feedback.v1.json";
 import transcriptFixture from "../contracts/examples/positive/dev_conversation_transcript.v1.json";
-import type { DevMessageRequest, DevStreamEvent } from "../generated";
+import type { DevAnswer, DevMessageRequest, DevStreamEvent } from "../generated";
 import {
     DevApiError,
     consumeDevSseStream,
@@ -86,6 +86,25 @@ describe("Ask Dev browser client", () => {
         const requestInit = fetchMock.mock.calls[0]?.[1];
         expect(JSON.parse(String(requestInit?.body))).toEqual(input);
         expect(onEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it("completes a done-only replay from its previously received answer", async () => {
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(sse(completedEvents().slice(2)));
+        const client = createDevApiClient({ fetch: fetchMock });
+
+        await expect(
+            client.resumeRun(
+                "run_01",
+                {
+                    schema_version: "dev_run_resume_request.v1",
+                    request_id: "request_resume_done_01",
+                    conversation_id: "conversation_01",
+                    last_sequence: 1,
+                    scope: conversationFixture.current_scope as DevMessageRequest["scope"],
+                },
+                { initialAnswer: answerFixture as unknown as DevAnswer },
+            ),
+        ).resolves.toMatchObject({ answer_id: "answer_01" });
     });
 
     it("accepts a nonterminal replay suffix as a still-running run", async () => {

--- a/src/lib/dev/__tests__/client.test.ts
+++ b/src/lib/dev/__tests__/client.test.ts
@@ -15,6 +15,7 @@ import {
     reduceDevConversationStream,
     type DevApiClient,
     type DevConversationCreateInput,
+    type DevRunResumeInput,
 } from "../client";
 
 function completedEvents(answer: unknown = answerFixture): DevStreamEvent[] {
@@ -60,6 +61,88 @@ describe("Ask Dev browser client", () => {
 
         expect(answer.answer_id).toBe("answer_01");
         expect(onEvent).toHaveBeenCalledTimes(3);
+    });
+
+    it("rejoins an existing run and consumes only the suffix after its cursor", async () => {
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(sse(completedEvents().slice(1)));
+        const client = createDevApiClient({ fetch: fetchMock });
+        const onEvent = vi.fn();
+        const input: DevRunResumeInput = {
+            schema_version: "dev_run_resume_request.v1",
+            request_id: "request_resume_01",
+            conversation_id: "conversation_01",
+            last_sequence: 0,
+            scope: conversationFixture.current_scope as DevMessageRequest["scope"],
+        };
+
+        await expect(client.resumeRun("run_01", input, { onEvent })).resolves.toMatchObject({
+            answer_id: "answer_01",
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "/api/v1/dev/runs/run_01/resume",
+            expect.objectContaining({ method: "POST", cache: "no-store" }),
+        );
+        const requestInit = fetchMock.mock.calls[0]?.[1];
+        expect(JSON.parse(String(requestInit?.body))).toEqual(input);
+        expect(onEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it("accepts a nonterminal replay suffix as a still-running run", async () => {
+        const progress = {
+            event: "progress",
+            occurred_at: "2026-07-29T12:00:01Z",
+            progress: "checking_evidence",
+            run_id: "run_01",
+            schema_version: "dev_stream_event.v1",
+            sequence: 1,
+        } as DevStreamEvent;
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(sse([progress]));
+        const client = createDevApiClient({ fetch: fetchMock });
+        const onEvent = vi.fn();
+
+        await expect(
+            client.resumeRun(
+                "run_01",
+                {
+                    schema_version: "dev_run_resume_request.v1",
+                    request_id: "request_resume_01",
+                    conversation_id: "conversation_01",
+                    last_sequence: 0,
+                    scope: conversationFixture.current_scope as DevMessageRequest["scope"],
+                },
+                { onEvent },
+            ),
+        ).resolves.toBeNull();
+        expect(onEvent).toHaveBeenCalledWith(progress);
+    });
+
+    it("preserves the retryable resume-unavailable contract", async () => {
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+            Response.json(
+                {
+                    schema_version: "dev_web_error.v1",
+                    code: "resume_unavailable",
+                    safe_message: "The live run has no durable event after this cursor.",
+                    retryable: true,
+                },
+                { status: 409 },
+            ),
+        );
+        const client = createDevApiClient({ fetch: fetchMock });
+
+        await expect(
+            client.resumeRun("run_01", {
+                schema_version: "dev_run_resume_request.v1",
+                request_id: "request_resume_01",
+                conversation_id: "conversation_01",
+                last_sequence: 0,
+                scope: conversationFixture.current_scope as DevMessageRequest["scope"],
+            }),
+        ).rejects.toMatchObject({
+            status: 409,
+            detail: { code: "resume_unavailable", retryable: true },
+        });
     });
 
     it("rejects a schema-valid envelope whose completed answer violates the pinned contract", async () => {

--- a/src/lib/dev/client.ts
+++ b/src/lib/dev/client.ts
@@ -44,7 +44,20 @@ export class DevApiError extends Error {
 
 export type DevRequestOptions = Readonly<{ signal?: AbortSignal }>;
 export type DevStreamOptions = DevRequestOptions &
-    Readonly<{ onEvent?: (event: DevStreamEvent) => void }>;
+    Readonly<{
+        onEvent?: (event: DevStreamEvent) => void;
+        /** Existing terminal state when a reconnect starts after that frame. */
+        initialAnswer?: DevAnswer;
+        initialError?: DevWebError;
+    }>;
+
+export type DevRunResumeInput = Readonly<{
+    schema_version: "dev_run_resume_request.v1";
+    request_id: string;
+    conversation_id: string;
+    last_sequence: number;
+    scope: DevMessageRequest["scope"];
+}>;
 
 /**
  * The newest streamed contract this web pin can parse. The server uses the
@@ -395,10 +408,25 @@ function isUnknownStreamEvent(decoded: { eventName: string; value: unknown }): b
     return !KNOWN_STREAM_EVENTS.has(name);
 }
 
+type DevSseConsumeOptions = DevStreamOptions &
+    Readonly<{
+        initialSequence?: number;
+        expectedRunId?: string;
+        allowIncompleteReplay?: boolean;
+    }>;
+
+export function consumeDevSseStream(
+    response: Response,
+    options?: DevSseConsumeOptions & Readonly<{ allowIncompleteReplay?: false }>,
+): Promise<DevAnswer>;
+export function consumeDevSseStream(
+    response: Response,
+    options: DevSseConsumeOptions & Readonly<{ allowIncompleteReplay: true }>,
+): Promise<DevAnswer | null>;
 export async function consumeDevSseStream(
     response: Response,
-    options: DevStreamOptions = {},
-): Promise<DevAnswer> {
+    options: DevSseConsumeOptions = {},
+): Promise<DevAnswer | null> {
     if (!response.ok) throw await responseError(response);
     if (!response.headers.get("content-type")?.startsWith("text/event-stream") || !response.body) {
         throw invalidResponse();
@@ -408,12 +436,17 @@ export async function consumeDevSseStream(
     const decoder = new TextDecoder("utf-8", { fatal: true });
     let buffer = "";
     let count = 0;
-    let runId: string | undefined;
-    let expectedSequence = 0;
-    let terminal: "answer" | "error" | undefined;
-    let terminalError: DevWebError | undefined;
-    let answer: DevAnswer | undefined;
+    let runId: string | undefined = options.expectedRunId;
+    let expectedSequence = options.initialSequence ?? 0;
+    let terminal: "answer" | "error" | undefined = options.initialAnswer
+        ? "answer"
+        : options.initialError
+          ? "error"
+          : undefined;
+    let terminalError: DevWebError | undefined = options.initialError;
+    let answer: DevAnswer | undefined = options.initialAnswer;
     let done = false;
+    let firstFrame = true;
 
     const consumeFrame = (frame: string): void => {
         const decoded = decodeFrame(frame);
@@ -426,7 +459,7 @@ export async function consumeDevSseStream(
         // FIRST frame is unrecognised tells us nothing about the run at all, so
         // that stays a hard failure rather than a run with no identity.
         if (isUnknownStreamEvent(decoded)) {
-            if (runId === undefined || done) {
+            if (runId === undefined || done || (firstFrame && expectedSequence === 0)) {
                 throw invalidResponse("Ask Dev stream did not start correctly.");
             }
             const unknown = decoded.value as { run_id?: unknown; sequence?: unknown };
@@ -454,6 +487,10 @@ export async function consumeDevSseStream(
         } else if (event.run_id !== runId) {
             throw invalidResponse("Ask Dev changed run identifiers mid-stream.");
         }
+        if (firstFrame && expectedSequence === 0 && event.event !== "run.started") {
+            throw invalidResponse("Ask Dev stream did not start correctly.");
+        }
+        firstFrame = false;
         if (terminal !== undefined && event.event !== "done") {
             throw invalidResponse("Ask Dev returned data after its terminal event.");
         }
@@ -504,6 +541,7 @@ export async function consumeDevSseStream(
                 },
             );
         }
+        if (terminal === undefined && options.allowIncompleteReplay) return null;
         throw invalidResponse("Ask Dev stream ended before a completed answer.");
     }
     return answer;
@@ -584,6 +622,11 @@ export interface DevApiClient {
         input: DevMessageRequest,
         options?: DevStreamOptions,
     ): Promise<DevAnswer>;
+    resumeRun(
+        runId: string,
+        input: DevRunResumeInput,
+        options?: DevStreamOptions,
+    ): Promise<DevAnswer | null>;
     expandEvidence(
         evidenceRefId: string,
         answerId: string,
@@ -690,7 +733,21 @@ export function createDevApiClient(options: ClientOptions = {}): DevApiClient {
                     streamOptions.signal,
                 ),
             );
-            return consumeDevSseStream(response, streamOptions);
+            const answer = await consumeDevSseStream(response, streamOptions);
+            if (!answer) throw invalidResponse("Ask Dev stream ended before a completed answer.");
+            return answer;
+        },
+        async resumeRun(runId, input, streamOptions = {}) {
+            const response = await request(
+                `/api/v1/dev/runs/${encodeId(runId)}/resume`,
+                jsonMutation("POST", input, streamOptions.signal),
+            );
+            return consumeDevSseStream(response, {
+                ...streamOptions,
+                allowIncompleteReplay: true,
+                initialSequence: input.last_sequence + 1,
+                expectedRunId: runId,
+            });
         },
         async expandEvidence(evidenceRefId, answerId, { signal } = {}) {
             const query = new URLSearchParams({ answer_id: answerId });

--- a/tests/mocks/context-fabric-browser-faults.test.ts
+++ b/tests/mocks/context-fabric-browser-faults.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     EMPTY_BROWSER_FAULTS,
+    createSessionRequestTracker,
     reconcileBrowserFaults,
     settledBrowserFaults,
     type BrowserFaultEvent,
@@ -26,6 +27,35 @@ const AUTH_SESSION_CONSOLE_ERROR = {
 } as const satisfies BrowserFaultEvent;
 
 describe("Context Fabric browser fault reconciliation", () => {
+    it("settles a prior-document session request when navigation has no lifecycle event", async () => {
+        const events: BrowserFaultEvent[] = [];
+        const tracker = createSessionRequestTracker<object>(events);
+        const abandonedRequest = {};
+        const recoveredRequest = {};
+        tracker.started(abandonedRequest);
+
+        let settled = false;
+        const pending = tracker.waitForPending().then(() => {
+            settled = true;
+        });
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        tracker.mainFrameNavigated();
+        await pending;
+        tracker.started(recoveredRequest);
+        tracker.responded(recoveredRequest, 200);
+        tracker.finished(recoveredRequest);
+
+        expect(reconcileBrowserFaults(events)).toEqual(EMPTY_BROWSER_FAULTS);
+
+        // A lifecycle event arriving late for the abandoned document must not
+        // duplicate the abort or let that same request recover itself.
+        tracker.responded(abandonedRequest, 200);
+        tracker.failed(abandonedRequest, "net::ERR_ABORTED");
+        expect(events).toEqual([ABORTED_SESSION_REQUEST, SUCCESSFUL_SESSION_RESPONSE]);
+    });
+
     it.each([
         [
             "console-first",

--- a/tests/mocks/context-fabric-browser-faults.ts
+++ b/tests/mocks/context-fabric-browser-faults.ts
@@ -15,6 +15,15 @@ export type BrowserFaultLog = {
     readonly settle: () => Promise<void>;
 };
 
+type SessionRequestTracker<RequestToken extends object> = {
+    readonly started: (request: RequestToken) => void;
+    readonly failed: (request: RequestToken, errorText: string) => void;
+    readonly finished: (request: RequestToken) => void;
+    readonly responded: (request: RequestToken, status: number) => void;
+    readonly mainFrameNavigated: () => void;
+    readonly waitForPending: () => Promise<void>;
+};
+
 export type BrowserFaultSummary = {
     readonly consoleErrors: readonly string[];
     readonly pageErrors: readonly string[];
@@ -41,19 +50,60 @@ function isAuthSessionFetchError(message: string): boolean {
     return message.includes(AUTH_SESSION_FETCH_ERROR) && message.includes("._getSession");
 }
 
-export function recordBrowserFaults(page: Page): BrowserFaultLog {
-    const events: BrowserFaultEvent[] = [];
-    const pendingSessionRequests = new Set<Request>();
+export function createSessionRequestTracker<RequestToken extends object>(
+    events: BrowserFaultEvent[],
+): SessionRequestTracker<RequestToken> {
+    let documentGeneration = 0;
+    const pending = new Map<RequestToken, number>();
+    const navigationSettled = new WeakSet<RequestToken>();
     const settlementWaiters = new Set<() => void>();
-    const markSessionRequestSettled = (request: Request): void => {
-        if (!pendingSessionRequests.delete(request) || pendingSessionRequests.size > 0) return;
+    const resolveIfSettled = (): void => {
+        if (pending.size > 0) return;
         for (const resolve of settlementWaiters) resolve();
         settlementWaiters.clear();
     };
-    const waitForPendingSessionRequests = (): Promise<void> => {
-        if (pendingSessionRequests.size === 0) return Promise.resolve();
-        return new Promise((resolve) => settlementWaiters.add(resolve));
+    const settle = (request: RequestToken): boolean => {
+        if (!pending.delete(request)) return false;
+        resolveIfSettled();
+        return true;
     };
+
+    return {
+        started: (request) => pending.set(request, documentGeneration),
+        failed: (request, errorText) => {
+            if (!settle(request)) return;
+            events.push({ kind: "session-request-failed", errorText });
+        },
+        finished: (request) => {
+            settle(request);
+        },
+        responded: (request, status) => {
+            if (navigationSettled.has(request)) return;
+            events.push({ kind: "session-response", status });
+        },
+        mainFrameNavigated: () => {
+            documentGeneration += 1;
+            for (const [request, generation] of pending) {
+                if (generation >= documentGeneration) continue;
+                pending.delete(request);
+                navigationSettled.add(request);
+                events.push({
+                    kind: "session-request-failed",
+                    errorText: SESSION_REQUEST_ABORTED,
+                });
+            }
+            resolveIfSettled();
+        },
+        waitForPending: () => {
+            if (pending.size === 0) return Promise.resolve();
+            return new Promise((resolve) => settlementWaiters.add(resolve));
+        },
+    };
+}
+
+export function recordBrowserFaults(page: Page): BrowserFaultLog {
+    const events: BrowserFaultEvent[] = [];
+    const sessionRequests = createSessionRequestTracker<Request>(events);
 
     page.on("console", (message) => {
         if (message.type() === "error") {
@@ -65,39 +115,40 @@ export function recordBrowserFaults(page: Page): BrowserFaultLog {
     });
     page.on("request", (request) => {
         if (isSessionRequest(request.url(), request.method())) {
-            pendingSessionRequests.add(request);
+            sessionRequests.started(request);
         }
     });
     page.on("requestfailed", (request) => {
         if (isSessionRequest(request.url(), request.method())) {
-            events.push({
-                kind: "session-request-failed",
-                errorText: request.failure()?.errorText ?? "",
-            });
-            markSessionRequestSettled(request);
+            sessionRequests.failed(request, request.failure()?.errorText ?? "");
         }
     });
     page.on("requestfinished", (request) => {
         if (isSessionRequest(request.url(), request.method())) {
-            markSessionRequestSettled(request);
+            sessionRequests.finished(request);
         }
     });
     page.on("response", (response) => {
         if (isSessionRequest(response.url(), response.request().method())) {
-            events.push({ kind: "session-response", status: response.status() });
+            sessionRequests.responded(response.request(), response.status());
+        }
+    });
+    page.on("framenavigated", (frame) => {
+        if (frame === page.mainFrame()) {
+            sessionRequests.mainFrameNavigated();
         }
     });
     return {
         events,
         settle: async () => {
-            await waitForPendingSessionRequests();
+            await sessionRequests.waitForPending();
             await page.evaluate(
                 () =>
                     new Promise<void>((resolve) => {
                         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
                     }),
             );
-            await waitForPendingSessionRequests();
+            await sessionRequests.waitForPending();
         },
     };
 }


### PR DESCRIPTION
## Summary

- rejoin an accepted Ask Dev run after a dropped SSE connection without creating a second run
- persist the tenant-keyed run ID, immutable scope, conversation, and last durable sequence for reload recovery
- consume finite Ops replay suffixes, poll retryable `resume_unavailable` responses, and advance the cursor across partial batches
- restore terminal failed/cancelled runs without polling forever and search bounded transcript pages before resuming
- add the authenticated streaming proxy route for `POST /api/v1/dev/runs/:runId/resume`

Linear: CHAOS-3690

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage ./node_modules/.bin/vitest run src/components/ask-dev/AskDevProvider.test.tsx src/components/ask-dev/AskDevTrigger.integration.test.tsx src/lib/dev/__tests__/client.test.ts src/app/api/v1/dev/runs/'[runId]'/resume/route.test.ts` — 91 passed
- `NODE_OPTIONS=--no-experimental-webstorage ./node_modules/.bin/tsc --noEmit`
- ESLint on changed files
- Prettier check on changed files
- `git diff --check`
- authenticated local visual check on an OS-assigned random port

The full unit suite reached 3,790 passed and 8 skipped; six unrelated `scripts/__tests__/run-owned-process.test.mjs` cases failed under local Node 26 (five at their exact 15-second process fallback and one exit-code mismatch). The focused W6 suite and static checks are green.

## Visual evidence

Screenshot captured locally as `chaos-3690-run-resume-after.png`. The installed GitHub image uploader is currently incompatible with this `gh` build and fails during repository-ID lookup before upload; the artifact is retained for attachment.
