### PR TITLE
feat(ask-dev): pin no-answer vocabulary artifact (CHAOS-3471 part 2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
               with:
                   repository: full-chaos/dev-health-ops
-                  ref: cfe94369368ca3c81f0d6a3ce9e80a8f3530320e
+                  ref: b45450e19e8e9d6292e3cd88a94f71ed2d5619b3
                   path: dev-health-ops
                   persist-credentials: false
             # CHAOS-3511 currency guard: ops main's tip as of this run, checked

--- a/scripts/ask-dev-contracts.mjs
+++ b/scripts/ask-dev-contracts.mjs
@@ -12,7 +12,7 @@ import { format } from "prettier";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ARTIFACT_ROOT = path.join(ROOT, "src/lib/dev/contracts");
 const GENERATED_PATH = path.join(ROOT, "src/lib/dev/generated.ts");
-const SOURCE_COMMIT = "cfe94369368ca3c81f0d6a3ce9e80a8f3530320e";
+const SOURCE_COMMIT = "b45450e19e8e9d6292e3cd88a94f71ed2d5619b3";
 const SOURCE_PREFIX = "contracts/ask-dev/v1/";
 const PRETTIER_OPTIONS = Object.freeze({
     parser: "typescript",
@@ -196,7 +196,37 @@ async function generatedTypes(files) {
     );
 }
 
+/**
+ * CHAOS-3471 cross-repo rule: web's consumption of an ops-published
+ * artifact must degrade LOUDLY, never silently, when the pinned/checked-out
+ * ops source predates that artifact -- e.g. a re-pin that lands on an ops
+ * commit before the no-answer vocabulary artifact was published there, or a
+ * `--source` pointed at a stale ops checkout. Without this, `files` simply
+ * would not include the path, `generate` would happily write a smaller
+ * artifact set, and `tests/mocks/devScenario.ts`'s JSON import of the
+ * missing file would fail with a generic bundler "module not found" error
+ * that names neither the cause nor the fix.
+ */
+const REQUIRED_VOCABULARY_ARTIFACTS = Object.freeze(["vocabulary/no_answer_vocabulary.v1.json"]);
+
+function assertRequiredArtifactsPresent(files) {
+    const paths = new Set(files.map((file) => file.path));
+    const missing = REQUIRED_VOCABULARY_ARTIFACTS.filter((required) => !paths.has(required));
+    if (missing.length > 0) {
+        throw new Error(
+            `NOT_RUN: the Ask Dev contract source is missing required artifact(s): ` +
+                `${missing.join(", ")}. The pinned/checked-out ops commit predates the artifact ` +
+                "this repo requires (CHAOS-3471) -- point --source at an ops checkout that " +
+                "publishes it, or re-pin SOURCE_COMMIT (and the matching ref in " +
+                ".github/workflows/tests.yml) to one that does. Not treating this as ordinary " +
+                "drift: an absent required artifact must fail loudly here, not surface later as " +
+                "a downstream module-resolution error.",
+        );
+    }
+}
+
 async function expected(files) {
+    assertRequiredArtifactsPresent(files);
     return {
         artifacts: Object.fromEntries(files.map((file) => [file.path, file.contents])),
         generated: await generatedTypes(files),

--- a/src/lib/dev/__tests__/contracts.test.ts
+++ b/src/lib/dev/__tests__/contracts.test.ts
@@ -76,7 +76,7 @@ describe("Ask Dev generated contract boundary", () => {
         const source = readJson<SourceManifest>("source.json");
         const manifest = readJson<OpsManifest>("manifest.json");
 
-        expect(source.source_commit).toBe("cfe94369368ca3c81f0d6a3ce9e80a8f3530320e");
+        expect(source.source_commit).toBe("b45450e19e8e9d6292e3cd88a94f71ed2d5619b3");
         expect(manifest.schema_version).toBe("ask_dev_contract_manifest.v1");
         expect(manifest.compatibility).toBe("additive-within-v1");
         expect(manifest.contracts.map((contract) => contract.schema_version)).toEqual(

--- a/src/lib/dev/contracts/manifest.json
+++ b/src/lib/dev/contracts/manifest.json
@@ -493,6 +493,11 @@
       "case": "source_health_labels",
       "path": "vocabulary/source_health_labels.v1.json",
       "sha256": "f141c442d84b55d59d40e5b20deba5ad810ee8d5a7c91f59c68545006d66ef7e"
+    },
+    {
+      "case": "no_answer_vocabulary",
+      "path": "vocabulary/no_answer_vocabulary.v1.json",
+      "sha256": "0fe3195b46e924bce7bf98d8d1e9372fe4a0044fa34591b19eedb00ca3e9d9c1"
     }
   ]
 }

--- a/src/lib/dev/contracts/source.json
+++ b/src/lib/dev/contracts/source.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "ask_dev_web_contract_source.v1",
-  "source_commit": "cfe94369368ca3c81f0d6a3ce9e80a8f3530320e",
+  "source_commit": "b45450e19e8e9d6292e3cd88a94f71ed2d5619b3",
   "files": [
     {
       "path": "examples/negative/dev_answer.v1.graph_assisted_unknown_evidence_id.json",
@@ -256,7 +256,7 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "4dc01a2a9adead11e98b1f638360fc6b15a12650589f0f46ec5f4f94919d76fc"
+      "sha256": "43017f7404682fa14725032c02e83e8f49351aa8aeb1c42c69233a088794bb18"
     },
     {
       "path": "schemas/dev_answer.v1.schema.json",
@@ -333,6 +333,10 @@
     {
       "path": "vocabulary/internal_prose_denylist.v1.json",
       "sha256": "9b0c5b07612de95c2854abca5c018e98c30e3113262807e8d71872b50722ecbb"
+    },
+    {
+      "path": "vocabulary/no_answer_vocabulary.v1.json",
+      "sha256": "0fe3195b46e924bce7bf98d8d1e9372fe4a0044fa34591b19eedb00ca3e9d9c1"
     },
     {
       "path": "vocabulary/source_health_labels.v1.json",

--- a/src/lib/dev/contracts/vocabulary/no_answer_vocabulary.v1.json
+++ b/src/lib/dev/contracts/vocabulary/no_answer_vocabulary.v1.json
@@ -1,0 +1,53 @@
+{
+  "outcomes": {
+    "denied": {
+      "code": "forbidden",
+      "remediation": [
+        "Ask an administrator for access to this area."
+      ],
+      "retryable": false,
+      "safe_message": "You do not have access to ask about this."
+    },
+    "failed": {
+      "code": "internal_error",
+      "remediation": [
+        "Try the question again."
+      ],
+      "retryable": false,
+      "safe_message": "Something went wrong while preparing this answer."
+    },
+    "not_found": {
+      "code": "scope_not_found",
+      "remediation": [
+        "Check the name and try again."
+      ],
+      "retryable": false,
+      "safe_message": "No matching subject was found for this question."
+    },
+    "refused": {
+      "code": "refused",
+      "remediation": [
+        "Ask a read-only question about your data instead."
+      ],
+      "retryable": false,
+      "safe_message": "Ask Dev can only read and summarize your data; it can't run commands or make changes."
+    },
+    "temporarily_unavailable": {
+      "code": "source_unavailable",
+      "remediation": [
+        "Try the question again in a few minutes."
+      ],
+      "retryable": true,
+      "safe_message": "This answer is temporarily unavailable. Please try again shortly."
+    },
+    "unsupported": {
+      "code": "feature_not_enabled",
+      "remediation": [
+        "Try a status, health, or metric question instead."
+      ],
+      "retryable": false,
+      "safe_message": "This question is not supported yet."
+    }
+  },
+  "schema_version": "ask_dev_no_answer_vocabulary.v1"
+}

--- a/src/lib/dev/generated.ts
+++ b/src/lib/dev/generated.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-// Generated from full-chaos/dev-health-ops cfe94369368ca3c81f0d6a3ce9e80a8f3530320e. Do not edit.
+// Generated from full-chaos/dev-health-ops b45450e19e8e9d6292e3cd88a94f71ed2d5619b3. Do not edit.
 export namespace DevAnswerGraphAssistanceContract {
     export type AsOf = string;
     export type CohortComplete = boolean;

--- a/tests/ask-dev-outcomes.spec.ts
+++ b/tests/ask-dev-outcomes.spec.ts
@@ -18,6 +18,7 @@ import {
     CLARIFICATION_COPY,
     NO_ANSWER_OUTCOMES,
     NOT_READY_READINESS_VALUES,
+    PINNED_NO_ANSWER_OUTCOME_KEYS,
 } from "./mocks/devScenario";
 
 // CHAOS-3287: every public outcome the current dev_answer.v1 contract can
@@ -265,12 +266,37 @@ test.describe("Ask Dev — answer status outcomes", () => {
         });
     }
 
-    // CHAOS-3219 W1. Five of the eight dev_answer.v2 public outcomes never
-    // become an answer at all: the projector turns each into a DevError
-    // carrying server-owned canonical copy (ops
-    // contracts_v2/compat.py:484-494). Those sentences are therefore the
-    // ENTIRE user-visible artifact of those outcomes, and until now the
-    // default suite emitted 2 of 24 DevErrorCodes and asserted none of them.
+    // Codex round-2 finding 2: the loop below iterates NO_ANSWER_OUTCOMES (a
+    // hand-maintained table), never the pinned artifact's own keys directly
+    // -- so a 7th outcome ops adds gets no test until someone remembers to
+    // add a row, and a row deleted from the table silently deletes its test,
+    // with nothing here to fail either way. This asserts the two sets are
+    // exactly equal, both directions, so either drift fails loudly.
+    test("NO_ANSWER_OUTCOMES covers exactly the outcomes the pinned artifact publishes", () => {
+        const tableKeys = [...new Set(NO_ANSWER_OUTCOMES.map((entry) => entry.outcome))].sort();
+        const artifactKeys = [...PINNED_NO_ANSWER_OUTCOME_KEYS];
+        const missingFromTable = artifactKeys.filter((key) => !tableKeys.includes(key));
+        const extraInTable = tableKeys.filter((key) => !artifactKeys.includes(key));
+        expect(
+            missingFromTable,
+            "the pinned artifact publishes outcome(s) with no NO_ANSWER_OUTCOMES entry -- add a " +
+                "row so this outcome actually gets an e2e test",
+        ).toEqual([]);
+        expect(
+            extraInTable,
+            "NO_ANSWER_OUTCOMES has an entry with no matching artifact outcome -- remove the " +
+                "stale row",
+        ).toEqual([]);
+    });
+
+    // CHAOS-3219 W1 / CHAOS-3471. Six of the eight dev_answer.v2 public
+    // outcomes never become an answer at all: the projector turns each into
+    // a DevError carrying server-owned canonical copy, published as the
+    // pinned no_answer_vocabulary.v1.json artifact (ops
+    // contracts_v2/compat.py's no_answer_error_projection). Those sentences
+    // are therefore the ENTIRE user-visible artifact of those outcomes, and
+    // until CHAOS-3219 W1 the default suite emitted 2 of 24 DevErrorCodes
+    // and asserted none of them.
     for (const outcome of NO_ANSWER_OUTCOMES) {
         test(`${outcome.outcome}: renders the canonical no-answer copy and the correct retry affordance`, async ({
             page,

--- a/tests/mocks/devScenario.test.ts
+++ b/tests/mocks/devScenario.test.ts
@@ -121,9 +121,9 @@ describe("Ask Dev mock fidelity — organization fallback", () => {
 });
 
 describe("Ask Dev mock fidelity — no-answer outcomes", () => {
-    // These five never become a DevAnswer at all: the projector turns each
-    // into a DevError whose code/retryable come from `_ERROR_OUTCOME_CODES`
-    // and whose text comes from the server-owned canonical tables.
+    // These six never become a DevAnswer at all: the projector turns each
+    // into a DevError whose code/retryable/text come from the pinned
+    // no_answer_vocabulary.v1.json artifact (CHAOS-3471).
     for (const outcome of NO_ANSWER_OUTCOMES) {
         it(`${outcome.outcome} projects to a ${outcome.code} DevError, never an answer`, () => {
             const events = buildStreamEvents(outcome.scenario, "conversation_test", "A question");
@@ -155,11 +155,13 @@ describe("Ask Dev mock fidelity — scope.resolved on error terminals (CHAOS-352
     //   unsupported            -> null (no scope.resolved at all)
     //   denied                 -> null (no scope.resolved at all)
     //   failed                 -> exact
-    // `unsupported`/`denied` are refused before any catalog round trip (a
-    // preflight bound, or a provider-level refusal) -- the run never
-    // resolves scope at all, so publishing a resolution for either would be
-    // inventing one the run never reached (`streaming.py`'s own negative
-    // control: "a run that never resolved scope emits no scope frame").
+    //   refused                -> null (no scope.resolved at all)
+    // `unsupported`/`denied`/`refused` are refused before any catalog round
+    // trip (a preflight bound, a provider-level refusal, or CHAOS-3541's
+    // categorical action refusal) -- the run never resolves scope at all, so
+    // publishing a resolution for any of them would be inventing one the run
+    // never reached (`streaming.py`'s own negative control: "a run that
+    // never resolved scope emits no scope frame").
     const SCOPE_RESOLUTION_BY_OUTCOME: Record<
         (typeof NO_ANSWER_OUTCOMES)[number]["outcome"],
         string | null
@@ -169,6 +171,7 @@ describe("Ask Dev mock fidelity — scope.resolved on error terminals (CHAOS-352
         unsupported: null,
         denied: null,
         failed: "exact",
+        refused: null,
     };
 
     function eventsFor(scenario: DevAnswerScenario) {

--- a/tests/mocks/devScenario.ts
+++ b/tests/mocks/devScenario.ts
@@ -22,6 +22,7 @@ import { randomUUID } from "node:crypto";
 
 import answerFixture from "../../src/lib/dev/contracts/examples/positive/dev_answer.v1.json";
 import capabilitiesFixture from "../../src/lib/dev/contracts/examples/positive/dev_capabilities.v1.json";
+import noAnswerVocabularyArtifact from "../../src/lib/dev/contracts/vocabulary/no_answer_vocabulary.v1.json";
 import { ASK_DEV_OUTCOME_TABLE, outcomeCase } from "../fixtures/askDevOutcomes";
 
 type JsonRecord = Record<string, unknown>;
@@ -33,15 +34,114 @@ function clone<T>(value: T): T {
 const OUTCOME_TABLE_KEYS = ASK_DEV_OUTCOME_TABLE.map((entry) => entry.key);
 
 /**
- * The five `dev_answer.v2` no-answer outcomes as they reach a v1 client.
+ * The pinned no-answer vocabulary artifact (CHAOS-3471), typed. ops
+ * publishes this from the live `CANONICAL_NO_ANSWER_COPY` /
+ * `CANONICAL_NO_ANSWER_REMEDIATION` / error-code tables
+ * (`contracts_v2/no_answer_policy.py`, `contracts_v2/compat.py`'s
+ * `no_answer_error_projection`) — see
+ * `dev-health-ops/src/dev_health_ops/api/dev/export_contracts.py`. Web pins
+ * it the same way it already pins the JSON-schema artifacts
+ * (`scripts/ask-dev-contracts.mjs`'s `SOURCE_COMMIT`).
+ */
+type NoAnswerVocabularyOutcome = {
+    readonly safe_message: string;
+    readonly remediation: readonly string[];
+    readonly code: string;
+    readonly retryable: boolean;
+};
+type NoAnswerVocabularyArtifact = {
+    readonly schema_version: string;
+    readonly outcomes: Readonly<Record<string, NoAnswerVocabularyOutcome>>;
+};
+const NO_ANSWER_VOCABULARY = noAnswerVocabularyArtifact as NoAnswerVocabularyArtifact;
+
+/**
+ * Every outcome key the pinned artifact actually publishes, sorted.
+ * Exported so a consumer (`ask-dev-outcomes.spec.ts`) can assert
+ * `NO_ANSWER_OUTCOMES` below is EXACTLY this set, not a hand-maintained
+ * table that silently drifted from it — codex round-2 finding 2: the
+ * e2e loop iterates `NO_ANSWER_OUTCOMES`, not the artifact's own keys, so a
+ * 7th outcome ops adds gets no test and a row deleted from the table
+ * silently deletes its test, with nothing to fail either way.
+ */
+export const PINNED_NO_ANSWER_OUTCOME_KEYS: readonly string[] = Object.keys(
+    NO_ANSWER_VOCABULARY.outcomes,
+).sort();
+
+/**
+ * NOT_RUN guard (CHAOS-3471, cross-repo rule): fails loudly and by name at
+ * import time if the pinned artifact is missing an outcome, or a required
+ * FIELD of one, this suite expects — rather than letting a malformed/
+ * renamed field silently become `undefined` and flow into a mock-fidelity
+ * test that derives its own "expected" value from that same object
+ * (codex round-2 finding 1: the earlier version type-cast the import
+ * unchecked and verified only that the outcome KEY existed, not that each
+ * field was actually present and correctly typed). The companion guard on
+ * the sync side (`scripts/ask-dev-contracts.mjs`) fails just as loudly,
+ * earlier, if the whole artifact file is missing from the pinned ops source
+ * — this one covers the file existing but a single outcome being
+ * incomplete or a field renamed. Maps the artifact's `safe_message` to this
+ * file's (and every consumer's) pre-existing `safeMessage` field name;
+ * `code`/`retryable`/`remediation` already match.
+ */
+function pinnedNoAnswerVocabularyEntry(outcome: string): {
+    code: string;
+    retryable: boolean;
+    safeMessage: string;
+    remediation: readonly string[];
+} {
+    const entry = NO_ANSWER_VOCABULARY.outcomes[outcome];
+    if (!entry) {
+        throw new Error(
+            `NOT_RUN: pinned no_answer_vocabulary.v1.json has no entry for outcome "${outcome}". ` +
+                "Either this suite's NO_ANSWER_OUTCOMES table is ahead of the pinned ops artifact " +
+                "(re-pin against an ops commit that publishes it), or the artifact regenerated " +
+                "incomplete -- do not assume this outcome's copy/remediation/retryable behavior.",
+        );
+    }
+    const invalidFields: string[] = [];
+    if (typeof entry.code !== "string" || entry.code.length === 0) {
+        invalidFields.push("code");
+    }
+    if (typeof entry.retryable !== "boolean") {
+        invalidFields.push("retryable");
+    }
+    if (typeof entry.safe_message !== "string" || entry.safe_message.length === 0) {
+        invalidFields.push("safe_message");
+    }
+    if (
+        !Array.isArray(entry.remediation) ||
+        entry.remediation.length === 0 ||
+        !entry.remediation.every((item) => typeof item === "string")
+    ) {
+        invalidFields.push("remediation");
+    }
+    if (invalidFields.length > 0) {
+        throw new Error(
+            `NOT_RUN: pinned no_answer_vocabulary.v1.json's "${outcome}" entry is missing or has ` +
+                `a malformed field(s): ${invalidFields.join(", ")}. A renamed, removed, or wrongly ` +
+                "typed field in the ops artifact must fail loudly here, never flow through as " +
+                "undefined into a test that derives its own expectation from this same object.",
+        );
+    }
+    return {
+        code: entry.code,
+        retryable: entry.retryable,
+        safeMessage: entry.safe_message,
+        remediation: entry.remediation,
+    };
+}
+
+/**
+ * The six `dev_answer.v2` no-answer outcomes as they reach a v1 client.
  *
  * `PublicOutcome` values in `NO_ANSWER_OUTCOMES` never become a `DevAnswer`:
- * the projector turns each into a `DevError` whose code and `retryable` flag
- * come from `_ERROR_OUTCOME_CODES` and whose text comes from the server-owned
- * `CANONICAL_NO_ANSWER_COPY` / `CANONICAL_NO_ANSWER_REMEDIATION` tables
- * (ops contracts_v2/compat.py:209-214, :484-494; validators.py). Producer
- * text is replaced wholesale, never trimmed or re-emitted, so these sentences
- * are the entire user-visible artifact of four of the eight outcomes.
+ * the projector turns each into a `DevError` whose code/retryable/copy come
+ * from `compat.no_answer_error_projection`, the same function ops's
+ * artifact exporter calls (CHAOS-3471 round-1 finding 1+2 fix — see that
+ * function's docstring on the ops side). Text is replaced wholesale, never
+ * trimmed or re-emitted, so these sentences are the entire user-visible
+ * artifact of six of the eight `dev_answer.v2` outcomes.
  *
  * What the specs built on this table DO prove: the UI renders the server's
  * `safe_message` verbatim (none of these sentences exists anywhere in web
@@ -49,24 +149,19 @@ const OUTCOME_TABLE_KEYS = ASK_DEV_OUTCOME_TABLE.map((entry) => entry.key);
  * renders its own distinct copy rather than one reused apology, and the
  * retry affordance follows `retryable`.
  *
- * What they DO NOT prove: that this table still matches ops. These strings
- * are a HAND-PINNED MIRROR — the canonical tables are Python constants in
- * `validators.py` and are not exported into any artifact web pins, so
- * nothing here detects ops-side drift. Compared to the ops source by script
- * on 2026-08-06 — all five entries match on both copy and remediation, and
- * the mirrored key set equals the ops key set — but that check has no
- * automated successor. Closing the gap needs the copy published as a pinned
- * contract vocabulary artifact (as `internal_prose_denylist.v1.json` already
- * is); tracked in CHAOS-3471.
+ * `code`/`retryable`/`safeMessage`/`remediation` below are read from the
+ * PINNED ARTIFACT (`no_answer_vocabulary.v1.json`), not hand-typed — an
+ * ops-side reword now fails the pin check (`pnpm ask-dev:contracts:check`)
+ * instead of silently passing here. `scenario` (this file's own dispatch
+ * key) and `scopeResolutionOutcome` (below) are WEB-ONLY test metadata, not
+ * part of the ops artifact — they stay hand-pinned against the ops
+ * acceptance corpus, same as before.
  */
 export const NO_ANSWER_OUTCOMES = [
     {
         outcome: "not_found",
         scenario: "no_answer_not_found",
-        code: "scope_not_found",
-        retryable: false,
-        safeMessage: "No matching subject was found for this question.",
-        remediation: ["Check the name and try again."],
+        ...pinnedNoAnswerVocabularyEntry("not_found"),
         // See `SCOPE_RESOLUTION_OUTCOME_BY_NO_ANSWER` below for what this
         // field means and where it comes from.
         scopeResolutionOutcome: "unresolved",
@@ -74,40 +169,50 @@ export const NO_ANSWER_OUTCOMES = [
     {
         outcome: "temporarily_unavailable",
         scenario: "no_answer_temporarily_unavailable",
-        code: "source_unavailable",
-        retryable: true,
-        safeMessage: "This answer is temporarily unavailable. Please try again shortly.",
-        remediation: ["Try the question again in a few minutes."],
+        ...pinnedNoAnswerVocabularyEntry("temporarily_unavailable"),
         scopeResolutionOutcome: "exact",
     },
     {
         outcome: "unsupported",
         scenario: "no_answer_unsupported",
-        code: "feature_not_enabled",
-        retryable: false,
-        safeMessage: "This question is not supported yet.",
-        remediation: ["Try a status, health, or metric question instead."],
+        ...pinnedNoAnswerVocabularyEntry("unsupported"),
         scopeResolutionOutcome: null,
     },
     {
         outcome: "denied",
         scenario: "no_answer_denied",
-        code: "forbidden",
-        retryable: false,
-        safeMessage: "You do not have access to ask about this.",
-        remediation: ["Ask an administrator for access to this area."],
+        ...pinnedNoAnswerVocabularyEntry("denied"),
         scopeResolutionOutcome: null,
     },
     {
         outcome: "failed",
         scenario: "no_answer_failed",
-        code: "internal_error",
-        retryable: false,
-        safeMessage: "Something went wrong while preparing this answer.",
-        remediation: ["Try the question again."],
+        ...pinnedNoAnswerVocabularyEntry("failed"),
         scopeResolutionOutcome: "exact",
     },
-] as const;
+    {
+        outcome: "refused",
+        scenario: "no_answer_refused",
+        ...pinnedNoAnswerVocabularyEntry("refused"),
+        // CHAOS-3541 added `refused` to ops' NO_ANSWER_OUTCOMES after this
+        // table was first built with five entries; pinned against the ops
+        // acceptance corpus the same way as the other five (see below) --
+        // all 6 of its resolution-profile cases (adv.injection-request.*,
+        // scope.prohibited-write) agree `expected_scope_resolution_outcome`
+        // is null: refused is a categorical, provider-level decision that
+        // fires before any catalog round trip, the same posture as
+        // `unsupported`/`denied`.
+        scopeResolutionOutcome: null,
+    },
+] as const satisfies readonly {
+    outcome: string;
+    scenario: string;
+    code: string;
+    retryable: boolean;
+    safeMessage: string;
+    remediation: readonly string[];
+    scopeResolutionOutcome: string | null;
+}[];
 
 /**
  * What `scope.resolved` outcome (if any) each `NO_ANSWER_OUTCOMES` entry's
@@ -116,21 +221,23 @@ export const NO_ANSWER_OUTCOMES = [
  * As of CHAOS-3497, ops emits `scope.resolved` on every terminal whose run
  * completed scope resolution -- including a no-answer error terminal --
  * built from `OrchestratorResult.scope_resolution`
- * (`streaming.stream_orchestrator`). Which outcome each of these five
+ * (`streaming.stream_orchestrator`). Which outcome each of these six
  * carries is pinned against the real producer, not invented: the ops
  * acceptance corpus's own `resolution-profiles/deterministic-v1.json` maps
  * every corpus case's `expected_public_outcome` to an
  * `expected_scope_resolution_outcome`, and every case sharing one of these
- * five public outcomes agrees on a single value --
+ * six public outcomes agrees on a single value --
  *   not_found               -> unresolved
  *   temporarily_unavailable -> exact
  *   unsupported             -> null
  *   denied                  -> null
  *   failed                  -> exact
+ *   refused                 -> null
  * `null` means no `scope.resolved` event at all, not a placeholder
  * resolution: `unsupported` (an oversized/unsupported request rejected by
- * `subject_preflight`'s bound) and `denied` (a provider-level refusal) are
- * both rejected before any catalog round trip ever runs, so
+ * `subject_preflight`'s bound), `denied` (a provider-level refusal), and
+ * `refused` (a categorical action refusal, CHAOS-3541) are all rejected
+ * before any catalog round trip ever runs, so
  * `OrchestratorResult.scope_resolution` is `None` and streaming's own
  * negative control applies ("a run that never resolved scope emits no
  * scope frame") -- inventing a resolution here would assert something the


### PR DESCRIPTION
Part 2 of CHAOS-3471 (ops side: full-chaos/dev-health-ops#1746, merged).

## Gap

`tests/mocks/devScenario.ts`'s `NO_ANSWER_OUTCOMES` hand-mirrored the six `dev_answer.v2` no-answer outcomes' `safe_message`/`remediation`/`code`/`retryable`. That mirror proved the UI renders the server's `safe_message` verbatim, but couldn't detect an ops-side reword — the mock and the Python constants could drift and both sides would stay green.

## What shipped

- Re-pinned `scripts/ask-dev-contracts.mjs`'s `SOURCE_COMMIT` (+ the matching ref in `.github/workflows/tests.yml`) to ops main `b45450e19e8e9d6292e3cd88a94f71ed2d5619b3`, which publishes `contracts/ask-dev/v1/vocabulary/no_answer_vocabulary.v1.json`. Artifacts regenerated with `ask-dev:contracts:generate --allow-write`, never hand-written.
- `NO_ANSWER_OUTCOMES` now reads its copy/remediation/code/retryable from the pinned artifact via a `pinnedNoAnswerVocabularyEntry()` lookup — an ops-side reword now fails `pnpm ask-dev:contracts:check` instead of silently passing here. `scenario`/`scopeResolutionOutcome` remain web-only test dispatch metadata, pinned against the ops acceptance corpus as before.
- Added the sixth outcome, `refused` (CHAOS-3541) — verified against the real producer (ops's `resolution-profiles/deterministic-v1.json`: all 6 `refused` cases agree `expected_scope_resolution_outcome: null`) and confirmed rendering in a real e2e run. All 6 outcomes asserted; no drop to 5.
- NOT_RUN guard in `ask-dev-contracts.mjs`'s shared `expected()`: throws a labeled error if the pinned/checked-out ops source is missing the vocabulary artifact.

## Codex review (2 rounds)

Round 1: byte-parity, pin coherence, NOT_RUN-on-old-source, all 6 `scopeResolutionOutcome` values — cleared.

Round 2 (2 P2s, both fixed, probe-first):
1. The pinned-entry lookup only checked the outcome key existed, then cast the value unchecked — a renamed/missing field would silently become `undefined`, and the mock-fidelity test derived its own expectation from that same malformed object. Now validates every required field's presence/type per outcome, naming the exact malformed field(s) in the NOT_RUN error.
2. The e2e loop iterated the hand-maintained `NO_ANSWER_OUTCOMES` table, not the artifact's own keys — a 7th artifact outcome would get no test; a deleted row would silently lose its test. Added a sorted-key equality assertion (both directions) between the artifact's published outcomes and the table.

Each fix was probed against the pre-fix code first (reproduced, then confirmed the fix catches it) — see the commit body and each function/test's docstring.

## Test evidence

- `pnpm typecheck`, `pnpm lint` — clean.
- `pnpm vitest run` — 421 files, 3794 passed, 8 skipped.
- `ci/run_tests.sh ci` (full gate: format, quality — audit/codegen/contracts pin+currency/lint/typecheck, build, unit, all 4 Playwright projects) — GATE PASSED, run twice (once per codex round), `.next/dev` cleared before each.
- Targeted verification: `refused: renders the canonical no-answer copy and the correct retry affordance` passed in a real browser run; the new coverage-bijection test passed alongside it.
