### PR TITLE
CHAOS-3762: Add focused backfill selector UX

### DIFF
--- a/src/components/admin/sync/BackfillOperations.test.tsx
+++ b/src/components/admin/sync/BackfillOperations.test.tsx
@@ -38,9 +38,9 @@ describe("BackfillOperations", () => {
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
         await user.click(screen.getByRole("button", { name: "Backfill" }));
 
-        expect(screen.getByRole("dialog", { name: "Run historical backfill" })).toBeInTheDocument();
+        expect(screen.getByRole("dialog", { name: "Run focused backfill" })).toBeInTheDocument();
         // Opened from the generic entry point: no gap prefill.
-        expect(screen.getByLabelText("From")).toHaveValue("");
+        expect(screen.getByLabelText("Since (inclusive)")).toHaveValue("");
     });
 
     it("opens the wizard prefilled with the gap's range from a timeline 'Backfill this gap' action", async () => {
@@ -50,8 +50,8 @@ describe("BackfillOperations", () => {
         await user.click(screen.getByRole("button", { name: "Backfill this gap" }));
 
         expect(screen.getByRole("dialog")).toBeInTheDocument();
-        expect(screen.getByLabelText("From")).toHaveValue("2026-01-02");
-        expect(screen.getByLabelText("To")).toHaveValue("2026-01-03");
+        expect(screen.getByLabelText("Since (inclusive)")).toHaveValue("2026-01-02");
+        expect(screen.getByLabelText("Before (exclusive)")).toHaveValue("2026-01-03");
     });
 
     it("opens the wizard with the exact server-owned canonical backfill window", async () => {
@@ -72,8 +72,8 @@ describe("BackfillOperations", () => {
         );
 
         expect(screen.getByRole("dialog")).toBeInTheDocument();
-        expect(screen.getByLabelText("From")).toHaveValue("2025-12-20");
-        expect(screen.getByLabelText("To")).toHaveValue("2026-01-01");
+        expect(screen.getByLabelText("Since (inclusive)")).toHaveValue("2025-12-20");
+        expect(screen.getByLabelText("Before (exclusive)")).toHaveValue("2026-01-01");
     });
 
     it("opens an unscoped recovery backfill when coverage cannot load", async () => {
@@ -91,9 +91,10 @@ describe("BackfillOperations", () => {
 
         await user.click(screen.getByRole("button", { name: "Backfill" }));
 
-        expect(screen.getByRole("dialog", { name: "Run historical backfill" })).toBeInTheDocument();
-        expect(screen.getByLabelText("From")).toHaveValue("");
-        expect(screen.getAllByText("No coverage data yet")).toHaveLength(2);
+        expect(screen.getByRole("dialog", { name: "Run focused backfill" })).toBeInTheDocument();
+        expect(screen.getByLabelText("Since (inclusive)")).toHaveValue("");
+        expect(screen.getByRole("radio", { name: /Choose specific sources/ })).toBeDisabled();
+        expect(screen.getByRole("radio", { name: /Choose specific datasets/ })).toBeDisabled();
     });
 
     it("closes the wizard via its Cancel action", async () => {

--- a/src/components/admin/sync/BackfillOperations.tsx
+++ b/src/components/admin/sync/BackfillOperations.tsx
@@ -58,9 +58,6 @@ export function BackfillOperations({
     };
     const closeWizard = () => setIsWizardOpen(false);
 
-    const datasetNames = coverage?.datasets.map((dataset) => dataset.dataset_key) ?? [];
-    const sourceNames = coverage?.sources.map((source) => source.source_name) ?? [];
-
     return (
         <>
             <SyncCoverageSummaryCard
@@ -89,8 +86,8 @@ export function BackfillOperations({
                     onCloseAction={closeWizard}
                     initialSince={wizardRange?.since}
                     initialBefore={wizardRange?.before}
-                    datasetNames={datasetNames}
-                    sourceNames={sourceNames}
+                    datasets={coverage?.datasets ?? []}
+                    sources={coverage?.sources ?? []}
                     testMode={testMode}
                 />
             )}

--- a/src/components/admin/sync/BackfillWizard.test.tsx
+++ b/src/components/admin/sync/BackfillWizard.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, userEvent } from "@/test/utils";
-import { BackfillWizard } from "./BackfillWizard";
+import type { SyncCoverageDataset, SyncCoverageSource } from "@/lib/admin/types";
+import { BackfillWizard, buildDatasetChoices } from "./BackfillWizard";
 
 const mockRefresh = vi.fn();
 vi.mock("next/navigation", () => ({
@@ -12,225 +13,219 @@ vi.mock("@/lib/admin/server", () => ({
     triggerBackfill: (...args: unknown[]) => triggerBackfill(...args),
 }));
 
+const baseDataset: Omit<SyncCoverageDataset, "dataset_key"> = {
+    status: "healthy",
+    covered_through: null,
+    requested_ranges: [],
+    covered_ranges: [],
+    gaps: [],
+    stale_ranges: [],
+    failed_ranges: [],
+};
+const datasets: SyncCoverageDataset[] = [
+    { ...baseDataset, dataset_key: "git" },
+    { ...baseDataset, dataset_key: "work-items" },
+    { ...baseDataset, dataset_key: "work-item-comments" },
+];
+const sources: SyncCoverageSource[] = [
+    {
+        source_id: "src-api",
+        source_name: "acme/api",
+        status: "healthy",
+        covered_through: null,
+        gap_count: 0,
+        failed_range_count: 0,
+    },
+    {
+        source_id: "src-web",
+        source_name: "acme/web",
+        status: "healthy",
+        covered_through: null,
+        gap_count: 0,
+        failed_range_count: 0,
+    },
+];
+
 function renderWizard(props: Partial<React.ComponentProps<typeof BackfillWizard>> = {}) {
     return render(
         <BackfillWizard
             configId="cfg-1"
             onCloseAction={vi.fn()}
-            datasetNames={["git", "prs"]}
-            sourceNames={["acme/repo"]}
+            datasets={datasets}
+            sources={sources}
             {...props}
         />,
     );
 }
 
-async function fillRange(user: ReturnType<typeof userEvent.setup>, since: string, before: string) {
-    const fromInput = screen.getByLabelText("From");
-    const toInput = screen.getByLabelText("To");
-    await user.clear(fromInput);
-    await user.type(fromInput, since);
-    await user.clear(toInput);
-    await user.type(toInput, before);
+async function fillRange(
+    user: ReturnType<typeof userEvent.setup>,
+    since = "2026-06-01",
+    before = "2026-06-05",
+) {
+    await user.type(screen.getByLabelText("Since (inclusive)"), since);
+    await user.type(screen.getByLabelText("Before (exclusive)"), before);
 }
 
-/** Add `days` whole days to a YYYY-MM-DD input, returned in the same format. */
-function addDays(dateStr: string, days: number): string {
-    const date = new Date(`${dateStr}T00:00:00.000Z`);
-    date.setUTCDate(date.getUTCDate() + days);
-    return date.toISOString().slice(0, 10);
+async function reviewAndSubmit(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await user.click(screen.getByRole("button", { name: "Run backfill" }));
 }
+
+describe("buildDatasetChoices", () => {
+    it("represents the canonical work-item family once while retaining every affected key", () => {
+        expect(buildDatasetChoices(datasets)).toEqual([
+            { id: "git", label: "Git Data (Commits, Branches)", datasetKeys: ["git"] },
+            {
+                id: "work-items",
+                label: "Work items (canonical family)",
+                datasetKeys: ["work-items", "work-item-comments"],
+            },
+        ]);
+    });
+});
 
 describe("BackfillWizard", () => {
     beforeEach(() => {
         vi.clearAllMocks();
-    });
-
-    it("blocks submit and shows an inline error when from >= to", async () => {
-        const user = userEvent.setup();
-        renderWizard();
-
-        await fillRange(user, "2026-06-10", "2026-06-01");
-
-        expect(screen.getByRole("alert")).toHaveTextContent("Start date must be before end date.");
-        expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
-        expect(screen.getByLabelText("From")).toHaveAttribute("aria-invalid", "true");
-        expect(screen.getByLabelText("From")).toHaveAttribute(
-            "aria-describedby",
-            "backfill-range-error",
-        );
-    });
-
-    it("advances to the preview step once the range is valid", async () => {
-        const user = userEvent.setup();
-        renderWizard();
-
-        await fillRange(user, "2026-06-01", "2026-06-05");
-        expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
-        await user.click(screen.getByRole("button", { name: "Continue" }));
-
-        expect(screen.getByText("Estimated chunks")).toBeInTheDocument();
-        expect(screen.getByText(/\(estimate\)/)).toBeInTheDocument();
-    });
-
-    it("shows affected dataset/source NAMES (never raw ids) on the range step", () => {
-        renderWizard({ datasetNames: ["git", "prs"], sourceNames: ["acme/repo"] });
-
-        expect(screen.getByText("git, prs")).toBeInTheDocument();
-        expect(screen.getByText("acme/repo")).toBeInTheDocument();
-    });
-
-    it("pre-fills the range from gap-driven props", () => {
-        renderWizard({ initialSince: "2026-06-20", initialBefore: "2026-06-26" });
-
-        expect(screen.getByLabelText("From")).toHaveValue("2026-06-20");
-        expect(screen.getByLabelText("To")).toHaveValue("2026-06-26");
-    });
-
-    it("requires explicit confirmation before submitting an expensive (>180 day) range", async () => {
-        const user = userEvent.setup();
-        renderWizard();
-
-        await fillRange(user, "2026-01-01", "2026-12-01");
-        await user.click(screen.getByRole("button", { name: "Continue" }));
-
-        expect(screen.getByRole("alert")).toHaveTextContent(/more than 180/);
-        const submitButton = screen.getByRole("button", { name: "Run backfill" });
-        expect(submitButton).toBeDisabled();
-
-        await user.click(
-            screen.getByRole("checkbox", { name: /understand this is a large backfill/i }),
-        );
-        expect(submitButton).toBeEnabled();
-    });
-
-    it("submits via triggerBackfill with the exact payload and links to the resulting run", async () => {
         triggerBackfill.mockResolvedValue({
-            data: {
-                task_id: "task-1",
-                status: "accepted",
-                backfill_job_id: "job-1",
-                sync_run_id: "run-42",
-            },
+            data: { status: "accepted", sync_run_id: "run-42", total_units: 2 },
         });
+    });
+
+    it("submits a date-only scope as the exact nested selector without legacy flat fields", async () => {
         const user = userEvent.setup();
         renderWizard();
+        await fillRange(user);
+        await reviewAndSubmit(user);
 
-        await fillRange(user, "2026-06-01", "2026-06-05");
-        await user.click(screen.getByRole("button", { name: "Continue" }));
-        await user.click(screen.getByRole("button", { name: "Run backfill" }));
-
-        expect(triggerBackfill).toHaveBeenCalledWith("cfg-1", "2026-06-01", "2026-06-05");
+        expect(triggerBackfill).toHaveBeenCalledWith("cfg-1", {
+            since: "2026-06-01T00:00:00.000Z",
+            before: "2026-06-05T00:00:00.000Z",
+        });
         expect(await screen.findByRole("link", { name: "View run" })).toHaveAttribute(
             "href",
             "/org/admin/sync/cfg-1/runs/run-42",
         );
-        expect(mockRefresh).toHaveBeenCalled();
     });
 
-    it("does not call the live server action in test mode (demo no-op submit path)", async () => {
+    it("submits a repository-only focused selector", async () => {
         const user = userEvent.setup();
-        renderWizard({ testMode: true });
+        renderWizard();
+        await fillRange(user);
+        await user.click(screen.getByRole("radio", { name: /Choose specific sources/ }));
+        await user.click(screen.getByLabelText("acme/web"));
+        await reviewAndSubmit(user);
 
-        await fillRange(user, "2026-06-01", "2026-06-05");
+        expect(triggerBackfill).toHaveBeenCalledWith(
+            "cfg-1",
+            expect.objectContaining({
+                source_ids: ["src-web"],
+            }),
+        );
+        expect(triggerBackfill.mock.calls[0]?.[1]).not.toHaveProperty("dataset_keys");
+    });
+
+    it("submits a unit-only selector and expands the canonical family to its affected datasets", async () => {
+        const user = userEvent.setup();
+        renderWizard();
+        await fillRange(user);
+        await user.click(screen.getByRole("radio", { name: /Choose specific datasets/ }));
+        await user.click(screen.getByRole("checkbox", { name: /Work items \(canonical family\)/ }));
         await user.click(screen.getByRole("button", { name: "Continue" }));
+
+        expect(screen.getByText(/Canonical work-item family affects:/)).toHaveTextContent(
+            "Work Items (Issues, Tickets), work item comments",
+        );
         await user.click(screen.getByRole("button", { name: "Run backfill" }));
-
-        expect(triggerBackfill).not.toHaveBeenCalled();
-        expect(await screen.findByText(/Backfill started/)).toBeInTheDocument();
+        expect(triggerBackfill).toHaveBeenCalledWith(
+            "cfg-1",
+            expect.objectContaining({
+                dataset_keys: ["work-items", "work-item-comments"],
+            }),
+        );
     });
 
-    it("disables Continue when both date fields are empty", () => {
-        renderWizard();
-        expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
-    });
-
-    it("blocks submit and shows an inline error when from == to", async () => {
+    it("submits combined source and dataset scope without broadening either dimension", async () => {
         const user = userEvent.setup();
         renderWizard();
+        await fillRange(user);
+        await user.click(screen.getByRole("radio", { name: /Choose specific sources/ }));
+        await user.click(screen.getByLabelText("acme/api"));
+        await user.click(screen.getByRole("radio", { name: /Choose specific datasets/ }));
+        await user.click(screen.getByLabelText("Git Data (Commits, Branches)"));
+        await reviewAndSubmit(user);
 
+        expect(triggerBackfill).toHaveBeenCalledWith("cfg-1", {
+            since: "2026-06-01T00:00:00.000Z",
+            before: "2026-06-05T00:00:00.000Z",
+            source_ids: ["src-api"],
+            dataset_keys: ["git"],
+        });
+    });
+
+    it("rejects an empty focused selection before review instead of silently widening it", async () => {
+        const user = userEvent.setup();
+        renderWizard();
+        await fillRange(user);
+        await user.click(screen.getByRole("radio", { name: /Choose specific sources/ }));
+
+        expect(screen.getByRole("alert")).toHaveTextContent("Choose at least one item");
+        expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+        expect(triggerBackfill).not.toHaveBeenCalled();
+    });
+
+    it("does not render or submit identities absent from authoritative page data", async () => {
+        const user = userEvent.setup();
+        renderWizard();
+        await fillRange(user);
+        await user.click(screen.getByRole("radio", { name: /Choose specific sources/ }));
+
+        expect(screen.queryByText("foreign/repo")).not.toBeInTheDocument();
+        expect(screen.getAllByRole("checkbox")).toHaveLength(2);
+    });
+
+    it("blocks an invalid exclusive window", async () => {
+        const user = userEvent.setup();
+        renderWizard();
         await fillRange(user, "2026-06-05", "2026-06-05");
 
-        expect(screen.getByRole("alert")).toHaveTextContent("Start date must be before end date.");
+        expect(screen.getByRole("alert")).toHaveTextContent("exclusive boundary");
         expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
     });
 
-    it("does not warn at exactly the 180-day threshold", async () => {
+    it("retains expensive-range confirmation for a focused final scope", async () => {
         const user = userEvent.setup();
         renderWizard();
-        const since = "2026-01-01";
-        const before = addDays(since, 180);
-
-        await fillRange(user, since, before);
-        await user.click(screen.getByRole("button", { name: "Continue" }));
-
-        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "Run backfill" })).toBeEnabled();
-    });
-
-    it("warns just past the 180-day threshold (181 days)", async () => {
-        const user = userEvent.setup();
-        renderWizard();
-        const since = "2026-01-01";
-        const before = addDays(since, 181);
-
-        await fillRange(user, since, before);
-        await user.click(screen.getByRole("button", { name: "Continue" }));
-
-        expect(screen.getByRole("alert")).toHaveTextContent(/more than 180/);
-        expect(screen.getByRole("button", { name: "Run backfill" })).toBeDisabled();
-    });
-
-    it("resets the expensive-range confirmation when the range changes after going back", async () => {
-        const user = userEvent.setup();
-        renderWizard();
-
         await fillRange(user, "2026-01-01", "2026-12-01");
+        await user.click(screen.getByRole("radio", { name: /Choose specific sources/ }));
+        await user.click(screen.getByLabelText("acme/api"));
         await user.click(screen.getByRole("button", { name: "Continue" }));
+
+        const submit = screen.getByRole("button", { name: "Run backfill" });
+        expect(submit).toBeDisabled();
         await user.click(
             screen.getByRole("checkbox", { name: /understand this is a large backfill/i }),
         );
-        expect(screen.getByRole("button", { name: "Run backfill" })).toBeEnabled();
-
-        await user.click(screen.getByRole("button", { name: "Back" }));
-        await user.clear(screen.getByLabelText("To"));
-        await user.type(screen.getByLabelText("To"), "2026-11-01");
-        await user.click(screen.getByRole("button", { name: "Continue" }));
-
-        expect(screen.getByRole("alert")).toHaveTextContent(/more than 180/);
-        expect(screen.getByRole("button", { name: "Run backfill" })).toBeDisabled();
+        expect(submit).toBeEnabled();
     });
 
-    it("moves focus to the dialog on open", () => {
-        renderWizard();
-        expect(screen.getByRole("dialog")).toHaveFocus();
+    it("keeps the test-mode journey local", async () => {
+        const user = userEvent.setup();
+        renderWizard({ testMode: true });
+        await fillRange(user);
+        await reviewAndSubmit(user);
+        expect(triggerBackfill).not.toHaveBeenCalled();
+        expect(
+            await screen.findByText(/Backfill started for the reviewed scope/),
+        ).toBeInTheDocument();
     });
 
-    it("restores focus to the previously focused trigger element on close", () => {
-        const trigger = document.createElement("button");
-        document.body.appendChild(trigger);
-        trigger.focus();
-        expect(trigger).toHaveFocus();
-
-        const { unmount } = renderWizard();
-        expect(screen.getByRole("dialog")).toHaveFocus();
-
-        unmount();
-        expect(trigger).toHaveFocus();
-
-        document.body.removeChild(trigger);
-    });
-
-    it("closes on Escape even when focus is not inside the dialog", async () => {
+    it("moves focus into the dialog and closes from Escape", async () => {
         const onCloseAction = vi.fn();
-        const trigger = document.createElement("button");
-        document.body.appendChild(trigger);
         renderWizard({ onCloseAction });
-        trigger.focus();
-        expect(trigger).toHaveFocus();
-
+        expect(screen.getByRole("dialog")).toHaveFocus();
         await userEvent.keyboard("{Escape}");
-
-        expect(onCloseAction).toHaveBeenCalledTimes(1);
-        document.body.removeChild(trigger);
+        expect(onCloseAction).toHaveBeenCalledOnce();
     });
 });

--- a/src/components/admin/sync/BackfillWizard.tsx
+++ b/src/components/admin/sync/BackfillWizard.tsx
@@ -1,39 +1,42 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { triggerBackfill } from "@/lib/admin/server";
+import type { SyncCoverageDataset, SyncCoverageSource } from "@/lib/admin/types";
+import { DATASET_LABELS } from "./config-form/constants";
 import { CTA_LABELS } from "@/lib/design/cta";
 
-/** Ranges longer than this need explicit confirmation before submit (CHAOS-2796). */
 const EXPENSIVE_RANGE_THRESHOLD_DAYS = 180;
-
-/**
- * Client-side ESTIMATE only, matching the non-Linear family default chunk
- * window in ops/sync/planner.py (`chunk_days = 7`). This is a display
- * estimate for the preview step, never the source of truth — the backend
- * planner computes actual chunking at dispatch time and per-provider policy
- * can differ (e.g. Linear's max window), so this must not be presented as
- * exact.
- */
 const ESTIMATED_CHUNK_DAYS = 7;
-
 const RANGE_ERROR_ID = "backfill-range-error";
+const SCOPE_ERROR_ID = "backfill-scope-error";
+const WORK_ITEM_FAMILY = new Set([
+    "work-items",
+    "work-item-labels",
+    "work-item-projects",
+    "work-item-history",
+    "work-item-comments",
+]);
 
-type WizardStep = "range" | "preview" | "result";
+type WizardStep = "scope" | "review" | "result";
+type ScopeMode = "all" | "selected";
+
+interface DatasetChoice {
+    id: string;
+    label: string;
+    datasetKeys: string[];
+}
 
 interface BackfillWizardProps {
     configId: string;
     onCloseAction: () => void;
-    /** Gap-driven prefill (YYYY-MM-DD) from the coverage timeline's "Backfill this gap" action. */
     initialSince?: string;
     initialBefore?: string;
-    /** Resolved dataset/source NAMES from the coverage summary already on the page — never raw ids. */
-    datasetNames: string[];
-    sourceNames: string[];
-    /** When true, submit is a no-op demo path instead of calling the live server action. */
+    datasets: SyncCoverageDataset[];
+    sources: SyncCoverageSource[];
     testMode?: boolean;
 }
 
@@ -43,12 +46,46 @@ function parseDateInput(value: string): Date | null {
     return Number.isNaN(date.getTime()) ? null : date;
 }
 
-/** Whole-day span between two YYYY-MM-DD inputs, or null if either is unparseable. */
 function rangeDays(since: string, before: string): number | null {
     const sinceDate = parseDateInput(since);
     const beforeDate = parseDateInput(before);
     if (!sinceDate || !beforeDate) return null;
-    return Math.round((beforeDate.getTime() - sinceDate.getTime()) / (24 * 60 * 60 * 1000));
+    return Math.round((beforeDate.getTime() - sinceDate.getTime()) / 86_400_000);
+}
+
+function toBoundary(value: string): string {
+    return `${value}T00:00:00.000Z`;
+}
+
+function datasetLabel(key: string): string {
+    return DATASET_LABELS[key] ?? key.replaceAll("-", " ");
+}
+
+/** Collapse the work-item aliases into the single canonical family operators execute. */
+export function buildDatasetChoices(datasets: SyncCoverageDataset[]): DatasetChoice[] {
+    const choices: DatasetChoice[] = [];
+    const familyKeys = datasets
+        .map((dataset) => dataset.dataset_key)
+        .filter((key) => WORK_ITEM_FAMILY.has(key));
+
+    for (const dataset of datasets) {
+        if (WORK_ITEM_FAMILY.has(dataset.dataset_key)) {
+            if (!choices.some((choice) => choice.id === "work-items")) {
+                choices.push({
+                    id: "work-items",
+                    label: "Work items (canonical family)",
+                    datasetKeys: familyKeys,
+                });
+            }
+            continue;
+        }
+        choices.push({
+            id: dataset.dataset_key,
+            label: datasetLabel(dataset.dataset_key),
+            datasetKeys: [dataset.dataset_key],
+        });
+    }
+    return choices;
 }
 
 export function BackfillWizard({
@@ -56,39 +93,37 @@ export function BackfillWizard({
     onCloseAction,
     initialSince = "",
     initialBefore = "",
-    datasetNames,
-    sourceNames,
+    datasets,
+    sources,
     testMode = false,
 }: BackfillWizardProps) {
     const router = useRouter();
-    const [step, setStep] = useState<WizardStep>("range");
+    const datasetChoices = useMemo(() => buildDatasetChoices(datasets), [datasets]);
+    const [step, setStep] = useState<WizardStep>("scope");
     const [since, setSince] = useState(initialSince);
     const [before, setBefore] = useState(initialBefore);
+    const [sourceMode, setSourceMode] = useState<ScopeMode>("all");
+    const [datasetMode, setDatasetMode] = useState<ScopeMode>("all");
+    const [selectedSourceIds, setSelectedSourceIds] = useState<string[]>([]);
+    const [selectedDatasetChoiceIds, setSelectedDatasetChoiceIds] = useState<string[]>([]);
     const [expensiveConfirmed, setExpensiveConfirmed] = useState(false);
     const [isPending, startTransition] = useTransition();
     const [submitError, setSubmitError] = useState<string | null>(null);
     const [submittedSyncRunId, setSubmittedSyncRunId] = useState<string | null>(null);
     const dialogRef = useRef<HTMLDivElement>(null);
     const onCloseActionRef = useRef(onCloseAction);
+
     useEffect(() => {
         onCloseActionRef.current = onCloseAction;
     }, [onCloseAction]);
 
-    // Modal a11y (CHAOS-2796): move focus into the dialog on open and restore
-    // it to whatever was focused before (the trigger button) on close. Escape
-    // is handled via a document-level listener — rather than an onKeyDown on
-    // the overlay — so it works no matter where focus currently sits; an
-    // overlay-only handler misses Escape while focus is still on the
-    // background trigger that opened the wizard.
     useEffect(() => {
         const previouslyFocused = document.activeElement as HTMLElement | null;
         dialogRef.current?.focus();
-
         function handleKeyDown(event: KeyboardEvent) {
             if (event.key === "Escape") onCloseActionRef.current();
         }
         document.addEventListener("keydown", handleKeyDown);
-
         return () => {
             document.removeEventListener("keydown", handleKeyDown);
             previouslyFocused?.focus();
@@ -98,28 +133,47 @@ export function BackfillWizard({
     const days = rangeDays(since, before);
     const hasBothDates = Boolean(since) && Boolean(before);
     const isRangeInvalid = hasBothDates && days !== null && days <= 0;
+    const sourceSelectionInvalid = sourceMode === "selected" && selectedSourceIds.length === 0;
+    const datasetSelectionInvalid =
+        datasetMode === "selected" && selectedDatasetChoiceIds.length === 0;
+    const isScopeInvalid = sourceSelectionInvalid || datasetSelectionInvalid;
     const isExpensiveRange = days !== null && days > EXPENSIVE_RANGE_THRESHOLD_DAYS;
     const chunkEstimate =
         days !== null && days > 0 ? Math.max(1, Math.ceil(days / ESTIMATED_CHUNK_DAYS)) : 0;
-
-    const canContinue = hasBothDates && !isRangeInvalid;
+    const canContinue = hasBothDates && !isRangeInvalid && !isScopeInvalid;
     const canSubmit = canContinue && (!isExpensiveRange || expensiveConfirmed);
+    const selectedDatasetKeys = datasetChoices
+        .filter((choice) => selectedDatasetChoiceIds.includes(choice.id))
+        .flatMap((choice) => choice.datasetKeys);
+    const selectedSourceNames = sources
+        .filter((source) => selectedSourceIds.includes(source.source_id))
+        .map((source) => source.source_name);
+    const selectedDatasetChoices = datasetChoices.filter((choice) =>
+        selectedDatasetChoiceIds.includes(choice.id),
+    );
+
+    const resetConfirmation = () => setExpensiveConfirmed(false);
+    const toggle = (values: string[], value: string): string[] =>
+        values.includes(value) ? values.filter((item) => item !== value) : [...values, value];
 
     const handleSubmit = () => {
         if (!canSubmit) return;
         setSubmitError(null);
+        const selector = {
+            since: toBoundary(since),
+            before: toBoundary(before),
+            ...(sourceMode === "selected" ? { source_ids: selectedSourceIds } : {}),
+            ...(datasetMode === "selected" ? { dataset_keys: selectedDatasetKeys } : {}),
+        };
 
         if (testMode) {
-            // Test-mode demo path: no live API call (web AGENTS test-mode rule).
-            // Mirrors the sample sync_run id already used by the gaps coverage
-            // sample so "View run" resolves to a valid sample run page.
             setSubmittedSyncRunId("sample-run-gaps");
             setStep("result");
             return;
         }
 
         startTransition(async () => {
-            const result = await triggerBackfill(configId, since, before);
+            const result = await triggerBackfill(configId, selector);
             if (result.error || !result.data) {
                 setSubmitError(result.error ?? "Failed to start backfill");
                 toast.error(result.error ?? "Failed to start backfill");
@@ -140,7 +194,7 @@ export function BackfillWizard({
                 aria-modal="true"
                 aria-labelledby="backfill-wizard-title"
                 tabIndex={-1}
-                className="w-full max-w-xl rounded-xl border border-(--card-stroke) bg-(--card) shadow-2xl focus:outline-none"
+                className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl border border-(--card-stroke) bg-(--card) shadow-2xl focus:outline-none"
             >
                 <div className="flex items-center justify-between border-b border-(--card-stroke) p-6">
                     <div>
@@ -148,10 +202,10 @@ export function BackfillWizard({
                             id="backfill-wizard-title"
                             className="text-lg font-semibold text-foreground"
                         >
-                            Run historical backfill
+                            Run focused backfill
                         </h2>
                         <p className="mt-1 text-xs text-(--ink-muted)">
-                            Step {step === "range" ? 1 : step === "preview" ? 2 : 3} of 3
+                            Step {step === "scope" ? 1 : step === "review" ? 2 : 3} of 3
                         </p>
                     </div>
                     <button
@@ -163,96 +217,234 @@ export function BackfillWizard({
                     </button>
                 </div>
 
-                <div className="space-y-4 p-6">
-                    {step === "range" && (
+                <div className="space-y-5 p-6">
+                    {step === "scope" && (
                         <>
                             <p className="text-sm text-(--ink-muted)">
-                                Backfill fetches historical data for the selected window. It does
-                                not affect incremental sync watermarks — regular scheduled syncs
-                                continue independently.
+                                Choose the exact historical window and scope. This run does not
+                                advance scheduled-sync watermarks.
                             </p>
-
-                            <div className="flex items-end gap-3">
-                                <div className="flex-1">
-                                    <label
-                                        htmlFor="backfill-since"
-                                        className="mb-1.5 block text-sm font-medium text-(--ink-muted)"
-                                    >
-                                        From
-                                    </label>
+                            <div className="grid gap-3 sm:grid-cols-2">
+                                <label
+                                    className="text-sm font-medium text-(--ink-muted)"
+                                    htmlFor="backfill-since"
+                                >
+                                    Since (inclusive)
                                     <input
                                         id="backfill-since"
                                         type="date"
                                         value={since}
                                         onChange={(event) => {
                                             setSince(event.target.value);
-                                            setExpensiveConfirmed(false);
+                                            resetConfirmation();
                                         }}
                                         aria-invalid={isRangeInvalid}
                                         aria-describedby={
                                             isRangeInvalid ? RANGE_ERROR_ID : undefined
                                         }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                        className="mt-1.5 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                                     />
-                                </div>
-                                <div className="flex-1">
-                                    <label
-                                        htmlFor="backfill-before"
-                                        className="mb-1.5 block text-sm font-medium text-(--ink-muted)"
-                                    >
-                                        To
-                                    </label>
+                                </label>
+                                <label
+                                    className="text-sm font-medium text-(--ink-muted)"
+                                    htmlFor="backfill-before"
+                                >
+                                    Before (exclusive)
                                     <input
                                         id="backfill-before"
                                         type="date"
                                         value={before}
                                         onChange={(event) => {
                                             setBefore(event.target.value);
-                                            setExpensiveConfirmed(false);
+                                            resetConfirmation();
                                         }}
                                         aria-invalid={isRangeInvalid}
                                         aria-describedby={
                                             isRangeInvalid ? RANGE_ERROR_ID : undefined
                                         }
-                                        className="w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
+                                        className="mt-1.5 w-full rounded-lg border border-(--card-stroke) bg-(--card-70) px-3 py-2 text-sm text-foreground focus:border-(--accent) focus:outline-none focus:ring-1 focus:ring-(--accent)"
                                     />
-                                </div>
+                                </label>
                             </div>
-
                             {isRangeInvalid && (
                                 <p
                                     id={RANGE_ERROR_ID}
                                     role="alert"
                                     className="text-sm text-(--negative)"
                                 >
-                                    Start date must be before end date.
+                                    Since must be before the exclusive boundary.
                                 </p>
                             )}
 
-                            <div className="grid gap-4 sm:grid-cols-2">
-                                <div className="space-y-1">
-                                    <p className="text-xs font-medium text-(--ink-muted) uppercase tracking-wider">
-                                        Affected datasets
-                                    </p>
-                                    <p className="text-sm text-foreground">
-                                        {datasetNames.length > 0
-                                            ? datasetNames.join(", ")
-                                            : "No coverage data yet"}
-                                    </p>
-                                </div>
-                                <div className="space-y-1">
-                                    <p className="text-xs font-medium text-(--ink-muted) uppercase tracking-wider">
-                                        Affected sources
-                                    </p>
-                                    <p className="text-sm text-foreground">
-                                        {sourceNames.length > 0
-                                            ? sourceNames.join(", ")
-                                            : "No coverage data yet"}
-                                    </p>
-                                </div>
-                            </div>
+                            <fieldset className="space-y-3 rounded-lg border border-(--card-stroke) p-4">
+                                <legend className="px-1 text-sm font-semibold text-foreground">
+                                    Repository or source scope
+                                </legend>
+                                <label className="flex items-start gap-2 text-sm">
+                                    <input
+                                        type="radio"
+                                        name="source-scope"
+                                        checked={sourceMode === "all"}
+                                        onChange={() => {
+                                            setSourceMode("all");
+                                            resetConfirmation();
+                                        }}
+                                        className="mt-0.5"
+                                    />
+                                    <span>
+                                        <span className="block text-foreground">
+                                            All enabled sources
+                                        </span>
+                                        <span className="text-xs text-(--ink-muted)">
+                                            Date-only compatible scope; the server resolves enabled
+                                            sources.
+                                        </span>
+                                    </span>
+                                </label>
+                                <label className="flex items-start gap-2 text-sm">
+                                    <input
+                                        type="radio"
+                                        name="source-scope"
+                                        checked={sourceMode === "selected"}
+                                        onChange={() => {
+                                            setSourceMode("selected");
+                                            resetConfirmation();
+                                        }}
+                                        disabled={sources.length === 0}
+                                        className="mt-0.5"
+                                    />
+                                    <span>
+                                        <span className="block text-foreground">
+                                            Choose specific sources
+                                        </span>
+                                        <span className="text-xs text-(--ink-muted)">
+                                            {sources.length === 0
+                                                ? "No authoritative source inventory is available."
+                                                : "Only checked sources will run."}
+                                        </span>
+                                    </span>
+                                </label>
+                                {sourceMode === "selected" && (
+                                    <div className="ml-6 grid gap-2 sm:grid-cols-2">
+                                        {sources.map((source) => (
+                                            <label
+                                                key={source.source_id}
+                                                className="flex items-center gap-2 text-sm text-foreground"
+                                            >
+                                                <input
+                                                    type="checkbox"
+                                                    checked={selectedSourceIds.includes(
+                                                        source.source_id,
+                                                    )}
+                                                    onChange={() => {
+                                                        setSelectedSourceIds((current) =>
+                                                            toggle(current, source.source_id),
+                                                        );
+                                                        resetConfirmation();
+                                                    }}
+                                                />
+                                                {source.source_name}
+                                            </label>
+                                        ))}
+                                    </div>
+                                )}
+                            </fieldset>
 
-                            <div className="flex items-center justify-end gap-2 pt-2">
+                            <fieldset className="space-y-3 rounded-lg border border-(--card-stroke) p-4">
+                                <legend className="px-1 text-sm font-semibold text-foreground">
+                                    Provider unit or dataset scope
+                                </legend>
+                                <label className="flex items-start gap-2 text-sm">
+                                    <input
+                                        type="radio"
+                                        name="dataset-scope"
+                                        checked={datasetMode === "all"}
+                                        onChange={() => {
+                                            setDatasetMode("all");
+                                            resetConfirmation();
+                                        }}
+                                        className="mt-0.5"
+                                    />
+                                    <span>
+                                        <span className="block text-foreground">
+                                            All enabled datasets
+                                        </span>
+                                        <span className="text-xs text-(--ink-muted)">
+                                            The server resolves the complete enabled dataset scope.
+                                        </span>
+                                    </span>
+                                </label>
+                                <label className="flex items-start gap-2 text-sm">
+                                    <input
+                                        type="radio"
+                                        name="dataset-scope"
+                                        checked={datasetMode === "selected"}
+                                        onChange={() => {
+                                            setDatasetMode("selected");
+                                            resetConfirmation();
+                                        }}
+                                        disabled={datasetChoices.length === 0}
+                                        className="mt-0.5"
+                                    />
+                                    <span>
+                                        <span className="block text-foreground">
+                                            Choose specific datasets
+                                        </span>
+                                        <span className="text-xs text-(--ink-muted)">
+                                            {datasetChoices.length === 0
+                                                ? "No authoritative dataset inventory is available."
+                                                : "Canonical work-item datasets are grouped into one execution family."}
+                                        </span>
+                                    </span>
+                                </label>
+                                {datasetMode === "selected" && (
+                                    <div className="ml-6 space-y-2">
+                                        {datasetChoices.map((choice) => (
+                                            <label
+                                                key={choice.id}
+                                                className="flex items-start gap-2 text-sm text-foreground"
+                                            >
+                                                <input
+                                                    type="checkbox"
+                                                    checked={selectedDatasetChoiceIds.includes(
+                                                        choice.id,
+                                                    )}
+                                                    onChange={() => {
+                                                        setSelectedDatasetChoiceIds((current) =>
+                                                            toggle(current, choice.id),
+                                                        );
+                                                        resetConfirmation();
+                                                    }}
+                                                    className="mt-0.5"
+                                                />
+                                                <span>
+                                                    {choice.label}
+                                                    {choice.datasetKeys.length > 1 && (
+                                                        <span className="block text-xs text-(--ink-muted)">
+                                                            Affects:{" "}
+                                                            {choice.datasetKeys
+                                                                .map(datasetLabel)
+                                                                .join(", ")}
+                                                        </span>
+                                                    )}
+                                                </span>
+                                            </label>
+                                        ))}
+                                    </div>
+                                )}
+                            </fieldset>
+
+                            {isScopeInvalid && (
+                                <p
+                                    id={SCOPE_ERROR_ID}
+                                    role="alert"
+                                    className="text-sm text-(--negative)"
+                                >
+                                    Choose at least one item in every focused scope, or switch that
+                                    scope to all enabled.
+                                </p>
+                            )}
+                            <div className="flex justify-end gap-2 pt-2">
                                 <button
                                     type="button"
                                     onClick={onCloseAction}
@@ -262,8 +454,9 @@ export function BackfillWizard({
                                 </button>
                                 <button
                                     type="button"
-                                    onClick={() => setStep("preview")}
+                                    onClick={() => setStep("review")}
                                     disabled={!canContinue}
+                                    aria-describedby={isScopeInvalid ? SCOPE_ERROR_ID : undefined}
                                     className="rounded-md bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90 disabled:opacity-50"
                                 >
                                     {CTA_LABELS.continueStep}
@@ -272,34 +465,66 @@ export function BackfillWizard({
                         </>
                     )}
 
-                    {step === "preview" && (
+                    {step === "review" && (
                         <>
-                            <dl className="grid grid-cols-2 gap-4 text-sm">
+                            <p className="text-sm text-(--ink-muted)">
+                                Review the exact bounded selector. Nothing outside this scope will
+                                be requested.
+                            </p>
+                            <dl className="grid gap-4 rounded-lg border border-(--card-stroke) p-4 text-sm sm:grid-cols-2">
                                 <div>
-                                    <dt className="text-xs font-medium text-(--ink-muted) uppercase tracking-wider">
-                                        Range
+                                    <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
+                                        Window
                                     </dt>
                                     <dd className="mt-1 text-foreground">
-                                        {since} → {before}
+                                        {since} inclusive → {before} exclusive
                                     </dd>
                                 </div>
                                 <div>
-                                    <dt className="text-xs font-medium text-(--ink-muted) uppercase tracking-wider">
+                                    <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
                                         Estimated chunks
                                     </dt>
                                     <dd className="mt-1 text-foreground">
-                                        ~{chunkEstimate} (estimate)
+                                        ~{chunkEstimate} per selected unit (estimate)
+                                    </dd>
+                                </div>
+                                <div>
+                                    <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
+                                        Sources
+                                    </dt>
+                                    <dd className="mt-1 text-foreground">
+                                        {sourceMode === "all"
+                                            ? "All enabled sources"
+                                            : selectedSourceNames.join(", ")}
+                                    </dd>
+                                </div>
+                                <div>
+                                    <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
+                                        Datasets
+                                    </dt>
+                                    <dd className="mt-1 text-foreground">
+                                        {datasetMode === "all"
+                                            ? "All enabled datasets"
+                                            : selectedDatasetChoices
+                                                  .map((choice) => choice.label)
+                                                  .join(", ")}
                                     </dd>
                                 </div>
                             </dl>
-
+                            {datasetMode === "selected" &&
+                                selectedDatasetKeys.length > selectedDatasetChoices.length && (
+                                    <p className="text-xs text-(--ink-muted)">
+                                        Canonical work-item family affects:{" "}
+                                        {selectedDatasetKeys.map(datasetLabel).join(", ")}.
+                                    </p>
+                                )}
                             {isExpensiveRange && (
                                 <div
                                     role="alert"
                                     className="space-y-3 rounded-lg border border-(--caution)/30 bg-(--caution)/15 p-4"
                                 >
                                     <p className="text-sm font-medium text-(--caution)">
-                                        ⚠ This range spans {days} days, more than{" "}
+                                        This range spans {days} days, more than{" "}
                                         {EXPENSIVE_RANGE_THRESHOLD_DAYS}. Large backfills can take a
                                         long time and consume significant sync capacity.
                                     </p>
@@ -320,17 +545,15 @@ export function BackfillWizard({
                                     </label>
                                 </div>
                             )}
-
                             {submitError && (
                                 <p role="alert" className="text-sm text-(--negative)">
                                     {submitError}
                                 </p>
                             )}
-
-                            <div className="flex items-center justify-end gap-2 pt-2">
+                            <div className="flex justify-end gap-2 pt-2">
                                 <button
                                     type="button"
-                                    onClick={() => setStep("range")}
+                                    onClick={() => setStep("scope")}
                                     className="rounded-md border border-(--card-stroke) px-4 py-2 text-sm"
                                 >
                                     {CTA_LABELS.backButton}
@@ -350,8 +573,8 @@ export function BackfillWizard({
                     {step === "result" && (
                         <>
                             <p className="text-sm text-foreground">
-                                Backfill started. Progress will appear on this page as the backend
-                                processes the range.
+                                Backfill started for the reviewed scope. Progress will appear on
+                                this page.
                             </p>
                             {submittedSyncRunId && (
                                 <Link
@@ -361,7 +584,7 @@ export function BackfillWizard({
                                     {CTA_LABELS.viewRun}
                                 </Link>
                             )}
-                            <div className="flex items-center justify-end pt-2">
+                            <div className="flex justify-end pt-2">
                                 <button
                                     type="button"
                                     onClick={onCloseAction}

--- a/src/lib/admin/__tests__/server.test.ts
+++ b/src/lib/admin/__tests__/server.test.ts
@@ -307,9 +307,27 @@ describe("admin/server sync config actions", () => {
                 ),
             );
 
-            const result = await triggerBackfill("cfg-coverage", "2026-06-01", "2026-06-05");
+            const result = await triggerBackfill("cfg-coverage", {
+                since: "2026-06-01T00:00:00.000Z",
+                before: "2026-06-05T00:00:00.000Z",
+                source_ids: ["source-1"],
+                dataset_keys: ["commits"],
+            });
 
             expect(result.data?.sync_run_id).toBe("run-1");
+            const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+            expect(url).toBe(
+                "http://test-ops:8000/api/v1/admin/sync-configs/cfg-coverage/backfill",
+            );
+            expect(JSON.parse(String(options?.body))).toEqual({
+                selector: {
+                    since: "2026-06-01T00:00:00.000Z",
+                    before: "2026-06-05T00:00:00.000Z",
+                    source_ids: ["source-1"],
+                    dataset_keys: ["commits"],
+                },
+            });
+            expect(JSON.parse(String(options?.body))).not.toHaveProperty("since");
             expect(revalidatePath).toHaveBeenCalledWith("/org/admin/sync");
             expect(revalidatePath).toHaveBeenCalledWith("/org/admin/sync/cfg-coverage");
             fetchSpy.mockRestore();

--- a/src/lib/admin/api/sync.ts
+++ b/src/lib/admin/api/sync.ts
@@ -15,6 +15,7 @@ import type {
     SyncRun,
     SyncRunUnitSummary,
     SyncCoverageSummary,
+    BackfillRequest,
 } from "../types";
 
 export interface SyncJobsListParams {
@@ -94,12 +95,7 @@ export const syncConfigsApi = {
             orgId,
         ),
 
-    backfill: (
-        id: string,
-        data: { since: string; before: string },
-        token?: string,
-        orgId?: string,
-    ) =>
+    backfill: (id: string, data: BackfillRequest, token?: string, orgId?: string) =>
         request<BackfillResponse>(
             `/sync-configs/${id}/backfill`,
             { method: "POST", body: JSON.stringify(data) },

--- a/src/lib/admin/server/sync.ts
+++ b/src/lib/admin/server/sync.ts
@@ -19,6 +19,7 @@ import type {
     SyncRun,
     SyncRunUnitSummary,
     SyncCoverageSummary,
+    BackfillSelector,
 } from "../types";
 import { requirePagerDutyCreationEntitlement } from "./canonicalIncidentIngestion";
 import { getSessionContext, withErrorHandling } from "./_shared";
@@ -114,12 +115,11 @@ export async function updateSyncConfigRepositories(
 
 export async function triggerBackfill(
     configId: string,
-    since: string,
-    before: string,
+    selector: BackfillSelector,
 ): Promise<ActionResult<BackfillResponse>> {
     return withErrorHandling(async () => {
         const { token, orgId } = await getSessionContext();
-        const res = await adminApi.syncConfigs.backfill(configId, { since, before }, token, orgId);
+        const res = await adminApi.syncConfigs.backfill(configId, { selector }, token, orgId);
         revalidatePath("/org/admin/sync");
         revalidatePath(`/org/admin/sync/${configId}`);
         return res;

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -428,17 +428,24 @@ export interface SyncConfigCreate {
     initial_sync_depth?: number | null;
 }
 
-export interface BackfillRequest {
+export interface BackfillSelector {
     since: string;
     before: string;
+    source_ids?: string[];
+    dataset_keys?: string[];
+}
+
+/** CHAOS-3758 structured selector. Never combine this with legacy flat fields. */
+export interface BackfillRequest {
+    selector: BackfillSelector;
 }
 
 export interface BackfillResponse {
-    task_id: string;
     status: string;
-    backfill_job_id: string;
-    /** Present on the backend response (routers/sync.py); optional here for defensive forward-compat. */
+    task_id?: string;
+    backfill_job_id?: string;
     sync_run_id?: string;
+    total_units?: number;
 }
 
 export interface BackfillJob {

--- a/tests/admin-sync-observability.spec.ts
+++ b/tests/admin-sync-observability.spec.ts
@@ -173,8 +173,8 @@ test.describe("Journey 2 — gap-driven backfill flow", () => {
             await expect(dialog).toBeVisible({ timeout: 3000 });
         }).toPass({ timeout: 30000, intervals: [300, 700, 1500] });
 
-        await expect(page.getByLabel("From", { exact: true })).toHaveValue("2026-06-24");
-        await expect(page.getByLabel("To", { exact: true })).toHaveValue("2026-06-26");
+        await expect(page.getByLabel("Since (inclusive)")).toHaveValue("2026-06-24");
+        await expect(page.getByLabel("Before (exclusive)")).toHaveValue("2026-06-26");
     });
 
     test("opens the wizard prefilled from a gap, validates the range, previews an estimate, gates an expensive submit, and completes in test mode", async ({
@@ -192,28 +192,38 @@ test.describe("Journey 2 — gap-driven backfill flow", () => {
 
         const dialog = page.getByRole("dialog");
         await expect(dialog).toBeVisible();
-        await expect(page.getByLabel("From", { exact: true })).toHaveValue("2026-06-24");
-        await expect(page.getByLabel("To", { exact: true })).toHaveValue("2026-06-26");
+        await expect(page.getByLabel("Since (inclusive)")).toHaveValue("2026-06-24");
+        await expect(page.getByLabel("Before (exclusive)")).toHaveValue("2026-06-26");
 
-        // Invalid range: "To" before "From" blocks Continue with an inline error.
-        await page.getByLabel("To", { exact: true }).fill("2026-06-20");
-        await expect(dialog.getByRole("alert")).toHaveText("Start date must be before end date.");
+        // Invalid range: exclusive boundary before since blocks Continue.
+        await page.getByLabel("Before (exclusive)").fill("2026-06-20");
+        await expect(dialog.getByRole("alert")).toContainText("exclusive boundary");
         await expect(dialog.getByRole("button", { name: "Continue" })).toBeDisabled();
 
         // Restore a valid range — the error clears and Continue is enabled.
-        await page.getByLabel("To", { exact: true }).fill("2026-06-26");
+        await page.getByLabel("Before (exclusive)").fill("2026-06-26");
         await expect(dialog.getByRole("alert")).toHaveCount(0);
+
+        // Focus both dimensions using only authoritative page inventory.
+        await dialog.getByRole("radio", { name: /Choose specific sources/ }).check();
+        await dialog.getByLabel("fullchaos/platform-api").check();
+        await dialog.getByRole("radio", { name: /Choose specific datasets/ }).check();
+        await dialog.getByLabel("Git Data (Commits, Branches)").check();
         await dialog.getByRole("button", { name: "Continue" }).click();
 
-        // Preview step shows an estimate.
+        // Review shows the exact focused scope and an estimate.
         await expect(dialog.getByText("Estimated chunks")).toBeVisible();
         await expect(dialog.getByText(/\(estimate\)/)).toBeVisible();
+        await expect(dialog.getByText("fullchaos/platform-api", { exact: true })).toBeVisible();
+        await expect(
+            dialog.getByText("Git Data (Commits, Branches)", { exact: true }),
+        ).toBeVisible();
         await expect(dialog.getByRole("alert")).toHaveCount(0);
 
         // Go back and set a >180 day range — the expensive-range warning gates submit.
         await dialog.getByRole("button", { name: /^Back$/ }).click();
-        await page.getByLabel("From", { exact: true }).fill("2026-01-01");
-        await page.getByLabel("To", { exact: true }).fill("2026-12-01");
+        await page.getByLabel("Since (inclusive)").fill("2026-01-01");
+        await page.getByLabel("Before (exclusive)").fill("2026-12-01");
         await dialog.getByRole("button", { name: "Continue" }).click();
 
         await expect(dialog.getByRole("alert")).toContainText("more than 180");

--- a/tests/screenshot-chaos-2795.spec.ts
+++ b/tests/screenshot-chaos-2795.spec.ts
@@ -25,10 +25,10 @@ test.describe("CHAOS-2795/2796 screenshots", () => {
         await page.getByRole("button", { name: "Backfill", exact: true }).first().click();
 
         await page.getByRole("dialog").waitFor({ timeout: NAV_TIMEOUT });
-        await page.getByLabel("From", { exact: true }).fill("2026-06-10");
-        await page.getByLabel("To", { exact: true }).fill("2026-06-01");
+        await page.getByLabel("Since (inclusive)", { exact: true }).fill("2026-06-10");
+        await page.getByLabel("Before (exclusive)", { exact: true }).fill("2026-06-01");
         await expect(page.getByRole("dialog").getByRole("alert")).toHaveText(
-            "Start date must be before end date.",
+            "Since must be before the exclusive boundary.",
         );
 
         await page.screenshot({
@@ -48,8 +48,8 @@ test.describe("CHAOS-2795/2796 screenshots", () => {
         await page.getByRole("button", { name: "Backfill", exact: true }).first().click();
         await page.getByRole("dialog").waitFor({ timeout: NAV_TIMEOUT });
 
-        await page.getByLabel("From", { exact: true }).fill("2026-01-01");
-        await page.getByLabel("To", { exact: true }).fill("2026-12-01");
+        await page.getByLabel("Since (inclusive)", { exact: true }).fill("2026-01-01");
+        await page.getByLabel("Before (exclusive)", { exact: true }).fill("2026-12-01");
         await page.getByRole("button", { name: "Continue" }).click();
 
         await expect(page.getByText("Estimated chunks")).toBeVisible();
@@ -70,7 +70,7 @@ test.describe("CHAOS-2795/2796 screenshots", () => {
         await gapButton.click();
 
         await page.getByRole("dialog").waitFor({ timeout: NAV_TIMEOUT });
-        const fromValue = await page.getByLabel("From", { exact: true }).inputValue();
+        const fromValue = await page.getByLabel("Since (inclusive)", { exact: true }).inputValue();
         expect(fromValue).not.toBe("");
 
         await page.screenshot({


### PR DESCRIPTION
## Summary

- extend the existing admin backfill wizard with exact inclusive/exclusive date, source, and dataset selectors
- submit only the CHAOS-3758 nested `{ selector: ... }` request shape while keeping the default date-only scope compatible
- prevent empty focused selections from silently widening to all enabled data
- collapse work-item aliases into one canonical family choice and show every affected dataset in review
- preserve server-owned gap/window prefills, expensive-range confirmation, focus management, and the test-mode journey

## Dependency

Depends on [dev-health-ops #1737](https://github.com/full-chaos/dev-health-ops/pull/1737), which adds the nested selector contract to the existing sync-config backfill endpoint.

## TEST-EVIDENCE

- `./node_modules/.bin/vitest run src/components/admin/sync/BackfillWizard.test.tsx src/components/admin/sync/BackfillOperations.test.tsx src/lib/admin/__tests__/server.test.ts --reporter=dot` — 3 files, 62 tests passed
- `./node_modules/.bin/playwright test tests/admin-sync-observability.spec.ts --project=authenticated` — 11 journeys passed
- `./node_modules/.bin/tsc --noEmit` — passed
- `./node_modules/.bin/eslint src` — passed
- `DESIGN_LINT=true ./node_modules/.bin/eslint src && node scripts/design-lint.mjs` — passed; all four static scan counters zero
- changed-file Prettier check and `git diff --check` — passed
- desktop selector and review states inspected at 1440x1100 in test mode; browser reported zero console errors

## RISK-NOTES

- This UI must not land independently of ops #1737 because current main accepts only legacy flat dates on the sync-config backfill endpoint.
- Focused options come only from the authoritative coverage response already loaded by the config page. When that inventory is unavailable, date-only remains usable and focused controls stay disabled rather than accepting guessed identifiers.
- The chunk count remains explicitly labelled as an estimate; backend planning is authoritative.

## Visual evidence

Focused source and dataset selector:

![Focused backfill selector](https://github.com/user-attachments/assets/1c4a9cac-df8c-4eba-97ac-dcdf891e02c9)

Exact bounded selector review:

![Focused backfill review](https://github.com/user-attachments/assets/a8031070-eb16-4e96-bc92-4cbf67000ce5)
