### PR TITLE
CHAOS-3787: present sync failures truthfully

### DIFF
--- a/src/components/admin/sync/BackfillStatus.test.tsx
+++ b/src/components/admin/sync/BackfillStatus.test.tsx
@@ -75,6 +75,23 @@ describe("BackfillStatus", () => {
         expect(screen.queryByText("Live — refreshing…")).not.toBeInTheDocument();
     });
 
+    it("translates a backend failure code for a terminal backfill", () => {
+        render(
+            <BackfillStatus
+                initialJob={{
+                    ...RUNNING_JOB,
+                    status: "partial_failed",
+                    progress_pct: 100,
+                    error_message: "provider_unit_exhausted",
+                }}
+                testMode
+            />,
+        );
+
+        expect(screen.getByText("Provider retries exhausted")).toBeInTheDocument();
+        expect(screen.queryByText("provider_unit_exhausted")).not.toBeInTheDocument();
+    });
+
     it("renders a fanout 'planned' job as non-terminal and waiting", () => {
         render(<BackfillStatus initialJob={{ ...RUNNING_JOB, status: "planned" }} testMode />);
 

--- a/src/components/admin/sync/BackfillStatus.tsx
+++ b/src/components/admin/sync/BackfillStatus.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getBackfillJobStatus } from "@/lib/admin/server";
 import { formatDateUTC } from "@/lib/formatters";
+import { getSyncUnitErrorPresentation } from "@/lib/admin/syncUnitErrorPresentation";
 import type { BackfillJob } from "@/lib/admin/types";
 
 /** How often to poll for live backfill status. */
@@ -42,6 +43,9 @@ interface BackfillStatusProps {
 
 /** Human-readable in-progress/terminal label for every status in both status families. */
 function statusLabel(job: BackfillJob): string {
+    const failureTitle = job.error_message
+        ? getSyncUnitErrorPresentation(job.error_message, null).title
+        : null;
     switch (job.status) {
         case "pending":
         case "planned":
@@ -54,9 +58,9 @@ function statusLabel(job: BackfillJob): string {
         case "success":
             return "Backfill complete";
         case "partial_failed":
-            return job.error_message || "Completed with failures";
+            return failureTitle ?? "Completed with failures";
         case "failed":
-            return job.error_message || "Backfill failed";
+            return failureTitle ?? "Backfill failed";
         default:
             return job.status;
     }
@@ -137,11 +141,15 @@ export function BackfillStatus({ initialJob, testMode = false }: BackfillStatusP
                     if (result.data.status === "completed" || result.data.status === "success") {
                         toast.success("Backfill completed successfully");
                     } else if (result.data.status === "partial_failed") {
-                        toast.warning(
-                            result.data.error_message || "Backfill completed with some failures",
-                        );
+                        const failureTitle = result.data.error_message
+                            ? getSyncUnitErrorPresentation(result.data.error_message, null).title
+                            : null;
+                        toast.warning(failureTitle ?? "Backfill completed with some failures");
                     } else {
-                        toast.error(result.data.error_message || "Backfill failed");
+                        const failureTitle = result.data.error_message
+                            ? getSyncUnitErrorPresentation(result.data.error_message, null).title
+                            : null;
+                        toast.error(failureTitle ?? "Backfill failed");
                     }
                     return;
                 }

--- a/src/components/admin/sync/SyncProgressBar.test.tsx
+++ b/src/components/admin/sync/SyncProgressBar.test.tsx
@@ -181,13 +181,43 @@ describe("SyncProgressBar", () => {
         render(<SyncProgressBar configId="cfg-1" />);
         await flush();
 
-        expect(screen.getByText("Syncing...")).toBeInTheDocument();
+        expect(screen.getByText("Syncing with failures...")).toBeInTheDocument();
         expect(screen.getByText(/3 \/ 4/)).toBeInTheDocument();
         expect(screen.getByText(/75% complete/)).toBeInTheDocument();
         expect(screen.getByRole("progressbar", { name: "Sync progress" })).toHaveAttribute(
             "aria-valuenow",
             "75",
         );
+    });
+
+    it("labels a terminal mixed result as completed with failures", async () => {
+        vi.mocked(getSyncJobs).mockResolvedValue({ data: [buildJob({ status: "running" })] });
+        vi.mocked(getSyncRunStatus).mockResolvedValue({
+            data: buildRun({
+                status: "partial_failed",
+                completed_units: 3,
+                failed_units: 1,
+                total_units: 4,
+            }),
+        });
+        vi.mocked(getSyncRunUnits).mockResolvedValue({
+            data: buildSummary({
+                by_status: { success: 3, failed: 1 },
+                failed_unit_count: 1,
+                unit_count: 4,
+                units: [
+                    buildUnit({ id: "success-1", status: "success" }),
+                    buildUnit({ id: "success-2", status: "success" }),
+                    buildUnit({ id: "success-3", status: "success" }),
+                    buildUnit({ id: "failed-1", status: "failed" }),
+                ],
+            }),
+        });
+
+        render(<SyncProgressBar configId="cfg-1" />);
+        await flush();
+
+        expect(screen.getByText("Sync completed with failures")).toBeInTheDocument();
     });
 
     it("keeps the last good unit rollup when a later units poll errors", async () => {
@@ -419,6 +449,31 @@ describe("SyncProgressBar", () => {
         await flush();
 
         expect(screen.getByText("Calculating...")).toBeInTheDocument();
+    });
+
+    it("states that automatic updates paused after the tracking safety window", async () => {
+        vi.mocked(getSyncJobs).mockResolvedValue({ data: [buildJob({ status: "running" })] });
+        vi.mocked(getSyncRunStatus).mockResolvedValue({
+            data: buildRun({ completed_units: 4, total_units: 10 }),
+        });
+
+        render(<SyncProgressBar configId="cfg-1" />);
+        await flush();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 3500);
+        });
+
+        expect(screen.getByText("Sync updates paused")).toBeInTheDocument();
+        expect(
+            screen.getByText("Automatic updates paused after 10 minutes. Refresh to resume."),
+        ).toBeInTheDocument();
+        const callsAtPause = vi.mocked(getSyncRunStatus).mock.calls.length;
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3500 * 2);
+        });
+        expect(getSyncRunStatus).toHaveBeenCalledTimes(callsAtPause);
     });
 
     it("clears the previous config's run once configId changes and the new config has no active run (stale-config leak regression, CHAOS-2799)", async () => {

--- a/src/components/admin/sync/SyncProgressBar.tsx
+++ b/src/components/admin/sync/SyncProgressBar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { SyncRun, SyncRunUnitSummary } from "@/lib/admin/types";
 import { getSyncJobs, getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
+import { getSyncRunPresentation } from "@/lib/admin/syncRunPresentation";
 import { isTerminalSyncStatus, mapPlannerRunStatus } from "@/lib/sync-types";
 import type { SyncJob } from "@/lib/admin/types";
 
@@ -55,39 +56,6 @@ function formatElapsed(seconds: number): string {
     return `${String(minutes).padStart(2, "0")}:${String(remainder).padStart(2, "0")}`;
 }
 
-function statusCount(summary: SyncRunUnitSummary | null, status: string): number | null {
-    if (!summary) return null;
-    return summary.by_status[status] ?? 0;
-}
-
-function totalUnitCount(run: SyncRun, summary: SyncRunUnitSummary | null): number {
-    return summary ? Math.max(summary.unit_count, run.total_units) : run.total_units;
-}
-
-function effectiveRunStatus(run: SyncRun, summary: SyncRunUnitSummary | null): string {
-    if (!summary) return run.status;
-
-    const successCount = statusCount(summary, "success") ?? 0;
-    const failedCount = statusCount(summary, "failed") ?? 0;
-    const settledCount = successCount + failedCount;
-    const totalUnits = totalUnitCount(run, summary);
-    if (totalUnits > 0 && settledCount >= totalUnits) {
-        if (failedCount === 0) return "success";
-        if (successCount === 0) return "failed";
-        return "partial_failed";
-    }
-    if (
-        settledCount > 0 ||
-        (statusCount(summary, "running") ?? 0) > 0 ||
-        (statusCount(summary, "retrying") ?? 0) > 0
-    ) {
-        return "running";
-    }
-    if ((statusCount(summary, "dispatching") ?? 0) > 0) return "dispatching";
-    if ((statusCount(summary, "planned") ?? 0) > 0) return "planned";
-    return run.status;
-}
-
 function hasActiveSyncRun(job: SyncJob): boolean {
     if (!job.sync_run?.sync_run_id) return false;
     if (job.status !== "running" && job.status !== "pending") return false;
@@ -104,12 +72,14 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
     } | null>(null);
     const [now, setNow] = useState(() => Date.now());
     const [terminalUntil, setTerminalUntil] = useState<number | null>(null);
+    const [pollingPaused, setPollingPaused] = useState(false);
 
     // The sync_run_id currently being tracked for THIS config instance. A ref
     // (not state) because it only drives poll branching inside the interval
     // callback, never rendering directly.
     const runIdRef = useRef<string | null>(null);
     const trackStartedAtRef = useRef<number | null>(null);
+    const trackingPausedRef = useRef(false);
     const inFlightRef = useRef(false);
     const lastSummaryByRunRef = useRef<Record<string, SyncRunUnitSummary>>({});
     // Invalidates any in-flight response once the effect tears down (configId
@@ -127,9 +97,10 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
         const effectSeq = seqRef.current;
         runIdRef.current = null;
         trackStartedAtRef.current = null;
+        trackingPausedRef.current = false;
 
         const tick = async () => {
-            if (inFlightRef.current) return;
+            if (inFlightRef.current || trackingPausedRef.current) return;
             inFlightRef.current = true;
             try {
                 if (!runIdRef.current) {
@@ -140,6 +111,7 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
                     if (!activeJob?.sync_run) return;
                     runIdRef.current = activeJob.sync_run.sync_run_id;
                     trackStartedAtRef.current = Date.now();
+                    setPollingPaused(false);
                 }
 
                 const runId = runIdRef.current;
@@ -165,7 +137,7 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
                 setTracked({ configId, run: runRes.data, summary });
                 setTerminalUntil(null);
 
-                const liveStatus = mapPlannerRunStatus(effectiveRunStatus(runRes.data, summary));
+                const liveStatus = getSyncRunPresentation(runRes.data, summary).badgeStatus;
                 const trackedTooLong =
                     trackStartedAtRef.current !== null &&
                     Date.now() - trackStartedAtRef.current > MAX_TRACK_DURATION_MS;
@@ -173,13 +145,16 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
                 if (isTerminalSyncStatus(liveStatus)) {
                     runIdRef.current = null;
                     trackStartedAtRef.current = null;
+                    setPollingPaused(false);
                     setTerminalUntil(Date.now() + TERMINAL_DISPLAY_MS);
                 } else if (trackedTooLong) {
-                    // Give up tracking a stuck run so the bar doesn't spin on
-                    // it forever; fall back to discovery.
+                    // Keep the last persisted snapshot visible and say exactly
+                    // what stopped. Rediscovering the same active row would
+                    // silently restart the 10-minute clock and look live forever.
+                    trackingPausedRef.current = true;
                     runIdRef.current = null;
                     trackStartedAtRef.current = null;
-                    setTracked(null);
+                    setPollingPaused(true);
                 }
             } finally {
                 inFlightRef.current = false;
@@ -205,17 +180,25 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
     const visibleSummary = visibleTracked?.summary ?? null;
     const runStatus = visibleRun?.status ?? null;
     const runStartedAt = visibleRun?.started_at ?? null;
+    const visiblePresentation = visibleRun
+        ? getSyncRunPresentation(visibleRun, visibleSummary)
+        : null;
 
     // 1s display timer while a run is actively tracked, purely for the
     // elapsed-time readout. Derives from persisted `started_at` rather than a
     // client-observed timestamp, per the render-persisted-state contract.
     useEffect(() => {
-        if (!runStartedAt || isTerminalSyncStatus(mapPlannerRunStatus(runStatus ?? ""))) {
+        if (
+            !runStartedAt ||
+            isTerminalSyncStatus(
+                visiblePresentation?.badgeStatus ?? mapPlannerRunStatus(runStatus ?? ""),
+            )
+        ) {
             return undefined;
         }
         const timer = setInterval(() => setNow(Date.now()), 1000);
         return () => clearInterval(timer);
-    }, [runStatus, runStartedAt]);
+    }, [runStatus, runStartedAt, visiblePresentation?.badgeStatus]);
 
     // Auto-clear a terminal result after a short grace period so the bar
     // doesn't linger indefinitely once a run finishes.
@@ -235,11 +218,9 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
 
     const run = visibleRun;
 
-    const liveStatus = mapPlannerRunStatus(effectiveRunStatus(run, visibleSummary));
-    const totalUnits = totalUnitCount(run, visibleSummary);
-    const completed = statusCount(visibleSummary, "success") ?? run.completed_units;
-    const failed = statusCount(visibleSummary, "failed") ?? run.failed_units;
-    const settled = Math.min(totalUnits, completed + failed);
+    const presentation = visiblePresentation ?? getSyncRunPresentation(run, visibleSummary);
+    const liveStatus = presentation.badgeStatus;
+    const { total: totalUnits, settled } = presentation.counts;
     const percentage = totalUnits > 0 ? Math.min(100, Math.round((settled / totalUnits) * 100)) : 0;
     const elapsedSeconds = run.started_at
         ? Math.max(0, Math.floor((now - new Date(run.started_at).getTime()) / 1000))
@@ -254,13 +235,6 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
             ? "Calculating..."
             : `~${Math.floor(estimatedSecondsRemaining / 60)}m ${estimatedSecondsRemaining % 60}s remaining`;
 
-    const statusLabel =
-        liveStatus === "running"
-            ? "Syncing..."
-            : liveStatus === "success"
-              ? "Sync completed"
-              : "Sync failed";
-
     return (
         <div
             className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6"
@@ -268,7 +242,9 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
             aria-live="polite"
         >
             <div className="mb-2 flex items-center justify-between text-sm">
-                <span className="font-medium text-foreground">{statusLabel}</span>
+                <span className="font-medium text-foreground">
+                    {pollingPaused ? "Sync updates paused" : presentation.progressLabel}
+                </span>
                 <span className="text-(--ink-muted)">
                     {settled} / {totalUnits} ({percentage}%)
                 </span>
@@ -295,6 +271,11 @@ export function SyncProgressBar({ configId, testMode = false }: SyncProgressBarP
                 </span>
                 <span>{liveStatus === "running" ? etaText : ""}</span>
             </div>
+            {pollingPaused && (
+                <p className="mt-2 text-xs text-(--ink-muted)">
+                    Automatic updates paused after 10 minutes. Refresh to resume.
+                </p>
+            )}
         </div>
     );
 }

--- a/src/components/admin/sync/SyncRunDetail.test.tsx
+++ b/src/components/admin/sync/SyncRunDetail.test.tsx
@@ -32,6 +32,187 @@ function renderDetail() {
 }
 
 describe("SyncRunDetailLive", () => {
+    it("labels a non-terminal run with settled failures as running with failures", () => {
+        render(
+            <SyncRunDetailLive
+                initialRun={{ ...SAMPLE_SYNC_RUN, status: "running" }}
+                initialSummary={SAMPLE_SYNC_RUN_UNIT_SUMMARY}
+                testMode
+            />,
+        );
+
+        expect(screen.getAllByText("Running with failures").length).toBeGreaterThan(0);
+        expect(screen.getByText("1 unit failed; 1 unit is still processing.")).toBeInTheDocument();
+        expect(screen.queryByText(/^running$/)).not.toBeInTheDocument();
+    });
+
+    it("labels a terminal mixed result as completed with failures", () => {
+        render(
+            <SyncRunDetailLive
+                initialRun={{ ...SAMPLE_SYNC_RUN, status: "partial_failed" }}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { success: 3, failed: 1 },
+                    units: SAMPLE_SYNC_RUN_UNIT_SUMMARY.units.map((unit) => ({
+                        ...unit,
+                        status: unit.status === "failed" ? "failed" : "success",
+                    })),
+                }}
+                testMode
+            />,
+        );
+
+        expect(screen.getAllByText("Completed with failures").length).toBeGreaterThan(0);
+        expect(screen.getByText("Run complete")).toBeInTheDocument();
+    });
+
+    it("groups repeated failures, includes provider-capacity waits, and translates machine codes", () => {
+        const baseUnit = SAMPLE_SYNC_RUN_UNIT_SUMMARY.units[0];
+        const failedUnits = Array.from({ length: 3 }, (_, index) => ({
+            ...baseUnit,
+            id: `feature-flag-failure-${index}`,
+            source_id: index === 2 ? "source-b" : "source-a",
+            source_full_name: index === 2 ? "fullchaos/chaos-ops" : "fullchaos/dev-health-ops",
+            dataset_key: "feature-flags",
+            status: "failed",
+            error: "provider_unit_exhausted",
+            error_category: "provider_unit_exhausted",
+        }));
+        const waitingUnit = {
+            ...baseUnit,
+            id: "cicd-capacity-wait",
+            source_id: "source-c",
+            source_full_name: "fullchaos/dev-health-web",
+            dataset_key: "cicd",
+            status: "dispatching",
+            error: "provider_budget_contention",
+            error_category: "provider_budget_contention",
+        };
+
+        render(
+            <SyncRunDetailLive
+                initialRun={{
+                    ...SAMPLE_SYNC_RUN,
+                    status: "running",
+                    total_units: 4,
+                    completed_units: 0,
+                    failed_units: 3,
+                }}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { failed: 3, dispatching: 1 },
+                    failed_unit_count: 3,
+                    failed_unit_ids: failedUnits.map((unit) => unit.id),
+                    unit_count: 4,
+                    units: [...failedUnits, waitingUnit],
+                }}
+                testMode
+            />,
+        );
+
+        const attention = screen.getByRole("region", { name: "Needs attention" });
+        expect(within(attention).getAllByText("Provider retries exhausted")).toHaveLength(1);
+        expect(within(attention).getByText("3 failed units · 2 sources")).toBeInTheDocument();
+        expect(within(attention).getByText("Waiting for provider capacity")).toBeInTheDocument();
+        expect(within(attention).getByText("1 waiting unit · 1 source")).toBeInTheDocument();
+        expect(within(attention).queryByText(/deferrals?/)).not.toBeInTheDocument();
+        expect(screen.queryByText("provider_unit_exhausted")).not.toBeInTheDocument();
+        expect(screen.queryByText("provider_budget_contention")).not.toBeInTheDocument();
+    });
+
+    it("preserves every distinct retry window with its sources and does not schedule terminal failures", () => {
+        const baseUnit = SAMPLE_SYNC_RUN_UNIT_SUMMARY.units[0];
+        const retryingUnits = [
+            {
+                ...baseUnit,
+                id: "tests-retry-one",
+                source_id: "source-a",
+                source_full_name: "fullchaos/dev-health-acr",
+                dataset_key: "tests",
+                status: "retrying",
+                error: "provider_unit_retryable",
+                error_category: "provider_unit_retryable",
+                available_at: "2026-08-13T18:00:00Z",
+            },
+            {
+                ...baseUnit,
+                id: "tests-retry-two",
+                source_id: "source-b",
+                source_full_name: "fullchaos/dev-health-web",
+                dataset_key: "tests",
+                status: "retrying",
+                error: "provider_unit_retryable",
+                error_category: "provider_unit_retryable",
+                available_at: "2026-08-13T18:05:00Z",
+            },
+        ];
+        const failedUnit = {
+            ...baseUnit,
+            id: "cicd-terminal-failure",
+            source_id: "source-c",
+            source_full_name: "fullchaos/dev-health-ops",
+            dataset_key: "cicd",
+            status: "failed",
+            error: "provider_unit_exhausted",
+            error_category: "provider_unit_exhausted",
+            available_at: "2026-08-13T18:10:00Z",
+        };
+
+        render(
+            <SyncRunDetailLive
+                initialRun={{ ...SAMPLE_SYNC_RUN, status: "running", total_units: 3 }}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { retrying: 2, failed: 1 },
+                    failed_unit_count: 1,
+                    failed_unit_ids: [failedUnit.id],
+                    unit_count: 3,
+                    units: [...retryingUnits, failedUnit],
+                }}
+                testMode
+            />,
+        );
+
+        const retrySchedule = screen.getByRole("list", {
+            name: "Provider request will retry retry schedule",
+        });
+        const retryWindows = within(retrySchedule).getAllByRole("listitem");
+        expect(retryWindows).toHaveLength(2);
+        expect(retryWindows[0]).toHaveTextContent("fullchaos/dev-health-acr");
+        expect(retryWindows[1]).toHaveTextContent("fullchaos/dev-health-web");
+        expect(
+            screen.queryByRole("list", { name: "Provider retries exhausted retry schedule" }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("humanizes an unknown machine error code instead of exposing snake case", () => {
+        const failedUnit = {
+            ...SAMPLE_SYNC_RUN_UNIT_SUMMARY.units[0],
+            id: "unknown-error-unit",
+            status: "failed",
+            error: "custom_provider_fault",
+            error_category: "custom_provider_fault",
+        };
+
+        render(
+            <SyncRunDetailLive
+                initialRun={{ ...SAMPLE_SYNC_RUN, status: "failed", total_units: 1 }}
+                initialSummary={{
+                    ...SAMPLE_SYNC_RUN_UNIT_SUMMARY,
+                    by_status: { failed: 1 },
+                    failed_unit_count: 1,
+                    failed_unit_ids: [failedUnit.id],
+                    unit_count: 1,
+                    units: [failedUnit],
+                }}
+                testMode
+            />,
+        );
+
+        expect(screen.getAllByText("Custom provider fault").length).toBeGreaterThan(0);
+        expect(screen.queryByText("custom_provider_fault")).not.toBeInTheDocument();
+    });
+
     it("renders overall progress and unit status counts", () => {
         renderDetail();
 
@@ -69,7 +250,7 @@ describe("SyncRunDetailLive", () => {
 
         expect(screen.getByText(/3 \/ 4/)).toBeInTheDocument();
         expect(screen.getByText(/75%/)).toBeInTheDocument();
-        expect(screen.getByText("running")).toBeInTheDocument();
+        expect(screen.getAllByText("Running with failures").length).toBeGreaterThan(0);
         const progressCard = screen.getByText("Overall progress").closest(".rounded-xl");
         expect(progressCard).toBeInstanceOf(HTMLElement);
         if (!(progressCard instanceof HTMLElement)) return;
@@ -105,7 +286,7 @@ describe("SyncRunDetailLive", () => {
         const headerCard = screen.getAllByText("Status")[0]?.closest(".rounded-xl");
         expect(headerCard).toBeInstanceOf(HTMLElement);
         if (!(headerCard instanceof HTMLElement)) return;
-        expect(within(headerCard).getByText("running")).toBeInTheDocument();
+        expect(within(headerCard).getAllByText("Running").length).toBeGreaterThan(0);
     });
 
     it("renders resolved source NAMES and never the raw source id", () => {
@@ -119,19 +300,17 @@ describe("SyncRunDetailLive", () => {
         expect(screen.queryByText("sample-source-2")).not.toBeInTheDocument();
     });
 
-    it("surfaces failed/retrying error_category and the next retry", () => {
+    it("translates failed/retrying categories and preserves useful detail and retry time", () => {
         renderDetail();
 
         expect(screen.getByText("Needs attention")).toBeInTheDocument();
         expect(screen.getByText(/Next retry/)).toBeInTheDocument();
-        expect(screen.getByText(/Category: rate_limit/)).toBeInTheDocument();
-        // Error text renders in both the attention panel and the unit table.
+        expect(screen.getAllByText("Waiting for provider rate limit").length).toBeGreaterThan(0);
+        expect(screen.queryByText("rate_limit")).not.toBeInTheDocument();
         expect(
-            screen.getAllByText("Upstream returned 500 while paginating pull requests").length,
-        ).toBeGreaterThan(0);
-        expect(screen.getAllByText("Secondary rate limit hit; backing off").length).toBeGreaterThan(
-            0,
-        );
+            screen.getByText("Upstream returned 500 while paginating pull requests"),
+        ).toBeInTheDocument();
+        expect(screen.getByText("Secondary rate limit hit; backing off")).toBeInTheDocument();
     });
 
     it("renders a distinct 'Blocked: budget' treatment with deferral count, next attempt, and the rollup chip", () => {
@@ -146,8 +325,10 @@ describe("SyncRunDetailLive", () => {
             />,
         );
 
-        // Badge (attention panel + unit table) replaces the generic "retrying" look.
-        expect(screen.getAllByText("Blocked: budget").length).toBe(2);
+        // The table keeps its compact badge while the attention summary uses
+        // a human-readable reason.
+        expect(screen.getByText("Blocked: budget")).toBeInTheDocument();
+        expect(screen.getAllByText("Waiting for sync budget").length).toBeGreaterThan(0);
         // Deferral count + next attempt render from the persisted fields.
         expect(screen.getByText(/6 deferrals/)).toBeInTheDocument();
         expect(screen.getByText(/Next attempt/)).toBeInTheDocument();
@@ -170,7 +351,8 @@ describe("SyncRunDetailLive", () => {
             />,
         );
 
-        expect(screen.getAllByText("Budget exhausted").length).toBe(2);
+        expect(screen.getByText("Budget exhausted")).toBeInTheDocument();
+        expect(screen.getAllByText("Sync budget wait limit reached").length).toBeGreaterThan(0);
         expect(
             screen.getAllByText(/Budget deferral cap exceeded for REST_CORE bucket/).length,
         ).toBeGreaterThan(0);
@@ -191,7 +373,8 @@ describe("SyncRunDetailLive", () => {
             />,
         );
 
-        expect(screen.getAllByText("Blocked: budget").length).toBe(2);
+        expect(screen.getByText("Blocked: budget")).toBeInTheDocument();
+        expect(screen.getAllByText("Waiting for sync budget").length).toBeGreaterThan(0);
         expect(screen.queryByText(/deferral/)).not.toBeInTheDocument();
         expect(screen.getByText(/Next attempt/)).toBeInTheDocument();
         // budget_blocked_unit_count wasn't set on this summary — chip omitted.
@@ -243,7 +426,7 @@ describe("SyncRunDetailLive", () => {
         );
 
         expect(screen.queryByText("Blocked: budget")).not.toBeInTheDocument();
-        expect(screen.getByText(/Category: worker_lost/)).toBeInTheDocument();
+        expect(screen.getAllByText("Worker stopped responding").length).toBeGreaterThan(0);
     });
 
     it("does NOT apply the budget-exhausted treatment to a failed unit whose category is the non-terminal budget_deferred", () => {
@@ -275,7 +458,7 @@ describe("SyncRunDetailLive", () => {
         );
 
         expect(screen.queryByText("Budget exhausted")).not.toBeInTheDocument();
-        expect(screen.getByText(/Category: budget_deferred/)).toBeInTheDocument();
+        expect(screen.getAllByText("Waiting for sync budget").length).toBeGreaterThan(0);
     });
 
     it("renders a distinct 'Deferrals exhausted' treatment and the actionable error text for error_category=deferral_exhausted", () => {
@@ -305,9 +488,10 @@ describe("SyncRunDetailLive", () => {
             />,
         );
 
-        // Badge (attention panel + unit table) — same exhausted-style treatment
-        // as budget_deferral_exhausted, distinct label.
-        expect(screen.getAllByText("Deferrals exhausted").length).toBe(2);
+        // The unit table keeps the compact badge while the attention summary
+        // explains the persisted machine category.
+        expect(screen.getByText("Deferrals exhausted")).toBeInTheDocument();
+        expect(screen.getAllByText("Sync deferral limit reached").length).toBeGreaterThan(0);
         // The actionable error text (naming the last episode kind and both
         // counters) surfaces prominently, same path as any failed unit.
         expect(
@@ -529,6 +713,28 @@ describe("SyncRunDetailLive — live poll error handling", () => {
         expect(screen.getByText(/Units \(4\)/)).toBeInTheDocument();
     });
 
+    it("states that live updates are paused when the polling safety window expires", async () => {
+        vi.mocked(getSyncRunStatus).mockResolvedValue({ data: RUNNING_RUN });
+        vi.mocked(getSyncRunUnits).mockResolvedValue({ data: SAMPLE_SYNC_RUN_UNIT_SUMMARY });
+
+        render(
+            <SyncRunDetailLive
+                initialRun={RUNNING_RUN}
+                initialSummary={SAMPLE_SYNC_RUN_UNIT_SUMMARY}
+            />,
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+        });
+
+        expect(screen.getByText("Live updates paused")).toBeInTheDocument();
+        expect(
+            screen.getByText("Automatic updates paused after 10 minutes. Refresh to resume."),
+        ).toBeInTheDocument();
+        expect(screen.queryByText("Live — refreshing…")).not.toBeInTheDocument();
+    });
+
     it("does not poll when initial unit rollups make a stale running run terminal", async () => {
         render(
             <SyncRunDetailLive
@@ -582,7 +788,7 @@ describe("SyncRunDetailLive — live poll error handling", () => {
 
         expect(screen.getByText(/1 \/ 4/)).toBeInTheDocument();
         expect(screen.getByText(/25%/)).toBeInTheDocument();
-        expect(screen.getByText("running")).toBeInTheDocument();
+        expect(screen.getAllByText("Running").length).toBeGreaterThan(0);
         await act(async () => {
             await vi.advanceTimersByTimeAsync(3500 * 2);
         });

--- a/src/components/admin/sync/SyncRunDetailLive.tsx
+++ b/src/components/admin/sync/SyncRunDetailLive.tsx
@@ -4,9 +4,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ClientTimestamp } from "@/components/ClientTimestamp";
 import { SyncStatusBadge } from "./SyncStatusBadge";
 import { getSyncRunStatus, getSyncRunUnits } from "@/lib/admin/server";
+import { getSyncRunPresentation } from "@/lib/admin/syncRunPresentation";
+import { getSyncUnitErrorPresentation } from "@/lib/admin/syncUnitErrorPresentation";
 import { CTA_LABELS } from "@/lib/design/cta";
 import { formatNumber, formatPercent, formatDateUTC } from "@/lib/formatters";
-import { type SyncStatus, isTerminalSyncStatus, mapPlannerRunStatus } from "@/lib/sync-types";
+import { type SyncStatus, isTerminalSyncStatus } from "@/lib/sync-types";
 import type { SyncRun, SyncRunUnit, SyncRunUnitSummary } from "@/lib/admin/types";
 
 /** How often to refresh live run + unit state while non-terminal. */
@@ -85,6 +87,38 @@ function isDeferralsExhaustedUnit(unit: SyncRunUnit): boolean {
     return unit.status === "failed" && unit.error_category === "deferral_exhausted";
 }
 
+function isProviderCapacityWaitingUnit(unit: SyncRunUnit): boolean {
+    return (
+        unit.error_category === "provider_budget_contention" ||
+        unit.error === "provider_budget_contention"
+    );
+}
+
+type AttentionDisposition = "failed" | "retrying" | "waiting";
+
+interface AttentionGroup {
+    key: string;
+    datasetKey: string;
+    disposition: AttentionDisposition;
+    title: string;
+    detail: string | null;
+    sourceNames: string[];
+    units: SyncRunUnit[];
+    retryWindows: Array<{
+        availableAt: string;
+        sourceNames: string[];
+    }>;
+    budgetDeferrals: number | null;
+}
+
+function attentionDisposition(unit: SyncRunUnit): AttentionDisposition {
+    if (isProviderCapacityWaitingUnit(unit) || unit.error_category === "budget_deferred") {
+        return "waiting";
+    }
+    if (unit.status === "failed") return "failed";
+    return "retrying";
+}
+
 /**
  * Distinct badge treatment for budget-guard states, styled with the same
  * theme-aware token idiom used elsewhere for warning/negative tones
@@ -115,39 +149,6 @@ function CatchingUpBadge() {
             Catching up
         </span>
     );
-}
-
-function statusCount(summary: SyncRunUnitSummary | null, status: string): number | null {
-    if (!summary) return null;
-    return summary.by_status[status] ?? 0;
-}
-
-function totalUnitCount(run: SyncRun, summary: SyncRunUnitSummary | null): number {
-    return summary ? Math.max(summary.unit_count, run.total_units) : run.total_units;
-}
-
-function effectiveRunStatus(run: SyncRun, summary: SyncRunUnitSummary | null): string {
-    if (!summary) return run.status;
-
-    const successCount = statusCount(summary, "success") ?? 0;
-    const failedCount = statusCount(summary, "failed") ?? 0;
-    const settledCount = successCount + failedCount;
-    const totalUnits = totalUnitCount(run, summary);
-    if (totalUnits > 0 && settledCount >= totalUnits) {
-        if (failedCount === 0) return "success";
-        if (successCount === 0) return "failed";
-        return "partial_failed";
-    }
-    if (
-        settledCount > 0 ||
-        (statusCount(summary, "running") ?? 0) > 0 ||
-        (statusCount(summary, "retrying") ?? 0) > 0
-    ) {
-        return "running";
-    }
-    if ((statusCount(summary, "dispatching") ?? 0) > 0) return "dispatching";
-    if ((statusCount(summary, "planned") ?? 0) > 0) return "planned";
-    return run.status;
 }
 
 function formatDuration(seconds: number | null): string {
@@ -262,6 +263,7 @@ export function SyncRunDetailLive({
     const [run, setRun] = useState<SyncRun>(initialRun);
     const [summary, setSummary] = useState<SyncRunUnitSummary | null>(initialSummary);
     const [unitsError, setUnitsError] = useState<string | null>(initialUnitsError);
+    const [liveUpdatesPaused, setLiveUpdatesPaused] = useState(false);
 
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -286,9 +288,8 @@ export function SyncRunDetailLive({
         }
     }, []);
 
-    const currentRunStatus = effectiveRunStatus(run, summary);
-    const liveStatus = mapPlannerRunStatus(currentRunStatus);
-    const isTerminal = isTerminalSyncStatus(liveStatus);
+    const runPresentation = getSyncRunPresentation(run, summary);
+    const isTerminal = isTerminalSyncStatus(runPresentation.badgeStatus);
 
     // Poll run + unit state while the run is non-terminal, mirroring the
     // cleanup/timeout discipline in useSyncTrigger.ts. State is only mutated
@@ -319,6 +320,7 @@ export function SyncRunDetailLive({
                 // stale/empty data (FIX 2).
                 if (runRes.error || unitsRes.error || !runRes.data || !unitsRes.data) {
                     stopPolling();
+                    setLiveUpdatesPaused(true);
                     setUnitsError(
                         runRes.error ?? unitsRes.error ?? "Live updates are unavailable.",
                     );
@@ -327,12 +329,11 @@ export function SyncRunDetailLive({
 
                 setSummary(unitsRes.data);
                 setUnitsError(null);
+                setLiveUpdatesPaused(false);
                 const nextRun = runRes.data;
                 setRun(nextRun);
-                const nextLiveStatus = mapPlannerRunStatus(
-                    effectiveRunStatus(nextRun, unitsRes.data),
-                );
-                if (isTerminalSyncStatus(nextLiveStatus)) {
+                const nextPresentation = getSyncRunPresentation(nextRun, unitsRes.data);
+                if (nextPresentation.terminal) {
                     stopPolling();
                 }
             } finally {
@@ -341,7 +342,10 @@ export function SyncRunDetailLive({
         };
 
         intervalRef.current = setInterval(() => void tick(), POLL_INTERVAL_MS);
-        timeoutRef.current = setTimeout(() => stopPolling(), MAX_POLL_DURATION_MS);
+        timeoutRef.current = setTimeout(() => {
+            stopPolling();
+            setLiveUpdatesPaused(true);
+        }, MAX_POLL_DURATION_MS);
 
         return () => {
             cancelled = true;
@@ -365,19 +369,81 @@ export function SyncRunDetailLive({
         [sourceNameById],
     );
 
-    const total = totalUnitCount(run, summary);
-    const completed = statusCount(summary, "success") ?? run.completed_units;
-    const failed = statusCount(summary, "failed") ?? run.failed_units;
-    const settled = Math.min(total, completed + failed);
+    const { total, completed, failed, settled } = runPresentation.counts;
     const percent = total > 0 ? Math.min(100, Math.round((settled / total) * 100)) : 0;
 
     const attentionUnits = useMemo(
         () =>
             (summary?.units ?? []).filter(
-                (unit) => unit.status === "failed" || unit.status === "retrying",
+                (unit) =>
+                    unit.status === "failed" ||
+                    unit.status === "retrying" ||
+                    isProviderCapacityWaitingUnit(unit),
             ),
         [summary],
     );
+
+    const attentionGroups = useMemo<AttentionGroup[]>(() => {
+        const groups = new Map<
+            string,
+            Omit<AttentionGroup, "sourceNames" | "retryWindows" | "budgetDeferrals"> & {
+                sourceNames: Set<string>;
+            }
+        >();
+
+        for (const unit of attentionUnits) {
+            const errorPresentation = getSyncUnitErrorPresentation(unit.error, unit.error_category);
+            const disposition = attentionDisposition(unit);
+            const key = `${unit.dataset_key}:${errorPresentation.code ?? errorPresentation.title}:${disposition}`;
+            const existing = groups.get(key);
+            if (existing) {
+                existing.units.push(unit);
+                existing.sourceNames.add(sourceLabel(unit.source_id));
+                continue;
+            }
+            groups.set(key, {
+                key,
+                datasetKey: unit.dataset_key,
+                disposition,
+                title: errorPresentation.title,
+                detail: errorPresentation.detail,
+                sourceNames: new Set([sourceLabel(unit.source_id)]),
+                units: [unit],
+            });
+        }
+
+        return Array.from(groups.values(), (group) => {
+            const sourcesByRetryWindow = new Map<string, Set<string>>();
+            if (group.disposition !== "failed") {
+                for (const unit of group.units) {
+                    if (!unit.available_at) continue;
+                    const sources =
+                        sourcesByRetryWindow.get(unit.available_at) ?? new Set<string>();
+                    sources.add(sourceLabel(unit.source_id));
+                    sourcesByRetryWindow.set(unit.available_at, sources);
+                }
+            }
+
+            return {
+                ...group,
+                sourceNames: Array.from(group.sourceNames).sort(),
+                retryWindows: Array.from(sourcesByRetryWindow, ([availableAt, sources]) => ({
+                    availableAt,
+                    sourceNames: Array.from(sources).sort(),
+                })).sort((left, right) => left.availableAt.localeCompare(right.availableAt)),
+                budgetDeferrals:
+                    group.units.some(isBudgetBlockedUnit) &&
+                    group.units.some((unit) => typeof unit.budget_deferrals === "number")
+                        ? group.units.reduce(
+                              (total, unit) => total + (unit.budget_deferrals ?? 0),
+                              0,
+                          )
+                        : null,
+            };
+        }).sort((left, right) =>
+            `${left.datasetKey}:${left.title}`.localeCompare(`${right.datasetKey}:${right.title}`),
+        );
+    }, [attentionUnits, sourceLabel]);
 
     // Unit table filters (CHAOS-2794) — client-side over the already-fetched
     // unit summary; narrows which persisted rows are displayed, never
@@ -479,7 +545,11 @@ export function SyncRunDetailLive({
                 <div className="flex flex-wrap items-start justify-between gap-4">
                     <div className="space-y-2">
                         <div className="flex items-center gap-3">
-                            <SyncStatusBadge status={liveStatus} className="text-sm px-3 py-1" />
+                            <SyncStatusBadge
+                                status={runPresentation.badgeStatus}
+                                label={runPresentation.label}
+                                className="text-sm px-3 py-1"
+                            />
                             <span
                                 className="text-sm text-(--ink-muted)"
                                 role="status"
@@ -487,17 +557,27 @@ export function SyncRunDetailLive({
                             >
                                 {isTerminal
                                     ? "Run complete"
-                                    : unitsError
+                                    : unitsError || liveUpdatesPaused
                                       ? "Live updates paused"
                                       : "Live — refreshing…"}
                             </span>
                         </div>
+                        {runPresentation.description && (
+                            <p className="text-sm text-(--ink-muted)">
+                                {runPresentation.description}
+                            </p>
+                        )}
+                        {liveUpdatesPaused && !unitsError && !isTerminal && (
+                            <p className="text-sm text-(--ink-muted)">
+                                Automatic updates paused after 10 minutes. Refresh to resume.
+                            </p>
+                        )}
                         <dl className="grid grid-cols-2 gap-x-8 gap-y-1 text-sm sm:grid-cols-4">
                             <div>
                                 <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
                                     Status
                                 </dt>
-                                <dd className="text-foreground">{currentRunStatus}</dd>
+                                <dd className="text-foreground">{runPresentation.label}</dd>
                             </div>
                             <div>
                                 <dt className="text-xs text-(--ink-muted) uppercase tracking-wider">
@@ -757,10 +837,16 @@ export function SyncRunDetailLive({
                     </div>
 
                     {/* Failed / retrying summary */}
-                    {attentionUnits.length > 0 && (
-                        <div className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6">
+                    {attentionGroups.length > 0 && (
+                        <section
+                            aria-labelledby="needs-attention-heading"
+                            className="rounded-xl border border-(--card-stroke) bg-(--card-80) p-6"
+                        >
                             <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-                                <h3 className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider">
+                                <h3
+                                    id="needs-attention-heading"
+                                    className="text-sm font-medium text-(--ink-muted) uppercase tracking-wider"
+                                >
                                     Needs attention
                                 </h3>
                                 <div className="flex flex-wrap items-center gap-3">
@@ -783,89 +869,74 @@ export function SyncRunDetailLive({
                                 </div>
                             </div>
                             <ul className="space-y-3">
-                                {attentionUnits.map((unit) => (
+                                {attentionGroups.map((group) => (
                                     <li
-                                        key={unit.id}
+                                        key={group.key}
                                         className="rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 text-sm"
                                     >
                                         <div className="flex flex-wrap items-center justify-between gap-2">
-                                            <span className="font-medium text-foreground">
-                                                {sourceLabel(unit.source_id)} · {unit.dataset_key}
-                                            </span>
-                                            {isBudgetBlockedUnit(unit) ? (
-                                                <BudgetGuardBadge
-                                                    tone="blocked"
-                                                    label="Blocked: budget"
-                                                />
-                                            ) : isBudgetExhaustedUnit(unit) ? (
-                                                <BudgetGuardBadge
-                                                    tone="exhausted"
-                                                    label="Budget exhausted"
-                                                />
-                                            ) : isDeferralsExhaustedUnit(unit) ? (
-                                                <BudgetGuardBadge
-                                                    tone="exhausted"
-                                                    label="Deferrals exhausted"
-                                                />
-                                            ) : (
-                                                <SyncStatusBadge
-                                                    status={unitBadgeStatus(unit.status)}
-                                                    label={unit.status}
-                                                />
-                                            )}
+                                            <div>
+                                                <p className="text-xs text-(--ink-muted)">
+                                                    {group.datasetKey}
+                                                </p>
+                                                <h4 className="font-medium text-foreground">
+                                                    {group.title}
+                                                </h4>
+                                            </div>
+                                            <SyncStatusBadge
+                                                status={
+                                                    group.disposition === "failed"
+                                                        ? "failed"
+                                                        : "running"
+                                                }
+                                                label={group.disposition}
+                                            />
                                         </div>
-                                        <div className="mt-1 text-xs text-(--ink-muted)">
-                                            {isBudgetBlockedUnit(unit) ? (
-                                                <>
-                                                    {typeof unit.budget_deferrals === "number" && (
-                                                        <span>
-                                                            {formatNumber(unit.budget_deferrals)}{" "}
-                                                            deferral
-                                                            {unit.budget_deferrals === 1 ? "" : "s"}
-                                                        </span>
-                                                    )}
-                                                    {typeof unit.budget_deferrals === "number" &&
-                                                        unit.available_at &&
-                                                        " · "}
-                                                    {unit.available_at && (
-                                                        <span>
-                                                            Next attempt{" "}
-                                                            <ClientTimestamp
-                                                                value={unit.available_at}
-                                                                fallback="—"
-                                                            />
-                                                        </span>
-                                                    )}
-                                                </>
-                                            ) : (
-                                                <>
-                                                    {unit.error_category && (
-                                                        <span>Category: {unit.error_category}</span>
-                                                    )}
-                                                    {unit.error_category &&
-                                                        unit.available_at &&
-                                                        " · "}
-                                                    {unit.available_at && (
-                                                        <span>
-                                                            Retry at{" "}
-                                                            <ClientTimestamp
-                                                                value={unit.available_at}
-                                                                fallback="—"
-                                                            />
-                                                        </span>
-                                                    )}
-                                                </>
-                                            )}
-                                        </div>
-                                        {unit.error && (
-                                            <p className="mt-1 text-xs text-red-500">
-                                                {unit.error}
+                                        <p className="mt-1 text-xs text-(--ink-muted)">
+                                            {formatNumber(group.units.length)} {group.disposition}{" "}
+                                            unit{group.units.length === 1 ? "" : "s"} ·{" "}
+                                            {formatNumber(group.sourceNames.length)} source
+                                            {group.sourceNames.length === 1 ? "" : "s"}
+                                        </p>
+                                        <p className="mt-1 text-xs text-(--ink-muted)">
+                                            {group.sourceNames.join(", ")}
+                                        </p>
+                                        {group.detail && (
+                                            <p className="mt-1 text-xs text-(--ink-muted)">
+                                                {group.detail}
                                             </p>
+                                        )}
+                                        {group.budgetDeferrals !== null && (
+                                            <p className="mt-1 text-xs text-(--ink-muted)">
+                                                {formatNumber(group.budgetDeferrals)} deferral
+                                                {group.budgetDeferrals === 1 ? "" : "s"}
+                                            </p>
+                                        )}
+                                        {group.retryWindows.length > 0 && (
+                                            <ul
+                                                aria-label={`${group.title} retry schedule`}
+                                                className="mt-1 space-y-1 text-xs text-(--ink-muted)"
+                                            >
+                                                {group.retryWindows.map((retryWindow) => (
+                                                    <li key={retryWindow.availableAt}>
+                                                        <span>
+                                                            {group.disposition === "waiting"
+                                                                ? "Next attempt"
+                                                                : "Retry at"}{" "}
+                                                            <ClientTimestamp
+                                                                value={retryWindow.availableAt}
+                                                                fallback="—"
+                                                            />{" "}
+                                                            · {retryWindow.sourceNames.join(", ")}
+                                                        </span>
+                                                    </li>
+                                                ))}
+                                            </ul>
                                         )}
                                     </li>
                                 ))}
                             </ul>
-                        </div>
+                        </section>
                     )}
 
                     {/* Unit table */}
@@ -980,78 +1051,97 @@ export function SyncRunDetailLive({
                                     </tr>
                                 </thead>
                                 <tbody className="divide-y divide-(--card-stroke)">
-                                    {filteredUnits.map((unit: SyncRunUnit) => (
-                                        <tr key={unit.id}>
-                                            <td className="px-4 py-3 font-mono text-xs text-(--ink-muted)">
-                                                {unit.id.slice(0, 8)}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-foreground">
-                                                {sourceLabel(unit.source_id)}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-(--ink-muted)">
-                                                {unit.dataset_key}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-(--ink-muted)">
-                                                {formatDateUTC(unit.since_at)}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-(--ink-muted)">
-                                                {formatDateUTC(unit.before_at)}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-(--ink-muted)">
-                                                {unit.cost_class}
-                                            </td>
-                                            <td className="px-4 py-3">
-                                                {isBudgetBlockedUnit(unit) ? (
-                                                    <BudgetGuardBadge
-                                                        tone="blocked"
-                                                        label="Blocked: budget"
-                                                    />
-                                                ) : isBudgetExhaustedUnit(unit) ? (
-                                                    <BudgetGuardBadge
-                                                        tone="exhausted"
-                                                        label="Budget exhausted"
-                                                    />
-                                                ) : isDeferralsExhaustedUnit(unit) ? (
-                                                    <BudgetGuardBadge
-                                                        tone="exhausted"
-                                                        label="Deferrals exhausted"
-                                                    />
-                                                ) : (
-                                                    <SyncStatusBadge
-                                                        status={unitBadgeStatus(unit.status)}
-                                                        label={unit.status}
-                                                    />
-                                                )}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-(--ink-muted)">
-                                                {formatNumber(unit.attempts)}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm text-(--ink-muted)">
-                                                {formatDuration(unit.duration_seconds)}
-                                            </td>
-                                            <td className="px-4 py-3 text-sm">
-                                                {unit.error ? (
-                                                    <span className="text-red-500">
-                                                        {unit.error}
-                                                    </span>
-                                                ) : unit.error_category ? (
-                                                    <span className="text-(--ink-muted)">
-                                                        {unit.error_category}
-                                                    </span>
-                                                ) : unit.available_at ? (
-                                                    <span className="text-(--ink-muted)">
-                                                        Retry{" "}
-                                                        <ClientTimestamp
-                                                            value={unit.available_at}
-                                                            fallback="—"
+                                    {filteredUnits.map((unit: SyncRunUnit) => {
+                                        const errorPresentation = getSyncUnitErrorPresentation(
+                                            unit.error,
+                                            unit.error_category,
+                                        );
+                                        return (
+                                            <tr key={unit.id}>
+                                                <td className="px-4 py-3 font-mono text-xs text-(--ink-muted)">
+                                                    {unit.id.slice(0, 8)}
+                                                </td>
+                                                <td className="px-4 py-3 text-sm text-foreground">
+                                                    {sourceLabel(unit.source_id)}
+                                                </td>
+                                                <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                                    {unit.dataset_key}
+                                                </td>
+                                                <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                                    {formatDateUTC(unit.since_at)}
+                                                </td>
+                                                <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                                    {formatDateUTC(unit.before_at)}
+                                                </td>
+                                                <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                                    {unit.cost_class}
+                                                </td>
+                                                <td className="px-4 py-3">
+                                                    {isBudgetBlockedUnit(unit) ? (
+                                                        <BudgetGuardBadge
+                                                            tone="blocked"
+                                                            label="Blocked: budget"
                                                         />
-                                                    </span>
-                                                ) : (
-                                                    <span className="text-(--ink-muted)">—</span>
-                                                )}
-                                            </td>
-                                        </tr>
-                                    ))}
+                                                    ) : isBudgetExhaustedUnit(unit) ? (
+                                                        <BudgetGuardBadge
+                                                            tone="exhausted"
+                                                            label="Budget exhausted"
+                                                        />
+                                                    ) : isDeferralsExhaustedUnit(unit) ? (
+                                                        <BudgetGuardBadge
+                                                            tone="exhausted"
+                                                            label="Deferrals exhausted"
+                                                        />
+                                                    ) : isProviderCapacityWaitingUnit(unit) ? (
+                                                        <BudgetGuardBadge
+                                                            tone="blocked"
+                                                            label="Waiting: provider capacity"
+                                                        />
+                                                    ) : (
+                                                        <SyncStatusBadge
+                                                            status={unitBadgeStatus(unit.status)}
+                                                            label={unit.status}
+                                                        />
+                                                    )}
+                                                </td>
+                                                <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                                    {formatNumber(unit.attempts)}
+                                                </td>
+                                                <td className="px-4 py-3 text-sm text-(--ink-muted)">
+                                                    {formatDuration(unit.duration_seconds)}
+                                                </td>
+                                                <td className="px-4 py-3 text-sm">
+                                                    {unit.error || unit.error_category ? (
+                                                        <span
+                                                            className={
+                                                                unit.status === "failed"
+                                                                    ? "text-red-500"
+                                                                    : "text-(--ink-muted)"
+                                                            }
+                                                            title={
+                                                                errorPresentation.detail ??
+                                                                undefined
+                                                            }
+                                                        >
+                                                            {errorPresentation.title}
+                                                        </span>
+                                                    ) : unit.available_at ? (
+                                                        <span className="text-(--ink-muted)">
+                                                            Retry{" "}
+                                                            <ClientTimestamp
+                                                                value={unit.available_at}
+                                                                fallback="—"
+                                                            />
+                                                        </span>
+                                                    ) : (
+                                                        <span className="text-(--ink-muted)">
+                                                            —
+                                                        </span>
+                                                    )}
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
                                 </tbody>
                             </table>
                         </div>

--- a/src/lib/admin/__tests__/syncUnitErrorPresentation.test.ts
+++ b/src/lib/admin/__tests__/syncUnitErrorPresentation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { getSyncUnitErrorPresentation } from "../syncUnitErrorPresentation";
+
+describe("getSyncUnitErrorPresentation", () => {
+    it.each([
+        ["provider_unit_exhausted", "Provider retries exhausted"],
+        ["provider_unit_retryable", "Provider request will retry"],
+        ["provider_budget_contention", "Waiting for provider capacity"],
+        ["budget_deferred", "Waiting for sync budget"],
+        ["budget_deferral_exhausted", "Sync budget wait limit reached"],
+        ["deferral_exhausted", "Sync deferral limit reached"],
+        ["effect_recovery_ambiguous", "Previous sync result could not be verified"],
+    ])("translates %s without exposing the machine code", (code, title) => {
+        const presentation = getSyncUnitErrorPresentation(code, code);
+
+        expect(presentation.title).toBe(title);
+        expect(presentation.detail).not.toContain(code);
+    });
+
+    it("keeps a detailed human-readable backend explanation under the translated title", () => {
+        expect(
+            getSyncUnitErrorPresentation(
+                "GitHub returned 503 while listing workflow runs",
+                "provider_unit_retryable",
+            ),
+        ).toEqual({
+            code: "provider_unit_retryable",
+            title: "Provider request will retry",
+            detail: "GitHub returned 503 while listing workflow runs",
+        });
+    });
+
+    it("humanizes an unknown machine code", () => {
+        expect(getSyncUnitErrorPresentation("custom_provider_fault", null)).toEqual({
+            code: "custom_provider_fault",
+            title: "Custom provider fault",
+            detail: null,
+        });
+    });
+});

--- a/src/lib/admin/syncRunPresentation.ts
+++ b/src/lib/admin/syncRunPresentation.ts
@@ -1,0 +1,156 @@
+import type { SyncRun, SyncRunUnitSummary } from "@/lib/admin/types";
+import { type SyncStatus, mapPlannerRunStatus } from "@/lib/sync-types";
+
+export interface SyncRunCounts {
+    total: number;
+    completed: number;
+    failed: number;
+    settled: number;
+    active: number;
+}
+
+export interface SyncRunPresentation {
+    effectiveStatus: string;
+    badgeStatus: SyncStatus;
+    label: string;
+    progressLabel: string;
+    description: string | null;
+    terminal: boolean;
+    counts: SyncRunCounts;
+}
+
+function statusCount(summary: SyncRunUnitSummary | null, status: string): number | null {
+    if (!summary) return null;
+    return summary.by_status[status] ?? 0;
+}
+
+export function getSyncRunCounts(run: SyncRun, summary: SyncRunUnitSummary | null): SyncRunCounts {
+    const total = summary ? Math.max(summary.unit_count, run.total_units) : run.total_units;
+    const completed = statusCount(summary, "success") ?? run.completed_units;
+    const failed = statusCount(summary, "failed") ?? run.failed_units;
+    const settled = Math.min(total, completed + failed);
+    return {
+        total,
+        completed,
+        failed,
+        settled,
+        active: Math.max(0, total - settled),
+    };
+}
+
+export function getEffectiveSyncRunStatus(
+    run: SyncRun,
+    summary: SyncRunUnitSummary | null,
+): string {
+    if (!summary) return run.status;
+
+    const counts = getSyncRunCounts(run, summary);
+    if (counts.total > 0 && counts.settled >= counts.total) {
+        if (counts.failed === 0) return "success";
+        if (counts.completed === 0) return "failed";
+        return "partial_failed";
+    }
+    if (
+        counts.settled > 0 ||
+        (statusCount(summary, "running") ?? 0) > 0 ||
+        (statusCount(summary, "retrying") ?? 0) > 0
+    ) {
+        return "running";
+    }
+    if ((statusCount(summary, "dispatching") ?? 0) > 0) return "dispatching";
+    if ((statusCount(summary, "planned") ?? 0) > 0) return "planned";
+    return run.status;
+}
+
+function unitPhrase(count: number, singular: string, plural = `${singular}s`): string {
+    return `${count} ${count === 1 ? singular : plural}`;
+}
+
+export function getSyncRunPresentation(
+    run: SyncRun,
+    summary: SyncRunUnitSummary | null,
+): SyncRunPresentation {
+    const counts = getSyncRunCounts(run, summary);
+    const effectiveStatus = getEffectiveSyncRunStatus(run, summary);
+    const badgeStatus = mapPlannerRunStatus(effectiveStatus);
+    const terminal =
+        effectiveStatus === "success" ||
+        effectiveStatus === "failed" ||
+        effectiveStatus === "partial_failed";
+
+    if (!terminal && counts.failed > 0) {
+        return {
+            effectiveStatus,
+            badgeStatus,
+            label: "Running with failures",
+            progressLabel: "Syncing with failures...",
+            description: `${unitPhrase(counts.failed, "unit")} failed; ${unitPhrase(counts.active, "unit")} ${counts.active === 1 ? "is" : "are"} still processing.`,
+            terminal,
+            counts,
+        };
+    }
+
+    switch (effectiveStatus) {
+        case "partial_failed":
+            return {
+                effectiveStatus,
+                badgeStatus,
+                label: "Completed with failures",
+                progressLabel: "Sync completed with failures",
+                description: `${unitPhrase(counts.completed, "unit")} completed and ${unitPhrase(counts.failed, "unit")} failed.`,
+                terminal,
+                counts,
+            };
+        case "failed":
+            return {
+                effectiveStatus,
+                badgeStatus,
+                label: "Failed",
+                progressLabel: "Sync failed",
+                description:
+                    counts.failed > 0 ? `${unitPhrase(counts.failed, "unit")} failed.` : null,
+                terminal,
+                counts,
+            };
+        case "success":
+            return {
+                effectiveStatus,
+                badgeStatus,
+                label: "Completed",
+                progressLabel: "Sync completed",
+                description: null,
+                terminal,
+                counts,
+            };
+        case "planned":
+            return {
+                effectiveStatus,
+                badgeStatus,
+                label: "Planned",
+                progressLabel: "Syncing...",
+                description: null,
+                terminal,
+                counts,
+            };
+        case "dispatching":
+            return {
+                effectiveStatus,
+                badgeStatus,
+                label: "Dispatching",
+                progressLabel: "Syncing...",
+                description: null,
+                terminal,
+                counts,
+            };
+        default:
+            return {
+                effectiveStatus,
+                badgeStatus,
+                label: "Running",
+                progressLabel: "Syncing...",
+                description: null,
+                terminal,
+                counts,
+            };
+    }
+}

--- a/src/lib/admin/syncUnitErrorPresentation.ts
+++ b/src/lib/admin/syncUnitErrorPresentation.ts
@@ -1,0 +1,121 @@
+export interface SyncUnitErrorPresentation {
+    code: string | null;
+    title: string;
+    detail: string | null;
+}
+
+const KNOWN_SYNC_UNIT_ERRORS: Record<string, { title: string; detail: string }> = {
+    provider_unit_exhausted: {
+        title: "Provider retries exhausted",
+        detail: "This unit used all retry attempts before it could complete.",
+    },
+    provider_unit_retryable: {
+        title: "Provider request will retry",
+        detail: "The provider request failed temporarily and will be tried again.",
+    },
+    provider_budget_contention: {
+        title: "Waiting for provider capacity",
+        detail: "Other provider work is using the available request capacity. This unit will resume automatically.",
+    },
+    budget_deferred: {
+        title: "Waiting for sync budget",
+        detail: "This unit is paused until sync capacity becomes available.",
+    },
+    budget_deferral_exhausted: {
+        title: "Sync budget wait limit reached",
+        detail: "This unit could not obtain sync capacity before its wait limit expired.",
+    },
+    deferral_exhausted: {
+        title: "Sync deferral limit reached",
+        detail: "This unit reached the maximum number of wait cycles before it could run.",
+    },
+    effect_recovery_ambiguous: {
+        title: "Previous sync result could not be verified",
+        detail: "The worker could not safely determine whether a previous write completed.",
+    },
+    rate_limit: {
+        title: "Waiting for provider rate limit",
+        detail: "The provider asked us to slow down. This unit will retry automatically.",
+    },
+    provider_error: {
+        title: "Provider request failed",
+        detail: "The provider returned an error while this unit was running.",
+    },
+    worker_lost: {
+        title: "Worker stopped responding",
+        detail: "The worker stopped before it reported a final result.",
+    },
+    soft_timeout: {
+        title: "Provider request timed out",
+        detail: "This unit exceeded its time limit and may retry.",
+    },
+    feature_disabled: {
+        title: "Sync route is disabled",
+        detail: "This dataset is not enabled for the current worker route.",
+    },
+    pagerduty_sync_disabled: {
+        title: "PagerDuty sync is disabled",
+        detail: "PagerDuty synchronization is disabled for this worker route.",
+    },
+    dispatch_denied: {
+        title: "Sync dispatch was denied",
+        detail: "The worker could not accept this unit for processing.",
+    },
+};
+
+const MACHINE_CODE_PATTERN = /^[a-z0-9]+(?:_[a-z0-9]+)+$/;
+
+function humanizeMachineCode(value: string): string {
+    const words = value.replaceAll("_", " ");
+    return `${words.charAt(0).toUpperCase()}${words.slice(1)}`;
+}
+
+function clean(value: string | null | undefined): string | null {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : null;
+}
+
+export function getSyncUnitErrorPresentation(
+    error: string | null | undefined,
+    errorCategory: string | null | undefined,
+): SyncUnitErrorPresentation {
+    const cleanError = clean(error);
+    const cleanCategory = clean(errorCategory);
+    const code =
+        cleanCategory ?? (cleanError && MACHINE_CODE_PATTERN.test(cleanError) ? cleanError : null);
+    const known = code ? KNOWN_SYNC_UNIT_ERRORS[code] : undefined;
+
+    if (known) {
+        const detailedError =
+            cleanError && cleanError !== code && !MACHINE_CODE_PATTERN.test(cleanError)
+                ? cleanError
+                : null;
+        return {
+            code,
+            title: known.title,
+            detail: detailedError ?? known.detail,
+        };
+    }
+
+    if (code) {
+        const detailedError =
+            cleanError && cleanError !== code && !MACHINE_CODE_PATTERN.test(cleanError)
+                ? cleanError
+                : null;
+        return {
+            code,
+            title: humanizeMachineCode(code),
+            detail: detailedError,
+        };
+    }
+
+    if (cleanError) {
+        return { code: null, title: cleanError, detail: null };
+    }
+
+    return {
+        code: null,
+        title: "Sync unit needs attention",
+        detail: null,
+    };
+}

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -346,8 +346,9 @@ export interface SyncRunUnit {
      * bucket, cap, and remedies), and "deferral_exhausted" (terminal —
      * aggregate cap: the unit oscillated between budget and rate-limit
      * deferral episodes without ever running; `error` names the last
-     * episode kind and both counters). Persisted strings — render verbatim,
-     * never invent variants.
+     * episode kind and both counters). Persisted strings are stable machine
+     * codes. Keep them intact in state and translate them through the shared
+     * web presentation map before rendering operator-facing copy.
      */
     error_category: string | null;
     last_heartbeat_at: string | null;


### PR DESCRIPTION
## Summary

- present active mixed-outcome syncs as **Running with failures** and terminal mixed outcomes as **Completed with failures** across the run header and progress surface
- stop silently restarting automatic polling after its 10-minute cap; keep the latest snapshot visible and state that updates are paused until refresh
- collapse repeated attention rows by dataset, human-readable reason, and disposition while preserving source counts and every distinct retry window
- treat provider-capacity contention as waiting work instead of a terminal failure
- translate backend operator codes into human-readable web copy in sync-run and backfill surfaces, with a safe fallback for unknown machine codes

The backend contract and persisted error values are unchanged.

Closes #883

## TEST-EVIDENCE

- canonical `ci/run_tests.sh ci`: PASS on exact head
  - production audit, generated contracts, lint, typecheck, and Next.js production build
  - Vitest: 3,812 passed / 8 skipped
  - default Playwright: 328 passed / 2 expected skips
  - onboarding Playwright: 10 passed
  - Context Fabric Playwright: 21 passed
  - PagerDuty final QA: 23 passed
- focused presentation suite: 86 passed
- RED-to-GREEN regression proves repeated retrying units preserve both retry windows with their affected sources and terminal failures do not advertise another retry
- inspected against a real read-only completed mixed-result sync; raw `provider_unit_exhausted` values collapsed into two human-readable dataset groups

## RISK-NOTES

- web-only presentation change; no backend, schema, retry, routing, or live-stack mutation
- unknown machine codes are title-cased rather than exposed as snake case; useful human backend detail remains visible
- grouped retries retain each distinct `available_at` value and its source set; terminal failures intentionally suppress stale retry timestamps

## Screenshots

### Truthful terminal status

![Completed with failures status](https://github.com/user-attachments/assets/a7a80886-8e78-4214-8120-a7452a26e46a)

### Grouped, human-readable attention summary

![Grouped attention summary](https://github.com/user-attachments/assets/21a0e73b-46cf-4611-a55a-10741716cdcc)
