### PR TITLE
fix(web): make coverage backfills actionable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,11 +194,11 @@ jobs:
                   retention-days: 90
 
     e2e-onboarding:
-        # Context Fabric runs sequentially in this job rather than as its own
-        # runner: GitHub's concurrency limits make every extra parallel job a
-        # queue liability, and the two suites are isolated by run_tests.sh
-        # regardless of which runner hosts them.
-        name: E2E tests (onboarding + Context Fabric)
+        # Route-stress suites and Context Fabric run sequentially in this job rather
+        # than as separate runners. GitHub's concurrency limits make every
+        # extra parallel job a queue liability, and run_tests.sh isolates all
+        # four suites regardless of which runner hosts them.
+        name: E2E tests (route stress + onboarding + Context Fabric)
         needs: [changes]
         if: needs.changes.outputs.e2e == 'true'
         runs-on: ubuntu-latest
@@ -210,6 +210,8 @@ jobs:
                   node-version: 22
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
+            - run: bash ci/run_tests.sh e2e-customer-push
+            - run: bash ci/run_tests.sh e2e-navigation
             - run: bash ci/run_tests.sh e2e-onboarding
             - run: bash ci/run_tests.sh e2e-context-fabric
             - name: Upload Playwright report

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: ci/run_tests.sh <format|quality|build|unit|e2e|e2e-default|e2e-onboarding|e2e-context-fabric|pagerduty-final-qa|live-e2e|design-lint|ci> [current/total]" >&2
+  echo "Usage: ci/run_tests.sh <format|quality|build|unit|e2e|e2e-default|e2e-customer-push|e2e-navigation|e2e-onboarding|e2e-context-fabric|pagerduty-final-qa|live-e2e|design-lint|ci> [current/total]" >&2
 }
 
 if [[ $# -lt 1 || $# -gt 2 ]]; then
@@ -130,6 +130,14 @@ prepare_playwright_artifacts() {
   rm -rf .next/dev
 }
 
+reset_dev_output() {
+  rm -rf .next/dev
+}
+
+reset_navigation_output() {
+  rm -rf .next/navigation
+}
+
 print_playwright_artifact_summary() {
   local report_root="${1:-${PLAYWRIGHT_REPORT_ROOT}}"
   local results_root="${2:-${PLAYWRIGHT_RESULTS_ROOT}}"
@@ -181,6 +189,23 @@ run_e2e() {
   run_timed "e2e default suite" run_playwright_suite default test:e2e || {
     status=$?
     echo "E2E tests failed. Captured artifacts:" >&2
+    print_playwright_artifact_summary
+    return "${status}"
+  }
+  # The long-lived Turbopack server can lose dynamic routes or stop completing
+  # requests after route-stress specs in hosted CI. Give each proven stressor
+  # its own short-lived server so compiler state cannot cross suites.
+  run_timed "customer-push dev reset" reset_dev_output
+  run_timed "e2e customer-push suite" run_playwright_suite customer-push test:e2e:customer-push || {
+    status=$?
+    echo "Customer-push E2E tests failed. Captured artifacts:" >&2
+    print_playwright_artifact_summary
+    return "${status}"
+  }
+  run_timed "navigation dev reset" reset_navigation_output
+  run_timed "e2e navigation suite" run_playwright_suite navigation test:e2e:navigation || {
+    status=$?
+    echo "Navigation E2E tests failed. Captured artifacts:" >&2
     print_playwright_artifact_summary
     return "${status}"
   }
@@ -270,6 +295,15 @@ run_e2e_default() {
   run_isolated_e2e_suite "${artifact_suite}" test:e2e --shard "${shard}"
 }
 
+run_e2e_customer_push() {
+  run_isolated_e2e_suite customer-push test:e2e:customer-push
+}
+
+run_e2e_navigation() {
+  reset_navigation_output
+  run_isolated_e2e_suite navigation test:e2e:navigation
+}
+
 run_e2e_onboarding() {
   run_isolated_e2e_suite onboarding test:e2e:onboarding
 }
@@ -301,6 +335,12 @@ case "${tier}" in
     ;;
   e2e-default)
     run_e2e_default "$2"
+    ;;
+  e2e-customer-push)
+    run_e2e_customer_push
+    ;;
+  e2e-navigation)
+    run_e2e_navigation
     ;;
   e2e-onboarding)
     run_e2e_onboarding

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
         "ask-dev:contracts:check": "node scripts/ask-dev-contracts.mjs check",
         "ask-dev:contracts:check-currency": "node scripts/ask-dev-contracts.mjs check-currency",
         "test:e2e": "playwright test --project=authenticated --project=unauthenticated",
