### PR TITLE
CHAOS-3800: raise the nanoid floor to the actual patched version (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   fast-uri: '>=3.1.5 <4'
   sharp: 0.35.3
   postcss: '>=8.5.18'
-  nanoid: '>=3.3.17 <4'
+  nanoid: '>=3.3.18 <4'
   minimatch@10>brace-expansion: '>=5.0.9'
 
 importers:
@@ -4269,8 +4269,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10030,7 +10030,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -10305,13 +10305,13 @@ snapshots:
 
   postcss@8.5.20:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,11 +17,19 @@ overrides:
     postcss: ">=8.5.18"
     # nanoid: reached only transitively, via @sentry/nextjs (its webpack and its
     # next > postcss chains — 6 paths, no direct dependency to upgrade). Floor
-    # raised past GHSA-2v37-7h3g-55p8 (custom generators can loop indefinitely when
-    # size is zero, fixed in 3.3.17); the tree resolved a single nanoid@3.3.16, one
-    # patch below the fix. Held inside major 3: postcss declares ^3.3.x and nanoid 5+
-    # is ESM-only, so an unbounded floor would break the consumers that need it.
-    nanoid: ">=3.3.17 <4"
+    # for GHSA-2v37-7h3g-55p8 (custom generators can loop indefinitely when size
+    # is zero) is >=3.3.18 per the advisory's own "Patched versions" field —
+    # >=3.3.17 (CHAOS-3594's original floor) still resolves to the vulnerable
+    # 3.3.17 itself and stayed red; this was not scoping rot, the floor was one
+    # patch short from day one (CHAOS-3800). Held inside major 3: postcss
+    # declares ^3.3.x and nanoid 5+ is ESM-only, so an unbounded floor would
+    # break the consumers that need it. Blanket (not per-dependent-path scoped)
+    # on purpose — every one of the 6 paths needs the same floor, there's no
+    # legitimate caller that wants the vulnerable version.
+    # Next bump: read the floor straight off the advisory's own "Patched
+    # versions" field, not off whatever version number looks adjacent to the
+    # one currently failing — that's exactly how this floor went stale.
+    nanoid: ">=3.3.18 <4"
     # brace-expansion: reached via @sentry/nextjs > @sentry/bundler-plugin-core > glob >
     # minimatch; 10.68.0 is the newest release in the declared ^10 range (GHSA-mh99-v99m-4gvg).
     # Scoped to minimatch@10 deliberately: an unscoped floor also hits minimatch@3, whose


### PR DESCRIPTION
## Summary
- `pnpm audit --audit-level=high --prod` is red on main for everyone: nanoid@3.3.17 < 3.3.18 (GHSA-2v37-7h3g-55p8, high), 6 transitive paths via postcss. `set -e` kills `ci/run_tests.sh` at the audit tier, so no web gate can pass.
- Root cause: the CHAOS-3594 override (950f5c04) was blanket but one patch short — `>=3.3.17 <4` still resolves to the vulnerable 3.3.17 itself; the advisory's patched floor is 3.3.18.
- Fix: bump the blanket override to `>=3.3.18 <4` (still capped below 4.x for CJS consumers) and regenerate the lockfile. The override comment now instructs future bumps to read the floor off the advisory's own Patched-versions field.

## Evidence
- Before (clean main clone @ 7ca2e708): 1 high, exit 1. After: "No known vulnerabilities found", exit 0.
- `pnpm build` clean; full unit suite green (422 files / 3812 passed / 8 skipped; one documented load-flake passed isolated and on clean rerun).
- Lockfile delta verified pure nanoid resolution changes; no 3.3.17 remains.

Fixes CHAOS-3800. Related: CHAOS-3594. Unblocks CHAOS-3791's web gate.