### PR TITLE
Fix sync run UX labels and backend error translation

### DIFF
--- a/src/components/admin/sync/BackfillStatus.test.tsx
+++ b/src/components/admin/sync/BackfillStatus.test.tsx
@@ -75,6 +75,22 @@ describe("BackfillStatus", () => {
         expect(screen.queryByText("Live — refreshing…")).not.toBeInTheDocument();
     });
 
+    it("humanizes backend failure text for terminal fanout jobs", () => {
+        render(
+            <BackfillStatus
+                initialJob={{
+                    ...RUNNING_JOB,
+                    status: "partial_failed",
+                    progress_pct: 100,
+                    error_message: "provider_unit_exhausted",
+                }}
+                testMode
+            />,
+        );
+
+        expect(screen.getByText("Provider unit exhausted")).toBeInTheDocument();
+    });
+
     it("renders a fanout 'planned' job as non-terminal and waiting", () => {
         render(<BackfillStatus initialJob={{ ...RUNNING_JOB, status: "planned" }} testMode />);
 

--- a/src/components/admin/sync/BackfillStatus.tsx
+++ b/src/components/admin/sync/BackfillStatus.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getBackfillJobStatus } from "@/lib/admin/server";
+import { formatSyncBackendText } from "@/lib/admin/syncDisplay";
 import { formatDateUTC } from "@/lib/formatters";
 import type { BackfillJob } from "@/lib/admin/types";
 
@@ -42,6 +43,7 @@ interface BackfillStatusProps {
 
 /** Human-readable in-progress/terminal label for every status in both status families. */
 function statusLabel(job: BackfillJob): string {
+    const humanErrorMessage = job.error_message ? formatSyncBackendText(job.error_message) : null;
     switch (job.status) {
         case "pending":
         case "planned":
@@ -54,11 +56,11 @@ function statusLabel(job: BackfillJob): string {
         case "success":
             return "Backfill complete";
         case "partial_failed":
-            return job.error_message || "Completed with failures";
+            return humanErrorMessage ?? "Completed with failures";
         case "failed":
-            return job.error_message || "Backfill failed";
+            return humanErrorMessage ?? "Backfill failed";
         default:
-            return job.status;
+            return formatSyncBackendText(job.status);
     }
 }
 
@@ -137,11 +139,17 @@ export function BackfillStatus({ initialJob, testMode = false }: BackfillStatusP
                     if (result.data.status === "completed" || result.data.status === "success") {
                         toast.success("Backfill completed successfully");
                     } else if (result.data.status === "partial_failed") {
+                        const humanErrorMessage = result.data.error_message
+                            ? formatSyncBackendText(result.data.error_message)
+                            : null;
                         toast.warning(
-                            result.data.error_message || "Backfill completed with some failures",
+                            humanErrorMessage || "Backfill completed with some failures",
                         );
                     } else {
-                        toast.error(result.data.error_message || "Backfill failed");
+                        const humanErrorMessage = result.data.error_message
+                            ? formatSyncBackendText(result.data.error_message)
+                            : null;
+                        toast.error(humanErrorMessage || "Backfill failed");
                     }
                     return;
                 }

--- a/src/components/admin/sync/SyncProgressBar.test.tsx
+++ b/src/components/admin/sync/SyncProgressBar.test.tsx
@@ -224,6 +224,38 @@ describe("SyncProgressBar", () => {
         expect(screen.getByText(/50% complete/)).toBeInTheDocument();
     });
 
+    it("renders a mixed terminal run as completed with failures", async () => {
+        vi.mocked(getSyncJobs).mockResolvedValue({ data: [buildJob({ status: "running" })] });
+        vi.mocked(getSyncRunStatus).mockResolvedValue({
+            data: buildRun({
+                status: "partial_failed",
+                completed_units: 2,
+                failed_units: 1,
+                total_units: 4,
+            }),
+        });
+        vi.mocked(getSyncRunUnits).mockResolvedValue({
+            data: buildSummary({
+                by_status: { success: 2, failed: 1, running: 1 },
+                unit_count: 4,
+                failed_unit_count: 1,
+                units: [
+                    buildUnit({ id: "unit-success-1", status: "success" }),
+                    buildUnit({ id: "unit-success-2", status: "success" }),
+                    buildUnit({ id: "unit-failed", status: "failed" }),
+                    buildUnit({ id: "unit-running", status: "running" }),
+                ],
+            }),
+        });
+
+        render(<SyncProgressBar configId="cfg-1" />);
+        await flush();
+
+        expect(screen.getByText("Completed with failures")).toBeInTheDocument();
+        expect(screen.getByText(/3 \/ 4/)).toBeInTheDocument();
+        expect(screen.getByText(/75% complete/)).toBeInTheDocument();
+    });
+
     it("does not rediscover a stale running job whose unit rollup is already terminal", async () => {
         vi.mocked(getSyncJobs).mockResolvedValue({
             data: [

--- a/src/components/admin/sync/SyncProgressBar.tsx
+++ b/src/components/admin/sync/SyncProgressBar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { SyncRun, SyncRunUnitSummary } from "@/lib/admin/types";
 import { getSyncJobs, getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
+import { formatSyncRunStatusLabel } from "@/lib/admin/syncDisplay";
 import { isTerminalSyncStatus, mapPlannerRunStatus } from "@/lib/sync-types";
 import type { SyncJob } from "@/lib/admin/types";
 
@@ -66,6 +67,7 @@ function totalUnitCount(run: SyncRun, summary: SyncRunUnitSummary | null): numbe
 
 function effectiveRunStatus(run: SyncRun, summary: SyncRunUnitSummary | null): string {
     if (!summary) return run.status;
+    if (run.status === "failed" || run.status === "partial_failed") return run.status;
 
     const successCount = statusCount(summary, "success") ?? 0;
     const failedCount = statusCount(summary, "failed") ?? 0;
@@ -254,12 +256,7 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
             ? "Calculating..."
             : `~${Math.floor(estimatedSecondsRemaining / 60)}m ${estimatedSecondsRemaining % 60}s remaining`;
 
-    const statusLabel =
-        liveStatus === "running"
-            ? "Syncing..."
-            : liveStatus === "success"
-              ? "Sync completed"
-              : "Sync failed";
+    const statusLabel = formatSyncRunStatusLabel(effectiveRunStatus(run, visibleSummary));
 
     return (
         <div

--- a/src/components/admin/sync/SyncRunDetail.test.tsx
+++ b/src/components/admin/sync/SyncRunDetail.test.tsx
@@ -69,7 +69,7 @@ describe("SyncRunDetailLive", () => {
 
         expect(screen.getByText(/3 \/ 4/)).toBeInTheDocument();
         expect(screen.getByText(/75%/)).toBeInTheDocument();
-        expect(screen.getByText("running")).toBeInTheDocument();
+        expect(screen.getAllByText("Syncing...").length).toBeGreaterThan(0);
         const progressCard = screen.getByText("Overall progress").closest(".rounded-xl");
         expect(progressCard).toBeInstanceOf(HTMLElement);
         if (!(progressCard instanceof HTMLElement)) return;
@@ -105,7 +105,7 @@ describe("SyncRunDetailLive", () => {
         const headerCard = screen.getAllByText("Status")[0]?.closest(".rounded-xl");
         expect(headerCard).toBeInstanceOf(HTMLElement);
         if (!(headerCard instanceof HTMLElement)) return;
-        expect(within(headerCard).getByText("running")).toBeInTheDocument();
+        expect(within(headerCard).getAllByText("Syncing...").length).toBeGreaterThan(0);
     });
 
     it("renders resolved source NAMES and never the raw source id", () => {
@@ -124,7 +124,7 @@ describe("SyncRunDetailLive", () => {
 
         expect(screen.getByText("Needs attention")).toBeInTheDocument();
         expect(screen.getByText(/Next retry/)).toBeInTheDocument();
-        expect(screen.getByText(/Category: rate_limit/)).toBeInTheDocument();
+        expect(screen.getByText(/Category: Rate limit/)).toBeInTheDocument();
         // Error text renders in both the attention panel and the unit table.
         expect(
             screen.getAllByText("Upstream returned 500 while paginating pull requests").length,
@@ -174,6 +174,41 @@ describe("SyncRunDetailLive", () => {
         expect(
             screen.getAllByText(/Budget deferral cap exceeded for REST_CORE bucket/).length,
         ).toBeGreaterThan(0);
+    });
+
+    it("renders a mixed terminal run as completed with failures instead of a raw partial_failed state", () => {
+        render(
+            <SyncRunDetailLive
+                initialRun={{
+                    ...SAMPLE_SYNC_RUN,
+                    completed_units: 2,
+                    failed_units: 2,
+                }}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { success: 2, failed: 2 },
+                    unit_count: 4,
+                    failed_unit_count: 2,
+                    failed_unit_ids: [
+                        SAMPLE_SYNC_RUN_UNIT_SUMMARY.units[2].id,
+                        SAMPLE_SYNC_RUN_UNIT_SUMMARY.units[3].id,
+                    ],
+                    units: SAMPLE_SYNC_RUN_UNIT_SUMMARY.units.map((unit, index) =>
+                        index < 2
+                            ? unit
+                            : {
+                                  ...unit,
+                                  status: "failed",
+                                  error_category: "provider_error",
+                              },
+                    ),
+                }}
+                testMode
+            />,
+        );
+
+        expect(screen.getAllByText("Completed with failures").length).toBeGreaterThan(0);
+        expect(screen.queryByText("partial_failed")).not.toBeInTheDocument();
     });
 
     it("renders the blocked-budget badge without the deferral count or rollup chip when the backend field is absent", () => {
@@ -243,7 +278,7 @@ describe("SyncRunDetailLive", () => {
         );
 
         expect(screen.queryByText("Blocked: budget")).not.toBeInTheDocument();
-        expect(screen.getByText(/Category: worker_lost/)).toBeInTheDocument();
+        expect(screen.getByText(/Category: Worker lost/)).toBeInTheDocument();
     });
 
     it("does NOT apply the budget-exhausted treatment to a failed unit whose category is the non-terminal budget_deferred", () => {
@@ -275,7 +310,7 @@ describe("SyncRunDetailLive", () => {
         );
 
         expect(screen.queryByText("Budget exhausted")).not.toBeInTheDocument();
-        expect(screen.getByText(/Category: budget_deferred/)).toBeInTheDocument();
+        expect(screen.getByText(/Category: Blocked by budget/)).toBeInTheDocument();
     });
 
     it("renders a distinct 'Deferrals exhausted' treatment and the actionable error text for error_category=deferral_exhausted", () => {
@@ -582,7 +617,7 @@ describe("SyncRunDetailLive — live poll error handling", () => {
 
         expect(screen.getByText(/1 \/ 4/)).toBeInTheDocument();
         expect(screen.getByText(/25%/)).toBeInTheDocument();
-        expect(screen.getByText("running")).toBeInTheDocument();
+        expect(screen.getAllByText("Syncing...").length).toBeGreaterThan(0);
         await act(async () => {
             await vi.advanceTimersByTimeAsync(3500 * 2);
         });

--- a/src/components/admin/sync/SyncRunDetailLive.tsx
+++ b/src/components/admin/sync/SyncRunDetailLive.tsx
@@ -6,6 +6,7 @@ import { SyncStatusBadge } from "./SyncStatusBadge";
 import { getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
 import { CTA_LABELS } from "@/lib/design/cta";
 import { formatNumber, formatPercent, formatDateUTC } from "@/lib/formatters";
+import { formatSyncBackendText, formatSyncRunStatusLabel } from "@/lib/admin/syncDisplay";
 import { type SyncStatus, isTerminalSyncStatus, mapPlannerRunStatus } from "@/lib/sync-types";
 import type { SyncRun, SyncRunUnit, SyncRunUnitSummary } from "@/lib/admin/types";
 
@@ -128,6 +129,7 @@ function totalUnitCount(run: SyncRun, summary: SyncRunUnitSummary | null): numbe
 
 function effectiveRunStatus(run: SyncRun, summary: SyncRunUnitSummary | null): string {
     if (!summary) return run.status;
+    if (run.status === "failed" || run.status === "partial_failed") return run.status;
 
     const successCount = statusCount(summary, "success") ?? 0;
     const failedCount = statusCount(summary, "failed") ?? 0;
@@ -478,8 +480,16 @@ export function SyncRunDetailLive({
             <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
                 <div className="flex flex-wrap items-start justify-between gap-4">
                     <div className="space-y-2">
-                        <div className="flex items-center gap-3">
-                            <SyncStatusBadge status={liveStatus} className="text-sm px-3 py-1" />
+                    <div className="flex items-center gap-3">
+                            <SyncStatusBadge
+                                status={liveStatus}
+                                className="text-sm px-3 py-1"
+                                label={
+                                    currentRunStatus === "partial_failed"
+                                        ? formatSyncRunStatusLabel(currentRunStatus)
+                                        : undefined
+                                }
+                            />
                             <span
                                 className="text-sm text-(--ink-muted)"
                                 role="status"
@@ -497,7 +507,9 @@ export function SyncRunDetailLive({
                                 <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
                                     Status
                                 </dt>
-                                <dd className="text-foreground">{currentRunStatus}</dd>
+                                <dd className="text-foreground">
+                                    {formatSyncRunStatusLabel(currentRunStatus)}
+                                </dd>
                             </div>
                             <div>
                                 <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
@@ -810,7 +822,6 @@ export function SyncRunDetailLive({
                                             ) : (
                                                 <SyncStatusBadge
                                                     status={unitBadgeStatus(unit.status)}
-                                                    label={unit.status}
                                                 />
                                             )}
                                         </div>
@@ -840,7 +851,12 @@ export function SyncRunDetailLive({
                                             ) : (
                                                 <>
                                                     {unit.error_category && (
-                                                        <span>Category: {unit.error_category}</span>
+                                                        <span>
+                                                            Category:{" "}
+                                                            {formatSyncBackendText(
+                                                                unit.error_category,
+                                                            )}
+                                                        </span>
                                                     )}
                                                     {unit.error_category &&
                                                         unit.available_at &&
@@ -859,7 +875,7 @@ export function SyncRunDetailLive({
                                         </div>
                                         {unit.error && (
                                             <p className="mt-1 text-xs text-red-500">
-                                                {unit.error}
+                                                {formatSyncBackendText(unit.error)}
                                             </p>
                                         )}
                                     </li>
@@ -1032,11 +1048,13 @@ export function SyncRunDetailLive({
                                             <td className="px-4 py-3 text-sm">
                                                 {unit.error ? (
                                                     <span className="text-red-500">
-                                                        {unit.error}
+                                                        {formatSyncBackendText(unit.error)}
                                                     </span>
                                                 ) : unit.error_category ? (
                                                     <span className="text-(--ink-muted)">
-                                                        {unit.error_category}
+                                                        {formatSyncBackendText(
+                                                            unit.error_category,
+                                                        )}
                                                     </span>
                                                 ) : unit.available_at ? (
                                                     <span className="text-(--ink-muted)">

--- a/src/lib/admin/__tests__/syncDisplay.test.ts
+++ b/src/lib/admin/__tests__/syncDisplay.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatSyncBackendText, formatSyncRunStatusLabel } from "../syncDisplay";
+
+describe("syncDisplay", () => {
+    it("humanizes sync run states for the UI", () => {
+        expect(formatSyncRunStatusLabel("partial_failed")).toBe("Completed with failures");
+        expect(formatSyncRunStatusLabel("running")).toBe("Syncing...");
+        expect(formatSyncRunStatusLabel("success")).toBe("Sync completed");
+    });
+
+    it("humanizes backend failure codes without changing normal prose", () => {
+        expect(formatSyncBackendText("provider_unit_exhausted")).toBe(
+            "Provider unit exhausted",
+        );
+        expect(formatSyncBackendText("provider_budget_contention")).toBe("Budget contention");
+        expect(formatSyncBackendText("Secondary rate limit hit; backing off")).toBe(
+            "Secondary rate limit hit; backing off",
+        );
+    });
+});

--- a/src/lib/admin/syncDisplay.ts
+++ b/src/lib/admin/syncDisplay.ts
@@ -1,0 +1,41 @@
+import { titleCase } from "../stringUtils";
+
+const RUN_STATUS_LABELS: Record<string, string> = {
+    failed: "Sync failed",
+    partial_failed: "Completed with failures",
+    planned: "Syncing...",
+    dispatching: "Syncing...",
+    running: "Syncing...",
+    success: "Sync completed",
+};
+
+const BACKEND_TEXT_LABELS: Record<string, string> = {
+    budget_deferred: "Blocked by budget",
+    budget_deferral_exhausted: "Budget exhausted",
+    deferral_exhausted: "Deferrals exhausted",
+    provider_budget_contention: "Budget contention",
+    provider_error: "Provider error",
+    provider_unit_exhausted: "Provider unit exhausted",
+    provider_unit_retryable: "Retrying",
+    rate_limit: "Rate limit",
+    worker_lost: "Worker lost",
+};
+
+function looksLikeBackendCode(value: string): boolean {
+    return /^[a-z][a-z0-9_]*$/.test(value) && value.includes("_");
+}
+
+export function formatSyncRunStatusLabel(status: string): string {
+    return RUN_STATUS_LABELS[status] ?? titleCase(status.replace(/_/g, " "));
+}
+
+export function formatSyncBackendText(value: string | null | undefined): string {
+    if (!value) return "—";
+    if (value in BACKEND_TEXT_LABELS) {
+        return BACKEND_TEXT_LABELS[value];
+    }
+    if (looksLikeBackendCode(value)) {
+        return titleCase(value.replace(/_/g, " "));
+    }
+    return value;
+}


### PR DESCRIPTION
## Summary\n- Humanize sync run terminal labels in the detail and progress views.\n- Translate backend failure codes to user-facing text in web only.\n- Keep raw backend codes out of the visible sync run detail surfaces.\n\n## Verification\n- 
 RUN  v4.1.10 /Users/chris/projects/full-chaos/dev-health/worktrees/web/chaos-3766-sync-run-ux


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  06:24:31
   Duration  87ms (transform 13ms, setup 0ms, import 18ms, tests 1ms, environment 0ms)\n- 
 RUN  v4.1.10 /Users/chris/projects/full-chaos/dev-health/worktrees/web/chaos-3766-sync-run-ux


 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  06:24:32
   Duration  524ms (transform 38ms, setup 53ms, import 105ms, tests 39ms, environment 260ms)\n- 
 RUN  v4.1.10 /Users/chris/projects/full-chaos/dev-health/worktrees/web/chaos-3766-sync-run-ux


 Test Files  1 passed (1)
      Tests  18 passed (18)
   Start at  06:24:33
   Duration  528ms (transform 43ms, setup 53ms, import 101ms, tests 62ms, environment 241ms)\n- 
 RUN  v4.1.10 /Users/chris/projects/full-chaos/dev-health/worktrees/web/chaos-3766-sync-run-ux


 Test Files  1 passed (1)
      Tests  38 passed (38)
   Start at  06:24:33
   Duration  1.31s (transform 73ms, setup 63ms, import 151ms, tests 771ms, environment 254ms)\n\n## Follow-up\n- Closes / links to GitHub issue #883 for remaining UX cleanup.