+        "test:e2e:customer-push": "playwright test -c playwright.customer-push.config.ts",
+        "test:e2e:navigation": "playwright test -c playwright.navigation.config.ts",
         "test:e2e:pagerduty-final-qa": "playwright test --project=pagerduty-final-qa",
         "test:e2e:pagerduty-final-qa:smoke": "playwright test --project=pagerduty-final-qa tests/pagerduty-final-qa-p0.spec.ts",
         "test:e2e:context-fabric": "node scripts/context-fabric-qa.mjs",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,11 +29,13 @@ export default defineConfig({
         "auth-onboard.spec.ts",
         "onboarding.setup.ts",
         "acr-context-fabric.production.spec.ts",
+        "admin-customer-push.spec.ts",
+        "nav-reachability.spec.ts",
     ],
     outputDir: resultsDirectory,
-    // The shared Next dev server intermittently loses dynamic route registrations after
-    // concurrent requests in CI, returning 404s for otherwise valid test-mode routes.
-    // Keep CI's test-mode fixture requests serial; local runs retain parallel feedback.
+    // Keep CI's test-mode fixture requests serial. Customer-push runs in its own
+    // short-lived Webpack config because this long-lived Turbopack server has
+    // lost that dynamic route family after earlier requests in hosted CI.
     workers: isCI ? 1 : undefined,
     reporter: [
         ["list"],
@@ -73,6 +75,8 @@ export default defineConfig({
                 /account-creation-journey\.spec\.ts/,
                 /auth-onboard-legacy\.spec\.ts/,
                 /acr-context-fabric\.production\.spec\.ts/,
+                /admin-customer-push\.spec\.ts/,
+                /nav-reachability\.spec\.ts/,
                 /pagerduty-final-qa-p[0-3]\.spec\.ts/,
             ],
             dependencies: ["auth-setup"],

--- a/playwright.customer-push.config.ts
+++ b/playwright.customer-push.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig } from "@playwright/test";
+
+const isCI = process.env.CI === "true" || process.env.CI === "1";
+const resultsDirectory =
+    process.env.PLAYWRIGHT_RESULTS_DIR ?? "test-results/playwright/customer-push";
+const htmlReportDirectory =
+    process.env.PLAYWRIGHT_HTML_REPORT ?? "test-results/playwright-html/customer-push";
+const mockServerPort = Number(process.env.PLAYWRIGHT_CUSTOMER_PUSH_MOCK_PORT ?? "8004");
+const webServerPort = Number(process.env.PLAYWRIGHT_CUSTOMER_PUSH_WEB_PORT ?? "3004");
+const baseURL = `http://127.0.0.1:${webServerPort}`;
+const mockServerURL = `http://127.0.0.1:${mockServerPort}`;
+const authFile = "test-results/.auth/state.json";
+
+export default defineConfig({
+    testDir: "./tests",
+    outputDir: resultsDirectory,
+    workers: 1,
+    retries: isCI ? 2 : 0,
+    forbidOnly: isCI,
+    reporter: [
+        ["list"],
+        ["html", { outputFolder: htmlReportDirectory, open: "never" }],
+        ["junit", { outputFile: `${resultsDirectory}/junit.xml` }],
+    ],
+    projects: [
+        { name: "customer-push-auth-setup", testMatch: /auth\.setup\.ts/ },
+        {
+            name: "customer-push",
+            testMatch: /admin-customer-push\.spec\.ts/,
+            dependencies: ["customer-push-auth-setup"],
+            use: { storageState: authFile },
+        },
+    ],
+    use: {
+        baseURL,
+        headless: true,
+        trace: "retain-on-failure",
+        video: "retain-on-failure",
+        screenshot: "only-on-failure",
+    },
+    webServer: [
+        {
+            command: "npx tsx ./tests/mocks/http-server.ts",
+            url: `${mockServerURL}/health`,
+            reuseExistingServer: false,
+            timeout: 30_000,
+            env: { MOCK_SERVER_PORT: String(mockServerPort) },
+        },
+        {
+            command: `npm run dev -- --webpack --hostname 127.0.0.1 --port ${webServerPort}`,
+            url: baseURL,
+            reuseExistingServer: false,
+            timeout: 120_000,
+            env: {
+                PLAYWRIGHT_TEST: "true",
+                DEV_HEALTH_TEST_MODE: "true",
+                NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: "true",
+                NEXT_PUBLIC_GUIDED_ONBOARDING: "false",
+                BACKEND_URL: mockServerURL,
+            },
+        },
+    ],
+});

--- a/playwright.navigation.config.ts
+++ b/playwright.navigation.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig } from "@playwright/test";
+
+const isCI = process.env.CI === "true" || process.env.CI === "1";
+const resultsDirectory = process.env.PLAYWRIGHT_RESULTS_DIR ?? "test-results/playwright/navigation";
+const htmlReportDirectory =
+    process.env.PLAYWRIGHT_HTML_REPORT ?? "test-results/playwright-html/navigation";
+const mockServerPort = Number(process.env.PLAYWRIGHT_NAVIGATION_MOCK_PORT ?? "8005");
+const webServerPort = Number(process.env.PLAYWRIGHT_NAVIGATION_WEB_PORT ?? "3005");
+const baseURL = `http://127.0.0.1:${webServerPort}`;
+const mockServerURL = `http://127.0.0.1:${mockServerPort}`;
+const authFile = "test-results/.auth/state.json";
+
+export default defineConfig({
+    testDir: "./tests",
+    outputDir: resultsDirectory,
+    workers: 1,
+    retries: isCI ? 2 : 0,
+    forbidOnly: isCI,
+    reporter: [
+        ["list"],
+        ["html", { outputFolder: htmlReportDirectory, open: "never" }],
+        ["junit", { outputFile: `${resultsDirectory}/junit.xml` }],
+    ],
+    projects: [
+        { name: "navigation-auth-setup", testMatch: /auth\.setup\.ts/ },
+        {
+            name: "navigation",
+            testMatch: /nav-reachability\.spec\.ts/,
+            dependencies: ["navigation-auth-setup"],
+            use: { storageState: authFile },
+        },
+    ],
+    use: {
+        baseURL,
+        headless: true,
+        trace: "retain-on-failure",
+        video: "retain-on-failure",
+        screenshot: "only-on-failure",
+    },
+    webServer: [
+        {
+            command: "npx tsx ./tests/mocks/http-server.ts",
+            url: `${mockServerURL}/health`,
+            reuseExistingServer: false,
+            timeout: 30_000,
+            env: { MOCK_SERVER_PORT: String(mockServerPort) },
+        },
+        {
+            command: `npm run dev -- --hostname 127.0.0.1 --port ${webServerPort}`,
+            url: baseURL,
+            reuseExistingServer: false,
+            timeout: 120_000,
+            env: {
+                NEXT_DIST_DIR: ".next/navigation",
+                PLAYWRIGHT_TEST: "true",
+                DEV_HEALTH_TEST_MODE: "true",
+                NEXT_PUBLIC_DEV_HEALTH_TEST_MODE: "true",
+                NEXT_PUBLIC_GUIDED_ONBOARDING: "false",
+                BACKEND_URL: mockServerURL,
+            },
+        },
+    ],
+});

--- a/scripts/__tests__/chaos-3017-ci-contract.test.mjs
+++ b/scripts/__tests__/chaos-3017-ci-contract.test.mjs
@@ -84,8 +84,14 @@ describe("CHAOS-3017 CI contracts", () => {
         expect(defaultE2e).toMatch(
             /^            - run: bash ci\/run_tests\.sh e2e-default \$\{\{ matrix\.shard \}\}\/3$/mu,
         );
-        // Context Fabric shares the onboarding runner (GitHub concurrency
-        // limits); both suites must still run, in one job.
+        // Route-stress suites and Context Fabric share the onboarding runner
+        // (GitHub concurrency limits); all suites must still run, in one job.
+        expect(job(workflow, "e2e-onboarding")).toMatch(
+            /^            - run: bash ci\/run_tests\.sh e2e-customer-push$/mu,
+        );
+        expect(job(workflow, "e2e-onboarding")).toMatch(
+            /^            - run: bash ci\/run_tests\.sh e2e-navigation$/mu,
+        );
         expect(job(workflow, "e2e-onboarding")).toMatch(
             /^            - run: bash ci\/run_tests\.sh e2e-onboarding$/mu,
         );
@@ -111,6 +117,8 @@ describe("CHAOS-3017 CI contracts", () => {
         // config. Listing them concurrently makes those processes race while the
         // broader Vitest suite is also active, producing incomplete inventories.
         const full = await listDefaultPlaywrightTests();
+        expect(full.some((entry) => entry.includes("admin-customer-push.spec.ts"))).toBe(false);
+        expect(full.some((entry) => entry.includes("nav-reachability.spec.ts"))).toBe(false);
         const shards = [];
         for (const shard of shardLabels) {
             shards.push(await listDefaultPlaywrightTests(shard));
@@ -213,9 +221,13 @@ describe("CHAOS-3017 CI contracts", () => {
         const harness = contents(HARNESS);
 
         expect(harness).toContain("e2e-default");
+        expect(harness).toContain("e2e-customer-push");
+        expect(harness).toContain("e2e-navigation");
         expect(harness).toContain("e2e-onboarding");
         expect(harness).toContain("e2e-context-fabric");
         expect(harness).toMatch(/e2e-default\)\n\s+run_e2e_default "\$2"/);
+        expect(harness).toMatch(/e2e-customer-push\)\n\s+run_e2e_customer_push/);
+        expect(harness).toMatch(/e2e-navigation\)\n\s+run_e2e_navigation/);
         expect(harness).toMatch(/e2e-onboarding\)\n\s+run_e2e_onboarding/);
         expect(harness).toMatch(/e2e-context-fabric\)\n\s+run_e2e_context_fabric/);
     });

--- a/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
+++ b/scripts/__tests__/chaos-3017-ci-execution-contract.test.mjs
@@ -73,9 +73,13 @@ const GENERAL_TIERS = [
     },
 ];
 const E2E_STAGES = ["e2e-default", "e2e-onboarding"];
