### PR TITLE
CHAOS-3710: render shared graph assistance

### DIFF
--- a/src/components/ask-dev/AskDevAnswer.tsx
+++ b/src/components/ask-dev/AskDevAnswer.tsx
@@ -22,6 +22,7 @@ import {
     type FeedbackSubmission,
 } from "./answer/FeedbackFooter";
 import { FollowUpSection } from "./answer/FollowUpSection";
+import { GraphAssistanceSection } from "./answer/GraphAssistanceSection";
 import type { CitationTargets } from "./answer/InlineCitations";
 import type { SafeProse } from "./answer/labels";
 import { LimitationsSection } from "./answer/LimitationsSection";
@@ -226,6 +227,7 @@ export function attestedText(answer: DevAnswer): string {
         ...(scope?.candidates ?? []).map((candidate) => candidate.entity_ref.display_label),
         ...(answer.evidence ?? []).map((item) => item.display_label),
         ...(answer.metrics ?? []).map((metric) => metric.label),
+        ...(answer.graph_assisted?.cohort?.members ?? []).map((member) => member.display_label),
     ].join(" ");
 }
 
@@ -362,6 +364,7 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
     // Section heading ids (used only for aria-labelledby) are static per
     // section kind, so they need the same per-answer scoping to stay unique
     // across a transcript with multiple answers.
+    const graphAssistanceHeadingId = "ask-dev-additional-context-" + answer.answer_id;
     const findingsHeadingId = `ask-dev-findings-${answer.answer_id}`;
     const metricsHeadingId = `ask-dev-metrics-${answer.answer_id}`;
     const evidenceHeadingId = `ask-dev-evidence-heading-${answer.answer_id}`;
@@ -491,6 +494,15 @@ export function AskDevAnswer({ answer }: { answer: DevAnswer }) {
             ) : null}
 
             {showCoverage ? <CoverageSection coverage={answer.coverage} /> : null}
