### PR TITLE
fix(web): support exact multi-window backfills

### DIFF
--- a/src/components/admin/sync/BackfillOperations.tsx
+++ b/src/components/admin/sync/BackfillOperations.tsx
@@ -41,7 +41,7 @@ export function BackfillOperations({
 }: BackfillOperationsProps) {
     const router = useRouter();
     const [isWizardOpen, setIsWizardOpen] = useState(false);
-    const [wizardWindow, setWizardWindow] = useState<SyncCoverageBackfillWindow | null>(null);
+    const [wizardWindows, setWizardWindows] = useState<SyncCoverageBackfillWindow[]>([]);
 
     useEffect(() => {
         if (testMode || coverage?.projection_refreshing !== true) return undefined;
@@ -49,9 +49,17 @@ export function BackfillOperations({
         return () => clearInterval(interval);
     }, [coverage?.projection_refreshing, router, testMode]);
 
-    const openWizard = (range?: SyncCoverageBackfillWindow) => {
+    const openWizard = (range?: SyncCoverageBackfillWindow | SyncCoverageBackfillWindow[]) => {
         const suggestions = coverage?.backfill_windows;
-        setWizardWindow(range ?? (suggestions?.length === 1 ? suggestions[0] : null));
+        setWizardWindows(
+            Array.isArray(range)
+                ? range
+                : range
+                  ? [range]
+                  : suggestions?.length === 1
+                    ? [suggestions[0]]
+                    : [],
+        );
         setIsWizardOpen(true);
     };
     const closeWizard = () => setIsWizardOpen(false);
@@ -94,13 +102,14 @@ export function BackfillOperations({
                 coverage={coverage}
                 error={coverageError}
                 onBackfillWindowAction={openWizard}
+                onBackfillWindowsAction={openWizard}
             />
 
             {isWizardOpen && (
                 <BackfillWizard
                     configId={configId}
                     onCloseAction={closeWizard}
-                    initialWindow={wizardWindow ?? undefined}
+                    initialWindows={wizardWindows}
                     suggestedWindows={coverage?.backfill_windows}
                     datasets={coverage?.datasets ?? []}
                     sources={coverage?.sources ?? []}

--- a/src/components/admin/sync/BackfillWizard.test.tsx
+++ b/src/components/admin/sync/BackfillWizard.test.tsx
@@ -69,7 +69,7 @@ async function fillRange(
 
 async function reviewAndSubmit(user: ReturnType<typeof userEvent.setup>) {
     await user.click(screen.getByRole("button", { name: "Continue" }));
-    await user.click(screen.getByRole("button", { name: "Run backfill" }));
+    await user.click(screen.getByRole("button", { name: /^Run (backfill|\d+ backfills)$/ }));
 }
 
 describe("buildDatasetChoices", () => {
@@ -128,18 +128,18 @@ describe("BackfillWizard", () => {
         await reviewAndSubmit(user);
 
         expect(triggerBackfill).toHaveBeenCalledWith("cfg-1", {
-            since: "2026-06-10T00:00:00.000Z",
-            before: "2026-06-12T00:00:00.000Z",
+            since: "2026-06-10T00:00:00Z",
+            before: "2026-06-12T00:00:00Z",
             source_ids: ["src-web"],
             dataset_keys: ["work-item-comments"],
         });
     });
 
-    it("offers separate quick choices for multiple server suggestions", async () => {
+    it("selects multiple exact suggestions and submits each selector without merging scope", async () => {
         const user = userEvent.setup();
         const firstWindow = {
-            since: "2026-06-01T00:00:00Z",
-            before: "2026-06-02T00:00:00Z",
+            since: "2026-06-01T05:30:00Z",
+            before: "2026-06-02T05:30:00Z",
             source_ids: ["src-api"],
             dataset_keys: ["git"],
             reasons: ["gap"] as const,
@@ -154,15 +154,93 @@ describe("BackfillWizard", () => {
         renderWizard({ suggestedWindows: [firstWindow, secondWindow] });
 
         await user.click(
-            screen.getByRole("button", {
+            screen.getByRole("checkbox", {
+                name: "2026-06-01 to 2026-06-02 · git",
+            }),
+        );
+        await user.click(
+            screen.getByRole("checkbox", {
                 name: "2026-06-10 to 2026-06-12 · work-item-comments",
+            }),
+        );
+
+        expect(screen.getByRole("status")).toHaveTextContent("2 exact windows selected");
+
+        await reviewAndSubmit(user);
+
+        expect(triggerBackfill).toHaveBeenCalledTimes(2);
+        expect(triggerBackfill).toHaveBeenNthCalledWith(1, "cfg-1", {
+            since: "2026-06-01T05:30:00Z",
+            before: "2026-06-02T05:30:00Z",
+            source_ids: ["src-api"],
+            dataset_keys: ["git"],
+        });
+        expect(triggerBackfill).toHaveBeenNthCalledWith(2, "cfg-1", {
+            since: "2026-06-10T00:00:00Z",
+            before: "2026-06-12T00:00:00Z",
+            source_ids: ["src-web"],
+            dataset_keys: ["work-item-comments"],
+        });
+        expect(await screen.findByText(/^2 backfills started/)).toBeInTheDocument();
+    });
+
+    it("auto-selects every source and dataset carried by one exact suggestion", async () => {
+        const user = userEvent.setup();
+        const window = {
+            since: "2026-06-10T00:00:00Z",
+            before: "2026-06-12T00:00:00Z",
+            source_ids: ["src-api", "src-web"],
+            dataset_keys: ["git", "work-item-comments"],
+            reasons: ["gap"] as const,
+        };
+        renderWizard({ suggestedWindows: [window] });
+
+        await user.click(
+            screen.getByRole("checkbox", {
+                name: "2026-06-10 to 2026-06-12 · git, work-item-comments",
             }),
         );
 
         expect(screen.getByLabelText("Since (inclusive)")).toHaveValue("2026-06-10");
         expect(screen.getByLabelText("Before (exclusive)")).toHaveValue("2026-06-12");
+        expect(screen.getByLabelText("acme/api")).toBeChecked();
         expect(screen.getByLabelText("acme/web")).toBeChecked();
+        expect(screen.getByLabelText("Git Data (Commits, Branches)")).toBeChecked();
         expect(screen.getByLabelText("Suggested work-item datasets")).toBeChecked();
+    });
+
+    it("reports each exact window when only part of a batch starts", async () => {
+        const user = userEvent.setup();
+        const windows = [
+            {
+                since: "2026-06-01T00:00:00Z",
+                before: "2026-06-02T00:00:00Z",
+                source_ids: ["src-api"],
+                dataset_keys: ["git"],
+                reasons: ["gap"] as const,
+            },
+            {
+                since: "2026-06-10T00:00:00Z",
+                before: "2026-06-12T00:00:00Z",
+                source_ids: ["src-web"],
+                dataset_keys: ["work-item-comments"],
+                reasons: ["failed"] as const,
+            },
+        ];
+        triggerBackfill
+            .mockResolvedValueOnce({ data: { status: "accepted", sync_run_id: "run-1" } })
+            .mockResolvedValueOnce({ error: "Source is already running" });
+        renderWizard({ initialWindows: windows, suggestedWindows: windows });
+
+        await reviewAndSubmit(user);
+
+        expect(await screen.findByText(/^1 backfill started; 1 failed/)).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "View run" })).toHaveAttribute(
+            "href",
+            "/org/admin/sync/cfg-1/runs/run-1",
+        );
+        expect(screen.getByRole("alert")).toHaveTextContent("Source is already running");
+        expect(triggerBackfill).toHaveBeenCalledTimes(2);
     });
 
     it("submits a repository-only focused selector", async () => {

--- a/src/components/admin/sync/BackfillWizard.tsx
+++ b/src/components/admin/sync/BackfillWizard.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { triggerBackfill } from "@/lib/admin/server";
 import type {
+    BackfillSelector,
     SyncCoverageBackfillWindow,
     SyncCoverageDataset,
     SyncCoverageSource,
@@ -39,11 +40,23 @@ interface BackfillWizardProps {
     onCloseAction: () => void;
     /** Server-authorized exact scope selected from coverage, if any. */
     initialWindow?: SyncCoverageBackfillWindow;
+    /** Several exact scopes selected from coverage. Each remains a separate request. */
+    initialWindows?: SyncCoverageBackfillWindow[];
     /** Present empty means Ops has no exact suggestion for this coverage state. */
     suggestedWindows?: SyncCoverageBackfillWindow[];
     datasets: SyncCoverageDataset[];
     sources: SyncCoverageSource[];
     testMode?: boolean;
+}
+
+interface SubmissionOutcome {
+    label: string;
+    syncRunId: string | null;
+    error: string | null;
+}
+
+function startedBackfillLabel(count: number): string {
+    return count === 1 ? "1 backfill started" : `${count} backfills started`;
 }
 
 function parseDateInput(value: string): Date | null {
@@ -57,6 +70,13 @@ function rangeDays(since: string, before: string): number | null {
     const beforeDate = parseDateInput(before);
     if (!sinceDate || !beforeDate) return null;
     return Math.round((beforeDate.getTime() - sinceDate.getTime()) / 86_400_000);
+}
+
+function exactWindowDays(window: SyncCoverageBackfillWindow): number | null {
+    const since = new Date(window.since);
+    const before = new Date(window.before);
+    if (Number.isNaN(since.getTime()) || Number.isNaN(before.getTime())) return null;
+    return (before.getTime() - since.getTime()) / 86_400_000;
 }
 
 function toBoundary(value: string): string {
@@ -151,18 +171,57 @@ function windowLabel(window: SyncCoverageBackfillWindow): string {
     return `${toDateInput(window.since)} to ${toDateInput(window.before)} · ${datasetScope}`;
 }
 
+function backfillWindowKey(window: SyncCoverageBackfillWindow): string {
+    return [
+        window.since,
+        window.before,
+        [...(window.dataset_keys ?? [])].sort().join(","),
+        [...(window.source_ids ?? [])].sort().join(","),
+    ].join("|");
+}
+
+function selectorForExactWindow(window: SyncCoverageBackfillWindow): BackfillSelector {
+    return {
+        since: window.since,
+        before: window.before,
+        ...(window.source_ids?.length ? { source_ids: window.source_ids } : {}),
+        ...(window.dataset_keys?.length ? { dataset_keys: window.dataset_keys } : {}),
+    };
+}
+
 export function BackfillWizard({
     configId,
     onCloseAction,
     initialWindow,
+    initialWindows,
     suggestedWindows,
     datasets,
     sources,
     testMode = false,
 }: BackfillWizardProps) {
     const router = useRouter();
+    const seededWindows = useMemo(
+        () =>
+            initialWindows && initialWindows.length > 0
+                ? initialWindows
+                : initialWindow
+                  ? [initialWindow]
+                  : [],
+        [initialWindow, initialWindows],
+    );
+    const selectableWindows = useMemo(() => {
+        const byKey = new Map<string, SyncCoverageBackfillWindow>();
+        for (const window of [...(suggestedWindows ?? []), ...seededWindows]) {
+            byKey.set(backfillWindowKey(window), window);
+        }
+        return [...byKey.values()];
+    }, [seededWindows, suggestedWindows]);
+    const singleInitialWindow = seededWindows.length === 1 ? seededWindows[0] : undefined;
+    const [selectedWindowKeys, setSelectedWindowKeys] = useState<string[]>(() =>
+        seededWindows.map(backfillWindowKey),
+    );
     const [scopedDatasetKeys, setScopedDatasetKeys] = useState<string[]>(
-        initialWindow?.dataset_keys ?? [],
+        singleInitialWindow?.dataset_keys ?? [],
     );
     const datasetChoices = useMemo(
         () => buildDatasetChoices(datasets, scopedDatasetKeys),
@@ -170,27 +229,26 @@ export function BackfillWizard({
     );
     const [step, setStep] = useState<WizardStep>("scope");
     const [since, setSince] = useState(() =>
-        initialWindow ? toDateInput(initialWindow.since) : "",
+        singleInitialWindow ? toDateInput(singleInitialWindow.since) : "",
     );
     const [before, setBefore] = useState(() =>
-        initialWindow ? toDateInput(initialWindow.before) : "",
+        singleInitialWindow ? toDateInput(singleInitialWindow.before) : "",
     );
     const [sourceMode, setSourceMode] = useState<ScopeMode>(() =>
-        initialWindow?.source_ids?.length ? "selected" : "all",
+        singleInitialWindow?.source_ids?.length ? "selected" : "all",
     );
     const [datasetMode, setDatasetMode] = useState<ScopeMode>(() =>
-        initialWindow?.dataset_keys?.length ? "selected" : "all",
+        singleInitialWindow?.dataset_keys?.length ? "selected" : "all",
     );
     const [selectedSourceIds, setSelectedSourceIds] = useState<string[]>(() =>
-        sourceIdsInInventory(initialWindow?.source_ids, sources),
+        sourceIdsInInventory(singleInitialWindow?.source_ids, sources),
     );
     const [selectedDatasetChoiceIds, setSelectedDatasetChoiceIds] = useState<string[]>(() =>
-        choiceIdsForDatasetScope(datasetChoices, initialWindow?.dataset_keys),
+        choiceIdsForDatasetScope(datasetChoices, singleInitialWindow?.dataset_keys),
     );
     const [expensiveConfirmed, setExpensiveConfirmed] = useState(false);
     const [isPending, startTransition] = useTransition();
-    const [submitError, setSubmitError] = useState<string | null>(null);
-    const [submittedSyncRunId, setSubmittedSyncRunId] = useState<string | null>(null);
+    const [submissionOutcomes, setSubmissionOutcomes] = useState<SubmissionOutcome[]>([]);
     const dialogRef = useRef<HTMLDivElement>(null);
     const onCloseActionRef = useRef(onCloseAction);
 
@@ -211,17 +269,49 @@ export function BackfillWizard({
         };
     }, []);
 
+    const selectedExactWindows = selectableWindows.filter((window) =>
+        selectedWindowKeys.includes(backfillWindowKey(window)),
+    );
+    const isExactBatch = selectedExactWindows.length > 1;
     const days = rangeDays(since, before);
     const hasBothDates = Boolean(since) && Boolean(before);
     const isRangeInvalid = hasBothDates && days !== null && days <= 0;
     const sourceSelectionInvalid = sourceMode === "selected" && selectedSourceIds.length === 0;
     const datasetSelectionInvalid =
         datasetMode === "selected" && selectedDatasetChoiceIds.length === 0;
-    const isScopeInvalid = sourceSelectionInvalid || datasetSelectionInvalid;
-    const isExpensiveRange = days !== null && days > EXPENSIVE_RANGE_THRESHOLD_DAYS;
+    const manualScopeInvalid = sourceSelectionInvalid || datasetSelectionInvalid;
+    const exactSelectionInvalid = selectedExactWindows.some((window) => {
+        const windowDays = exactWindowDays(window);
+        const availableSourceIds = sourceIdsInInventory(window.source_ids, sources);
+        const availableDatasetChoices = choiceIdsForDatasetScope(
+            buildDatasetChoices(datasets, window.dataset_keys),
+            window.dataset_keys,
+        );
+        return (
+            windowDays === null ||
+            windowDays <= 0 ||
+            (window.source_ids !== undefined &&
+                availableSourceIds.length !== window.source_ids.length) ||
+            (window.dataset_keys !== undefined &&
+                window.dataset_keys.length > 0 &&
+                availableDatasetChoices.length === 0)
+        );
+    });
+    const isScopeInvalid =
+        selectedExactWindows.length > 0 ? exactSelectionInvalid : manualScopeInvalid;
+    const isExpensiveRange =
+        selectedExactWindows.length > 0
+            ? selectedExactWindows.some((window) => {
+                  const windowDays = exactWindowDays(window);
+                  return windowDays !== null && windowDays > EXPENSIVE_RANGE_THRESHOLD_DAYS;
+              })
+            : days !== null && days > EXPENSIVE_RANGE_THRESHOLD_DAYS;
     const chunkEstimate =
         days !== null && days > 0 ? Math.max(1, Math.ceil(days / ESTIMATED_CHUNK_DAYS)) : 0;
-    const canContinue = hasBothDates && !isRangeInvalid && !isScopeInvalid;
+    const canContinue =
+        selectedExactWindows.length > 0
+            ? !exactSelectionInvalid
+            : hasBothDates && !isRangeInvalid && !manualScopeInvalid;
     const canSubmit = canContinue && (!isExpensiveRange || expensiveConfirmed);
     const selectedDatasetKeys = datasetChoices
         .filter((choice) => selectedDatasetChoiceIds.includes(choice.id))
@@ -232,8 +322,14 @@ export function BackfillWizard({
     const selectedDatasetChoices = datasetChoices.filter((choice) =>
         selectedDatasetChoiceIds.includes(choice.id),
     );
+    const successfulOutcomes = submissionOutcomes.filter((outcome) => outcome.error === null);
+    const failedOutcomes = submissionOutcomes.filter((outcome) => outcome.error !== null);
 
     const resetConfirmation = () => setExpensiveConfirmed(false);
+    const beginManualEdit = () => {
+        setSelectedWindowKeys([]);
+        resetConfirmation();
+    };
     const toggle = (values: string[], value: string): string[] =>
         values.includes(value) ? values.filter((item) => item !== value) : [...values, value];
 
@@ -253,33 +349,87 @@ export function BackfillWizard({
         resetConfirmation();
     };
 
+    const toggleSuggestedWindow = (window: SyncCoverageBackfillWindow) => {
+        const key = backfillWindowKey(window);
+        const nextKeys = selectedWindowKeys.includes(key)
+            ? selectedWindowKeys.filter((value) => value !== key)
+            : [...selectedWindowKeys, key];
+        setSelectedWindowKeys(nextKeys);
+        const nextWindows = selectableWindows.filter((candidate) =>
+            nextKeys.includes(backfillWindowKey(candidate)),
+        );
+        if (nextWindows.length === 1) applySuggestedWindow(nextWindows[0]);
+        resetConfirmation();
+    };
+
     const handleSubmit = () => {
         if (!canSubmit) return;
-        setSubmitError(null);
-        const selector = {
-            since: toBoundary(since),
-            before: toBoundary(before),
-            ...(sourceMode === "selected" ? { source_ids: selectedSourceIds } : {}),
-            ...(datasetMode === "selected" ? { dataset_keys: selectedDatasetKeys } : {}),
-        };
+        const selectors: BackfillSelector[] =
+            selectedExactWindows.length > 0
+                ? selectedExactWindows.map(selectorForExactWindow)
+                : [
+                      {
+                          since: toBoundary(since),
+                          before: toBoundary(before),
+                          ...(sourceMode === "selected" ? { source_ids: selectedSourceIds } : {}),
+                          ...(datasetMode === "selected"
+                              ? { dataset_keys: selectedDatasetKeys }
+                              : {}),
+                      },
+                  ];
+        const labels =
+            selectedExactWindows.length > 0
+                ? selectedExactWindows.map(windowLabel)
+                : [`${since} to ${before}`];
 
         if (testMode) {
-            setSubmittedSyncRunId("sample-run-gaps");
+            setSubmissionOutcomes(
+                selectors.map((_, index) => ({
+                    label: labels[index],
+                    syncRunId:
+                        selectors.length === 1 ? "sample-run-gaps" : `sample-run-gaps-${index + 1}`,
+                    error: null,
+                })),
+            );
             setStep("result");
             return;
         }
 
         startTransition(async () => {
-            const result = await triggerBackfill(configId, selector);
-            if (result.error || !result.data) {
-                setSubmitError(result.error ?? "Failed to start backfill");
-                toast.error(result.error ?? "Failed to start backfill");
-                return;
+            const outcomes: SubmissionOutcome[] = [];
+            for (const [index, selector] of selectors.entries()) {
+                try {
+                    const result = await triggerBackfill(configId, selector);
+                    outcomes.push({
+                        label: labels[index],
+                        syncRunId: result.data?.sync_run_id ?? null,
+                        error:
+                            result.error || !result.data
+                                ? (result.error ?? "Failed to start backfill")
+                                : null,
+                    });
+                } catch {
+                    outcomes.push({
+                        label: labels[index],
+                        syncRunId: null,
+                        error: "Failed to start backfill",
+                    });
+                }
             }
-            toast.success("Backfill started");
-            setSubmittedSyncRunId(result.data.sync_run_id ?? null);
+            const startedCount = outcomes.filter((outcome) => outcome.error === null).length;
+            const failedCount = outcomes.length - startedCount;
+            if (failedCount === 0) {
+                toast.success(
+                    startedCount === 1 ? "Backfill started" : startedBackfillLabel(startedCount),
+                );
+            } else if (startedCount === 0) {
+                toast.error("No backfills could be started");
+            } else {
+                toast.warning(`${startedBackfillLabel(startedCount)}; ${failedCount} failed`);
+            }
+            setSubmissionOutcomes(outcomes);
             setStep("result");
-            router.refresh();
+            if (startedCount > 0) router.refresh();
         });
     };
 
@@ -330,36 +480,46 @@ export function BackfillWizard({
                                     date range and scope to continue.
                                 </p>
                             )}
-                            {suggestedWindows && suggestedWindows.length > 1 && (
+                            {suggestedWindows && suggestedWindows.length > 0 && (
                                 <fieldset className="space-y-2 rounded-lg border border-(--card-stroke) p-4">
                                     <legend className="px-1 text-sm font-semibold text-foreground">
                                         Suggested exact windows
                                     </legend>
                                     <p className="text-xs text-(--ink-muted)">
-                                        Choose one server-authorized window, or set a different
-                                        exact scope below.
+                                        Select one or more server-authorized windows. Each selected
+                                        window keeps its own dates, sources, and datasets.
                                     </p>
-                                    <div className="flex flex-wrap gap-2">
+                                    <div className="space-y-2">
                                         {suggestedWindows.map((window) => (
-                                            <button
-                                                key={`${window.since}-${window.before}-${window.dataset_keys?.join(",") ?? "all"}-${window.source_ids?.join(",") ?? "all"}`}
-                                                type="button"
-                                                onClick={() => applySuggestedWindow(window)}
-                                                className="rounded-md border border-(--card-stroke) px-3 py-2 text-left text-sm text-foreground hover:border-(--accent)"
+                                            <label
+                                                key={backfillWindowKey(window)}
+                                                className="flex items-start gap-2 rounded-md border border-(--card-stroke) px-3 py-2 text-sm text-foreground hover:border-(--accent)"
                                             >
-                                                {windowLabel(window)}
-                                            </button>
+                                                <input
+                                                    type="checkbox"
+                                                    checked={selectedWindowKeys.includes(
+                                                        backfillWindowKey(window),
+                                                    )}
+                                                    onChange={() => toggleSuggestedWindow(window)}
+                                                    className="mt-0.5"
+                                                />
+                                                <span>{windowLabel(window)}</span>
+                                            </label>
                                         ))}
                                     </div>
                                 </fieldset>
                             )}
-                            {suggestedWindows?.length === 1 && initialWindow && (
-                                <p role="status" className="text-sm text-(--ink-muted)">
-                                    The server-suggested window is selected. You can edit it before
-                                    confirmation.
+                            {selectedExactWindows.length > 0 && (
+                                <p
+                                    role="status"
+                                    className="rounded-lg border border-(--accent)/30 bg-(--accent)/10 p-3 text-sm text-foreground"
+                                >
+                                    {selectedExactWindows.length === 1
+                                        ? "1 exact window selected. Its repositories and datasets are set below; editing them switches to a manual selector."
+                                        : `${selectedExactWindows.length} exact windows selected. Each window will run with its server-set repositories and datasets.`}
                                 </p>
                             )}
-                            <div className="grid gap-3 sm:grid-cols-2">
+                            <div hidden={isExactBatch} className="grid gap-3 sm:grid-cols-2">
                                 <label
                                     className="text-sm font-medium text-(--ink-muted)"
                                     htmlFor="backfill-since"
@@ -371,7 +531,7 @@ export function BackfillWizard({
                                         value={since}
                                         onChange={(event) => {
                                             setSince(event.target.value);
-                                            resetConfirmation();
+                                            beginManualEdit();
                                         }}
                                         aria-invalid={isRangeInvalid}
                                         aria-describedby={
@@ -391,7 +551,7 @@ export function BackfillWizard({
                                         value={before}
                                         onChange={(event) => {
                                             setBefore(event.target.value);
-                                            resetConfirmation();
+                                            beginManualEdit();
                                         }}
                                         aria-invalid={isRangeInvalid}
                                         aria-describedby={
@@ -401,7 +561,7 @@ export function BackfillWizard({
                                     />
                                 </label>
                             </div>
-                            {isRangeInvalid && (
+                            {!isExactBatch && isRangeInvalid && (
                                 <p
                                     id={RANGE_ERROR_ID}
                                     role="alert"
@@ -411,7 +571,10 @@ export function BackfillWizard({
                                 </p>
                             )}
 
-                            <fieldset className="space-y-3 rounded-lg border border-(--card-stroke) p-4">
+                            <fieldset
+                                hidden={isExactBatch}
+                                className="space-y-3 rounded-lg border border-(--card-stroke) p-4"
+                            >
                                 <legend className="px-1 text-sm font-semibold text-foreground">
                                     Repository or source scope
                                 </legend>
@@ -422,7 +585,7 @@ export function BackfillWizard({
                                         checked={sourceMode === "all"}
                                         onChange={() => {
                                             setSourceMode("all");
-                                            resetConfirmation();
+                                            beginManualEdit();
                                         }}
                                         className="mt-0.5"
                                     />
@@ -443,7 +606,7 @@ export function BackfillWizard({
                                         checked={sourceMode === "selected"}
                                         onChange={() => {
                                             setSourceMode("selected");
-                                            resetConfirmation();
+                                            beginManualEdit();
                                         }}
                                         disabled={sources.length === 0}
                                         className="mt-0.5"
@@ -475,7 +638,7 @@ export function BackfillWizard({
                                                         setSelectedSourceIds((current) =>
                                                             toggle(current, source.source_id),
                                                         );
-                                                        resetConfirmation();
+                                                        beginManualEdit();
                                                     }}
                                                 />
                                                 {source.source_name}
@@ -485,7 +648,10 @@ export function BackfillWizard({
                                 )}
                             </fieldset>
 
-                            <fieldset className="space-y-3 rounded-lg border border-(--card-stroke) p-4">
+                            <fieldset
+                                hidden={isExactBatch}
+                                className="space-y-3 rounded-lg border border-(--card-stroke) p-4"
+                            >
                                 <legend className="px-1 text-sm font-semibold text-foreground">
                                     Provider unit or dataset scope
                                 </legend>
@@ -496,7 +662,7 @@ export function BackfillWizard({
                                         checked={datasetMode === "all"}
                                         onChange={() => {
                                             setDatasetMode("all");
-                                            resetConfirmation();
+                                            beginManualEdit();
                                         }}
                                         className="mt-0.5"
                                     />
@@ -516,7 +682,7 @@ export function BackfillWizard({
                                         checked={datasetMode === "selected"}
                                         onChange={() => {
                                             setDatasetMode("selected");
-                                            resetConfirmation();
+                                            beginManualEdit();
                                         }}
                                         disabled={datasetChoices.length === 0}
                                         className="mt-0.5"
@@ -548,7 +714,7 @@ export function BackfillWizard({
                                                         setSelectedDatasetChoiceIds((current) =>
                                                             toggle(current, choice.id),
                                                         );
-                                                        resetConfirmation();
+                                                        beginManualEdit();
                                                     }}
                                                     className="mt-0.5"
                                                 />
@@ -575,8 +741,9 @@ export function BackfillWizard({
                                     role="alert"
                                     className="text-sm text-(--negative)"
                                 >
-                                    Choose at least one item in every focused scope, or switch that
-                                    scope to all enabled.
+                                    {selectedExactWindows.length > 0
+                                        ? "One selected server window is not available in the current source or dataset inventory."
+                                        : "Choose at least one item in every focused scope, or switch that scope to all enabled."}
                                 </p>
                             )}
                             <div className="flex justify-end gap-2 pt-2">
@@ -606,47 +773,101 @@ export function BackfillWizard({
                                 Review the exact bounded selector. Nothing outside this scope will
                                 be requested.
                             </p>
-                            <dl className="grid gap-4 rounded-lg border border-(--card-stroke) p-4 text-sm sm:grid-cols-2">
-                                <div>
-                                    <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
-                                        Window
-                                    </dt>
-                                    <dd className="mt-1 text-foreground">
-                                        {since} inclusive → {before} exclusive
-                                    </dd>
-                                </div>
-                                <div>
-                                    <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
-                                        Estimated chunks
-                                    </dt>
-                                    <dd className="mt-1 text-foreground">
-                                        ~{chunkEstimate} per selected unit (estimate)
-                                    </dd>
-                                </div>
-                                <div>
-                                    <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
-                                        Sources
-                                    </dt>
-                                    <dd className="mt-1 text-foreground">
-                                        {sourceMode === "all"
-                                            ? "All enabled sources"
-                                            : selectedSourceNames.join(", ")}
-                                    </dd>
-                                </div>
-                                <div>
-                                    <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
-                                        Datasets
-                                    </dt>
-                                    <dd className="mt-1 text-foreground">
-                                        {datasetMode === "all"
-                                            ? "All enabled datasets"
-                                            : selectedDatasetChoices
-                                                  .map((choice) => choice.label)
-                                                  .join(", ")}
-                                    </dd>
-                                </div>
-                            </dl>
-                            {datasetMode === "selected" &&
+                            {isExactBatch ? (
+                                <ol className="space-y-3">
+                                    {selectedExactWindows.map((window, index) => {
+                                        const windowDays = exactWindowDays(window);
+                                        return (
+                                            <li
+                                                key={backfillWindowKey(window)}
+                                                className="rounded-lg border border-(--card-stroke) p-4 text-sm"
+                                            >
+                                                <p className="font-medium text-foreground">
+                                                    Window {index + 1}: {windowLabel(window)}
+                                                </p>
+                                                <p className="mt-1 text-(--ink-muted)">
+                                                    Sources:{" "}
+                                                    {window.source_ids?.length
+                                                        ? window.source_ids
+                                                              .map(
+                                                                  (id) =>
+                                                                      sources.find(
+                                                                          (source) =>
+                                                                              source.source_id ===
+                                                                              id,
+                                                                      )?.source_name ?? id,
+                                                              )
+                                                              .join(", ")
+                                                        : "All enabled sources"}
+                                                </p>
+                                                <p className="text-(--ink-muted)">
+                                                    Datasets:{" "}
+                                                    {window.dataset_keys?.length
+                                                        ? window.dataset_keys
+                                                              .map(datasetLabel)
+                                                              .join(", ")
+                                                        : "All enabled datasets"}
+                                                </p>
+                                                <p className="text-xs text-(--ink-muted)">
+                                                    ~
+                                                    {windowDays && windowDays > 0
+                                                        ? Math.max(
+                                                              1,
+                                                              Math.ceil(
+                                                                  windowDays / ESTIMATED_CHUNK_DAYS,
+                                                              ),
+                                                          )
+                                                        : 0}{" "}
+                                                    chunks per selected unit (estimate)
+                                                </p>
+                                            </li>
+                                        );
+                                    })}
+                                </ol>
+                            ) : (
+                                <dl className="grid gap-4 rounded-lg border border-(--card-stroke) p-4 text-sm sm:grid-cols-2">
+                                    <div>
+                                        <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
+                                            Window
+                                        </dt>
+                                        <dd className="mt-1 text-foreground">
+                                            {since} inclusive → {before} exclusive
+                                        </dd>
+                                    </div>
+                                    <div>
+                                        <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
+                                            Estimated chunks
+                                        </dt>
+                                        <dd className="mt-1 text-foreground">
+                                            ~{chunkEstimate} per selected unit (estimate)
+                                        </dd>
+                                    </div>
+                                    <div>
+                                        <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
+                                            Sources
+                                        </dt>
+                                        <dd className="mt-1 text-foreground">
+                                            {sourceMode === "all"
+                                                ? "All enabled sources"
+                                                : selectedSourceNames.join(", ")}
+                                        </dd>
+                                    </div>
+                                    <div>
+                                        <dt className="text-xs font-medium uppercase tracking-wider text-(--ink-muted)">
+                                            Datasets
+                                        </dt>
+                                        <dd className="mt-1 text-foreground">
+                                            {datasetMode === "all"
+                                                ? "All enabled datasets"
+                                                : selectedDatasetChoices
+                                                      .map((choice) => choice.label)
+                                                      .join(", ")}
+                                        </dd>
+                                    </div>
+                                </dl>
+                            )}
+                            {!isExactBatch &&
+                                datasetMode === "selected" &&
                                 selectedDatasetKeys.length > selectedDatasetChoices.length && (
                                     <p className="text-xs text-(--ink-muted)">
                                         Canonical work-item family affects:{" "}
@@ -659,9 +880,11 @@ export function BackfillWizard({
                                     className="space-y-3 rounded-lg border border-(--caution)/30 bg-(--caution)/15 p-4"
                                 >
                                     <p className="text-sm font-medium text-(--caution)">
-                                        This range spans {days} days, more than{" "}
-                                        {EXPENSIVE_RANGE_THRESHOLD_DAYS}. Large backfills can take a
-                                        long time and consume significant sync capacity.
+                                        {isExactBatch
+                                            ? `One or more selected windows span more than ${EXPENSIVE_RANGE_THRESHOLD_DAYS} days.`
+                                            : `This range spans ${days} days, more than ${EXPENSIVE_RANGE_THRESHOLD_DAYS}.`}{" "}
+                                        Large backfills can take a long time and consume significant
+                                        sync capacity.
                                     </p>
                                     <label
                                         htmlFor="backfill-expensive-confirm"
@@ -680,11 +903,6 @@ export function BackfillWizard({
                                     </label>
                                 </div>
                             )}
-                            {submitError && (
-                                <p role="alert" className="text-sm text-(--negative)">
-                                    {submitError}
-                                </p>
-                            )}
                             <div className="flex justify-end gap-2 pt-2">
                                 <button
                                     type="button"
@@ -699,7 +917,11 @@ export function BackfillWizard({
                                     disabled={!canSubmit || isPending}
                                     className="rounded-md bg-(--accent) px-4 py-2 text-sm font-medium text-white hover:bg-(--accent)/90 disabled:opacity-50"
                                 >
-                                    {isPending ? "Starting..." : CTA_LABELS.runBackfill}
+                                    {isPending
+                                        ? "Starting..."
+                                        : isExactBatch
+                                          ? `Run ${selectedExactWindows.length} backfills`
+                                          : CTA_LABELS.runBackfill}
                                 </button>
                             </div>
                         </>
@@ -708,17 +930,39 @@ export function BackfillWizard({
                     {step === "result" && (
                         <>
                             <p className="text-sm text-foreground">
-                                Backfill started for the reviewed scope. Progress will appear on
-                                this page.
+                                {successfulOutcomes.length === 1 && failedOutcomes.length === 0
+                                    ? "Backfill started for the reviewed scope. Progress will appear on this page."
+                                    : successfulOutcomes.length > 0
+                                      ? `${startedBackfillLabel(successfulOutcomes.length)}${failedOutcomes.length > 0 ? `; ${failedOutcomes.length} failed` : ""}. Progress will appear on this page.`
+                                      : "No backfills could be started."}
                             </p>
-                            {submittedSyncRunId && (
-                                <Link
-                                    href={`/org/admin/sync/${configId}/runs/${submittedSyncRunId}`}
-                                    className="inline-block text-sm text-(--accent) hover:underline"
-                                >
-                                    {CTA_LABELS.viewRun}
-                                </Link>
-                            )}
+                            <ul className="space-y-2">
+                                {submissionOutcomes.map((outcome, index) => (
+                                    <li
+                                        key={`${outcome.label}-${index}`}
+                                        className="rounded-lg border border-(--card-stroke) p-3 text-sm"
+                                    >
+                                        <p className="text-foreground">{outcome.label}</p>
+                                        {outcome.error ? (
+                                            <p role="alert" className="mt-1 text-(--negative)">
+                                                {outcome.error}
+                                            </p>
+                                        ) : outcome.syncRunId ? (
+                                            <Link
+                                                href={`/org/admin/sync/${configId}/runs/${outcome.syncRunId}`}
+                                                className="mt-1 inline-block text-(--accent) hover:underline"
+                                            >
+                                                {CTA_LABELS.viewRun}
+                                            </Link>
+                                        ) : (
+                                            <p className="mt-1 text-(--ink-muted)">
+                                                Backfill accepted; refresh this page to view
+                                                progress.
+                                            </p>
+                                        )}
+                                    </li>
+                                ))}
+                            </ul>
                             <div className="flex justify-end pt-2">
                                 <button
                                     type="button"

--- a/src/components/admin/sync/SyncCoverageTimeline.test.tsx
+++ b/src/components/admin/sync/SyncCoverageTimeline.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, userEvent, within } from "@/test/utils";
 import { SyncCoverageTimeline } from "./SyncCoverageTimeline";
 import {
     COMPLETE_COVERAGE_SUMMARY,
+    FAILED_COVERAGE_SUMMARY,
     LEGACY_INSUFFICIENT_DATA_SUMMARY,
     PARTIAL_COVERAGE_SUMMARY,
     TRUNCATED_COVERAGE_SUMMARY,
@@ -10,6 +11,7 @@ import {
 import {
     SAMPLE_COVERAGE_CONCURRENT_CONFIG,
     SAMPLE_COVERAGE_OVERLAPPING_RETRY,
+    SAMPLE_COVERAGE_TRUNCATED,
 } from "@/data/syncCoverageSample";
 
 describe("SyncCoverageTimeline", () => {
@@ -117,6 +119,55 @@ describe("SyncCoverageTimeline", () => {
 
         await user.click(screen.getByRole("button", { name: "Backfill this gap" }));
         expect(onBackfillWindowAction).toHaveBeenCalledWith(window);
+    });
+
+    it("opens a failed-row action only for its exact server-authorized window", async () => {
+        const onBackfillWindowAction = vi.fn();
+        const user = userEvent.setup();
+        const window = {
+            since: "2026-01-02T00:00:00Z",
+            before: "2026-01-03T00:00:00Z",
+            source_ids: ["src-repo"],
+            dataset_keys: ["commits"],
+            reasons: ["failed"] as const,
+        };
+        render(
+            <SyncCoverageTimeline
+                coverage={{ ...FAILED_COVERAGE_SUMMARY, backfill_windows: [window] }}
+                onBackfillWindowAction={onBackfillWindowAction}
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Backfill this failure" }));
+        expect(onBackfillWindowAction).toHaveBeenCalledWith(window);
+    });
+
+    it("selects actionable gaps and failures together for one focused batch", async () => {
+        const onBackfillWindowsAction = vi.fn();
+        const user = userEvent.setup();
+        render(
+            <SyncCoverageTimeline
+                coverage={SAMPLE_COVERAGE_TRUNCATED}
+                onBackfillWindowAction={vi.fn()}
+                onBackfillWindowsAction={onBackfillWindowsAction}
+            />,
+        );
+
+        await user.click(
+            screen.getByRole("checkbox", {
+                name: /Select gap Jun 24, 2026 to Jun 26, 2026 for backfill/,
+            }),
+        );
+        await user.click(
+            screen.getByRole("checkbox", {
+                name: /Select failed Jun 25, 2026 to Jun 27, 2026 for backfill/,
+            }),
+        );
+        await user.click(screen.getByRole("button", { name: "Backfill selected (2)" }));
+
+        expect(onBackfillWindowsAction).toHaveBeenCalledWith(
+            SAMPLE_COVERAGE_TRUNCATED.backfill_windows,
+        );
     });
 
     it("does not infer a backfill action from gaps when canonical windows are explicitly empty", () => {

--- a/src/components/admin/sync/SyncCoverageTimeline.tsx
+++ b/src/components/admin/sync/SyncCoverageTimeline.tsx
@@ -17,6 +17,8 @@ interface SyncCoverageTimelineProps {
     error?: string | null;
     /** Opens the backfill wizard with a server-owned or legacy-compatible date window. */
     onBackfillWindowAction: (range: SyncCoverageBackfillWindow) => void;
+    /** Opens the wizard with several exact server-owned selectors. */
+    onBackfillWindowsAction?: (ranges: SyncCoverageBackfillWindow[]) => void;
 }
 
 type BandKind = "covered" | "gap" | "stale" | "failed";
@@ -48,6 +50,30 @@ interface TimelineRow {
     datasetKey: string;
 }
 
+function windowLabel(window: SyncCoverageBackfillWindow): string {
+    const datasetScope = window.dataset_keys?.length
+        ? window.dataset_keys.join(", ")
+        : "all datasets";
+    return `${formatDateUTC(window.since)} – ${formatDateUTC(window.before)} · ${datasetScope}`;
+}
+
+function backfillWindowKey(window: SyncCoverageBackfillWindow): string {
+    return [
+        window.since,
+        window.before,
+        [...(window.dataset_keys ?? [])].sort().join(","),
+        [...(window.source_ids ?? [])].sort().join(","),
+    ].join("|");
+}
+
+function selectionReason(window: SyncCoverageBackfillWindow): "gap" | "failed" {
+    return window.reasons?.includes("failed") && !window.reasons.includes("gap") ? "failed" : "gap";
+}
+
+function windowSelectionLabel(window: SyncCoverageBackfillWindow): string {
+    return `Select ${selectionReason(window)} ${formatDateUTC(window.since)} to ${formatDateUTC(window.before)} for backfill`;
+}
+
 function sameBoundary(left: string, right: string): boolean {
     const leftTime = new Date(left).getTime();
     const rightTime = new Date(right).getTime();
@@ -62,34 +88,35 @@ function sameScope(left: string[], right: string[]): boolean {
 }
 
 /**
- * Return only the server-authorized window for this exact dataset/source gap.
- * An explicit empty array is authoritative: it never falls back to a client
- * inferred action. The undefined fallback is for an independently deployed
- * legacy Ops server that did not emit the contract field yet.
+ * Return the server-authorized windows for this exact dataset/source gap or
+ * failure. An explicit empty array is authoritative: it never falls back to a
+ * client inferred action. The undefined fallback is for an independently
+ * deployed legacy Ops server that did not emit the contract field yet.
  */
-function backfillWindowForRow(
+function backfillWindowsForRow(
     row: TimelineRow,
     backfillWindows: SyncCoverageBackfillWindow[] | undefined,
-): SyncCoverageBackfillWindow | null {
+): SyncCoverageBackfillWindow[] {
     if (backfillWindows === undefined) {
-        return {
-            since: row.range.since,
-            before: row.range.before,
-            source_ids: row.range.source_ids,
-            dataset_keys: [row.datasetKey],
-        };
+        return [
+            {
+                since: row.range.since,
+                before: row.range.before,
+                source_ids: row.range.source_ids,
+                dataset_keys: [row.datasetKey],
+            },
+        ];
     }
 
-    return (
-        backfillWindows.find(
-            (window) =>
-                window.dataset_keys?.length === 1 &&
-                window.dataset_keys[0] === row.datasetKey &&
-                window.source_ids !== undefined &&
-                sameScope(window.source_ids, row.range.source_ids) &&
-                sameBoundary(window.since, row.range.since) &&
-                sameBoundary(window.before, row.range.before),
-        ) ?? null
+    return backfillWindows.filter(
+        (window) =>
+            window.dataset_keys !== undefined &&
+            window.dataset_keys.length > 0 &&
+            window.dataset_keys.includes(row.datasetKey) &&
+            window.source_ids !== undefined &&
+            sameScope(window.source_ids, row.range.source_ids) &&
+            sameBoundary(window.since, row.range.since) &&
+            sameBoundary(window.before, row.range.before),
     );
 }
 
@@ -168,9 +195,11 @@ export function SyncCoverageTimeline({
     coverage,
     error,
     onBackfillWindowAction,
+    onBackfillWindowsAction,
 }: SyncCoverageTimelineProps) {
     const [datasetFilter, setDatasetFilter] = useState<string>("all");
     const [sourceFilter, setSourceFilter] = useState<string>("all");
+    const [selectedBackfillWindowKeys, setSelectedBackfillWindowKeys] = useState<string[]>([]);
 
     const sourceNameById = useMemo(() => {
         const map: Record<string, string> = {};
@@ -187,6 +216,20 @@ export function SyncCoverageTimeline({
         if (datasetFilter === "all") return all;
         return all.filter((dataset) => dataset.dataset_key === datasetFilter);
     }, [coverage, datasetFilter]);
+
+    const selectedBackfillWindows = useMemo(() => {
+        const selected = new Set(selectedBackfillWindowKeys);
+        return (coverage?.backfill_windows ?? []).filter((window) =>
+            selected.has(backfillWindowKey(window)),
+        );
+    }, [coverage?.backfill_windows, selectedBackfillWindowKeys]);
+
+    const toggleBackfillWindow = (window: SyncCoverageBackfillWindow) => {
+        const key = backfillWindowKey(window);
+        setSelectedBackfillWindowKeys((current) =>
+            current.includes(key) ? current.filter((value) => value !== key) : [...current, key],
+        );
+    };
 
     if (error) {
         return (
@@ -296,18 +339,30 @@ export function SyncCoverageTimeline({
                     <ul className="space-y-2">
                         {coverage.backfill_windows.map((window) => (
                             <li
-                                key={`${window.since}-${window.before}-${window.dataset_keys?.join(",") ?? "all"}-${window.source_ids?.join(",") ?? "all"}`}
+                                key={backfillWindowKey(window)}
                                 className="flex flex-wrap items-center justify-between gap-3"
                             >
-                                <span className="text-sm text-foreground">
-                                    {formatDateUTC(window.since)} – {formatDateUTC(window.before)}
-                                    {window.dataset_keys && window.dataset_keys.length > 0 && (
-                                        <> · {window.dataset_keys.join(", ")}</>
-                                    )}
-                                    {window.source_ids && window.source_ids.length > 0 && (
-                                        <> · {window.source_ids.map(sourceLabel).join(", ")}</>
-                                    )}
-                                </span>
+                                <label className="flex min-w-0 items-start gap-2 text-sm text-foreground">
+                                    <input
+                                        type="checkbox"
+                                        aria-label={`Select suggested ${selectionReason(window)} ${formatDateUTC(window.since)} to ${formatDateUTC(window.before)} for backfill`}
+                                        checked={selectedBackfillWindowKeys.includes(
+                                            backfillWindowKey(window),
+                                        )}
+                                        onChange={() => toggleBackfillWindow(window)}
+                                        className="mt-0.5"
+                                    />
+                                    <span>
+                                        {formatDateUTC(window.since)} –{" "}
+                                        {formatDateUTC(window.before)}
+                                        {window.dataset_keys && window.dataset_keys.length > 0 && (
+                                            <> · {window.dataset_keys.join(", ")}</>
+                                        )}
+                                        {window.source_ids && window.source_ids.length > 0 && (
+                                            <> · {window.source_ids.map(sourceLabel).join(", ")}</>
+                                        )}
+                                    </span>
+                                </label>
                                 <button
                                     type="button"
                                     aria-label={`Backfill ${formatDateUTC(window.since)} to ${formatDateUTC(window.before)}`}
@@ -319,6 +374,18 @@ export function SyncCoverageTimeline({
                             </li>
                         ))}
                     </ul>
+                    {onBackfillWindowsAction && (
+                        <div className="flex justify-end border-t border-(--card-stroke) pt-3">
+                            <button
+                                type="button"
+                                disabled={selectedBackfillWindows.length === 0}
+                                onClick={() => onBackfillWindowsAction(selectedBackfillWindows)}
+                                className="rounded-md bg-(--accent) px-3 py-2 text-sm font-medium text-white hover:bg-(--accent)/90 disabled:opacity-50"
+                            >
+                                Backfill selected ({selectedBackfillWindows.length})
+                            </button>
+                        </div>
+                    )}
                 </div>
             )}
 
@@ -452,13 +519,13 @@ export function SyncCoverageTimeline({
                                             </tr>
                                         ) : (
                                             rows.map((row) => {
-                                                const backfillWindow =
-                                                    row.kind === "gap"
-                                                        ? backfillWindowForRow(
+                                                const backfillWindows =
+                                                    row.kind === "gap" || row.kind === "failed"
+                                                        ? backfillWindowsForRow(
                                                               row,
                                                               coverage.backfill_windows,
                                                           )
-                                                        : null;
+                                                        : [];
                                                 return (
                                                     <tr key={rangeKey(row.kind, row.range)}>
                                                         <td className="px-2 py-2">
@@ -481,21 +548,94 @@ export function SyncCoverageTimeline({
                                                                       .join(", ")}
                                                         </td>
                                                         <td className="px-2 py-2">
-                                                            {backfillWindow ? (
-                                                                <button
-                                                                    type="button"
-                                                                    onClick={() =>
-                                                                        onBackfillWindowAction(
-                                                                            backfillWindow,
-                                                                        )
-                                                                    }
-                                                                    className="text-(--accent) hover:underline"
-                                                                >
-                                                                    {CTA_LABELS.backfillThisGap}
-                                                                </button>
-                                                            ) : row.kind === "gap" &&
-                                                              coverage.backfill_windows !==
-                                                                  undefined ? (
+                                                            {backfillWindows.length === 1 ? (
+                                                                <div className="flex items-center gap-2">
+                                                                    {onBackfillWindowsAction &&
+                                                                        coverage.backfill_windows !==
+                                                                            undefined && (
+                                                                            <input
+                                                                                type="checkbox"
+                                                                                aria-label={`Select ${row.kind} ${formatDateUTC(row.range.since)} to ${formatDateUTC(row.range.before)} for backfill`}
+                                                                                checked={selectedBackfillWindowKeys.includes(
+                                                                                    backfillWindowKey(
+                                                                                        backfillWindows[0],
+                                                                                    ),
+                                                                                )}
+                                                                                onChange={() =>
+                                                                                    toggleBackfillWindow(
+                                                                                        backfillWindows[0],
+                                                                                    )
+                                                                                }
+                                                                            />
+                                                                        )}
+                                                                    <button
+                                                                        type="button"
+                                                                        onClick={() =>
+                                                                            onBackfillWindowAction(
+                                                                                backfillWindows[0],
+                                                                            )
+                                                                        }
+                                                                        className="text-(--accent) hover:underline"
+                                                                    >
+                                                                        {row.kind === "failed"
+                                                                            ? CTA_LABELS.backfillThisFailure
+                                                                            : CTA_LABELS.backfillThisGap}
+                                                                    </button>
+                                                                </div>
+                                                            ) : backfillWindows.length > 1 ? (
+                                                                <div className="flex flex-col gap-1">
+                                                                    {backfillWindows.map(
+                                                                        (window) => (
+                                                                            <div
+                                                                                key={backfillWindowKey(
+                                                                                    window,
+                                                                                )}
+                                                                                className="flex items-start gap-2"
+                                                                            >
+                                                                                {onBackfillWindowsAction &&
+                                                                                    coverage.backfill_windows !==
+                                                                                        undefined && (
+                                                                                        <input
+                                                                                            type="checkbox"
+                                                                                            aria-label={windowSelectionLabel(
+                                                                                                window,
+                                                                                            )}
+                                                                                            checked={selectedBackfillWindowKeys.includes(
+                                                                                                backfillWindowKey(
+                                                                                                    window,
+                                                                                                ),
+                                                                                            )}
+                                                                                            onChange={() =>
+                                                                                                toggleBackfillWindow(
+                                                                                                    window,
+                                                                                                )
+                                                                                            }
+                                                                                        />
+                                                                                    )}
+                                                                                <button
+                                                                                    type="button"
+                                                                                    onClick={() =>
+                                                                                        onBackfillWindowAction(
+                                                                                            window,
+                                                                                        )
+                                                                                    }
+                                                                                    className="text-left text-(--accent) hover:underline"
+                                                                                >
+                                                                                    {
+                                                                                        CTA_LABELS.backfillThisWindow
+                                                                                    }
+                                                                                    <span className="block text-xs text-(--ink-muted)">
+                                                                                        {windowLabel(
+                                                                                            window,
+                                                                                        )}
+                                                                                    </span>
+                                                                                </button>
+                                                                            </div>
+                                                                        ),
+                                                                    )}
+                                                                </div>
+                                                            ) : row.kind === "gap" ||
+                                                              row.kind === "failed" ? (
                                                                 <span className="text-xs text-(--ink-muted)">
                                                                     No exact backfill suggestion
                                                                 </span>

--- a/src/lib/design/cta.ts
+++ b/src/lib/design/cta.ts
@@ -146,6 +146,8 @@ export const CTA_LABELS = {
     backfill: "Backfill",
     /** Gap-scoped backfill deep-link from the coverage timeline (CHAOS-2793). */
     backfillThisGap: "Backfill this gap",
+    /** Failure-scoped backfill deep-link from the coverage timeline. */
+    backfillThisFailure: "Backfill this failure",
     /** Server-owned config-wide backfill window from the coverage timeline. */
     backfillThisWindow: "Backfill this window",
     allDatasets: "All datasets",

--- a/tests/admin-sync-observability.spec.ts
+++ b/tests/admin-sync-observability.spec.ts
@@ -178,6 +178,55 @@ test.describe("Journey 1 — coverage-first config detail", () => {
 });
 
 test.describe("Journey 2 — gap-driven backfill flow", () => {
+    test("selects gap and failure rows together and preserves each exact scope", async ({
+        page,
+    }) => {
+        await page.goto(`${DETAIL_URL}?coverage_scenario=truncated`);
+        const timeline = timelineRegion(page);
+
+        await timeline
+            .getByRole("checkbox", {
+                name: "Select gap Jun 24, 2026 to Jun 26, 2026 for backfill",
+            })
+            .check();
+        await timeline
+            .getByRole("checkbox", {
+                name: "Select failed Jun 25, 2026 to Jun 27, 2026 for backfill",
+            })
+            .check();
+        await timeline.getByRole("button", { name: "Backfill selected (2)" }).click();
+
+        const dialog = page.getByRole("dialog");
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByRole("status")).toContainText("2 exact windows selected");
+        await dialog.getByRole("button", { name: "Continue" }).click();
+
+        await expect(dialog.getByText(/Window 1: 2026-06-24 to 2026-06-26/)).toBeVisible();
+        await expect(dialog.getByText(/Window 2: 2026-06-25 to 2026-06-27/)).toBeVisible();
+        await expect(dialog.getByText("Sources: fullchaos/platform-api")).toBeVisible();
+        await expect(dialog.getByText("Sources: fullchaos/billing-service")).toBeVisible();
+        await expect(dialog.getByText("Datasets: Git Data (Commits, Branches)")).toBeVisible();
+        await expect(dialog.getByText("Datasets: Pull Requests")).toBeVisible();
+
+        await dialog.getByRole("button", { name: "Run 2 backfills" }).click();
+        await expect(dialog.getByText(/^2 backfills started/)).toBeVisible();
+        await expect(dialog.getByRole("link", { name: "View run" })).toHaveCount(2);
+    });
+
+    test("opens a failed row with its source and dataset selected", async ({ page }) => {
+        await page.goto(`${DETAIL_URL}?coverage_scenario=truncated`);
+        const timeline = timelineRegion(page);
+
+        await timeline.getByRole("button", { name: "Backfill this failure" }).click();
+
+        const dialog = page.getByRole("dialog");
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByLabel("Since (inclusive)")).toHaveValue("2026-06-25");
+        await expect(dialog.getByLabel("Before (exclusive)")).toHaveValue("2026-06-27");
+        await expect(dialog.getByLabel("fullchaos/billing-service")).toBeChecked();
+        await expect(dialog.getByLabel("Pull Requests")).toBeChecked();
+    });
+
     test("canonical backfill entry prefills the exact server-owned window", async ({ page }) => {
         await page.goto(`${DETAIL_URL}?coverage_scenario=truncated`);
         const backfillButton = page.getByRole("button", {


### PR DESCRIPTION
## Summary

- allow admins to select several exact gap and failure windows from the coverage timeline
- open failed rows directly and auto-select the server-provided dates, repositories, and datasets
- start one backfill request per canonical window, preserving exact timestamps and reporting partial failures per window

## Verification

- 43 focused component tests passed
- 14 of 14 admin sync observability browser tests passed
- 3 of 3 targeted post-refactor browser tests passed
- TypeScript, focused ESLint, repository design lint, and production build passed

## Visual evidence

### Multi-window selection
![Multi-window selection](https://github.com/user-attachments/assets/bb1f2df0-3e95-4a00-87b3-47b2ceecf825)

### Exact two-window review
![Exact two-window review](https://github.com/user-attachments/assets/665c2f8e-21b9-42a3-ab18-fc2ca35661fe)

### Failed-window automatic scope
![Failed-window automatic scope](https://github.com/user-attachments/assets/837a8f4b-0746-4a81-a286-8e504c0f4d1e)

Refs CHAOS-3819