-// Context Fabric's tier runs inside the e2e-onboarding job (one runner,
-// two sequential suites — GitHub concurrency limits).
-const DEDICATED_E2E = [["e2e-onboarding", "e2e-onboarding"]];
+// Route-stress suites and Context Fabric run inside the e2e-onboarding job
+// (one runner, four sequential suites — GitHub concurrency limits).
+const DEDICATED_E2E = [
+    ["e2e-onboarding", "e2e-customer-push"],
+    ["e2e-onboarding", "e2e-navigation"],
+    ["e2e-onboarding", "e2e-onboarding"],
+];
 const E2E_HARNESS_CASES = [
     ...["1/3", "2/3", "3/3"].map((shard) => ({
         args: ["e2e-default", shard],
@@ -83,6 +87,18 @@ const E2E_HARNESS_CASES = [
         failScript: "test:e2e",
         name: `default shard ${shard}`,
     })),
+    {
+        args: ["e2e-customer-push"],
+        expectedCommand: "test:e2e:customer-push",
+        failScript: "test:e2e:customer-push",
+        name: "customer push",
+    },
+    {
+        args: ["e2e-navigation"],
+        expectedCommand: "test:e2e:navigation",
+        failScript: "test:e2e:navigation",
+        name: "navigation",
+    },
     {
         args: ["e2e-onboarding"],
         expectedCommand: "test:e2e:onboarding",
@@ -194,6 +210,12 @@ describe("CHAOS-3017 executable CI boundaries", () => {
         expect(scripts["test:e2e:onboarding"]).toBe(
             "playwright test -c playwright.onboarding.config.ts",
         );
+        expect(scripts["test:e2e:customer-push"]).toBe(
+            "playwright test -c playwright.customer-push.config.ts",
+        );
+        expect(scripts["test:e2e:navigation"]).toBe(
+            "playwright test -c playwright.navigation.config.ts",
+        );
         expect(scripts["test:e2e:context-fabric"]).toBe("node scripts/context-fabric-qa.mjs");
 
         const defaultJob = job(workflow, "e2e-default");
@@ -212,7 +234,7 @@ describe("CHAOS-3017 executable CI boundaries", () => {
             );
         }
 
-        // Context Fabric runs as a second step of the onboarding job.
+        // Context Fabric runs as the fourth step of the onboarding job.
         expect(
             runStep(job(workflow, "e2e-onboarding"), "bash ci/run_tests.sh e2e-context-fabric"),
         ).toBe("            - run: bash ci/run_tests.sh e2e-context-fabric");

--- a/scripts/__tests__/playwright-config.test.mjs
+++ b/scripts/__tests__/playwright-config.test.mjs
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import config from "../../playwright.config.ts";
+import customerPushConfig from "../../playwright.customer-push.config.ts";
+import navigationConfig from "../../playwright.navigation.config.ts";
 
 const packageJson = JSON.parse(
     readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
@@ -29,6 +31,55 @@ describe("default Playwright web servers", () => {
 
         expect(Array.isArray(webServers)).toBe(true);
         expect(webServers[1]?.env).not.toHaveProperty("NEXT_PRIVATE_DISABLE_DEV_OVERLAY_UX");
+    });
+
+    it("moves proven route-stress specs to a short-lived Webpack suite", () => {
+        expect(config.testIgnore).toContain("admin-customer-push.spec.ts");
+        expect(config.testIgnore).toContain("nav-reachability.spec.ts");
+        const authenticatedProject = config.projects?.find(
+            (project) => project.name === "authenticated",
+        );
+        expect(authenticatedProject?.testIgnore).toContainEqual(/admin-customer-push\.spec\.ts/);
+        expect(authenticatedProject?.testIgnore).toContainEqual(/nav-reachability\.spec\.ts/);
+        expect(customerPushConfig.workers).toBe(1);
+        expect(customerPushConfig.projects?.map((project) => project.name)).toEqual([
+            "customer-push-auth-setup",
+            "customer-push",
+        ]);
+        expect(navigationConfig.workers).toBe(1);
+        expect(navigationConfig.projects?.map((project) => project.name)).toEqual([
+            "navigation-auth-setup",
+            "navigation",
+        ]);
+
+        for (const dedicatedConfig of [customerPushConfig, navigationConfig]) {
+            const webServers = dedicatedConfig.webServer;
+            expect(Array.isArray(webServers)).toBe(true);
+            expect(webServers).toHaveLength(2);
+            expect(webServers.map((server) => server.reuseExistingServer)).toEqual([false, false]);
+        }
+        expect(customerPushConfig.webServer?.[1]?.command).toContain(" --webpack ");
+        expect(navigationConfig.webServer?.[1]?.command).toContain(
+            "npm run dev -- --hostname 127.0.0.1 --port 3005",
+        );
+        expect(navigationConfig.webServer?.[1]?.env).toMatchObject({
+            NEXT_DIST_DIR: ".next/navigation",
+        });
+
+        expect(packageJson.scripts["test:e2e:customer-push"]).toBe(
+            "playwright test -c playwright.customer-push.config.ts",
+        );
+        expect(packageJson.scripts["test:e2e:navigation"]).toBe(
+            "playwright test -c playwright.navigation.config.ts",
+        );
+        expect(ciRunner).toContain("run_e2e_customer_push()");
+        expect(ciRunner).toContain("run_e2e_navigation()");
+        expect(ciRunner).toContain('run_timed "customer-push dev reset" reset_dev_output');
+        expect(ciRunner).toContain('run_timed "navigation dev reset" reset_navigation_output');
+        expect(ciRunner).toMatch(/e2e-customer-push\)\n\s+run_e2e_customer_push/);
+        expect(ciRunner).toMatch(/e2e-navigation\)\n\s+run_e2e_navigation/);
+        expect(testsWorkflow).toContain("bash ci/run_tests.sh e2e-customer-push");
+        expect(testsWorkflow).toContain("bash ci/run_tests.sh e2e-navigation");
     });
 
     it("isolates stateful PagerDuty QA files in one dedicated worker", () => {

--- a/src/components/admin/sync/BackfillOperations.test.tsx
+++ b/src/components/admin/sync/BackfillOperations.test.tsx
@@ -118,6 +118,57 @@ describe("BackfillOperations", () => {
         expect(screen.getByLabelText("Since (inclusive)")).toHaveValue("");
     });
 
+    it("auto-selects the one server-authorized suggestion with its exact scope", async () => {
+        const user = userEvent.setup();
+        const window = {
+            since: "2026-01-02T00:00:00Z",
+            before: "2026-01-03T00:00:00Z",
+            source_ids: ["src-repo"],
+            dataset_keys: ["commits"],
+            reasons: ["gap"] as const,
+        };
+        render(
+            <BackfillOperations
+                configId="cfg-1"
+                coverage={{ ...PARTIAL_COVERAGE_SUMMARY, backfill_windows: [window] }}
+                coverageError={undefined}
+                isActive
+                activeBackfillJob={null}
+                testMode
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Backfill" }));
+
+        expect(screen.getByLabelText("Since (inclusive)")).toHaveValue("2026-01-02");
+        expect(screen.getByLabelText("Before (exclusive)")).toHaveValue("2026-01-03");
+        expect(screen.getByRole("radio", { name: /Choose specific sources/ })).toBeChecked();
+        expect(screen.getByLabelText("acme/repo")).toBeChecked();
+        expect(screen.getByRole("radio", { name: /Choose specific datasets/ })).toBeChecked();
+        expect(screen.getByLabelText("commits")).toBeChecked();
+    });
+
+    it("states when Ops supplied no exact suggestion and leaves manual scope empty", async () => {
+        const user = userEvent.setup();
+        render(
+            <BackfillOperations
+                configId="cfg-1"
+                coverage={{ ...PARTIAL_COVERAGE_SUMMARY, backfill_windows: [] }}
+                coverageError={undefined}
+                isActive
+                activeBackfillJob={null}
+                testMode
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Backfill" }));
+
+        expect(screen.getByRole("status")).toHaveTextContent(
+            "No server-suggested backfill window is available",
+        );
+        expect(screen.getByLabelText("Since (inclusive)")).toHaveValue("");
+    });
+
     it("opens the wizard prefilled with the gap's range from a timeline 'Backfill this gap' action", async () => {
         const user = userEvent.setup();
         renderOperations();

--- a/src/components/admin/sync/BackfillOperations.tsx
+++ b/src/components/admin/sync/BackfillOperations.tsx
@@ -22,18 +22,7 @@ interface BackfillOperationsProps {
     testMode?: boolean;
 }
 
-interface WizardRange {
-    since: string;
-    before: string;
-}
-
 const COVERAGE_REFRESH_INTERVAL_MS = 5000;
-
-function toDateInput(value: string): string {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return "";
-    return date.toISOString().slice(0, 10);
-}
 
 /**
  * Owns backfill as an OPERATIONAL action on the config detail page
@@ -52,7 +41,7 @@ export function BackfillOperations({
 }: BackfillOperationsProps) {
     const router = useRouter();
     const [isWizardOpen, setIsWizardOpen] = useState(false);
-    const [wizardRange, setWizardRange] = useState<WizardRange | null>(null);
+    const [wizardWindow, setWizardWindow] = useState<SyncCoverageBackfillWindow | null>(null);
 
     useEffect(() => {
         if (testMode || coverage?.projection_refreshing !== true) return undefined;
@@ -61,9 +50,8 @@ export function BackfillOperations({
     }, [coverage?.projection_refreshing, router, testMode]);
 
     const openWizard = (range?: SyncCoverageBackfillWindow) => {
-        setWizardRange(
-            range ? { since: toDateInput(range.since), before: toDateInput(range.before) } : null,
-        );
+        const suggestions = coverage?.backfill_windows;
+        setWizardWindow(range ?? (suggestions?.length === 1 ? suggestions[0] : null));
         setIsWizardOpen(true);
     };
     const closeWizard = () => setIsWizardOpen(false);
@@ -112,8 +100,8 @@ export function BackfillOperations({
                 <BackfillWizard
                     configId={configId}
                     onCloseAction={closeWizard}
-                    initialSince={wizardRange?.since}
-                    initialBefore={wizardRange?.before}
+                    initialWindow={wizardWindow ?? undefined}
+                    suggestedWindows={coverage?.backfill_windows}
                     datasets={coverage?.datasets ?? []}
                     sources={coverage?.sources ?? []}
                     testMode={testMode}

--- a/src/components/admin/sync/BackfillWizard.test.tsx
+++ b/src/components/admin/sync/BackfillWizard.test.tsx
@@ -109,6 +109,62 @@ describe("BackfillWizard", () => {
         );
     });
 
+    it("preserves a server-selected child dataset without broadening the work-item family", async () => {
+        const user = userEvent.setup();
+        const window = {
+            since: "2026-06-10T00:00:00Z",
+            before: "2026-06-12T00:00:00Z",
+            source_ids: ["src-web"],
+            dataset_keys: ["work-item-comments"],
+            reasons: ["gap"] as const,
+        };
+        renderWizard({ initialWindow: window, suggestedWindows: [window] });
+
+        expect(screen.getByLabelText("Since (inclusive)")).toHaveValue("2026-06-10");
+        expect(screen.getByLabelText("Before (exclusive)")).toHaveValue("2026-06-12");
+        expect(screen.getByLabelText("acme/web")).toBeChecked();
+        expect(screen.getByLabelText("Suggested work-item datasets")).toBeChecked();
+
+        await reviewAndSubmit(user);
+
+        expect(triggerBackfill).toHaveBeenCalledWith("cfg-1", {
+            since: "2026-06-10T00:00:00.000Z",
+            before: "2026-06-12T00:00:00.000Z",
+            source_ids: ["src-web"],
+            dataset_keys: ["work-item-comments"],
+        });
+    });
+
+    it("offers separate quick choices for multiple server suggestions", async () => {
+        const user = userEvent.setup();
+        const firstWindow = {
+            since: "2026-06-01T00:00:00Z",
+            before: "2026-06-02T00:00:00Z",
+            source_ids: ["src-api"],
+            dataset_keys: ["git"],
+            reasons: ["gap"] as const,
+        };
+        const secondWindow = {
+            since: "2026-06-10T00:00:00Z",
+            before: "2026-06-12T00:00:00Z",
+            source_ids: ["src-web"],
+            dataset_keys: ["work-item-comments"],
+            reasons: ["gap"] as const,
+        };
+        renderWizard({ suggestedWindows: [firstWindow, secondWindow] });
+
+        await user.click(
+            screen.getByRole("button", {
+                name: "2026-06-10 to 2026-06-12 · work-item-comments",
+            }),
+        );
+
+        expect(screen.getByLabelText("Since (inclusive)")).toHaveValue("2026-06-10");
+        expect(screen.getByLabelText("Before (exclusive)")).toHaveValue("2026-06-12");
+        expect(screen.getByLabelText("acme/web")).toBeChecked();
+        expect(screen.getByLabelText("Suggested work-item datasets")).toBeChecked();
+    });
+
     it("submits a repository-only focused selector", async () => {
         const user = userEvent.setup();
         renderWizard();

--- a/src/components/admin/sync/BackfillWizard.tsx
+++ b/src/components/admin/sync/BackfillWizard.tsx
@@ -5,7 +5,11 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { triggerBackfill } from "@/lib/admin/server";
-import type { SyncCoverageDataset, SyncCoverageSource } from "@/lib/admin/types";
+import type {
+    SyncCoverageBackfillWindow,
+    SyncCoverageDataset,
+    SyncCoverageSource,
+} from "@/lib/admin/types";
 import { DATASET_LABELS } from "./config-form/constants";
 import { CTA_LABELS } from "@/lib/design/cta";
 
@@ -33,8 +37,10 @@ interface DatasetChoice {
 interface BackfillWizardProps {
     configId: string;
     onCloseAction: () => void;
-    initialSince?: string;
-    initialBefore?: string;
+    /** Server-authorized exact scope selected from coverage, if any. */
+    initialWindow?: SyncCoverageBackfillWindow;
+    /** Present empty means Ops has no exact suggestion for this coverage state. */
+    suggestedWindows?: SyncCoverageBackfillWindow[];
     datasets: SyncCoverageDataset[];
     sources: SyncCoverageSource[];
     testMode?: boolean;
@@ -57,12 +63,28 @@ function toBoundary(value: string): string {
     return `${value}T00:00:00.000Z`;
 }
 
+function toDateInput(value: string): string {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "";
+    return date.toISOString().slice(0, 10);
+}
+
 function datasetLabel(key: string): string {
     return DATASET_LABELS[key] ?? key.replaceAll("-", " ");
 }
 
+function sameDatasetKeys(left: string[], right: string[]): boolean {
+    if (left.length !== right.length) return false;
+    const sortedLeft = [...left].sort();
+    const sortedRight = [...right].sort();
+    return sortedLeft.every((key, index) => key === sortedRight[index]);
+}
+
 /** Collapse the work-item aliases into the single canonical family operators execute. */
-export function buildDatasetChoices(datasets: SyncCoverageDataset[]): DatasetChoice[] {
+export function buildDatasetChoices(
+    datasets: SyncCoverageDataset[],
+    scopedDatasetKeys: string[] = [],
+): DatasetChoice[] {
     const choices: DatasetChoice[] = [];
     const familyKeys = datasets
         .map((dataset) => dataset.dataset_key)
@@ -85,27 +107,86 @@ export function buildDatasetChoices(datasets: SyncCoverageDataset[]): DatasetCho
             datasetKeys: [dataset.dataset_key],
         });
     }
+
+    const scopedFamilyKeys = scopedDatasetKeys.filter((key) => WORK_ITEM_FAMILY.has(key));
+    if (scopedFamilyKeys.length > 0 && !sameDatasetKeys(scopedFamilyKeys, familyKeys)) {
+        choices.unshift({
+            id: "server-scoped-work-items",
+            label: "Suggested work-item datasets",
+            datasetKeys: scopedFamilyKeys,
+        });
+    }
     return choices;
+}
+
+function choiceIdsForDatasetScope(
+    choices: DatasetChoice[],
+    datasetKeys: string[] | undefined,
+): string[] {
+    if (!datasetKeys || datasetKeys.length === 0) return [];
+    const exactChoice = choices.find((choice) => sameDatasetKeys(choice.datasetKeys, datasetKeys));
+    if (exactChoice) return [exactChoice.id];
+
+    const remaining = new Set(datasetKeys);
+    const selectedChoiceIds: string[] = [];
+    for (const choice of choices) {
+        if (choice.datasetKeys.every((key) => remaining.has(key))) {
+            selectedChoiceIds.push(choice.id);
+            choice.datasetKeys.forEach((key) => remaining.delete(key));
+        }
+    }
+    return remaining.size === 0 ? selectedChoiceIds : [];
+}
+
+function sourceIdsInInventory(
+    sourceIds: string[] | undefined,
+    sources: SyncCoverageSource[],
+): string[] {
+    const available = new Set(sources.map((source) => source.source_id));
+    return (sourceIds ?? []).filter((sourceId) => available.has(sourceId));
+}
+
+function windowLabel(window: SyncCoverageBackfillWindow): string {
+    const datasetScope = window.dataset_keys?.join(", ") ?? "all datasets";
+    return `${toDateInput(window.since)} to ${toDateInput(window.before)} · ${datasetScope}`;
 }
 
 export function BackfillWizard({
     configId,
     onCloseAction,
-    initialSince = "",
-    initialBefore = "",
+    initialWindow,
+    suggestedWindows,
     datasets,
     sources,
     testMode = false,
 }: BackfillWizardProps) {
     const router = useRouter();
-    const datasetChoices = useMemo(() => buildDatasetChoices(datasets), [datasets]);
+    const [scopedDatasetKeys, setScopedDatasetKeys] = useState<string[]>(
+        initialWindow?.dataset_keys ?? [],
+    );
+    const datasetChoices = useMemo(
+        () => buildDatasetChoices(datasets, scopedDatasetKeys),
+        [datasets, scopedDatasetKeys],
+    );
     const [step, setStep] = useState<WizardStep>("scope");
-    const [since, setSince] = useState(initialSince);
-    const [before, setBefore] = useState(initialBefore);
-    const [sourceMode, setSourceMode] = useState<ScopeMode>("all");
-    const [datasetMode, setDatasetMode] = useState<ScopeMode>("all");
-    const [selectedSourceIds, setSelectedSourceIds] = useState<string[]>([]);
-    const [selectedDatasetChoiceIds, setSelectedDatasetChoiceIds] = useState<string[]>([]);
+    const [since, setSince] = useState(() =>
+        initialWindow ? toDateInput(initialWindow.since) : "",
+    );
+    const [before, setBefore] = useState(() =>
+        initialWindow ? toDateInput(initialWindow.before) : "",
+    );
+    const [sourceMode, setSourceMode] = useState<ScopeMode>(() =>
+        initialWindow?.source_ids?.length ? "selected" : "all",
+    );
+    const [datasetMode, setDatasetMode] = useState<ScopeMode>(() =>
+        initialWindow?.dataset_keys?.length ? "selected" : "all",
+    );
+    const [selectedSourceIds, setSelectedSourceIds] = useState<string[]>(() =>
+        sourceIdsInInventory(initialWindow?.source_ids, sources),
+    );
+    const [selectedDatasetChoiceIds, setSelectedDatasetChoiceIds] = useState<string[]>(() =>
+        choiceIdsForDatasetScope(datasetChoices, initialWindow?.dataset_keys),
+    );
     const [expensiveConfirmed, setExpensiveConfirmed] = useState(false);
     const [isPending, startTransition] = useTransition();
     const [submitError, setSubmitError] = useState<string | null>(null);
@@ -155,6 +236,22 @@ export function BackfillWizard({
     const resetConfirmation = () => setExpensiveConfirmed(false);
     const toggle = (values: string[], value: string): string[] =>
         values.includes(value) ? values.filter((item) => item !== value) : [...values, value];
+
+    const applySuggestedWindow = (window: SyncCoverageBackfillWindow) => {
+        setSince(toDateInput(window.since));
+        setBefore(toDateInput(window.before));
+        setSourceMode(window.source_ids?.length ? "selected" : "all");
+        setSelectedSourceIds(sourceIdsInInventory(window.source_ids, sources));
+        setDatasetMode(window.dataset_keys?.length ? "selected" : "all");
+        setScopedDatasetKeys(window.dataset_keys ?? []);
+        setSelectedDatasetChoiceIds(
+            choiceIdsForDatasetScope(
+                buildDatasetChoices(datasets, window.dataset_keys),
+                window.dataset_keys,
+            ),
+        );
+        resetConfirmation();
+    };
 
     const handleSubmit = () => {
         if (!canSubmit) return;
@@ -224,6 +321,44 @@ export function BackfillWizard({
                                 Choose the exact historical window and scope. This run does not
                                 advance scheduled-sync watermarks.
                             </p>
+                            {suggestedWindows?.length === 0 && (
+                                <p
+                                    role="status"
+                                    className="rounded-lg border border-(--card-stroke) bg-(--card-70) p-3 text-sm text-(--ink-muted)"
+                                >
+                                    No server-suggested backfill window is available. Enter a manual
+                                    date range and scope to continue.
+                                </p>
+                            )}
+                            {suggestedWindows && suggestedWindows.length > 1 && (
+                                <fieldset className="space-y-2 rounded-lg border border-(--card-stroke) p-4">
+                                    <legend className="px-1 text-sm font-semibold text-foreground">
+                                        Suggested exact windows
+                                    </legend>
+                                    <p className="text-xs text-(--ink-muted)">
+                                        Choose one server-authorized window, or set a different
+                                        exact scope below.
+                                    </p>
+                                    <div className="flex flex-wrap gap-2">
+                                        {suggestedWindows.map((window) => (
+                                            <button
+                                                key={`${window.since}-${window.before}-${window.dataset_keys?.join(",") ?? "all"}-${window.source_ids?.join(",") ?? "all"}`}
+                                                type="button"
+                                                onClick={() => applySuggestedWindow(window)}
+                                                className="rounded-md border border-(--card-stroke) px-3 py-2 text-left text-sm text-foreground hover:border-(--accent)"
+                                            >
+                                                {windowLabel(window)}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </fieldset>
+                            )}
+                            {suggestedWindows?.length === 1 && initialWindow && (
+                                <p role="status" className="text-sm text-(--ink-muted)">
+                                    The server-suggested window is selected. You can edit it before
+                                    confirmation.
+                                </p>
+                            )}
                             <div className="grid gap-3 sm:grid-cols-2">
                                 <label
                                     className="text-sm font-medium text-(--ink-muted)"

--- a/src/components/admin/sync/SyncCoverageTimeline.test.tsx
+++ b/src/components/admin/sync/SyncCoverageTimeline.test.tsx
@@ -98,6 +98,27 @@ describe("SyncCoverageTimeline", () => {
         });
     });
 
+    it("opens a gap action only for its exact server-authorized source and dataset window", async () => {
+        const onBackfillWindowAction = vi.fn();
+        const user = userEvent.setup();
+        const window = {
+            since: "2026-01-02T00:00:00Z",
+            before: "2026-01-03T00:00:00Z",
+            source_ids: ["src-repo"],
+            dataset_keys: ["commits"],
+            reasons: ["gap"] as const,
+        };
+        render(
+            <SyncCoverageTimeline
+                coverage={{ ...PARTIAL_COVERAGE_SUMMARY, backfill_windows: [window] }}
+                onBackfillWindowAction={onBackfillWindowAction}
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Backfill this gap" }));
+        expect(onBackfillWindowAction).toHaveBeenCalledWith(window);
+    });
+
     it("does not infer a backfill action from gaps when canonical windows are explicitly empty", () => {
         render(
             <SyncCoverageTimeline
@@ -108,6 +129,7 @@ describe("SyncCoverageTimeline", () => {
 
         expect(screen.getAllByText("Gap").length).toBeGreaterThan(0);
         expect(screen.queryByRole("button", { name: /Backfill/ })).not.toBeInTheDocument();
+        expect(screen.getAllByText("No exact backfill suggestion").length).toBeGreaterThan(0);
     });
 
     it("uses the server coverage bounds as the decorative timeline extent", () => {

--- a/src/components/admin/sync/SyncCoverageTimeline.tsx
+++ b/src/components/admin/sync/SyncCoverageTimeline.tsx
@@ -48,6 +48,51 @@ interface TimelineRow {
     datasetKey: string;
 }
 
+function sameBoundary(left: string, right: string): boolean {
+    const leftTime = new Date(left).getTime();
+    const rightTime = new Date(right).getTime();
+    return Number.isFinite(leftTime) && leftTime === rightTime;
+}
+
+function sameScope(left: string[], right: string[]): boolean {
+    if (left.length !== right.length) return false;
+    const sortedLeft = [...left].sort();
+    const sortedRight = [...right].sort();
+    return sortedLeft.every((value, index) => value === sortedRight[index]);
+}
+
+/**
+ * Return only the server-authorized window for this exact dataset/source gap.
+ * An explicit empty array is authoritative: it never falls back to a client
+ * inferred action. The undefined fallback is for an independently deployed
+ * legacy Ops server that did not emit the contract field yet.
+ */
+function backfillWindowForRow(
+    row: TimelineRow,
+    backfillWindows: SyncCoverageBackfillWindow[] | undefined,
+): SyncCoverageBackfillWindow | null {
+    if (backfillWindows === undefined) {
+        return {
+            since: row.range.since,
+            before: row.range.before,
+            source_ids: row.range.source_ids,
+            dataset_keys: [row.datasetKey],
+        };
+    }
+
+    return (
+        backfillWindows.find(
+            (window) =>
+                window.dataset_keys?.length === 1 &&
+                window.dataset_keys[0] === row.datasetKey &&
+                window.source_ids !== undefined &&
+                sameScope(window.source_ids, row.range.source_ids) &&
+                sameBoundary(window.since, row.range.since) &&
+                sameBoundary(window.before, row.range.before),
+        ) ?? null
+    );
+}
+
 /** Content-derived row/band key — stable across re-renders, unlike array index. */
 function rangeKey(kind: BandKind, range: SyncCoverageRange): string {
     return `${kind}-${range.since}-${range.before}-${range.source_ids.join(",")}`;
@@ -245,17 +290,23 @@ export function SyncCoverageTimeline({
                     <div>
                         <h4 className="font-medium text-foreground">Available backfills</h4>
                         <p className="mt-1 text-sm text-(--ink-muted)">
-                            These config-wide windows are provided by the coverage service.
+                            These exact, scoped windows are authorized by the coverage service.
                         </p>
                     </div>
                     <ul className="space-y-2">
                         {coverage.backfill_windows.map((window) => (
                             <li
-                                key={`${window.since}-${window.before}`}
+                                key={`${window.since}-${window.before}-${window.dataset_keys?.join(",") ?? "all"}-${window.source_ids?.join(",") ?? "all"}`}
                                 className="flex flex-wrap items-center justify-between gap-3"
                             >
                                 <span className="text-sm text-foreground">
                                     {formatDateUTC(window.since)} – {formatDateUTC(window.before)}
+                                    {window.dataset_keys && window.dataset_keys.length > 0 && (
+                                        <> · {window.dataset_keys.join(", ")}</>
+                                    )}
+                                    {window.source_ids && window.source_ids.length > 0 && (
+                                        <> · {window.source_ids.map(sourceLabel).join(", ")}</>
+                                    )}
                                 </span>
                                 <button
                                     type="button"
@@ -400,49 +451,63 @@ export function SyncCoverageTimeline({
                                                 </td>
                                             </tr>
                                         ) : (
-                                            rows.map((row) => (
-                                                <tr key={rangeKey(row.kind, row.range)}>
-                                                    <td className="px-2 py-2">
-                                                        <CoverageBadge
-                                                            tone={BAND_TONE[row.kind]}
-                                                            label={BAND_LABEL[row.kind]}
-                                                        />
-                                                    </td>
-                                                    <td className="px-2 py-2 text-foreground">
-                                                        {formatDateUTC(row.range.since)}
-                                                    </td>
-                                                    <td className="px-2 py-2 text-foreground">
-                                                        {formatDateUTC(row.range.before)}
-                                                    </td>
-                                                    <td className="px-2 py-2 text-(--ink-muted)">
-                                                        {row.range.source_ids.length === 0
-                                                            ? "—"
-                                                            : row.range.source_ids
-                                                                  .map((id) => sourceLabel(id))
-                                                                  .join(", ")}
-                                                    </td>
-                                                    <td className="px-2 py-2">
-                                                        {row.kind === "gap" &&
-                                                        coverage.backfill_windows === undefined ? (
-                                                            <button
-                                                                type="button"
-                                                                onClick={() =>
-                                                                    onBackfillWindowAction(
-                                                                        row.range,
-                                                                    )
-                                                                }
-                                                                className="text-(--accent) hover:underline"
-                                                            >
-                                                                {CTA_LABELS.backfillThisGap}
-                                                            </button>
-                                                        ) : (
-                                                            <span className="text-(--ink-muted)">
-                                                                —
-                                                            </span>
-                                                        )}
-                                                    </td>
-                                                </tr>
-                                            ))
+                                            rows.map((row) => {
+                                                const backfillWindow =
+                                                    row.kind === "gap"
+                                                        ? backfillWindowForRow(
+                                                              row,
+                                                              coverage.backfill_windows,
+                                                          )
+                                                        : null;
+                                                return (
+                                                    <tr key={rangeKey(row.kind, row.range)}>
+                                                        <td className="px-2 py-2">
+                                                            <CoverageBadge
+                                                                tone={BAND_TONE[row.kind]}
+                                                                label={BAND_LABEL[row.kind]}
+                                                            />
+                                                        </td>
+                                                        <td className="px-2 py-2 text-foreground">
+                                                            {formatDateUTC(row.range.since)}
+                                                        </td>
+                                                        <td className="px-2 py-2 text-foreground">
+                                                            {formatDateUTC(row.range.before)}
+                                                        </td>
+                                                        <td className="px-2 py-2 text-(--ink-muted)">
+                                                            {row.range.source_ids.length === 0
+                                                                ? "—"
+                                                                : row.range.source_ids
+                                                                      .map((id) => sourceLabel(id))
+                                                                      .join(", ")}
+                                                        </td>
+                                                        <td className="px-2 py-2">
+                                                            {backfillWindow ? (
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() =>
+                                                                        onBackfillWindowAction(
+                                                                            backfillWindow,
+                                                                        )
+                                                                    }
+                                                                    className="text-(--accent) hover:underline"
+                                                                >
+                                                                    {CTA_LABELS.backfillThisGap}
+                                                                </button>
+                                                            ) : row.kind === "gap" &&
+                                                              coverage.backfill_windows !==
+                                                                  undefined ? (
+                                                                <span className="text-xs text-(--ink-muted)">
+                                                                    No exact backfill suggestion
+                                                                </span>
+                                                            ) : (
+                                                                <span className="text-(--ink-muted)">
+                                                                    —
+                                                                </span>
+                                                            )}
+                                                        </td>
+                                                    </tr>
+                                                );
+                                            })
                                         )}
                                     </tbody>
                                 </table>

--- a/src/data/syncCoverageSample.ts
+++ b/src/data/syncCoverageSample.ts
@@ -278,12 +278,18 @@ export const SAMPLE_COVERAGE_TRUNCATED: SyncCoverageSummary = {
     truncation_reason: "lookback_limit",
     backfill_windows: [
         {
-            since: "2026-06-24",
-            before: "2026-06-26",
+            since: "2026-06-24T00:00:00.000Z",
+            before: "2026-06-26T00:00:00.000Z",
+            source_ids: [SOURCE_PLATFORM],
+            dataset_keys: ["git"],
+            reasons: ["gap"],
         },
         {
-            since: "2026-06-28",
-            before: "2026-07-01",
+            since: "2026-06-25T00:00:00.000Z",
+            before: "2026-06-27T00:00:00.000Z",
+            source_ids: [SOURCE_BILLING],
+            dataset_keys: ["prs"],
+            reasons: ["failed"],
         },
     ],
 };

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -164,10 +164,19 @@ export interface SyncCoverageRange {
     run_ids: string[];
 }
 
-/** Server-owned, config-wide date range accepted by the backfill endpoint. */
+/**
+ * Server-authorized half-open backfill selector for one coverage gap.
+ *
+ * Scope fields are optional only while Ops and Web roll out independently.
+ * A row-level action requires both fields; Web must never infer them from a
+ * displayed gap when the server sends an explicit empty list.
+ */
 export interface SyncCoverageBackfillWindow {
     since: string;
     before: string;
+    source_ids?: string[];
+    dataset_keys?: string[];
+    reasons?: ReadonlyArray<"gap" | "failed">;
 }
 
 export interface SyncRunJobEnrichment {
@@ -230,7 +239,7 @@ export interface SyncCoverageSummary {
      * is built. Optional while Web and Ops deploy independently.
      */
     projection_refreshing?: boolean;
-    /** Authoritative config-wide actions. Present empty means no action is available. */
+    /** Authoritative exact backfill suggestions. Present empty means no suggestion is available. */
     backfill_windows?: SyncCoverageBackfillWindow[];
     overall: SyncCoverageOverall;
     datasets: SyncCoverageDataset[];

--- a/tests/admin-sync-observability.spec.ts
+++ b/tests/admin-sync-observability.spec.ts
@@ -136,9 +136,7 @@ test.describe("Journey 1 — coverage-first config detail", () => {
         await expect(page.getByText(/unknown/i)).toHaveCount(0);
     });
 
-    test("truncated coverage labels the server-owned window and exposes only canonical backfills", async ({
-        page,
-    }) => {
+    test("truncated coverage exposes only exact server-authorized backfills", async ({ page }) => {
         await page.goto(`${DETAIL_URL}?coverage_scenario=truncated`);
 
         await expect(page.getByTestId("coverage-window")).toContainText(
@@ -149,7 +147,8 @@ test.describe("Journey 1 — coverage-first config detail", () => {
         );
         const timeline = timelineRegion(page);
         await expect(timeline.getByTestId("coverage-backfill-windows")).toBeVisible();
-        await expect(timeline.getByRole("button", { name: "Backfill this gap" })).toHaveCount(0);
+        await expect(timeline.getByRole("button", { name: "Backfill this gap" })).toHaveCount(1);
+        await expect(timeline.getByText("No exact backfill suggestion")).toBeVisible();
         await expect(
             timeline.getByRole("button", { name: "Backfill Jun 24, 2026 to Jun 26, 2026" }),
         ).toBeVisible();


### PR DESCRIPTION
## Summary

- Show row-level backfill only for an exact, server-authorized source-and-dataset window.
- Preserve the server half-open bounds and scoped source/dataset choices in focused backfill.
- Offer one suggestion automatically, several suggestions as quick choices, and a clear manual state for zero suggestions.
- Keep the two route-stress specs mandatory, but run each on a fresh isolated server after hosted CI proved that the long-lived default servers could lose routes or stop completing requests.

## Hosted CI repair

- Default shards exclude `admin-customer-push.spec.ts` and `nav-reachability.spec.ts`.
- The existing sequential E2E job now runs dedicated customer-push and navigation tiers before onboarding and Context Fabric.
- Customer-push uses a fresh one-worker Webpack server.
- Navigation uses a fresh one-worker Turbopack server with its own `.next/navigation` output.
- Cleanup is scoped to dev output and does not delete the production build.

## Validation

- Full `bash ci/run_tests.sh ci` passed after the repair.
- Unit and coverage: 422 files, 3,832 passed, 8 skipped.
- Default E2E: 307 passed, 2 expected skips.
- Customer-push E2E: 16 passed.
- Navigation E2E: 7 passed.
- Onboarding E2E: 10 passed.
- Context Fabric E2E: 21 passed.
- PagerDuty final QA: 23 passed.
- Focused CI contract tests: 46 passed.
- Independent read-only diff review: APPROVE; no unrelated application change found.

## Visual verification

Multiple exact server suggestions; none is selected automatically:

![chaos-3819-actionable-backfill-after.png](https://github.com/user-attachments/assets/8bcf5d70-4cfd-421e-bf4b-98d4c666aa47)

Chosen exact window preserves the Since-inclusive and Before-exclusive values plus scoped source and dataset selections:

![chaos-3819-actionable-backfill-selected.png](https://github.com/user-attachments/assets/e292dc7a-8ed0-4e77-a6ad-35e801f9c4ba)

Refs CHAOS-3819
