### PR TITLE
feat(ask-dev): render driver judgments (CHAOS-3741)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,18 +98,19 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
               with:
                   repository: full-chaos/dev-health-ops
-                  ref: 42063ceb8f70d03648cc4401b4f37c7e36def38e
+                  ref: 2963df821301c9d052ac83e8c8300ee5966b9eb4
                   path: dev-health-ops
                   persist-credentials: false
-            # CHAOS-3511 currency guard: ops main's tip as of this run, checked
-            # out to a SEPARATE path so it never disturbs the pinned checkout's
-            # exact-SHA requirement above. ask-dev:contracts:check-currency
-            # diffs the two over the consumed surface only.
-            - name: Checkout current ops main
+            # CHAOS-3511 currency guard: ordinary PRs compare to ops main. The
+            # trusted Context Fabric feature-stack base compares to the closed,
+            # corresponding Ops feature ref. Never accept the PR head/source as
+            # input. This separate path preserves the pinned checkout's exact
+            # SHA while check-currency diffs the consumed surface only.
+            - name: Checkout current ops currency authority
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
               with:
                   repository: full-chaos/dev-health-ops
-                  ref: main
+                  ref: ${{ github.base_ref == 'feature/chaos-3498-context-fabric' && 'feature/chaos-3498-context-fabric' || 'main' }}
                   path: dev-health-ops-main
                   persist-credentials: false
             - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271