+
+            {answer.graph_assisted ? (
+                <GraphAssistanceSection
+                    graphAssistance={answer.graph_assisted}
+                    headingId={graphAssistanceHeadingId}
+                    safeProse={safeProse}
+                    targets={citationTargets}
+                />
+            ) : null}
 
             {/*
              * CHAOS-3377 HIGH: claims are model-authored prose, exactly

--- a/src/components/ask-dev/answer/GraphAssistanceSection.test.tsx
+++ b/src/components/ask-dev/answer/GraphAssistanceSection.test.tsx
@@ -1,0 +1,334 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+
+import graphAssistanceFixture from "@/lib/dev/contracts/examples/positive/dev_answer_graph_assistance.v1.json";
+
+import { AskDevAnswer } from "../AskDevAnswer";
+
+const actions = vi.hoisted(() => ({
+    expandEvidence: vi.fn(),
+    selectProposedEntity: vi.fn(),
+    submitAnswerFeedback: vi.fn(),
+    submitQuestion: vi.fn(),
+}));
+
+vi.mock("../AskDevProvider", () => ({ useAskDev: () => actions }));
+
+const evidence = {
+    citation_text: "A supporting work item was completed.",
+    confidence: 0.94,
+    display_label: "Completed work item",
+    entity_id: "work-item-1",
+    entity_type: "work_unit",
+    evidence_ref_id: "evidence-1",
+    flags: {},
+    freshness: "fresh",
+    observed_at: "2026-07-28T12:00:00Z",
+    provenance: "Work graph",
+    source_system: "work_graph",
+    source_version: "v1",
+};
+
+const graphAssistance = {
+    ...graphAssistanceFixture,
+    ranked_drivers: graphAssistanceFixture.ranked_drivers?.map((driver) => ({
+        ...driver,
+        evidence_ref_ids: ["evidence-1"],
+    })),
+} as unknown as NonNullable<DevAnswer["graph_assisted"]>;
+
+const baseAnswer = {
+    answer_id: "answer-graph-1",
+    as_of: "2026-07-28T12:00:00Z",
+    claims: [],
+    conflicts: [],
+    conversation_id: "conversation-graph-1",
+    coverage: {
+        available_source_count: 1,
+        required_source_count: 1,
+    },
+    direct_summary:
+        "The available evidence suggests delivery pressure is concentrated in Platform.",
+    evidence: [evidence],
+    generated_at: "2026-07-28T12:00:00Z",
+    metrics: [],
+    model: {
+        model_fingerprint: "model-1",
+        provider_family: "openai_compatible",
+        provider_source: "platform",
+    },
+    resolved_scope: {
+        authorized_entity_ids: [],
+        authorized_repository_ids: [],
+        candidates: [],
+        outcome: "exact",
+        resolved_at: "2026-07-28T12:00:00Z",
+        schema_version: "dev_scope_resolution.v1",
+        warnings: [],
+    },
+    schema_version: "dev_answer.v1",
+    status: "complete",
+    suggested_follow_up_questions: [],
+    versions: {
+        metric_definition_version: "v1",
+        prompt_version: "v1",
+        query_version: "v1",
+        tool_contract_version: "v1",
+    },
+    warnings: [],
+} as unknown as DevAnswer;
+
+type GraphState = NonNullable<DevAnswer["graph_assisted"]>["state"];
+
+function answerForState(state: GraphState): DevAnswer {
+    return {
+        ...baseAnswer,
+        graph_assisted: {
+            ...graphAssistance,
+            limitations: state === "truncated" ? graphAssistance.limitations : [],
+            state,
+        },
+    } as unknown as DevAnswer;
+}
+
+describe("AskDevAnswer graph assistance rendering", () => {
+    beforeAll(() => {
+        window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        };
+    });
+
+    beforeEach(() => {
+        Object.values(actions).forEach((action) => action.mockReset());
+        actions.expandEvidence.mockResolvedValue({
+            evidence_ref_id: "evidence-1",
+            safe_excerpt: "The authorized evidence excerpt.",
+            state: "available",
+        });
+    });
+
+    it("renders cohort rationale, ranked drivers, lineage, limitations, and shared evidence focus", async () => {
+        const user = userEvent.setup();
+        const { container } = render(<AskDevAnswer answer={answerForState("truncated")} />);
+
+        expect(screen.getByText("Additional evidence context")).toBeVisible();
+        expect(screen.getByText("Source health:")).toBeVisible();
+        expect(screen.getAllByText("Partial context")).toHaveLength(2);
+        expect(screen.getByText("Platform")).toBeVisible();
+        expect(
+            screen.getByText("Included based on the team's current pressure signal."),
+        ).toBeVisible();
+        expect(screen.getByRole("heading", { name: "Ranked drivers" })).toBeVisible();
+        expect(screen.getByText("60% contribution")).toBeVisible();
+        expect(screen.getByRole("heading", { name: "Evidence lineage" })).toBeVisible();
+        expect(screen.getByText("Team")).toBeVisible();
+        expect(screen.getByText("Project")).toBeVisible();
+        expect(screen.getByText("The evidence path is partial.")).toBeVisible();
+
+        await user.click(
+            screen.getByRole("button", {
+                name: "Open evidence citation 1 for driver 1",
+            }),
+        );
+
+        expect(actions.expandEvidence).toHaveBeenCalledWith("evidence-1", "answer-graph-1");
+        expect(await screen.findByText("The authorized evidence excerpt.")).toBeVisible();
+        await waitFor(() =>
+            expect(document.getElementById("ask-dev-evidence-answer-graph-1-1")).toHaveFocus(),
+        );
+
+        const rendered = container.textContent ?? "";
+        for (const token of [
+            "enabled",
+            "team_pressure",
+            "truncated_traversal",
+            "graph_assisted",
+            "Graphiti",
+            "Cypher",
+        ]) {
+            expect(rendered).not.toContain(token);
+        }
+    });
+
+    it.each([
+        ["enabled", "Available", "Additional evidence context is ready for this answer."],
+        [
+            "unavailable",
+            "Not available",
+            "Additional context could not be read, so this answer uses the evidence currently available.",
+        ],
+        [
+            "stale",
+            "Needs review",
+            "Additional context may be out of date; review the dates shown with the evidence.",
+        ],
+        [
+            "lagging",
+            "Catching up",
+            "Additional context is still catching up, so this answer uses the evidence currently available.",
+        ],
+        [
+            "truncated",
+            "Partial context",
+            "Only part of the related context was available. The answer includes the resulting limits below.",
+        ],
+        [
+            "fallback",
+            "Available evidence only",
+            "Additional context could not be used, so this answer uses the evidence currently available.",
+        ],
+    ] as const)("uses customer-safe source-health copy for %s", (state, label, explanation) => {
+        const { container } = render(<AskDevAnswer answer={answerForState(state)} />);
+
+        expect(screen.getAllByText(label)).toHaveLength(2);
+        expect(screen.getByText(explanation)).toBeVisible();
+        const rendered = container.textContent ?? "";
+        expect(rendered).not.toMatch(new RegExp("\\b" + state + "\\b", "iu"));
+        expect(rendered).not.toContain("graph_assisted");
+        expect(rendered).toContain(baseAnswer.direct_summary);
+    });
+
+    it("renders the canonical available-evidence answer when graph context is unavailable", () => {
+        render(<AskDevAnswer answer={answerForState("unavailable")} />);
+
+        expect(
+            screen.getByText(
+                "Additional context could not be read, so this answer uses the evidence currently available.",
+            ),
+        ).toBeVisible();
+        expect(screen.getByText(baseAnswer.direct_summary)).toBeVisible();
+        expect(screen.queryByText("unavailable")).not.toBeInTheDocument();
+    });
+
+    it.each([
+        ["missing_source", "A required source was unavailable."],
+        ["stale_source", "Some supporting data may be out of date."],
+        ["conflicting_evidence", "The available sources did not fully agree."],
+        ["authorization_filtered", "Some related records were not included."],
+        ["truncated_traversal", "The evidence path is partial."],
+        ["absent_staffing_denominator", "Staffing context was not available."],
+        [
+            "historical_slice_not_comparable",
+            "The historical comparison is not directly comparable.",
+        ],
+        ["interpretation_uncertainty", "This result needs interpretation alongside the evidence."],
+    ] as const)("maps the %s limitation to sanctioned copy", (limitation, copy) => {
+        render(
+            <AskDevAnswer
+                answer={{
+                    ...answerForState(
+                        limitation === "truncated_traversal" ? "truncated" : "enabled",
+                    ),
+                    graph_assisted: {
+                        ...graphAssistance,
+                        limitations: [limitation],
+                        state: limitation === "truncated_traversal" ? "truncated" : "enabled",
+                    },
+                }}
+            />,
+        );
+
+        expect(screen.getByText(copy)).toBeVisible();
+        expect(screen.queryByText(limitation)).not.toBeInTheDocument();
+    });
+
+    it("renders the sanctioned project-capacity inclusion rationale", () => {
+        const cohort = graphAssistance.cohort;
+        if (!cohort) throw new Error("canonical graph fixture must include a cohort");
+        render(
+            <AskDevAnswer
+                answer={{
+                    ...answerForState("enabled"),
+                    graph_assisted: {
+                        ...graphAssistance,
+                        cohort: {
+                            ...cohort,
+                            members: [
+                                {
+                                    ...cohort.members[0],
+                                    display_label: "Mobile",
+                                    entity_id: "project-mobile",
+                                    inclusion_basis: "project_capacity",
+                                },
+                            ],
+                        },
+                    },
+                }}
+            />,
+        );
+
+        expect(screen.getByText("Mobile")).toBeVisible();
+        expect(
+            screen.getByText("Included based on the project's current capacity signal."),
+        ).toBeVisible();
+        expect(screen.queryByText("project_capacity")).not.toBeInTheDocument();
+    });
+
+    it.each(["not_ready", "Graphiti", "Cypher"])(
+        "preserves the authorized cohort label %s",
+        (displayLabel) => {
+            const cohort = graphAssistance.cohort;
+            if (!cohort) throw new Error("canonical graph fixture must include a cohort");
+            render(
+                <AskDevAnswer
+                    answer={{
+                        ...answerForState("enabled"),
+                        graph_assisted: {
+                            ...graphAssistance,
+                            limitations: [],
+                            cohort: {
+                                ...cohort,
+                                members: [
+                                    {
+                                        ...cohort.members[0],
+                                        display_label: displayLabel,
+                                    },
+                                ],
+                            },
+                        },
+                    }}
+                />,
+            );
+
+            expect(screen.getByText(displayLabel)).toBeVisible();
+        },
+    );
+
+    it("withholds graph labels and notes containing internal terminology", () => {
+        const cohort = graphAssistance.cohort;
+        expect(cohort).toBeTruthy();
+        if (!cohort) throw new Error("canonical graph fixture must include a cohort");
+        const leaked = {
+            ...baseAnswer,
+            graph_assisted: {
+                ...graphAssistance,
+                cohort: {
+                    ...cohort,
+                    members: [
+                        {
+                            ...cohort.members[0],
+                            display_label: "team_pressure",
+                        },
+                    ],
+                    warnings: ["absent_staffing_denominator", "work_unit"],
+                },
+                evidence_lineage: [
+                    { label: "project_capacity" },
+                    { label: "conflicting_evidence" },
+                    { label: "pull_request" },
+                ],
+            },
+        } as unknown as DevAnswer;
+
+        const { container } = render(<AskDevAnswer answer={leaked} />);
+
+        expect(container.textContent).not.toMatch(
+            /team_pressure|project_capacity|absent_staffing_denominator|conflicting_evidence|work_unit|pull_request/iu,
+        );
+        expect(screen.getAllByText("This part of the answer could not be shown.")).toHaveLength(6);
+    });
+});

--- a/src/components/ask-dev/answer/GraphAssistanceSection.tsx
+++ b/src/components/ask-dev/answer/GraphAssistanceSection.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import type { DevAnswer } from "@/lib/dev/generated";
+import { WITHHELD_COPY } from "@/lib/dev/internalTokens";
+import { formatNumber, formatPercent, formatTimestamp } from "@/lib/formatters";
+
+import { InlineCitations, type CitationTargets } from "./InlineCitations";
+import type { SafeProse } from "./labels";
+
+type GraphAssistance = NonNullable<DevAnswer["graph_assisted"]>;
+type GraphState = GraphAssistance["state"];
+type GraphCohort = NonNullable<GraphAssistance["cohort"]>;
+type CohortEntityKind = GraphCohort["entity_kind"];
+type CohortInclusionBasis = GraphCohort["members"][number]["inclusion_basis"];
+type GraphLimitation = NonNullable<GraphAssistance["limitations"]>[number];
+
+/**
+ * Customer-safe source-health labels for the graph contribution.
+ *
+ * These records are deliberately total over the pinned wire unions. A new
+ * backend state must get an explicit product label before it can reach the
+ * answer, rather than silently rendering its machine value.
+ */
+export const GRAPH_STATE_LABELS: Record<GraphState, string> = {
+    enabled: "Available",
+    unavailable: "Not available",
+    stale: "Needs review",
+    lagging: "Catching up",
+    truncated: "Partial context",
+    fallback: "Available evidence only",
+};
+
+export const GRAPH_STATE_EXPLANATIONS: Record<GraphState, string> = {
+    enabled: "Additional evidence context is ready for this answer.",
+    unavailable:
+        "Additional context could not be read, so this answer uses the evidence currently available.",
+    stale: "Additional context may be out of date; review the dates shown with the evidence.",
+    lagging:
+        "Additional context is still catching up, so this answer uses the evidence currently available.",
+    truncated:
+        "Only part of the related context was available. The answer includes the resulting limits below.",
+    fallback:
+        "Additional context could not be used, so this answer uses the evidence currently available.",
+};
+
+export const COHORT_ENTITY_LABELS: Record<CohortEntityKind, string> = {
+    repository: "Repository",
+    project: "Project",
+    work_unit: "Work item",
+    issue: "Issue",
+    pull_request: "Pull request",
+    team: "Team",
+};
+
+export const COHORT_INCLUSION_LABELS: Record<CohortInclusionBasis, string> = {
+    team_pressure: "Included based on the team's current pressure signal.",
+    project_capacity: "Included based on the project's current capacity signal.",
+};
+
+export const GRAPH_LIMITATION_LABELS: Record<GraphLimitation, string> = {
+    missing_source: "A required source was unavailable.",
+    stale_source: "Some supporting data may be out of date.",
+    conflicting_evidence: "The available sources did not fully agree.",
+    authorization_filtered: "Some related records were not included.",
+    truncated_traversal: "The evidence path is partial.",
+    absent_staffing_denominator: "Staffing context was not available.",
+    historical_slice_not_comparable: "The historical comparison is not directly comparable.",
+    interpretation_uncertainty: "This result needs interpretation alongside the evidence.",
+};
+
+const GRAPH_ATTESTABLE_INTERNAL_TERMS = ["Graphiti", "Cypher"] as const;
+const GRAPH_NEVER_ATTESTABLE_TERMS = [
+    "graph_assisted",
+    "resolved_scope",
+    "canonical_enrichment",
+    ...Object.keys(COHORT_ENTITY_LABELS).filter((value) => value.includes("_")),
+    ...Object.keys(COHORT_INCLUSION_LABELS),
+    ...Object.keys(GRAPH_LIMITATION_LABELS),
+] as const;
+const GRAPH_NEVER_ATTESTABLE_TERM_SET = new Set(
+    GRAPH_NEVER_ATTESTABLE_TERMS.map((term) => term.toLowerCase()),
+);
+const GRAPH_INTERNAL_TERMS = new RegExp(
+    `\\b(?:${[...GRAPH_ATTESTABLE_INTERNAL_TERMS, ...GRAPH_NEVER_ATTESTABLE_TERMS].join("|")})\\b`,
+    "giu",
+);
+
+/**
+ * The shared graph contribution rendered in both the compact window and the
+ * full Ask Dev workspace through AskDevAnswer.
+ *
+ * The wire object is a contribution to an answer, not a second answer. This
+ * component therefore only presents the server-owned state, cohort context,
+ * driver evidence, lineage, and declared limits. Evidence references use the
+ * same targets as claims and metrics, so a citation opens and focuses the
+ * existing evidence lane rather than creating a second detail path.
+ */
+export function GraphAssistanceSection({
+    graphAssistance,
+    headingId,
+    safeProse,
+    targets,
+}: {
+    graphAssistance: GraphAssistance;
+    headingId: string;
+    safeProse: SafeProse;
+    targets: CitationTargets;
+}) {
+    const {
+        cohort,
+        evidence_lineage: evidenceLineage,
+        limitations,
+        ranked_drivers: rankedDrivers,
+    } = graphAssistance;
+    const stateLabel = GRAPH_STATE_LABELS[graphAssistance.state];
+    const stateExplanation = GRAPH_STATE_EXPLANATIONS[graphAssistance.state];
+    const graphAttested = (cohort?.members ?? [])
+        .map((member) => member.display_label)
+        .join(" ")
+        .toLowerCase();
+    const safeGraphProse: SafeProse = (value) => {
+        const safeValue = safeProse(value);
+        for (const match of safeValue.matchAll(GRAPH_INTERNAL_TERMS)) {
+            const term = match[0].toLowerCase();
+            if (GRAPH_NEVER_ATTESTABLE_TERM_SET.has(term) || !graphAttested.includes(term)) {
+                return WITHHELD_COPY;
+            }
+        }
+        return safeValue;
+    };
+
+    return (
+        <section className="space-y-4 border-t border-(--border) pt-4" aria-labelledby={headingId}>
+            <div className="space-y-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 id={headingId} className="text-label-caps text-(--text-muted)">
+                        Additional evidence context
+                    </h3>
+                    <span className="rounded-(--radius-pill) border border-(--border) px-2 py-1 text-label-caps text-(--text-secondary)">
+                        {stateLabel}
+                    </span>
+                </div>
+                <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-(--text-muted)">
+                    <span>
+                        Source health: <strong className="font-medium">{stateLabel}</strong>
+                    </span>
+                    <span>Updated {formatTimestamp(graphAssistance.as_of)}</span>
+                </div>
+                <p className="text-sm leading-6 text-(--text-secondary)">{stateExplanation}</p>
+            </div>
+
+            {cohort ? (
+                <section className="space-y-2" aria-label="Included context">
+                    <div className="flex flex-wrap items-baseline justify-between gap-2">
+                        <h4 className="text-h3 text-(--text-primary)">Included context</h4>
+                        <span className="text-xs text-(--text-muted)">
+                            {COHORT_ENTITY_LABELS[cohort.entity_kind]} ·{" "}
+                            {formatNumber(cohort.members.length, { maximumFractionDigits: 0 })}{" "}
+                            included
+                        </span>
+                    </div>
+                    {!cohort.cohort_complete ? (
+                        <p className="text-xs text-(--caution)">
+                            This list is partial; some related context may not be included.
+                        </p>
+                    ) : null}
+                    <ul className="divide-y divide-(--border) rounded-(--radius-md) border border-(--border)">
+                        {cohort.members.map((member) => (
+                            <li
+                                key={member.entity_id + ":" + member.inclusion_basis}
+                                className="grid gap-1 px-3 py-2.5 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] sm:gap-4"
+                            >
+                                <span className="text-sm text-(--text-secondary)">
+                                    {safeGraphProse(member.display_label)}
+                                </span>
+                                <span className="text-xs leading-5 text-(--text-muted)">
+                                    {COHORT_INCLUSION_LABELS[member.inclusion_basis]}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                    {cohort.warnings?.length ? (
+                        <ul
+                            className="space-y-1 text-xs text-(--caution)"
+                            aria-label="Context notes"
+                        >
+                            {cohort.warnings.map((warning) => (
+                                <li key={warning}>{safeGraphProse(warning)}</li>
+                            ))}
+                        </ul>
+                    ) : null}
+                </section>
+            ) : null}
+
+            {rankedDrivers?.length ? (
+                <section className="space-y-2" aria-label="Ranked drivers">
+                    <h4 className="text-h3 text-(--text-primary)">Ranked drivers</h4>
+                    <ol className="divide-y divide-(--border) rounded-(--radius-md) border border-(--border)">
+                        {rankedDrivers.map((driver) => (
+                            <li
+                                key={driver.rank + ":" + driver.evidence_ref_ids.join(",")}
+                                className="grid gap-2 px-3 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-start sm:gap-3"
+                            >
+                                <span
+                                    aria-label={"Rank " + driver.rank}
+                                    className="flex h-6 min-w-6 items-center justify-center rounded-(--radius-pill) bg-(--accent-ai)/12 px-1.5 text-xs font-medium text-(--accent-ai)"
+                                >
+                                    {driver.rank}
+                                </span>
+                                <div className="min-w-0">
+                                    <p className="text-sm text-(--text-secondary)">
+                                        Driver {driver.rank}
+                                        <InlineCitations
+                                            evidenceRefIds={driver.evidence_ref_ids}
+                                            ownerLabel={"driver " + driver.rank}
+                                            targets={targets}
+                                        />
+                                    </p>
+                                    <p className="mt-1 text-xs text-(--text-muted)">
+                                        Supporting evidence for this driver is shown below.
+                                    </p>
+                                </div>
+                                <span className="text-xs text-(--text-muted) sm:text-right">
+                                    {formatPercent(driver.contribution * 100)} contribution
+                                </span>
+                            </li>
+                        ))}
+                    </ol>
+                </section>
+            ) : null}
+
+            {evidenceLineage?.length ? (
+                <section className="space-y-2" aria-label="Evidence lineage">
+                    <h4 className="text-h3 text-(--text-primary)">Evidence lineage</h4>
+                    <ol className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-(--text-secondary)">
+                        {evidenceLineage.map((hop, index) => (
+                            <li
+                                key={hop.label + ":" + index}
+                                className="inline-flex items-center gap-2"
+                            >
+                                <span>{safeGraphProse(hop.label)}</span>
+                                {index < evidenceLineage.length - 1 ? (
+                                    <span aria-hidden="true" className="text-(--text-muted)">
+                                        →
+                                    </span>
+                                ) : null}
+                            </li>
+                        ))}
+                    </ol>
+                </section>
+            ) : null}
+
+            {limitations?.length ? (
+                <section
+                    className="rounded-(--radius-md) border border-(--caution)/30 bg-(--caution)/8 p-3"
+                    aria-label="Context limitations"
+                >
+                    <p className="text-label-caps text-(--caution)">Context limitations</p>
+                    <ul className="mt-2 space-y-1 text-sm leading-6 text-(--text-secondary)">
+                        {limitations.map((limitation) => (
+                            <li key={limitation}>{GRAPH_LIMITATION_LABELS[limitation]}</li>
+                        ))}
+                    </ul>
+                </section>
+            ) : null}
+        </section>
+    );
+}

--- a/tests/ask-dev-graph-assistance.spec.ts
+++ b/tests/ask-dev-graph-assistance.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+
+import {
+    askDevAnswerArticle,
+    askDevTranscript,
+    getAskDevRequestCounts,
+    openAskDevWindow,
+    resetAskDevMock,
+    scenarioQuestion,
+    submitAskDevQuestion,
+} from "./helpers/askDev";
+
+const INTERNAL_TERMS = [
+    "graph_assisted",
+    "team_pressure",
+    "truncated_traversal",
+    "Graphiti",
+    "Cypher",
+    "canonical_enrichment",
+];
+
+function normalizeAnswerText(value: string): string {
+    return value.replace(/\s+/gu, " ").trim();
+}
+
+test.beforeEach(async ({ request }) => {
+    await resetAskDevMock(request);
+});
+
+test("graph assistance uses one shared answer and evidence path across both surfaces", async ({
+    page,
+    request,
+}, testInfo) => {
+    const visibleQuestion = "Which teams need attention, and why?";
+    await page.route("**/api/v1/dev/conversations/*/messages", async (route) => {
+        const body = route.request().postDataJSON() as Record<string, unknown>;
+        await route.continue({
+            postData: JSON.stringify({
+                ...body,
+                question: scenarioQuestion("graph_assisted", visibleQuestion),
+            }),
+        });
+    });
+    await page.goto("/diagnose", { waitUntil: "domcontentloaded" });
+    await openAskDevWindow(page);
+    await submitAskDevQuestion(page, visibleQuestion);
+
+    const windowAnswer = askDevAnswerArticle(page);
+    await expect(windowAnswer).toBeVisible();
+    await expect(windowAnswer).toContainText("Additional evidence context");
+    await expect(windowAnswer).toContainText("Partial context");
+    await expect(windowAnswer).toContainText("Platform");
+    await expect(windowAnswer).toContainText("60% contribution");
+    await expect(windowAnswer).toContainText("Team");
+    await expect(windowAnswer).toContainText("Project");
+    await expect(windowAnswer).toContainText("The evidence path is partial.");
+
+    const answerId = await windowAnswer.getAttribute("id");
+    expect(answerId).toMatch(/^ask-dev-answer-/u);
+    const windowText = normalizeAnswerText(await windowAnswer.innerText());
+    const beforeNavigation = await getAskDevRequestCounts(request);
+    expect(beforeNavigation.messages).toBe(1);
+
+    for (const term of INTERNAL_TERMS) {
+        expect(await askDevTranscript(page).innerText()).not.toContain(term);
+    }
+
+    await page.getByRole("link", { name: "Ask Dev workspace" }).click();
+    await expect(page).toHaveURL(/\/dev(?:\?|$)/u);
+    await expect(page.getByRole("region", { name: "Ask Dev workspace" })).toBeVisible();
+
+    const workspaceAnswer = askDevAnswerArticle(page);
+    await expect(workspaceAnswer).toBeVisible();
+    expect(await workspaceAnswer.getAttribute("id")).toBe(answerId);
+    expect(normalizeAnswerText(await workspaceAnswer.innerText())).toBe(windowText);
+    expect(await getAskDevRequestCounts(request)).toEqual(beforeNavigation);
+
+    const graphRegion = workspaceAnswer.getByRole("region", {
+        name: "Additional evidence context",
+    });
+    await graphRegion
+        .getByRole("heading", { name: "Additional evidence context" })
+        .scrollIntoViewIfNeeded();
+    await testInfo.attach("chaos-3710-graph-assistance-after.png", {
+        body: await page.screenshot({ fullPage: true }),
+        contentType: "image/png",
+    });
+    await graphRegion.getByText("The evidence path is partial.").scrollIntoViewIfNeeded();
+    await testInfo.attach("chaos-3710-graph-assistance-limitations-after.png", {
+        body: await page.screenshot({ fullPage: true }),
+        contentType: "image/png",
+    });
+
+    await workspaceAnswer
+        .getByRole("button", { name: "Open evidence citation 1 for driver 1" })
+        .click();
+    await expect(workspaceAnswer.getByText(/Evidence excerpt 1 for answer_e2e_/u)).toBeVisible();
+
+    for (const term of INTERNAL_TERMS) {
+        expect(await askDevTranscript(page).innerText()).not.toContain(term);
+    }
+
+    await testInfo.attach("chaos-3710-graph-assistance-evidence-after.png", {
+        body: await page.screenshot({ fullPage: true }),
+        contentType: "image/png",
+    });
+});

--- a/tests/helpers/askDev.ts
+++ b/tests/helpers/askDev.ts
@@ -3,12 +3,11 @@ import { expect, type APIRequestContext, type Page } from "@playwright/test";
 import type { DevAnswerScenario, DevCapabilitiesState } from "../mocks/devScenario";
 
 /**
- * The mock backend's own base URL (not the Next.js app's). Existing specs
- * (acr-secret-boundary.spec.ts, acr-explorer-shell.spec.ts, …) already hit
- * `/__test/*` control endpoints on this same hardcoded port, which mirrors
- * playwright.config.ts's `PLAYWRIGHT_MOCK_PORT` default.
+ * The mock backend's own base URL (not the Next.js app's). Keep the default
+ * for the checked-in Playwright config, but honor its env override so local
+ * suites can run several environments without contending for one port.
  */
-const MOCK_SERVER_URL = "http://127.0.0.1:8001";
+const MOCK_SERVER_URL = `http://127.0.0.1:${process.env.PLAYWRIGHT_MOCK_PORT ?? "8001"}`;
 
 /** Encodes which canned dev_answer.v1 the mock should return for one question. */
 export function scenarioQuestion(scenario: DevAnswerScenario, question: string): string {

--- a/tests/mocks/devScenario.test.ts
+++ b/tests/mocks/devScenario.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "vitest";
 
 import {
+    applyMessage,
     buildStreamEvents,
     CLARIFICATION_COPY,
+    createConversation,
+    getTranscript,
     NO_ANSWER_OUTCOMES,
+    parseScenario,
     type DevAnswerScenario,
 } from "./devScenario";
+
+import graphAssistanceFixture from "../../src/lib/dev/contracts/examples/positive/dev_answer_graph_assistance.v1.json";
 
 /**
  * Fixture-fidelity oracle for the Ask Dev mock (CHAOS-3219).
@@ -81,6 +87,68 @@ describe("Ask Dev mock fidelity — clarification projection", () => {
         expect(requested.direct_scope).toBe("organization");
         expect(requested.repositories).toEqual([]);
         expect(requested.entity_refs).toEqual([]);
+    });
+});
+
+describe("Ask Dev mock fidelity — graph assistance rendering scenario", () => {
+    it("selects the scenario marker and applies production state precedence", () => {
+        expect(parseScenario("[[ask-dev:graph_assisted]] Show the drivers")).toEqual({
+            scenario: "graph_assisted",
+            visibleQuestion: "Show the drivers",
+        });
+
+        const answer = answerFor("graph_assisted");
+        expect(answer.graph_assisted).toEqual({
+            ...graphAssistanceFixture,
+            state: "truncated",
+        });
+
+        const graphAssisted = answer.graph_assisted as JsonRecord;
+        expect(graphAssisted.schema_version).toBe("dev_answer_graph_assistance.v1");
+        expect(graphAssisted.state).toBe("truncated");
+        expect((graphAssisted.cohort as JsonRecord).members).toEqual([
+            {
+                display_label: "Platform",
+                entity_id: "team_platform",
+                inclusion_basis: "team_pressure",
+            },
+        ]);
+        expect(graphAssisted.ranked_drivers).toEqual([
+            {
+                contribution: 0.6,
+                evidence_ref_ids: ["ev_01"],
+                rank: 1,
+            },
+        ]);
+
+        const evidenceIds = new Set(
+            (answer.evidence as JsonRecord[]).map((item) => item.evidence_ref_id),
+        );
+        for (const driver of graphAssisted.ranked_drivers as JsonRecord[]) {
+            for (const evidenceRefId of driver.evidence_ref_ids as string[]) {
+                expect(evidenceIds.has(evidenceRefId)).toBe(true);
+            }
+        }
+    });
+
+    it("keeps the test-only scenario marker out of the customer-visible title", () => {
+        const conversation = createConversation(
+            {},
+            "[[ask-dev:graph_assisted]] Which teams need attention?",
+        );
+
+        expect(conversation.title).toBe("Which teams need attention?");
+
+        const conversationId = String(conversation.conversation_id);
+        applyMessage(
+            conversationId,
+            "client-message-graph",
+            "[[ask-dev:graph_assisted]] Which teams need attention?",
+            {},
+            null,
+        );
+        const transcript = getTranscript(conversationId);
+        expect((transcript?.items as JsonRecord[])[0].question).toBe("Which teams need attention?");
     });
 });
 

--- a/tests/mocks/devScenario.ts
+++ b/tests/mocks/devScenario.ts
@@ -22,6 +22,7 @@ import { randomUUID } from "node:crypto";
 
 import answerFixture from "../../src/lib/dev/contracts/examples/positive/dev_answer.v1.json";
 import capabilitiesFixture from "../../src/lib/dev/contracts/examples/positive/dev_capabilities.v1.json";
+import graphAssistanceFixture from "../../src/lib/dev/contracts/examples/positive/dev_answer_graph_assistance.v1.json";
 import { ASK_DEV_OUTCOME_TABLE, outcomeCase } from "../fixtures/askDevOutcomes";
 
 type JsonRecord = Record<string, unknown>;
@@ -150,6 +151,7 @@ export type DevAnswerScenario =
     | "degraded_sources_only"
     | "leaky_prose"
     | "full_sections"
+    | "graph_assisted"
     | "refused_with_grounding"
     | "scope_unresolved"
     | "scope_organization_fallback"
@@ -167,6 +169,7 @@ const KNOWN_SCENARIOS: ReadonlySet<string> = new Set<DevAnswerScenario>([
     "degraded_sources_only",
     "leaky_prose",
     "full_sections",
+    "graph_assisted",
     "refused_with_grounding",
     "scope_unresolved",
     "scope_organization_fallback",
@@ -448,6 +451,20 @@ function buildAnswer(
                 },
             ];
             base.warnings = ["Deployment evidence covers only part of the window."];
+            return base;
+        }
+        case "graph_assisted": {
+            // Keep the browser scenario assembled from the same generated
+            // graph-assistance contract example used by the renderer tests.
+            // The answer fixture supplies the surrounding dev_answer.v1
+            // envelope and evidence refs. Production routing promotes a
+            // truncated-traversal limitation to the truncated state, so keep
+            // that semantic precedence even though the shape fixture carries
+            // the independently valid `enabled` enum example.
+            base.graph_assisted = {
+                ...clone(graphAssistanceFixture),
+                state: "truncated",
+            };
             return base;
         }
         case "refused_with_grounding": {
@@ -930,6 +947,7 @@ export function resetDevMockState(): void {
 export function createConversation(currentScope: unknown, title: unknown): JsonRecord {
     const conversationId = `conversation_e2e_${randomUUID()}`;
     const nowIso = new Date().toISOString();
+    const visibleTitle = typeof title === "string" ? parseScenario(title).visibleQuestion : null;
     const conversation: JsonRecord = {
         conversation_id: conversationId,
         created_at: nowIso,
@@ -941,7 +959,7 @@ export function createConversation(currentScope: unknown, title: unknown): JsonR
         retention_days: 30,
         schema_version: "dev_conversation.v1",
         state: "active",
-        title: typeof title === "string" ? title : null,
+        title: visibleTitle,
     };
     conversations.set(conversationId, {
         conversation,
@@ -1063,7 +1081,7 @@ export function applyMessage(
         answer: null,
         created_at: nowIso,
         message_id: `message_e2e_${randomUUID()}`,
-        question: rawQuestion,
+        question: visibleQuestion,
         retry_of_run_id: null,
         role: "user",
         run_id: runId,


### PR DESCRIPTION
## Summary

- render the optional `graph_assisted` contribution through the shared Ask Dev answer used by both the window and `/dev`
- present total customer-safe source health, cohort rationale, ranked-driver contribution, evidence lineage, limitations, and the existing citation/evidence path
- preserve authorized entity names while withholding graph implementation vocabulary and machine enums
- add a production-semantic mock scenario and browser proof for one shared answer/run across both surfaces

## Verification

- focused Vitest: 38 passed
- Playwright on OS-selected ports 60186/60187: 2 passed
- TypeScript, ESLint, Prettier, design lint, contract currency, and `git diff --check`: green
- broad local Vitest: 3774 passed, 8 skipped; 54 unrelated host-environment failures (48 cascade from Node 26 lacking `window.localStorage`, 6 process-group tests hit sandbox timeouts)

## Visual evidence

Post-review screenshots were captured from the passing browser journey and will be attached in a follow-up comment.

## Scope boundary

This delivers shared rendering and production-shaped mock coverage. Live graph-backed payload proof remains blocked by the CHAOS-3669 public projection contract and is not claimed here.

Linear: CHAOS-3710