### PR TITLE
fix(sync): explain unavailable provider datasets

### DIFF
--- a/src/lib/admin/__tests__/syncUnitErrorPresentation.test.ts
+++ b/src/lib/admin/__tests__/syncUnitErrorPresentation.test.ts
@@ -5,6 +5,7 @@ describe("getSyncUnitErrorPresentation", () => {
     it.each([
         ["provider_unit_exhausted", "Provider retries exhausted"],
         ["provider_unit_retryable", "Provider request will retry"],
+        ["provider_dataset_unavailable", "Provider data unavailable"],
         ["provider_budget_contention", "Waiting for provider capacity"],
         ["budget_deferred", "Waiting for sync budget"],
         ["budget_deferral_exhausted", "Sync budget wait limit reached"],
@@ -15,6 +16,19 @@ describe("getSyncUnitErrorPresentation", () => {
 
         expect(presentation.title).toBe(title);
         expect(presentation.detail).not.toContain(code);
+    });
+
+    it("explains how to resolve an unavailable provider dataset", () => {
+        expect(
+            getSyncUnitErrorPresentation(
+                "provider_dataset_unavailable",
+                "provider_dataset_unavailable",
+            ),
+        ).toEqual({
+            code: "provider_dataset_unavailable",
+            title: "Provider data unavailable",
+            detail: "This dataset may be disabled for the project or unavailable to the integration's current access level.",
+        });
     });
 
     it("keeps a detailed human-readable backend explanation under the translated title", () => {

--- a/src/lib/admin/syncUnitErrorPresentation.ts
+++ b/src/lib/admin/syncUnitErrorPresentation.ts
@@ -13,6 +13,10 @@ const KNOWN_SYNC_UNIT_ERRORS: Record<string, { title: string; detail: string }> 
         title: "Provider request will retry",
         detail: "The provider request failed temporarily and will be tried again.",
     },
+    provider_dataset_unavailable: {
+        title: "Provider data unavailable",
+        detail: "This dataset may be disabled for the project or unavailable to the integration's current access level.",
+    },
     provider_budget_contention: {
         title: "Waiting for provider capacity",
         detail: "Other provider work is using the available request capacity. This unit will resume automatically.",


### PR DESCRIPTION
## Summary

- Translate `provider_dataset_unavailable` into operator-facing sync guidance.
- Preserve a detailed backend explanation when one is supplied.
- Keep status/progress behavior unchanged: no misrepresentation was reproduced.

## Validation

- `pnpm exec vitest run src/lib/admin/__tests__/syncUnitErrorPresentation.test.ts --reporter=verbose`
- Playwright isolated local fixture for a persisted failed GitLab feature-flags unit (screenshot attached in a follow-up).

Closes CHAOS-3806