--- a/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
+++ b/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
@@ -148,11 +148,10 @@ describe("CHAOS-3017 executable CI boundaries", () => {
                 expect(workflowJob).toContain("repository: full-chaos/dev-health-ops");
                 expect(workflowJob).toContain(`ref: ${pinnedOpsCommit()}`);
                 expect(workflowJob).toContain("path: dev-health-ops");
-                // CHAOS-3511 currency guard: a SECOND, separate ops checkout
-                // at main's current tip -- never the same path as the pinned
-                // one, or the pinned checkout's exact-SHA requirement above
-                // would be violated by whichever checkout runs second.
-                expect(workflowJob).toContain("ref: main");
+                // CHAOS-3511 currency guard: a SECOND, separate ops checkout --
+                // never the same path as the pinned one, or the pinned
+                // checkout's exact-SHA requirement above would be violated by
+                // whichever checkout runs second.
                 expect(workflowJob).toContain("path: dev-health-ops-main");
             }
             for (const [name, implementation] of Object.entries(packageScripts)) {
@@ -169,6 +168,15 @@ describe("CHAOS-3017 executable CI boundaries", () => {
             }
         },
     );
+
+    it("maps the trusted Context Fabric base to its Ops feature and all other bases to main", () => {
+        const workflowJob = job(contents(TESTS_WORKFLOW), "quality");
+        const currencyCheckout = step(workflowJob, "Checkout current ops currency authority");
+        expect(currencyCheckout).toContain(
+            "ref: ${{ github.base_ref == 'feature/chaos-3498-context-fabric' && 'feature/chaos-3498-context-fabric' || 'main' }}",
+        );
+        expect(currencyCheckout).not.toContain("github.head_ref");
+    });
 
     it("keeps aggregate CI unit execution independent of the test:unit alias", () => {
         const scripts = JSON.parse(contents(PACKAGE_JSON)).scripts;

--- a/scripts/ask-dev-contracts.mjs
+++ b/scripts/ask-dev-contracts.mjs
@@ -12,7 +12,7 @@ import { format } from "prettier";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ARTIFACT_ROOT = path.join(ROOT, "src/lib/dev/contracts");
 const GENERATED_PATH = path.join(ROOT, "src/lib/dev/generated.ts");
-const SOURCE_COMMIT = "42063ceb8f70d03648cc4401b4f37c7e36def38e";
+const SOURCE_COMMIT = "2963df821301c9d052ac83e8c8300ee5966b9eb4";
 const SOURCE_PREFIX = "contracts/ask-dev/v1/";
 const PRETTIER_OPTIONS = Object.freeze({
     parser: "typescript",

--- a/src/components/ask-dev/answer/GraphAssistanceSection.test.tsx
+++ b/src/components/ask-dev/answer/GraphAssistanceSection.test.tsx
@@ -154,6 +154,144 @@ describe("AskDevAnswer graph assistance rendering", () => {
         }
     });
 
+    it("renders evidence-closed driver judgments without turning an absent contribution into 0%", async () => {
+        const user = userEvent.setup();
+        const answer = {
+            ...answerForState("enabled"),
+            evidence: [
+                evidence,
+                {
+                    ...evidence,
+                    display_label: "Conflicting deployment evidence",
+                    evidence_ref_id: "evidence-2",
+                },
+            ],
+            graph_assisted: {
+                ...graphAssistance,
+                ranked_drivers: [
+                    {
+                        category: "delivery_pressure",
+                        confidence: "qualified",
+                        conflicting_evidence_ref_ids: ["evidence-2"],
+                        contribution: null,
+                        evidence_ref_ids: ["evidence-1"],
+                        exclusion_reason: null,
+                        freshness: "fresh",
+                        rank: 1,
+                        relevance: "current",
+                        role: "driver",
+                        staffing_qualification: {
+                            denominator_source_classes: ["work_item"],
+                            denominator_state: "allocation_evidence_available",
+                        },
+                        standing: "principal_driver",
+                        withheld_reason: null,
+                    },
+                    {
+                        category: "dependency_pressure",
+                        confidence: "uncertain",
+                        conflicting_evidence_ref_ids: [],
+                        contribution: 0.35,
+                        evidence_ref_ids: ["evidence-1"],
+                        exclusion_reason: null,
+                        freshness: "stale",
+                        rank: 2,
+                        relevance: "recently_current",
+                        role: "driver",
+                        staffing_qualification: {
+                            denominator_source_classes: ["work_graph"],
+                            denominator_state: "partial_allocation_evidence",
+                        },
+                        standing: "contributing_driver",
+                        withheld_reason: null,
+                    },
+                ],
+            },
+        } as unknown as DevAnswer;
+
+        render(<AskDevAnswer answer={answer} />);
+
+        const drivers = screen.getByRole("region", { name: "Ranked drivers" });
+        expect(within(drivers).getByText("Principal driver")).toBeVisible();
+        expect(within(drivers).getByText("Contributing driver")).toBeVisible();
+        expect(within(drivers).getByText("Delivery pressure")).toBeVisible();
+        expect(within(drivers).getByText("Dependency pressure")).toBeVisible();
+        expect(
+            within(drivers).getByText("Qualified confidence · Current · Current evidence"),
+        ).toBeVisible();
+        expect(
+            within(drivers).getByText(
+                "Uncertain confidence · Recently current · Out-of-date evidence",
+            ),
+        ).toBeVisible();
+        expect(within(drivers).getByText("Allocation evidence available")).toBeVisible();
+        expect(within(drivers).getByText("Partial allocation evidence")).toBeVisible();
+        expect(within(drivers).getByText("Evidence sources: Work items")).toBeVisible();
+        expect(within(drivers).getByText("Evidence sources: Work graph")).toBeVisible();
+        expect(within(drivers).queryByText("0% contribution")).not.toBeInTheDocument();
+        expect(within(drivers).getByText("35% contribution")).toBeVisible();
+
+        await user.click(
+            within(drivers).getByRole("button", {
+                name: "Open evidence citation 2 for conflicting evidence for driver 1",
+            }),
+        );
+        expect(actions.expandEvidence).toHaveBeenCalledWith("evidence-2", "answer-graph-1");
+    });
+
+    it("renders symptom, exclusion, withheld, denominator, and historical qualifications safely", () => {
+        const answer = {
+            ...answerForState("enabled"),
+            graph_assisted: {
+                ...graphAssistance,
+                ranked_drivers: [
+                    {
+                        category: "capacity_or_staffing",
+                        confidence: "unsupported",
+                        conflicting_evidence_ref_ids: [],
+                        contribution: null,
+                        evidence_ref_ids: ["evidence-1"],
+                        exclusion_reason: "symptom_of_another_candidate",
+                        freshness: "unknown",
+                        rank: 3,
+                        relevance: "historical_only",
+                        role: "symptom",
+                        staffing_qualification: {
+                            denominator_source_classes: [],
+                            denominator_state: "denominator_absent",
+                        },
+                        standing: "excluded",
+                        withheld_reason: "evidence_unavailable",
+                    },
+                ],
+            },
+        } as unknown as DevAnswer;
+
+        const { container } = render(<AskDevAnswer answer={answer} />);
+
+        const drivers = screen.getByRole("region", { name: "Ranked drivers" });
+        expect(within(drivers).getByText("Excluded")).toBeVisible();
+        expect(within(drivers).getByText("Symptom")).toBeVisible();
+        expect(within(drivers).getByText("Capacity or staffing")).toBeVisible();
+        expect(
+            within(drivers).getByText(
+                "Unsupported confidence · Historical only · Freshness unknown",
+            ),
+        ).toBeVisible();
+        expect(within(drivers).getByText("Staffing denominator unavailable")).toBeVisible();
+        expect(
+            within(drivers).getByText(
+                "Excluded because it appears to be a symptom of another candidate.",
+            ),
+        ).toBeVisible();
+        expect(
+            within(drivers).getByText("Supporting evidence is currently unavailable."),
+        ).toBeVisible();
+        expect(container.textContent).not.toMatch(
+            /capacity_or_staffing|unsupported|historical_only|denominator_absent|symptom_of_another_candidate|evidence_unavailable/u,
+        );
+    });
+
     it.each([
         ["enabled", "Available", "Additional evidence context is ready for this answer."],
         [
@@ -358,7 +496,7 @@ describe("AskDevAnswer graph assistance rendering", () => {
         );
     });
 
-    it.each(["not_ready", "Graphiti", "Cypher"])(
+    it.each(["not_ready", "driver", "Graphiti", "Cypher"])(
         "preserves the authorized cohort label %s",
         (displayLabel) => {
             const cohort = graphAssistance.cohort;

--- a/src/components/ask-dev/answer/GraphAssistanceSection.tsx
+++ b/src/components/ask-dev/answer/GraphAssistanceSection.tsx
@@ -24,6 +24,18 @@ type EnrichmentGap = NonNullable<CohortSignal["gap"]>;
 type EvidenceSourceClass = NonNullable<CohortSignal["evidence_source_classes"]>[number];
 type SignalFreshness = NonNullable<CohortSignal["freshness"]>;
 type GraphLimitation = NonNullable<GraphAssistance["limitations"]>[number];
+type RankedDriver = NonNullable<GraphAssistance["ranked_drivers"]>[number];
+type DriverStanding = NonNullable<RankedDriver["standing"]>;
+type DriverRole = NonNullable<RankedDriver["role"]>;
+type DriverCategory = NonNullable<RankedDriver["category"]>;
+type DriverConfidence = NonNullable<RankedDriver["confidence"]>;
+type DriverRelevance = NonNullable<RankedDriver["relevance"]>;
+type DriverFreshness = NonNullable<RankedDriver["freshness"]>;
+type DriverStaffing = NonNullable<RankedDriver["staffing_qualification"]>;
+type DriverDenominatorState = DriverStaffing["denominator_state"];
+type DriverEvidenceSource = NonNullable<DriverStaffing["denominator_source_classes"]>[number];
+type DriverWithheldReason = NonNullable<RankedDriver["withheld_reason"]>;
+type DriverExclusionReason = NonNullable<RankedDriver["exclusion_reason"]>;
 
 /**
  * Customer-safe source-health labels for the graph contribution.
@@ -165,6 +177,95 @@ export const GRAPH_LIMITATION_LABELS: Record<GraphLimitation, string> = {
     interpretation_uncertainty: "This result needs interpretation alongside the evidence.",
 };
 
+export const DRIVER_STANDING_LABELS: Record<DriverStanding, string> = {
+    principal_driver: "Principal driver",
+    contributing_driver: "Contributing driver",
+    candidate_only: "Candidate for review",
+    excluded: "Excluded",
+};
+
+export const DRIVER_ROLE_LABELS: Record<DriverRole, string> = {
+    driver: "Driver",
+    symptom: "Symptom",
+    contextual_correlate: "Related context",
+};
+
+export const DRIVER_CATEGORY_LABELS: Record<DriverCategory, string> = {
+    delivery_pressure: "Delivery pressure",
+    review_pressure: "Review pressure",
+    operational_pressure: "Operational pressure",
+    dependency_pressure: "Dependency pressure",
+    investment_mix: "Investment mix",
+    capacity_or_staffing: "Capacity or staffing",
+    scope_change: "Scope change",
+    quality_or_defect: "Quality or defect",
+    external_blocker: "External blocker",
+    data_coverage: "Data coverage",
+};
+
+export const DRIVER_CONFIDENCE_LABELS: Record<DriverConfidence, string> = {
+    measured_certain: "Measured confidence",
+    qualified: "Qualified confidence",
+    uncertain: "Uncertain confidence",
+    unsupported: "Unsupported confidence",
+};
+
+export const DRIVER_RELEVANCE_LABELS: Record<DriverRelevance, string> = {
+    current: "Current",
+    recently_current: "Recently current",
+    historical_only: "Historical only",
+    unknown: "Relevance unknown",
+};
+
+export const DRIVER_FRESHNESS_LABELS: Record<DriverFreshness, string> = {
+    fresh: "Current evidence",
+    stale: "Out-of-date evidence",
+    unavailable: "Evidence unavailable",
+    unknown: "Freshness unknown",
+};
+
+export const DRIVER_DENOMINATOR_LABELS: Record<DriverDenominatorState, string> = {
+    allocation_evidence_available: "Allocation evidence available",
+    partial_allocation_evidence: "Partial allocation evidence",
+    denominator_absent: "Staffing denominator unavailable",
+};
+
+export const DRIVER_EVIDENCE_SOURCE_LABELS: Record<DriverEvidenceSource, string> = {
+    status_change: "Status history",
+    work_item: "Work items",
+    work_graph: "Work graph",
+    pull_request: "Pull requests",
+    code_change: "Code changes",
+    review: "Reviews",
+    ci_run: "CI runs",
+    test_report: "Test reports",
+    deployment: "Deployments",
+    incident: "Incidents",
+    operational_control: "Operational controls",
+    source_health: "Source health",
+    cognitive_load: "Cognitive load",
+    investment_allocation: "Investment allocation",
+    health_profile: "Health profile",
+    deficiency_inventory: "Readiness checks",
+    temporal_context: "Historical context",
+};
+
+export const DRIVER_WITHHELD_LABELS: Record<DriverWithheldReason, string> = {
+    evidence_refused: "Supporting evidence could not be included.",
+    evidence_unavailable: "Supporting evidence is currently unavailable.",
+    authorization_filtered: "Some supporting evidence was not included.",
+};
+
+export const DRIVER_EXCLUSION_LABELS: Record<DriverExclusionReason, string> = {
+    no_supporting_path: "Excluded because no supporting evidence path was available.",
+    evidence_conflict_unresolved: "Excluded because its supporting evidence did not agree.",
+    not_currently_relevant: "Excluded because it is not currently relevant.",
+    symptom_of_another_candidate:
+        "Excluded because it appears to be a symptom of another candidate.",
+    unauthorized_evidence: "Excluded because its supporting evidence was not visible.",
+    insufficient_measurement: "Excluded because the available measurement was insufficient.",
+};
+
 const GRAPH_ATTESTABLE_INTERNAL_TERMS = ["Graphiti", "Cypher"] as const;
 const GRAPH_NEVER_ATTESTABLE_TERMS = [
     "graph_assisted",
@@ -182,6 +283,15 @@ const GRAPH_NEVER_ATTESTABLE_TERMS = [
     ...Object.keys(SIGNAL_FRESHNESS_LABELS),
     ...Object.keys(EVIDENCE_SOURCE_LABELS),
     ...Object.keys(GRAPH_LIMITATION_LABELS),
+    ...Object.keys(DRIVER_STANDING_LABELS).filter((value) => value.includes("_")),
+    ...Object.keys(DRIVER_ROLE_LABELS).filter((value) => value.includes("_")),
+    ...Object.keys(DRIVER_CATEGORY_LABELS).filter((value) => value.includes("_")),
+    ...Object.keys(DRIVER_CONFIDENCE_LABELS).filter((value) => value.includes("_")),
+    ...Object.keys(DRIVER_RELEVANCE_LABELS).filter((value) => value.includes("_")),
+    ...Object.keys(DRIVER_FRESHNESS_LABELS).filter((value) => value.includes("_")),
+    ...Object.keys(DRIVER_DENOMINATOR_LABELS).filter((value) => value.includes("_")),
+    ...Object.keys(DRIVER_WITHHELD_LABELS).filter((value) => value.includes("_")),
+    ...Object.keys(DRIVER_EXCLUSION_LABELS).filter((value) => value.includes("_")),
 ] as const;
 const GRAPH_NEVER_ATTESTABLE_TERM_SET = new Set(
     GRAPH_NEVER_ATTESTABLE_TERMS.map((term) => term.toLowerCase()),
@@ -403,7 +513,7 @@ export function GraphAssistanceSection({
                         {rankedDrivers.map((driver) => (
                             <li
                                 key={driver.rank + ":" + driver.evidence_ref_ids.join(",")}
-                                className="grid gap-2 px-3 py-3 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-start sm:gap-3"
+                                className="grid gap-2 px-3 py-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-start sm:gap-3"
                             >
                                 <span
                                     aria-label={"Rank " + driver.rank}
@@ -411,22 +521,103 @@ export function GraphAssistanceSection({
                                 >
                                     {driver.rank}
                                 </span>
-                                <div className="min-w-0">
-                                    <p className="text-sm text-(--text-secondary)">
-                                        Driver {driver.rank}
+                                <div className="min-w-0 space-y-2">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <p className="text-sm font-medium text-(--text-primary)">
+                                            {driver.standing
+                                                ? DRIVER_STANDING_LABELS[driver.standing]
+                                                : `Driver ${driver.rank}`}
+                                        </p>
+                                        {driver.role ? (
+                                            <span className="rounded-(--radius-pill) border border-(--border) px-2 py-0.5 text-xs text-(--text-secondary)">
+                                                {DRIVER_ROLE_LABELS[driver.role]}
+                                            </span>
+                                        ) : null}
+                                        {driver.category ? (
+                                            <span className="text-xs text-(--text-muted)">
+                                                {DRIVER_CATEGORY_LABELS[driver.category]}
+                                            </span>
+                                        ) : null}
                                         <InlineCitations
                                             evidenceRefIds={driver.evidence_ref_ids}
                                             ownerLabel={"driver " + driver.rank}
                                             targets={targets}
                                         />
-                                    </p>
-                                    <p className="mt-1 text-xs text-(--text-muted)">
+                                    </div>
+                                    {driver.confidence || driver.relevance || driver.freshness ? (
+                                        <p className="text-xs text-(--text-muted)">
+                                            {[
+                                                driver.confidence
+                                                    ? DRIVER_CONFIDENCE_LABELS[driver.confidence]
+                                                    : null,
+                                                driver.relevance
+                                                    ? DRIVER_RELEVANCE_LABELS[driver.relevance]
+                                                    : null,
+                                                driver.freshness
+                                                    ? DRIVER_FRESHNESS_LABELS[driver.freshness]
+                                                    : null,
+                                            ]
+                                                .filter((value): value is string => value !== null)
+                                                .join(" · ")}
+                                        </p>
+                                    ) : null}
+                                    {driver.staffing_qualification ? (
+                                        <div className="text-xs leading-5 text-(--text-muted)">
+                                            <p>
+                                                {
+                                                    DRIVER_DENOMINATOR_LABELS[
+                                                        driver.staffing_qualification
+                                                            .denominator_state
+                                                    ]
+                                                }
+                                            </p>
+                                            {driver.staffing_qualification
+                                                .denominator_source_classes?.length ? (
+                                                <p>
+                                                    Evidence sources:{" "}
+                                                    {driver.staffing_qualification.denominator_source_classes
+                                                        .map(
+                                                            (source) =>
+                                                                DRIVER_EVIDENCE_SOURCE_LABELS[
+                                                                    source
+                                                                ],
+                                                        )
+                                                        .join(", ")}
+                                                </p>
+                                            ) : null}
+                                        </div>
+                                    ) : null}
+                                    {driver.exclusion_reason ? (
+                                        <p className="text-xs leading-5 text-(--caution)">
+                                            {DRIVER_EXCLUSION_LABELS[driver.exclusion_reason]}
+                                        </p>
+                                    ) : null}
+                                    {driver.withheld_reason ? (
+                                        <p className="text-xs leading-5 text-(--caution)">
+                                            {DRIVER_WITHHELD_LABELS[driver.withheld_reason]}
+                                        </p>
+                                    ) : null}
+                                    {driver.conflicting_evidence_ref_ids?.length ? (
+                                        <p className="text-xs text-(--caution)">
+                                            Conflicting evidence
+                                            <InlineCitations
+                                                evidenceRefIds={driver.conflicting_evidence_ref_ids}
+                                                ownerLabel={
+                                                    "conflicting evidence for driver " + driver.rank
+                                                }
+                                                targets={targets}
+                                            />
+                                        </p>
+                                    ) : null}
+                                    <p className="text-xs text-(--text-muted)">
                                         Supporting evidence for this driver is shown below.
                                     </p>
+                                    {typeof driver.contribution === "number" ? (
+                                        <p className="text-xs text-(--text-muted)">
+                                            {formatPercent(driver.contribution * 100)} contribution
+                                        </p>
+                                    ) : null}
                                 </div>
-                                <span className="text-xs text-(--text-muted) sm:text-right">
-                                    {formatPercent(driver.contribution * 100)} contribution
-                                </span>
                             </li>
                         ))}
                     </ol>

--- a/src/lib/dev/__tests__/contracts.test.ts
+++ b/src/lib/dev/__tests__/contracts.test.ts
@@ -76,7 +76,7 @@ describe("Ask Dev generated contract boundary", () => {
         const source = readJson<SourceManifest>("source.json");
         const manifest = readJson<OpsManifest>("manifest.json");
 
-        expect(source.source_commit).toBe("42063ceb8f70d03648cc4401b4f37c7e36def38e");
+        expect(source.source_commit).toBe("2963df821301c9d052ac83e8c8300ee5966b9eb4");
         expect(manifest.schema_version).toBe("ask_dev_contract_manifest.v1");
         expect(manifest.compatibility).toBe("additive-within-v1");
         expect(manifest.contracts.map((contract) => contract.schema_version)).toEqual(
@@ -159,6 +159,28 @@ describe("Ask Dev generated contract boundary", () => {
             "examples/positive/dev_tool_result.v1.json",
         );
         expect(validateAskDevSemanticInvariants({ ...golden, ...plant })).toBe(false);
+    });
+
+    it("rejects a dangling conflicting-evidence reference from a public driver judgment", () => {
+        const golden = readJson<Record<string, unknown>>(
+            "examples/positive/dev_answer.v1.graph_assisted.json",
+        );
+        const graphAssisted = structuredClone(golden.graph_assisted) as Record<string, unknown>;
+        const rankedDrivers = structuredClone(graphAssisted.ranked_drivers) as Record<
+            string,
+            unknown
+        >[];
+        rankedDrivers[0] = {
+            ...rankedDrivers[0],
+            conflicting_evidence_ref_ids: ["ev_not_in_evidence_array"],
+        };
+
+        expect(
+            validateAskDevSemanticInvariants({
+                ...golden,
+                graph_assisted: { ...graphAssisted, ranked_drivers: rankedDrivers },
+            }),
+        ).toBe(false);
     });
 
     // CHAOS-3298's re-pin admitted `team` to DirectScope/EntityType (ops

--- a/src/lib/dev/contractValidation.ts
+++ b/src/lib/dev/contractValidation.ts
@@ -216,7 +216,8 @@ function validateAnswer(answer: JsonRecord): boolean {
         return false;
     }
 
-    // `graph_assisted.ranked_drivers[].evidence_ref_ids` cites into this SAME
+    // `graph_assisted.ranked_drivers[].evidence_ref_ids` and
+    // `conflicting_evidence_ref_ids` cite into this SAME
     // answer's `evidence[]` array -- ops documents this on
     // `DevAnswerDriverEntry` and enforces it server-side
     // (`DevAnswer.validate_answer_invariants`). Schema-only surface today (no
@@ -229,7 +230,9 @@ function validateAnswer(answer: JsonRecord): boolean {
         const rankedDrivers = asRecords(graphAssisted.ranked_drivers);
         if (
             rankedDrivers.some(
-                (driver) => !referencesOnlyKnown(driver.evidence_ref_ids, knownEvidence),
+                (driver) =>
+                    !referencesOnlyKnown(driver.evidence_ref_ids, knownEvidence) ||
+                    !referencesOnlyKnown(driver.conflicting_evidence_ref_ids ?? [], knownEvidence),
             )
         ) {
             return false;

--- a/src/lib/dev/contracts/manifest.json
+++ b/src/lib/dev/contracts/manifest.json
@@ -78,7 +78,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
-        "sha256": "248d1075aa99da9424c5242e9691fdd2943d9b04b11218cd9cb2e322ce566db1"
+        "sha256": "cf0fe9afc11d5d529f116ff857727738d3545cfad76a010a0144f0a53c25bc31"
       },
       "schema_version": "dev_conversation_transcript.v1"
     },
@@ -167,7 +167,7 @@
       ],
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
-        "sha256": "ba4020ba258c7b13359af1a9feb48276962c700c0aa0d12e9422150ecb13438e"
+        "sha256": "61ea8ea026ae401f86683d9c0f6a17bfc57a88607d30b65672de601f452c82f3"
       },
       "schema_version": "dev_answer.v1"
     },
@@ -186,7 +186,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer_graph_assistance.v1.schema.json",
-        "sha256": "74504d5a246dec800432d9ee1136ad008f0f6292f650417151fbdeccd7837c39"
+        "sha256": "4eb3955abd33da096d8b51cab7059ea46585bc18fa952690beb634b1a8d429a8"
       },
       "schema_version": "dev_answer_graph_assistance.v1"
     },
@@ -440,7 +440,7 @@
       ],
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
-        "sha256": "b183846008dc5859db39393f9a4d227b301191af142672ad6ea968591e97ed19"
+        "sha256": "284ec561c391caf51ea4cbeb6a5a7c360a195fa4b26f3124e3c09e326aa0540d"
       },
       "schema_version": "dev_stream_event.v1"
     },

--- a/src/lib/dev/contracts/schemas/dev_answer.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_answer.v1.schema.json
@@ -336,15 +336,84 @@
       "title": "DevAnswerCohortSlot",
       "type": "object"
     },
+    "DevAnswerDriverCategory": {
+      "description": "Closed, product-safe driver categories; no packet prose crosses over.",
+      "enum": [
+        "delivery_pressure",
+        "review_pressure",
+        "operational_pressure",
+        "dependency_pressure",
+        "investment_mix",
+        "capacity_or_staffing",
+        "scope_change",
+        "quality_or_defect",
+        "external_blocker",
+        "data_coverage"
+      ],
+      "title": "DevAnswerDriverCategory",
+      "type": "string"
+    },
+    "DevAnswerDriverConfidence": {
+      "description": "The packet's qualification, not a fabricated numeric score.",
+      "enum": [
+        "measured_certain",
+        "qualified",
+        "uncertain",
+        "unsupported"
+      ],
+      "title": "DevAnswerDriverConfidence",
+      "type": "string"
+    },
     "DevAnswerDriverEntry": {
       "additionalProperties": false,
-      "description": "CHAOS-3660 \u00a78(d). ``evidence_ref_ids`` point into the SAME answer's\nown ``evidence[]`` array -- see ``DevAnswer.validate_answer_invariants``\nbelow, which enforces that as a real constraint, not just a naming\nconvention.",
+      "description": "One evidence-closed, qualified public driver judgment.\n\n``rank`` is an ordinal presentation order from the packet's deterministic\ncandidate order.  It is not a contribution or importance score, so\n``contribution`` is optional and remains ``None`` for the production\nprojection until a canonical scoring contract exists.  ``evidence_ref_ids``\npoint into the SAME answer's own ``evidence[]`` array -- see\n``DevAnswer.validate_answer_invariants`` below, which enforces that as a\nreal constraint, not just a naming convention.",
       "properties": {
+        "category": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverCategory"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverConfidence"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "conflicting_evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Conflicting Evidence Ref Ids",
+          "type": "array"
+        },
         "contribution": {
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Contribution",
-          "type": "number"
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contribution"
         },
         "evidence_ref_ids": {
           "items": {
@@ -358,19 +427,149 @@
           "title": "Evidence Ref Ids",
           "type": "array"
         },
+        "exclusion_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverExclusionReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FreshnessState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "rank": {
           "minimum": 1,
           "title": "Rank",
           "type": "integer"
+        },
+        "relevance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverRelevance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverRole"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "staffing_qualification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerStaffingQualification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "standing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverStanding"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "withheld_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverWithheldReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
         "rank",
-        "contribution",
         "evidence_ref_ids"
       ],
       "title": "DevAnswerDriverEntry",
       "type": "object"
+    },
+    "DevAnswerDriverExclusionReason": {
+      "description": "Why W4 excluded a candidate from asserted driver standing.",
+      "enum": [
+        "no_supporting_path",
+        "evidence_conflict_unresolved",
+        "not_currently_relevant",
+        "symptom_of_another_candidate",
+        "unauthorized_evidence",
+        "insufficient_measurement"
+      ],
+      "title": "DevAnswerDriverExclusionReason",
+      "type": "string"
+    },
+    "DevAnswerDriverRelevance": {
+      "enum": [
+        "current",
+        "recently_current",
+        "historical_only",
+        "unknown"
+      ],
+      "title": "DevAnswerDriverRelevance",
+      "type": "string"
+    },
+    "DevAnswerDriverRole": {
+      "description": "The bounded public distinction between causes and effects.",
+      "enum": [
+        "driver",
+        "symptom",
+        "contextual_correlate"
+      ],
+      "title": "DevAnswerDriverRole",
+      "type": "string"
+    },
+    "DevAnswerDriverStanding": {
+      "description": "How strongly the investigation supports one driver candidate.",
+      "enum": [
+        "principal_driver",
+        "contributing_driver",
+        "candidate_only",
+        "excluded"
+      ],
+      "title": "DevAnswerDriverStanding",
+      "type": "string"
+    },
+    "DevAnswerDriverWithheldReason": {
+      "description": "Why some packet support did not become canonical answer evidence.",
+      "enum": [
+        "evidence_refused",
+        "evidence_unavailable",
+        "authorization_filtered"
+      ],
+      "title": "DevAnswerDriverWithheldReason",
+      "type": "string"
     },
     "DevAnswerEnrichmentGap": {
       "enum": [
@@ -523,6 +722,37 @@
       ],
       "title": "DevAnswerSourceRequirementState",
       "type": "string"
+    },
+    "DevAnswerStaffingDenominatorState": {
+      "enum": [
+        "allocation_evidence_available",
+        "partial_allocation_evidence",
+        "denominator_absent"
+      ],
+      "title": "DevAnswerStaffingDenominatorState",
+      "type": "string"
+    },
+    "DevAnswerStaffingQualification": {
+      "additionalProperties": false,
+      "description": "Bounded denominator disclosure for a capacity/staffing driver.\n\nThe packet's qualification note is intentionally not copied to the public\nanswer: it is arm prose, not a canonical fact.  The denominator state and\nclosed source classes are sufficient for a client to label the judgment\nhonestly and keep a missing denominator visible.",
+      "properties": {
+        "denominator_source_classes": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerEvidenceSourceClass"
+          },
+          "maxItems": 10,
+          "title": "Denominator Source Classes",
+          "type": "array"
+        },
+        "denominator_state": {
+          "$ref": "#/$defs/DevAnswerStaffingDenominatorState"
+        }
+      },
+      "required": [
+        "denominator_state"
+      ],
+      "title": "DevAnswerStaffingQualification",
+      "type": "object"
     },
     "DevCitationLink": {
       "additionalProperties": false,
@@ -1586,7 +1816,7 @@
       "type": "string"
     },
     "PacketLimitationKind": {
-      "description": "CHAOS-3660 \u00a78(d)/(h). Reserved fresh here for the same reason as the\ntwo enums above -- the owning module\n(``investigation_contract/vocabulary.py``) is feature-branch-only\ntoday; must be reconciled to that module's definition when it lands on\n``main``.",
+      "description": "Closed public mirror of the investigation packet limitations.\n\nKeep this vocabulary aligned with\n``investigation_contract.vocabulary.PacketLimitationKind``.  The graph\nroute converts packet limitations at the public boundary, so every\ninternal limitation that can reach a production packet must be declared\nhere rather than silently dropped or raising during answer assembly.",
       "enum": [
         "missing_source",
         "stale_source",

--- a/src/lib/dev/contracts/schemas/dev_answer_graph_assistance.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_answer_graph_assistance.v1.schema.json
@@ -296,15 +296,84 @@
       "title": "DevAnswerCohortSlot",
       "type": "object"
     },
+    "DevAnswerDriverCategory": {
+      "description": "Closed, product-safe driver categories; no packet prose crosses over.",
+      "enum": [
+        "delivery_pressure",
+        "review_pressure",
+        "operational_pressure",
+        "dependency_pressure",
+        "investment_mix",
+        "capacity_or_staffing",
+        "scope_change",
+        "quality_or_defect",
+        "external_blocker",
+        "data_coverage"
+      ],
+      "title": "DevAnswerDriverCategory",
+      "type": "string"
+    },
+    "DevAnswerDriverConfidence": {
+      "description": "The packet's qualification, not a fabricated numeric score.",
+      "enum": [
+        "measured_certain",
+        "qualified",
+        "uncertain",
+        "unsupported"
+      ],
+      "title": "DevAnswerDriverConfidence",
+      "type": "string"
+    },
     "DevAnswerDriverEntry": {
       "additionalProperties": false,
-      "description": "CHAOS-3660 \u00a78(d). ``evidence_ref_ids`` point into the SAME answer's\nown ``evidence[]`` array -- see ``DevAnswer.validate_answer_invariants``\nbelow, which enforces that as a real constraint, not just a naming\nconvention.",
+      "description": "One evidence-closed, qualified public driver judgment.\n\n``rank`` is an ordinal presentation order from the packet's deterministic\ncandidate order.  It is not a contribution or importance score, so\n``contribution`` is optional and remains ``None`` for the production\nprojection until a canonical scoring contract exists.  ``evidence_ref_ids``\npoint into the SAME answer's own ``evidence[]`` array -- see\n``DevAnswer.validate_answer_invariants`` below, which enforces that as a\nreal constraint, not just a naming convention.",
       "properties": {
+        "category": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverCategory"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverConfidence"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "conflicting_evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Conflicting Evidence Ref Ids",
+          "type": "array"
+        },
         "contribution": {
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Contribution",
-          "type": "number"
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contribution"
         },
         "evidence_ref_ids": {
           "items": {
@@ -318,19 +387,149 @@
           "title": "Evidence Ref Ids",
           "type": "array"
         },
+        "exclusion_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverExclusionReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FreshnessState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "rank": {
           "minimum": 1,
           "title": "Rank",
           "type": "integer"
+        },
+        "relevance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverRelevance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverRole"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "staffing_qualification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerStaffingQualification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "standing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverStanding"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "withheld_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverWithheldReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
         "rank",
-        "contribution",
         "evidence_ref_ids"
       ],
       "title": "DevAnswerDriverEntry",
       "type": "object"
+    },
+    "DevAnswerDriverExclusionReason": {
+      "description": "Why W4 excluded a candidate from asserted driver standing.",
+      "enum": [
+        "no_supporting_path",
+        "evidence_conflict_unresolved",
+        "not_currently_relevant",
+        "symptom_of_another_candidate",
+        "unauthorized_evidence",
+        "insufficient_measurement"
+      ],
+      "title": "DevAnswerDriverExclusionReason",
+      "type": "string"
+    },
+    "DevAnswerDriverRelevance": {
+      "enum": [
+        "current",
+        "recently_current",
+        "historical_only",
+        "unknown"
+      ],
+      "title": "DevAnswerDriverRelevance",
+      "type": "string"
+    },
+    "DevAnswerDriverRole": {
+      "description": "The bounded public distinction between causes and effects.",
+      "enum": [
+        "driver",
+        "symptom",
+        "contextual_correlate"
+      ],
+      "title": "DevAnswerDriverRole",
+      "type": "string"
+    },
+    "DevAnswerDriverStanding": {
+      "description": "How strongly the investigation supports one driver candidate.",
+      "enum": [
+        "principal_driver",
+        "contributing_driver",
+        "candidate_only",
+        "excluded"
+      ],
+      "title": "DevAnswerDriverStanding",
+      "type": "string"
+    },
+    "DevAnswerDriverWithheldReason": {
+      "description": "Why some packet support did not become canonical answer evidence.",
+      "enum": [
+        "evidence_refused",
+        "evidence_unavailable",
+        "authorization_filtered"
+      ],
+      "title": "DevAnswerDriverWithheldReason",
+      "type": "string"
     },
     "DevAnswerEnrichmentGap": {
       "enum": [
@@ -423,6 +622,37 @@
       "title": "DevAnswerSourceRequirementState",
       "type": "string"
     },
+    "DevAnswerStaffingDenominatorState": {
+      "enum": [
+        "allocation_evidence_available",
+        "partial_allocation_evidence",
+        "denominator_absent"
+      ],
+      "title": "DevAnswerStaffingDenominatorState",
+      "type": "string"
+    },
+    "DevAnswerStaffingQualification": {
+      "additionalProperties": false,
+      "description": "Bounded denominator disclosure for a capacity/staffing driver.\n\nThe packet's qualification note is intentionally not copied to the public\nanswer: it is arm prose, not a canonical fact.  The denominator state and\nclosed source classes are sufficient for a client to label the judgment\nhonestly and keep a missing denominator visible.",
+      "properties": {
+        "denominator_source_classes": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerEvidenceSourceClass"
+          },
+          "maxItems": 10,
+          "title": "Denominator Source Classes",
+          "type": "array"
+        },
+        "denominator_state": {
+          "$ref": "#/$defs/DevAnswerStaffingDenominatorState"
+        }
+      },
+      "required": [
+        "denominator_state"
+      ],
+      "title": "DevAnswerStaffingQualification",
+      "type": "object"
+    },
     "EntityType": {
       "enum": [
         "repository",
@@ -459,7 +689,7 @@
       "type": "string"
     },
     "PacketLimitationKind": {
-      "description": "CHAOS-3660 \u00a78(d)/(h). Reserved fresh here for the same reason as the\ntwo enums above -- the owning module\n(``investigation_contract/vocabulary.py``) is feature-branch-only\ntoday; must be reconciled to that module's definition when it lands on\n``main``.",
+      "description": "Closed public mirror of the investigation packet limitations.\n\nKeep this vocabulary aligned with\n``investigation_contract.vocabulary.PacketLimitationKind``.  The graph\nroute converts packet limitations at the public boundary, so every\ninternal limitation that can reach a production packet must be declared\nhere rather than silently dropped or raising during answer assembly.",
       "enum": [
         "missing_source",
         "stale_source",

--- a/src/lib/dev/contracts/schemas/dev_conversation_transcript.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_conversation_transcript.v1.schema.json
@@ -469,15 +469,84 @@
       "title": "DevAnswerCohortSlot",
       "type": "object"
     },
+    "DevAnswerDriverCategory": {
+      "description": "Closed, product-safe driver categories; no packet prose crosses over.",
+      "enum": [
+        "delivery_pressure",
+        "review_pressure",
+        "operational_pressure",
+        "dependency_pressure",
+        "investment_mix",
+        "capacity_or_staffing",
+        "scope_change",
+        "quality_or_defect",
+        "external_blocker",
+        "data_coverage"
+      ],
+      "title": "DevAnswerDriverCategory",
+      "type": "string"
+    },
+    "DevAnswerDriverConfidence": {
+      "description": "The packet's qualification, not a fabricated numeric score.",
+      "enum": [
+        "measured_certain",
+        "qualified",
+        "uncertain",
+        "unsupported"
+      ],
+      "title": "DevAnswerDriverConfidence",
+      "type": "string"
+    },
     "DevAnswerDriverEntry": {
       "additionalProperties": false,
-      "description": "CHAOS-3660 \u00a78(d). ``evidence_ref_ids`` point into the SAME answer's\nown ``evidence[]`` array -- see ``DevAnswer.validate_answer_invariants``\nbelow, which enforces that as a real constraint, not just a naming\nconvention.",
+      "description": "One evidence-closed, qualified public driver judgment.\n\n``rank`` is an ordinal presentation order from the packet's deterministic\ncandidate order.  It is not a contribution or importance score, so\n``contribution`` is optional and remains ``None`` for the production\nprojection until a canonical scoring contract exists.  ``evidence_ref_ids``\npoint into the SAME answer's own ``evidence[]`` array -- see\n``DevAnswer.validate_answer_invariants`` below, which enforces that as a\nreal constraint, not just a naming convention.",
       "properties": {
+        "category": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverCategory"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverConfidence"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "conflicting_evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Conflicting Evidence Ref Ids",
+          "type": "array"
+        },
         "contribution": {
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Contribution",
-          "type": "number"
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contribution"
         },
         "evidence_ref_ids": {
           "items": {
@@ -491,19 +560,149 @@
           "title": "Evidence Ref Ids",
           "type": "array"
         },
+        "exclusion_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverExclusionReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FreshnessState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "rank": {
           "minimum": 1,
           "title": "Rank",
           "type": "integer"
+        },
+        "relevance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverRelevance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverRole"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "staffing_qualification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerStaffingQualification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "standing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverStanding"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "withheld_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverWithheldReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
         "rank",
-        "contribution",
         "evidence_ref_ids"
       ],
       "title": "DevAnswerDriverEntry",
       "type": "object"
+    },
+    "DevAnswerDriverExclusionReason": {
+      "description": "Why W4 excluded a candidate from asserted driver standing.",
+      "enum": [
+        "no_supporting_path",
+        "evidence_conflict_unresolved",
+        "not_currently_relevant",
+        "symptom_of_another_candidate",
+        "unauthorized_evidence",
+        "insufficient_measurement"
+      ],
+      "title": "DevAnswerDriverExclusionReason",
+      "type": "string"
+    },
+    "DevAnswerDriverRelevance": {
+      "enum": [
+        "current",
+        "recently_current",
+        "historical_only",
+        "unknown"
+      ],
+      "title": "DevAnswerDriverRelevance",
+      "type": "string"
+    },
+    "DevAnswerDriverRole": {
+      "description": "The bounded public distinction between causes and effects.",
+      "enum": [
+        "driver",
+        "symptom",
+        "contextual_correlate"
+      ],
+      "title": "DevAnswerDriverRole",
+      "type": "string"
+    },
+    "DevAnswerDriverStanding": {
+      "description": "How strongly the investigation supports one driver candidate.",
+      "enum": [
+        "principal_driver",
+        "contributing_driver",
+        "candidate_only",
+        "excluded"
+      ],
+      "title": "DevAnswerDriverStanding",
+      "type": "string"
+    },
+    "DevAnswerDriverWithheldReason": {
+      "description": "Why some packet support did not become canonical answer evidence.",
+      "enum": [
+        "evidence_refused",
+        "evidence_unavailable",
+        "authorization_filtered"
+      ],
+      "title": "DevAnswerDriverWithheldReason",
+      "type": "string"
     },
     "DevAnswerEnrichmentGap": {
       "enum": [
@@ -656,6 +855,37 @@
       ],
       "title": "DevAnswerSourceRequirementState",
       "type": "string"
+    },
+    "DevAnswerStaffingDenominatorState": {
+      "enum": [
+        "allocation_evidence_available",
+        "partial_allocation_evidence",
+        "denominator_absent"
+      ],
+      "title": "DevAnswerStaffingDenominatorState",
+      "type": "string"
+    },
+    "DevAnswerStaffingQualification": {
+      "additionalProperties": false,
+      "description": "Bounded denominator disclosure for a capacity/staffing driver.\n\nThe packet's qualification note is intentionally not copied to the public\nanswer: it is arm prose, not a canonical fact.  The denominator state and\nclosed source classes are sufficient for a client to label the judgment\nhonestly and keep a missing denominator visible.",
+      "properties": {
+        "denominator_source_classes": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerEvidenceSourceClass"
+          },
+          "maxItems": 10,
+          "title": "Denominator Source Classes",
+          "type": "array"
+        },
+        "denominator_state": {
+          "$ref": "#/$defs/DevAnswerStaffingDenominatorState"
+        }
+      },
+      "required": [
+        "denominator_state"
+      ],
+      "title": "DevAnswerStaffingQualification",
+      "type": "object"
     },
     "DevCitationLink": {
       "additionalProperties": false,
@@ -1838,7 +2068,7 @@
       "type": "string"
     },
     "PacketLimitationKind": {
-      "description": "CHAOS-3660 \u00a78(d)/(h). Reserved fresh here for the same reason as the\ntwo enums above -- the owning module\n(``investigation_contract/vocabulary.py``) is feature-branch-only\ntoday; must be reconciled to that module's definition when it lands on\n``main``.",
+      "description": "Closed public mirror of the investigation packet limitations.\n\nKeep this vocabulary aligned with\n``investigation_contract.vocabulary.PacketLimitationKind``.  The graph\nroute converts packet limitations at the public boundary, so every\ninternal limitation that can reach a production packet must be declared\nhere rather than silently dropped or raising during answer assembly.",
       "enum": [
         "missing_source",
         "stale_source",

--- a/src/lib/dev/contracts/schemas/dev_stream_event.v1.schema.json
+++ b/src/lib/dev/contracts/schemas/dev_stream_event.v1.schema.json
@@ -469,15 +469,84 @@
       "title": "DevAnswerCohortSlot",
       "type": "object"
     },
+    "DevAnswerDriverCategory": {
+      "description": "Closed, product-safe driver categories; no packet prose crosses over.",
+      "enum": [
+        "delivery_pressure",
+        "review_pressure",
+        "operational_pressure",
+        "dependency_pressure",
+        "investment_mix",
+        "capacity_or_staffing",
+        "scope_change",
+        "quality_or_defect",
+        "external_blocker",
+        "data_coverage"
+      ],
+      "title": "DevAnswerDriverCategory",
+      "type": "string"
+    },
+    "DevAnswerDriverConfidence": {
+      "description": "The packet's qualification, not a fabricated numeric score.",
+      "enum": [
+        "measured_certain",
+        "qualified",
+        "uncertain",
+        "unsupported"
+      ],
+      "title": "DevAnswerDriverConfidence",
+      "type": "string"
+    },
     "DevAnswerDriverEntry": {
       "additionalProperties": false,
-      "description": "CHAOS-3660 \u00a78(d). ``evidence_ref_ids`` point into the SAME answer's\nown ``evidence[]`` array -- see ``DevAnswer.validate_answer_invariants``\nbelow, which enforces that as a real constraint, not just a naming\nconvention.",
+      "description": "One evidence-closed, qualified public driver judgment.\n\n``rank`` is an ordinal presentation order from the packet's deterministic\ncandidate order.  It is not a contribution or importance score, so\n``contribution`` is optional and remains ``None`` for the production\nprojection until a canonical scoring contract exists.  ``evidence_ref_ids``\npoint into the SAME answer's own ``evidence[]`` array -- see\n``DevAnswer.validate_answer_invariants`` below, which enforces that as a\nreal constraint, not just a naming convention.",
       "properties": {
+        "category": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverCategory"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverConfidence"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "conflicting_evidence_ref_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Conflicting Evidence Ref Ids",
+          "type": "array"
+        },
         "contribution": {
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Contribution",
-          "type": "number"
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Contribution"
         },
         "evidence_ref_ids": {
           "items": {
@@ -491,19 +560,149 @@
           "title": "Evidence Ref Ids",
           "type": "array"
         },
+        "exclusion_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverExclusionReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FreshnessState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "rank": {
           "minimum": 1,
           "title": "Rank",
           "type": "integer"
+        },
+        "relevance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverRelevance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverRole"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "staffing_qualification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerStaffingQualification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "standing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverStanding"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "withheld_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerDriverWithheldReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
         "rank",
-        "contribution",
         "evidence_ref_ids"
       ],
       "title": "DevAnswerDriverEntry",
       "type": "object"
+    },
+    "DevAnswerDriverExclusionReason": {
+      "description": "Why W4 excluded a candidate from asserted driver standing.",
+      "enum": [
+        "no_supporting_path",
+        "evidence_conflict_unresolved",
+        "not_currently_relevant",
+        "symptom_of_another_candidate",
+        "unauthorized_evidence",
+        "insufficient_measurement"
+      ],
+      "title": "DevAnswerDriverExclusionReason",
+      "type": "string"
+    },
+    "DevAnswerDriverRelevance": {
+      "enum": [
+        "current",
+        "recently_current",
+        "historical_only",
+        "unknown"
+      ],
+      "title": "DevAnswerDriverRelevance",
+      "type": "string"
+    },
+    "DevAnswerDriverRole": {
+      "description": "The bounded public distinction between causes and effects.",
+      "enum": [
+        "driver",
+        "symptom",
+        "contextual_correlate"
+      ],
+      "title": "DevAnswerDriverRole",
+      "type": "string"
+    },
+    "DevAnswerDriverStanding": {
+      "description": "How strongly the investigation supports one driver candidate.",
+      "enum": [
+        "principal_driver",
+        "contributing_driver",
+        "candidate_only",
+        "excluded"
+      ],
+      "title": "DevAnswerDriverStanding",
+      "type": "string"
+    },
+    "DevAnswerDriverWithheldReason": {
+      "description": "Why some packet support did not become canonical answer evidence.",
+      "enum": [
+        "evidence_refused",
+        "evidence_unavailable",
+        "authorization_filtered"
+      ],
+      "title": "DevAnswerDriverWithheldReason",
+      "type": "string"
     },
     "DevAnswerEnrichmentGap": {
       "enum": [
@@ -656,6 +855,37 @@
       ],
       "title": "DevAnswerSourceRequirementState",
       "type": "string"
+    },
+    "DevAnswerStaffingDenominatorState": {
+      "enum": [
+        "allocation_evidence_available",
+        "partial_allocation_evidence",
+        "denominator_absent"
+      ],
+      "title": "DevAnswerStaffingDenominatorState",
+      "type": "string"
+    },
+    "DevAnswerStaffingQualification": {
+      "additionalProperties": false,
+      "description": "Bounded denominator disclosure for a capacity/staffing driver.\n\nThe packet's qualification note is intentionally not copied to the public\nanswer: it is arm prose, not a canonical fact.  The denominator state and\nclosed source classes are sufficient for a client to label the judgment\nhonestly and keep a missing denominator visible.",
+      "properties": {
+        "denominator_source_classes": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerEvidenceSourceClass"
+          },
+          "maxItems": 10,
+          "title": "Denominator Source Classes",
+          "type": "array"
+        },
+        "denominator_state": {
+          "$ref": "#/$defs/DevAnswerStaffingDenominatorState"
+        }
+      },
+      "required": [
+        "denominator_state"
+      ],
+      "title": "DevAnswerStaffingQualification",
+      "type": "object"
     },
     "DevCitationLink": {
       "additionalProperties": false,
@@ -1812,7 +2042,7 @@
       "type": "string"
     },
     "PacketLimitationKind": {
-      "description": "CHAOS-3660 \u00a78(d)/(h). Reserved fresh here for the same reason as the\ntwo enums above -- the owning module\n(``investigation_contract/vocabulary.py``) is feature-branch-only\ntoday; must be reconciled to that module's definition when it lands on\n``main``.",
+      "description": "Closed public mirror of the investigation packet limitations.\n\nKeep this vocabulary aligned with\n``investigation_contract.vocabulary.PacketLimitationKind``.  The graph\nroute converts packet limitations at the public boundary, so every\ninternal limitation that can reach a production packet must be declared\nhere rather than silently dropped or raising during answer assembly.",
       "enum": [
         "missing_source",
         "stale_source",

--- a/src/lib/dev/contracts/source.json
+++ b/src/lib/dev/contracts/source.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "ask_dev_web_contract_source.v1",
-  "source_commit": "42063ceb8f70d03648cc4401b4f37c7e36def38e",
+  "source_commit": "2963df821301c9d052ac83e8c8300ee5966b9eb4",
   "files": [
     {
       "path": "examples/negative/dev_answer.v1.graph_assisted_unknown_evidence_id.json",
@@ -256,15 +256,15 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "01e4aeaca1f79ff18dc2b87134c627f88721e2db5211fdda435f9b455120cd4b"
+      "sha256": "c72c1b12d0b844f7c29f53c3eec6d8e38a7049a8e897b1d53df97c937de925bd"
     },
     {
       "path": "schemas/dev_answer.v1.schema.json",
-      "sha256": "ba4020ba258c7b13359af1a9feb48276962c700c0aa0d12e9422150ecb13438e"
+      "sha256": "61ea8ea026ae401f86683d9c0f6a17bfc57a88607d30b65672de601f452c82f3"
     },
     {
       "path": "schemas/dev_answer_graph_assistance.v1.schema.json",
-      "sha256": "74504d5a246dec800432d9ee1136ad008f0f6292f650417151fbdeccd7837c39"
+      "sha256": "4eb3955abd33da096d8b51cab7059ea46585bc18fa952690beb634b1a8d429a8"
     },
     {
       "path": "schemas/dev_capabilities.v1.schema.json",
@@ -284,7 +284,7 @@
     },
     {
       "path": "schemas/dev_conversation_transcript.v1.schema.json",
-      "sha256": "248d1075aa99da9424c5242e9691fdd2943d9b04b11218cd9cb2e322ce566db1"
+      "sha256": "cf0fe9afc11d5d529f116ff857727738d3545cfad76a010a0144f0a53c25bc31"
     },
     {
       "path": "schemas/dev_error.v1.schema.json",
@@ -320,7 +320,7 @@
     },
     {
       "path": "schemas/dev_stream_event.v1.schema.json",
-      "sha256": "b183846008dc5859db39393f9a4d227b301191af142672ad6ea968591e97ed19"
+      "sha256": "284ec561c391caf51ea4cbeb6a5a7c360a195fa4b26f3124e3c09e326aa0540d"
     },
     {
       "path": "schemas/dev_tool_request.v1.schema.json",

--- a/src/lib/dev/generated.ts
+++ b/src/lib/dev/generated.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-// Generated from full-chaos/dev-health-ops 42063ceb8f70d03648cc4401b4f37c7e36def38e. Do not edit.
+// Generated from full-chaos/dev-health-ops 2963df821301c9d052ac83e8c8300ee5966b9eb4. Do not edit.
 export namespace DevAnswerGraphAssistanceContract {
     export type AsOf = string;
     export type CohortComplete = boolean;
@@ -614,11 +614,13 @@ export namespace DevAnswerGraphAssistanceContract {
               PacketLimitationKind,
           ];
     /**
-     * CHAOS-3660 §8(d)/(h). Reserved fresh here for the same reason as the
-     * two enums above -- the owning module
-     * (``investigation_contract/vocabulary.py``) is feature-branch-only
-     * today; must be reconciled to that module's definition when it lands on
-     * ``main``.
+     * Closed public mirror of the investigation packet limitations.
+     *
+     * Keep this vocabulary aligned with
+     * ``investigation_contract.vocabulary.PacketLimitationKind``.  The graph
+     * route converts packet limitations at the public boundary, so every
+     * internal limitation that can reach a production packet must be declared
+     * here rather than silently dropped or raising during answer assembly.
      */
     export type PacketLimitationKind =
         | "missing_source"
@@ -629,7 +631,41 @@ export namespace DevAnswerGraphAssistanceContract {
         | "absent_staffing_denominator"
         | "historical_slice_not_comparable"
         | "interpretation_uncertainty";
-    export type Contribution = number;
+    /**
+     * Closed, product-safe driver categories; no packet prose crosses over.
+     */
+    export type DevAnswerDriverCategory =
+        | "delivery_pressure"
+        | "review_pressure"
+        | "operational_pressure"
+        | "dependency_pressure"
+        | "investment_mix"
+        | "capacity_or_staffing"
+        | "scope_change"
+        | "quality_or_defect"
+        | "external_blocker"
+        | "data_coverage";
+    /**
+     * The packet's qualification, not a fabricated numeric score.
+     */
+    export type DevAnswerDriverConfidence =
+        "measured_certain" | "qualified" | "uncertain" | "unsupported";
+    /**
+     * @maxItems 10
+     */
+    export type ConflictingEvidenceRefIds =
+        | []
+        | [string]
+        | [string, string]
+        | [string, string, string]
+        | [string, string, string, string]
+        | [string, string, string, string, string]
+        | [string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string, string, string];
+    export type Contribution = number | null;
     /**
      * @minItems 1
      * @maxItems 10
@@ -645,7 +681,106 @@ export namespace DevAnswerGraphAssistanceContract {
         | [string, string, string, string, string, string, string, string]
         | [string, string, string, string, string, string, string, string, string]
         | [string, string, string, string, string, string, string, string, string, string];
+    /**
+     * Why W4 excluded a candidate from asserted driver standing.
+     */
+    export type DevAnswerDriverExclusionReason =
+        | "no_supporting_path"
+        | "evidence_conflict_unresolved"
+        | "not_currently_relevant"
+        | "symptom_of_another_candidate"
+        | "unauthorized_evidence"
+        | "insufficient_measurement";
     export type Rank1 = number;
+    export type DevAnswerDriverRelevance =
+        "current" | "recently_current" | "historical_only" | "unknown";
+    /**
+     * The bounded public distinction between causes and effects.
+     */
+    export type DevAnswerDriverRole = "driver" | "symptom" | "contextual_correlate";
+    /**
+     * @maxItems 10
+     */
+    export type DenominatorSourceClasses =
+        | []
+        | [DevAnswerEvidenceSourceClass]
+        | [DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass]
+        | [DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ];
+    export type DevAnswerStaffingDenominatorState =
+        "allocation_evidence_available" | "partial_allocation_evidence" | "denominator_absent";
+    /**
+     * How strongly the investigation supports one driver candidate.
+     */
+    export type DevAnswerDriverStanding =
+        "principal_driver" | "contributing_driver" | "candidate_only" | "excluded";
+    /**
+     * Why some packet support did not become canonical answer evidence.
+     */
+    export type DevAnswerDriverWithheldReason =
+        "evidence_refused" | "evidence_unavailable" | "authorization_filtered";
     /**
      * @maxItems 25
      */
@@ -741,15 +876,42 @@ export namespace DevAnswerGraphAssistanceContract {
         label: Label;
     }
     /**
-     * CHAOS-3660 §8(d). ``evidence_ref_ids`` point into the SAME answer's
-     * own ``evidence[]`` array -- see ``DevAnswer.validate_answer_invariants``
-     * below, which enforces that as a real constraint, not just a naming
-     * convention.
+     * One evidence-closed, qualified public driver judgment.
+     *
+     * ``rank`` is an ordinal presentation order from the packet's deterministic
+     * candidate order.  It is not a contribution or importance score, so
+     * ``contribution`` is optional and remains ``None`` for the production
+     * projection until a canonical scoring contract exists.  ``evidence_ref_ids``
+     * point into the SAME answer's own ``evidence[]`` array -- see
+     * ``DevAnswer.validate_answer_invariants`` below, which enforces that as a
+     * real constraint, not just a naming convention.
      */
     export interface DevAnswerDriverEntry {
-        contribution: Contribution;
+        category?: DevAnswerDriverCategory | null;
+        confidence?: DevAnswerDriverConfidence | null;
+        conflicting_evidence_ref_ids?: ConflictingEvidenceRefIds;
+        contribution?: Contribution;
         evidence_ref_ids: EvidenceRefIds;
+        exclusion_reason?: DevAnswerDriverExclusionReason | null;
+        freshness?: FreshnessState | null;
         rank: Rank1;
+        relevance?: DevAnswerDriverRelevance | null;
+        role?: DevAnswerDriverRole | null;
+        staffing_qualification?: DevAnswerStaffingQualification | null;
+        standing?: DevAnswerDriverStanding | null;
+        withheld_reason?: DevAnswerDriverWithheldReason | null;
+    }
+    /**
+     * Bounded denominator disclosure for a capacity/staffing driver.
+     *
+     * The packet's qualification note is intentionally not copied to the public
+     * answer: it is arm prose, not a canonical fact.  The denominator state and
+     * closed source classes are sufficient for a client to label the judgment
+     * honestly and keep a missing denominator visible.
+     */
+    export interface DevAnswerStaffingQualification {
+        denominator_source_classes?: DenominatorSourceClasses;
+        denominator_state: DevAnswerStaffingDenominatorState;
     }
 }
 export type DevAnswerGraphAssistance = DevAnswerGraphAssistanceContract.DevAnswerGraphAssistance;
@@ -2896,11 +3058,13 @@ export namespace DevAnswerContract {
               PacketLimitationKind,
           ];
     /**
-     * CHAOS-3660 §8(d)/(h). Reserved fresh here for the same reason as the
-     * two enums above -- the owning module
-     * (``investigation_contract/vocabulary.py``) is feature-branch-only
-     * today; must be reconciled to that module's definition when it lands on
-     * ``main``.
+     * Closed public mirror of the investigation packet limitations.
+     *
+     * Keep this vocabulary aligned with
+     * ``investigation_contract.vocabulary.PacketLimitationKind``.  The graph
+     * route converts packet limitations at the public boundary, so every
+     * internal limitation that can reach a production packet must be declared
+     * here rather than silently dropped or raising during answer assembly.
      */
     export type PacketLimitationKind =
         | "missing_source"
@@ -2911,7 +3075,41 @@ export namespace DevAnswerContract {
         | "absent_staffing_denominator"
         | "historical_slice_not_comparable"
         | "interpretation_uncertainty";
-    export type Contribution = number;
+    /**
+     * Closed, product-safe driver categories; no packet prose crosses over.
+     */
+    export type DevAnswerDriverCategory =
+        | "delivery_pressure"
+        | "review_pressure"
+        | "operational_pressure"
+        | "dependency_pressure"
+        | "investment_mix"
+        | "capacity_or_staffing"
+        | "scope_change"
+        | "quality_or_defect"
+        | "external_blocker"
+        | "data_coverage";
+    /**
+     * The packet's qualification, not a fabricated numeric score.
+     */
+    export type DevAnswerDriverConfidence =
+        "measured_certain" | "qualified" | "uncertain" | "unsupported";
+    /**
+     * @maxItems 10
+     */
+    export type ConflictingEvidenceRefIds =
+        | []
+        | [string]
+        | [string, string]
+        | [string, string, string]
+        | [string, string, string, string]
+        | [string, string, string, string, string]
+        | [string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string, string, string];
+    export type Contribution = number | null;
     /**
      * @minItems 1
      * @maxItems 10
@@ -2927,7 +3125,106 @@ export namespace DevAnswerContract {
         | [string, string, string, string, string, string, string, string]
         | [string, string, string, string, string, string, string, string, string]
         | [string, string, string, string, string, string, string, string, string, string];
+    /**
+     * Why W4 excluded a candidate from asserted driver standing.
+     */
+    export type DevAnswerDriverExclusionReason =
+        | "no_supporting_path"
+        | "evidence_conflict_unresolved"
+        | "not_currently_relevant"
+        | "symptom_of_another_candidate"
+        | "unauthorized_evidence"
+        | "insufficient_measurement";
     export type Rank1 = number;
+    export type DevAnswerDriverRelevance =
+        "current" | "recently_current" | "historical_only" | "unknown";
+    /**
+     * The bounded public distinction between causes and effects.
+     */
+    export type DevAnswerDriverRole = "driver" | "symptom" | "contextual_correlate";
+    /**
+     * @maxItems 10
+     */
+    export type DenominatorSourceClasses =
+        | []
+        | [DevAnswerEvidenceSourceClass]
+        | [DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass]
+        | [DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ];
+    export type DevAnswerStaffingDenominatorState =
+        "allocation_evidence_available" | "partial_allocation_evidence" | "denominator_absent";
+    /**
+     * How strongly the investigation supports one driver candidate.
+     */
+    export type DevAnswerDriverStanding =
+        "principal_driver" | "contributing_driver" | "candidate_only" | "excluded";
+    /**
+     * Why some packet support did not become canonical answer evidence.
+     */
+    export type DevAnswerDriverWithheldReason =
+        "evidence_refused" | "evidence_unavailable" | "authorization_filtered";
     /**
      * @maxItems 25
      */
@@ -4041,15 +4338,42 @@ export namespace DevAnswerContract {
         label: Label;
     }
     /**
-     * CHAOS-3660 §8(d). ``evidence_ref_ids`` point into the SAME answer's
-     * own ``evidence[]`` array -- see ``DevAnswer.validate_answer_invariants``
-     * below, which enforces that as a real constraint, not just a naming
-     * convention.
+     * One evidence-closed, qualified public driver judgment.
+     *
+     * ``rank`` is an ordinal presentation order from the packet's deterministic
+     * candidate order.  It is not a contribution or importance score, so
+     * ``contribution`` is optional and remains ``None`` for the production
+     * projection until a canonical scoring contract exists.  ``evidence_ref_ids``
+     * point into the SAME answer's own ``evidence[]`` array -- see
+     * ``DevAnswer.validate_answer_invariants`` below, which enforces that as a
+     * real constraint, not just a naming convention.
      */
     export interface DevAnswerDriverEntry {
-        contribution: Contribution;
+        category?: DevAnswerDriverCategory | null;
+        confidence?: DevAnswerDriverConfidence | null;
+        conflicting_evidence_ref_ids?: ConflictingEvidenceRefIds;
+        contribution?: Contribution;
         evidence_ref_ids: EvidenceRefIds2;
+        exclusion_reason?: DevAnswerDriverExclusionReason | null;
+        freshness?: FreshnessState | null;
         rank: Rank1;
+        relevance?: DevAnswerDriverRelevance | null;
+        role?: DevAnswerDriverRole | null;
+        staffing_qualification?: DevAnswerStaffingQualification | null;
+        standing?: DevAnswerDriverStanding | null;
+        withheld_reason?: DevAnswerDriverWithheldReason | null;
+    }
+    /**
+     * Bounded denominator disclosure for a capacity/staffing driver.
+     *
+     * The packet's qualification note is intentionally not copied to the public
+     * answer: it is arm prose, not a canonical fact.  The denominator state and
+     * closed source classes are sufficient for a client to label the judgment
+     * honestly and keep a missing denominator visible.
+     */
+    export interface DevAnswerStaffingQualification {
+        denominator_source_classes?: DenominatorSourceClasses;
+        denominator_state: DevAnswerStaffingDenominatorState;
     }
     export interface DevMetricRef {
         aggregation: Aggregation;
@@ -7471,11 +7795,13 @@ export namespace DevConversationTranscriptContract {
               PacketLimitationKind,
           ];
     /**
-     * CHAOS-3660 §8(d)/(h). Reserved fresh here for the same reason as the
-     * two enums above -- the owning module
-     * (``investigation_contract/vocabulary.py``) is feature-branch-only
-     * today; must be reconciled to that module's definition when it lands on
-     * ``main``.
+     * Closed public mirror of the investigation packet limitations.
+     *
+     * Keep this vocabulary aligned with
+     * ``investigation_contract.vocabulary.PacketLimitationKind``.  The graph
+     * route converts packet limitations at the public boundary, so every
+     * internal limitation that can reach a production packet must be declared
+     * here rather than silently dropped or raising during answer assembly.
      */
     export type PacketLimitationKind =
         | "missing_source"
@@ -7486,7 +7812,41 @@ export namespace DevConversationTranscriptContract {
         | "absent_staffing_denominator"
         | "historical_slice_not_comparable"
         | "interpretation_uncertainty";
-    export type Contribution = number;
+    /**
+     * Closed, product-safe driver categories; no packet prose crosses over.
+     */
+    export type DevAnswerDriverCategory =
+        | "delivery_pressure"
+        | "review_pressure"
+        | "operational_pressure"
+        | "dependency_pressure"
+        | "investment_mix"
+        | "capacity_or_staffing"
+        | "scope_change"
+        | "quality_or_defect"
+        | "external_blocker"
+        | "data_coverage";
+    /**
+     * The packet's qualification, not a fabricated numeric score.
+     */
+    export type DevAnswerDriverConfidence =
+        "measured_certain" | "qualified" | "uncertain" | "unsupported";
+    /**
+     * @maxItems 10
+     */
+    export type ConflictingEvidenceRefIds =
+        | []
+        | [string]
+        | [string, string]
+        | [string, string, string]
+        | [string, string, string, string]
+        | [string, string, string, string, string]
+        | [string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string, string, string];
+    export type Contribution = number | null;
     /**
      * @minItems 1
      * @maxItems 10
@@ -7502,7 +7862,106 @@ export namespace DevConversationTranscriptContract {
         | [string, string, string, string, string, string, string, string]
         | [string, string, string, string, string, string, string, string, string]
         | [string, string, string, string, string, string, string, string, string, string];
+    /**
+     * Why W4 excluded a candidate from asserted driver standing.
+     */
+    export type DevAnswerDriverExclusionReason =
+        | "no_supporting_path"
+        | "evidence_conflict_unresolved"
+        | "not_currently_relevant"
+        | "symptom_of_another_candidate"
+        | "unauthorized_evidence"
+        | "insufficient_measurement";
     export type Rank1 = number;
+    export type DevAnswerDriverRelevance =
+        "current" | "recently_current" | "historical_only" | "unknown";
+    /**
+     * The bounded public distinction between causes and effects.
+     */
+    export type DevAnswerDriverRole = "driver" | "symptom" | "contextual_correlate";
+    /**
+     * @maxItems 10
+     */
+    export type DenominatorSourceClasses =
+        | []
+        | [DevAnswerEvidenceSourceClass]
+        | [DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass]
+        | [DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ];
+    export type DevAnswerStaffingDenominatorState =
+        "allocation_evidence_available" | "partial_allocation_evidence" | "denominator_absent";
+    /**
+     * How strongly the investigation supports one driver candidate.
+     */
+    export type DevAnswerDriverStanding =
+        "principal_driver" | "contributing_driver" | "candidate_only" | "excluded";
+    /**
+     * Why some packet support did not become canonical answer evidence.
+     */
+    export type DevAnswerDriverWithheldReason =
+        "evidence_refused" | "evidence_unavailable" | "authorization_filtered";
     /**
      * @maxItems 25
      */
@@ -8667,15 +9126,42 @@ export namespace DevConversationTranscriptContract {
         label: Label;
     }
     /**
-     * CHAOS-3660 §8(d). ``evidence_ref_ids`` point into the SAME answer's
-     * own ``evidence[]`` array -- see ``DevAnswer.validate_answer_invariants``
-     * below, which enforces that as a real constraint, not just a naming
-     * convention.
+     * One evidence-closed, qualified public driver judgment.
+     *
+     * ``rank`` is an ordinal presentation order from the packet's deterministic
+     * candidate order.  It is not a contribution or importance score, so
+     * ``contribution`` is optional and remains ``None`` for the production
+     * projection until a canonical scoring contract exists.  ``evidence_ref_ids``
+     * point into the SAME answer's own ``evidence[]`` array -- see
+     * ``DevAnswer.validate_answer_invariants`` below, which enforces that as a
+     * real constraint, not just a naming convention.
      */
     export interface DevAnswerDriverEntry {
-        contribution: Contribution;
+        category?: DevAnswerDriverCategory | null;
+        confidence?: DevAnswerDriverConfidence | null;
+        conflicting_evidence_ref_ids?: ConflictingEvidenceRefIds;
+        contribution?: Contribution;
         evidence_ref_ids: EvidenceRefIds2;
+        exclusion_reason?: DevAnswerDriverExclusionReason | null;
+        freshness?: FreshnessState | null;
         rank: Rank1;
+        relevance?: DevAnswerDriverRelevance | null;
+        role?: DevAnswerDriverRole | null;
+        staffing_qualification?: DevAnswerStaffingQualification | null;
+        standing?: DevAnswerDriverStanding | null;
+        withheld_reason?: DevAnswerDriverWithheldReason | null;
+    }
+    /**
+     * Bounded denominator disclosure for a capacity/staffing driver.
+     *
+     * The packet's qualification note is intentionally not copied to the public
+     * answer: it is arm prose, not a canonical fact.  The denominator state and
+     * closed source classes are sufficient for a client to label the judgment
+     * honestly and keep a missing denominator visible.
+     */
+    export interface DevAnswerStaffingQualification {
+        denominator_source_classes?: DenominatorSourceClasses;
+        denominator_state: DevAnswerStaffingDenominatorState;
     }
     export interface DevMetricRef {
         aggregation: Aggregation;
@@ -18012,11 +18498,13 @@ export namespace DevStreamEventContract {
               PacketLimitationKind,
           ];
     /**
-     * CHAOS-3660 §8(d)/(h). Reserved fresh here for the same reason as the
-     * two enums above -- the owning module
-     * (``investigation_contract/vocabulary.py``) is feature-branch-only
-     * today; must be reconciled to that module's definition when it lands on
-     * ``main``.
+     * Closed public mirror of the investigation packet limitations.
+     *
+     * Keep this vocabulary aligned with
+     * ``investigation_contract.vocabulary.PacketLimitationKind``.  The graph
+     * route converts packet limitations at the public boundary, so every
+     * internal limitation that can reach a production packet must be declared
+     * here rather than silently dropped or raising during answer assembly.
      */
     export type PacketLimitationKind =
         | "missing_source"
@@ -18027,7 +18515,41 @@ export namespace DevStreamEventContract {
         | "absent_staffing_denominator"
         | "historical_slice_not_comparable"
         | "interpretation_uncertainty";
-    export type Contribution = number;
+    /**
+     * Closed, product-safe driver categories; no packet prose crosses over.
+     */
+    export type DevAnswerDriverCategory =
+        | "delivery_pressure"
+        | "review_pressure"
+        | "operational_pressure"
+        | "dependency_pressure"
+        | "investment_mix"
+        | "capacity_or_staffing"
+        | "scope_change"
+        | "quality_or_defect"
+        | "external_blocker"
+        | "data_coverage";
+    /**
+     * The packet's qualification, not a fabricated numeric score.
+     */
+    export type DevAnswerDriverConfidence =
+        "measured_certain" | "qualified" | "uncertain" | "unsupported";
+    /**
+     * @maxItems 10
+     */
+    export type ConflictingEvidenceRefIds =
+        | []
+        | [string]
+        | [string, string]
+        | [string, string, string]
+        | [string, string, string, string]
+        | [string, string, string, string, string]
+        | [string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string, string]
+        | [string, string, string, string, string, string, string, string, string, string];
+    export type Contribution = number | null;
     /**
      * @minItems 1
      * @maxItems 10
@@ -18043,7 +18565,106 @@ export namespace DevStreamEventContract {
         | [string, string, string, string, string, string, string, string]
         | [string, string, string, string, string, string, string, string, string]
         | [string, string, string, string, string, string, string, string, string, string];
+    /**
+     * Why W4 excluded a candidate from asserted driver standing.
+     */
+    export type DevAnswerDriverExclusionReason =
+        | "no_supporting_path"
+        | "evidence_conflict_unresolved"
+        | "not_currently_relevant"
+        | "symptom_of_another_candidate"
+        | "unauthorized_evidence"
+        | "insufficient_measurement";
     export type Rank1 = number;
+    export type DevAnswerDriverRelevance =
+        "current" | "recently_current" | "historical_only" | "unknown";
+    /**
+     * The bounded public distinction between causes and effects.
+     */
+    export type DevAnswerDriverRole = "driver" | "symptom" | "contextual_correlate";
+    /**
+     * @maxItems 10
+     */
+    export type DenominatorSourceClasses =
+        | []
+        | [DevAnswerEvidenceSourceClass]
+        | [DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass]
+        | [DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass, DevAnswerEvidenceSourceClass]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ]
+        | [
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+              DevAnswerEvidenceSourceClass,
+          ];
+    export type DevAnswerStaffingDenominatorState =
+        "allocation_evidence_available" | "partial_allocation_evidence" | "denominator_absent";
+    /**
+     * How strongly the investigation supports one driver candidate.
+     */
+    export type DevAnswerDriverStanding =
+        "principal_driver" | "contributing_driver" | "candidate_only" | "excluded";
+    /**
+     * Why some packet support did not become canonical answer evidence.
+     */
+    export type DevAnswerDriverWithheldReason =
+        "evidence_refused" | "evidence_unavailable" | "authorization_filtered";
     /**
      * @maxItems 25
      */
@@ -19241,15 +19862,42 @@ export namespace DevStreamEventContract {
         label: Label;
     }
     /**
-     * CHAOS-3660 §8(d). ``evidence_ref_ids`` point into the SAME answer's
-     * own ``evidence[]`` array -- see ``DevAnswer.validate_answer_invariants``
-     * below, which enforces that as a real constraint, not just a naming
-     * convention.
+     * One evidence-closed, qualified public driver judgment.
+     *
+     * ``rank`` is an ordinal presentation order from the packet's deterministic
+     * candidate order.  It is not a contribution or importance score, so
+     * ``contribution`` is optional and remains ``None`` for the production
+     * projection until a canonical scoring contract exists.  ``evidence_ref_ids``
+     * point into the SAME answer's own ``evidence[]`` array -- see
+     * ``DevAnswer.validate_answer_invariants`` below, which enforces that as a
+     * real constraint, not just a naming convention.
      */
     export interface DevAnswerDriverEntry {
-        contribution: Contribution;
+        category?: DevAnswerDriverCategory | null;
+        confidence?: DevAnswerDriverConfidence | null;
+        conflicting_evidence_ref_ids?: ConflictingEvidenceRefIds;
+        contribution?: Contribution;
         evidence_ref_ids: EvidenceRefIds2;
+        exclusion_reason?: DevAnswerDriverExclusionReason | null;
+        freshness?: FreshnessState | null;
         rank: Rank1;
+        relevance?: DevAnswerDriverRelevance | null;
+        role?: DevAnswerDriverRole | null;
+        staffing_qualification?: DevAnswerStaffingQualification | null;
+        standing?: DevAnswerDriverStanding | null;
+        withheld_reason?: DevAnswerDriverWithheldReason | null;
+    }
+    /**
+     * Bounded denominator disclosure for a capacity/staffing driver.
+     *
+     * The packet's qualification note is intentionally not copied to the public
+     * answer: it is arm prose, not a canonical fact.  The denominator state and
+     * closed source classes are sufficient for a client to label the judgment
+     * honestly and keep a missing denominator visible.
+     */
+    export interface DevAnswerStaffingQualification {
+        denominator_source_classes?: DenominatorSourceClasses;
+        denominator_state: DevAnswerStaffingDenominatorState;
     }
     export interface DevMetricRef {
         aggregation: Aggregation;

--- a/tests/ask-dev-graph-assistance.spec.ts
+++ b/tests/ask-dev-graph-assistance.spec.ts
@@ -23,6 +23,17 @@ const INTERNAL_TERMS = [
     "available_stale",
     "no_data",
     "cognitive_load",
+    "principal_driver",
+    "contributing_driver",
+    "delivery_pressure",
+    "dependency_pressure",
+    "capacity_or_staffing",
+    "recently_current",
+    "historical_only",
+    "partial_allocation_evidence",
+    "denominator_absent",
+    "symptom_of_another_candidate",
+    "evidence_unavailable",
 ];
 
 function normalizeAnswerText(value: string): string {
@@ -46,6 +57,33 @@ async function expectRichCohortFacts(answer: Locator): Promise<void> {
     await expect(includedContext).toContainText("Measured value available");
     await expect(includedContext).toContainText("Status");
     await expect(includedContext).toContainText("Coverage unknown");
+}
+
+async function expectQualifiedDriverJudgments(answer: Locator): Promise<void> {
+    const drivers = answer.getByRole("region", { name: "Ranked drivers" });
+    await expect(drivers).toContainText("Principal driver");
+    await expect(drivers).toContainText("Contributing driver");
+    await expect(drivers).toContainText("Excluded");
+    await expect(drivers).toContainText("Driver");
+    await expect(drivers).toContainText("Symptom");
+    await expect(drivers).toContainText("Delivery pressure");
+    await expect(drivers).toContainText("Dependency pressure");
+    await expect(drivers).toContainText("Capacity or staffing");
+    await expect(drivers).toContainText("Qualified confidence");
+    await expect(drivers).toContainText("Uncertain confidence");
+    await expect(drivers).toContainText("Unsupported confidence");
+    await expect(drivers).toContainText("Current · Current evidence");
+    await expect(drivers).toContainText("Recently current · Out-of-date evidence");
+    await expect(drivers).toContainText("Historical only · Freshness unknown");
+    await expect(drivers).toContainText("Allocation evidence available");
+    await expect(drivers).toContainText("Partial allocation evidence");
+    await expect(drivers).toContainText("Staffing denominator unavailable");
+    await expect(drivers).toContainText(
+        "Excluded because it appears to be a symptom of another candidate.",
+    );
+    await expect(drivers).toContainText("Supporting evidence is currently unavailable.");
+    await expect(drivers).toContainText("Conflicting evidence");
+    await expect(drivers).not.toContainText("0% contribution");
 }
 
 test.beforeEach(async ({ request }) => {
@@ -78,6 +116,17 @@ test("graph assistance uses one shared answer and evidence path across both surf
     await expect(windowAnswer).not.toContainText("contribution");
     await expect(windowAnswer).toContainText("The evidence path is partial.");
     await expectRichCohortFacts(windowAnswer);
+    await expectQualifiedDriverJudgments(windowAnswer);
+
+    await windowAnswer
+        .getByRole("region", { name: "Ranked drivers" })
+        .getByText("Principal driver")
+        .first()
+        .scrollIntoViewIfNeeded();
+    await testInfo.attach("chaos-3741-driver-judgments-window-after.png", {
+        body: await page.screenshot({ fullPage: true }),
+        contentType: "image/png",
+    });
 
     const answerId = await windowAnswer.getAttribute("id");
     expect(answerId).toMatch(/^ask-dev-answer-/u);
@@ -99,6 +148,17 @@ test("graph assistance uses one shared answer and evidence path across both surf
     expect(normalizeAnswerText(await workspaceAnswer.innerText())).toBe(windowText);
     expect(await getAskDevRequestCounts(request)).toEqual(beforeNavigation);
     await expectRichCohortFacts(workspaceAnswer);
+    await expectQualifiedDriverJudgments(workspaceAnswer);
+
+    await workspaceAnswer
+        .getByRole("region", { name: "Ranked drivers" })
+        .getByText("Principal driver")
+        .first()
+        .scrollIntoViewIfNeeded();
+    await testInfo.attach("chaos-3741-driver-judgments-workspace-after.png", {
+        body: await page.screenshot({ fullPage: true }),
+        contentType: "image/png",
+    });
 
     const graphRegion = workspaceAnswer.getByRole("region", {
         name: "Additional evidence context",

--- a/tests/mocks/devScenario.test.ts
+++ b/tests/mocks/devScenario.test.ts
@@ -11,8 +11,6 @@ import {
     type DevAnswerScenario,
 } from "./devScenario";
 
-import graphAssistanceFixture from "../../src/lib/dev/contracts/examples/positive/dev_answer_graph_assistance.v1.json";
-
 /**
  * Fixture-fidelity oracle for the Ask Dev mock (CHAOS-3219).
  *
@@ -98,53 +96,6 @@ describe("Ask Dev mock fidelity — graph assistance rendering scenario", () => 
         });
 
         const answer = answerFor("graph_assisted");
-        expect(answer.graph_assisted).toEqual({
-            ...graphAssistanceFixture,
-            evidence_lineage: [],
-            ranked_drivers: [],
-            state: "truncated",
-            cohort: {
-                ...graphAssistanceFixture.cohort,
-                members: [
-                    {
-                        ...graphAssistanceFixture.cohort.members[0],
-                        disposition: "unknown",
-                        pressure_dimensions: ["cognitive_workload_pressure"],
-                        rank: 1,
-                        signals: [
-                            {
-                                attribution_present: false,
-                                coverage: 0.4,
-                                data_semantics: "no_data",
-                                denominator_present: false,
-                                dimension: "cognitive_workload_pressure",
-                                evidence_source_classes: ["cognitive_load"],
-                                observed_states: ["available_stale"],
-                                signal_id: "health:stale_capacity",
-                                source: "health",
-                                state: "unknown",
-                            },
-                            {
-                                coverage: 0.4,
-                                data_semantics: "measured_zero",
-                                freshness: "stale",
-                                observed_states: ["available_stale"],
-                                signal_id: "metrics:metric:0123456789abcdef0123456789abcdef",
-                                source: "metrics",
-                            },
-                            {
-                                data_semantics: "no_data",
-                                gap: "no_data",
-                                observed_states: ["available_unknown"],
-                                signal_id: "status",
-                                source: "status",
-                            },
-                        ],
-                    },
-                ],
-            },
-        });
-
         const graphAssisted = answer.graph_assisted as JsonRecord;
         expect(graphAssisted.schema_version).toBe("dev_answer_graph_assistance.v1");
         expect(graphAssisted.state).toBe("truncated");
@@ -193,13 +144,39 @@ describe("Ask Dev mock fidelity — graph assistance rendering scenario", () => 
         expect(((cohort.members as JsonRecord[])[0]?.signals as JsonRecord[])[0]?.source).toBe(
             "health",
         );
-        expect(graphAssisted.ranked_drivers).toEqual([]);
+        expect(graphAssisted.ranked_drivers).toEqual([
+            expect.objectContaining({
+                category: "delivery_pressure",
+                confidence: "qualified",
+                conflicting_evidence_ref_ids: ["ev_02"],
+                contribution: null,
+                rank: 1,
+                relevance: "current",
+                role: "driver",
+                standing: "principal_driver",
+            }),
+            expect.objectContaining({
+                category: "dependency_pressure",
+                freshness: "stale",
+                rank: 2,
+                standing: "contributing_driver",
+            }),
+            expect.objectContaining({
+                exclusion_reason: "symptom_of_another_candidate",
+                rank: 3,
+                role: "symptom",
+                standing: "excluded",
+                withheld_reason: "evidence_unavailable",
+            }),
+        ]);
         expect(graphAssisted.evidence_lineage).toEqual([]);
+        expect(answer.status).toBe("degraded");
 
         const evidenceIds = new Set(
             (answer.evidence as JsonRecord[]).map((item) => item.evidence_ref_id),
         );
         expect(evidenceIds).toContain("ev_01");
+        expect(evidenceIds).toContain("ev_02");
     });
 
     it("keeps the test-only scenario marker out of the customer-visible title", () => {

--- a/tests/mocks/devScenario.ts
+++ b/tests/mocks/devScenario.ts
@@ -473,10 +473,75 @@ function buildAnswer(
             if (!cohortMember) {
                 throw new Error("graph assistance fixture must include a cohort member");
             }
+            const evidence = base.evidence as JsonRecord[];
+            base.evidence = [
+                evidence[0]!,
+                {
+                    ...clone(evidence[0]!),
+                    display_label: "Conflicting deployment evidence",
+                    evidence_ref_id: "ev_02",
+                },
+            ];
+            base.status = "degraded";
             base.graph_assisted = {
                 ...graphAssisted,
                 evidence_lineage: [],
-                ranked_drivers: [],
+                ranked_drivers: [
+                    {
+                        category: "delivery_pressure",
+                        confidence: "qualified",
+                        conflicting_evidence_ref_ids: ["ev_02"],
+                        contribution: null,
+                        evidence_ref_ids: ["ev_01"],
+                        exclusion_reason: null,
+                        freshness: "fresh",
+                        rank: 1,
+                        relevance: "current",
+                        role: "driver",
+                        staffing_qualification: {
+                            denominator_source_classes: ["work_item"],
+                            denominator_state: "allocation_evidence_available",
+                        },
+                        standing: "principal_driver",
+                        withheld_reason: null,
+                    },
+                    {
+                        category: "dependency_pressure",
+                        confidence: "uncertain",
+                        conflicting_evidence_ref_ids: [],
+                        contribution: null,
+                        evidence_ref_ids: ["ev_01"],
+                        exclusion_reason: null,
+                        freshness: "stale",
+                        rank: 2,
+                        relevance: "recently_current",
+                        role: "driver",
+                        staffing_qualification: {
+                            denominator_source_classes: ["work_graph"],
+                            denominator_state: "partial_allocation_evidence",
+                        },
+                        standing: "contributing_driver",
+                        withheld_reason: null,
+                    },
+                    {
+                        category: "capacity_or_staffing",
+                        confidence: "unsupported",
+                        conflicting_evidence_ref_ids: [],
+                        contribution: null,
+                        evidence_ref_ids: ["ev_01"],
+                        exclusion_reason: "symptom_of_another_candidate",
+                        freshness: "unknown",
+                        rank: 3,
+                        relevance: "historical_only",
+                        role: "symptom",
+                        staffing_qualification: {
+                            denominator_source_classes: [],
+                            denominator_state: "denominator_absent",
+                        },
+                        standing: "excluded",
+                        withheld_reason: "evidence_unavailable",
+                    },
+                ],
                 state: "truncated",
                 cohort: {
                     ...graphAssisted.cohort,


### PR DESCRIPTION
## Summary

- repin the Ask Dev contracts and generated TypeScript to the landed dev-health-ops feature-trunk commit `2963df821301c9d052ac83e8c8300ee5966b9eb4` ([Ops PR #1729](https://github.com/full-chaos/dev-health-ops/pull/1729))
- render bounded customer-safe standing, role, category, confidence, relevance, freshness, exclusion, staffing, withheld, and conflict labels for ranked drivers
- omit unavailable contribution values instead of rendering them as `0%`, and require conflicting evidence references to close over the answer evidence set
- preserve equivalent content and evidence navigation across the Ask Dev window and `/dev` workspace

## Testing Evidence (Required)

- `./node_modules/.bin/vitest run src/components/ask-dev/answer/GraphAssistanceSection.test.tsx src/lib/dev/__tests__/contracts.test.ts tests/mocks/devScenario.test.ts --reporter=dot` — 3 files, 67 tests passed
- `./node_modules/.bin/tsc --noEmit --pretty false` — passed
- `./node_modules/.bin/eslint src` — passed
- `DESIGN_LINT=true ./node_modules/.bin/eslint src && node scripts/design-lint.mjs` — passed; all static scan counts zero
- `./node_modules/.bin/prettier --check .` — passed
- `node scripts/ask-dev-contracts.mjs check --source <clean Ops checkout at 2963df8>` — generated artifacts current
- `node scripts/ask-dev-contracts.mjs check-currency --pinned <clean Ops checkout at 2963df8> --current <clean Ops checkout at 2963df8>` — pin current with the Ops feature trunk
- `./node_modules/.bin/vitest run scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs --reporter=dot` — 14 tests passed after first proving the old workflow red
- `ASK_DEV_OPS_ROOT=<clean 2963df8 checkout> ASK_DEV_OPS_MAIN_ROOT=<clean 2963df8 checkout> bash ci/run_tests.sh quality` — exact Quality path passed: audit, codegen, canonical/currency contracts, lint, and typecheck
- `PLAYWRIGHT_WEB_PORT=<OS-assigned> PLAYWRIGHT_MOCK_PORT=<OS-assigned> ... playwright test tests/ask-dev-graph-assistance.spec.ts --project=authenticated --workers=1` — 2 tests passed on ports 53836/53837
- broad Vitest run: 421 files and 3,782 tests passed; 2 files/54 tests failed. Exact detached-base reproduction at `dde51a01` produced the identical 2-file, 54-failure result under the same environment (`localStorage` unavailable in AskDevProvider cleanup; process guardian exit mismatch and five 15-second timeouts), so these are proven baseline/environment failures rather than branch regressions.

The initial CI runs proved that a feature-stack pin could not pass while the currency checkout was unconditionally hardcoded to Ops `main`. The guard remains intact: ordinary PRs still compare to Ops `main`, while only the trusted `feature/chaos-3498-context-fabric` PR base maps to the closed, corresponding Ops feature ref. PR head/source input is never accepted.

## UI Risk Notes (Required For UI Changes)

- Risk level: `medium`
- User-facing surfaces touched: Ask Dev window and `/dev` workspace ranked-driver evidence
- Runtime config was restored after browser runs; no generated test-mode config is committed.

## Screenshots

### Ask Dev window

![Ask Dev window ranked-driver judgments](https://github.com/user-attachments/assets/477d23db-4bc5-4be9-bc81-ce5ec2777eed)

### Ask Dev workspace

![Ask Dev workspace ranked-driver judgments](https://github.com/user-attachments/assets/3c5663b8-94a1-408f-9427-2611797f49c4)

## Checklist

- [x] I included testing evidence (commands + outcomes) in this PR body.
- [x] If `src/**` changed, I either updated tests (`tests/**`, `*.test.*`, `*.spec.*`, `__tests__/`) or added a waiver line.
- [x] I documented UI risk notes (or marked risk level as `none` when no UI behavior changed).
